### PR TITLE
Added support for Observers in GrainReference.

### DIFF
--- a/src/Orleans/IDs/GuidId.cs
+++ b/src/Orleans/IDs/GuidId.cs
@@ -1,0 +1,124 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+﻿using System;
+using Orleans.Concurrency;
+using Orleans.Serialization;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Wrapper object around Guid.
+    /// Can be used in places where Guid is optional and in those cases it can be set to null and will not use the storage of an empty Guid struct.
+    /// </summary>
+    [Serializable]
+    [Immutable]
+    public class GuidId : IEquatable<GuidId>, IComparable<GuidId>
+    {
+        private static readonly Lazy<Interner<Guid, GuidId>> guidIdInternCache = new Lazy<Interner<Guid, GuidId>>(
+                    () => new Interner<Guid, GuidId>(InternerConstants.SIZE_LARGE, InternerConstants.DefaultCacheCleanupFreq));
+
+        public readonly Guid Guid;
+
+        // TODO: Need to integrate with Orleans serializer to really use Interner.
+        private GuidId(Guid guid)
+        {
+            this.Guid = guid;
+        }
+
+        public static GuidId GetNewGuidId()
+        {
+            return FindOrCreateGuidId(Guid.NewGuid());
+        }
+
+        public static GuidId GetGuidId(Guid guid)
+        {
+            return FindOrCreateGuidId(guid);
+        }
+
+        private static GuidId FindOrCreateGuidId(Guid guid)
+        {
+            return guidIdInternCache.Value.FindOrCreate(guid, () => new GuidId(guid));
+        }
+
+        #region IComparable<GuidId> Members
+
+        public int CompareTo(GuidId other)
+        {
+            return this.Guid.CompareTo(other.Guid);
+        }
+
+        #endregion
+
+        #region IEquatable<GuidId> Members
+
+        public virtual bool Equals(GuidId other)
+        {
+            return other != null && this.Guid.Equals(other.Guid);
+        }
+
+        #endregion
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as GuidId);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Guid.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return this.Guid.ToString().Substring(0, 8);
+        }
+
+        internal string ToDetailedString()
+        {
+            return this.Guid.ToString();
+        }
+
+        public string ToParsableString()
+        {
+            return Guid.ToString();
+        }
+
+        public static GuidId FromParsableString(string guidId)
+        {
+            Guid id = System.Guid.Parse(guidId);
+            return GetGuidId(id);
+        }
+
+        public void SerializeToStream(BinaryTokenStreamWriter stream)
+        {
+            stream.Write(this.Guid);
+        }
+
+        internal static GuidId DeserializeFromStream(BinaryTokenStreamReader stream)
+        {
+            Guid guid = stream.ReadGuid();
+            return GuidId.GetGuidId(guid);
+        }
+    }
+}

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Core\Exceptions.cs" />
     <Compile Include="Core\IGrainState.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="IDs\GuidId.cs" />
     <Compile Include="Messaging\GatewayManager.cs" />
     <Compile Include="Messaging\RequestInvocationHistory.cs" />
     <Compile Include="Messaging\Response.cs" />

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -38,6 +38,7 @@ namespace Orleans.Runtime
     public class GrainReference : IAddressable, IEquatable<GrainReference>, ISerializable
     {
         private readonly string genericArguments;
+        private readonly GuidId observerId;
         
         [NonSerialized]
         private static readonly TraceLogger logger = TraceLogger.GetLogger("GrainReference", TraceLogger.LoggerType.Runtime);
@@ -49,12 +50,19 @@ namespace Orleans.Runtime
         [NonSerialized]
         private readonly bool isUnordered = false;
 
+        internal bool IsSystemTarget { get { return GrainId.IsSystemTarget; } }
+
+        private bool IsClientAddressableObject { get { return GrainId.IsClientAddressableObject && UseObserverId; } }
+        private static bool UseObserverId { get { return false; } } // for now disable, untill we switch to actualy use NewObserverGrainReference creater.
+
+        private bool HasGenericArgument { get { return !String.IsNullOrEmpty(genericArguments); } }
+
         internal GrainId GrainId { get; private set; }
 
         /// <summary>
         /// Called from generated code.
         /// </summary>
-        protected internal SiloAddress SystemTargetSilo { get; private set; }
+        protected internal readonly SiloAddress SystemTargetSilo;
 
         /// <summary>
         /// Whether the runtime environment for system targets has been initialized yet.
@@ -70,15 +78,48 @@ namespace Orleans.Runtime
         /// Constructs a reference to the grain with the specified Id.
         /// </summary>
         /// <param name="grainId">The Id of the grain to refer to.</param>
-        private GrainReference(GrainId grainId, string genericArguments = null, SiloAddress systemTargetSilo = null)
+        private GrainReference(GrainId grainId, string genericArgument = null, SiloAddress systemTargetSilo = null)
         {
             GrainId = grainId;
-            this.genericArguments = genericArguments;
-            if (String.IsNullOrEmpty(this.genericArguments))
+            this.genericArguments = genericArgument;
+            SystemTargetSilo = systemTargetSilo;
+            if (String.IsNullOrEmpty(genericArgument))
             {
                 this.genericArguments = null; // always keep it null instead of empty.
             }
-            SystemTargetSilo = systemTargetSilo;
+            if (grainId.IsSystemTarget && systemTargetSilo==null)
+            {
+                throw new ArgumentNullException("systemTargetSilo", String.Format("Trying to create a GrainReference for SystemTarget grain id {0}, but passing null systemTargetSilo.", grainId));
+            }
+            if (!grainId.IsSystemTarget && systemTargetSilo != null)
+            {
+                throw new ArgumentException("systemTargetSilo", String.Format("Trying to create a GrainReference for non-SystemTarget grain id {0}, but passing a non-null systemTargetSilo {1}.", grainId, systemTargetSilo));
+            }
+            if (grainId.IsSystemTarget && genericArguments != null)
+            {
+                throw new ArgumentException("genericArguments",
+                    String.Format("Trying to create a GrainReference for SystemTarget grain id {0}, and also passing non-null genericArguments {1}.", grainId, genericArguments));
+            }
+            isUnordered = GetUnordered();
+        }
+
+        private GrainReference(GrainId grainId, GuidId observerId)
+        {
+            GrainId = grainId;
+            if (UseObserverId && !grainId.IsClientAddressableObject)
+            {
+                throw new ArgumentException("grainId", String.Format("Trying to create a GrainReference for Observer with grain id {0}, but passing non ClientAddressableObject grainId.", grainId));
+            }
+            if (UseObserverId && observerId == null)
+            {
+                throw new ArgumentNullException("observerId", String.Format("Trying to create a GrainReference for Observer with grain id {0}, but passing null observerId.", grainId));
+            }
+            this.observerId = observerId;
+
+            if (grainId.IsSystemTarget)
+            {
+                throw new ArgumentException("systemTargetSilo", String.Format("Trying to create an Observer GrainReference for SystemTarget grain id {0}", grainId));
+            }
             isUnordered = GetUnordered();
         }
 
@@ -87,16 +128,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="other">The reference to copy.</param>
         protected GrainReference(GrainReference other)
-        {
-            GrainId = other.GrainId;
-            genericArguments = other.genericArguments;
-            if (String.IsNullOrEmpty(genericArguments))
-            {
-                genericArguments = null; // always keep it null instead of empty.
-            }
-            SystemTargetSilo = other.SystemTargetSilo;
-            isUnordered = GetUnordered();
-        }
+            : this(other.GrainId, other.genericArguments, other.SystemTargetSilo) { }
 
         #endregion
 
@@ -111,6 +143,27 @@ namespace Orleans.Runtime
             return new GrainReference(grainId, genericArguments, systemTargetSilo);
         }
 
