### PR TITLE
Allow Build.cmd to run in GfW PowerShell

### DIFF
--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -1,45 +1,48 @@
 @REM NOTE: This script must be run from a Visual Studio command prompt window
 
-@ECHO on
+@ECHO off
 
 SET CMDHOME=%~dp0.
-SET MSBUILDVER=v4.0.30319
-SET MSBUILDEXE=%FrameworkDir%\%MSBUILDVER%\MSBuild.exe
+if "%FrameworkDir%" == "" set FrameworkDir=%WINDIR%\Microsoft.NET\Framework
+if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
 
-@echo Build Debug
+SET MSBUILDEXEDIR=%FrameworkDir%\%FrameworkVersion%
+SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe
+
+@echo Build Debug ==============================
 SET CONFIGURATION=Debug
 SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
-%MSBUILDEXE% %CMDHOME%\Orleans.sln
+"%MSBUILDEXE%" %CMDHOME%\Orleans.sln
 @if ERRORLEVEL 1 GOTO :ErrorStop
 
-@REM Install Visual Stusio SDK and uncomment the following lines 
-@REM to build Visual Stusio project templates.
+@REM Install Visual Studio SDK and uncomment the following lines 
+@REM to build Visual Studio project templates.
 @REM
 @REM %MSBUILDEXE% %CMDHOME%\OrleansVSTools\OrleansVSTools.sln
 @REM xcopy /s /y %CMDHOME%\SDK\VSIX %OutDir%\VSIX\
 @REM @if ERRORLEVEL 1 GOTO :ErrorStop
 
-%MSBUILDEXE% /p:Configuration=%CONFIGURATION% /p:OutputPath=. %CMDHOME%\Build\OrleansSetup.wixproj
+"%MSBUILDEXE%" /p:Configuration=%CONFIGURATION% /p:OutputPath=. %CMDHOME%\Build\OrleansSetup.wixproj
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD succeeded for %CONFIGURATION%
 
 
-@echo Build Release
+@echo Build Release ============================
 SET CONFIGURATION=Release
 SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
-%MSBUILDEXE% %CMDHOME%\Orleans.sln
+"%MSBUILDEXE%" %CMDHOME%\Orleans.sln
 @if ERRORLEVEL 1 GOTO :ErrorStop
 
-@REM Install Visual Stusio SDK and uncomment the following lines 
-@REM to build Visual Stusio project templates.
+@REM Install Visual Studio SDK and uncomment the following lines 
+@REM to build Visual Studio project templates.
 @REM
 @REM %MSBUILDEXE% %CMDHOME%\OrleansVSTools\OrleansVSTools.sln
 @REM xcopy /s /y %CMDHOME%\SDK\VSIX %OutDir%\VSIX\
 @REM @if ERRORLEVEL 1 GOTO :ErrorStop
 
-%MSBUILDEXE% /p:Configuration=%CONFIGURATION% /p:OutputPath=. %CMDHOME%\Build\OrleansSetup.wixproj
+"%MSBUILDEXE%" /p:Configuration=%CONFIGURATION% /p:OutputPath=. %CMDHOME%\Build\OrleansSetup.wixproj
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD succeeded for %CONFIGURATION%
 @GOTO :EOF

--- a/src/Test.cmd
+++ b/src/Test.cmd
@@ -3,9 +3,15 @@
 @ECHO on
 
 SET CMDHOME=%~dp0.
-SET CONFIGURATION=Debug
+if "%FrameworkDir%" == "" set FrameworkDir=%WINDIR%\Microsoft.NET\Framework
+if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
+
+SET MSTESTEXEDIR=%VS120COMNTOOLS%..\IDE
+SET MSTESTEXE=%MSTESTEXEDIR%\MSTest.exe
+
+SET CONFIGURATION=Release
 SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
-cd %CMDHOME%
+cd "%CMDHOME%"
 
-mstest.exe /testcontainer:%OutDir%\Tester.dll
+"%MSTESTEXE%"  /testcontainer:%OutDir%\Tester.dll


### PR DESCRIPTION
- Allow Build.cmd and Test.cmd to be run from Git Shell when
GitForWindows shell option is set to use PowerShell [+PoshGit]
- Add quotes around EXE paths to avoid any problems with spaces in
directory names.
- Use full path for MsTest.exe
- Run tests against the Release build rather than Debug, because that is
what people will most likely want to install.