### PR TITLE
Don't Generate NuGet Pkgs for Debug Builds

### DIFF
--- a/src/Build/PostBuild.cmd
+++ b/src/Build/PostBuild.cmd
@@ -9,6 +9,14 @@ if "%BuildingInsideVisualStudio%" == "true" (
 copy /y "%SolutionDir%SDK\OrleansConfiguration.xml" "%TargetDir%"
 copy /y "%SolutionDir%SDK\ClientConfiguration.xml" "%TargetDir%"
 
+if "%BuildOrleansNuGet%" == "" (
+    if "%Configuration%" == "Release" (
+        set BuildOrleansNuGet=true
+    ) else (
+        set BuildOrleansNuGet=false
+    )
+)
+
 @echo BuildingInsideVisualStudio = %BuildingInsideVisualStudio% BuildOrleansNuGet = %BuildOrleansNuGet%
 
 copy /y "%SolutionDir%NuGet\*.props" "%TargetDir%\"
@@ -16,18 +24,18 @@ copy /y "%SolutionDir%NuGet\EmptyFile.cs" "%TargetDir%\"
 copy /y "%SolutionDir%NuGet\*Install.ps1" "%TargetDir%\"
 
 if not "%BuildingInsideVisualStudio%" == "true" (
-    @echo Clean old generated Orleans NuGet packages from %TargetDir%
-    del /q *.nupkg
+    if "%BuildOrleansNuGet%" == "true" (
+        @echo Clean old generated Orleans NuGet packages from %TargetDir%
+        del /q *.nupkg
 
-    @echo Build Orleans NuGet packages from %TargetDir%
-    call "%SolutionDir%NuGet\CreateOrleansPackages.bat" . .\Version.txt
-    if ERRORLEVEL 1 EXIT /B 1
+        @echo Build Orleans NuGet packages from %TargetDir%
+        call "%SolutionDir%NuGet\CreateOrleansPackages.bat" . .\Version.txt
+        if ERRORLEVEL 1 EXIT /B 1
     
-    if "%Configuration%" == "Release" (
         @echo Copying Orleans NuGet packages to %PKG_DIR%
         if not exist "%PKG_DIR%" (md "%PKG_DIR%") else (del /s/q "%PKG_DIR%\*")
         xcopy /y *.nupkg "%PKG_DIR%\"
     ) else (
-        @echo Skipping copying Orleans NuGet packages to %PKG_DIR% because Configuration=%Configuration% is not Release
+        @echo Skipping generation of Orleans NuGet packages for Configuration=%Configuration% because BuildOrleansNuGet=%BuildOrleansNuGet%
     )
 )


### PR DESCRIPTION
- Don't generate NuGet packages in Debug builds. Only the Release versions are ever used.

- Also still allow NuGet package creation to be disabled for Release build through the BuildOrleansNuGet build variable.
