### PR TITLE
Updated Microsoft.WindowsAzure.Storage and Microsoft.WindowsAzure.ConfigurationManager to the latest Nuget packages and code converted accordingly

### DIFF
--- a/src/Build/OrleansSetup.wxs
+++ b/src/Build/OrleansSetup.wxs
@@ -65,7 +65,7 @@
                 <File Id="File_CL_ClientGenerator.exe" Name="ClientGenerator.exe" Source="$(var.SDK_binaries_clnt_src)\ClientGenerator.exe" />
                 <File Id="File_CL_ClientGenerator.exe.config" Name="ClientGenerator.exe.config" Source="$(var.SDK_binaries_clnt_src)\ClientGenerator.exe.config" />
                 <File Id="File_CL_Microsoft.WindowsAzure.Configuration.dll" Name="Microsoft.WindowsAzure.Configuration.dll" Source="$(var.SDK_binaries_clnt_src)\Microsoft.WindowsAzure.Configuration.dll" />
-                <File Id="File_CL_Microsoft.WindowsAzure.StorageClient.dll" Name="Microsoft.WindowsAzure.StorageClient.dll" Source="$(var.SDK_binaries_clnt_src)\Microsoft.WindowsAzure.StorageClient.dll" />
+                <File Id="File_CL_Microsoft.WindowsAzure.Storage.dll" Name="Microsoft.WindowsAzure.Storage.dll" Source="$(var.SDK_binaries_clnt_src)\Microsoft.WindowsAzure.Storage.dll" />
                 <File Id="File_CL_Orleans.dll" Name="Orleans.dll" Source="$(var.SDK_binaries_clnt_src)\Orleans.dll" />
                 <File Id="File_CL_Orleans.SDK.targets" Name="Orleans.SDK.targets" Source="$(var.SDK_binaries_clnt_src)\Orleans.SDK.targets" />
                 <File Id="File_CL_Orleans.xml" Name="Orleans.xml" Source="$(var.SDK_binaries_clnt_src)\Orleans.xml" />
@@ -86,7 +86,7 @@
                 <File Id="File_SE_CounterControl.exe.config" Name="CounterControl.exe.config" Source="$(var.SDK_binaries_server_src)\CounterControl.exe.config" />
                 <File Id="File_SE_Microsoft.WindowsAzure.Configuration.dll" Name="Microsoft.WindowsAzure.Configuration.dll" Source="$(var.SDK_binaries_server_src)\Microsoft.WindowsAzure.Configuration.dll" />
                 <File Id="File_SE_Microsoft.WindowsAzure.ServiceRuntime.dll" Name="Microsoft.WindowsAzure.ServiceRuntime.dll" Source="$(var.SDK_binaries_server_src)\Microsoft.WindowsAzure.ServiceRuntime.dll" />
-                <File Id="File_SE_Microsoft.WindowsAzure.StorageClient.dll" Name="Microsoft.WindowsAzure.StorageClient.dll" Source="$(var.SDK_binaries_server_src)\Microsoft.WindowsAzure.StorageClient.dll" />
+                <File Id="File_SE_Microsoft.WindowsAzure.Storage.dll" Name="Microsoft.WindowsAzure.Storage.dll" Source="$(var.SDK_binaries_server_src)\Microsoft.WindowsAzure.Storage.dll" />
                 <File Id="File_SE_Orleans.dll" Name="Orleans.dll" Source="$(var.SDK_binaries_server_src)\Orleans.dll" />
                 <File Id="File_SE_Orleans.SDK.targets" Name="Orleans.SDK.targets" Source="$(var.SDK_binaries_server_src)\Orleans.SDK.targets" />
                 <File Id="File_SE_Orleans.xml" Name="Orleans.xml" Source="$(var.SDK_binaries_server_src)\Orleans.xml" />
