### PR TITLE
NuGet package build improvements

### DIFF
--- a/src/Build/PostBuild.cmd
+++ b/src/Build/PostBuild.cmd
@@ -1,13 +1,5 @@
 @echo Begin Post-Build script
 
-if "%BuildingInsideVisualStudio%" == "true" (
-    set PKG_DIR=%SolutionDir%\NuGet.Packages
-) else (
-    set PKG_DIR=%TargetDir%\..\NuGet.Packages
-)
-
-if not exist "%PKG_DIR%" (md "%PKG_DIR%") else (del /s/q "%PKG_DIR%\*")
-
 copy /y "%SolutionDir%SDK\OrleansConfiguration.xml" "%TargetDir%"
 copy /y "%SolutionDir%SDK\ClientConfiguration.xml" "%TargetDir%"
 
@@ -20,7 +12,8 @@ copy /y "%SolutionDir%NuGet\*.props" "%TargetDir%\"
 copy /y "%SolutionDir%NuGet\EmptyFile.cs" "%TargetDir%\"
 copy /y "%SolutionDir%NuGet\*Install.ps1" "%TargetDir%\"
 
-@echo Build Orleans NuGet packages from %TargetDir%
-call "%SolutionDir%NuGet\CreateOrleansPackages.bat" . .\Version.txt
-@echo Copying Orleans NuGet packages to %PKG_DIR%
-xcopy /y *.nupkg "%PKG_DIR%\"
+if not "%BuildingInsideVisualStudio%"=="true" (
+	@echo Build Orleans NuGet packages from %TargetDir%
+	call "%SolutionDir%NuGet\CreateOrleansPackages.bat" . .\Version.txt
+	if ERRORLEVEL 1 EXIT /B 1
+)

--- a/src/Build/PostBuild.cmd
+++ b/src/Build/PostBuild.cmd
@@ -1,19 +1,33 @@
 @echo Begin Post-Build script
 
+if "%BuildingInsideVisualStudio%" == "true" (
+    set PKG_DIR=%SolutionDir%\NuGet.Packages
+) else (
+    set PKG_DIR=%TargetDir%\..\NuGet.Packages
+)
+
 copy /y "%SolutionDir%SDK\OrleansConfiguration.xml" "%TargetDir%"
 copy /y "%SolutionDir%SDK\ClientConfiguration.xml" "%TargetDir%"
 
 @echo BuildingInsideVisualStudio = %BuildingInsideVisualStudio% BuildOrleansNuGet = %BuildOrleansNuGet%
 
-@echo Clean old generated Orleans NuGet packages from %TargetDir%
-del /q *.nupkg
-
 copy /y "%SolutionDir%NuGet\*.props" "%TargetDir%\"
 copy /y "%SolutionDir%NuGet\EmptyFile.cs" "%TargetDir%\"
 copy /y "%SolutionDir%NuGet\*Install.ps1" "%TargetDir%\"
 
-if not "%BuildingInsideVisualStudio%"=="true" (
-	@echo Build Orleans NuGet packages from %TargetDir%
-	call "%SolutionDir%NuGet\CreateOrleansPackages.bat" . .\Version.txt
-	if ERRORLEVEL 1 EXIT /B 1
+if not "%BuildingInsideVisualStudio%" == "true" (
+    @echo Clean old generated Orleans NuGet packages from %TargetDir%
+    del /q *.nupkg
+
+    @echo Build Orleans NuGet packages from %TargetDir%
+    call "%SolutionDir%NuGet\CreateOrleansPackages.bat" . .\Version.txt
+    if ERRORLEVEL 1 EXIT /B 1
+    
+    if "%Configuration%" == "Release" (
+        @echo Copying Orleans NuGet packages to %PKG_DIR%
+        if not exist "%PKG_DIR%" (md "%PKG_DIR%") else (del /s/q "%PKG_DIR%\*")
+        xcopy /y *.nupkg "%PKG_DIR%\"
+    ) else (
+        @echo Skipping copying Orleans NuGet packages to %PKG_DIR% because Configuration=%Configuration% is not Release
+    )
 )

--- a/src/NuGet/CreateOrleansPackages.bat
+++ b/src/NuGet/CreateOrleansPackages.bat
@@ -37,6 +37,7 @@ if EXIST "%VERSION%" (
 
 FOR %%G IN ("%~dp0*.nuspec") DO (
   "%NUGET_EXE%" pack "%%G" -Version %VERSION% -BasePath "%BASE_PATH%" %NUGET_PACK_OPTS%
+  if ERRORLEVEL 1 EXIT /B 1
 )
 
 GOTO EOF

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -189,6 +189,7 @@ set SolutionDir=$(SolutionDir)
 set OutDir=$(OutDir)
 set TargetDir=$(TargetDir)
 set BuildingInsideVisualStudio=$(BuildingInsideVisualStudio)
+set Configuration=$(Configuration)
 
 @echo Calling Build\PostBuild.cmd
 call "$(SolutionDir)Build\PostBuild.cmd"</PostBuildEvent>


### PR DESCRIPTION
- Make NuGet package creation fail the build if it fails
- Removes the extra copy from /Binaries/Release/*.nupkg to
  /Binaries/NuGet.Packages/ to prevent excess disk I/O
- Only build NuGet packages from within Build.cmd (not within Visual
  Studio). Decreases the build time withing Visual Studio. Packages built
  within Visual Studio weren't correct anyways (they were missing
  *.exe.config)