### PR TITLE
Fix warning CA2002: Do not lock on objects with weak identity

### DIFF
--- a/src/OrleansProviders/Storage/HierarchicalKeyStore.cs
+++ b/src/OrleansProviders/Storage/HierarchicalKeyStore.cs
@@ -41,6 +41,7 @@ namespace Orleans.Storage
         [NonSerialized]
         private readonly IDictionary<string, IDictionary<string, object>> dataTable;
         private readonly int numKeyLayers;
+        private readonly object lockable = new object();
 
         public HierarchicalKeyStore(int keyLayers)
         {
@@ -57,7 +58,7 @@ namespace Orleans.Storage
                 throw new ArgumentOutOfRangeException("keys", keys.Count, error);
             }
 
-            lock (this)
+            lock (lockable)
             {
                 var storedData = GetDataStore(keys);
 
@@ -85,7 +86,7 @@ namespace Orleans.Storage
                 throw new ArgumentOutOfRangeException("keys", keys.Count, error);
             }
 
-            lock (this)
+            lock (lockable)
             {
                 IDictionary<string, object> data = GetDataStore(keys);
                 
@@ -105,7 +106,7 @@ namespace Orleans.Storage
                     string.Format("Too many key supplied -- Expected count = {0} Received = {1}", numKeyLayers, keys.Count));
             }
 
-            lock (this)
+            lock (lockable)
             {
                 IList<IDictionary<string, object>> results = FindDataStores(keys);
 #if DEBUG
@@ -127,7 +128,7 @@ namespace Orleans.Storage
             string keyStr = MakeStoreKey(keys);
 
             bool removedEntry = false;
-            lock (this)
+            lock (lockable)
             {
                 IDictionary<string, object> data;
                 if (dataTable.TryGetValue(keyStr, out data))
@@ -153,7 +154,7 @@ namespace Orleans.Storage
 #if DEBUG
             Trace.TraceInformation("Clear Table");
 #endif
-            lock (this)
+            lock (lockable)
             {
                 dataTable.Clear();
             }
@@ -162,7 +163,7 @@ namespace Orleans.Storage
         public string DumpData(bool printDump = true)
         {
             var sb = new StringBuilder();
-            lock (this)
+            lock (lockable)
             {
                 string[] keys = dataTable.Keys.ToArray();
                 foreach (var key in keys)
@@ -184,7 +185,7 @@ namespace Orleans.Storage
         {
             string keyStr = MakeStoreKey(keys);
 
-            lock (this)
+            lock (lockable)
             {
                 IDictionary<string, object> data;
                 if (dataTable.ContainsKey(keyStr))
@@ -215,7 +216,7 @@ namespace Orleans.Storage
             {
                 string keyStr = MakeStoreKey(keys);
 
-                lock (this)
+                lock (lockable)
                 {
                     foreach (var key in dataTable.Keys)
                     if (key.StartsWith(keyStr))

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -37,6 +37,7 @@ namespace Orleans.Runtime
         private readonly TraceLogger logger = TraceLogger.GetLogger("GrainTypeManager");
         private readonly GrainInterfaceMap grainInterfaceMap;
         private readonly Dictionary<int, InvokerData> invokers = new Dictionary<int, InvokerData>();
+        private static readonly object lockable = new object();
 
         public static GrainTypeManager Instance { get; private set; }
 
@@ -50,7 +51,7 @@ namespace Orleans.Runtime
         public GrainTypeManager(bool localTestMode)
         {
             grainInterfaceMap = new GrainInterfaceMap(localTestMode);
-            lock (typeof (GrainTypeManager))
+            lock (lockable)
             {
                 if (Instance != null)
                     throw new InvalidOperationException("An attempt to create a second insance of GrainTypeManager.");

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -93,6 +93,7 @@ namespace Orleans.Runtime
         private readonly TimeSpan stopTimeout = TimeSpan.FromMinutes(1);
         private readonly Catalog catalog;
         private readonly List<IHealthCheckParticipant> healthCheckParticipants;
+        private readonly object lockable = new object();
         
         
         internal readonly string Name;
@@ -357,7 +358,7 @@ namespace Orleans.Runtime
 
         private void DoStart()
         {
-            lock (this)
+            lock (lockable)
             {
                 if (SystemStatus.Current != SystemStatus.Created)
                     throw new InvalidOperationException(String.Format("Calling Silo.Start() on a silo which is not in the Start state. This silo is in the {0} state.", SystemStatus.Current));
@@ -523,7 +524,7 @@ namespace Orleans.Runtime
         public void Stop()
         {
             bool stopAlreadyInProgress = false;
-            lock (this)
+            lock (lockable)
             {
                 if (SystemStatus.Current.Equals(SystemStatus.Stopping) || 
                     SystemStatus.Current.Equals(SystemStatus.ShuttingDown) || 
@@ -649,7 +650,7 @@ namespace Orleans.Runtime
 
             try
             {
-                lock (this)
+                lock (lockable)
                 {
                     if (SystemStatus.Current != SystemStatus.Running) return;
                     


### PR DESCRIPTION
This commit fixes warning CA2002. HierarchicalKeyStore extends
MarshalByRefObject which allows code code running in one AppDomain
to lock on an object in another AppDomain. Fix is to lock on a private
object which only HierarchicalKeyStore is knowledgeable about.