@@ -130,7 +130,7 @@
             <Component Id="Comp_LocalSilo" DiskId="1" Guid="3a1adaef-360a-4dfa-9924-3451201688c6">
               <File Id="File_LS_Microsoft.WindowsAzure.Configuration.dll" Name="Microsoft.WindowsAzure.Configuration.dll" Source="$(var.SDK_binaries_server_src)\Microsoft.WindowsAzure.Configuration.dll" />
               <File Id="File_LS_Microsoft.WindowsAzure.ServiceRuntime.dll" Name="Microsoft.WindowsAzure.ServiceRuntime.dll" Source="$(var.SDK_binaries_server_src)\Microsoft.WindowsAzure.ServiceRuntime.dll" />
-              <File Id="File_LS_Microsoft.WindowsAzure.StorageClient.dll" Name="Microsoft.WindowsAzure.StorageClient.dll" Source="$(var.SDK_binaries_server_src)\Microsoft.WindowsAzure.StorageClient.dll" />
+              <File Id="File_LS_Microsoft.WindowsAzure.Storage.dll" Name="Microsoft.WindowsAzure.Storage.dll" Source="$(var.SDK_binaries_server_src)\Microsoft.WindowsAzure.Storage.dll" />
               <File Id="File_LS_Orleans.dll" Name="Orleans.dll" Source="$(var.SDK_binaries_server_src)\Orleans.dll" />
               <File Id="File_LS_Orleans.SDK.targets" Name="Orleans.SDK.targets" Source="$(var.SDK_binaries_server_src)\Orleans.SDK.targets" />
               <File Id="File_LS_Orleans.xml" Name="Orleans.xml" Source="$(var.SDK_binaries_server_src)\Orleans.xml" />

--- a/src/NuGet/Microsoft.Orleans.Core.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Core.nuspec
@@ -18,8 +18,8 @@
     <copyright>Copyright Microsoft 2015</copyright>
     <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
     <dependencies>
-        <dependency id="WindowsAzure.Storage" version="[1.7.0.0]" />
-        <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="[2.0.0.0]" />
+        <dependency id="WindowsAzure.Storage" version="4.3.0.0" />
+        <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -21,9 +21,10 @@
       <dependency id="Microsoft.Orleans.Core" version="1.0.0.0" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="1.0.0.0" />
       
-      <dependency id="WindowsAzure.Storage" version="[1.7.0.0]" />
-      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="[2.0.0.0]" />
-      <dependency id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.4.0.0" />
+      <dependency id="WindowsAzure.Storage" version="4.3.0.0" />
+      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3.0" />
+            
+      <dependency id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
@@ -21,8 +21,8 @@
       <dependency id="Microsoft.Orleans.Core" version="1.0.0.0" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="1.0.0.0" />
       
-      <dependency id="WindowsAzure.Storage" version="[1.7.0.0]" />
-      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="[2.0.0.0]" />
+      <dependency id="WindowsAzure.Storage" version="4.3.0.0" />
+      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3.0" />
       <dependency id="Newtonsoft.Json" version="5.0.8" />
     </dependencies>
   </metadata>

--- a/src/Orleans/AzureUtils/AzureQueueDataManager.cs
+++ b/src/Orleans/AzureUtils/AzureQueueDataManager.cs
@@ -24,10 +24,11 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.StorageClient;
 
 using Orleans.Runtime;
 using Orleans.Storage;
+using Microsoft.WindowsAzure.Storage.RetryPolicies;
+using Microsoft.WindowsAzure.Storage.Queue;
 
 namespace Orleans.AzureUtils
 {
@@ -49,19 +50,19 @@ namespace Orleans.AzureUtils
         public static int MaxQueueOperationRetries;
         public static TimeSpan PauseBetweenQueueOperationRetries;
         public static TimeSpan QueueOperationTimeout;
-        public static RetryPolicy QueueOperationRetryPolicy;
+        public static IRetryPolicy QueueOperationRetryPolicy;
 
         static AzureQueueDefaultPolicies()
         {
             MaxQueueOperationRetries = 5;
             PauseBetweenQueueOperationRetries = TimeSpan.FromMilliseconds(100);
-            QueueOperationRetryPolicy = RetryPolicies.Retry(MaxQueueOperationRetries, PauseBetweenQueueOperationRetries); // 5 x 100ms
+            QueueOperationRetryPolicy = new LinearRetry(PauseBetweenQueueOperationRetries, MaxQueueOperationRetries); // 5 x 100ms
             QueueOperationTimeout = PauseBetweenQueueOperationRetries.Multiply(MaxQueueOperationRetries).Multiply(6);    // 3 sec
         }
     }
 
     /// <summary>
