### PR TITLE
SqlReminderTable: Reduce storage requirement for hashes

### DIFF
--- a/src/OrleansProviders/SQLServer/CreateTables.sql
+++ b/src/OrleansProviders/SQLServer/CreateTables.sql
@@ -43,7 +43,7 @@ CREATE TABLE [dbo].[OrleansRemindersTable]
     [ReminderName] NVARCHAR(150) NOT NULL,
     [StartTime] DATETIME NOT NULL, 
     [Period] INT NOT NULL,
-    [GrainIdConsistentHash] BIGINT NOT NULL,
+    [GrainIdConsistentHash] INT NOT NULL,
     [ETag] NVARCHAR(50) NOT NULL,
     PRIMARY KEY ([ServiceId],[GrainId],[ReminderName])
 )

--- a/src/OrleansRuntime/ReminderService/SqlReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/SqlReminderTable.cs
@@ -70,8 +70,8 @@ namespace Orleans.Runtime.ReminderService
 
                 var command = new SqlCommand((begin < end) ? READ_RANGE_ROWS_1 : READ_RANGE_ROWS_2);
                 command.Parameters.Add(new SqlParameter { ParameterName = "@id", DbType = DbType.String, Value = serviceId });
-                command.Parameters.Add(new SqlParameter { ParameterName = "@beginhash", DbType = DbType.Int64, Value = begin });
-                command.Parameters.Add(new SqlParameter { ParameterName = "@endhash", DbType = DbType.Int64, Value = end });
+                command.Parameters.Add(new SqlParameter { ParameterName = "@beginhash", DbType = DbType.Int32, Value = (int)begin });
+                command.Parameters.Add(new SqlParameter { ParameterName = "@endhash", DbType = DbType.Int32, Value = (int)end });
                 command.Connection = conn;
 
                 return await ProcessResults(command);
@@ -200,7 +200,7 @@ namespace Orleans.Runtime.ReminderService
             command.Parameters.Add(new SqlParameter { ParameterName = "@name", DbType = DbType.String, Value = entry.ReminderName });
             command.Parameters.Add(new SqlParameter { ParameterName = "@starttime", DbType = DbType.DateTime, Value = entry.StartAt });
             command.Parameters.Add(new SqlParameter { ParameterName = "@period", DbType = DbType.Int32, Value = entry.Period.TotalMilliseconds });
-            command.Parameters.Add(new SqlParameter { ParameterName = "@hash", DbType = DbType.Int64, Value = entry.GrainRef.GetUniformHashCode() });
+            command.Parameters.Add(new SqlParameter { ParameterName = "@hash", DbType = DbType.Int32, Value = (int)entry.GrainRef.GetUniformHashCode() });
             command.Parameters.Add(new SqlParameter { ParameterName = "@newetag", DbType = DbType.String, Value = newETag });
             return newETag;
         }


### PR DESCRIPTION
The use of 64-bit integers in SQL Server has been reduced to 32-bit signed
integers by casting the grain hashes to int as there is no external dependencies
to the SqlReminderTable that depends on the values.

Fixes #12.

Supercedes change from unsigned 32-bit integers to 64-bit signed integers in
77ba17804a67b2948dc7043805b1b41804d92474.

Updated with comments from @gabikliot on https://github.com/dotnet/orleans/pull/52. Tested manually in project using SqlServer-based reminder service.