### PR TITLE
Fix nuspecs

### DIFF
--- a/src/Build/PostBuild.cmd
+++ b/src/Build/PostBuild.cmd
@@ -1,7 +1,7 @@
 @echo Begin Post-Build script
 
 if "%BuildingInsideVisualStudio%" == "true" (
-	set PKG_DIR=%SolutionDir%\NuGet.Packages
+    set PKG_DIR=%SolutionDir%\NuGet.Packages
 ) else (
     set PKG_DIR=%TargetDir%\..\NuGet.Packages
 )
@@ -18,6 +18,7 @@ del /q *.nupkg
 
 copy /y "%SolutionDir%NuGet\*.props" "%TargetDir%\"
 copy /y "%SolutionDir%NuGet\EmptyFile.cs" "%TargetDir%\"
+copy /y "%SolutionDir%NuGet\*Install.ps1" "%TargetDir%\"
 
 @echo Build Orleans NuGet packages from %TargetDir%
 call "%SolutionDir%NuGet\CreateOrleansPackages.bat" . .\Version.txt

--- a/src/NuGet/ClientInstall.ps1
+++ b/src/NuGet/ClientInstall.ps1
@@ -1,0 +1,5 @@
+param($installPath, $toolsPath, $package, $project)
+
+$configXml = $project.ProjectItems.Item("ClientConfiguration.xml")
+$copyToOutput = $configXml.Properties.Item("CopyToOutputDirectory")
+$copyToOutput.Value = 2

--- a/src/NuGet/Microsoft.Orleans.Client.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Client.nuspec
@@ -24,6 +24,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="ClientConfiguration.xml" target="lib\net45" />
+    <file src="ClientConfiguration.xml" target="content" />
+    <file src="ClientInstall.ps1" target="tools\install.ps1" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.Server.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Server.nuspec
@@ -27,7 +27,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansConfiguration.xml" target="lib\net45" />
-    <file src="Configuration\OrleansConfiguration.xsd" target="lib\net45" />
+    <file src="OrleansConfiguration.xml" target="content" />
+    <file src="Configuration\OrleansConfiguration.xsd" target="content" />
+    <file src="ServerInstall.ps1" target="tools\install.ps1" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.Templates.Grains.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Templates.Grains.nuspec
@@ -32,7 +32,7 @@
     <!-- Auto-import MSBuild targets and props files into target project.
            http://docs.nuget.org/docs/creating-packages/creating-and-publishing-a-package#Import_MSBuild_targets_and_props_files_into_project_(Requires_NuGet_2.5_or_above)
       -->
-    <file src="Orleans.SDK.targets" target="build\Orleans.Grains.targets" />
-    <file src="Orleans.Grains.props" target="build\Orleans.Grains.props" />
+    <file src="Orleans.SDK.targets" target="build\Microsoft.Orleans.Templates.Grains.targets" />
+    <file src="Orleans.Grains.props" target="build\Microsoft.Orleans.Templates.Grains.props" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.Templates.Interfaces.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Templates.Interfaces.nuspec
@@ -32,7 +32,7 @@
     <!-- Auto-import MSBuild targets and props files into target project.
            http://docs.nuget.org/docs/creating-packages/creating-and-publishing-a-package#Import_MSBuild_targets_and_props_files_into_project_(Requires_NuGet_2.5_or_above)
       -->
-    <file src="Orleans.SDK.targets" target="build\Orleans.Interfaces.targets" />
-    <file src="Orleans.Interfaces.props" target="build\Orleans.Interfaces.props" />
+    <file src="Orleans.SDK.targets" target="build\Microsoft.Orleans.Templates.Interfaces.targets" />
+    <file src="Orleans.Interfaces.props" target="build\Microsoft.Orleans.Templates.Interfaces.props" />
   </files>
 </package>

--- a/src/NuGet/ServerInstall.ps1
+++ b/src/NuGet/ServerInstall.ps1
@@ -1,0 +1,5 @@
+param($installPath, $toolsPath, $package, $project)
+
+$configXml = $project.ProjectItems.Item("OrleansConfiguration.xml")
+$copyToOutput = $configXml.Properties.Item("CopyToOutputDirectory")
+$copyToOutput.Value = 2

--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{013DFD29-E1DB-4968-A67B-C2342E6F5B6E}"
 	ProjectSection(SolutionItems) = preProject
@@ -54,6 +54,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{856B8F
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{014CD19F-3112-4AF6-927E-8C88F3EA556A}"
 	ProjectSection(SolutionItems) = preProject
+		NuGet\ClientInstall.ps1 = NuGet\ClientInstall.ps1
 		NuGet\CreateOrleansPackages.bat = NuGet\CreateOrleansPackages.bat
 		NuGet\EmptyFile.cs = NuGet\EmptyFile.cs
 		NuGet\Microsoft.Orleans.Client.nuspec = NuGet\Microsoft.Orleans.Client.nuspec
@@ -71,6 +72,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{014CD19F
 		NuGet\Microsoft.Orleans.Templates.Interfaces.nuspec = NuGet\Microsoft.Orleans.Templates.Interfaces.nuspec
 		BuildDefinitions\NuGet\Orleans.Grains.props = BuildDefinitions\NuGet\Orleans.Grains.props
 		BuildDefinitions\NuGet\Orleans.Interfaces.props = BuildDefinitions\NuGet\Orleans.Interfaces.props
+		NuGet\ServerInstall.ps1 = NuGet\ServerInstall.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SDK", "SDK", "{80801A64-30AD-4B07-801C-2479A87AC527}"


### PR DESCRIPTION
Fix <i>Microsoft.Orleans.Templates.Grains</i> and <i>Microsoft.Orleans.Templates.Interfaces</i> nuspecs to import targets and props to the target project.

Fix <i>Microsoft.Orleans.Client</i> and <i>Microsoft.Orleans.Server</i> nuspecs to copy configuration files to the root of target project