### PR TITLE
Added GetAllSubscriptionHandles to IAsyncStream

### DIFF
--- a/src/Orleans/Streams/Core/IAsyncStream.cs
+++ b/src/Orleans/Streams/Core/IAsyncStream.cs
@@ -22,6 +22,8 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 ﻿using System;
+﻿using System.Collections.Generic;
+﻿using System.Threading.Tasks;
 
 namespace Orleans.Streams
 {
@@ -41,5 +43,11 @@ namespace Orleans.Streams
 
         /// <summary> Stream Provider Name. </summary>
         string ProviderName { get; }
+
+        /// <summary>
+        /// Retrieves a list of all active subscriptions created by the caller for this stream.
+        /// </summary>
+        /// <returns></returns>
+        Task<List<StreamSubscriptionHandle<T>>> GetAllSubscriptionHandles();
     }
 }

--- a/src/Orleans/Streams/Core/IAsyncStream.cs
+++ b/src/Orleans/Streams/Core/IAsyncStream.cs
@@ -48,6 +48,6 @@ namespace Orleans.Streams
         /// Retrieves a list of all active subscriptions created by the caller for this stream.
         /// </summary>
         /// <returns></returns>
-        Task<List<StreamSubscriptionHandle<T>>> GetAllSubscriptionHandles();
+        Task<IList<StreamSubscriptionHandle<T>>> GetAllSubscriptionHandles();
     }
 }

--- a/src/Orleans/Streams/Internal/IInternalAsyncObservable.cs
+++ b/src/Orleans/Streams/Internal/IInternalAsyncObservable.cs
@@ -21,6 +21,7 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Orleans.Streams
@@ -33,5 +34,7 @@ namespace Orleans.Streams
             StreamSequenceToken token = null);
 
         Task UnsubscribeAsync(StreamSubscriptionHandle<T> handle);
+
+        Task<List<StreamSubscriptionHandle<T>>> GetAllSubscriptions();
     }
 }

--- a/src/Orleans/Streams/Internal/IInternalAsyncObservable.cs
+++ b/src/Orleans/Streams/Internal/IInternalAsyncObservable.cs
@@ -35,6 +35,6 @@ namespace Orleans.Streams
 
         Task UnsubscribeAsync(StreamSubscriptionHandle<T> handle);
 
-        Task<List<StreamSubscriptionHandle<T>>> GetAllSubscriptions();
+        Task<IList<StreamSubscriptionHandle<T>>> GetAllSubscriptions();
     }
 }

--- a/src/Orleans/Streams/Internal/StreamConsumer.cs
+++ b/src/Orleans/Streams/Internal/StreamConsumer.cs
@@ -163,7 +163,7 @@ namespace Orleans.Streams
             handleImpl.Invalidate();
         }
 
-        public async Task<List<StreamSubscriptionHandle<T>>> GetAllSubscriptions()
+        public async Task<IList<StreamSubscriptionHandle<T>>> GetAllSubscriptions()
         {
             await BindExtensionLazy();
 

--- a/src/Orleans/Streams/Internal/StreamConsumer.cs
+++ b/src/Orleans/Streams/Internal/StreamConsumer.cs
@@ -22,7 +22,9 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 ﻿using System;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+﻿using System.Linq;
+﻿using System.Threading.Tasks;
 using Orleans.Runtime;
 
 namespace Orleans.Streams
@@ -159,6 +161,15 @@ namespace Orleans.Streams
             await pubSub.UnregisterConsumer(handleImpl.SubscriptionId, stream.StreamId, streamProviderName);
 
             handleImpl.Invalidate();
+        }
+
+        public async Task<List<StreamSubscriptionHandle<T>>> GetAllSubscriptions()
+        {
+            await BindExtensionLazy();
+
+            List<GuidId> subscriptionIds = await pubSub.GetAllSubscriptions(stream.StreamId, myGrainReference);
+            return subscriptionIds.Select(id => new StreamSubscriptionHandleImpl<T>(id, stream))
+                                  .ToList<StreamSubscriptionHandle<T>>();
         }
 
         internal bool InternalRemoveObserver(StreamSubscriptionHandle<T> handle)

--- a/src/Orleans/Streams/Internal/StreamImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamImpl.cs
@@ -41,7 +41,7 @@ namespace Orleans.Streams
         [NonSerialized]
         private volatile IAsyncBatchObserver<T>                 producerInterface;
         [NonSerialized]
-        private IInternalAsyncObservable<T>                         consumerInterface;
+        private IInternalAsyncObservable<T>                     consumerInterface;
         [NonSerialized]
         private readonly object                                 initLock; // need the lock since the same code runs in the provider on the client and in the silo.
         
@@ -51,7 +51,6 @@ namespace Orleans.Streams
         public Guid Guid                                        { get { return streamId.Guid; } }
         public string Namespace                                 { get { return streamId.Namespace; } }
         public string ProviderName                              { get { return streamId.ProviderName; } }
