### PR TITLE
Code generation VB fixes #43

### DIFF
--- a/src/ClientGenerator/CSharpCodeGenerator.cs
+++ b/src/ClientGenerator/CSharpCodeGenerator.cs
@@ -39,7 +39,7 @@ namespace Orleans.CodeGeneration
     internal class CSharpCodeGenerator : NamespaceGenerator
     {
         public CSharpCodeGenerator(Assembly grainAssembly, string nameSpace)
-            : base(grainAssembly, nameSpace)
+            : base(grainAssembly, nameSpace, Language.CSharp)
         {}
 
         protected override string GetGenericTypeName(Type type, Action<Type> referred, Func<Type, bool> noNamespace = null)
@@ -50,7 +50,7 @@ namespace Orleans.CodeGeneration
 
             referred(type);
 
-            var name = (noNamespace(type) && !type.IsNested) ? type.Name : TypeUtils.GetFullName(type);
+            var name = (noNamespace(type) && !type.IsNested) ? type.Name : TypeUtils.GetFullName(type, Language.CSharp);
 
             if (!type.IsGenericType)
             {
@@ -193,7 +193,7 @@ namespace Orleans.CodeGeneration
                 var t = new System.Threading.Tasks.TaskCompletionSource<object>();
                 t.SetException(new NotImplementedException(""No grain interfaces for type {0}""));
                 return t.Task;
-                ", TypeUtils.GetFullName(grainType));
+                ", TypeUtils.GetFullName(grainType, Language.CSharp));
             }
 
             var builder = new StringBuilder();
@@ -523,7 +523,7 @@ namespace Orleans.CodeGeneration
                 if (paramInfo.ParameterType.GetInterface("Orleans.Runtime.IAddressable") != null && !typeof(GrainReference).IsAssignableFrom(paramInfo.ParameterType))
                     invokeArguments += string.Format("{0} is global::Orleans.Grain ? {2}.{1}.Cast({0}.AsReference()) : {0}",
                         GetParameterName(paramInfo),
-                        GrainInterfaceData.GetFactoryClassForInterface(paramInfo.ParameterType),
+                        GrainInterfaceData.GetFactoryClassForInterface(paramInfo.ParameterType, Language.CSharp),
                         paramInfo.ParameterType.Namespace);
                 else
                     invokeArguments += GetParameterName(paramInfo);

--- a/src/ClientGenerator/CodeGeneratorBase.cs
+++ b/src/ClientGenerator/CodeGeneratorBase.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Project Orleans Cloud Service SDK ver. 1.0
  
 Copyright (c) Microsoft Corporation
@@ -21,7 +21,7 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-﻿using System;
+using System;
 using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
@@ -50,6 +50,7 @@ namespace Orleans.CodeGeneration
         protected const string CODE_GENERATOR_NAME = "Orleans-CodeGenerator";
         protected static readonly string CodeGeneratorVersion = RuntimeVersion.FileVersion;
         protected string CurrentNamespace;
+        private readonly Language language;
 
         /// <summary>
         /// Returns a name string for a nested class type name (ClassName.TypeName)
@@ -80,10 +81,11 @@ namespace Orleans.CodeGeneration
             return builder.ToString();
         }
 
-        protected CodeGeneratorBase()
+        protected CodeGeneratorBase(Language language)
         {
             ReferencedNamespaces = new HashSet<string>();
             ReferencedAssemblies = new HashSet<string>();
+            this.language = language;
         }
 
         internal HashSet<string> ReferencedNamespaces { get; private set; }
@@ -132,11 +134,11 @@ namespace Orleans.CodeGeneration
             return methodInfo.DeclaringType.IsInterface && typeof(IAddressable).IsAssignableFrom(methodInfo.DeclaringType);
         }
         
