### PR TITLE
Applying of binding redirectys & a fix for reflection-only assembly load

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -177,7 +177,7 @@ namespace Orleans.Runtime
 
                 // This is a workaround for the behavior of ReflectionOnlyLoad/ReflectionOnlyLoadFrom
                 // that appear not to automatically resolve dependencies.
-                // We are trying to preload all dlls we find in the folder, so that if one of these
+                // We are trying to pre-load all dlls we find in the folder, so that if one of these
                 // assemblies happens to be a dependency of an assembly we later on call 
                 // Assembly.GetTypes() on, the dependency will be already loaded and will get
                 // automatically resolved. Ugly, but seems to solve the problem.
@@ -191,7 +191,7 @@ namespace Orleans.Runtime
                     }
                     catch (Exception exc)
                     {
-                        if (logger.IsVerbose) logger.Verbose("Failed to pload assembly {0} in reflection-only context.", exc);
+                        if (logger.IsVerbose) logger.Verbose("Failed to pre-load assembly {0} in reflection-only context.", exc);
                     }
                 }
 

--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -174,6 +174,27 @@ namespace Orleans.Runtime
                     .Select(Path.GetFullPath)
                     .Distinct()
                     .ToArray();
+
+                // This is a workaround for the behavior of ReflectionOnlyLoad/ReflectionOnlyLoadFrom
+                // that appear not to automatically resolve dependencies.
+                // We are trying to preload all dlls we find in the folder, so that if one of these
+                // assemblies happens to be a dependency of an assembly we later on call 
+                // Assembly.GetTypes() on, the dependency will be already loaded and will get
+                // automatically resolved. Ugly, but seems to solve the problem.
+
+                foreach (var j in candidates)
+                {
+                    try
+                    {
+                        if(logger.IsVerbose) logger.Verbose("Trying to pre-load {0} to reflection-only context.");
+                        Assembly.ReflectionOnlyLoadFrom(j);
+                    }
+                    catch (Exception exc)
+                    {
+                        if (logger.IsVerbose) logger.Verbose("Failed to pload assembly {0} in reflection-only context.", exc);
+                    }
+                }
+
                 foreach (var j in candidates)
                 {
                     if (AssemblyPassesLoadCriteria(j))

--- a/src/Orleans/AssemblyLoader/CachedReflectionOnlyTypeResolver.cs
+++ b/src/Orleans/AssemblyLoader/CachedReflectionOnlyTypeResolver.cs
@@ -68,7 +68,7 @@ namespace Orleans.Runtime
                 var name = AppDomain.CurrentDomain.ApplyPolicy(args.Name);
                 return Assembly.ReflectionOnlyLoad(name);
             }
-            catch (FileNotFoundException)
+            catch (IOException)
             {
                 if (logger.IsVerbose2)
                 {

--- a/src/Orleans/AssemblyLoader/CachedReflectionOnlyTypeResolver.cs
+++ b/src/Orleans/AssemblyLoader/CachedReflectionOnlyTypeResolver.cs
@@ -65,7 +65,8 @@ namespace Orleans.Runtime
 
             try
             {
-                return Assembly.ReflectionOnlyLoad(args.Name);
+                var name = AppDomain.CurrentDomain.ApplyPolicy(args.Name);
+                return Assembly.ReflectionOnlyLoad(name);
             }
             catch (FileNotFoundException)
             {


### PR DESCRIPTION
Apply binding redirect policy before loading an assembly into reflection-only context.

Try to pre-load all dlls in the target folder into reflection-only context as a workaround for ReflectionOnlyLoad/ReflectionOnlyLoadFrom not resolving them properly.