### PR TITLE
Fix for warning CS0472: The result of the expression is always 'false' 

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -278,7 +278,7 @@
     <Compile Include="Async\ObserverSubscriptionManager.cs" />
     <Compile Include="CodeGeneration\GrainInterfaceData.cs" />
     <Compile Include="IDs\ActivationAddress.cs" />
-    <Compile Include="IDs\ActivationID.cs" />
+    <Compile Include="IDs\ActivationId.cs" />
     <Compile Include="Runtime\AsynchAgent.cs" />
     <Compile Include="Runtime\AsynchQueueAgent.cs" />
     <Compile Include="Messaging\ByteArrayBuilder.cs" />
@@ -291,7 +291,7 @@
     <Compile Include="Logging\ConsoleText.cs" />
     <Compile Include="Runtime\Constants.cs" />
     <Compile Include="Messaging\CorrelationId.cs" />
-    <Compile Include="IDs\GrainID.cs" />
+    <Compile Include="IDs\GrainId.cs" />
     <Compile Include="Messaging\IMessageCenter.cs" />
     <Compile Include="IDs\Interner.cs" />
     <Compile Include="Placement\PlacementResult.cs" />

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -63,9 +63,6 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         public IAsyncStream<T> GetStream<T>(Guid id, string streamNamespace)
         {
-            if (id == null)
-                throw new ArgumentNullException("id");
-
             var streamId = StreamId.GetStreamId(id, Name, streamNamespace);
             return providerRuntime.GetStreamDirectory().GetOrAddStream<T>(
                 streamId,

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamProvider.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamProvider.cs
@@ -119,8 +119,6 @@ namespace Orleans.Providers.Streams.Common
 
         public IAsyncStream<T> GetStream<T>(Guid id, string streamNamespace)
         {
-            if (id == null) throw new ArgumentNullException("id");
-
             var streamId = StreamId.GetStreamId(id, Name, streamNamespace);
             return providerRuntime.GetStreamDirectory().GetOrAddStream<T>(
                 streamId, () => new StreamImpl<T>(streamId, this, IsRewindable));


### PR DESCRIPTION
Removed an unnecessary check for null reference which is causing a warning during compilation:

CS0472: The result of the expression is always 'false' since a value of type 'System.Guid' is never equal to 'null'.