### PR TITLE
ClientGenerator support for F# 4.0 / Visual Studio 2015

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -703,6 +703,10 @@ namespace Orleans.CodeGeneration
                             options.FSharpCompilerPath = path;
                             if (!string.IsNullOrEmpty(path))
                                 Console.WriteLine("F# compiler path = '{0}' ", options.FSharpCompilerPath);
+                            else
+                            {
+                                Console.Error.WriteLine("F# compiler path not set!");
+                            }
                         }
                         else if (arg.StartsWith("/rootns:") || arg.StartsWith("/rns:"))
                         {

--- a/src/Orleans.SDK.targets
+++ b/src/Orleans.SDK.targets
@@ -52,6 +52,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <FSharpCompilerPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\fsc.exe</FSharpCompilerPath>
       </PropertyGroup>
     </When>
+    <When Condition="'$(VisualStudioVersion)' == '14.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Fsc.exe')">
+        <FSharpCompilerPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Fsc.exe</FSharpCompilerPath>
+      </PropertyGroup>
+    </When>
     <Otherwise>
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Fsc.exe')">
         <FSharpCompilerPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\fsc.exe</FSharpCompilerPath>


### PR DESCRIPTION
* [Orleans.SDK.targets] add a case in FSharpCompilerPath resolution
* [ClientGenerator.cs] output error message when fsharp compiler path is not set when /fsharp: argument is passed but don't have any value