### PR TITLE
Prepare syntax highlighting in orleans documentation on github pages.

### DIFF
--- a/Step-by-step-Tutorials/My-First-Orleans-Application.md
+++ b/Step-by-step-Tutorials/My-First-Orleans-Application.md
@@ -28,25 +28,26 @@ After starting either Visual Studio 2012 or 2013, go to create a new project. Un
  The main code does three things: it creates a silo in a separate app domain, initializes the Orleans client runtime, and waits for user input before terminating:
 
 
-    static void Main(string[] args)
-    {
-        AppDomain hostDomain = AppDomain.CreateDomain("OrleansHost", null, 
-            new AppDomainSetup
-            {
-                AppDomainInitializer = InitSilo,
-                AppDomainInitializerArguments = args,
-            });
+``` csharp
+static void Main(string[] args)
+{
+    AppDomain hostDomain = AppDomain.CreateDomain("OrleansHost", null, 
+        new AppDomainSetup
+        {
+            AppDomainInitializer = InitSilo,
+            AppDomainInitializerArguments = args,
+        });
 
-        Orleans.GrainClient.Initialize("DevTestClientConfiguration.xml");
+    Orleans.GrainClient.Initialize("DevTestClientConfiguration.xml");
 
-        // TODO: once the previous call returns, the silo is up and running.
-        //       This is the place your custom logic, for example calling client logic
-        //       or initializing an HTTP front end for accepting incoming requests.
+    // TODO: once the previous call returns, the silo is up and running.
+    //       This is the place your custom logic, for example calling client logic
+    //       or initializing an HTTP front end for accepting incoming requests.
 
-        Console.WriteLine("Orleans Silo is running.\nPress Enter to terminate...");
-        Console.ReadLine();
-    }
-
+    Console.WriteLine("Orleans Silo is running.\nPress Enter to terminate...");
+    Console.ReadLine();
+}
+```
 
 ## Adding Some Grains
 
@@ -65,11 +66,12 @@ At this point, we have everything we need except some actual Orleans-based code.
  Open the IGrain1.cs file and add a method 'SayHello()' to it. We should have something like this:
 
 
-    public interface IGrain1 : Orleans.IGrain
-    {
-        Task<string> SayHello();
-    }
-
+``` csharp
+public interface IGrain1 : Orleans.IGrain
+{
+    Task<string> SayHello();
+}
+```
 
 
 Note that we're relying on TPL tasks in the interface method's return type -- an essential means to achiving scalability in the lightweight Orleans programming model is to use asynchronous I/O everywhere, and Orleans forces you to do so. Use Task or Task<T> as the return type of all methods of communication interfaces.
@@ -77,27 +79,31 @@ Next, we turn our attention to the grain implementation, which is found in Grain
 
  Then, we ask VS to generate the method stub for the one interface method we defined earlier:
 
-
-    public Task<string> SayHello()
-    {
-        throw new NotImplementedException();
-    }
+``` csharp
+public Task<string> SayHello()
+{
+    throw new NotImplementedException();
+}
+```
 
 
  We're finally ready to add the much-anticipated "Hello World!" code. Just return the string as the contents of a Task:
 
 
-    public Task<string> SayHello()
-    {
-        return Task.FromResult("Hello World!");
-    }
-
+``` csharp
+public Task<string> SayHello()
+{
+    return Task.FromResult("Hello World!");
+}
+```
 
  OK, we're nearly done. All we need is a bit of client code, which we will return to Program.cs in order to add. In place of the comment following the call to OrleansClient.Initialize(), add these two lines:
 
 
+``` csharp
     var hello = MyGrainInterfaces1.Grain1Factory.GetGrain(0);
     Console.WriteLine("\n\n{0}\n\n", hello.SayHello().Result);
+```
 
 
  That's it! Hit F5, let the silo initialization code take its time. This will take a few seconds, maybe as much as ten, and there will be a lot of log messages printed. At the very end, you should see the printout of the greeting.

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,13 @@
 permalink: /:categories/:year/:month/:day/:title 
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-pygments: true
+highlighter: pygments
+markdown: redcarpet
 
+# Make redcarpet behave like GitHub Flavored Markdown
+redcarpet:
+  extensions: ["no_intra_emphasis", "fenced_code_blocks", "tables", "autolink", "strikethrough", "superscript", "with_toc_data"]
+  
 # Themes are encouraged to use these universal variables 
 # so be sure to set them if your theme uses them.
 #

--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,7 @@ JB :
   #   - Only the following values are falsy: ["", null, false]
   #   - When setting BASE_PATH it must be a valid url.
   #     This means always setting the protocol (http|https) or prefixing with "/"
-  BASE_PATH : false
+  BASE_PATH : /orleans
 
   # By default, the asset_path is automatically defined relative to BASE_PATH plus the enabled theme.
   # ex: [BASE_PATH]/assets/themes/[THEME-NAME]

--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -22,6 +22,7 @@
     <!--
     <link href="{{ ASSET_PATH }}/css/style.css" rel="stylesheet" type="text/css" media="all">
     -->
+    <link href="{{ ASSET_PATH }}/css/syntax.css" rel="stylesheet" type="text/css" media="all">
 
     <!-- Le fav and touch icons -->
   <!-- Update these with your own images

--- a/assets/themes/twitter/css/syntax.css
+++ b/assets/themes/twitter/css/syntax.css
@@ -1,0 +1,33 @@
+.hll { background-color: #ffffcc }
+.c { color: #008000 } /* Comment */
+.err { border: 1px solid #FF0000 } /* Error */
+.k { color: #0000ff } /* Keyword */
+.cm { color: #008000 } /* Comment.Multiline */
+.cp { color: #0000ff } /* Comment.Preproc */
+.c1 { color: #008000 } /* Comment.Single */
+.cs { color: #008000 } /* Comment.Special */
+.ge { font-style: italic } /* Generic.Emph */
+.gh { font-weight: bold } /* Generic.Heading */
+.gp { font-weight: bold } /* Generic.Prompt */
+.gs { font-weight: bold } /* Generic.Strong */
+.gu { font-weight: bold } /* Generic.Subheading */
+.kc { color: #0000ff } /* Keyword.Constant */
+.kd { color: #0000ff } /* Keyword.Declaration */
+.kn { color: #0000ff } /* Keyword.Namespace */
+.kp { color: #0000ff } /* Keyword.Pseudo */
+.kr { color: #0000ff } /* Keyword.Reserved */
+.kt { color: #2b91af } /* Keyword.Type */
+.s { color: #a31515 } /* Literal.String */
+.nc { color: #2b91af } /* Name.Class */
+.ow { color: #0000ff } /* Operator.Word */
+.sb { color: #a31515 } /* Literal.String.Backtick */
+.sc { color: #a31515 } /* Literal.String.Char */
+.sd { color: #a31515 } /* Literal.String.Doc */
+.s2 { color: #a31515 } /* Literal.String.Double */
+.se { color: #a31515 } /* Literal.String.Escape */
+.sh { color: #a31515 } /* Literal.String.Heredoc */
+.si { color: #a31515 } /* Literal.String.Interpol */
+.sx { color: #a31515 } /* Literal.String.Other */
+.sr { color: #a31515 } /* Literal.String.Regex */
+.s1 { color: #a31515 } /* Literal.String.Single */
+.ss { color: #a31515 } /* Literal.String.Symbol */


### PR DESCRIPTION
Current version of Orleans documentation on github pages does not have source code syntax highlighting enabled. I've made a few changes so it can be added:
- changed default markdown rendering engine to "redcarpet" as [AFAIK](https://github.com/blog/832-rolling-out-the-redcarpet) it is a precursor of the engine used on github (however, not in github pages by default) and [set some options](http://stackoverflow.com/a/28114624/3568443) to make it close to the one from github.
- added simple css file for syntax highlighter similar to default Visual Studio style. I used following command:

    ```pygmentize -S vs -f html > assets/themes/twitter/css/syntax.css```

- set csharp syntax for highlighter on My-First-Orleans-Application page to prove it worked

You can check final effect [here](http://ksuszka.github.io/orleans/Step-by-step-Tutorials/My-First-Orleans-Application)
