### PR TITLE
Added Newtonsoft.Json.dll to SDK

### DIFF
--- a/src/Build/OrleansSetup.wxs
+++ b/src/Build/OrleansSetup.wxs
@@ -102,6 +102,7 @@
                 <File Id="File_SE_OrleansRuntime.dll" Name="OrleansRuntime.dll" Source="$(var.SDK_binaries_server_src)\OrleansRuntime.dll" />
                 <File Id="File_SE_StartOrleans.cmd" Name="StartOrleans.cmd" Source="$(var.SDK_binaries_server_src)\StartOrleans.cmd" />
                 <File Id="File_SE_CreateTables.sql" Name="CreateTables.sql" Source="$(var.Orleans_src)\OrleansProviders\SQLServer\CreateTables.sql" />
+                <File Id="File_SE_Newtonsoft.Json.dll" Name="Newtonsoft.Json.dll" Source="$(var.SDK_binaries_server_src)\Newtonsoft.Json.dll" />
                 <RemoveFolder Id='SDK_Binaries_OrleansServer' On='uninstall'/>
                 <RegistryValue Root='HKLM' Key='Software\Microsoft\OrleansSDK\Preview\v$(var.ProductVersion)\SDK' Type='string' Value='' KeyPath='yes' />
               </Component>
@@ -146,6 +147,7 @@
               <File Id="File_LS_OrleansHost.exe.config" Name="OrleansHost.exe.config" Source="$(var.SDK_binaries_server_src)\OrleansHost.exe.config" />
               <File Id="File_LS_OrleansRuntime.dll" Name="OrleansRuntime.dll" Source="$(var.SDK_binaries_server_src)\OrleansRuntime.dll" />
               <File Id="File_LS_StartOrleans.cmd" Name="StartOrleans.cmd" Source="$(var.SDK_binaries_server_src)\StartOrleans.cmd" />
+              <File Id="File_LS_Newtonsoft.Json.dll" Name="Newtonsoft.Json.dll" Source="$(var.SDK_binaries_server_src)\Newtonsoft.Json.dll" />
               <RemoveFolder Id='SDK_LocalSilo' On='uninstall'/>
               <RegistryValue Root='HKLM' Key='Software\Microsoft\OrleansSDK\Preview\v$(var.ProductVersion)\SDK' Type='string' Value='' KeyPath='yes' />
             </Component>


### PR DESCRIPTION
Added Newtonsoft.Json.dll to SDK because OrleansProviders.dll has a dependency on it.