### PR TITLE
Update Visual Studio Extension manifest:

### DIFF
--- a/src/OrleansVSTools/OrleansVSTools/source.extension.vsixmanifest
+++ b/src/OrleansVSTools/OrleansVSTools/source.extension.vsixmanifest
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="462db41f-31a4-48f0-834c-1bdcc0578511" Version="1.0.0" Language="en-US" Publisher="Microsoft" />
     <DisplayName>OrleansVSTools11</DisplayName>
-    <Description>Orleans Tools for Visual Studio 2012</Description>
+    <Description>Orleans Tools for Visual Studio 2012, 2013, 2015</Description>
     <MoreInfo>http://toolbox/orleans</MoreInfo>
     <License>License.txt</License>
     <Icon>Orleans.ico</Icon>
@@ -11,12 +11,12 @@
     <Tags>MS Internal Only,Orleans,Cloud Computing,Actor Model,Actors,Distributed Systems</Tags>
   </Metadata>
   <Installation AllUsers="false">
-    <InstallationTarget Version="[11.0,13.0)" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,13.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,13.0)" Id="Microsoft.VisualStudio.Ultimate" />
+    <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Premium" />
+    <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Ultimate" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="11.0" />
   </Dependencies>
   <Assets>


### PR DESCRIPTION
* support Visual Studio 2015
* support .NET 4.6 (otherwise it won't install on Windows 10 by default)
* fix the extension title (not only for Visual Studio 2012)