### PR TITLE
Changed Sub to Function in codegen to match c# version.

### DIFF
--- a/src/ClientGenerator/VBCodeGenerator.cs
+++ b/src/ClientGenerator/VBCodeGenerator.cs
@@ -171,7 +171,7 @@ End If", pair.Key, pair.Value);
             factoryClass.Members.Add(createObjectReferenceMethod);
 
             methodImpl = String.Format(@"
-        Public Shared Sub DeleteObjectReference(reference As {0}) As System.Threading.Tasks.Task
+        Public Shared Function DeleteObjectReference(reference As {0}) As System.Threading.Tasks.Task
             Return Global.Orleans.Runtime.GrainReference.DeleteObjectReference(reference)
         End Sub",
             grainInterfaceData.TypeName);


### PR DESCRIPTION
I've updated the VBCodeGeneratortor replace an invalid line which doesn't compile.

Simple switch Sub to Function to match the c# version of the C#CodeGenerator