### PR TITLE
Delete repositories.config

### DIFF
--- a/src/OrleansVSTools/packages/repositories.config
+++ b/src/OrleansVSTools/packages/repositories.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<repositories>
-  <repository path="..\VSProjectTemplateGrainImplementation\packages.config" />
-  <repository path="..\VSProjectTemplateGrainInterface\packages.config" />
-</repositories>


### PR DESCRIPTION
The packages directory, including repositories.config file should not be checked into source code control.