### PR TITLE
Build-scripts

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,0 +1,1 @@
+%~dp0src\Build.cmd

--- a/Test.cmd
+++ b/Test.cmd
@@ -1,0 +1,1 @@
+%~dp0src\Test.cmd

--- a/TestAll.cmd
+++ b/TestAll.cmd
@@ -1,0 +1,1 @@
+%~dp0src\TestAll.cmd

--- a/src/Test.cmd
+++ b/src/Test.cmd
@@ -14,6 +14,6 @@ SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
 cd "%CMDHOME%"
 
-"%MSTESTEXE%"  /testcontainer:%OutDir%\TesterInternal.dll /category:"BVT"
+set TEST_ARGS= /testcontainer:%OutDir%\Tester.dl /testcontainer:%OutDir%\TesterInternal.dll 
 
-"%MSTESTEXE%"  /testcontainer:%OutDir%\Tester.dll /category:"BVT"
+"%MSTESTEXE%" %TEST_ARGS% /category:"BVT"

--- a/src/Test.cmd
+++ b/src/Test.cmd
@@ -14,6 +14,6 @@ SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
 cd "%CMDHOME%"
 
-set TEST_ARGS= /testcontainer:%OutDir%\Tester.dl /testcontainer:%OutDir%\TesterInternal.dll 
+set TEST_ARGS= /testcontainer:%OutDir%\Tester.dll /testcontainer:%OutDir%\TesterInternal.dll 
 
 "%MSTESTEXE%" %TEST_ARGS% /category:"BVT"

--- a/src/TestAll.cmd
+++ b/src/TestAll.cmd
@@ -14,6 +14,6 @@ SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
 cd "%CMDHOME%"
 
-"%MSTESTEXE%"  /testcontainer:%OutDir%\TesterInternal.dll /category:"BVT|Nightly"
+set TEST_ARGS= /testcontainer:%OutDir%\Tester.dl /testcontainer:%OutDir%\TesterInternal.dll 
 
-"%MSTESTEXE%"  /testcontainer:%OutDir%\Tester.dll /category:"BVT|Nightly"
+"%MSTESTEXE%" %TEST_ARGS% /category:"BVT|Nightly"

--- a/src/TestAll.cmd
+++ b/src/TestAll.cmd
@@ -14,6 +14,6 @@ SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
 cd "%CMDHOME%"
 
-set TEST_ARGS= /testcontainer:%OutDir%\Tester.dl /testcontainer:%OutDir%\TesterInternal.dll 
+set TEST_ARGS= /testcontainer:%OutDir%\Tester.dll /testcontainer:%OutDir%\TesterInternal.dll 
 
 "%MSTESTEXE%" %TEST_ARGS% /category:"BVT|Nightly"


### PR DESCRIPTION
- For easier discovery, add Build.cmd and Test.*cmd scripts at root of
repo which just redirect to the "real" ones in src/ directory.
- Combine test cases from Tester.dll and TesterInternal.dll into a
single MsTest.exe run, for easier tracking.