### PR TITLE
Include AzureTableErrorCodeTests in BVT

### DIFF
--- a/src/TesterInternal/OrleansRuntime/Streams/BestFitBalancerTests.cs
+++ b/src/TesterInternal/OrleansRuntime/Streams/BestFitBalancerTests.cs
@@ -27,7 +27,7 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans.Streams;
 
-namespace TesterInternal.OrleansRuntime.Streams
+namespace UnitTests.OrleansRuntime.Streams
 {
     [TestClass]
     public class BestFitBalancerTests

--- a/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
+++ b/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
@@ -1,14 +1,35 @@
-﻿using System;
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
-using Orleans.AzureUtils;
 using Orleans.Runtime.MembershipService;
 
 namespace UnitTests.StorageTests
@@ -53,7 +74,7 @@ namespace UnitTests.StorageTests
             GlobalConfiguration config = new GlobalConfiguration
             {
                 DeploymentId = deploymentId,
-                DataConnectionString = TestConstants.DataConnectionString
+                DataConnectionString = StorageTestConstants.DataConnectionString
             };
 
             membership = AzureBasedMembershipTable.GetMembershipTable(config, true)

--- a/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
@@ -1,10 +1,32 @@
-﻿using System;
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.StorageClient;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.AzureUtils;
@@ -37,7 +59,7 @@ namespace UnitTests.StorageTests
 
         private async Task<AzureQueueDataManager> GetTableManager(string qName)
         {
-            AzureQueueDataManager manager = new AzureQueueDataManager(qName, DeploymentId, TestConstants.DataConnectionString);
+            AzureQueueDataManager manager = new AzureQueueDataManager(qName, DeploymentId, StorageTestConstants.DataConnectionString);
             await manager.InitQueueAsync();
             return manager;
         }

--- a/src/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -6,12 +29,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
-using Orleans.Runtime;
-using Orleans.Storage;
 using Orleans.AzureUtils;
-using Microsoft.WindowsAzure.StorageClient;
-using System.Data.Services.Common;
-using System.Text;
 using UnitTests.Tester;
 
 namespace UnitTests.StorageTests
@@ -28,7 +46,7 @@ namespace UnitTests.StorageTests
             UnitTestUtils.ConfigureThreadPoolSettingsForStorageTests();
 
             // Pre-create table, if required
-            manager = new UnitTestAzureTableDataManager(TestConstants.DataConnectionString);
+            manager = new UnitTestAzureTableDataManager(StorageTestConstants.DataConnectionString);
 
             PartitionKey = "AzureTableTests-" + Guid.NewGuid();
         }

--- a/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
@@ -1,9 +1,31 @@
-﻿using System;
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
 using System.Net;
 using System.Data.Services.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.StorageClient;
-using Orleans;
 using Orleans.Runtime;
 using Orleans.AzureUtils;
 
