### PR TITLE
Add Orleans.dll to ClientGenerator NuGet.

### DIFF
--- a/src/NuGet/Microsoft.Orleans.ClientGenerator.nuspec
+++ b/src/NuGet/Microsoft.Orleans.ClientGenerator.nuspec
@@ -25,5 +25,6 @@
   <files>
     <file src="ClientGenerator.exe" target="lib\net45" />
     <file src="ClientGenerator.exe.config" target="lib\net45" />
+    <file src="Orleans.dll" target="lib\net45" />
   </files>
 </package>


### PR DESCRIPTION
This is just to make ClientGenerator.exe runnable from its location. This is needed for projects that don't use the project templates but have NuGet packages checked in into their source tree.