### PR TITLE
Remove use of MSBuild.Escape

### DIFF
--- a/src/Orleans.SDK.targets
+++ b/src/Orleans.SDK.targets
@@ -81,7 +81,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <WriteLinesToFile Overwrite="true" File="$(ArgsFile)" Lines="/nomerge"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/in:$(IntermediateOutputPath)$(TargetName)$(TargetExt)"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/key:$(SnkFile)"/>
-    <WriteLinesToFile File="$(ArgsFile)" Lines="/d:$([MSBuild]::Escape($(DefineConstants)))"/>
+    <!-- Next line is equivalent to MSBuild.Escape but works on Mono xbuild too -->
+    <WriteLinesToFile File="$(ArgsFile)" Lines="/d:$(DefineConstants.Replace(';','%3B'))"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="@(Import->'/imports:%(Identity)')"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/rns:$(RootNamespace)"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="@(ReferencePath->'/r:%(Identity)')"/>
@@ -119,7 +120,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <WriteLinesToFile Overwrite="true" File="$(ArgsFile)" Lines="/svr"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/in:$(IntermediateOutputPath)$(TargetName)$(TargetExt)"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/key:$(SnkFile)"/>
-    <WriteLinesToFile File="$(ArgsFile)" Lines="/d:$([MSBuild]::Escape($(DefineConstants)))"/>
+    <!-- Next line is equivalent to MSBuild.Escape but works on Mono xbuild too -->
+    <WriteLinesToFile File="$(ArgsFile)" Lines="/d:$(DefineConstants.Replace(';','%3B'))"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="@(Import->'/imports:%(Identity)')"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="/rns:$(RootNamespace)"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="@(ReferencePath->'/r:%(Identity)')"/>

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -412,7 +412,8 @@
     <WriteLinesToFile Overwrite="true" File="$(ArgsFile)" Lines="/nomerge" />
     <WriteLinesToFile File="$(ArgsFile)" Lines="/in:$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
     <WriteLinesToFile File="$(ArgsFile)" Lines="/key:$(AssemblyOriginatorKeyFile)" />
-    <WriteLinesToFile File="$(ArgsFile)" Lines="/d:$([MSBuild]::Escape($(DefineConstants)))" />
+    <!-- Next line is equivalent to MSBuild.Escape but works on Mono xbuild too -->
+    <WriteLinesToFile File="$(ArgsFile)" Lines="/d:$(DefineConstants.Replace(';','%3B'))"/>
     <WriteLinesToFile File="$(ArgsFile)" Lines="@(Import->'/imports:%(Identity)')" />
     <WriteLinesToFile File="$(ArgsFile)" Lines="/rns:$(RootNamespace)" />
     <WriteLinesToFile File="$(ArgsFile)" Lines="@(ReferencePath->'/r:%(Identity)')" />


### PR DESCRIPTION
- Remove the use of MSBuild.Escape in build scripts because that
function is not implemented in mono xbuild.