### PR TITLE
Downgrade dependency on Microsoft.WindowsAzure.ServiceRuntime to 2.4

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -24,7 +24,7 @@
       <dependency id="WindowsAzure.Storage" version="4.2.0.0" />
       <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" />
             
-      <dependency id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" />
+      <dependency id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.4.0.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -75,7 +75,7 @@
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime">
-      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
+      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.4.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
       <HintPath>..\packages\WindowsAzure.Storage.4.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>

--- a/src/OrleansAzureUtils/packages.config
+++ b/src/OrleansAzureUtils/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
-  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
+  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.4.0.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.2.0" targetFramework="net45" />
 </packages>

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -78,7 +78,7 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime">
       <Private>True</Private>
-      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
+      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.4.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
       <HintPath>..\packages\WindowsAzure.Storage.4.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>

--- a/src/OrleansRuntime/packages.config
+++ b/src/OrleansRuntime/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
-  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
+  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.4.0.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.2.0" targetFramework="net45" />
 </packages>

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -68,7 +68,7 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime">
       <Private>True</Private>
-      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
+      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.4.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
       <HintPath>..\packages\WindowsAzure.Storage.4.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>

--- a/src/Tester/packages.config
+++ b/src/Tester/packages.config
@@ -6,6 +6,6 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
-  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
+  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.4.0.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.2.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Downgrade dependency on Microsoft.WindowsAzure.ServiceRuntime from 2.5 to 2.4 to be consistent with the "-1" rule for Azure SDK dependencies. We recently ran into issues upgrading Orleans-based solutions because of this version inconsistency.