+        internal static GrainReference NewObserverGrainReference(GrainId grainId, GuidId observerId)
+        {
+            return new GrainReference(grainId, observerId);
+        }
+
+        /// <summary>
+        /// Called from generated code.
+        /// </summary>
+        public static Task<GrainReference> CreateObjectReference(IAddressable o, IGrainMethodInvoker invoker)
+        {
+            return RuntimeClient.Current.CreateObjectReference(o, invoker);
+        }
+
+        /// <summary>
+        /// Called from generated code.
+        /// </summary>
+        public static Task DeleteObjectReference(IAddressable observer)
+        {
+            return RuntimeClient.Current.DeleteObjectReference(observer);
+        }
+
         #endregion
 
         /// <summary>
@@ -123,6 +176,7 @@ namespace Orleans.Runtime
         {
             return Equals(obj as GrainReference);
         }
+        
         public bool Equals(GrainReference other)
         {
             if (other == null)
@@ -130,14 +184,41 @@ namespace Orleans.Runtime
 
             if (genericArguments != other.genericArguments)
                 return false;
-
-            return Equals(SystemTargetSilo, other.SystemTargetSilo) && GrainId.Equals(other.GrainId);
+            if (!GrainId.Equals(other.GrainId))
+            {
+                return false;
+            }
+            if (IsSystemTarget)
+            {
+                return Equals(SystemTargetSilo, other.SystemTargetSilo);
+            }
+            if (IsClientAddressableObject)
+            {
+                return observerId.Equals(other.observerId);
+            }
+            return true;
         }
 
         /// <summary> Calculates a hash code for a grain reference. </summary>
         public override int GetHashCode()
         {
-            return SystemTargetSilo == null ? GrainId.GetHashCode() : GrainId.GetHashCode() ^ SystemTargetSilo.GetHashCode();
+            int hash = GrainId.GetHashCode();
+            if (IsSystemTarget)
+            {
+                hash = hash ^ SystemTargetSilo.GetHashCode();
+            }
+            if (IsClientAddressableObject)
+            {
+                hash = hash ^ observerId.GetHashCode();
+            }
+            return hash;
+        }
+
+        /// <summary>Get a uniform hash code for this grain reference.</summary>
+        public uint GetUniformHashCode()
+        {
+            // GrainId already includes the hashed type code for generic arguments.
+            return GrainId.GetUniformHashCode();
         }
 
         /// <summary>
