### PR TITLE
Call PostBuild.cmd from final project built in solution.

### DIFF
--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -159,36 +159,7 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>@echo Tester - Start Post-Build script
-
-set TEST_INPUT_DIR=$(TargetDir)TestInput
-if not exist "%25TEST_INPUT_DIR%25" ( mkdir "%25TEST_INPUT_DIR%25" )
-copy /y "$(ProjectDir)*.xml"  "%25TEST_INPUT_DIR%25\"
-
-if "$(BuildingInsideVisualStudio)" == "true" (
-  copy /y "$(SolutionDir)TestGrains\bin\$(ConfigurationName)\TestGrains.*"  "%25TEST_INPUT_DIR%25\"
-  copy /y "$(SolutionDir)TestGrainInterfaces\bin\$(ConfigurationName)\TestGrainInterfaces.*"  "%25TEST_INPUT_DIR%25\"
-) else (
-  copy /y "%25TargetDir%25TestGrains.*"  "%25TEST_INPUT_DIR%25\"
-  copy /y "%25TargetDir%25TestGrainInterfaces.*"  "%25TEST_INPUT_DIR%25\"
-)
-
-set SolutionDir=$(SolutionDir)
-set OutDir=$(OutDir)
-set TargetDir=$(TargetDir)
-set BuildingInsideVisualStudio=$(BuildingInsideVisualStudio)
-set Configuration=$(Configuration)
-
-@echo Calling Build\PostBuild.cmd
-call "$(SolutionDir)Build\PostBuild.cmd"</PostBuildEvent>
-  </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -109,7 +109,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <!-- PostBuild.cmd script is platform specific, so for now we only want to run it on Windows -->
     <PostBuildEvent>@echo Tester - Start Post-Build script
 
 set TEST_INPUT_DIR=$(TargetDir)TestInput

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -109,6 +109,31 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>@echo Tester - Start Post-Build script
+
+set TEST_INPUT_DIR=$(TargetDir)TestInput
+if not exist "%25TEST_INPUT_DIR%25" ( mkdir "%25TEST_INPUT_DIR%25" )
+copy /y "$(ProjectDir)*.xml"  "%25TEST_INPUT_DIR%25\"
+
+if "$(BuildingInsideVisualStudio)" == "true" (
+  copy /y "$(SolutionDir)TestGrains\bin\$(ConfigurationName)\TestGrains.*"  "%25TEST_INPUT_DIR%25\"
+  copy /y "$(SolutionDir)TestGrainInterfaces\bin\$(ConfigurationName)\TestGrainInterfaces.*"  "%25TEST_INPUT_DIR%25\"
+) else (
+  copy /y "%25TargetDir%25TestGrains.*"  "%25TEST_INPUT_DIR%25\"
+  copy /y "%25TargetDir%25TestGrainInterfaces.*"  "%25TEST_INPUT_DIR%25\"
+)
+
+set SolutionDir=$(SolutionDir)
+set OutDir=$(OutDir)
+set TargetDir=$(TargetDir)
+set BuildingInsideVisualStudio=$(BuildingInsideVisualStudio)
+set Configuration=$(Configuration)
+
+@echo Calling Build\PostBuild.cmd
+call "$(SolutionDir)Build\PostBuild.cmd"
+</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
- Move the call to PostBuild.cmd from Tester to TesterInternal project because that has build order dependency on Tester.

Failure symptoms:
Building the WIX installer fails to find OrleansConfiguration.xml during first-time build of fresh checkout or after deleting the Binaries output directory.