### PR TITLE
HelloWorld-USE_INPROC_SILO

### DIFF
--- a/Samples/HelloWorld/HelloWorld/Program.cs
+++ b/Samples/HelloWorld/HelloWorld/Program.cs
@@ -13,6 +13,11 @@
 //    permissions and limitations under the License.
 //
 //*********************************************************
+
+// Unset this to run external local silo
+// http://dotnet.github.io/orleans/Step-by-step-Tutorials/Running-in-a-Stand-alone-Silo
+#define USE_INPROC_SILO
+
 using System;
 using Orleans;
 using HelloWorldInterfaces;
@@ -26,6 +31,7 @@ namespace HelloWorld
     {
         static void Main(string[] args)
         {
+#if USE_INPROC_SILO
             // The Orleans silo environment is initialized in its own app domain in order to more
             // closely emulate the distributed situation, when the client and the server cannot
             // pass data via shared memory.
@@ -34,7 +40,7 @@ namespace HelloWorld
                 AppDomainInitializer = InitSilo,
                 AppDomainInitializerArguments = args,
             });
-
+#endif
             GrainClient.Initialize("DevTestClientConfiguration.xml");
 
             var friend = GrainFactory.GetGrain<IHello>(0);
@@ -43,9 +49,12 @@ namespace HelloWorld
             Console.WriteLine("Orleans Silo is running.\nPress Enter to terminate...");
             Console.ReadLine();
 
+#if USE_INPROC_SILO
             hostDomain.DoCallBack(ShutdownSilo);
+#endif
         }
 
+#if USE_INPROC_SILO
         static void InitSilo(string[] args)
         {
             hostWrapper = new OrleansHostWrapper(args);
@@ -66,5 +75,6 @@ namespace HelloWorld
         }
 
         private static OrleansHostWrapper hostWrapper;
+#endif
     }
 }

--- a/Samples/HelloWorldNuget/HelloWorldNuget/Program.cs
+++ b/Samples/HelloWorldNuget/HelloWorldNuget/Program.cs
@@ -13,6 +13,11 @@
 //    permissions and limitations under the License.
 //
 //*********************************************************
+
+// Unset this to run external local silo
+// http://dotnet.github.io/orleans/Step-by-step-Tutorials/Running-in-a-Stand-alone-Silo
+#define USE_INPROC_SILO
+
 using System;
 using Orleans;
 using HelloWorldNugetInterfaces;
@@ -26,6 +31,7 @@ namespace HelloWorldNuget
     {
         static void Main(string[] args)
         {
+#if USE_INPROC_SILO
             // The Orleans silo environment is initialized in its own app domain in order to more
             // closely emulate the distributed situation, when the client and the server cannot
             // pass data via shared memory.
@@ -34,7 +40,7 @@ namespace HelloWorldNuget
                 AppDomainInitializer = InitSilo,
                 AppDomainInitializerArguments = args,
             });
-
+#endif
             GrainClient.Initialize("DevTestClientConfiguration.xml");
 
             var friend = GrainFactory.GetGrain<IHello>(0);
@@ -43,9 +49,12 @@ namespace HelloWorldNuget
             Console.WriteLine("Orleans Silo is running.\nPress Enter to terminate...");
             Console.ReadLine();
 
+#if USE_INPROC_SILO
             hostDomain.DoCallBack(ShutdownSilo);
+#endif
         }
 
+#if USE_INPROC_SILO
         static void InitSilo(string[] args)
         {
             hostWrapper = new OrleansHostWrapper(args);
@@ -66,5 +75,6 @@ namespace HelloWorldNuget
         }
 
         private static OrleansHostWrapper hostWrapper;
+#endif
     }
 }


### PR DESCRIPTION
- Add #define USE_INPROC_SILO to make it easier to swithc from in-process to external standalone silo demo.
- Based on user feedback on http://dotnet.github.io/orleans/Step-by-step-Tutorials/Running-in-a-Stand-alone-Silo