### PR TITLE
Fixed a typo in string format

### DIFF
--- a/src/TestGrains/SimpleGrain.cs
+++ b/src/TestGrains/SimpleGrain.cs
@@ -46,7 +46,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync()
         {
-            logger = GetLogger(String.Format("{0}-{1}-{1}", typeof(SimpleGrain).Name, base.IdentityString, base.RuntimeIdentity));
+            logger = GetLogger(String.Format("{0}-{1}-{2}", typeof(SimpleGrain).Name, base.IdentityString, base.RuntimeIdentity));
             logger.Info("Activate.");
             return TaskDone.Done;
         }

--- a/src/TestGrains/SimpleObserverableGrain.cs
+++ b/src/TestGrains/SimpleObserverableGrain.cs
@@ -47,7 +47,7 @@ namespace UnitTests.Grains
         {
             EventDelay = 1000;
             Observers = new ObserverSubscriptionManager<ISimpleGrainObserver>();
-            logger = GetLogger(String.Format("{0}-{1}-{1}", typeof(SimpleObserverableGrain).Name, base.IdentityString, base.RuntimeIdentity));
+            logger = GetLogger(String.Format("{0}-{1}-{2}", typeof(SimpleObserverableGrain).Name, base.IdentityString, base.RuntimeIdentity));
             logger.Info("Activate.");
             return TaskDone.Done;
         }


### PR DESCRIPTION
The third argument wasn't referenced.