### PR TITLE
Touch - orleans.codegen.cs

### DIFF
--- a/src/Orleans.SDK.targets
+++ b/src/Orleans.SDK.targets
@@ -66,7 +66,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!-- This target is run just before Compile for an Orleans Grain Interface Project -->
   <Target Name="OrleansClientPreprocessing"
-          AfterTargets="BeforeCompile"
+          AfterTargets="BeforeCompile;ResolveReferences"
           BeforeTargets="CoreCompile"
           Condition="'$(OrleansProjectType)'=='Client'"
           Inputs="@(Compile);@(ReferencePath)"
@@ -79,6 +79,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 - Using CodeGenToolExe location=$(CodeGenToolExe)
 " />
     <MakeDir Directories="$(IntermediateOutputPath)Generated"/>
+    <Touch Files="$(ProjectDir)Properties\orleans.codegen.cs"
+      Condition="!Exists('$(ProjectDir)Properties\orleans.codegen.cs')"
+      ForceTouch="true"
+      AlwaysCreate="true"
+      ContinueOnError="true" />
     <PropertyGroup>
       <ArgsFile>$(IntermediateOutputPath)$(TargetName).codegen.args.txt</ArgsFile>
     </PropertyGroup>
@@ -104,7 +109,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!-- This target is run just after Compile for an Orleans Grain Implementation Project -->
   <Target Name="OrleansServerObjProcessing"
-          AfterTargets="BeforeCompile"
+          AfterTargets="BeforeCompile;ResolveReferences"
           BeforeTargets="CoreCompile"
           Condition="'$(OrleansProjectType)'=='Server'"
           Inputs="@(Compile);@(ReferencePath);$(ProjectDir)$(IntermediateOutputPath)$(TargetName)$(TargetExt)"
@@ -116,6 +121,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 - OrleansSDK=$(OrleansSDK)
 - Using CodeGenToolExe location=$(CodeGenToolExe)
 "/>
+    <Touch Files="$(ProjectDir)Properties\orleans.codegen.cs"
+      Condition="!Exists('$(ProjectDir)Properties\orleans.codegen.cs')"
+      ForceTouch="true"
+      AlwaysCreate="true"
+      ContinueOnError="true" />
     <PropertyGroup>
       <ArgsFile>$(IntermediateOutputPath)$(TargetName).codegen.args.txt</ArgsFile>
     </PropertyGroup>


### PR DESCRIPTION
Touch - orleans.codegen.cs 

- Pre-create the orleans.codegen.cs file otherwise a new project created from Orleans VSIX templates will not build first time [CSC complains about missing file]