@@ -400,69 +481,6 @@ namespace Orleans.Runtime
             return grainWrapper;
         }
 
-        /// <summary>
-        /// Called from generated code.
-        /// </summary>
-        public static Task<GrainReference> CreateObjectReference(IAddressable o, IGrainMethodInvoker invoker)
-        {
-            return RuntimeClient.Current.CreateObjectReference(o, invoker);
-        }
-
-        /// <summary>
-        /// Called from generated code.
-        /// </summary>
-        public static Task DeleteObjectReference(IAddressable observer)
-        {
-            return RuntimeClient.Current.DeleteObjectReference(observer);
-        }
-
-        /// <summary> Serializer function for grain reference.</summary>
-        /// <seealso cref="SerializationManager"/>
-        [SerializerMethod]
-        protected internal static void SerializeGrainReference(object obj, BinaryTokenStreamWriter stream, Type expected)
-        {
-            var input = (GrainReference) obj;
-            stream.Write(input.GrainId);
-            stream.Write((byte) (input.SystemTargetSilo != null ? 1 : 0));
-            if (input.SystemTargetSilo != null)
-            {
-                stream.Write(input.SystemTargetSilo);
-            }
-            // store as null, serialize as empty.
-            var genericArg = input.genericArguments;
-            if (String.IsNullOrEmpty(genericArg))
-                genericArg = String.Empty;
-            stream.Write(genericArg);
-        }
-
-        /// <summary> Deserializer function for grain reference.</summary>
-        /// <seealso cref="SerializationManager"/>
-        [DeserializerMethod]
-        protected internal static object DeserializeGrainReference(Type t, BinaryTokenStreamReader stream)
-        {
-            GrainId id = stream.ReadGrainId();
-            SiloAddress silo = null;
-            byte siloAddressPresent = stream.ReadByte();
-            if (siloAddressPresent != 0)
-            {
-                silo = stream.ReadSiloAddress();
-            }
-            // store as null, serialize as empty.
-            var genericArg = stream.ReadString();
-            if (String.IsNullOrEmpty(genericArg))
-                genericArg = null;
-
-            return FromGrainId(id, genericArg, silo);
-        }
-
-        /// <summary> Copier function for grain reference. </summary>
-        /// <seealso cref="SerializationManager"/>
-        [CopierMethod]
-        protected internal static object CopyGrainReference(object original)
-        {
-            return (GrainReference)original;
-        }
-
         private static String GetDebugContext(string interfaceName, string methodName, object[] arguments)
         {
             // String concatenation is approx 35% faster than string.Format here
@@ -520,42 +538,124 @@ namespace Orleans.Runtime
             }
         }
 
