### PR TITLE
CodeGenTool Build Script Variable Names

### DIFF
--- a/src/Orleans.SDK.targets
+++ b/src/Orleans.SDK.targets
@@ -16,32 +16,32 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Using Orleans NuGet packages -->
     <When Condition="Exists('$(MSBuildThisFileDirectory)..\tools')">
       <PropertyGroup>
-        <ClientGenExeDir>$(MSBuildThisFileDirectory)..\tools</ClientGenExeDir>
+        <CodeGenToolExeDir>$(MSBuildThisFileDirectory)..\tools</CodeGenToolExeDir>
       </PropertyGroup>
     </When>
     <!-- Internal build within Orleans.sln -->
     <When Condition="'$(OrleansReferencesBase)' != ''">
       <PropertyGroup>
-        <ClientGenExeDir>$(OrleansReferencesBase)</ClientGenExeDir>
+        <CodeGenToolExeDir>$(OrleansReferencesBase)</CodeGenToolExeDir>
       </PropertyGroup>
     </When>
     <!-- Legacy support for OrleansSDK -->
     <When Condition="'$(OrleansSDK)' != ''">
       <PropertyGroup>
-        <ClientGenExeDir>$(OrleansSDK)\Binaries\OrleansClient</ClientGenExeDir>
+        <CodeGenToolExeDir>$(OrleansSDK)\Binaries\OrleansClient</CodeGenToolExeDir>
       </PropertyGroup>
     </When>
   </Choose>
 
   <Choose>
-    <When Condition="HasTrailingSlash('$(ClientGenExeDir)')">
+    <When Condition="HasTrailingSlash('$(CodeGenToolExeDir)')">
       <PropertyGroup>
-        <ClientGenExe>$(ClientGenExeDir)ClientGenerator.exe</ClientGenExe>
+        <CodeGenToolExe>$(CodeGenToolExeDir)ClientGenerator.exe</CodeGenToolExe>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <ClientGenExe>$(ClientGenExeDir)\ClientGenerator.exe</ClientGenExe>
+        <CodeGenToolExe>$(CodeGenToolExeDir)\ClientGenerator.exe</CodeGenToolExe>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -68,10 +68,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           Outputs="$(ProjectDir)$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
     <Message Text="[OrleansClientPreprocessing] - Project=$(ProjectName)" Importance="high"/>
     <Message Text="[OrleansClientPreprocessing] 
-- ClientGenExeDir=$(ClientGenExeDir)
+- CodeGenToolExeDir=$(CodeGenToolExeDir)
 - OrleansReferencesBase=$(OrleansReferencesBase)
 - OrleansSDK=$(OrleansSDK)
-- Using ClientGenExe location=$(ClientGenExe)
+- Using CodeGenToolExe location=$(CodeGenToolExe)
 " />
     <MakeDir Directories="$(IntermediateOutputPath)Generated"/>
     <PropertyGroup>
@@ -94,7 +94,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <WriteLinesToFile File="$(ArgsFile)" Lines="/OptionInfer:$(OptionInfer)"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/MyType:$(MyType)"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="@(Compile->'/src:%(Identity)')"/>
-    <Exec Command='"$(ClientGenExe)" "@$(ArgsFile)"' />
+    <Exec Command='"$(CodeGenToolExe)" "@$(ArgsFile)"' />
   </Target>
 
   <!-- This target is run just after Compile for an Orleans Grain Implementation Project -->
@@ -106,15 +106,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           Outputs="$(ProjectDir)$(IntermediateOutputPath)orleans.codegen.timpestamp">
     <Message Text="[OrleansServerObjProcessing] - Creating Server for Project=$(ProjectName)" Importance="high"/>
     <Message Text="[OrleansServerObjProcessing] 
-- ClientGenExeDir=$(ClientGenExeDir)
+- CodeGenToolExeDir=$(CodeGenToolExeDir)
 - OrleansReferencesBase=$(OrleansReferencesBase)
 - OrleansSDK=$(OrleansSDK)
-- Using ClientGenExe location=$(ClientGenExe)
+- Using CodeGenToolExe location=$(CodeGenToolExe)
 "/>
     <PropertyGroup>
       <ArgsFile>$(IntermediateOutputPath)$(TargetName).codegen.args.txt</ArgsFile>
     </PropertyGroup>
     <Message Text="[OrleansServerObjProcessing] - Code-gen args file=$(ArgsFile)"/>
+    <Message Text="[OrleansServerObjProcessing] - DefineConstants=$(DefineConstants)"/>
     <WriteLinesToFile Overwrite="true" File="$(ArgsFile)" Lines="/svr"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/in:$(IntermediateOutputPath)$(TargetName)$(TargetExt)"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/key:$(SnkFile)"/>
