### PR TITLE
Ports HelloWorld sample to use Nuget packages

### DIFF
--- a/Samples/AzureWebSample/OrleansAzureSilos/OrleansAzureSilos.csproj
+++ b/Samples/AzureWebSample/OrleansAzureSilos/OrleansAzureSilos.csproj
@@ -139,7 +139,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\HelloWorld\HelloWorldGrains\HelloWorldGrains.csproj">
       <Project>{98d4db83-175e-44d5-a14b-9c66ee89f037}</Project>
-      <Name>HelloWordGrains</Name>
+      <Name>HelloWorldGrains</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\HelloWorld\HelloWorldInterfaces\HelloWorldInterfaces.csproj">
       <Project>{163cce80-c506-468c-9b28-e2ff198097e3}</Project>

--- a/Samples/HelloWorldNuget/HelloWorldNuget.sln
+++ b/Samples/HelloWorldNuget/HelloWorldNuget.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorldNuget", "HelloWorldNuget\HelloWorldNuget.csproj", "{E4EE0184-1DC6-4528-9463-987B3BE57752}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorldNugetInterfaces", "HelloWorldNugetInterfaces\HelloWorldNugetInterfaces.csproj", "{3BD01348-ACC3-4378-A49E-4D62FB0BD3D0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorldNugetGrains", "HelloWorldNugetGrains\HelloWorldNugetGrains.csproj", "{943794E3-F54E-4678-B225-B45018344AEC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E4EE0184-1DC6-4528-9463-987B3BE57752}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4EE0184-1DC6-4528-9463-987B3BE57752}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4EE0184-1DC6-4528-9463-987B3BE57752}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4EE0184-1DC6-4528-9463-987B3BE57752}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BD01348-ACC3-4378-A49E-4D62FB0BD3D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BD01348-ACC3-4378-A49E-4D62FB0BD3D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BD01348-ACC3-4378-A49E-4D62FB0BD3D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BD01348-ACC3-4378-A49E-4D62FB0BD3D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{943794E3-F54E-4678-B225-B45018344AEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{943794E3-F54E-4678-B225-B45018344AEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{943794E3-F54E-4678-B225-B45018344AEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{943794E3-F54E-4678-B225-B45018344AEC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Samples/HelloWorldNuget/HelloWorldNuget/App.config
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <gcServer enabled="true"/>
+  </runtime>
+</configuration>

--- a/Samples/HelloWorldNuget/HelloWorldNuget/DevTestClientConfiguration.xml
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/DevTestClientConfiguration.xml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- 
+	This is a sample client configuration file. 
+	For a detailed reference, see "Orleans Configuration Reference.html".
+-->
+<ClientConfiguration xmlns="urn:orleans">
+  <GatewayProvider ProviderType="Config"/>
+  <Gateway Address="localhost" Port="30000"/>
+  <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true"/>
+  <Tracing DefaultTraceLevel="Warning" TraceToConsole="true" TraceToFile="{0}-{1}.log">
+    <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
+  </Tracing>
+</ClientConfiguration>

--- a/Samples/HelloWorldNuget/HelloWorldNuget/DevTestServerConfiguration.xml
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/DevTestServerConfiguration.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <StorageProviders>
+      <Provider Type="Orleans.Storage.MemoryStorage" Name="MemoryStore" />
+      <!-- To use Azure storage, uncomment one of the following lines: -->
+      <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" DataConnectionString="UseDevelopmentStorage=true" />-->
+      <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" DataConnectionString="DefaultEndpointsProtocol=https;AccountName=MYACCOUNTNAME;AccountKey=MYACCOUNTKEY" />-->
+    </StorageProviders>
+    <SeedNode Address="localhost" Port="11111" />
+  </Globals>
+  <Defaults>
+    <Networking Address="localhost" Port="11111" />
+    <ProxyingGateway Address="localhost" Port="30000" />
+    <Tracing DefaultTraceLevel="Warning" TraceToConsole="true" TraceToFile="{0}-{1}.log">
+      <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
+    </Tracing>
+    <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true"/>
+  </Defaults>
+  <Override Node="Primary">
+    <Networking Address="localhost" Port="11111" />
+    <ProxyingGateway Address="localhost" Port="30000" />
+  </Override>
+</OrleansConfiguration>

--- a/Samples/HelloWorldNuget/HelloWorldNuget/HelloWorldNuget.csproj
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/HelloWorldNuget.csproj
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{E4EE0184-1DC6-4528-9463-987B3BE57752}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HelloWorldNuget</RootNamespace>
+    <AssemblyName>HelloWorldNuget</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>$(OrleansSDK)\LocalSilo\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>$(OrleansSDK)\LocalSilo\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="CounterControl, Version=1.0.0.0, Culture=neutral, PublicKeyToken=070f47935e3ed133, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Orleans.CounterControl.1.0.3\lib\net45\CounterControl.exe</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Orleans, Version=1.0.0.0, Culture=neutral, PublicKeyToken=070f47935e3ed133, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.0.3\lib\net45\Orleans.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansAzureUtils, Version=1.0.0.0, Culture=neutral, PublicKeyToken=070f47935e3ed133, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Orleans.OrleansAzureUtils.1.0.3\lib\net45\OrleansAzureUtils.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansHost, Version=1.0.0.0, Culture=neutral, PublicKeyToken=070f47935e3ed133, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Orleans.OrleansHost.1.0.3\lib\net45\OrleansHost.exe</HintPath>
+    </Reference>
+    <Reference Include="OrleansProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=070f47935e3ed133, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Orleans.OrleansProviders.1.0.3\lib\net45\OrleansProviders.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansRuntime">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansRuntime.1.0.3\lib\net45\OrleansRuntime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="OrleansHostWrapper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="OrleansConfiguration.xsd">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="DevTestClientConfiguration.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="DevTestServerConfiguration.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="OrleansConfiguration.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HelloWorldNugetInterfaces\HelloWorldNugetInterfaces.csproj">
+      <Project>{3bd01348-acc3-4378-a49e-4d62fb0bd3d0}</Project>
+      <Name>HelloWorldNugetInterfaces</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Samples/HelloWorldNuget/HelloWorldNuget/OrleansConfiguration.xml
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/OrleansConfiguration.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <StorageProviders>
+      <Provider Type="Orleans.Storage.MemoryStorage" Name="MemoryStore" />
+      <!-- To use Azure storage, uncomment one of the following lines: -->
+      <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" DataConnectionString="UseDevelopmentStorage=true" />-->
+      <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" DataConnectionString="DefaultEndpointsProtocol=https;AccountName=MYACCOUNTNAME;AccountKey=MYACCOUNTKEY" />-->
+    </StorageProviders>
+    <SeedNode Address="localhost" Port="11111" />
+  </Globals>
+  <Defaults>
+    <Networking Address="localhost" Port="11111" />
+    <ProxyingGateway Address="localhost" Port="30000" />
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
+        <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
+    </Tracing>
+    <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
+  </Defaults>
+</OrleansConfiguration>

--- a/Samples/HelloWorldNuget/HelloWorldNuget/OrleansConfiguration.xsd
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/OrleansConfiguration.xsd
@@ -1,0 +1,1055 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           targetNamespace="urn:orleans" xmlns:tns="urn:orleans">
+  <xs:simpleType name="TraceLevel">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Off" />
+      <xs:enumeration value="Error" />
+      <xs:enumeration value="Warning" />
+      <xs:enumeration value="Info" />
+      <xs:enumeration value="Verbose" />
+      <xs:enumeration value="Verbose2" />
+      <xs:enumeration value="Verbose3" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AddressFamily">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="InterNetwork" />
+      <xs:enumeration value="InterNetworkV6" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SystemStorageType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="SqlServer" />
+      <xs:enumeration value="AzureTable" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LivenessType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SiloDirectoryGrain" />
+      <xs:enumeration value="MembershipTableGrain" />
+      <xs:enumeration value="File" />
+      <xs:enumeration value="SqlServer" />
+      <xs:enumeration value="AzureTable" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReminderServiceType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="ReminderTableGrain" />
+      <xs:enumeration value="SqlServer" />
+      <xs:enumeration value="AzureTable" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="StatisticsCollectionLevelType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Critical" />
+      <xs:enumeration value="Info" />
+      <xs:enumeration value="Verbose" />
+      <xs:enumeration value="Verbose2" />
+      <xs:enumeration value="Verbose3" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="GatewayProviderType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="AzureTable" />
+      <xs:enumeration value="SQL" />
+      <xs:enumeration value="Config" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DirectoryCachingStrategyType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="LRU" />
+      <xs:enumeration value="Adaptive" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DeactivationLimits">
+    <xs:attribute name="AgeLimit" type="tns:TimeSpan" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          The AgeLimit attribute specifies the maximum amount of time that an activation should remain idle before being deactivated by the runtime.
+          This can either be specified to apply globally to all types using the Defaults element, or on a per-type baseis using the GrainType element.
+          If this attribute does not appear, or if the value is zero or negative, then collection will not be initiated based on activation age.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="SpecificTypeControlInfo">
+    <xs:all>
+      <xs:element name="Deactivation" minOccurs="1" maxOccurs="1" type="tns:DeactivationLimits">
+        <xs:annotation>
+          <xs:documentation>
+            The Deactivation element permits the operator to specify how long an activation should be idle before the system deactivates it to reclaim unsued resources.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:all>
+    <xs:attribute name="Type" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Use the Type attribute to specify the grain class' typename (i.e. typeof(TGrainClass).FullName).
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:simpleType name="TimeSpan">
+    <xs:restriction base="xs:string">
+      <!-- Multiple patterns are logically ORed -->
+      <xs:pattern value="\d+"/>
+      <!-- If no unit is specified, the default is seconds -->
+      <xs:pattern value="\d+ms"/>
+      <xs:pattern value="\d+s"/>
+      <xs:pattern value="\d+m"/>
+      <xs:pattern value="\d+hr"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="IPEndPoint">
+    <xs:annotation>
+      <xs:documentation>
+        The IPEndPoint type is used to define an IP endpoint, which consists of an IP address and an associated port number.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="Address" type="xs:NMTOKEN" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The Address attribute holds either the endpoint's hostname or its IP address in dotted-quad (IPv4) or colon-hex (IPv6) notation.
+          In addition, either of the special strings "loopback" or "localhost" may be used to specify the IP loopback address, 127.0.0.1.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Port" type="xs:unsignedInt" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The Port attribute holds the TCP port for the endpoint.
+          This must be an addressable port; that is, it cannot be 0.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Subnet" type="xs:unsignedShort" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The Subnet attribute affects the selection of IP address that the node's message center will bind to.
+          If no explicit address is specified, either as an IP address or as a hostname, then the system will
+          iterate through all of the IPv4 addresses associated with the system and pick the one whose top-order byte
+          (first quad in dotted-quad notation) matches the Subnet specified in this attribute.
+          For instance, if the node is available at 10.54.13.174 and at 157.13.88.27, and Subnet="10", then the 10.54.13.174 address
+          will be used.
+          If no Subnet attribute is provided, then the one with the lowest address, comparing byte-by-byte in reverse order, is selected.
+          Thus, in our example, if no Subnet is specified, then the 157.13.88.27 address will be selected because 27 is less than 174.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="PreferredFamily" type="tns:AddressFamily" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The PreferredFamily attribute specifies whether IPv4 or IPv6 addressing should be preferred
+          if a hostname is provided for the Address attribute.
+          The default is to prefer IPv4.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="GatewayAddress">
+    <xs:annotation>
+      <xs:documentation>
+        The GatewayAddress type is used to define a gateway IP address for non-grain clients to use.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tns:IPEndPoint">
+        <xs:attribute name="Proxied" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              The Proxied attribute indicates whether the gateway silo is a proxying gateway;
+              that is, the client opens a single, bi-directional connection to the gateway, 
+              and the gateway proxies all of the client requests.
+              If the Proxied attribute is false or does not appear, then the gateway silo is
+              a non-proxying gateway. In this case, the client uses the gateway as a point of entry,
+              but will open direct connections for grains it has interacted with and will listen for
+              direct response connections from the various silos.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="MessagingConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        Specifies global messaging configuration.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="ResponseTimeout" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The ResponseTimeout attribute specifies the default timeout, in seconds, before a request is assumed to have failed.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="MaxResendCount" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The MaxResendCount attribute specifies the maximal number of resends of the same message.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="SiloSenderQueues" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The SiloSenderQueues attribute specifies the number of parallel queues and attendant threads used by the silo to send outbound
+          messages (requests, responses, and notifications) to other silos.
+          If this attribute is not specified, then System.Environment.ProcessorCount is used.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="GatewaySenderQueues" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The GatewaySenderQueues attribute specifies the number of parallel queues and attendant threads used by the silo Gateway to send outbound
+          messages (requests, responses, and notifications) to clients that are connected to it.
+          If this attribute is not specified, then System.Environment.ProcessorCount is used.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ClientSenderBuckets" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The ClientSenderBuckets attribute specifies the total number of grain buckets used by the client in client-to-gateway communication
+          protocol. In this protocol, grains are mapped to buckets and buckets are mapped to gateway connections, in order to enable stickiness
+          of grain to gateway (messages to the same grain go to the same gateway, while evenly spreading grains across gateways).
+          This number should be about 10 to 100 times larger than the expected number of gateway connections.
+          If this attribute is not specified, then Math.Pow(2, 13) is used.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="UseStandardSerializer" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The UseStandardSerializer attribute, if provided and set to "true", forces the use of the standard .NET serializer instead
+          of the custom Orleans serializer.
+          This parameter is intended for use only for testing and troubleshooting.
+          In production, the custom Orleans serializer should always be used because it performs significantly better.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="MaxForwardCount" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The MaxForwardCount attribute specifies the maximal number of times a message is being forwared from one silo to another.
+          Forwarding is used internally by the tuntime as a recovery mechanism when silos fail and the membership is unstable.
+          In such times the messages might not be routed correctly to destination, and runtime attempts to forward such messages a number of times before rejecting them.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="SystemStoreConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        The SystemStore type is used to define system-storage-related configuration settings.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="SystemStoreType" type="tns:SystemStorageType" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Specifies the kind of system store that should be used: AzureTable or SqlServer.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ServiceId" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+           Specifies a unique identifier of this service, with will survive deployment and redeployment.
+         </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="DeploymentId" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Specifies a unique identifier of this deployment.
+          If the silos are deployed on Azure (run as workers roles), deployment id is set automatically by Azure runtime,
+          accessible to the role via RoleEnvironment.DeploymentId static variable and is passed to the silo automatically by the role via config.
+          So if the silos are run as Azure roles this variable should not be specified in the OrleansConmfiguration.xml (it will be overwritten if specified).
+          If the silos are deployed on the cluster and not as Azure roles, this variable should be set by a deployment script in the OrleansConmfiguration.xml file.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="DataConnectionString" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Specifies the connection string for azure storage account or SQL database.
+          If the silos are deployed on Azure (run as workers roles), DataConnectionString may be specified via RoleEnvironment.GetConfigurationSettingValue("DataConnectionString");
+          In such a case it is taken from there and passed to the silo automatically by the role via config.
+          So if the silos are run as Azure roles and this config is specified via RoleEnvironment, 
+          this variable should not be specified in the OrleansConfiguration.xml (it will be overwritten if specified).
+          If the silos are deployed on the cluster and not as Azure roles,  this variable should be set in the OrleansConmfiguration.xml file.
+          If not set at all, DevelopmentStorageAccount will be used.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="LivenessConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        Specifies global liveness configuration.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="LivenessType" type="tns:LivenessType" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The LivenessType attribute controls the liveness method used for silo reliability.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="LivenessEnabled" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The LivenessEnabled attribute, if provided and set to "false", suppresses liveness enforcement.
+          If a silo is suspected to be dead, but this attribute is set to "false", the suspicions will not propagated to the system and enforced,
+          This parameter is intended for use only for testing and troubleshooting.
+          In production, liveness should always be enabled.
+          Default is true (eanabled)
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ProbeTimeout" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The number of seconds to periodically probe other silos for their liveness or for the silo to send "I am alive" heartbeat  messages about itself.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="TableRefreshTimeout" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The number of seconds to periodically fetch updates from the membership table.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="DeathVoteExpirationTimeout" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Expiration time in seconds for death vote in the membership table.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="NumMissedProbesLimit" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The number of missed "I am alive" heartbeat messages from a silo or number of un-replied probes that lead to suspecting this silo as dead.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="NumProbedSilos" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The number of silos each silo probes for liveness.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="NumVotesForDeathDeclaration" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The number of non-expired votes that are needed to declare some silo as dead (should be at most NumMissedProbesLimit)
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="UseLivenessGossip" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Whether to use the gossip optimization to speed up spreading liveness information.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="IAmAliveTablePublishTimeout" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+           The number of seconds to periodically write in the membership table that this silo is alive. Used ony for diagnostics.
+         </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="NumMissedTableIAmAliveLimit" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The number of missed "I am alive" updates  in the table from a silo that causes warning to be logged. Does not impact the liveness protocol.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="MaxJoinAttemptTime" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+           The number of seconds to attempt to join a cluster of silos before giving up.
+         </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ExpectedClusterSize" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+           The expected size of a cluster. Need not be very accurate, can be an overestimate.
+         </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="ReminderServiceConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        Specifies global reminder service configuration.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="ReminderServiceType" type="tns:ReminderServiceType" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The ReminderServiceType attribute controls the type of the reminder service implementation used by silos.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="TracingConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        The TracingConfiguration type contains various tracing-related configuration parameters.
+        For production use, the default value of these parameters should be fine.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="LogConsumer" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            The LogConsumer element provides a mechanism to allow additional custom log writers to receive log messages produced by Orleans applications.
+            The contents of the LogConsumer element should be a fully qualified class name that implements the Orleans.ILogConsumer interface,
+            plus the assembly that class should be loaded from.
+            Example: Example.MyLogConsumer,MyLibrary
+            In addition to the LogConsumers added here, setting TraceToConsole or TraceToFile will also add additonal LogConsumers to this list as required.
+            There is also an Orleans LogConsumer class that can be added to send log messages to any .NET Trace Listeners configured for this application:
+            &lt;LogConsumer&gt;Orleans.LogWriterToTrace&lt;/LogConsumer&gt;
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="TraceLevelOverride" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            The TraceLevelOverride element provides a mechanism to allow the tracing level to be set differently for different
+            parts of the Orleans system.
+            The tracing level for a logger is set based on a prefix match on the logger's name.
+            TraceLevelOverrides are applied in length order; that is, the override with the longest matching
+            LogPrefix takes precedence and specifies the tracing level for all matching loggers.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="LogPrefix" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                The LogPrefix attribute specifies a string prefix that is used to match against logger names.
+                Logger names begin with one of "Runtime", "Grain", or "Application", followed by a period, followed by
+                an application-dependent name (usually the name of the class writing the log entries).
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="TraceLevel" use="required" type="tns:TraceLevel">
+            <xs:annotation>
+              <xs:documentation>
+                The TraceLevel attribute specifies the tracing level to use for use with loggers that match the associated LogPrefix.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="DefaultTraceLevel" use="optional" type="tns:TraceLevel">
+      <xs:annotation>
+        <xs:documentation>
+          The DefaultTraceLevel attribute specifies the default tracing level for all Orleans loggers, unless overridden by
+          a specific TraceLevelOverride element.
+          The default level is Info if this attribute does not appear.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="TraceToConsole" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The TraceToConsole attribute specifies whether trace output should be written to the console.
+          The default is not to write trace data to the console.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="TraceToFile" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The TraceToFile attribute specifies the name of a file that trace output should be written to.
+          The silo Name may be embedded in the file name by including the sequence {0}.
+          The current timestamp in "round trip" format may be embedded by including the sequence {1}.
+          The machine host name may be embedded by including the sequence {2}.
+          If the value is an empty string, "", then trace output is not written to a file at all.
+          The default is to write to a file in the local directory named "{0}-{1}.log".
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="MetricWritePeriod" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The MetricWritePeriod attribute specifies how frequently metric data should be written to the console.
+          If this attribute does not appear, or if the value is zero or negative, then no metrics will be written.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="WriteMessagingTraces" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The WriteMessagingTraces attribute specifies whether or not message traces will be collected and reported.
+          Message traces are written when the message is completed (that is, when the response promise is resolved).
+          Traces are written at Verbose level.
+          The default is to not collect and write message traces, as trace collection is moderately expensive.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="LargeMessageWarningThreshold" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The LargeMessageWarningThreshold attribute specifies what size of messages will be considered "large".
+          The runtime will write an Info log with for any messages sent or received which exceed this threshold.
+          The default is 85000 bytes.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="PropagateActivityId" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The PropagateActivityId attribute specifies whether the value of Tracing.CorrelationManager.ActivityId should be propagated into grain calls, to support E2E tracing.
+          The default is not to propagate ActivityId.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="BulkMessageLimit" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The BulkMessageLimit attribute specifies how to bulk (aggregate) trace messages with identical erro code.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+  </xs:complexType>
+
+  <xs:complexType name="StatisticsConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        The StatisticsConfiguration type contains various statistics output related configuration parameters.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="MetricsTableWriteInterval" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The MetricsTableWriteInterval attribute specifies the frequency of updating the metrics in Azure table.
+          The default is 30 seconds.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="PerfCounterWriteInterval" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The PerfCounterWriteInterval attribute specifies the frequency of updating the windows performance counters.
+          The default is 30 seconds.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="LogWriteInterval" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The LogWriteInterval attribute specifies the frequency of updating the statistics in the log file.
+          The default is 5 minutes.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="WriteLogStatisticsToTable" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The WriteLogStatisticsToTable attribute specifies whether log statistics should also be written into a separate, special Azure table.
+          The default is yes.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="StatisticsCollectionLevel" type="tns:StatisticsCollectionLevelType" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The StatisticsCollectionLevel attribute specifies the verbosity level of statistics to collect.
+          The default is Info.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="LimitsConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        The LimitsConfiguration type contains various limits value configuration parameters.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Limit" type="tns:LimitValue" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="LimitValue">
+    <xs:annotation>
+      <xs:documentation>
+        The LimitValue type contains configuration parameters for a specific limit.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="Name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          The Name attribute idenfifies thias particular limit setting.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="SoftLimit" type="xs:int">
+      <xs:annotation>
+        <xs:documentation>
+          The SoftLimit attribute specifies the threshold value for this limit at which warnings will be generated.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="HardLimit" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The HardLimit attribute specifies threshold value for this limit at which warnings will be generated.
+          Default is zero, indicating hard limit thresholds are not applied for this limit.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="CachingConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        Specifies the global grain directory caching configuration.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="CacheSize" type="xs:positiveInteger" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The CacheSize attribute specifies the maximum number of grains to cache directory information for.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="InitialTTL" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The InitialTTL attribute specifies the initial (minimum) time, in seconds, to keep a cache entry before revalidating.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="MaximumTTL" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The MaximumTTL attribute specifies the maximum time, in seconds, to keep a cache entry before revalidating.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="TTLExtensionFactor" type="xs:double" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The TTLExtensionFactor attribute specifies the factor by which cache entry TTLs should be extended when they are found to be stable.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="DirectoryCachingStrategy" type="tns:DirectoryCachingStrategyType" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The DirectoryCachingStrategy attribute specifies the caching strategy to use.
+          The options are None, which means don't cache directory entries locally;
+          LRU, which indicates that a standard fixed-size least recently used strategy should be used; and
+          Adaptive, which indicates that an adaptive strategy with a fixed maximum size should be used.
+          The Adaptive strategy is used by default.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="GlobalConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        This type is used to specify global configuration information; that is, configuration which is not silo-specific.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="StorageProviders" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            The optional StorageProviders element contains information relating to storage provider instances used for grain persistence.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Provider" type="tns:ProviderInstanceConfig" minOccurs="0" maxOccurs="unbounded" />
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Application" minOccurs="0" maxOccurs="1">
+        <xs:complexType>
+          <xs:annotation>
+            <xs:documentation>
+              todo: document Application element
+            </xs:documentation>
+          </xs:annotation>
+          <xs:sequence>
+            <xs:element name="Defaults" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  The Defaults element permits the operator to specify default values for certain settings.
+                </xs:documentation>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Deactivation" minOccurs="1" maxOccurs="1" type="tns:DeactivationLimits">
+                    <xs:annotation>
+                      <xs:documentation>
+                        The Deactivation element permits the operator to specify how long an activation should be idle before the system deactivates it to reclaim unsued resources.
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="GrainType" minOccurs="1" maxOccurs="unbounded" type="tns:SpecificTypeControlInfo">
+              <xs:annotation>
+                <xs:documentation>
+                  The GrainType element permits the operator to specify type-specific settings for grains.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:element name="PlacementStrategy" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Specify placement strategy to be used for silo selection for activations.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="DefaultPlacementStrategy" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                Type of placement strategy which is chosen at startup. If not specfied, RandomPlacement is used.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="DeploymentLoadPublisherRefreshTime" type="tns:TimeSpan" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                Specifies the default time interval that a silo uses to publish its statistics updates to other silos for load aware placement.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="ActivationCountBasedPlacementChooseOutOf" type="xs:int" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                  Choose out of X elements (default is 2) -- for Load Aware PowerOfK Director.
+               </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="SeedNode" type="tns:IPEndPoint">
+        <xs:annotation>
+          <xs:documentation>
+            Each SeedNode element specifies a directory seed node.
+            The current Orleans directory implementation requires at least one seed node.
+            Note that the first seed node must be started before any other silo is started.
+            The first seed node is also used as the "primary" node; that is, the controller and domain grains are created there when it starts up.
+            Additional seed nodes may be specified if desired, and will add some (limited) failure resilience and scalability.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="SystemStore" type="tns:SystemStoreConfiguration">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the type and connection info to be used for the system store.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="Networking">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies global networking configuration.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="Subnet" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                The Subnet attribute affects the selection of IP address that the node's message center will bind to.
+                If no explicit address is specified, eiuther as an IP address or as a hostname, then the message center will
+                iterate through all of the IPv4 addresses associated with the system and pick the one whose top-order byte
+                (first quad in dotted-quad notation) matches the Subnet specified in this attribute.
+                For instance, if the node is available at 10.54.13.174 and at 157.13.88.27, and Subnet="10", then the 10.54.13.174 address
+                will be used.
+                If no Subnet attribute is provided, then the one with the lowest address, comparing byte-by-byte in reverse order, is selected.
+                Thus, in our example, if no Subnet is specified, then the 157.13.88.27 address will be selected because 27 is less than 174.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="Messaging" type="tns:MessagingConfiguration" />
+      <xs:element minOccurs="0" maxOccurs="1" name="Caching" type="tns:CachingConfiguration" />
+      <xs:element minOccurs="0" maxOccurs="1" name="Liveness" type="tns:LivenessConfiguration" />
+      <xs:element minOccurs="0" maxOccurs="1" name="ReminderService" type="tns:ReminderServiceConfiguration" />
+      <xs:element minOccurs="0" maxOccurs="1" name="Directory">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the configuration of the distributed grain directory.
+          </xs:documentation>
+        </xs:annotation>        
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NodeConfiguration">
+    <xs:annotation>
+      <xs:documentation>
+        The NodeConfiguration element is used to specify node-specific configuration data.
+        It is used in two contexts: to specify default data for all nodes, and to specify node-specific overrides.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Networking" minOccurs="0" type="tns:IPEndPoint">
+        <xs:annotation>
+          <xs:documentation>
+            The Networking element specifies the address that the node's message center will listen on.
+            Typically the Port is filled in for the default configuration, and the Address is filled in for nodes with multiple NICs.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ProxyingGateway" minOccurs="0" type="tns:IPEndPoint">
+        <xs:annotation>
+          <xs:documentation>
+            The Gateway element specifies that the node should run a proxying gateway at the specified IP endpoint.
+            Typically the Port is filled in for the default configuration, and the Address is filled in for nodes with multiple NICs.
+            Note that non-proxying gateways are always run on the standard networking endpoint.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Scheduler" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            The Scheduler element holds configuration related to the Orleans turn-scheduling mechanism.
+            In most cases, the default values for these parameters will lead to acceptable behavior.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="MaxActiveThreads" type="xs:unsignedShort" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                The MaxActiveThreads attribute specifies the maximum number of simultaneous active threads the scheduler will allow.
+                Generally this number should be roughly equal to the number of cores on the node.
+                Using a value of 0 will look at System.Environment.ProcessorCount to decide the number instead.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="DelayWarningThreshold" type="tns:TimeSpan" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                The DelayWarningThreshold attribute specifies the work item queuing delay threshold, at which a warning log message is written.
+                That is, if the delay between enqueuing the work item and executing the work item is greater than DelayWarningThreshold, a warning log is written.
+                The default value is 10 seconds.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="ActivationSchedulingQuantum" type="tns:TimeSpan" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                ActivationSchedulingQuantum is a soft time limit on the duration of activation macro-turn (a number of micro-turns).
+                If a activation was running its micro-turns longer than this, we will give up the thread.
+                If this is set to zero or a negative number, then the full work queue is drained (MaxWorkItemsPerTurn allowing).
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="TurnWarningLengthThreshold" type="tns:TimeSpan" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+              TurnWarningLengthThreshold is a soft time limit to generate trace warning when the micro-turn executes longer then this period in CPU.
+            </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="LoadShedding" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            The LoadShedding element specifies the gateway load shedding configuration for the node.
+            If it does not appear, gateway load shedding is disabled.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="Enabled" type="xs:boolean" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                The Enabled attribute controls whether gateway load shedding is enabled for the gateway node.
+                By default, load shedding is not enabled.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="LoadLimit" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                The LoadLimit attribute specifies the system load, in CPU%, at which load begins to be shed.
+                Note that this value is in %, so valid values range from 1 to 100, and a reasonable value is
+                typically between 80 and 95.
+                This value is ignored if load shedding is disabled, which is the default.
+                If load shedding is enabled and this attribute does not appear, then the default limit is 95%.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Tracing" minOccurs="0" type="tns:TracingConfiguration">
+        <xs:annotation>
+          <xs:documentation>
+            The Tracing element contains various tracing-related configuration parameters.
+            For production use, the default value of these parameters should be fine.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Statistics" minOccurs="0" type="tns:StatisticsConfiguration" />
+      <xs:element name="Limits" minOccurs="0" type="tns:LimitsConfiguration" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="OrleansConfiguration">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Globals" type="tns:GlobalConfiguration">
+          <xs:annotation>
+            <xs:documentation>
+              The Globals element contains global configuration information that is not silo-specific.
+              See the description of the GlobalConfiguration type, above, for details.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="Defaults" type="tns:NodeConfiguration">
+          <xs:annotation>
+            <xs:documentation>
+              The Defaults element contains the default node configuration for this deployment.
+              See the description of the NodeConfiguration type, above, for details.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element minOccurs="0" maxOccurs="unbounded" name="Override">
+          <xs:annotation>
+            <xs:documentation>
+              The Override element contains node-specific configuration overrides.
+              See the description of the DeploymentConfiguration type, above, for details.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="tns:NodeConfiguration">
+                <xs:attribute name="Node" type="xs:NMTOKEN" use="required">
+                  <xs:annotation>
+                    <xs:documentation>
+                      The Node attribute specifies the node (silo) that these overrides apply to.
+                      It must match the Name attribute (not HostNames) of one of the Silo elements in the Deployment element.
+                    </xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ClientConfiguration">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element minOccurs="1" maxOccurs="unbounded" name="Gateway" type="tns:GatewayAddress">
+            <xs:annotation>
+              <xs:documentation>
+                Each GatewayNode element specifies an outside grain client gateway node.
+                If outside (non-Orleans) clients are to connect to the Orleans system, then at least one gateway node must be specified.
+                Additional gateway nodes may be specified if desired, and will add some failure resilience and scalability.
+                If multiple gateways are specified, then each client will select one from the list at random.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element minOccurs="1" maxOccurs="1" name="SystemStore" type="tns:SystemStoreConfiguration">
+            <xs:annotation>
+              <xs:documentation>
+                Specifies the type and connection info to be used for the system store.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+        <xs:element name="Tracing" minOccurs="0" type="tns:TracingConfiguration" />
+        <xs:element name="Statistics" minOccurs="0" type="tns:StatisticsConfiguration" />
+        <xs:element name="Limits" minOccurs="0" type="tns:LimitsConfiguration" />
+        <xs:element name="Messaging" minOccurs="0" type="tns:MessagingConfiguration" />
+        
+        <xs:element name="LocalAddress" minOccurs="0">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                This element allows the preferred address family for the client to be specified.
+                If it does not appear, then the InterNetwork (IPv4) family is used.
+                The client always listens at the first recorded address for the local machine in the preferred family,
+                on a port assigned randomly by the local operating system.
+                Note that this element is ignored if present if a proxying gateway is used.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:attribute name="PreferredFamily" type="tns:AddressFamily" use="optional" />
+            <xs:attribute name="Interface" type="xs:string" use="optional">
+              <xs:annotation>
+                <xs:documentation>
+                  The Interface attribute specifies the name of the network interface to use to work out an IP address for this machine.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Port" type="xs:unsignedInt" use="optional">
+              <xs:annotation>
+                <xs:documentation>
+                  The Port attribute specifies the specific listen port for this client machine.
+                  If value is zero, then a random machine-assigned port number will be used.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="ProviderInstanceConfig">
+    <xs:annotation>
+      <xs:documentation>
+        Initialization info for one provider instance.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="Type" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          The Type attribute specifies the class to be used for this provider instance.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          The Name attribute specifies the name to be used for this provider instance.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:anyAttribute namespace="##local" processContents="lax">
+      <xs:annotation>
+        <xs:documentation>
+          Additional initialization values that will passed to this provider instance during intialization.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:anyAttribute>
+  </xs:complexType>
+</xs:schema>

--- a/Samples/HelloWorldNuget/HelloWorldNuget/OrleansHostWrapper.cs
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/OrleansHostWrapper.cs
@@ -1,0 +1,192 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************
+using System;
+using System.Net;
+
+using Orleans.Runtime.Host;
+
+namespace HelloWorldNuget
+{
+    internal class OrleansHostWrapper : IDisposable
+    {
+        public bool Debug
+        {
+            get { return siloHost != null && siloHost.Debug; }
+            set { siloHost.Debug = value; }
+        }
+
+        private SiloHost siloHost;
+
+        public OrleansHostWrapper(string[] args)
+        {
+            ParseArguments(args);
+            Init();
+        }
+
+        public bool Run()
+        {
+            bool ok = false;
+
+            try
+            {
+                siloHost.InitializeOrleansSilo();
+
+                ok = siloHost.StartOrleansSilo();
+
+                if (ok)
+                {
+                    Console.WriteLine(string.Format("Successfully started Orleans silo '{0}' as a {1} node.", siloHost.Name, siloHost.Type));
+                }
+                else
+                {
+                    throw new SystemException(string.Format("Failed to start Orleans silo '{0}' as a {1} node.", siloHost.Name, siloHost.Type));
+                }
+            }
+            catch (Exception exc)
+            {
+                siloHost.ReportStartupError(exc);
+                var msg = string.Format("{0}:\n{1}\n{2}", exc.GetType().FullName, exc.Message, exc.StackTrace);
+                Console.WriteLine(msg);
+            }
+
+            return ok;
+        }
+
+        public bool Stop()
+        {
+            bool ok = false;
+
+            try
+            {
+                siloHost.StopOrleansSilo();
+
+                Console.WriteLine(string.Format("Orleans silo '{0}' shutdown.", siloHost.Name));
+            }
+            catch (Exception exc)
+            {
+                siloHost.ReportStartupError(exc);
+                var msg = string.Format("{0}:\n{1}\n{2}", exc.GetType().FullName, exc.Message, exc.StackTrace);
+                Console.WriteLine(msg);
+            }
+
+            return ok;
+        }
+
+        private void Init()
+        {
+            siloHost.LoadOrleansConfig();
+        }
+
+        private bool ParseArguments(string[] args)
+        {
+            string deploymentId = null;
+
+            string configFileName = "DevTestServerConfiguration.xml";
+            string siloName = Dns.GetHostName(); // Default to machine name
+
+            int argPos = 1;
+            for (int i = 0; i < args.Length; i++)
+            {
+                string a = args[i];
+                if (a.StartsWith("-") || a.StartsWith("/"))
+                {
+                    switch (a.ToLowerInvariant())
+                    {
+                        case "/?":
+                        case "/help":
+                        case "-?":
+                        case "-help":
+                            // Query usage help
+                            return false;
+                        default:
+                            Console.WriteLine("Bad command line arguments supplied: " + a);
+                            return false;
+                    }
+                }
+                else if (a.Contains("="))
+                {
+                    string[] split = a.Split('=');
+                    if (String.IsNullOrEmpty(split[1]))
+                    {
+                        Console.WriteLine("Bad command line arguments supplied: " + a);
+                        return false;
+                    }
+                    switch (split[0].ToLowerInvariant())
+                    {
+                        case "deploymentid":
+                            deploymentId = split[1];
+                            break;
+                        case "deploymentgroup":
+                            // TODO: Remove this at some point in future
+                            Console.WriteLine("Ignoring deprecated command line argument: " + a);
+                            break;
+                        default:
+                            Console.WriteLine("Bad command line arguments supplied: " + a);
+                            return false;
+                    }
+                }
+                // unqualified arguments below
+                else if (argPos == 1)
+                {
+                    siloName = a;
+                    argPos++;
+                }
+                else if (argPos == 2)
+                {
+                    configFileName = a;
+                    argPos++;
+                }
+                else
+                {
+                    // Too many command line arguments
+                    Console.WriteLine("Too many command line arguments supplied: " + a);
+                    return false;
+                }
+            }
+
+            siloHost = new SiloHost(siloName);
+            siloHost.ConfigFileName = configFileName;
+            if (deploymentId != null)
+                siloHost.DeploymentId = deploymentId;
+
+            return true;
+        }
+
+        public void PrintUsage()
+        {
+            Console.WriteLine(
+@"USAGE: 
+    OrleansHost.exe [<siloName> [<configFile>]] [DeploymentId=<idString>] [/debug]
+Where:
+    <siloName>      - Name of this silo in the Config file list (optional)
+    <configFile>    - Path to the Config file to use (optional)
+    DeploymentId=<idString> 
+                    - Which deployment group this host instance should run in (optional)
+    /debug          - Turn on extra debug output during host startup (optional)");
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool dispose)
+        {
+            siloHost.Dispose();
+            siloHost = null;
+        }
+    }
+}

--- a/Samples/HelloWorldNuget/HelloWorldNuget/Program.cs
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/Program.cs
@@ -1,0 +1,70 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************
+using System;
+using Orleans;
+using HelloWorldNugetInterfaces;
+
+namespace HelloWorldNuget
+{
+    /// <summary>
+    /// Orleans test silo host
+    /// </summary>
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            // The Orleans silo environment is initialized in its own app domain in order to more
+            // closely emulate the distributed situation, when the client and the server cannot
+            // pass data via shared memory.
+            AppDomain hostDomain = AppDomain.CreateDomain("OrleansHost", null, new AppDomainSetup
+            {
+                AppDomainInitializer = InitSilo,
+                AppDomainInitializerArguments = args,
+            });
+
+            GrainClient.Initialize("DevTestClientConfiguration.xml");
+
+            var friend = GrainFactory.GetGrain<IHello>(0);
+            Console.WriteLine("\n\n{0}\n\n", friend.SayHello("Good morning, my nuget friend!").Result);
+
+            Console.WriteLine("Orleans Silo is running.\nPress Enter to terminate...");
+            Console.ReadLine();
+
+            hostDomain.DoCallBack(ShutdownSilo);
+        }
+
+        static void InitSilo(string[] args)
+        {
+            hostWrapper = new OrleansHostWrapper(args);
+
+            if (!hostWrapper.Run())
+            {
+                Console.Error.WriteLine("Failed to initialize Orleans silo");
+            }
+        }
+
+        static void ShutdownSilo()
+        {
+            if (hostWrapper != null)
+            {
+                hostWrapper.Dispose();
+                GC.SuppressFinalize(hostWrapper);
+            }
+        }
+
+        private static OrleansHostWrapper hostWrapper;
+    }
+}

--- a/Samples/HelloWorldNuget/HelloWorldNuget/Properties/AssemblyInfo.cs
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/Properties/AssemblyInfo.cs
@@ -1,0 +1,51 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HelloWorldNuget")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("HelloWorldNuget")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e4ee0184-1dc6-4528-9463-987b3be57752")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Samples/HelloWorldNuget/HelloWorldNuget/packages.config
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/packages.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Core" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.CounterControl" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansAzureUtils" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansHost" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansProviders" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansRuntime" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Server" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
+  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.2.0" targetFramework="net45" />
+</packages>

--- a/Samples/HelloWorldNuget/HelloWorldNugetGrains/ClientConfiguration.xml
+++ b/Samples/HelloWorldNuget/HelloWorldNugetGrains/ClientConfiguration.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- 
+	This is a sample client configuration file. 
+-->
+<ClientConfiguration xmlns="urn:orleans">
+  <GatewayProvider ProviderType="Config"/>
+  <Gateway Address="localhost" Port="30000"/>
+  <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
+</ClientConfiguration>

--- a/Samples/HelloWorldNuget/HelloWorldNugetGrains/HelloGrain.cs
+++ b/Samples/HelloWorldNuget/HelloWorldNugetGrains/HelloGrain.cs
@@ -1,0 +1,35 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text;
+using Orleans;
+
+namespace HelloWorldNugetGrains
+{
+    /// <summary>
+    /// Orleans grain implementation class HelloGrain.
+    /// </summary>
+    public class HelloGrain : Orleans.Grain, HelloWorldNugetInterfaces.IHello
+    {
+        Task<string> HelloWorldNugetInterfaces.IHello.SayHello(string greeting)
+        {
+            return Task.FromResult("You said: '" + greeting + "', I say: Hello!");
+        }
+    }
+}

--- a/Samples/HelloWorldNuget/HelloWorldNugetGrains/HelloWorldNugetGrains.csproj
+++ b/Samples/HelloWorldNuget/HelloWorldNugetGrains/HelloWorldNugetGrains.csproj
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Orleans.Templates.Grains.1.0.3\build\Microsoft.Orleans.Templates.Grains.props" Condition="Exists('..\packages\Microsoft.Orleans.Templates.Grains.1.0.3\build\Microsoft.Orleans.Templates.Grains.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{943794E3-F54E-4678-B225-B45018344AEC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HelloWorldNugetGrains</RootNamespace>
+    <AssemblyName>HelloWorldNugetGrains</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>07da0a61</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(OrleansSDK)\LocalSilo\OrleansHost.exe</StartProgram>
+    <StartWorkingDirectory>$(OrleansSDK)\LocalSilo</StartWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ClientGenerator">
+      <HintPath>..\packages\Microsoft.Orleans.ClientGenerator.1.0.3\lib\net45\ClientGenerator.exe</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Orleans">
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.0.3\lib\net45\Orleans.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansAzureUtils">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansAzureUtils.1.0.3\lib\net45\OrleansAzureUtils.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansProviders">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansProviders.1.0.3\lib\net45\OrleansProviders.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansRuntime">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansRuntime.1.0.3\lib\net45\OrleansRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="HelloGrain.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\orleans.codegen.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HelloWorldNugetInterfaces\HelloWorldNugetInterfaces.csproj">
+      <Project>{163cce80-c506-468c-9b28-e2ff198097e3}</Project>
+      <Name>HelloWorldInterfaces</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="ClientConfiguration.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+      if exist "$(OrleansSDK)\LocalSilo" (
+      if not exist "$(OrleansSDK)\LocalSilo\Applications" (md "$(OrleansSDK)\LocalSilo\Applications")
+      if not exist  "$(OrleansSDK)\LocalSilo\Applications\$(RootNamespace)" (md "$(OrleansSDK)\LocalSilo\Applications\$(RootNamespace)")
+      copy /y *.dll  "$(OrleansSDK)\LocalSilo\Applications\$(RootNamespace)\"
+      copy /y *.pdb  "$(OrleansSDK)\LocalSilo\Applications\$(RootNamespace)\"
+      )
+      if exist "$(OrleansSDK)\Binaries" (
+      if not exist "$(OrleansSDK)\Binaries\Applications" (md "$(OrleansSDK)\Binaries\Applications")
+      if not exist  "$(OrleansSDK)\Binaries\Applications\$(RootNamespace)" (md "$(OrleansSDK)\Binaries\Applications\$(RootNamespace)")
+      copy /y *.dll "$(OrleansSDK)\Binaries\Applications\$(RootNamespace)\"
+      copy /y *.pdb "$(OrleansSDK)\Binaries\Applications\$(RootNamespace)\"
+      )
+    </PostBuildEvent>
+  </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.Templates.Grains.1.0.3\build\Microsoft.Orleans.Templates.Grains.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.Templates.Grains.1.0.3\build\Microsoft.Orleans.Templates.Grains.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.Templates.Grains.1.0.3\build\Microsoft.Orleans.Templates.Grains.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.Templates.Grains.1.0.3\build\Microsoft.Orleans.Templates.Grains.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Orleans.Templates.Grains.1.0.3\build\Microsoft.Orleans.Templates.Grains.targets" Condition="Exists('..\packages\Microsoft.Orleans.Templates.Grains.1.0.3\build\Microsoft.Orleans.Templates.Grains.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>-->
+</Project>

--- a/Samples/HelloWorldNuget/HelloWorldNugetGrains/Properties/AssemblyInfo.cs
+++ b/Samples/HelloWorldNuget/HelloWorldNugetGrains/Properties/AssemblyInfo.cs
@@ -1,0 +1,51 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HelloWorldNugetGrains")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("HelloWorldNugetGrains")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("943794e3-f54e-4678-b225-b45018344aec")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Samples/HelloWorldNuget/HelloWorldNugetGrains/packages.config
+++ b/Samples/HelloWorldNuget/HelloWorldNugetGrains/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Client" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.ClientGenerator" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Core" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Development" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansAzureUtils" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansProviders" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansRuntime" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Templates.Grains" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
+  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.2.0" targetFramework="net45" />
+</packages>

--- a/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/ClientConfiguration.xml
+++ b/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/ClientConfiguration.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- 
+	This is a sample client configuration file. 
+-->
+<ClientConfiguration xmlns="urn:orleans">
+  <GatewayProvider ProviderType="Config"/>
+  <Gateway Address="localhost" Port="30000"/>
+  <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
+</ClientConfiguration>

--- a/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/HelloWorldNugetInterfaces.csproj
+++ b/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/HelloWorldNugetInterfaces.csproj
@@ -1,0 +1,122 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Orleans.Templates.Interfaces.1.0.3\build\Microsoft.Orleans.Templates.Interfaces.props" Condition="Exists('..\packages\Microsoft.Orleans.Templates.Interfaces.1.0.3\build\Microsoft.Orleans.Templates.Interfaces.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{3BD01348-ACC3-4378-A49E-4D62FB0BD3D0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HelloWorldNugetInterfaces</RootNamespace>
+    <AssemblyName>HelloWorldNugetInterfaces</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>b7a6117c</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ClientGenerator">
+      <HintPath>..\packages\Microsoft.Orleans.ClientGenerator.1.0.3\lib\net45\ClientGenerator.exe</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Orleans">
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.0.3\lib\net45\Orleans.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansAzureUtils">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansAzureUtils.1.0.3\lib\net45\OrleansAzureUtils.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansProviders">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansProviders.1.0.3\lib\net45\OrleansProviders.dll</HintPath>
+    </Reference>
+    <Reference Include="OrleansRuntime">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansRuntime.1.0.3\lib\net45\OrleansRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="IHello.cs" />
+    <Compile Include="Properties\orleans.codegen.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="ClientConfiguration.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.Templates.Interfaces.1.0.3\build\Microsoft.Orleans.Templates.Interfaces.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.Templates.Interfaces.1.0.3\build\Microsoft.Orleans.Templates.Interfaces.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.Templates.Interfaces.1.0.3\build\Microsoft.Orleans.Templates.Interfaces.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.Templates.Interfaces.1.0.3\build\Microsoft.Orleans.Templates.Interfaces.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Orleans.Templates.Interfaces.1.0.3\build\Microsoft.Orleans.Templates.Interfaces.targets" Condition="Exists('..\packages\Microsoft.Orleans.Templates.Interfaces.1.0.3\build\Microsoft.Orleans.Templates.Interfaces.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/IHello.cs
+++ b/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/IHello.cs
@@ -1,0 +1,32 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text;
+using Orleans;
+
+namespace HelloWorldNugetInterfaces
+{
+    /// <summary>
+    /// Orleans grain communication interface IHello
+    /// </summary>
+    public interface IHello : Orleans.IGrainWithIntegerKey
+    {
+        Task<string> SayHello(string greeting);
+    }
+}

--- a/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/Properties/AssemblyInfo.cs
+++ b/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/Properties/AssemblyInfo.cs
@@ -1,0 +1,51 @@
+﻿//*********************************************************//
+//    Copyright (c) Microsoft. All rights reserved.
+//    
+//    Apache 2.0 License
+//    
+//    You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//    
+//    Unless required by applicable law or agreed to in writing, software 
+//    distributed under the License is distributed on an "AS IS" BASIS, 
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+//    implied. See the License for the specific language governing 
+//    permissions and limitations under the License.
+//
+//*********************************************************
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HelloWorldNugetInterfaces")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("HelloWorldNugetInterfaces")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3bd01348-acc3-4378-a49e-4d62fb0bd3d0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/packages.config
+++ b/Samples/HelloWorldNuget/HelloWorldNugetInterfaces/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Client" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.ClientGenerator" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Core" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Development" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansAzureUtils" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansProviders" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.OrleansRuntime" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Orleans.Templates.Interfaces" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
+  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.2.0" targetFramework="net45" />
+</packages>

--- a/Samples/README.txt
+++ b/Samples/README.txt
@@ -1,4 +1,6 @@
-In order to run the samples you need first to install the Orleans installer msi, as described here:
+HelloWorldNuget uses Nuget packages available at https://www.nuget.org/packages?q=microsoft.orleans.
+
+In order to run the rest of the samples you need first to install the Orleans installer msi, as described here:
 https://github.com/dotnet/orleans/wiki/Installation
 
 If you previously used an older version of Orleans, notably the 0.9 version, we recommend first to completely uninstall it.


### PR DESCRIPTION
Adds HelloWorldNuget example to the repository

This PR adds HelloWorldNuget example to use the publicly available
1.0.3 Nuget packages. Other than the Nuget packages and the hello
message this is exactly the same example as the HelloWorld one based
on the MSI package.

* This makes verifying #174 easy as the sample is small. First the silo
  starts, after running "Update-Package" from the Package Manager
  Console the silo won't start anymore.

* This uses the current Nugets which have a dependency to Azure SDK 2.5.
  It may be necessary to update this example after the new packages are public.

* This conversion may help others with issues as described in #192, with
  reference to conversion instructions currently at
  https://github.com/dotnet/orleans/wiki/Convert-Orleans-v0.9-csproj-to-Use-v1.0-NuGet.

* Even if using the Nuget packages, the SDK is needed as per issue #213.