-    /// Utility class to encapsulate access to Azure queue storage .
+    /// Utility class to encapsulate access to Azure queue storage.
     /// </summary>
     /// <remarks>
     /// Used by Azure queue streaming provider.
@@ -114,7 +115,7 @@ namespace Orleans.AzureUtils
 
                 // Create the queue if it doesn't already exist.
 
-                bool didCreate = await Task<bool>.Factory.FromAsync(queue.BeginCreateIfNotExist, queue.EndCreateIfNotExist, null);
+                bool didCreate = await Task<bool>.Factory.FromAsync(queue.BeginCreateIfNotExists, queue.EndCreateIfNotExists, null);
 
                 logger.Info(ErrorCode.AzureQueue_01, "{0} Azure storage queue {1}", (didCreate ? "Created" : "Attached to"), QueueName);
             }

--- a/src/Orleans/AzureUtils/AzureStorageUtils.cs
+++ b/src/Orleans/AzureUtils/AzureStorageUtils.cs
@@ -23,16 +23,18 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.Services.Client;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Xml;
 using Microsoft.WindowsAzure;
-using Microsoft.WindowsAzure.StorageClient;
-
 using Orleans.Runtime;
+using Microsoft.WindowsAzure.Storage.Shared.Protocol;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.WindowsAzure.Storage.RetryPolicies;
+using System.Data.Services.Client;
 
 
 namespace Orleans.AzureUtils