-        internal static CodeDomProvider GetCodeProvider(GrainClientGenerator.Language language, bool debug = false)
+        internal static CodeDomProvider GetCodeProvider(Language language, bool debug = false)
         {
             switch (language)
             {
-                case GrainClientGenerator.Language.CSharp:
+                case Language.CSharp:
                 {
                     var providerOptions = new Dictionary<string, string> { { "CompilerVersion", "v4.0" } };
                     if (debug)
@@ -144,7 +146,7 @@ namespace Orleans.CodeGeneration
 
                     return new CSharpCodeProvider(providerOptions);
                 }
-                case GrainClientGenerator.Language.VisualBasic:
+                case Language.VisualBasic:
                 {
                     var providerOptions = new Dictionary<string, string>();
                     if (debug)
@@ -266,7 +268,7 @@ namespace Orleans.CodeGeneration
                     AddReferencedAssembly(argument);
             }
 
-            var typeName = TypeUtils.GetTemplatedName(type, t => CurrentNamespace != t.Namespace && !ReferencedNamespaces.Contains(t.Namespace));
+            var typeName = TypeUtils.GetTemplatedName(type, t => CurrentNamespace != t.Namespace && !ReferencedNamespaces.Contains(t.Namespace), language);
             return GetNestedClassName(typeName);
         }
 

--- a/src/ClientGenerator/FSharpCodeGenerator.cs
+++ b/src/ClientGenerator/FSharpCodeGenerator.cs
@@ -51,7 +51,7 @@ namespace Orleans.CodeGeneration
         readonly StringBuilder generatedCode = new StringBuilder();
 
         public FSharpCodeGenerator(Assembly grainAssembly, string nameSpace)
-            : base(grainAssembly, nameSpace)
+            : base(grainAssembly, nameSpace, Language.FSharp)
         {
             indentLevel = 0;
             generatedCode.AppendFormat(@"namespace {0}", nameSpace);
@@ -70,7 +70,7 @@ namespace Orleans.CodeGeneration
                 noNamespace = t => true;
 
             referred(type);
-            var name = (noNamespace(type) && !type.IsNested) ? type.Name : TypeUtils.GetFullName(type);
+            var name = (noNamespace(type) && !type.IsNested) ? type.Name : TypeUtils.GetFullName(type, Language.FSharp);
 
             if (!type.IsGenericType)
             {

--- a/src/ClientGenerator/Serialization/SerializationGenerator.cs
+++ b/src/ClientGenerator/Serialization/SerializationGenerator.cs
@@ -44,7 +44,7 @@ namespace Orleans.CodeGeneration.Serialization
         /// <summary>
         /// Generate all the necessary logic for serialization of payload types used by grain interfaces.
         /// </summary>
-        internal static void GenerateSerializationForClass(Type t, CodeNamespace container, HashSet<string> referencedNamespaces, GrainClientGenerator.Language language)
+        internal static void GenerateSerializationForClass(Type t, CodeNamespace container, HashSet<string> referencedNamespaces, Language language)
         {
             var generateSerializers = !CheckForCustomSerialization(t);
             var generateCopier = !CheckForCustomCopier(t);
@@ -52,7 +52,7 @@ namespace Orleans.CodeGeneration.Serialization
             if (!generateSerializers && !generateCopier)
                 return; // If the class declares all custom implementations, then we don't need to do anything...
 
-            bool notVB = (language != GrainClientGenerator.Language.VisualBasic);
+            bool notVB = (language != Language.VisualBasic);
             var openGenerics = notVB ? "<" : "(Of ";
             var closeGenerics = notVB ? ">" : ")";
 
@@ -210,7 +210,7 @@ namespace Orleans.CodeGeneration.Serialization
                 else
                 {
                     var typeName = TypeUtils.GetParameterizedTemplateName(t, tt => tt.Namespace != container.Name && !referencedNamespaces.Contains(tt.Namespace), true);
-                    if (language == GrainClientGenerator.Language.VisualBasic)
+                    if (language == Language.VisualBasic)
                         typeName = typeName.Replace("<", "(Of ").Replace(">", ")");
                     constructor = new CodeVariableDeclarationStatement(classTypeReference, "result", 
                         new CodeObjectCreateExpression(typeName));
@@ -305,7 +305,7 @@ namespace Orleans.CodeGeneration.Serialization
                     }
                 }
 
-                var typeName = fld.FieldType.OrleansTypeName();
+                var typeName = TypeUtils.GetTemplatedName(fld.FieldType, _ => !_.IsGenericParameter, language);
 
                 // See if it's a public field
                 if ((getter == null) || (setter == null))

--- a/src/ClientGenerator/Serialization/SerializerGenerationManager.cs
+++ b/src/ClientGenerator/Serialization/SerializerGenerationManager.cs
@@ -135,7 +135,7 @@ namespace Orleans.CodeGeneration.Serialization
             return true;
         }
 
-        internal static void GenerateSerializers(Assembly grainAssembly, Dictionary<string, NamespaceGenerator> namespaceDictionary, string outputAssemblyName, GrainClientGenerator.Language language)
+        internal static void GenerateSerializers(Assembly grainAssembly, Dictionary<string, NamespaceGenerator> namespaceDictionary, string outputAssemblyName, Language language)
         {
             Type toGen;
             NamespaceGenerator extraNamespace = null;
@@ -150,7 +150,7 @@ namespace Orleans.CodeGeneration.Serialization
                     if (extraNamespace == null)
                     {
                         // Calculate a unique namespace name based on the output assembly name
-                        extraNamespace = new NamespaceGenerator(grainAssembly, outputAssemblyName + "Serializers");
+                        extraNamespace = new NamespaceGenerator(grainAssembly, outputAssemblyName + "Serializers", language);
                         namespaceDictionary.Add("OrleansSerializers", extraNamespace);
                     }
 

--- a/src/ClientGenerator/VBCodeGenerator.cs
+++ b/src/ClientGenerator/VBCodeGenerator.cs
@@ -40,7 +40,7 @@ namespace Orleans.CodeGeneration
     internal class VBCodeGenerator : NamespaceGenerator
     {
         public VBCodeGenerator(Assembly grainAssembly, string nameSpace)
-            : base(grainAssembly, nameSpace)
+            : base(grainAssembly, nameSpace, Language.VisualBasic)
         {}
 
         protected override string FixupTypeName(string str)
@@ -56,12 +56,14 @@ namespace Orleans.CodeGeneration
 
             referred(type);
 
-            var name = (noNamespace(type) && !type.IsNested) ? type.Name : TypeUtils.GetFullName(type);
+            var name = (noNamespace(type) && !type.IsNested) ? 
+                    TypeUtils.GetTemplatedName(type, language: Language.VisualBasic) 
+                    : TypeUtils.GetFullName(type, Language.VisualBasic);
 
             if (!type.IsGenericType)
             {
-                if (type.FullName == null) 
-                    return type.Name;
+                if (type.FullName == null)
+                    return TypeUtils.GetTemplatedName(type, language: Language.VisualBasic);
 
                 var result = GetNestedClassName(name);
                 return result == "Void" ? "void" : result;
@@ -246,7 +248,7 @@ End If", pair.Key, pair.Value);
             Dim t = New System.Threading.Tasks.TaskCompletionSource(Of Object)()
             t.SetException(New NotImplementedException(""No grain interfaces for type {0}""))
             Return t.Task
-                ", TypeUtils.GetFullName(grainType));
+                ", TypeUtils.GetFullName(grainType, Language.VisualBasic));
             }
 
             var builder = new StringBuilder();
@@ -525,7 +527,7 @@ Return System.Threading.Tasks.Task.FromResult(CObj(True))
                 if (paramInfo.ParameterType.GetInterface("Orleans.Runtime.IAddressable") != null && !typeof(GrainReference).IsAssignableFrom(paramInfo.ParameterType))
                     invokeArguments += string.Format("If(typeof({0}) is Global.Orleans.Grain,{2}.{1}.Cast({0}.AsReference()),{0})",
                         GetParameterName(paramInfo),
-                        GrainInterfaceData.GetFactoryClassForInterface(paramInfo.ParameterType),
+                        GrainInterfaceData.GetFactoryClassForInterface(paramInfo.ParameterType, Language.VisualBasic),
                         paramInfo.ParameterType.Namespace);
                 else
                     invokeArguments += GetParameterName(paramInfo);
@@ -676,7 +678,7 @@ Return System.Threading.Tasks.Task.FromResult(CObj(True))
                 foreach (Type argument in type.GetGenericArguments())
                     AddReferencedAssembly(argument);
 
-            var typeName = TypeUtils.GetTemplatedName(type, t => CurrentNamespace != t.Namespace && !ReferencedNamespaces.Contains(t.Namespace));
+            var typeName = TypeUtils.GetTemplatedName(type, t => CurrentNamespace != t.Namespace && !ReferencedNamespaces.Contains(t.Namespace), Language.VisualBasic);
             typeName = GetNestedClassName(typeName);
             typeName = typeName.Replace("<", "(Of ").Replace(">", ")");
             return typeName;

--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -63,44 +63,48 @@ namespace Orleans.CodeGeneration
         
         public string FactoryClassName
         {
-            get { return TypeUtils.GetParameterizedTemplateName(FactoryClassBaseName, Type); }
+            get { return TypeUtils.GetParameterizedTemplateName(FactoryClassBaseName, Type, language: language); }
         }
 
         public string ReferenceClassBaseName { get; set; }
 
         public string ReferenceClassName
         {
-            get { return TypeUtils.GetParameterizedTemplateName(ReferenceClassBaseName, Type); }
+            get { return TypeUtils.GetParameterizedTemplateName(ReferenceClassBaseName, Type, language: language); }
         }
 
         public string InterfaceTypeName
         {
-            get { return TypeUtils.GetParameterizedTemplateName(Type); }
+            get { return TypeUtils.GetParameterizedTemplateName(Type, language: language); }
         }
 
         public string StateClassBaseName { get; internal set; }
 
         public string StateClassName
         {
-            get { return TypeUtils.GetParameterizedTemplateName(StateClassBaseName, Type); }
+            get { return TypeUtils.GetParameterizedTemplateName(StateClassBaseName, Type, language: language); }
         }
 
         public string InvokerClassBaseName { get; internal set; }
 
         public string InvokerClassName
         {
-            get { return TypeUtils.GetParameterizedTemplateName(InvokerClassBaseName, Type); }
+            get { return TypeUtils.GetParameterizedTemplateName(InvokerClassBaseName, Type, language: language); }
         }
 
         public string TypeFullName
         {
-            get { return Namespace + "." + TypeUtils.GetParameterizedTemplateName(Type); }
+            get { return Namespace + "." + TypeUtils.GetParameterizedTemplateName(Type, language: language); }
         }
 
-        public GrainInterfaceData()
-        {}
+        private readonly Language language;
 
-        public GrainInterfaceData(Type type)
+        public GrainInterfaceData(Language language)
+        {
+            this.language = language;
+        }
+
+        public GrainInterfaceData(Language language, Type type) : this(language)
         {
             if (!IsGrainInterface(type))
                 throw new ArgumentException(String.Format("{0} is not a grain interface", type.FullName));
@@ -116,9 +120,9 @@ namespace Orleans.CodeGeneration
             DefineClassNames(true);
         }
 
-        public static GrainInterfaceData FromGrainClass(Type grainType)
+        public static GrainInterfaceData FromGrainClass(Type grainType, Language language)
         {
-            var gi = new GrainInterfaceData {Type = grainType};
+            var gi = new GrainInterfaceData(language) { Type = grainType };
             gi.DefineClassNames(false);
             return gi;
         }
@@ -159,13 +163,13 @@ namespace Orleans.CodeGeneration
             return methodInfos.ToArray();
         }
 
-        public static string GetFactoryClassForInterface(Type referenceInterface)
+        public static string GetFactoryClassForInterface(Type referenceInterface, Language language)
         {
             // remove "Reference" from the end of the type name
             var name = referenceInterface.Name;
             if (name.EndsWith("Reference", StringComparison.Ordinal)) 
                 name = name.Substring(0, name.Length - 9);
-            return TypeUtils.GetParameterizedTemplateName(GetFactoryNameBase(name), referenceInterface);
+            return TypeUtils.GetParameterizedTemplateName(GetFactoryNameBase(name), referenceInterface, language: language);
         }
 
         public static string GetFactoryNameBase(string typeName)
@@ -342,7 +346,7 @@ namespace Orleans.CodeGeneration
         
         private void DefineClassNames(bool client)
         {
-            var typeNameBase = TypeUtils.GetSimpleTypeName(Type, t => false);
+            var typeNameBase = TypeUtils.GetSimpleTypeName(Type, t => false, language);
             if (Type.IsInterface && typeNameBase.Length > 1 && typeNameBase[0] == 'I' && Char.IsUpper(typeNameBase[1]))
                 typeNameBase = typeNameBase.Substring(1);
 
@@ -350,7 +354,7 @@ namespace Orleans.CodeGeneration
             IsGeneric = Type.IsGenericType;
             if (IsGeneric)
             {
-                Name = TypeUtils.GetParameterizedTemplateName(Type);
+                Name = TypeUtils.GetParameterizedTemplateName(Type, language: language);
                 GenericTypeParams = TypeUtils.GenericTypeParameters(Type);
             }
             else
@@ -358,7 +362,7 @@ namespace Orleans.CodeGeneration
                 Name = Type.Name;
             }
 
-            TypeName = client ? InterfaceTypeName : TypeUtils.GetParameterizedTemplateName(Type);
+            TypeName = client ? InterfaceTypeName : TypeUtils.GetParameterizedTemplateName(Type, language:language);
             FactoryClassBaseName = GetFactoryNameBase(typeNameBase);
             InvokerClassBaseName = typeNameBase + "MethodInvoker";
             StateClassBaseName = typeNameBase + "State";

--- a/src/Orleans/CodeGeneration/Language.cs
+++ b/src/Orleans/CodeGeneration/Language.cs
@@ -1,0 +1,9 @@
+namespace Orleans.CodeGeneration
+{
+    public enum Language
+    {
+        CSharp,
+        FSharp,
+        VisualBasic,
+    }
+}

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AzureUtils\SiloMetricsTableDataManager.cs" />
     <Compile Include="CodeGeneration\GrainState.cs" />
     <Compile Include="CodeGeneration\IGrainMethodInvoker.cs" />
+    <Compile Include="CodeGeneration\Language.cs" />
     <Compile Include="Configuration\LimitNames.cs" />
     <Compile Include="Configuration\LimitValue.cs" />
     <Compile Include="Core\Exceptions.cs" />


### PR DESCRIPTION
To fix VB code generation bugs (issue #43), a Language parameter was added to many of the TypeUtils methods and
CodeGeneration language files.

Reproduced and resolved cases mentioned in bug.