### PR TITLE
Modify Test.cmd to run only BVT tests (runs automatically in CI). Add TestAll.cmd to run all tests.

### DIFF
--- a/src/TestAll.cmd
+++ b/src/TestAll.cmd
@@ -14,6 +14,6 @@ SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
 cd "%CMDHOME%"
 
-"%MSTESTEXE%"  /testcontainer:%OutDir%\TesterInternal.dll /category:"BVT"
+"%MSTESTEXE%"  /testcontainer:%OutDir%\TesterInternal.dll /category:"BVT|Nightly"
 
-"%MSTESTEXE%"  /testcontainer:%OutDir%\Tester.dll /category:"BVT"
+"%MSTESTEXE%"  /testcontainer:%OutDir%\Tester.dll /category:"BVT|Nightly"


### PR DESCRIPTION
CI tests should be short and have no external dependencies (like on Azure Storage emulator). 
Thus modified Test.cmd, that runs automatically in CI, to run only BVT tests.
Add  a new file TestAll.cmd to run all tests.