### PR TITLE
added extension method to get a grain's primary key as a string

### DIFF
--- a/src/Orleans/Core/GrainExtensions.cs
+++ b/src/Orleans/Core/GrainExtensions.cs
@@ -131,6 +131,11 @@ namespace Orleans
         {
             return GetGrainId(grain).GetPrimaryKey();
         }
+
+        public static string GetPrimaryKeyString(this IGrainWithStringKey grain)
+        {
+            return GetGrainId(grain).GetPrimaryKeyString();
+        }
     }
 }
 


### PR DESCRIPTION
A convenience method (and for completeness) to get a grain's primary key as a string when the grain inherits `IGrainWithStringKey`.