### PR TITLE
Fixed spelling error (trancated -> truncated) and reformatted call to String.Format().

### DIFF
--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -825,7 +825,7 @@ namespace Orleans.Runtime
             bool logMessageTruncated = false;
             if (message.Length > MAX_LOG_MESSAGE_SIZE)
             {
-                message = String.Format("{0}. MESSAGE TRUNCATED AT THIS POINT!! Max message size = {2}", message.Substring(0, MAX_LOG_MESSAGE_SIZE), MAX_LOG_MESSAGE_SIZE);
+                message = String.Format("{0}. MESSAGE TRUNCATED AT THIS POINT!! Max message size = {1}", message.Substring(0, MAX_LOG_MESSAGE_SIZE), MAX_LOG_MESSAGE_SIZE);
                 logMessageTruncated = true;
             }
 

--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -825,7 +825,7 @@ namespace Orleans.Runtime
             bool logMessageTruncated = false;
             if (message.Length > MAX_LOG_MESSAGE_SIZE)
             {
-                message = String.Format("{0}. {1} {2}", message.Substring(0, MAX_LOG_MESSAGE_SIZE), "MESSAGE TRANCATED AT THIS POINT!! Max message size =", MAX_LOG_MESSAGE_SIZE);
+                message = String.Format("{0}. MESSAGE TRUNCATED AT THIS POINT!! Max message size = {2}", message.Substring(0, MAX_LOG_MESSAGE_SIZE), MAX_LOG_MESSAGE_SIZE);
                 logMessageTruncated = true;
             }
 


### PR DESCRIPTION
Minor formatting change... just something I noticed and jumped in on. Thanks!