-
 
         // IMPORTANT: This constructor needs to be public for Json deserialization to work.
         public StreamImpl()
@@ -124,6 +123,11 @@ namespace Orleans.Streams
             StreamSequenceToken token)
         {
             return GetConsumerInterface().ResumeAsync(handle, observer, token);
+        }
+
+        public Task<List<StreamSubscriptionHandle<T>>> GetAllSubscriptionHandles()
+        {
+            return GetConsumerInterface().GetAllSubscriptions();
         }
 
         internal Task UnsubscribeAsync(StreamSubscriptionHandle<T> handle)

--- a/src/Orleans/Streams/Internal/StreamImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamImpl.cs
@@ -125,7 +125,7 @@ namespace Orleans.Streams
             return GetConsumerInterface().ResumeAsync(handle, observer, token);
         }
 
-        public Task<List<StreamSubscriptionHandle<T>>> GetAllSubscriptionHandles()
+        public Task<IList<StreamSubscriptionHandle<T>>> GetAllSubscriptionHandles()
         {
             return GetConsumerInterface().GetAllSubscriptions();
         }

--- a/src/Orleans/Streams/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamSubscriptionHandleImpl.cs
@@ -22,6 +22,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 
@@ -42,8 +43,16 @@ namespace Orleans.Streams
         public GuidId SubscriptionId { get; protected set; }
         public bool IsValid { get; private set; }
 
+        public StreamSubscriptionHandleImpl(GuidId subscriptionId, StreamImpl<T> stream)
+            : this(subscriptionId, null, stream, null)
+        {
+        }
+
         public StreamSubscriptionHandleImpl(GuidId subscriptionId, IAsyncObserver<T> observer, StreamImpl<T> stream, IStreamFilterPredicateWrapper filterWrapper)
         {
+            if (subscriptionId == null) throw new ArgumentNullException("subscriptionId");
+            if (stream == null) throw new ArgumentNullException("stream");
+
             IsValid = true;
             this.observer = observer;
             streamImpl = stream;

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -25,7 +25,6 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System.Threading.Tasks;
 
 using Orleans.Runtime;
-using Orleans.Concurrency;
 using Orleans.Runtime.Configuration;
 using Orleans.Streams;
 

--- a/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
+++ b/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
@@ -134,6 +134,8 @@ namespace Orleans.Streams
 
         Task<int> ConsumerCount(Guid streamId, string streamProvider, string streamNamespace);
 
+        Task<List<GuidId>> GetAllSubscriptions(StreamId streamId, IStreamConsumerExtension streamConsumer);
+
         GuidId CreateSubscriptionId(IAddressable requesterAddress, StreamId streamId);
     }
 }

--- a/src/Orleans/Streams/PubSub/IPubSubRendezvousGrain.cs
+++ b/src/Orleans/Streams/PubSub/IPubSubRendezvousGrain.cs
@@ -45,5 +45,7 @@ namespace Orleans.Streams
         Task<PubSubSubscriptionState[]> DiagGetConsumers(StreamId streamId);
 
         Task Validate();
+
+        Task<List<GuidId>> GetAllSubscriptions(StreamId streamId, IStreamConsumerExtension streamConsumer);
     }
 }

--- a/src/Orleans/Streams/PubSub/PubSubRuntime.cs
+++ b/src/Orleans/Streams/PubSub/PubSubRuntime.cs
@@ -69,6 +69,12 @@ namespace Orleans.Streams
             return streamRendezvous.ConsumerCount(streamId);
         }
 
+        public Task<List<GuidId>> GetAllSubscriptions(StreamId streamId, IStreamConsumerExtension streamConsumer)
+        {
+            var streamRendezvous = GetRendezvousGrain(streamId);
+            return streamRendezvous.GetAllSubscriptions(streamId, streamConsumer);
+        }
+
         private static IPubSubRendezvousGrain GetRendezvousGrain(StreamId streamId)
         {
             return (IPubSubRendezvousGrain)GrainClient.InvokeStaticMethodThroughReflection(
@@ -150,6 +156,13 @@ namespace Orleans.Streams
         public Task<int> ConsumerCount(Guid streamId, string streamProvider, string streamNamespace)
         {
             return explicitPubSub.ConsumerCount(streamId, streamProvider, streamNamespace); 
+        }
+
+        public async Task<List<GuidId>> GetAllSubscriptions(StreamId streamId, IStreamConsumerExtension streamConsumer)
+        {
+            return IsImplicitSubscriber(streamConsumer, streamId)
+                ? new List<GuidId>( new [] { GuidId.GetGuidId(streamConsumer.GetPrimaryKey()) } )
+                : await explicitPubSub.GetAllSubscriptions(streamId, streamConsumer);
         }
 
         private bool IsImplicitSubscriber(IAddressable addressable, StreamId streamId)

--- a/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -329,5 +329,13 @@ namespace Orleans.Streams
                     throw new Exception(String.Format("State mismatch between PubSubRendezvousGrain and its persistent state. captureConsumers={0}, State.Consumers={1}",
                         Utils.EnumerableToString(captureConsumers), Utils.EnumerableToString(State.Consumers)));
         }
+
+        public Task<List<GuidId>> GetAllSubscriptions(StreamId streamId, IStreamConsumerExtension streamConsumer)
+        {
+            List<GuidId> subscriptionIds = State.Consumers.Where(c => c.Consumer.Equals(streamConsumer))
+                                                          .Select(c => c.SubscriptionId)
+                                                          .ToList();
+            return Task.FromResult(subscriptionIds);
+        }
     }
 }

