### PR TITLE
Make GrainReference.InterfaceName property public instead of protected, so other application code can extract InterfaceName from it.

### DIFF
--- a/src/ClientGenerator/NamespaceGenerator.cs
+++ b/src/ClientGenerator/NamespaceGenerator.cs
@@ -213,7 +213,7 @@ namespace Orleans.CodeGeneration
             {
                 Name = "InterfaceName",
                 Type = new CodeTypeReference(typeof (string)),
-                Attributes = MemberAttributes.Family | MemberAttributes.Override,
+                Attributes = MemberAttributes.Public | MemberAttributes.Override,
                 HasSet = false,
                 HasGet = true
             };

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -277,7 +277,7 @@ namespace Orleans.Runtime
         /// Return the name of the interface for this GrainReference. 
         /// Implemented in Orleans generated code.
         /// </summary>
-        protected virtual string InterfaceName
+        public virtual string InterfaceName
         {
             get
             {


### PR DESCRIPTION
Make GrainReference.InterfaceName property public instead of protected, so other application code can extract InterfaceName from it.
Asked by @jesuspsalas.