### PR TITLE
Call Start() only for stream providers that implement IStreamProviderImpl

### DIFF
--- a/src/Orleans/Streams/Providers/StreamProviderManager.cs
+++ b/src/Orleans/Streams/Providers/StreamProviderManager.cs
@@ -50,8 +50,11 @@ namespace Orleans.Streams
             var providers = appStreamProviders.GetProviders();
             foreach (IStreamProvider streamProvider in providers)
             {
-                var provider = (IStreamProviderImpl) streamProvider;
-                await provider.Start();   
+                var provider = streamProvider as IStreamProviderImpl;
+                if (provider != null)
+                {
+                    await provider.Start();   
+                }
             }
         }
 


### PR DESCRIPTION
The IStreamProviderImpl is an internal interface - not accessible to stream provider implementers. 
Since only internal Orleans providers can (and do) implement IStreamProviderImpl, attempting to call Start() on stream providers implemented outside Orleans binaries crashes the silo at start-up.