--- a/src/TestGrainInterfaces/IMultipleSubscriptionConsumerGrain.cs
+++ b/src/TestGrainInterfaces/IMultipleSubscriptionConsumerGrain.cs
@@ -37,6 +37,8 @@ namespace TestGrainInterfaces
 
         Task StopConsuming(StreamSubscriptionHandle<int> handle);
 
+        Task<List<StreamSubscriptionHandle<int>>> GetAllSubscriptions(Guid streamId, string streamNamespace, string providerToUse);
+
         Task<Dictionary<StreamSubscriptionHandle<int>, int>> GetNumberConsumed();
 
         Task ClearNumberConsumed();

--- a/src/TestGrainInterfaces/IMultipleSubscriptionConsumerGrain.cs
+++ b/src/TestGrainInterfaces/IMultipleSubscriptionConsumerGrain.cs
@@ -37,7 +37,7 @@ namespace TestGrainInterfaces
 
         Task StopConsuming(StreamSubscriptionHandle<int> handle);
 
-        Task<List<StreamSubscriptionHandle<int>>> GetAllSubscriptions(Guid streamId, string streamNamespace, string providerToUse);
+        Task<IList<StreamSubscriptionHandle<int>>> GetAllSubscriptions(Guid streamId, string streamNamespace, string providerToUse);
 
         Task<Dictionary<StreamSubscriptionHandle<int>, int>> GetNumberConsumed();
 

--- a/src/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/src/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -96,6 +96,18 @@ namespace TestGrains
             consumedMessageCounts.Remove(handle);
         }
 
+        public Task<List<StreamSubscriptionHandle<int>>> GetAllSubscriptions(Guid streamId, string streamNamespace, string providerToUse)
+        {
+            logger.Info("GetAllSubscriptionHandles");
+
+            // get stream
+            IStreamProvider streamProvider = GetStreamProvider(providerToUse);
+            var stream = streamProvider.GetStream<int>(streamId, streamNamespace);
+
+            // get all active subscription handles for this stream.
+            return stream.GetAllSubscriptionHandles();
+        }
+
         public Task<Dictionary<StreamSubscriptionHandle<int>, int>> GetNumberConsumed()
         {
             return Task.FromResult(consumedMessageCounts.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Value));

--- a/src/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/src/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -96,7 +96,7 @@ namespace TestGrains
             consumedMessageCounts.Remove(handle);
         }
 
-        public Task<List<StreamSubscriptionHandle<int>>> GetAllSubscriptions(Guid streamId, string streamNamespace, string providerToUse)
+        public Task<IList<StreamSubscriptionHandle<int>>> GetAllSubscriptions(Guid streamId, string streamNamespace, string providerToUse)
         {
             logger.Info("GetAllSubscriptionHandles");
 

--- a/src/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
@@ -82,5 +82,12 @@ namespace Tester.StreamingTests
             logger.Info("************************ ResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        public async Task SMSActiveSubscriptionTest()
+        {
+            logger.Info("************************ SMSActiveSubscriptionTest *********************************");
+            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+        }
     }
 }

--- a/src/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/src/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -207,7 +207,7 @@ namespace Tester.StreamingTests
             List<StreamSubscriptionHandle<int>> expectedSubscriptions = (await Task.WhenAll(subscriptionTasks)).ToList();
 
             // query actuall subscriptions
-            List<StreamSubscriptionHandle<int>> actualSubscriptions = await consumer.GetAllSubscriptions(streamGuid, streamNamespace, streamProviderName);
+            IList<StreamSubscriptionHandle<int>> actualSubscriptions = await consumer.GetAllSubscriptions(streamGuid, streamNamespace, streamProviderName);
 
             // validate
             Assert.AreEqual(subscriptionCount, actualSubscriptions.Count, "Subscription Count");


### PR DESCRIPTION
The new IAsyncStream.GetAllSubscriptionHandles call returns the list of active subscription handles that the caller currently has on the stream.  This is useful in recovering after silo crashes scenarios or other errors.  It is also useful for stream processing grains that do not wish to persist state.