### PR TITLE
MSBuild-HasTrainlingSlash

### DIFF
--- a/src/Orleans.SDK.targets
+++ b/src/Orleans.SDK.targets
@@ -34,7 +34,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Choose>
 
   <Choose>
-    <When Condition="HasTrailingSlash($(ClientGenExeDir))">
+    <When Condition="HasTrailingSlash('$(ClientGenExeDir)')">
       <PropertyGroup>
         <ClientGenExe>$(ClientGenExeDir)ClientGenerator.exe</ClientGenExe>
       </PropertyGroup>
@@ -64,7 +64,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           AfterTargets="BeforeCompile"
           BeforeTargets="CoreCompile"
           Condition="'$(OrleansProjectType)'=='Client'"
-          Inputs="@(Compile);@(ReferencePath);"
+          Inputs="@(Compile);@(ReferencePath)"
           Outputs="$(ProjectDir)$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
     <Message Text="[OrleansClientPreprocessing] - Project=$(ProjectName)" Importance="high"/>
     <Message Text="[OrleansClientPreprocessing] 
@@ -73,7 +73,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 - OrleansSDK=$(OrleansSDK)
 - Using ClientGenExe location=$(ClientGenExe)
 " />
-    <MakeDir Directories="$(IntermediateOutputPath)Generated;"/>
+    <MakeDir Directories="$(IntermediateOutputPath)Generated"/>
     <PropertyGroup>
       <ArgsFile>$(IntermediateOutputPath)$(TargetName).codegen.args.txt</ArgsFile>
     </PropertyGroup>


### PR DESCRIPTION
MSBuild-HasTrainlingSlash
- The value passed to HasTrainlingSlash() [and Exists()] should be
enclosed in single quotes according to
https://msdn.microsoft.com/en-us/ibrary/7szfhaft.aspx
- Remove some spurious colon character cruft.