### PR TITLE
Minor improvements to the Getting Started section.

### DIFF
--- a/Getting-Started-With-Orleans/Developing-a-Client.md
+++ b/Getting-Started-With-Orleans/Developing-a-Client.md
@@ -6,12 +6,12 @@ title: Developing a Client
 
 Once we have our grain type implemented, we can write a client application that uses the type. 
 
-The following Orleans DLL's from either the `[SDK-ROOT]\Binaries\PresenceClient` or `[SDK-ROOT]\Samples\References` directories need to be referenced in the client application project:
+The following Orleans DLLs from either the `[SDK-ROOT]\Binaries\PresenceClient` or `[SDK-ROOT]\Samples\References` directories need to be referenced in the client application project:
 
 * Orleans.dll 
 * OrleansRuntimeInterfaces.dll 
 
- Almost any client will involve use of the grain factory class. The GetGrain method is used for getting a grain reference for a particular ID. As was already mentioned, grains cannot be explicitly created or deleted.
+ Almost any client will involve use of the grain factory class. The `GetGrain()` method is used for getting a grain reference for a particular ID. As was already mentioned, grains cannot be explicitly created or deleted.
 
     OrleansClient.Initialize(); 
   
@@ -25,19 +25,19 @@ The following Orleans DLL's from either the `[SDK-ROOT]\Binaries\PresenceClient`
     await game.SubscribeForGameUpdates(); 
 
 
-If this code is used from the main thread of a console application, you have to call Wait() on the task returned by game.SubscribeForGameUpdates() because await does not prevent the Main function from returning, which will cause the client process to exit.
+If this code is used from the main thread of a console application, you have to call `Wait()` on the task returned by `game.SubscribeForGameUpdates()` because `await` does not prevent the `Main()` function from returning, which will cause the client process to exit.
 
-See the Key Concepts section for more details on the various ways to use Tasks for execution scheduling and exception flow.
+See the Key Concepts section for more details on the various ways to use `Task`s for execution scheduling and exception flow.
 
 ## Find or create grains
 
-After establishing a connection by calling OrleansClient.Initialize(), static methods in the generated factory classes may be used to get a reference to a grain, such as PlayerGrainFactory.GetGrain() for the PlayerGrain.
+After establishing a connection by calling `OrleansClient.Initialize()`, static methods in the generated factory classes may be used to get a reference to a grain, such as `PlayerGrainFactory.GetGrain()` for the `PlayerGrain`.
 
-Starting with the September 2014 preview update, there is also a static class 'GrainFactory' in the Orleans namespace, which can be used to create grain references without using the generated classes. The grain interface is passed as a type argument to GrainFactory.GetGrain&lt;T&gt;() when using this methodology.
+Starting with the September 2014 preview update, there is also a static class `GrainFactory` in the Orleans namespace, which can be used to create grain references without using the generated classes. The grain interface is passed as a type argument to `GrainFactory.GetGrain<T>()` when using this methodology.
 
 ## Sending messages to grains
 
-The programming model for communicating with grains from a client is almost the same as from a grain. The client holds grain references which implement a grain interface like IPlayerGrain. It invokes methods on that grain reference, and these return asynchronous values: Task/Task&lt;T&gt;, or another grain interface inheriting from IGrain. The client can use await keyword or ContinueWith() method to queue continuations to be executed when these asynchronous values resolve, or Wait() method to block the current thread. 
+The programming model for communicating with grains from a client is almost the same as from a grain. The client holds grain references which implement a grain interface like `IPlayerGrain`. It invokes methods on that grain reference, and these return asynchronous values: `Task`/`Task<T>`, or another grain interface inheriting from `IGrain`. The client can use the `await` keyword or `ContinueWith()` method to queue continuations to be executed when these asynchronous values resolve, or the `Wait()` method to block the current thread. 
 
 The one key difference between communicating with a grain from within a client or from within another grain is the single-threaded execution model. Grains are constrained to be single-threaded by the Orleans scheduler, while clients may be multi-threaded. The client library uses the TPL thread pool to manage continuations and callbacks, and so it is up to the client to manage its own concurrency using whatever synchronization constructs are appropriate for its environment – locks, events, TPL tasks, etc.
 