-        /// <summary>Get a uniform hash code for this grain reference.</summary>
-        public uint GetUniformHashCode()
+        /// <summary> Serializer function for grain reference.</summary>
+        /// <seealso cref="SerializationManager"/>
+        [SerializerMethod]
+        protected internal static void SerializeGrainReference(object obj, BinaryTokenStreamWriter stream, Type expected)
         {
-            // GrainId already includes the hashed type code for generic arguments.
-            return GrainId.GetUniformHashCode();
+            var input = (GrainReference)obj;
+            stream.Write(input.GrainId);
+            if (input.IsSystemTarget)
+            {
+                stream.Write((byte)1);
+                stream.Write(input.SystemTargetSilo);
+            }
+            else
+            {
+                stream.Write((byte)0);
+            }
+
+            if (input.IsClientAddressableObject)
+            {
+                input.observerId.SerializeToStream(stream);
+            }
+
+            // store as null, serialize as empty.
+            var genericArg = String.Empty;
+            if (input.HasGenericArgument)
+                genericArg = input.genericArguments;
+            stream.Write(genericArg);
         }
 
+        /// <summary> Deserializer function for grain reference.</summary>
+        /// <seealso cref="SerializationManager"/>
+        [DeserializerMethod]
+        protected internal static object DeserializeGrainReference(Type t, BinaryTokenStreamReader stream)
+        {
+            GrainId id = stream.ReadGrainId();
+            SiloAddress silo = null;
+            GuidId observerId = null;
+            byte siloAddressPresent = stream.ReadByte();
+            if (siloAddressPresent != 0)
+            {
+                silo = stream.ReadSiloAddress();
+            }
+            bool expectObserverId = id.IsClientAddressableObject && UseObserverId;
+            if (expectObserverId)
+            {
+                observerId = GuidId.DeserializeFromStream(stream);
+            }
+            // store as null, serialize as empty.
+            var genericArg = stream.ReadString();
+            if (String.IsNullOrEmpty(genericArg))
+                genericArg = null;
+
+            if (expectObserverId)
+            {
+                return NewObserverGrainReference(id, observerId);
+            }
+            return FromGrainId(id, genericArg, silo);
+        }
+
+        /// <summary> Copier function for grain reference. </summary>
+        /// <seealso cref="SerializationManager"/>
+        [CopierMethod]
+        protected internal static object CopyGrainReference(object original)
+        {
+            return (GrainReference)original;
+        }
 
         private const string GRAIN_REFERENCE_STR = "GrainReference";
         private const string SYSTEM_TARGET_STR = "SystemTarget";
