### PR TITLE
Orleans.Templates-NuGet

### DIFF
--- a/src/NuGet/Microsoft.Orleans.Templates.Grains.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Templates.Grains.nuspec
@@ -17,9 +17,6 @@
     </description>
     <copyright>Copyright Microsoft 2015</copyright>
     <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
-    <dependencies>
-      <dependency id="Microsoft.Orleans.Development" version="1.0.0.0" />
-    </dependencies>
   </metadata>
   <files>
     <file src="Orleans.dll" target="lib\net45" />

--- a/src/NuGet/Microsoft.Orleans.Templates.Interfaces.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Templates.Interfaces.nuspec
@@ -17,9 +17,6 @@
     </description>
     <copyright>Copyright Microsoft 2015</copyright>
     <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
-    <dependencies>
-      <dependency id="Microsoft.Orleans.Development" version="1.0.0.0" />
-    </dependencies>
   </metadata>
   <files>
     <file src="Orleans.dll" target="lib\net45" />


### PR DESCRIPTION
- The NuGet package for grain interfaces and grain classes don't need to
contain dependency on the full Microsoft.Orleans.Development meta
package -- everything that is needed for building those projects
(Orleans.dll & ClientGenerator.exe & .target & .props files) is already
included in those packages.