@@ -131,7 +132,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <WriteLinesToFile File="$(ArgsFile)" Lines="/OptionInfer:$(OptionInfer)"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/MyType:$(MyType)"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="@(Compile->'/src:%(Identity)')"/>
-    <Exec Command='"$(ClientGenExe)" "@$(ArgsFile)"'
+    <Exec Command='"$(CodeGenToolExe)" "@$(ArgsFile)"'
           Outputs='$(IntermediateOutputPath)$(TargetName)$(TargetExt)' />
   </Target>
 

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -336,7 +336,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <ClientGenReferences>System.Data.dll;System.Data.Services.Client.dll;System.Management.dll</ClientGenReferences>
+    <CodeGenToolReferences>System.Data.dll;System.Data.Services.Client.dll;System.Management.dll</CodeGenToolReferences>
   </PropertyGroup>
   <Target Name="GenerateVersionNumber" BeforeTargets="VersionInit" 
           Condition="'$(BuildingInsideVisualStudio)' != 'true'" 
@@ -352,53 +352,53 @@
     <!-- Show values of some useful properties -->
     <Message Importance="high" Text="Orleans.csproj -- Build Properties =  &#xD;&#xA;TeamProject=$(TeamProject)&#xD;&#xA;SolutionRoot=$(SolutionRoot)&#xD;&#xA;SourcesDirectory=$(SourcesDirectory)&#xD;&#xA;BinariesDirectory=$(BinariesDirectory)&#xD;&#xA;BinariesRoot=$(BinariesRoot)&#xD;&#xA;BuildDirectory=$(BuildDirectory)&#xD;&#xA;BuildProjectFolderPath=$(BuildProjectFolderPath)&#xD;&#xA;MSBuildProjectDirectory=$(MSBuildProjectDirectory)&#xD;&#xA;OutputPath=$(OutputPath)&#xD;&#xA;OutDir=$(OutDir)&#xD;&#xA;DropLocation=$(DropLocation)&#xD;&#xA;PackagesDirectory=$(PackagesDirectory)&#xD;&#xA;BuildNumber=$(BuildNumber)&#xD;&#xA;builduri=$(builduri)&#xD;&#xA;BuildUri=$(BuildUri)&#xD;&#xA;MSBuildForwardPropertiesFromChild=$(MSBuildForwardPropertiesFromChild)&#xD;&#xA;BuildingInsideVisualStudio=$(BuildingInsideVisualStudio)&#xD;&#xA;IsDesktopBuild=$(IsDesktopBuild)" />
   </Target>
-  <Target Name="OrleansDllBootstrapUsingClientGen" 
+  <Target Name="OrleansDllBootstrapUsingCodeGen"
           AfterTargets="BeforeCompile" BeforeTargets="CoreCompile" 
           Inputs="@(Compile);@(ReferencePath)" 
           Outputs="$(ProjectDir)$(IntermediateOutputPath)$(TargetName)$(TargetExt)">
-    <Message Text="[OrleansDllBootstrapUsingClientGen] - Bootstrapping the Orleans.dll" Importance="high" />
+    <Message Text="[OrleansDllBootstrapUsingCodeGen] - Bootstrapping the Orleans.dll" Importance="high" />
     <!-- Clean Generated directory -->
-    <Message Text="[OrleansDllBootstrapUsingClientGen] - Deleting/cleaning generated files for Project=$(ProjectName)" />
+    <Message Text="[OrleansDllBootstrapUsingCodeGen] - Deleting/cleaning generated files for Project=$(ProjectName)" />
     <MakeDir Directories="$(IntermediateOutputPath)Generated" />
     <Touch Files="$(ProjectDir)Properties\orleans.codegen.cs" ForceTouch="true" AlwaysCreate="true" ContinueOnError="true" Condition="!Exists('$(ProjectDir)Properties\orleans.codegen.cs')" />
-    <!-- Extract the sources for clientgen -->
-    <Message Text="[OrleansDllBootstrapUsingClientGen] - Searching for ClientGen sources" Importance="high" />
+    <!-- Extract the sources for Orleans codegen tool -->
+    <Message Text="[OrleansDllBootstrapUsingCodeGen] - Searching for Orleans CodeGen tool sources" Importance="high" />
     <ItemGroup>
       <CodeGenSrcFiles Include="$(SolutionDir)ClientGenerator\*.cs" />
       <CodeGenSrcFiles Include="$(SolutionDir)ClientGenerator\*\*.cs" />
     </ItemGroup>
     <PropertyGroup>
-      <ClientGenSources>@(CodeGenSrcFiles->'%(Identity)')</ClientGenSources>
+      <CodeGenToolSources>@(CodeGenSrcFiles->'%(Identity)')</CodeGenToolSources>
     </PropertyGroup>