@@ -12,7 +34,7 @@ namespace UnitTests.StorageTests
     [TestClass]
     public class AzureTableErrorCodeTests
     {
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_ExtractRestErrorCode()
         {
             string xml =
@@ -30,7 +52,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(StorageErrorCodeStrings.OperationTimedOut, strCode);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_ExtractRestErrorCode_ServerBusy()
         {
             string xml =
@@ -53,7 +75,7 @@ namespace UnitTests.StorageTests
             //Assert.IsTrue(Async_AzureTableDataManager<SiloMetricsData>.IsRetriableHttpError((HttpStatusCode)500, "ServerBusy"));
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_ExtractRestErrorCode_InsufficientAccountPermissions()
         {
             string xml =
@@ -73,7 +95,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual("InsufficientAccountPermissions", strCode);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_ExtractRestErrorCode_ResourceNotFound()
         {
             string xml =
@@ -111,7 +133,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(StorageErrorCodeStrings.ResourceNotFound, strCode);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_ResourceNotFound()
         {
             string xml =
@@ -149,9 +171,7 @@ namespace UnitTests.StorageTests
             Assert.IsTrue(isTableStorageDataNotFound, "Is TableStorageDataNotFound " + superWrapped1);
         }
 
-
-
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_UpdateConditionNotSatisfied()
         {
             string xml =
@@ -168,7 +188,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(TableErrorCodeStrings.UpdateConditionNotSatisfied, strCode);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_ExtractRestErrorCode_BadData_Garbage()
         {
             string xml = "GARBAGE";
@@ -182,7 +202,7 @@ namespace UnitTests.StorageTests
             Assert.IsNull(strCode);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_ExtractRestErrorCode_BadData_Null()
         {
             string xml = null;
@@ -196,7 +216,7 @@ namespace UnitTests.StorageTests
             Assert.IsNull(strCode);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_IsRetriableHttpError()
         {
             Assert.IsTrue(AzureStorageUtils.IsRetriableHttpError((HttpStatusCode) 503, null));
@@ -211,7 +231,7 @@ namespace UnitTests.StorageTests
             Assert.IsFalse(AzureStorageUtils.IsRetriableHttpError((HttpStatusCode) 200, null));
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_IsContentionError()
         {
             Assert.IsTrue(AzureStorageUtils.IsContentionError(HttpStatusCode.PreconditionFailed));
@@ -228,7 +248,7 @@ namespace UnitTests.StorageTests
             Assert.IsFalse(AzureStorageUtils.IsContentionError((HttpStatusCode) 200));
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         [ExpectedException(typeof (ArgumentException))]
         public void AzureTableErrorCode_BadTableName()
         {

--- a/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
+++ b/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -6,10 +29,9 @@ using System.Net;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
+using Orleans.AzureUtils;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
-using Orleans.AzureUtils;
-using Orleans.Runtime.MembershipService;
 
 namespace UnitTests.StorageTests
 {
@@ -62,7 +84,7 @@ namespace UnitTests.StorageTests
             logger.Info("DeploymentId={0} Generation={1}", deploymentId, generation);
 
             logger.Info("Initializing SiloInstanceManager");
-            manager = OrleansSiloInstanceManager.GetManager(deploymentId, TestConstants.DataConnectionString)
+            manager = OrleansSiloInstanceManager.GetManager(deploymentId, StorageTestConstants.DataConnectionString)
                 .WaitForResultWithThrow(SiloInstanceTableTestConstants.Timeout);
         }
 

--- a/src/TesterInternal/StorageTests/StorageTestConstants.cs
+++ b/src/TesterInternal/StorageTests/StorageTestConstants.cs
@@ -1,0 +1,34 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace UnitTests.StorageTests
+{
+    public class StorageTestConstants
+    {
+        // Set DataConnectionString to your actual Azure Storage DataConnectionString
+        // public static string DataConnectionString ="DefaultEndpointsProtocol=https;AccountName=XXX;AccountKey=YYY"
+        // OR:
+        // start local storage emulator and UseDevelopmentStorage.
+        public static readonly string DataConnectionString = "UseDevelopmentStorage=true";
+    }
+}

--- a/src/TesterInternal/StorageTests/UnitTestAzureTableDataManager.cs
+++ b/src/TesterInternal/StorageTests/UnitTestAzureTableDataManager.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
 using System.Text;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,17 +34,6 @@ using Orleans.AzureUtils;
 
 namespace UnitTests.StorageTests
 {
-    public class TestConstants
-    {
-        // Set DataConnectionString to your actual Azure Storage DataConnectionString
-        // public static string DataConnectionString ="DefaultEndpointsProtocol=https;AccountName=XXX;AccountKey=YYY"
-        // OR:
-        // start locval stoarge emulator and UseDevelopmentStorage.
-        public static string DataConnectionString = "UseDevelopmentStorage=true";
-       
-    }
-
-
     [Serializable]
     [DataServiceKey("PartitionKey", "RowKey")]
     public class UnitTestAzureTableData : TableServiceEntity

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -6,7 +6,7 @@
     <ProjectGuid>{09610024-F5B9-4065-9557-BD9E36A32421}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>TesterInternal</RootNamespace>
+    <RootNamespace>UnitTests</RootNamespace>
     <AssemblyName>TesterInternal</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -60,6 +60,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StorageTests\AzureTableErrorCodeTests.cs" />
     <Compile Include="StorageTests\AzureMembershipTableTests.cs" />
+    <Compile Include="StorageTests\StorageTestConstants.cs" />
     <Compile Include="StorageTests\UnitTestAzureTableDataManager.cs" />
     <Compile Include="StorageTests\AzureTableDataManagerTests.cs" />
     <Compile Include="StorageTests\SiloInstanceTableManagerTests.cs" />


### PR DESCRIPTION
Include the test cases in AzureTableErrorCodeTests in the BVT suite,
because they all run locally and have no external dependency on Azure
storage.