### PR TITLE
ReadMe - .NET Contribution Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,36 @@ Orleans - Distributed Actor Model
 
 [![Build status](http://corefx-ci.cloudapp.net/jenkins/job/dotnet_orleans/badge/icon)](http://corefx-ci.cloudapp.net/jenkins/job/dotnet_orleans/)
 
-Orleans is a framework that provides a straightforward approach to building distributed high-scale computing applications, without the need to learn and apply complex concurrency or other scaling patterns. It was created by Microsoft Research and designed for use in the cloud. Orleans has been used extensively in Microsoft Azure by several Microsoft product groups, most notably by 343 Industries as a platform for all of Halo 4 cloud services, as well as by a number of other companies.
+Orleans is a framework that provides a straight-forward approach to building distributed high-scale computing applications, without the need to learn and apply complex concurrency or other scaling patterns. 
+It was created by [Microsoft Research][MSR-ProjectOrleans] and designed for use in the cloud. 
+Orleans has been used extensively running in Microsoft Azure by several Microsoft product groups, most notably by 343 Industries as a platform for all of Halo 4 cloud services, as well as by a number of other projects and companies.
 
 Documentation 
 =======
 Documentation is located [here] (https://github.com/dotnet/orleans/wiki).
 
-
 License
 =======
 This project is licensed under the [MIT license] (https://github.com/dotnet/orleans/blob/master/LICENSE).
 
-
-[Ideas for Contributions](https://github.com/dotnet/orleans/wiki/Ideas-for-Contributions)
+Contributing To This Project
 =======
+
+* List of [Ideas for Contributions]
+
+* How to Contribute
+    * [Contributing Guide]
+    * [Developer Guide]
+
+* Coding Standards
+	* The coding standards / style guide used for Orleans code is the [.NET Framework Design Guidelines][DotNet Framework Design Guidelines]:
+
+You are also encouraged to start a discussion by filing an issue.
+See the [contributing guides][Contributing Guide] for more details.
+
+
+[MSR-ProjectOrleans]: http://research.microsoft.com/projects/orleans/
+[Ideas for Contributions]: https://github.com/dotnet/orleans/wiki/Ideas-for-Contributions
+[Contributing Guide]: https://github.com/dotnet/corefx/wiki/Contributing
+[Developer Guide]: https://github.com/dotnet/corefx/wiki/Developer-Guide
+[DotNet Framework Design Guidelines]: https://github.com/dotnet/corefx/wiki/Framework-Design-Guidelines-Digest


### PR DESCRIPTION
- Add details of the Contributing Guidelines for .NET projects on GitHub.
- Add pointer to the .NET Framework Design Guidelines.
- Add link to the original MSR Project Orleans web pages, for historical context.