### PR TITLE
SetExpectedClusterSize in AzureHost to the number of instances in the current role.

### DIFF
--- a/src/OrleansAzureUtils/AzureSilo.cs
+++ b/src/OrleansAzureUtils/AzureSilo.cs
@@ -185,6 +185,7 @@ namespace Orleans.Runtime.Host
             // Always use Azure table for membership when running silo in Azure
             host.SetSiloLivenessType(GlobalConfiguration.LivenessProviderType.AzureTable);
             host.SetReminderServiceType(GlobalConfiguration.ReminderServiceProviderType.AzureTable);
+            host.SetExpectedClusterSize(RoleEnvironment.CurrentRoleInstance.Role.Instances.Count);
             siloInstanceManager.RegisterSiloInstance(myEntry);
 
             // Initialise this Orleans silo instance

--- a/src/OrleansRuntime/Silo/SiloHost.cs
+++ b/src/OrleansRuntime/Silo/SiloHost.cs
@@ -360,6 +360,16 @@ namespace Orleans.Runtime.Host
         }
 
         /// <summary>
+        /// Set expected deployment size.
+        /// </summary>
+        /// <param name="size">The expected deployment size.</param>
+        public void SetExpectedClusterSize(int size)
+        {
+            logger.Info(ErrorCode.SetSiloLivenessType, "Setting Expected Cluster Size to={0}", size);
+            Config.Globals.ExpectedClusterSize = size;
+        }
+
+        /// <summary>
         /// Report an error during silo startup.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
@javier-alvarez reported that this improved the silo startup time significantly in his deployment.
This setting controls the exponential backoff algorithm in the membership oracle, significantly reduces contention on the Azure Silo Instance table and improves start up time for large deployments.
