### PR TITLE
ConfigUtilities.ParseTimeSpan overflows too easily: use double instead of int

### DIFF
--- a/src/Orleans/Configuration/ConfigUtilities.cs
+++ b/src/Orleans/Configuration/ConfigUtilities.cs
@@ -311,8 +311,8 @@ namespace Orleans.Runtime.Configuration
                 unitSize = 1000; // Default is seconds
                 numberInput = trimmedInput;
             }
-            int rawTimeSpan;
-            if (!Int32.TryParse(numberInput, out rawTimeSpan))
+            double rawTimeSpan;
+            if (!double.TryParse(numberInput, out rawTimeSpan))
             {
                 throw new FormatException(errorMessage + ". Tried to parse " + input);
             }


### PR DESCRIPTION
Currently, ConfigUtilities.ParseTimeSpan parses values into a string before multiplying them into milliseconds and passing them into TimeSpan.FromMilliseconds, which expects a double.

Multiplying the parsed value into milliseconds can cause it to overflow, resulting in a negative TimeSpan.

By parsing directly into double, these overflows can be largely avoided.