### PR TITLE
AzureWebSample

### DIFF
--- a/Samples/AzureWebSample/OrleansAzureSilos/OrleansAzureSilos.csproj
+++ b/Samples/AzureWebSample/OrleansAzureSilos/OrleansAzureSilos.csproj
@@ -66,7 +66,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Samples/AzureWebSample/OrleansAzureSilos/OrleansConfiguration.xml
+++ b/Samples/AzureWebSample/OrleansAzureSilos/OrleansConfiguration.xml
@@ -1,10 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- 
+	This is a sample silo configuration file for use by an Azure worker role acting as an Orleans silo. 
+	The comments illustrate common customizations.
+	Elements and attributes with no comments should not usually need to be modified.
+	For a detailed reference, see "Orleans Configuration Reference.html".
+-->
 <OrleansConfiguration xmlns="urn:orleans">
   <Globals>
     <Liveness LivenessType="AzureTable" />
   </Globals>
 	<Defaults>
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" >
+	  <!-- 
+	  To turn tracing off, set DefaultTraceLevel="Off" and have no overrides. To see a minimum of messages, set DefaultTraceLevel="Error".
+      For the trace log file name, {0} is the silo name and {1} is the current time. 
+	  Setting WriteTraces to true will cause detailed performance information to be collected and logged about the individual steps in the
+	  message lifecycle. This may be useful debugging performance issues.
+	  -->
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="none" >
+		  <!--
+		  To get more detailed application logging, you can change the TraceLevel attribute value to "Verbose" or "Verbose2".
+		  Depending on the log levels you have used in your code, this will cause additional messages to be written to the log.
+		  -->
+  		<TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
     </Tracing>
 	</Defaults>
 </OrleansConfiguration>

--- a/Samples/AzureWebSample/WebRole/ClientConfiguration.xml
+++ b/Samples/AzureWebSample/WebRole/ClientConfiguration.xml
@@ -12,7 +12,7 @@
 	Setting WriteTraces to true will cause detailed performance information to be collected and logged about the individual steps in the
 	message lifecycle. This may be useful debugging performance issues.
 	-->
-	<Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" WriteTraces="false">
+	<Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="none" >
 		<!--
 		To get more detailed application logging, you can change the TraceLevel attribute value to "Verbose" or "Verbose2".
 		Depending on the log levels you have used in your code, this will cause additional messages to be written to the log.

--- a/Samples/AzureWebSample/WebRole/WebRole.csproj
+++ b/Samples/AzureWebSample/WebRole/WebRole.csproj
@@ -57,7 +57,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>


### PR DESCRIPTION
- ~~Turn log file off by default in AzureWebsample~~
- Normalize default tracing config in AzureWebSemple between silo work role and client web role configs.
- Fix typo in package version in proj files which was causing build warning.