### PR TITLE
Fix add to configuration

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,3 @@
+/runBuild.bat
+/runTest.bat
+/cleanAll.bat

--- a/src/Orleans/Configuration/ProviderConfiguration.cs
+++ b/src/Orleans/Configuration/ProviderConfiguration.cs
@@ -144,12 +144,14 @@ namespace Orleans.Runtime.Configuration
                 child.SetProviderManager(manager);
         }
 
-        internal void AddProperty(string key, string val)
+        internal bool AddProperty(string key, string val)
         {
             if (!properties.ContainsKey(key))
             {
                 properties.Add(key, val);
+                return true;
             }
+            return false;
         }
 
         public override string ToString()

--- a/src/Orleans/Configuration/ProviderConfiguration.cs
+++ b/src/Orleans/Configuration/ProviderConfiguration.cs
@@ -146,7 +146,10 @@ namespace Orleans.Runtime.Configuration
 
         internal void AddProperty(string key, string val)
         {
-            properties.Add(key, val);
+            if (!properties.ContainsKey(key))
+            {
+                properties.Add(key, val);
+            }
         }
 
         public override string ToString()


### PR DESCRIPTION
Don't add a property to provider configuration if it is already there.
The bug was exposed by our internal unit test that adjusted the stream provider configuration to add a storage account key.

The change to .ignore was committed by mistake, but it doesn't really matter. I can't undo it now. Will be more careful next time.