### PR TITLE
More programmatic support to provider configuration.

### DIFF
--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -28,6 +28,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Xml;
+using Orleans.Providers;
 
 namespace Orleans.Runtime.Configuration
 {
@@ -308,17 +309,16 @@ namespace Orleans.Runtime.Configuration
                         default:
                             if (child.LocalName.EndsWith("Providers", StringComparison.Ordinal))
                             {
-                                var providerConfig = new ProviderCategoryConfiguration();
-                                providerConfig.Load(child);
+                                var providerCategory = ProviderCategoryConfiguration.Load(child);
 
-                                if (ProviderConfigurations.ContainsKey(providerConfig.Name))
+                                if (ProviderConfigurations.ContainsKey(providerCategory.Name))
                                 {
-                                    var existingProviderConfig = ProviderConfigurations[providerConfig.Name];
-                                    existingProviderConfig.Merge(providerConfig);
+                                    var existingCategory = ProviderConfigurations[providerCategory.Name];
+                                    existingCategory.Merge(providerCategory);
                                 }
                                 else
                                 {
-                                    ProviderConfigurations.Add(providerConfig.Name, providerConfig);
+                                    ProviderConfigurations.Add(providerCategory.Name, providerCategory);
                                 }
                             }
                             break;
@@ -375,6 +375,27 @@ namespace Orleans.Runtime.Configuration
         {
             ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, providerTypeFullName, providerName, properties);
         }
+
+        /// <summary>
+        /// Retrieves an existing provider configuration
+        /// </summary>
+        /// <param name="providerTypeFullName">Full name of the stream provider type</param>
+        /// <param name="providerName">Name of the stream provider</param>
+        /// <param name="config">The provider configuration, if exists</param>
+        /// <returns>True if a configuration for this provider already exists, false otherwise.</returns>
+        public bool TryGetProviderConfiguration(string providerTypeFullName, string providerName, out IProviderConfiguration config)
+        {
+            return ProviderConfigurationUtility.TryGetProviderConfiguration(ProviderConfigurations, providerTypeFullName, providerName, out config);
+        }
+
+        /// <summary>
+        /// Retrieves an enumeration of all currently configured provider configurations.
+        /// </summary>
+        /// <returns>An enumeration of all currently configured provider configurations.</returns>
+        public IEnumerable<IProviderConfiguration> GetAllProviderConfigurations()
+        {
+            return ProviderConfigurationUtility.GetAllProviderConfigurations(ProviderConfigurations);
+        } 
 
         /// <summary>
         /// This method may be called by the client host or test host to tweak a provider configuration after it has been already loaded.

--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -671,17 +671,16 @@ namespace Orleans.Runtime.Configuration
                     default:
                         if (child.LocalName.EndsWith("Providers", StringComparison.Ordinal))
                         {
-                            var providerConfig = new ProviderCategoryConfiguration();
-                            providerConfig.Load(child);
+                            var providerCategory = ProviderCategoryConfiguration.Load(child);
 
-                            if (ProviderConfigurations.ContainsKey(providerConfig.Name))
+                            if (ProviderConfigurations.ContainsKey(providerCategory.Name))
                             {
-                                var existingProviderConfig = ProviderConfigurations[providerConfig.Name];
-                                existingProviderConfig.Merge(providerConfig);
+                                var existingCategory = ProviderConfigurations[providerCategory.Name];
+                                existingCategory.Merge(providerCategory);
                             }
                             else
                             {
-                                ProviderConfigurations.Add(providerConfig.Name, providerConfig);
+                                ProviderConfigurations.Add(providerCategory.Name, providerCategory);
                             }
                         }
                         break;
@@ -772,5 +771,26 @@ namespace Orleans.Runtime.Configuration
         {
             ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STORAGE_PROVIDER_CATEGORY_NAME, providerTypeFullName, providerName, properties);
         }
+
+        /// <summary>
+        /// Retrieves an existing provider configuration
+        /// </summary>
+        /// <param name="providerTypeFullName">Full name of the stream provider type</param>
+        /// <param name="providerName">Name of the stream provider</param>
+        /// <param name="config">The provider configuration, if exists</param>
+        /// <returns>True if a configuration for this provider already exists, false otherwise.</returns>
+        public bool TryGetProviderConfiguration(string providerTypeFullName, string providerName, out IProviderConfiguration config)
+        {
+            return ProviderConfigurationUtility.TryGetProviderConfiguration(ProviderConfigurations, providerTypeFullName, providerName, out config);
+        }
+
+        /// <summary>
+        /// Retrieves an enumeration of all currently configured provider configurations.
+        /// </summary>
+        /// <returns>An enumeration of all currently configured provider configurations.</returns>
+        public IEnumerable<IProviderConfiguration> GetAllProviderConfigurations()
+        {
+            return ProviderConfigurationUtility.GetAllProviderConfigurations(ProviderConfigurations);
+        } 
     }
 }

--- a/src/Orleans/Providers/IOrleansProvider.cs
+++ b/src/Orleans/Providers/IOrleansProvider.cs
@@ -22,6 +22,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
 
@@ -74,16 +75,41 @@ namespace Orleans.Providers
     /// </summary>
     public interface IProviderConfiguration
     {
+        /// <summary>
+        /// Full type name of this provider.
+        /// </summary>
+        string Type { get; }
+
+        /// <summary>
+        /// Name of this provider.
+        /// </summary>
         string Name { get; }
 
         /// <summary>
         /// Configuration properties for this provider instance, as name-value pairs.
         /// </summary>
-        IDictionary<string, string> Properties { get; }
+        ReadOnlyDictionary<string, string> Properties { get; }
 
         /// <summary>
         /// Nested providers in case of a hierarchical tree of dependencies
         /// </summary>
         IList<IProvider> Children { get; }
+
+        /// <summary>
+        /// Set a property in this provider configuration.
+        /// If the property with this key already exists, it is been overwritten with the new value, otherwise it is just added.
+        /// </summary>
+        /// <param name="key">The key of the property</param>
+        /// <param name="val">The value of the property</param>
+        /// <returns>Provider instance with the given name</returns>
+        void SetProperty(string key, string val);
+
+        /// <summary>
+        /// Removes a property in this provider configuration.
+        /// </summary>
+        /// <param name="key">The key of the property.</param>
+        /// <returns>True if the property was found and removed, false otherwise.</returns>
+        bool RemoveProperty(string key);
+
     }
 }


### PR DESCRIPTION
1) Added: TryGetProviderConfiguration and GetAllProviderConfigurations
2) Added constructor to ProviderConfiguration class.
3) Added more functions to IProviderConfiguration: Type, SetProperty, RemoveProperty, ReadOnlyDictionary<string, string> Properties.
4) Updated examples in AzureWebSample.

The important new parts are in:
1) IProviderConfiguration.cs
2) public bool TryGetProviderConfiguration(string providerTypeFullName, string providerName, out IProviderConfiguration config) 
3) public IEnumerable<IProviderConfiguration> GetAllProviderConfigurations() 
