### PR TITLE
SqlReminderTable: Fix hash type mapping to database (issue12)

### DIFF
--- a/src/OrleansProviders/SQLServer/CreateTables.sql
+++ b/src/OrleansProviders/SQLServer/CreateTables.sql
@@ -43,7 +43,7 @@ CREATE TABLE [dbo].[OrleansRemindersTable]
     [ReminderName] NVARCHAR(150) NOT NULL,
     [StartTime] DATETIME NOT NULL, 
     [Period] INT NOT NULL,
-    [GrainIdConsistentHash] INT NOT NULL, 
+    [GrainIdConsistentHash] BIGINT NOT NULL,
     [ETag] NVARCHAR(50) NOT NULL,
     PRIMARY KEY ([ServiceId],[GrainId],[ReminderName])
 )

--- a/src/OrleansRuntime/ReminderService/SqlReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/SqlReminderTable.cs
@@ -70,8 +70,8 @@ namespace Orleans.Runtime.ReminderService
 
                 var command = new SqlCommand((begin < end) ? READ_RANGE_ROWS_1 : READ_RANGE_ROWS_2);
                 command.Parameters.Add(new SqlParameter { ParameterName = "@id", DbType = DbType.String, Value = serviceId });
-                command.Parameters.Add(new SqlParameter { ParameterName = "@beginhash", DbType = DbType.UInt32, Value = begin });
-                command.Parameters.Add(new SqlParameter { ParameterName = "@endhash", DbType = DbType.UInt32, Value = end });
+                command.Parameters.Add(new SqlParameter { ParameterName = "@beginhash", DbType = DbType.Int64, Value = begin });
+                command.Parameters.Add(new SqlParameter { ParameterName = "@endhash", DbType = DbType.Int64, Value = end });
                 command.Connection = conn;
 
                 return await ProcessResults(command);
@@ -200,7 +200,7 @@ namespace Orleans.Runtime.ReminderService
             command.Parameters.Add(new SqlParameter { ParameterName = "@name", DbType = DbType.String, Value = entry.ReminderName });
             command.Parameters.Add(new SqlParameter { ParameterName = "@starttime", DbType = DbType.DateTime, Value = entry.StartAt });
             command.Parameters.Add(new SqlParameter { ParameterName = "@period", DbType = DbType.Int32, Value = entry.Period.TotalMilliseconds });
-            command.Parameters.Add(new SqlParameter { ParameterName = "@hash", DbType = DbType.UInt32, Value = entry.GrainRef.GetUniformHashCode() });
+            command.Parameters.Add(new SqlParameter { ParameterName = "@hash", DbType = DbType.Int64, Value = entry.GrainRef.GetUniformHashCode() });
             command.Parameters.Add(new SqlParameter { ParameterName = "@newetag", DbType = DbType.String, Value = newETag });
             return newETag;
         }


### PR DESCRIPTION
The hash is an unsigned integer in the grain, but was previously represented as
an integer in the SQL script. This caused an ArgumentException when
DbType.UInt32 was attempted to be converted to an SqlDbType as there is no
mapping from DbType.UInt32 to a corresponding SqlDbType value.

To accomodate the unsigned integer, the hash in the reminder table has been
changed to a bigint, and the calling code now uses DbType.Int64 instead.