@@ -238,7 +240,7 @@ namespace Orleans.AzureUtils
 
         internal static CloudQueueClient GetCloudQueueClient(
             string storageConnectionString,
-            RetryPolicy retryPolicy,
+            IRetryPolicy retryPolicy,
             TimeSpan timeout,
             TraceLogger logger)
         {
@@ -246,8 +248,8 @@ namespace Orleans.AzureUtils
             {
                 var storageAccount = GetCloudStorageAccount(storageConnectionString);
                 CloudQueueClient operationsClient = storageAccount.CreateCloudQueueClient();
-                operationsClient.RetryPolicy = retryPolicy;
-                operationsClient.Timeout = timeout;
+                operationsClient.DefaultRequestOptions.RetryPolicy = retryPolicy;
+                operationsClient.DefaultRequestOptions.ServerTimeout = timeout;
                 return operationsClient;
             }
             catch (Exception exc)
@@ -324,7 +326,7 @@ namespace Orleans.AzureUtils
         {
             return String.Format("CloudQueueMessage: Id = {0}, NextVisibleTime = {1}, DequeueCount = {2}, PopReceipt = {3}, Content = {4}",
                     message.Id,
-                    message.NextVisibleTime.HasValue ? TraceLogger.PrintDate(message.NextVisibleTime.Value) : "",
+                    message.NextVisibleTime.HasValue ? TraceLogger.PrintDate(message.NextVisibleTime.Value.DateTime) : "",
                     message.DequeueCount,
                     message.PopReceipt,
                     message.AsString);

--- a/src/Orleans/AzureUtils/AzureTableDefaultPolicies.cs
+++ b/src/Orleans/AzureUtils/AzureTableDefaultPolicies.cs
@@ -23,8 +23,8 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 ﻿using System;
 using System.Diagnostics;
-using Microsoft.WindowsAzure.StorageClient;
 using Orleans.Runtime;
+using Microsoft.WindowsAzure.Storage.RetryPolicies;
 
 namespace Orleans.AzureUtils
 {
@@ -48,8 +48,8 @@ namespace Orleans.AzureUtils
         public static TimeSpan TableOperationTimeout { get; private set; }
         public static TimeSpan BusyRetriesTimeout { get; private set; }
 
-        public static RetryPolicy TableCreationRetryPolicy { get; private set; }
-        public static RetryPolicy TableOperationRetryPolicy { get; private set; }
+        public static IRetryPolicy TableCreationRetryPolicy { get; private set; }
+        public static IRetryPolicy TableOperationRetryPolicy { get; private set; }
 
         public const int MAX_BULK_UPDATE_ROWS = 100;
 
@@ -71,10 +71,10 @@ namespace Orleans.AzureUtils
                 PauseBetweenBusyRetries = PauseBetweenBusyRetries.Multiply(10);
             }
 #endif
-            TableCreationRetryPolicy = RetryPolicies.Retry(MaxTableCreationRetries, PauseBetweenTableCreationRetries); // 60 x 1s
+            TableCreationRetryPolicy = new LinearRetry(PauseBetweenTableCreationRetries, MaxTableCreationRetries); // 60 x 1s
             TableCreationTimeout = PauseBetweenTableCreationRetries.Multiply(MaxTableCreationRetries).Multiply(3);    // 3 min
 
-            TableOperationRetryPolicy = RetryPolicies.Retry(MaxTableOperationRetries, PauseBetweenTableOperationRetries); // 5 x 100ms
+            TableOperationRetryPolicy = new LinearRetry(PauseBetweenTableOperationRetries, MaxTableOperationRetries); // 5 x 100ms
             TableOperationTimeout = PauseBetweenTableOperationRetries.Multiply(MaxTableOperationRetries).Multiply(6);    // 3 sec
 
             BusyRetriesTimeout = PauseBetweenBusyRetries.Multiply(MaxBusyRetries);  // 1 minute

--- a/src/Orleans/AzureUtils/ClientMetricsTableDataManager.cs
+++ b/src/Orleans/AzureUtils/ClientMetricsTableDataManager.cs
@@ -27,15 +27,14 @@ using System.Data.Services.Common;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.StorageClient;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Orleans.AzureUtils
 {
     [Serializable]
-    [DataServiceKey("PartitionKey", "RowKey")]
-    internal class ClientMetricsData : TableServiceEntity
+    internal class ClientMetricsData : TableEntity
     {
         public string DeploymentId { get; set; }
         public string Address { get; set; }

--- a/src/Orleans/AzureUtils/OrleansSiloInstanceManager.cs
+++ b/src/Orleans/AzureUtils/OrleansSiloInstanceManager.cs
@@ -31,13 +31,12 @@ using System.Linq.Expressions;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.StorageClient;
 using Orleans.Runtime;
+using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Orleans.AzureUtils
 {
-    [DataServiceKey("PartitionKey", "RowKey")]
-    internal class SiloInstanceTableEntry : TableServiceEntity
+    internal class SiloInstanceTableEntry : TableEntity
     {
         public string DeploymentId { get; set; }    // PartitionKey
         public string Address { get; set; }         // RowKey

--- a/src/Orleans/AzureUtils/SiloMetricsTableDataManager.cs
+++ b/src/Orleans/AzureUtils/SiloMetricsTableDataManager.cs
@@ -26,14 +26,13 @@ using System.Data.Services.Common;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.StorageClient;
 using Orleans.Runtime;
+using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Orleans.AzureUtils
 {
     [Serializable]
-    [DataServiceKey("PartitionKey", "RowKey")]
-    internal class SiloMetricsData : TableServiceEntity
+    internal class SiloMetricsData : TableEntity
     {
         public string DeploymentId { get; set; }
         public string Address { get; set; }

--- a/src/Orleans/AzureUtils/StatsTableDataManager.cs
+++ b/src/Orleans/AzureUtils/StatsTableDataManager.cs
@@ -28,14 +28,13 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.StorageClient;
 using Orleans.Runtime;
+using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Orleans.AzureUtils
 {
     [Serializable]
-    [DataServiceKey("PartitionKey", "RowKey")]
-    internal class StatsTableData : TableServiceEntity
+    internal class StatsTableData: TableEntity
     {
         public string DeploymentId { get; set; }
         public string Time { get; set; }

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -71,13 +71,35 @@
     <WarningsAsErrors>4014</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -332,11 +354,13 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <ClientGenReferences>System.Data.dll;System.Data.Services.Client.dll;System.Management.dll</ClientGenReferences>
+    <ClientGenReferences>System.Data.dll;$(SolutionDir)packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll;</ClientGenReferences>
   </PropertyGroup>
   <Target Name="GenerateVersionNumber" BeforeTargets="VersionInit" 
           Condition="'$(BuildingInsideVisualStudio)' != 'true'" 
@@ -373,16 +397,9 @@
     <Message Text="ClientGenSources extracted: $(ClientGenSources)" Importance="high" />
     <!-- Compile orleans dll -->
     <Message Text="[OrleansDllBootstrapUsingClientGen] - Compiling Orleans.dll for boot strap" Importance="high" />
-    <csc Sources="@(Compile)" 
-         OutputAssembly="$(ProjectDir)$(IntermediateOutputPath)Generated\$(TargetName)$(TargetExt)" 
-         EmitDebugInformation="true" 
-         PdbFile="$(PdbFile)" 
-         Platform="$(PlatformTarget)" 
-         References="$(ClientGenReferences);$(SolutionDir)packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll" 
-         DefineConstants="$(DefineConstants);EXCLUDE_CODEGEN" 
-         KeyFile="$(AssemblyOriginatorKeyFile)" 
-         TargetType="$(OutputType)" />
-    <!-- Compile clientgen exe -->
+    <csc Sources="@(Compile)" OutputAssembly="$(ProjectDir)$(IntermediateOutputPath)Generated\$(TargetName)$(TargetExt)" EmitDebugInformation="true" PdbFile="$(PdbFile)" Platform="$(PlatformTarget)" References="$(ClientGenReferences);Microsoft.VisualBasic.dll;$(SolutionDir)packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll" DefineConstants="$(DefineConstants);EXCLUDE_CODEGEN;" KeyFile="$(AssemblyOriginatorKeyFile)" TargetType="$(OutputType)" />
+    <!-- $(SolutionDir)Dependencies\Windows-Azure-SDK\v$(AzureSdkVersion)\ref\Microsoft.WindowsAzure.StorageClient.dll; -->
+    <!-- Compile clientgen-->
     <Message Text="[OrleansDllBootstrapUsingClientGen] - Compiling ClientGenerator for BootStrap" Importance="high" />
     <csc Sources="$(ClientGenSources)" 
          OutputAssembly="$(ProjectDir)$(IntermediateOutputPath)Generated\ClientGenerator.exe" 

--- a/src/Orleans/SystemTargetInterfaces/IReminderTable.cs
+++ b/src/Orleans/SystemTargetInterfaces/IReminderTable.cs
@@ -55,7 +55,7 @@ namespace Orleans
         Task<string> UpsertRow(ReminderEntry entry);
 
         /// <summary>
-        /// Remove a row from the table
+        /// Remove a row from the table.
         /// </summary>
         /// <param name="grainRef"></param>
         /// <param name="reminderName"></param>

--- a/src/Orleans/packages.config
+++ b/src/Orleans/packages.config
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.7.0.0" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="1.7.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
   <package id="WiX.Toolset" version="3.9.1006.0" targetFramework="net4000" />
 </packages>

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -72,19 +72,38 @@
     <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.Services.Client" />
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/OrleansAzureUtils/packages.config
+++ b/src/OrleansAzureUtils/packages.config
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
   <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="1.7.0.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/OrleansHost/OrleansHost.csproj
+++ b/src/OrleansHost/OrleansHost.csproj
@@ -13,10 +13,14 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PlatformTarget>x86</PlatformTarget>
-    <SccProjectName></SccProjectName>
-    <SccLocalPath></SccLocalPath>
-    <SccAuxPath></SccAuxPath>
-    <SccProvider></SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
@@ -92,9 +96,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\..\Test\FunctionalTests\UnitTests\OrleansConfiguration.xml">
-      <Link>OrleansConfiguration.xml</Link>
-    </Content>
     <Content Include="OrleansLocal.xml" />
     <Content Include="StartOrleans.cmd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/OrleansHost/app.config
+++ b/src/OrleansHost/app.config
@@ -19,12 +19,8 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.ServiceRuntime" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.WindowsAzure.StorageClient" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.7.0.0" newVersion="1.7.0.0"/>
-      </dependentAssembly>
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0"/>
+      </dependentAssembly>      
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -12,10 +12,14 @@
     <AssemblyName>OrleansProviders</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SccProjectName></SccProjectName>
-    <SccLocalPath></SccLocalPath>
-    <SccAuxPath></SccAuxPath>
-    <SccProvider></SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkProfile />
@@ -45,11 +49,24 @@
     <WarningsAsErrors>4014</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -58,9 +75,12 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Entity" />
-    <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/OrleansProviders/Storage/AzureTableStorage.cs
+++ b/src/OrleansProviders/Storage/AzureTableStorage.cs
@@ -27,8 +27,7 @@ using System.Data.Services.Common;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.StorageClient;
-
+using Microsoft.WindowsAzure.Storage.Table;
 using Orleans.AzureUtils;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
@@ -353,9 +352,8 @@ namespace Orleans.Storage
         }
 
 
-        [Serializable]
-        [DataServiceKey("PartitionKey", "RowKey")]
-        internal class GrainStateEntity : TableServiceEntity
+        [Serializable]        
+        internal class GrainStateEntity : TableEntity
         {
             public byte[] Data { get; set; }
             public string StringData { get; set; }

--- a/src/OrleansProviders/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/OrleansProviders/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -25,8 +25,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.StorageClient;
-
+using Microsoft.WindowsAzure.Storage.Queue;
 using Orleans.AzureUtils;
 using Orleans.Providers.Streams.Common;
 using Orleans.Streams;

--- a/src/OrleansProviders/Streams/AzureQueue/AzureQueueBatchContainer.cs
+++ b/src/OrleansProviders/Streams/AzureQueue/AzureQueueBatchContainer.cs
@@ -24,8 +24,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.WindowsAzure.StorageClient;
-
+using Microsoft.WindowsAzure.Storage.Queue;
 using Orleans.Providers.Streams.Common;
 using Orleans.Serialization;
 using Orleans.Streams;

--- a/src/OrleansProviders/packages.config
+++ b/src/OrleansProviders/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="1.7.0.0" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -72,21 +72,40 @@
     <WarningsAsErrors>4014</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.Services.Client" />
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/OrleansRuntime/ReminderService/RemindersTableManager.cs
+++ b/src/OrleansRuntime/ReminderService/RemindersTableManager.cs
@@ -29,14 +29,13 @@ using System.Linq.Expressions;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.StorageClient;
 using Orleans.AzureUtils;
-
+using Microsoft.WindowsAzure.Storage.Table;
+                                     
 
 namespace Orleans.Runtime.ReminderService
-{
-    [DataServiceKey("PartitionKey", "RowKey")]
-    internal class ReminderTableEntry : TableServiceEntity
+{    
+    internal class ReminderTableEntry : TableEntity
     {
         public string GrainReference        { get; set; }    // Part of RowKey
         public string ReminderName          { get; set; }    // Part of RowKey
@@ -45,8 +44,7 @@ namespace Orleans.Runtime.ReminderService
         public string StartAt               { get; set; }    
         public string Period                { get; set; }    
         public string GrainRefConsistentHash { get; set; }    // Part of PartitionKey
-        public string ETag                  { get; set; }    
-        
+                
 
         public static string ConstructRowKey(GrainReference grainRef, string reminderName)
         {

--- a/src/OrleansRuntime/packages.config
+++ b/src/OrleansRuntime/packages.config
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
   <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="1.7.0.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -12,10 +12,14 @@
     <AssemblyName>TestGrainInterfaces</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SccProjectName></SccProjectName>
-    <SccLocalPath></SccLocalPath>
-    <SccAuxPath></SccAuxPath>
-    <SccProvider></SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -48,16 +52,33 @@
     <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.Services.Client">
-      <Private>False</Private>
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/TestGrainInterfaces/packages.config
+++ b/src/TestGrainInterfaces/packages.config
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="1.7.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -13,10 +13,14 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PlatformTarget>x86</PlatformTarget>
-    <SccProjectName></SccProjectName>
-    <SccLocalPath></SccLocalPath>
-    <SccAuxPath></SccAuxPath>
-    <SccProvider></SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkProfile />
@@ -50,18 +54,37 @@
     <WarningsAsErrors>4014</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>

--- a/src/TestGrains/packages.config
+++ b/src/TestGrains/packages.config
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="1.7.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -60,16 +60,32 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -84,6 +100,10 @@
     <Reference Include="System.Management.Automation" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Tester/packages.config
+++ b/src/Tester/packages.config
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.7.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
   <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="1.7.0.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
+++ b/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
@@ -32,6 +32,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.MembershipService;
 
+
 namespace UnitTests.StorageTests
 {
     /// <summary>

--- a/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
@@ -25,12 +25,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.StorageClient;
+using Microsoft.WindowsAzure.Storage.Queue;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.AzureUtils;
-
 
 namespace UnitTests.StorageTests
 {

--- a/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
@@ -25,7 +25,8 @@ using System;
 using System.Net;
 using System.Data.Services.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.WindowsAzure.StorageClient;
+using Microsoft.WindowsAzure.Storage.Shared.Protocol;
+using Microsoft.WindowsAzure.Storage.Table.Protocol;
 using Orleans.Runtime;
 using Orleans.AzureUtils;
 

--- a/src/TesterInternal/StorageTests/UnitTestAzureTableDataManager.cs
+++ b/src/TesterInternal/StorageTests/UnitTestAzureTableDataManager.cs
@@ -27,16 +27,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Data.Services.Common;
-using Microsoft.WindowsAzure.StorageClient;
+using Microsoft.WindowsAzure.Storage.Table;
 using Orleans;
 using Orleans.AzureUtils;
 
-
 namespace UnitTests.StorageTests
 {
-    [Serializable]
-    [DataServiceKey("PartitionKey", "RowKey")]
-    public class UnitTestAzureTableData : TableServiceEntity
+    [Serializable]    
+    public class UnitTestAzureTableData : TableEntity
     {
         public byte[] Data { get; set; }
         public string StringData { get; set; }

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -47,15 +47,37 @@
     <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Services" />
-    <Reference Include="System.Data.Services.Client" />
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="General\Identifiertests.cs" />

--- a/src/TesterInternal/packages.config
+++ b/src/TesterInternal/packages.config
@@ -1,4 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="WindowsAzure.Storage" version="1.7.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This resolves #79 *when* the converted code works as intended.

With this I sought to see approximately how much effort it would take to stab the storage system and what issues there would be. There aren’t many storage related tests and I thought that creating them would take too much effort for what I aimed at. I am not sure if this would be the best approach forward. One could reason testing (and fixing) these new binaries could be done observing by experience if they behave well enough. That is, there are other means besides a test harness to be assured of functionality, e.g. logs, alerts, experience of running a sufficiently busy system. If nothing else, this refactoring attempt presents some way to transform the code to quite close the needed functionality.

The resulting code is not good nor is it even correct in all parts. This uses the new binaries, but there needs to be cleanup especially in [AzureTableDataManager](https://github.com/veikkoeeva/orleans/blob/master/src/Orleans/AzureUtils/AzureTableDataManager.cs) storage methods. Even after that, it feels it’s somewhat a throw-away phase. Albeit this might be the case, I feel it would be an important step when assessing the conformance of this new version with the previous one. Especially this version would allow using newer libraries with the Orleans Nuget packages. In the meantime there could be incremental performance updates and even a new storage system implementation. There’s a blog post [Windows Azure Storage Client Library 2.0 Tables Deep Dive]( http://blogs.msdn.com/b/windowsazurestorage/archive/2012/11/06/windows-azure-storage-client-library-2-0-tables-deep-dive.aspx) which explains the newer constructs quite well.

###### Some spots that look potential bugs and cases for improvement
* [DeleteTableEntriesAsync(IReadOnlyCollection<Tuple<T, string>> list)](https://github.com/veikkoeeva/orleans/blob/master/src/Orleans/AzureUtils/AzureTableDataManager.cs#L517)
doesn’t check the list length. The batches are limited to 100 elements by Azure runtime. Even better would be take an arbitrary length list and chunk it to appropriately sized batches.
* It’s counterpart [BulkInsertTableEntries(IReadOnlyCollection<T> data)](https://github.com/veikkoeeva/orleans/blob/master/src/Orleans/AzureUtils/AzureTableDataManager.cs#L634)
does have a check, but it could also do chunking.
* [ReadTableEntriesAndEtagsAsync(Expression<Func<T, bool>> predicate)](https://github.com/veikkoeeva/orleans/blob/master/src/Orleans/AzureUtils/AzureTableDataManager.cs#L574)
look like do not need complicated custom error handling anymore.
* Currently ``ClouldTableClient`` is passed as a parameter to a lot of function. Perhaps better would be to pass ``CloudTable``, as usually the immediate call is ``var tableReference = tableClient.GetTableReference(TableName);`` to obtain a reference and then use it.
* Perhaps functionality to explicitly resolve entity type and do reflection isn’t needed anymore with refactoring the storage functionality.
* ~~In [ReminderTableEntry](https://github.com/veikkoeeva/orleans/blob/master/src/OrleansRuntime/ReminderService/RemindersTableManager.cs#L47) the ETag is shadowed.~~
* ~~This refactoring isn't ready. There are todos, which should be turned into issues, commented code that ought to be removed and, as mentioned, issues with how to update, insert, upsert, merge entities. This could be minor issues if someone points out the desired behaviour in terms of the new library (or straight HTTP verbs).~~

###### How to proceed
* I don't mind other people taking this code to make progress or adding to this here (I'm not sure how to do that, but probably doable).
* Can someone provide tests to provide the correct functinality or run the refactored code to attain a reasonable idea if it works correctly? If not, then perhaps one path forwards would be to capture data from a present system, create test material and check the results of the new system against this material. This probably needs to be done soon after this update anyway (but perhaps this update may alter the way entities are stored, which is desirably differently than currently).

###### A bold aim
I think the bolder aim could be to provide a stream to storage, or two streams. One stream could save straight to storage, the other could batch messages and save (adaptively on load?) based either on some time interval or elements in the queue. This stream perhaps could have a configurable failover so that when, say, Azure Table Storage (ATS) goes offline, a secondary system would be attempted (a SQL Server, or another ATS storage (via connectionstring)). This system could be perhaps provide library components to a common pubsub functionality. This kind of batching doesn’t look like too complicated from an Rx perspective. As an example: http://blog.petegoo.com/2013/01/20/reactive-extensions-in-message-processing/ (though delay sensitive stream would be more complicated).

These streams could, naturally, provide a place to intercept the messages.