### PR TITLE
Fix for warning CS0472: The result of the expression is always 'false' 

### DIFF
--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -63,9 +63,6 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         public IAsyncStream<T> GetStream<T>(Guid id, string streamNamespace)
         {
-            if (id == null)
-                throw new ArgumentNullException("id");
-
             var streamId = StreamId.GetStreamId(id, Name, streamNamespace);
             return providerRuntime.GetStreamDirectory().GetOrAddStream<T>(
                 streamId,

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamProvider.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamProvider.cs
@@ -119,8 +119,6 @@ namespace Orleans.Providers.Streams.Common
 
         public IAsyncStream<T> GetStream<T>(Guid id, string streamNamespace)
         {
-            if (id == null) throw new ArgumentNullException("id");
-
             var streamId = StreamId.GetStreamId(id, Name, streamNamespace);
             return providerRuntime.GetStreamDirectory().GetOrAddStream<T>(
                 streamId, () => new StreamImpl<T>(streamId, this, IsRewindable));


### PR DESCRIPTION
Removed an unnecessary check for null reference which is causing a warning during compilation:

CS0472: The result of the expression is always 'false' since a value of type 'System.Guid' is never equal to 'null'.