### PR TITLE
Avoid extra forced project rebuilds during Incremental

### DIFF
--- a/src/Orleans/Logging/ConsoleText.cs
+++ b/src/Orleans/Logging/ConsoleText.cs
@@ -83,17 +83,22 @@ namespace Orleans.Runtime
                 Console.WriteLine("Ignoring error from Console.ForegroundColor : " + errorIgnored);
             }
 
-            Console.WriteLine(msg);
-
-            if (doResetColor)
+            try
             {
-                try
+                Console.WriteLine(msg);
+            }
+            finally
+            {
+                if (doResetColor)
                 {
-                    Console.ResetColor();
-                }
-                catch (Exception errorIgnored)
-                {
-                    Console.WriteLine("Ignoring error from Console.ResetColor : " + errorIgnored);
+                    try
+                    {
+                        Console.ResetColor();
+                    }
+                    catch (Exception errorIgnored)
+                    {
+                        Console.WriteLine("Ignoring error from Console.ResetColor : " + errorIgnored);
+                    }
                 }
             }
         }

--- a/src/Orleans/Logging/ConsoleText.cs
+++ b/src/Orleans/Logging/ConsoleText.cs
@@ -36,17 +36,18 @@ namespace Orleans.Runtime
 
         public static void WriteError(string msg, Exception exc)
         {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine(msg);
-            Console.WriteLine("Exception = " + exc);
-            Console.ResetColor();
+            String logMsg = 
+                msg 
+                + Environment.NewLine
+                + "Exception = " + exc 
+                + Environment.NewLine;
+
+            WriteLine(ConsoleColor.Red, logMsg);
         }
 
         public static void WriteStatus(string msg)
         {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine(msg);
-            Console.ResetColor();
+            WriteLine(ConsoleColor.Green, msg);
         }
 
         public static void WriteStatus(string format, params object[] args)
@@ -56,9 +57,7 @@ namespace Orleans.Runtime
 
         public static void WriteUsage(string msg)
         {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine(msg);
-            Console.ResetColor();
+            WriteLine(ConsoleColor.Yellow, msg);
         }
 
         public static void WriteLine(string msg)
@@ -69,6 +68,34 @@ namespace Orleans.Runtime
         public static void WriteLine(string format, params object[] args)
         {
             Console.WriteLine(format,args);
+        }
+
+        private static void WriteLine(ConsoleColor color, string msg)
+        {
+            bool doResetColor = false;
+            try
+            {
+                Console.ForegroundColor = color;
+                doResetColor = true;
+            }
+            catch (Exception errorIgnored)
+            {
+                Console.WriteLine("Ignoring error from Console.ForegroundColor : " + errorIgnored);
+            }
+
+            Console.WriteLine(msg);
+
+            if (doResetColor)
+            {
+                try
+                {
+                    Console.ResetColor();
+                }
+                catch (Exception errorIgnored)
+                {
+                    Console.WriteLine("Ignoring error from Console.ResetColor : " + errorIgnored);
+                }
+            }
         }
     }
 }

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -336,20 +336,20 @@
   <ItemGroup>
     <Content Include="..\Orleans.SDK.targets">
       <Link>Orleans.SDK.targets</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
     <Content Include="..\NuGet\Orleans.Grains.props">
       <Link>Orleans.Grains.props</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\NuGet\Orleans.Interfaces.props">
       <Link>Orleans.Interfaces.props</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Configuration\OrleansConfiguration.xsd">
       <SubType>Designer</SubType>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/src/OrleansHost/OrleansHost.csproj
+++ b/src/OrleansHost/OrleansHost.csproj
@@ -79,7 +79,7 @@
   <ItemGroup>
     <Content Include="OrleansLocal.xml" />
     <Content Include="StartOrleans.cmd">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/src/OrleansManager/OrleansManager.csproj
+++ b/src/OrleansManager/OrleansManager.csproj
@@ -67,7 +67,7 @@
       <Link>ClientConfiguration.xml</Link>
     </Content>
     <Content Include="README.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>
@@ -76,7 +76,7 @@
     </None>
     <None Include="app.config" />
     <None Include="runOrleansManager.cmd">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -113,7 +113,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="SQLServer\CreateTables.sql">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup />

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -98,14 +98,14 @@
   <ItemGroup>
     <Content Include="..\Build\Version.txt">
       <Link>Version.txt</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="ClientConfigurationForUnitTests.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
     <Content Include="OrleansConfigurationForUnitTests.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Avoid some unnecessary rebuilds being forced during F6 incremental build
due to CopyAlways=True on some static files.

This change gets things to the stead state of 4 projects force rebuild
and 8 up-to-date for normal F6 incremental builds in VS.

Remaining 4 forced rebuilts occur from this error symptom in build log:

1>Project 'OrleansRuntime' is not up to date. Error (0x8000FFFF).