### PR TITLE
Fix build warning in SMSSubscriptionMultiplicityTests.cs

### DIFF
--- a/src/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
@@ -50,7 +50,7 @@ namespace Tester.StreamingTests
 
         // Use ClassCleanup to run code after all tests in a class have run
         [ClassCleanup]
-        public static new void MyClassCleanup()
+        public static void MyClassCleanup()
         {
             StopAllSilos();
         }


### PR DESCRIPTION
Failure mode:

StreamingTests\SMSSubscriptionMultiplicityTests.cs(53,32): warning CS0109:
The member 'Tester.StreamingTests.SMSSubscriptionMultiplicityTests.MyClassCleanup()' does not hide an inherited member. The new keyword is not required.