@@ -45,14 +45,14 @@ The one key difference between communicating with a grain from within a client o
 
 There are situations in which a simple message/response pattern is not enough, and the client needs to receive asynchronous notifications. For example, a user might want to be notified when a new message has been published by someone that she is following.
 
-An observer is a one-way asynchronous interface that inherits from IGrainObserver, and all its methods must be void. The grain sends a notification to the observer by invoking it like a grain interface method, except that it has no return value, and so the grain need not depend on the result. The Orleans runtime will ensure one-way delivery of the notifications. A grain that publishes such notifications should provide an API to add or remove observers.
+An observer is a one-way asynchronous interface that inherits from `IGrainObserver`, and all its methods must be `void`. The grain sends a notification to the observer by invoking it like a grain interface method, except that it has no return value, and so the grain need not depend on the result. The Orleans runtime will ensure one-way delivery of the notifications. A grain that publishes such notifications should provide an API to add or remove observers.
 
-To subscribe to a notification, the client must first create a local C# object that implements the observer interface. It then calls a static method on the observer factory, CreateObjectReference(), to turn the C# object into a grain reference, which can then be passed to the subscription method on the notifying grain.
+To subscribe to a notification, the client must first create a local C# object that implements the observer interface. It then calls a static method on the observer factory, `CreateObjectReference()`, to turn the C# object into a grain reference, which can then be passed to the subscription method on the notifying grain.
 
