### PR TITLE
Fix to ClusterConfiguration and ManagementGrain resource leaks

### DIFF
--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -145,10 +145,14 @@ namespace Orleans.Runtime.Configuration
 
         private static string WriteXml(XmlElement element)
         {
-            var text = new StringWriter();
-            var xml = new XmlTextWriter(text);
-            element.WriteTo(xml);
-            return text.ToString();
+            using(var text = new StringWriter())
+            {
+                using(var xml = new XmlTextWriter(text))
+                { 
+                    element.WriteTo(xml);
+                    return text.ToString();
+                }
+            }
         }
 
         private void CalculateOverrides()


### PR DESCRIPTION
There are (at least) two mild resource leaks:

* [ManagementGrain on line 187](https://github.com/dotnet/orleans/blob/master/src/OrleansRuntime/Core/ManagementGrain.cs#L187) doesn't dispose the writer objects.
* [ClusterConfiguration on line 148](https://github.com/dotnet/orleans/blob/master/src/Orleans/Configuration/ClusterConfiguration.cs#L148) doesn't dispose the writer objects.

Fixes #256.

I also ran a few regex searches and didn't find any others.