### PR TITLE
Removed dependency on Microsoft.Orleans.Runtime

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
@@ -19,7 +19,6 @@
     <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
     <dependencies>
       <dependency id="Microsoft.Orleans.Core" version="1.0.3" />
-      <dependency id="Microsoft.Orleans.OrleansRuntime" version="1.0.3" />
       
       <dependency id="WindowsAzure.Storage" version="4.2.0.0" />
       <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" />


### PR DESCRIPTION
Removed dependency on Microsoft.Orleans.Runtime, as OrleansProviders.dll does not depend on OrleansRuntime.dll anymore.