-    <Message Text="ClientGenSources extracted: $(ClientGenSources)" Importance="high" />
+    <Message Text="CodeGenToolSources extracted: $(CodeGenToolSources)" Importance="high" />
     <!-- Compile orleans dll -->
-    <Message Text="[OrleansDllBootstrapUsingClientGen] - Compiling Orleans.dll for boot strap" Importance="high" />
+    <Message Text="[OrleansDllBootstrapUsingCodeGen] - Compiling Orleans.dll for boot strap" Importance="high" />
     <csc Sources="@(Compile)" 
          OutputAssembly="$(ProjectDir)$(IntermediateOutputPath)Generated\$(TargetName)$(TargetExt)" 
          EmitDebugInformation="true" 
          PdbFile="$(PdbFile)" 
          Platform="$(PlatformTarget)" 
-         References="$(ClientGenReferences);$(SolutionDir)packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll" 
+         References="$(CodeGenToolReferences);$(SolutionDir)packages\WindowsAzure.Storage.1.7.0.0\lib\net35-full\Microsoft.WindowsAzure.StorageClient.dll" 
          DefineConstants="$(DefineConstants);EXCLUDE_CODEGEN" 
          KeyFile="$(AssemblyOriginatorKeyFile)" 
          TargetType="$(OutputType)" />
-    <!-- Compile clientgen exe -->
-    <Message Text="[OrleansDllBootstrapUsingClientGen] - Compiling ClientGenerator for BootStrap" Importance="high" />
-    <csc Sources="$(ClientGenSources)" 
+    <!-- Compile codegen tool exe -->
+    <Message Text="[OrleansDllBootstrapUsingCodeGen] - Compiling Orleans codegen tool for BootStrap" Importance="high" />
+    <csc Sources="$(CodeGenToolSources)"
          OutputAssembly="$(ProjectDir)$(IntermediateOutputPath)Generated\ClientGenerator.exe" 
          EmitDebugInformation="true" 
          PdbFile="$(PdbFile)" 
          Platform="$(PlatformTarget)" 
-         References="$(ClientGenReferences);$(ProjectDir)$(IntermediateOutputPath)Generated\$(TargetName)$(TargetExt)" 
+         References="$(CodeGenToolReferences);$(ProjectDir)$(IntermediateOutputPath)Generated\$(TargetName)$(TargetExt)" 
          DefineConstants="$(DefineConstants);CLIENTGEN_PROJECT" 
          KeyFile="$(AssemblyOriginatorKeyFile)" />
     <!-- Finally invoke ClientGenerator.exe on the recently built Orleans.dll -->
-    <Message Text="[OrleansDllBootstrapUsingClientGen] - Preprocessing $(TargetName)$(TargetExt) with ClientGenerator.exe" Importance="high" />
+    <Message Text="[OrleansDllBootstrapUsingCodeGen] - Preprocessing $(TargetName)$(TargetExt) with ClientGenerator.exe" Importance="high" />
     <PropertyGroup>
-      <ClientGenCmd>"$(ProjectDir)$(IntermediateOutputPath)Generated\ClientGenerator.exe" /nomerge /bootstrap "/in:$(IntermediateOutputPath)Generated\$(TargetName)$(TargetExt)" "/keyfile:$(AssemblyOriginatorKeyFile)" "/reference:@(ReferencePath)" "/sources:@(Compile)" "/define:$(DefineConstants)" $(ClientGenOptions)</ClientGenCmd>
+      <CodeGenToolExecCmd>"$(ProjectDir)$(IntermediateOutputPath)Generated\ClientGenerator.exe" /nomerge /bootstrap "/in:$(IntermediateOutputPath)Generated\$(TargetName)$(TargetExt)" "/keyfile:$(AssemblyOriginatorKeyFile)" "/reference:@(ReferencePath)" "/sources:@(Compile)" "/define:$(DefineConstants)" $(ClientGenOptions)</CodeGenToolExecCmd>
     </PropertyGroup>
-    <Message Text="[OrleansDllBootstrapUsingClientGen] - CodeGen Cmd = $(ClientGenCmd)" />
-    <Exec Command="$(ClientGenCmd)" />
+    <Message Text="[OrleansDllBootstrapUsingCodeGen] - CodeGen Cmd = $(CodeGenToolExecCmd)" />
+    <Exec Command="$(CodeGenToolExecCmd)" />
   </Target>
   <Target Name="WriteArgsToFileForDebugging" 
           AfterTargets="BeforeCompile" BeforeTargets="CoreCompile" 


### PR DESCRIPTION
[No functional changes]
- For clarity, rename "client-gen" related comments and variables in build scripts to be "code-gen tool"
- Code-gen exe name remains unchanged for now - ClientGenerator.exe