+        private const string OBSERVER_ID_STR = "ObserverId";
         private const string GENERIC_ARGUMENTS_STR = "GenericArguments";
 
         /// <summary>Returns a string representation of this reference.</summary>
         public override string ToString()
         {
-            return GrainId.IsSystemTarget
-                ? String.Format("{0}:{1}/{2}", SYSTEM_TARGET_STR, GrainId, SystemTargetSilo)
-                : String.Format("{0}:{1}{2}", GRAIN_REFERENCE_STR, GrainId,
-                   String.IsNullOrEmpty(genericArguments) ? String.Empty : String.Format("<{0}>", genericArguments)); 
+            if (IsSystemTarget)
+            {
+                return String.Format("{0}:{1}/{2}", SYSTEM_TARGET_STR, GrainId, SystemTargetSilo);
+            }
+            if (IsClientAddressableObject)
+            {
+                return String.Format("{0}:{1}/{2}", OBSERVER_ID_STR, GrainId, observerId);
+            }
+            return String.Format("{0}:{1}{2}", GRAIN_REFERENCE_STR, GrainId,
+                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", genericArguments)); 
         }
 
         internal string ToDetailedString()
         {
-            return GrainId.IsSystemTarget
-                ? String.Format("{0}:{1}/{2}", SYSTEM_TARGET_STR, GrainId.ToDetailedString(), SystemTargetSilo)
-                : String.Format("{0}:{1}{2}", GRAIN_REFERENCE_STR, GrainId.ToDetailedString(),
-                    String.IsNullOrEmpty(genericArguments) ? String.Empty : String.Format("<{0}>", genericArguments)); 
+            if (IsSystemTarget)
+            {
+                return String.Format("{0}:{1}/{2}", SYSTEM_TARGET_STR, GrainId.ToDetailedString(), SystemTargetSilo);
+            }
+            if (IsClientAddressableObject)
+            {
+                return String.Format("{0}:{1}/{2}", OBSERVER_ID_STR, GrainId.ToDetailedString(), observerId.ToDetailedString());
+            }
+            return String.Format("{0}:{1}{2}", GRAIN_REFERENCE_STR, GrainId.ToDetailedString(),
+                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", genericArguments)); 
         }
 
 
         /// <summary> Get the key value for this grain, as a string. </summary>
         public string ToKeyString()
         {
-            return String.IsNullOrEmpty(genericArguments) ?
-                String.Format("{0}={1}", GRAIN_REFERENCE_STR, GrainId.ToParsableString()) :
-                String.Format("{0}={1} {2}={3}", GRAIN_REFERENCE_STR, GrainId.ToParsableString(), GENERIC_ARGUMENTS_STR, genericArguments);
+            if (IsClientAddressableObject)
+            {
+                return String.Format("{0}={1} {2}={3}", GRAIN_REFERENCE_STR, GrainId.ToParsableString(), OBSERVER_ID_STR, observerId.ToParsableString());
+            }
+            if (IsSystemTarget)
+            {
+                return String.Format("{0}={1} {2}={3}", GRAIN_REFERENCE_STR, GrainId.ToParsableString(), SYSTEM_TARGET_STR, SystemTargetSilo.ToParsableString());
+            }
+            if (HasGenericArgument)
+            {
+                return String.Format("{0}={1} {2}={3}", GRAIN_REFERENCE_STR, GrainId.ToParsableString(), GENERIC_ARGUMENTS_STR, genericArguments);
+            }
+            return String.Format("{0}={1}", GRAIN_REFERENCE_STR, GrainId.ToParsableString());
         }
 
         public static GrainReference FromKeyString(string key)
@@ -563,24 +663,43 @@ namespace Orleans.Runtime
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentNullException("key", "GrainReference.FromKeyString cannot parse null key");
             
             string trimmed = key.Trim();
-            string generic = null;
             string grainIdStr;
-            int genericIndex = trimmed.IndexOf(GENERIC_ARGUMENTS_STR + "=", StringComparison.Ordinal);
             int grainIdIndex = (GRAIN_REFERENCE_STR + "=").Length;
+
+            int genericIndex = trimmed.IndexOf(GENERIC_ARGUMENTS_STR + "=", StringComparison.Ordinal);
+            int observerIndex = trimmed.IndexOf(OBSERVER_ID_STR + "=", StringComparison.Ordinal);
+            int systemTargetIndex = trimmed.IndexOf(SYSTEM_TARGET_STR + "=", StringComparison.Ordinal);
+
             if (genericIndex >= 0)
             {
                 grainIdStr = trimmed.Substring(grainIdIndex, genericIndex);
-                generic = trimmed.Substring(genericIndex + (GENERIC_ARGUMENTS_STR + "=").Length);
-                if (String.IsNullOrEmpty(generic))
+                string genericStr = trimmed.Substring(genericIndex + (GENERIC_ARGUMENTS_STR + "=").Length);
+                if (String.IsNullOrEmpty(genericStr))
                 {
-                    generic = null;
+                    genericStr = null;
                 }
+                return FromGrainId(GrainId.FromParsableString(grainIdStr), genericStr);
+            }
+            else if (observerIndex >= 0)
+            {
+                grainIdStr = trimmed.Substring(grainIdIndex, observerIndex);
+                string observerIdStr = trimmed.Substring(observerIndex + (OBSERVER_ID_STR + "=").Length);
+                GuidId observerId = GuidId.FromParsableString(observerIdStr);
+                return NewObserverGrainReference(GrainId.FromParsableString(grainIdStr), observerId);
+            }
+            else if (systemTargetIndex >= 0)
+            {
+                grainIdStr = trimmed.Substring(grainIdIndex, systemTargetIndex);
+                string systemTargetStr = trimmed.Substring(systemTargetIndex + (SYSTEM_TARGET_STR + "=").Length);
+                SiloAddress siloAddress = SiloAddress.FromParsableString(systemTargetStr);
+                return FromGrainId(GrainId.FromParsableString(grainIdStr), null, siloAddress);
             }
             else
             {
                 grainIdStr = trimmed.Substring(grainIdIndex);
+                return FromGrainId(GrainId.FromParsableString(grainIdStr));
             }
-            return FromGrainId(GrainId.FromParsableString(grainIdStr), generic);
+            //return FromGrainId(GrainId.FromParsableString(grainIdStr), generic);
         }
 
 
@@ -590,13 +709,17 @@ namespace Orleans.Runtime
         {
             // Use the AddValue method to specify serialized values.
             info.AddValue("GrainId", GrainId.ToParsableString(), typeof(string));
-            if (GrainId.IsSystemTarget)
+            if (IsSystemTarget)
             {
                 info.AddValue("SystemTargetSilo", SystemTargetSilo.ToParsableString(), typeof(string));
             }
-            var genericArg = genericArguments;
-            if (String.IsNullOrEmpty(genericArg))
-                genericArg = String.Empty;
+            if (IsClientAddressableObject)
+            {
+                info.AddValue(OBSERVER_ID_STR, observerId.ToParsableString(), typeof(string));
+            }
+            string genericArg = String.Empty;
+            if (HasGenericArgument)
+                genericArg = genericArguments;
             info.AddValue("GenericArguments", genericArg, typeof(string));
         }
 
@@ -606,10 +729,15 @@ namespace Orleans.Runtime
             // Reset the property value using the GetValue method.
             var grainIdStr = info.GetString("GrainId");
             GrainId = GrainId.FromParsableString(grainIdStr);
-            if (GrainId.IsSystemTarget)
+            if (IsSystemTarget)
             {
                 var siloAddressStr = info.GetString("SystemTargetSilo");
                 SystemTargetSilo = SiloAddress.FromParsableString(siloAddressStr);
+            }
+            if (IsClientAddressableObject)
+            {
+                var observerIdStr = info.GetString(OBSERVER_ID_STR);
+                observerId = GuidId.FromParsableString(observerIdStr);
             }
             var genericArg = info.GetString("GenericArguments");
             if (String.IsNullOrEmpty(genericArg))

--- a/src/Orleans/Serialization/BinaryTokenStreamReader.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamReader.cs
@@ -421,6 +421,12 @@ namespace Orleans.Serialization
             return UniqueKey.NewKey(n0, n1, typeCodeData, keyExt);
         }
 
+        internal Guid ReadGuid()
+        {
+            byte[] bytes = ReadBytes(16);
+            return new Guid(bytes);
+        }
+
         /// <summary> Read an <c>ActivationAddress</c> value from the stream. </summary>
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         internal ActivationAddress ReadActivationAddress()


### PR DESCRIPTION
Added support for an additional ObserverId to be stored inside GrainReference.
This is the next step in the bigger feature of improving Observers scalability and perf.