-This model can also be used by other grains to receive asynchronous notifications. Unlike in the client subscription case, the subscribing grain simply implements the observer interface as a facet, and passes in a reference to itself (e.g. ChirperViewerFactory.Cast(this).
+This model can also be used by other grains to receive asynchronous notifications. Unlike in the client subscription case, the subscribing grain simply implements the observer interface as a facet, and passes in a reference to itself (e.g. `ChirperViewerFactory.Cast(this)`).
 
 
-> Note: starting with the September 2014 refresh, there is also a generic method 'Cast&lt;T&gt;()' in the static class 'GrainFactory.'
+> Note: starting with the September 2014 refresh, there is also a generic method `Cast<T>()` in the static class `GrainFactory`.
 
 Example
 

--- a/Getting-Started-With-Orleans/Developing-a-Grain.md
+++ b/Getting-Started-With-Orleans/Developing-a-Grain.md
@@ -4,21 +4,21 @@ title: Developing a Grain
 ---
 {% include JB/setup %}
 
-In this section we walk through the steps involved in defining and using a new Player grain type as used in the Presence sample application in the Orleans SDK. The grain type we define will have one property that returns a reference to the game the player is currently in, and two methods for joining and leaving a game.
+In this section we walk through the steps involved in defining and using a new `Player` grain type as used in the `Presence` sample application in the Orleans SDK. The grain type we define will have one property that returns a reference to the game the player is currently in, and two methods for joining and leaving a game.
 
  We will create three separate pieces of code: the grain interface definition, the grain implementation, and a standard C# class that uses the grain. Each of these belongs in a different project, built into a different DLL: the interface needs to be available on both the “client” and “server” sides, while the implementation class should be hidden from the client, and the client class from the server.
 
  The interface project should be created using the Visual Studio “Orleans Grain Interface Project” template that is included in the Orleans SDK, and the grain implementation project should be created using the Visual Studio “Orleans Grain Implementation Class Project” template. The grain client project can use any standard .NET code project template, such as the standard Console Application or Class Library templates.
 
- A grain cannot be explicitly created or deleted. It always exists “virtually” and is activated automatically when a request is sent to it. A grain has either a GUID or a long integer key within the grain type. Application code creates a reference to a grain by calling the GetGrain(Guid id) or GetGrain(long id) static factory methods for a specific grain identity. GetGrain() call is a purely local operation to create a grain reference. It does not trigger creation of a grain activation and has not impact on its lifecycle. A grain activation is automatically created by the Orleans runtime upon a first request sent to the grain.
+ A grain cannot be explicitly created or deleted. It always exists “virtually” and is activated automatically when a request is sent to it. A grain has either a GUID or a long integer key within the grain type. Application code creates a reference to a grain by calling the `GetGrain(Guid id)` or `GetGrain(long id)` static factory methods for a specific grain identity. The `GetGrain()` call is a purely local operation to create a grain reference. It does not trigger creation of a grain activation and has not impact on its lifecycle. A grain activation is automatically created by the Orleans runtime upon a first request sent to the grain.
 
- A grain interface must inherit from IGrain. The GUID or long integer key of a grain can later be retrieved via the IGrain.GetPrimaryKey() or IGrain.GetPrimaryKeyLong() extension methods respectively.
+ A grain interface must inherit from `IGrain`. The GUID or long integer key of a grain can later be retrieved via the `IGrain.GetPrimaryKey()` or `IGrain.GetPrimaryKeyLong()` extension methods, respectively.
 
 ## Defining the Grain Interface
 
-A grain type is defined by an interface that inherits from the IGrain marker interface.
+A grain type is defined by an interface that inherits from the `IGrain` marker interface.
 
- All of the methods in the grain interface must return a Task or a Task&lt;T&gt; for .NET 4.5. The underlying type T for value Task must be serializable.
+ All of the methods in the grain interface must return a `Task` or a `Task<T>` for .NET 4.5. The underlying type `T` for value `Task` must be serializable.
 
  Example:
 
@@ -32,15 +32,15 @@ A grain type is defined by an interface that inherits from the IGrain marker int
 
 ## Generating the Class Factory
 
-After the grain interface has been defined, building the project originally created with the Orleans Visual Studio project template will use the Orleans-specific MSBuild targets to generate client proxy and factory classes corresponding to the user-defined grain interfaces, and to merge this additional code back into the interface DLL. The code generation tool, ClientGenerator.exe, can also be invoked directly as a part of post-build processing. However this should be used with caution and is generally not recommended.
+After the grain interface has been defined, building the project originally created with the Orleans Visual Studio project template will use the Orleans-specific MSBuild targets to generate client proxy and factory classes corresponding to the user-defined grain interfaces, and to merge this additional code back into the interface DLL. The code generation tool, `ClientGenerator.exe`, can also be invoked directly as a part of post-build processing. However this should be used with caution and is generally not recommended.
 
- The most important class in the generated proxy code is the grain factory class, which is named after the grain interface by stripping off the initial “I” and appending “Factory”. For instance, if your grain interface is IPlayerGrain, then your grain factory class will be called PlayerGrainFactory. The namespace for this factory class is the same as that of the grain interface.
+ The most important class in the generated proxy code is the grain factory class, which is named after the grain interface by stripping off the initial “I” and appending “Factory”. For instance, if your grain interface is `IPlayerGrain`, then your grain factory class will be called `PlayerGrainFactory`. The namespace for this factory class is the same as that of the grain interface.
 
 ## The Implementation Class
 
-A grain type is materialized by a class that implements the grain type’s interface and inherits directly or indirectly from Orleans.Grain. 
+A grain type is materialized by a class that implements the grain type’s interface and inherits directly or indirectly from `Orleans.Grain`. 
 
- The PlayerGrain grain class implements the IPlayerGrain interface. 
+ The `PlayerGrain` grain class implements the `IPlayerGrain` interface. 
 
     public class PlayerGrain : Grain, IPlayerGrain 
     { 
@@ -85,17 +85,17 @@ Goals:
 
 Grain types can be declared in one of two ways:
 
-* Extend Grain if they do not have any persistent state, or if they will handle all persistent state themselves, or 
-* Extend Grain&lt;T&gt; if they have some persistent state that they want the Orleans runtime to handle. 
-Stated another way, by extending Grain&lt;T&gt; a grain type is automatically opted-in to the Orleans system managed persistence framework.
+* Extend `Grain` if they do not have any persistent state, or if they will handle all persistent state themselves, or 
+* Extend `Grain<T>` if they have some persistent state that they want the Orleans runtime to handle. 
+Stated another way, by extending `Grain<T>` a grain type is automatically opted-in to the Orleans system managed persistence framework.
 
- For the remainder of this section, we will only be considering Option #2 / Grain&lt;T&gt; because Option #1 grains will continue to run as now without any behavior changes.
+ For the remainder of this section, we will only be considering Option #2 / `Grai<T>` because Option #1 grains will continue to run as now without any behavior changes.
 
 ## Grain State Stores
 
-Grain classes that inherit from Grain&lt;T&gt; (where T is an application-specific state data type derived from IGrainState) will have their state loaded automatically from a specified storage. 
+Grain classes that inherit from `Grain<T>` (where `T` is an application-specific state data type derived from `IGrainState`) will have their state loaded automatically from a specified storage. 
 
- Grains will be marked with a [Storage] attribute that specifies a named instance of a storage provider to use for reading / writing the state data for this grain. 
+ Grains will be marked with a `[StorageProvider]` attribute that specifies a named instance of a storage provider to use for reading / writing the state data for this grain. 
 
     [StorageProvider(ProviderName=”store1”)]
     public class MyGrain<IMyGrainState> ...
@@ -115,15 +115,15 @@ Grain classes that inherit from Grain&lt;T&gt; (where T is an application-specif
              DataConnectionString="DefaultEndpointsProtocol=https;AccountName=data2;AccountKey=SOMETHING2"  />
         </StorageProviders>
 
- Note: storage provider Type= "Orleans.Storage.AzureTableStorage" and "Orleans.Storage.DevStorage" are two standard storage providers built in to the Orleans runtime.
+ Note: storage provider types `Orleans.Storage.AzureTableStorage` and `Orleans.Storage.DevStorage` are two standard storage providers built in to the Orleans runtime.
 
- If there is no [Storage] attribute specified for a Grain&lt;T&gt; grain class, then a provider named “Default” will be searched for instead. If not found then this is treated as a missing storage provider.
+ If there is no `[StorageProvider]` attribute specified for a `Grain<T>` grain class, then a provider named `Default` will be searched for instead. If not found then this is treated as a missing storage provider.
 
- If there is only one provider in the silo config file, it will be considered to be the “Default” provider for this silo.
+ If there is only one provider in the silo config file, it will be considered to be the `Default` provider for this silo.
 
- A grain that uses a storage provider which is not present & defined in the silo configuration when the silo loads will fail to load, but the rest of the grains in that silo can still load and run. Any later calls to that grain type will fail with an Orleans.Storage.BadProviderConfigException error specifying that the grain type is not loaded.
+ A grain that uses a storage provider which is not present & defined in the silo configuration when the silo loads will fail to load, but the rest of the grains in that silo can still load and run. Any later calls to that grain type will fail with an `Orleans.Storage.BadProviderConfigException` error specifying that the grain type is not loaded.
 
- The storage provider instance to use for a given grain type is determined by the combination of the storage provider name defined in the [Storage] attribute on that grain type, plus the provider type & configuration options for that provider defined in the silo config.
+ The storage provider instance to use for a given grain type is determined by the combination of the storage provider name defined in the `[StorageProvider]` attribute on that grain type, plus the provider type & configuration options for that provider defined in the silo config.
 
  Different grain types can use different configured storage providers, even if both are the same type: for example, two different Azure table storage provider instances, connected to different Azure storage accounts (see config file example above).
 
@@ -135,7 +135,7 @@ There are two main parts to the grain state / persistence APIs: Grain-to-Runtime
 
 ## Grain State Storage API
 
-The grain state storage functionality in the Orleans Runtime will provide Read and Write operations to automatically populate / save the IGrainState data object for that grain. Under the covers, these functions will be connected (within the code generated by Orleans client-gen tool) through to the appropriate persistence provider configured for that grain.
+The grain state storage functionality in the Orleans Runtime will provide Read and Write operations to automatically populate / save the `IGrainState` data object for that grain. Under the covers, these functions will be connected (within the code generated by Orleans client-gen tool) through to the appropriate persistence provider configured for that grain.
 
     public interface IGrainState
     {
@@ -149,23 +149,23 @@ The grain state storage functionality in the Orleans Runtime will provide Read a
 
 Grain state will automatically be READ when the grain is activated, but grains are responsible for explicitly triggering the WRITE for any changed grain state as and when necessary. See the Failure Modes section below for details of error handling mechanisms.
 
- GrainState will be READ automatically (using the equivalent of IGrainState.ReadStateAsync) BEFORE the Activate method is called for that activation. GrainState will NOT be refreshed before any method calls to that grain, unless the grain was Activated for this call. 
+ `GrainState` will be READ automatically (using the equivalent of `IGrainState.ReadStateAsync()`) BEFORE the `OnActivateAsync()` method is called for that activation. `GrainState` will NOT be refreshed before any method calls to that grain, unless the grain was Activated for this call. 
 
- During any grain method call, a grain can request the Orleans runtime to WRITE the current grain state data for that activation to the designated storage provider by calling IGrainState.WriteStateAsync. The grain is responsible for explicitly performing WRITE operations when they make significant updates to their state data. Most commonly, the grain method will return the IGrainState.WriteStateAsync Task as the final result Task returned from that grain method, but it is not required to follow this pattern. The runtime will NOT automatically update stored grain state after ANY grain methods. 
+ During any grain method call, a grain can request the Orleans runtime to WRITE the current grain state data for that activation to the designated storage provider by calling `IGrainState.WriteStateAsync()`. The grain is responsible for explicitly performing WRITE operations when they make significant updates to their state data. Most commonly, the grain method will return the `IGrainState.WriteStateAsync()` `Task` as the final result `Task` returned from that grain method, but it is not required to follow this pattern. The runtime will NOT automatically update stored grain state after ANY grain methods. 
 
- During any grain method or timer callback handler in the grain, the grain can request the Orleans runtime to REREAD the current grain state data for that activation from the designated storage provider by calling IGrainState.ReadStateAsync. This will completely overwrite any current state data currently stored in the grain state object with the latest values read from persistent store. 
+ During any grain method or timer callback handler in the grain, the grain can request the Orleans runtime to REREAD the current grain state data for that activation from the designated storage provider by calling `IGrainState.ReadStateAsync()`. This will completely overwrite any current state data currently stored in the grain state object with the latest values read from persistent store. 
 
- An opaque provider-specific “Etag” value (String) MAY be set by a storage provider as part of the grain state metadata populated when state was read. Some providers MAY choose to leave this as Null if they do not use Etags. 
+ An opaque provider-specific `Etag` value (String) MAY be set by a storage provider as part of the grain state metadata populated when state was read. Some providers MAY choose to leave this as `null` if they do not use `Etag`s. 
 
  Conceptually, the Orleans Runtime will take a DEEP COPY of the grain state data object for its own use during any WRITE operations. Under the covers, the runtime MAY use optimization rules and heuristics to avoid performing some or all of the deep copy in some circumstances, provided that the expected logical isolation semantics are preserved. 
 
 ## Sample Code for Grain State Read / Write Operations
 
-Grains must extend the Grain&lt;T&gt; class in order to participate in the Orleans grain state persistence mechanisms. The ‘T’ in the above definition will be replaced by an application-specific grain state interface type for this grain; see the example below.
+Grains must extend the `Grain<T>` class in order to participate in the Orleans grain state persistence mechanisms. The `T` in the above definition will be replaced by an application-specific grain state interface type for this grain; see the example below.
 
  The grain class will also implement its specific grain interface, as with any other Orleans grain.
 
- The grain class should also be annotated with a [Storage] attribute that tells the runtime which storage provider (instance) to use with grains of this type.
+ The grain class should also be annotated with a `[StorageProvider]` attribute that tells the runtime which storage provider (instance) to use with grains of this type.
 
     public interface IMyGrainState : IGrainState
     {
@@ -173,7 +173,7 @@ Grains must extend the Grain&lt;T&gt; class in order to participate in the Orlea
        string Field2 { get; set; }
     }
 
-    [Storage(ProviderName="store1")]
+    [StorageProvider(ProviderName="store1")]
     public class MyPersistenceGrain : Grain<IMyGrainState>, IMyPersistenceGrain
     {
        ...
@@ -181,11 +181,11 @@ Grains must extend the Grain&lt;T&gt; class in order to participate in the Orlea
 
 ## Grain State Read
 
-The initial read of the grain state will occur automatically by the Orleans runtime before the grain’s ActivateAsync method is called; no application code is required to make this happen. From that point forward, the grain’s state will be available through the Grain<T>.State property inside the grain class.
+The initial read of the grain state will occur automatically by the Orleans runtime before the grain’s `OnActivateAsync()` method is called; no application code is required to make this happen. From that point forward, the grain’s state will be available through the `Grain<T>.State` property inside the grain class.
 
 ## Grain State Write
 
-After making any appropriate changes to the grain’s in-memory state, the grain should call the Grain<T>.State.WriteStateAsync() method to write the changes to the persistent store via the defined storage provider for this grain type. This method is asynchronous and returns a Task that will typically be returned by the grain method as its own completion Task.
+After making any appropriate changes to the grain’s in-memory state, the grain should call the `Grain<T>.State.WriteStateAsync()` method to write the changes to the persistent store via the defined storage provider for this grain type. This method is asynchronous and returns a Task that will typically be returned by the grain method as its own completion Task.
 
 
     public Task DoWrite(int val)
@@ -197,7 +197,7 @@ After making any appropriate changes to the grain’s in-memory state, the grain
 
 ## Grain State Refresh
 
-If a grain wishes to explicitly re-read the latest state for this grain from backing store, the grain should call the Grain<T>.State.ReadStateAsync() method. This will reload the grain state from persistent store, via the defined storage provider for this grain type, and any previous in-memory copy of the grain state will be overwritten and replaced when the ReadStateAsync Task completes.
+If a grain wishes to explicitly re-read the latest state for this grain from backing store, the grain should call the `Grain<T>.State.ReadStateAsync()` method. This will reload the grain state from persistent store, via the defined storage provider for this grain type, and any previous in-memory copy of the grain state will be overwritten and replaced when the `ReadStateAsync()` `Task` completes.
 
     public async Task<int> DoRead()
     {
@@ -210,21 +210,21 @@ If a grain wishes to explicitly re-read the latest state for this grain from bac
 
 ## Failure Modes for Grain State Read Operations
 
-Failures returned by the storage provider during the initial READ of state data for that particular grain will result in the Activate operation for that grain to be failed; in this case, there will NOT be any call to that grain’s ActivateAsync lifecycle callback method. The original request to that grain which caused the activation will be faulted back to the caller the same way as any other failure during grain activation. Failures encountered by the storage provider to READ state data for a particular grain will result in the ReadStateAsync Task to be broken / faulted. The grain can choose to handle or ignore that broken Task, just like any other Task in Orleans. 
+Failures returned by the storage provider during the initial READ of state data for that particular grain will result in the Activate operation for that grain to be failed; in this case, there will NOT be any call to that grain’s `OnActivateAsync()` lifecycle callback method. The original request to that grain which caused the activation will be faulted back to the caller the same way as any other failure during grain activation. Failures encountered by the storage provider to READ state data for a particular grain will result in the `ReadStateAsync()` `Task` to be broken / faulted. The grain can choose to handle or ignore that broken `Task`, just like any other `Task` in Orleans. 
 
- Any attempt to send a message to a grain which failed to load at silo startup time due to a missing / bad storage provider config will return the Permanent error Orleans.BadProviderConfigException. 
+ Any attempt to send a message to a grain which failed to load at silo startup time due to a missing / bad storage provider config will return the permanent error `Orleans.BadProviderConfigException`. 
 
 ## Failure Modes for Grain State Write Operations
 
-Failures encountered by the storage provider to WRITE state data for a particular grain will result in the WriteStateAsync Task to be faulted. Usually, this will mean the grain call will be faulted back to the client caller provided the WriteAsync Task is correctly chained in to the final return Task for this grain method. However, it will be possible for certain advanced scenarios to write grain code to specifically handle such Write errors, just like they can handle any other faulted Task. 
+Failures encountered by the storage provider to WRITE state data for a particular grain will result in the `WriteStateAsync()` `Task` to be faulted. Usually, this will mean the grain call will be faulted back to the client caller provided the `WriteStateAsync()` `Task` is correctly chained in to the final return Task for this grain method. However, it will be possible for certain advanced scenarios to write grain code to specifically handle such Write errors, just like they can handle any other faulted `Task`. 
 
- Grains that execute error-handling / recovery code MUST catch exceptions / faulted WriteStateAsync Tasks and not rethrow to signify that they have successfully handled the write error. 
+ Grains that execute error-handling / recovery code MUST catch exceptions / faulted `WriteStateAsync()` `Task`s and not rethrow to signify that they have successfully handled the write error. 
 
 ## Storage Provider Framework
 
-There is a service provider API for writing additional persistence providers – IStorageProvider.
+There is a service provider API for writing additional persistence providers – `IStorageProvider`.
 
- Persistence Provider API covers Read and Write operations for GrainState data.
+ The Persistence Provider API covers Read and Write operations for GrainState data.
 
     public interface IStorageProvider
     {
@@ -239,7 +239,7 @@ There is a service provider API for writing additional persistence providers –
 
 ## Storage Provider Semantics
 
-Any attempt to perform a WRITE operation when the storage provider detects an Etag constraint violation SHOULD cause the Write Task to be faulted with Transient error Orleans.InconsistentStateException and wrapping the underlying storage exception. 
+Any attempt to perform a WRITE operation when the storage provider detects an `Etag` constraint violation SHOULD cause the Write `Task` to be faulted with transient error `Orleans.InconsistentStateException` and wrapping the underlying storage exception. 
 
 
     public class InconsistentStateException : AggregateException
@@ -266,7 +266,7 @@ Any attempt to perform a WRITE operation when the storage provider detects an Et
     }
 
 
- Any other failure conditions from a Write operation SHOULD cause the Write Task to be broken with an exception containing the underlying storage exception. 
+ Any other failure conditions from a Write operation SHOULD cause the Write `Task` to be broken with an exception containing the underlying storage exception. 
 
 ## Data Mapping
 

--- a/Getting-Started-With-Orleans/Grains.md
+++ b/Getting-Started-With-Orleans/Grains.md
@@ -16,7 +16,7 @@ Grains are building blocks of an Orleans application. Grains are the atomic unit
 
 ## Grain Interfaces
 
-Grains interact with each other by invoking methods declared as part of the respective grain interfaces. A grain implements one or more previously declared grain interfaces. All methods of a grain interface are required to be asynchronous. That is, their return types have to be Tasks (see Asynchrony and Tasks for more details). 
+Grains interact with each other by invoking methods declared as part of the respective grain interfaces. A grain implements one or more previously declared grain interfaces. All methods of a grain interface are required to be asynchronous. That is, their return types have to be `Task`s (see Asynchrony and Tasks for more details). 
 
 Example:
 
@@ -32,4 +32,4 @@ Example:
 
 ## Grain Reference
 
-A grain reference is a logical endpoint that allows other grains, as well as non-grain client code, to invoke methods and properties of a particular grain interface implemented by a grain. A grain reference is a proxy object that implements the corresponding grain interface. A grain reference can be constructed by passing the identity of the grain to the GetGrain() method of the factory class auto-generated at compile time for the corresponding grain interface, or receiving the return value of a method or property. A grain reference can be passed as an argument to a method call.
+A grain reference is a logical endpoint that allows other grains, as well as non-grain client code, to invoke methods and properties of a particular grain interface implemented by a grain. A grain reference is a proxy object that implements the corresponding grain interface. A grain reference can be constructed by passing the identity of the grain to the `GetGrain()` method of the factory class auto-generated at compile time for the corresponding grain interface, or receiving the return value of a method or property. A grain reference can be passed as an argument to a method call.

--- a/Getting-Started-With-Orleans/Observers.md
+++ b/Getting-Started-With-Orleans/Observers.md
@@ -6,8 +6,8 @@ title: Observers
 
 Because the standard .NET event facility is explicitly synchronous, it doesn’t fit into an asynchronous framework such as Orleans. Instead, Orleans uses the Observer pattern.
 
-A grain type that allows observation will define an observer interface that inherits from the IGrainObserver interface. Methods on an observer interface correspond to events that the observed grain type makes available. An observer would implement this interface and then subscribe to notifications from a particular grain. The observed grain would call back to the observer through the observer interface methods when an event has occurred.
+A grain type that allows observation will define an observer interface that inherits from the `IGrainObserver` interface. Methods on an observer interface correspond to events that the observed grain type makes available. An observer would implement this interface and then subscribe to notifications from a particular grain. The observed grain would call back to the observer through the observer interface methods when an event has occurred.
 
-Methods on observer interfaces must be void since event messages are one-way. If the observer needs to interact with the observed grain as a result of a notification, it must do so by invoking normal methods on the observed grain.
+Methods on observer interfaces must be `void` since event messages are one-way. If the observer needs to interact with the observed grain as a result of a notification, it must do so by invoking normal methods on the observed grain.
 
-The observed grain type must expose a method to allow observers to subscribe to event notifications from a grain. In addition, it is usually convenient to expose a method that allows an existing subscription to be cancelled. Grain developers may use the Orleans ObserverSubscriptionManager<T> generic class to simplify development of observed grain types.
+The observed grain type must expose a method to allow observers to subscribe to event notifications from a grain. In addition, it is usually convenient to expose a method that allows an existing subscription to be canceled. Grain developers may use the Orleans `ObserverSubscriptionManager<T>` generic class to simplify development of observed grain types.

--- a/Getting-Started-With-Orleans/Running-the-Application.md
+++ b/Getting-Started-With-Orleans/Running-the-Application.md
@@ -15,11 +15,11 @@ To allow applications to communicate with grains from outside Orleans, the frame
 
 ## Connecting to a Gateway
 
-To establish a connection, a client calls OrleansClient.Initialize(). This will connect to the gateway silo at the IP address and port specified in the ClientConfiguration.xml file. This file must be placed in the same directory as the Orleans.dll library used by the client. As an alternative, a configuration object can be passed to OrleansClient.Initialize programmatically instead of loading it from a file.
+To establish a connection, a client calls `OrleansClient.Initialize()`. This will connect to the gateway silo at the IP address and port specified in the `ClientConfiguration.xml` file. This file must be placed in the same directory as the `Orleans.dll` library used by the client. As an alternative, a configuration object can be passed to `OrleansClient.Initialize()` programmatically instead of loading it from a file.
 
 ## Configuring the Client
 
-In ClientConfiguration.xml, the Gateway element specifies the address and port of the gateway endpoint that need to match those in OrleansConfiguration.xml on the silo side:
+In `ClientConfiguration.xml`, the Gateway element specifies the address and port of the gateway endpoint that need to match those in `OrleansConfiguration.xml` on the silo side:
 
     <ClientConfiguration xmlns="urn:orleans">
        <Gateway Address="<IP address or host name of silo>" Port="30000" />
@@ -29,7 +29,7 @@ If an Orleans-based application runs in Windows Azure, the client automatically 
 
 ## Configuring Silos
 
-In OrleansConfiguration.xml, the ProxyingGateway element specifies the gateway endpoint of the silo, which is separate from the inter-silo endpoint defined by the Networking element and must have a different port number:
+In `OrleansConfiguration.xml`, the `ProxyingGateway` element specifies the gateway endpoint of the silo, which is separate from the inter-silo endpoint defined by the Networking element and must have a different port number:
 
     <?xml version="1.0" encoding="utf-8"?>
     <OrleansConfiguration xmlns="urn:orleans">


### PR DESCRIPTION
Specifics:

- Method names end with `()`.
- Inline references to/mentions of types, interfaces, methods, filenames and keywords are `surrounded by backticks` to make them stand out.
- Minor spelling and grammar improvements.
- Updated referenced type and method names to match version 1.0.1 of the SDK. For example: `Storage` => `StorageProvider`