### PR TITLE
Enable syntax highlighing on more files (mostly for xml snippets)

### DIFF
--- a/Advanced-Concepts/Activation-Garbage-Collection.md
+++ b/Advanced-Concepts/Activation-Garbage-Collection.md
@@ -57,18 +57,18 @@ hr  | hour(s)
 
 The default collection age limit that applies to all grain types can be customized by adding the OrleansConfiguation/Globals/Application/Defaults/Deactivation element to the OrleansConfiguration.xml file. The following example specifies that all activations that have been idle for 10 minutes or more should be considered eligible for deactivation.
 
-
-    <?xml version="1.0" encoding="utf-8"?>
-    <OrleansConfiguration xmlns="urn:orleans">
-      <Globals>
-        <Application>
-          <Defaults>
-            <Deactivation AgeLimit="10m"/>
-          </Defaults>
-        </Application>
-      </Globals>
-    </OrleansConfiguration>
-
+``` xml
+<?xml version="1.0" encoding="utf-8"?>
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <Application>
+      <Defaults>
+        <Deactivation AgeLimit="10m"/>
+      </Defaults>
+    </Application>
+  </Globals>
+</OrleansConfiguration>
+```
 
 ## Specifying per-Type Age Limits
 
@@ -77,20 +77,21 @@ Individual grain types may specify a collection age limit that is independent fr
  In the following example, activations that have been idle for 10 minutes are eligible for collection, except activations that are instantiations of the MyGrainAssembly.DoNotDeactivateMeOften class, which are not considered collectable unless idle for a full 24 hours:
 
 
-    <?xml version="1.0" encoding="utf-8"?>
-    <OrleansConfiguration xmlns="urn:orleans">
-      <Globals>
-        <Application>
-          <Defaults>
-            <Deactivation AgeLimit="10m"/>
-          </Defaults>
-          <GrainType Type="MyGrainAssembly.DoNotDeactivateMeOften">
-            <Deactivation AgeLimit="24hr"/>
-          </GrainType>
-        </Application>
-      </Globals>
-    </OrleansConfiguration>
-
+``` xml
+<?xml version="1.0" encoding="utf-8"?>
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <Application>
+      <Defaults>
+        <Deactivation AgeLimit="10m"/>
+      </Defaults>
+      <GrainType Type="MyGrainAssembly.DoNotDeactivateMeOften">
+        <Deactivation AgeLimit="24hr"/>
+      </GrainType>
+    </Application>
+  </Globals>
+</OrleansConfiguration>
+```
 
  Any number of GrainType elements may be specified.
 
@@ -98,7 +99,9 @@ Individual grain types may specify a collection age limit that is independent fr
 
 An activation can also configure its own activation GC, by calling the method on the Orleans.Grain base class:
 
-       protected void DelayDeactivation(TimeSpan timeSpan)
+``` csharp
+protected void DelayDeactivation(TimeSpan timeSpan)
+```
 
 This call will delay deactivation of this activation for at least the specified time duration.
 

--- a/Advanced-Concepts/Application-Bootstrap-within-a-Silo.md
+++ b/Advanced-Concepts/Application-Bootstrap-within-a-Silo.md
@@ -12,23 +12,27 @@ Some examples include, but are not limited to:
 
 We have now added support for this auto-run functionality through configuring "bootstrap providers" for Orleans silos. For example:
 
-    <OrleansConfiguration xmlns="urn:orleans">
-      <Globals>
-        <BootstrapProviders>
-          <Provider Type="My.App.BootstrapClass1" Name="bootstrap1" />
-          <Provider Type="My.App.BootstrapClass2" Name="bootstrap2" />
-        </BootstrapProviders>
-      </Globals>
-    </OrleansConfiguration>
+``` xml
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <BootstrapProviders>
+      <Provider Type="My.App.BootstrapClass1" Name="bootstrap1" />
+      <Provider Type="My.App.BootstrapClass2" Name="bootstrap2" />
+    </BootstrapProviders>
+  </Globals>
+</OrleansConfiguration>
+```
 
  These bootstrap providers are C# classes that implement the Orleans.IBootstrapProvider interface.
 
 When each silo starts up, the Orleans runtime will instantiate each of the listed app bootstrap classes, and then call their Init method in an appropriate runtime execution context that allows those classes to act as a client and send messages to grains.
 
-    Task Init(
-        string name, 
-        IProviderRuntime providerRuntime, 
-        IProviderConfiguration config)
+``` csharp
+Task Init(
+    string name, 
+    IProviderRuntime providerRuntime, 
+    IProviderConfiguration config)
+```
 
 Any Exceptions that are thrown from an Init method of a bootstrap provider will be reported by the Orleans runtime in the silo log, then the silo startup will be halted. 
 

--- a/Advanced-Concepts/Configuring-.NET-Garbage-Collection.md
+++ b/Advanced-Concepts/Configuring-.NET-Garbage-Collection.md
@@ -6,12 +6,13 @@ title: Configuring .NET Garbage Collection
 
 For good performance, is it important to configure .NET garbage collection for the silo process the right way. The best combination of settings we found if to set gcServer=true and gcConcurrent=false. The are easy to set via the application config file in case a silo runs as a standalone process. You can use OrleansHost.exe.config in SDK\LocalSilo directory of the Orleans SDK as an example.
 
-    <configuration>
-        <runtime>
-            <gcServer enabled="true"/>
-            <gcConcurrent enabled="false"/>
-        </runtime>
-    </configuration>
-
+``` xml
+<configuration>
+  <runtime>
+    <gcServer enabled="true"/>
+    <gcConcurrent enabled="false"/>
+  </runtime>
+</configuration>
+```
 
 However, this is not as easy to do if a silo runs as part of an Azure Worker Role, which by default is configured to use workstation GC. This blog post shows how to set the same configuration for an Azure Worker Role -  http://blogs.msdn.com/b/cclayton/archive/2014/06/05/server-garbage-collection-mode-in-microsoft-azure.aspx

--- a/Advanced-Concepts/Timers-and-Reminders.md
+++ b/Advanced-Concepts/Timers-and-Reminders.md
@@ -16,7 +16,9 @@ The Orleans runtime provides two mechanisms, called timers and reminders, that e
 ## Usage
 To start a timer, use the **Grain.RegisterTimer** method, which returns an  **IDisposable** reference:
 
-    protected IDisposable RegisterTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
+``` csharp
+protected IDisposable RegisterTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
+```    
 
 * asyncCallback is the function to be invoked when the timer ticks. 
 * state is an object that will be passed to asyncCallback when the timer ticks. 
@@ -46,15 +48,16 @@ To start a timer, use the **Grain.RegisterTimer** method, which returns an  **ID
 ## Configuration
 Reminders, being persistent, rely upon storage to function. You must specify which storage backing to use before the reminder subsystem will function. The reminder functionality is controlled by the SystemStore element in the server-side configuration. It works with either Azure Table or SQL Server as the store.
 
-     <SystemStore SystemStoreType="AzureTable" /> OR 
-     <SystemStore SystemStoreType="SqlServer" />
-
+``` xml
+<SystemStore SystemStoreType="AzureTable" /> OR 
+<SystemStore SystemStoreType="SqlServer" />
+```
 
  If you just want a placeholder implementation of reminders to work with without needing to set up an Azure account or SQL database, then adding this element to the configuration file (under 'Globals') will give you a development-only implementation of the reminder system:
 
-
-    <ReminderService ReminderServiceType="ReminderTableGrain"/>
-
+``` xml
+<ReminderService ReminderServiceType="ReminderTableGrain"/>
+```
 
 ## Usage
 A grain that uses reminders must implement the **IRemindable.RecieveReminder **method.

--- a/Convert-Orleans-v0.9-csproj-to-Use-v1.0-NuGet.md
+++ b/Convert-Orleans-v0.9-csproj-to-Use-v1.0-NuGet.md
@@ -22,21 +22,25 @@ Steps to to change Orleans Grain Interface project:
 
 1. Do Build->Clean on the project to remove any old binaries.
 2. Remove old v0.9 assembly references for any Orleans binaries.
-```
-<ItemGroup>
-    <Reference Include="Orleans">
-          <HintPath>$(OrleansSDK)\Binaries\OrleansClient\Orleans.dll</HintPath>
-          <Private>False</Private>
-     </Reference>
-</ItemGroup>
-```
+
+	``` xml
+	<ItemGroup>
+	    <Reference Include="Orleans">
+	          <HintPath>$(OrleansSDK)\Binaries\OrleansClient\Orleans.dll</HintPath>
+	          <Private>False</Private>
+	     </Reference>
+	</ItemGroup>
+	```
+
 3. Remove old v0.9 Orleans code-gen metadata and script trigger.
-```
-<PropertyGroup>
-      <OrleansProjectType>Server</OrleansProjectType>
-</PropertyGroup>
-<Import Project="$(OrleansSDK)\Binaries\OrleansClient\Orleans.SDK.targets" />
-```
+
+	``` xml
+	<PropertyGroup>
+	      <OrleansProjectType>Server</OrleansProjectType>
+	</PropertyGroup>
+	<Import Project="$(OrleansSDK)\Binaries\OrleansClient\Orleans.SDK.targets" />
+	```
+	
 4. **Make sure to re-save the .csproj to disk at this point, otherwise the next step will fail !**
 5. Use Visual Studio Package manager to add the `Microsoft.Orleans.Templates.Interfaces` package to the grain interfaces project.
   * Do this by right-click on project node in Solution Explorer, select "Manage NuGet Packages..." context menu item, then search for **Orleans** and select the `Microsoft.Orleans.Templates.Interfaces` package.

--- a/Orleans-Configuration-Guide/Client-Configuration.md
+++ b/Orleans-Configuration-Guide/Client-Configuration.md
@@ -9,12 +9,13 @@ The key parameter that has to be configured for a client is the silo’s client 
 ## Fixed Gateway Configuration 
 A fixed set of gateways is specified in the ClientConfiguration.xml with one or more Gateway nodes:
 
-    <ClientConfiguration xmlns="urn:orleans">
-        <Gateway Address="gateway1" Port="30000"/>
-        <Gateway Address="gateway2" Port="30000"/>
-        <Gateway Address="gateway3" Port="30000"/>
-    </ClientConfiguration>
-
+``` xml
+<ClientConfiguration xmlns="urn:orleans">
+  <Gateway Address="gateway1" Port="30000"/>
+  <Gateway Address="gateway2" Port="30000"/>
+  <Gateway Address="gateway3" Port="30000"/>
+</ClientConfiguration>
+```
 
  One gateway is generally enough. Multiple gateway connections help increase throughput and reliability of the system.
 
@@ -22,53 +23,59 @@ A fixed set of gateways is specified in the ClientConfiguration.xml with one or 
 To configure the client to automatically find gateways from the silo cluster membership table, you need to specify the Azure Table or SQL Server connection string and the target deployment ID.
 
 
-    <ClientConfiguration xmlns="urn:orleans">
-        <SystemStore SystemStoreType="AzureTable"
-                     DeploymentId="target deployment ID"
-                     DataConnectionString="Azure storage connection string"/>
-    </ClientConfiguration>
+``` xml
+<ClientConfiguration xmlns="urn:orleans">
+  <SystemStore SystemStoreType="AzureTable"
+               DeploymentId="target deployment ID"
+               DataConnectionString="Azure storage connection string"/>
+</ClientConfiguration>
+```
 
  or 
 
-    <ClientConfiguration xmlns="urn:orleans">
-        <SystemStore SystemStoreType="SqlServer"
-                     DeploymentId="target deployment ID"
-                     DataConnectionString="SQL connection string"/>
-    </ClientConfiguration>
-
+``` xml
+<ClientConfiguration xmlns="urn:orleans">
+  <SystemStore SystemStoreType="SqlServer"
+               DeploymentId="target deployment ID"
+               DataConnectionString="SQL connection string"/>
+</ClientConfiguration>
+```
 
 
 ## Local Silo
 For the local development/test configuration that uses a local silo, the client gateway should be configured to 'localhost.'
 
 
-    <ClientConfiguration xmlns="urn:orleans">
-        <Gateway Address="localhost" Port="30000"/>
-    </ClientConfiguration>
-
+``` xml
+<ClientConfiguration xmlns="urn:orleans">
+  <Gateway Address="localhost" Port="30000"/>
+</ClientConfiguration>
+```
 
 ## Web Role Client in Azure
 When the client is a web role running inside the same Azure deployment as the silo worker roles, all gateway address information is read from the OrleansSiloInstances table when OrleansAzureClient.Initialize() is called. The Azure storage connection string used to find the correct OrleansSiloInstances table is specified in the "DataConnectionString" setting defined in the service configuration for the deployment & role. 
 
 
-    <ServiceConfiguration  ...>
-        <Role name="WebRole"> ...
-            <ConfigurationSettings>
-                <Setting name="DataConnectionString" value="DefaultEndpointsProtocol=https;AccountName=MYACCOUNTNAME;AccountKey=MYACCOUNTKEY" />
-            </ConfigurationSettings>
-        </Role>
-        ... 
-    </ServiceConfiguration>
-
+``` xml
+<ServiceConfiguration  ...>
+  <Role name="WebRole"> ...
+    <ConfigurationSettings>
+      <Setting name="DataConnectionString" value="DefaultEndpointsProtocol=https;AccountName=MYACCOUNTNAME;AccountKey=MYACCOUNTKEY" />
+    </ConfigurationSettings>
+  </Role>
+  ... 
+</ServiceConfiguration>
+```
 
 Both the silo worker roles and web client roles need to be use the same Azure storage account in order to successfully discover each other successfully.
 
 When using OrleansAzureClient.Initialize() and OrleansSiloInstances table for gateway address discovery, no additional gateway address info in required in the client config file. Typically the ClientConfiguration.xml file will only contain some minimal debug / tracing configuration settings, although even that is not required.
 
 
-    <ClientConfiguration xmlns="urn:orleans">
-        <Tracing DefaultTraceLevel="Info" >
-            <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
-        </Tracing>
-    </ClientConfiguration>
-
+``` xml
+<ClientConfiguration xmlns="urn:orleans">
+  <Tracing DefaultTraceLevel="Info" >
+    <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
+  </Tracing>
+</ClientConfiguration>
+```

--- a/Orleans-Configuration-Guide/Server-Configuration.md
+++ b/Orleans-Configuration-Guide/Server-Configuration.md
@@ -18,9 +18,9 @@ The connectivity settings define two TCP/IP endpoints: one for inter-silo commun
 
 **Inter-silo Endpoint**
 
-
-    <Networking Address=" " Port="11111" />
-
+``` xml
+<Networking Address=" " Port="11111" />
+```
 
  Address: IP address or host name to use. If left empty, silo will pick the first available IPv4 address. Orleans supports IPv6 as well as IPv4.
 
@@ -31,16 +31,18 @@ The connectivity settings define two TCP/IP endpoints: one for inter-silo commun
  For local development environment, you can simply use localhost as the host name:
 
 
-    <Networking Address="localhost" Port="11111" />
-
+``` xml
+<Networking Address="localhost" Port="11111" />
+```
 
 ## Client Gateway Endpoint
 
  The setting for client gateway endpoint is identical to the inter-silo endpoint except for the XML element name:
 
 
-     <ProxyingGateway Address="localhost" Port="30000" />
-
+``` xml
+<ProxyingGateway Address="localhost" Port="30000" />
+```
 
  You have to specify a port number different from the one used for the inter-silo endpoint.
 
@@ -53,26 +55,28 @@ The connectivity settings define two TCP/IP endpoints: one for inter-silo commun
  For reliable management of cluster membership, Orleans uses the Azure Table or SQL Server for synchronization of nodes. The reliable membership setup requires configuring the 'SystemStore' element settings in the silo configuration file:
 
 
-     <SystemStore SystemStoreType ="AzureTable"
+``` xml
+<SystemStore SystemStoreType="AzureTable"
              DeploymentId="..."
              DataConnectionString="..."/>
-
+```
 
  or 
 
-
-     <SystemStore SystemStoreType ="SqlServer"
+``` xml
+<SystemStore SystemStoreType="SqlServer"
              DeploymentId="..."
              DataConnectionString="..."/>
-
+```
 
  DeploymentId is a unique string that defines a particular deployment. When deploying an Orleans based service to Azure it makes most sense to use the Azure deployment ID of the worker role.
 
  For development or if it’s not possible to use Azure Table, silos can be configured to use the membership grain instead. Such a configuration is unreliable as it will not survive a failure of the primary silo that hosts the membership grain. “MembershipTableGrain” is the default value of LivenessType.
 
 
-    <Liveness LivenessType ="MembershipTableGrain" />
-
+``` xml
+<Liveness LivenessType ="MembershipTableGrain" />
+```
 
 ## Primary Silo
 In a reliable deployment, one that is configured with membership using Azure Table, all silos are created equal, with no notion of primary or secondary silos. That is the configuration that is recommended for production that will survive a failure of any individual node or a combination of nodes. For example, Azure periodically rolls out OS patches and that causes all of the role instances to reboot eventually.
@@ -82,5 +86,7 @@ In a reliable deployment, one that is configured with membership using Azure Tab
  In a non-Azure environment, Primary is designated in the configuration file with the following setting within the Globals section.
 
 
-    <SeedNode Address="<host name or IP address of the primary node>" Port="11111" />
+``` xml
+<SeedNode Address="<host name or IP address of the primary node>" Port="11111" />
+```
 

--- a/Orleans-Configuration-Guide/Typical-Configurations.md
+++ b/Orleans-Configuration-Guide/Typical-Configurations.md
@@ -9,23 +9,25 @@ Below are examples of typical configurations that can be used for development an
 ## Local Development 
 For local development, where there is only one silo running locally on the programmer’s machine, the configuration is already included in the SDK. The local silo that can be started with the StartLocalSilo.cmd script in the top Orleans SDK folder is configured as follows.
 
-    <OrleansConfiguration xmlns="urn:orleans">
-        <Globals>
-            <SeedNode Address="localhost" Port="11111" />
-        </Globals>
-        <Defaults>
-            <Networking Address="localhost" Port="11111" />
-            <ProxyingGateway Address="localhost" Port="30000" />
-        </Defaults>
-    </OrleansConfiguration>
-
+``` xml
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <SeedNode Address="localhost" Port="11111" />
+  </Globals>
+  <Defaults>
+    <Networking Address="localhost" Port="11111" />
+    <ProxyingGateway Address="localhost" Port="30000" />
+  </Defaults>
+</OrleansConfiguration>
+```
 
 To connect to the local silo, the client needs to be configured to localhost and can only connect from the same machine.
 
-    <ClientConfiguration xmlns="urn:orleans">
-        <Gateway Address="localhost" Port="30000"/>
-    </ClientConfiguration>
-
+``` xml
+<ClientConfiguration xmlns="urn:orleans">
+  <Gateway Address="localhost" Port="30000"/>
+</ClientConfiguration>
+```
 
 ## Reliable Production Deployment 
 For a reliable production deployment, you need to use the Azure Table option for cluster membership. This configuration is typical of deployments to either on-premise servers or Azure virtual machine instances.
@@ -33,127 +35,137 @@ For a reliable production deployment, you need to use the Azure Table option for
  The format of the DataConnection string is "DefaultEndpointsProtocol=https;AccountName=<Azure storage account>;AccountKey=<Azure table storage account key>"
 
 
-    <OrleansConfiguration xmlns="urn:orleans">
-        <Globals>
-            <Liveness LivenessType ="AzureTable" />
-            <Azure DeploymentId="<your deployment ID>" DataConnectionString="<<see comment above>>"/>
-        </Globals>
-        <Defaults>
-            <Networking Address="" Port="11111" />
-            <ProxyingGateway Address="" Port="30000" />
-        </Defaults>
-    </OrleansConfiguration>
-
+``` xml
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <Liveness LivenessType ="AzureTable" />
+    <Azure DeploymentId="<your deployment ID>" DataConnectionString="<<see comment above>>"/>
+  </Globals>
+  <Defaults>
+    <Networking Address="" Port="11111" />
+    <ProxyingGateway Address="" Port="30000" />
+  </Defaults>
+</OrleansConfiguration>
+```
 
 Clients need to be configured to use Azure Table for discovering the gateways, the addresses of the Orleans servers are not statically known to the clients.
 
-    <ClientConfiguration xmlns="urn:orleans">
-        <Azure DeploymentId="target deployment ID" DataConnectionString="<<see comment above>>"/>
-    </ClientConfiguration>
-
+``` xml
+<ClientConfiguration xmlns="urn:orleans">
+  <Azure DeploymentId="target deployment ID" DataConnectionString="<<see comment above>>"/>
+</ClientConfiguration>
+```
 
 ## Unreliable Deployment on a Cluster of Dedicated Servers 
 For testing on a cluster of dedicated servers when reliability isn’t a concern you can leverage MembershipTableGrain and avoid dependency on Azure Table. You just need to designate one of the nodes as a Primary.
 
-
-    <OrleansConfiguration xmlns="urn:orleans">
-        <Globals>
-            <SeedNode Address="<primary node>" Port="11111" />
-            <Liveness LivenessType ="MembershipTableGrain" />
-        </Globals>
-        <Defaults>
-            <Networking Address=" " Port="11111" />
-            <ProxyingGateway Address=" " Port="30000" />
-        </Defaults>
-    </OrleansConfiguration>
-
+``` xml
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <SeedNode Address="<primary node>" Port="11111" />
+    <Liveness LivenessType ="MembershipTableGrain" />
+  </Globals>
+  <Defaults>
+    <Networking Address=" " Port="11111" />
+    <ProxyingGateway Address=" " Port="30000" />
+  </Defaults>
+</OrleansConfiguration>
+```
 
  For the client:
 
-
-    <ClientConfiguration xmlns="urn:orleans">
-        <Gateway Address="node-1" Port="30000"/>
-        <Gateway Address="node-2" Port="30000"/>
-        <Gateway Address="node-3" Port="30000"/>
-    </ClientConfiguration>
-
+``` xml
+<ClientConfiguration xmlns="urn:orleans">
+  <Gateway Address="node-1" Port="30000"/>
+  <Gateway Address="node-2" Port="30000"/>
+  <Gateway Address="node-3" Port="30000"/>
+</ClientConfiguration>
+```
 
 ## Azure Worker Role Deployment
 When Orleans is deployed into an Azure Worker role, as opposed to VM instances, most of the server-side configuration is actually done in files other than the OrleansConfiguration, which looks something like this:
 
 
-     <OrleansConfiguration xmlns="urn:orleans">
-        <Globals>
-          <Liveness LivenessType="AzureTable" />
-       </Globals>
-       <Defaults>
-          <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" />
-       </Defaults>
-    </OrleansConfiguration>
-
+``` xml
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <Liveness LivenessType="AzureTable" />
+  </Globals>
+  <Defaults>
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" />
+  </Defaults>
+</OrleansConfiguration>
+```
 
  Some information is kept in the service configuration file, in which the worker role section looks like this:
 
-    <Role name="OrleansAzureSilos">
-        <Instances count="2" />
-        <ConfigurationSettings>
-          <Setting name="DataConnectionString" value="<<see earlier comment>>" />
-          <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="<<see earlier comment>>" />
-        </ConfigurationSettings>
-      </Role>
-
+``` xml
+<Role name="OrleansAzureSilos">
+  <Instances count="2" />
+  <ConfigurationSettings>
+    <Setting name="DataConnectionString" value="<<see earlier comment>>" />
+    <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="<<see earlier comment>>" />
+  </ConfigurationSettings>
+</Role>
+```
 
 The data connection string and the diagnostics connection string do not have to be the same.
 
 Some configuration information is kept in the service definition file. The worker role has to be configured there, too:
 
-      <WorkerRole name="OrleansAzureSilos" vmsize="Large">
-        <Imports>
-          <Import moduleName="Diagnostics" />
-        </Imports>
-        <ConfigurationSettings>
-          <Setting name="DataConnectionString" />
-       </ConfigurationSettings>
-       <LocalResources>
-          <LocalStorage name="LocalStoreDirectory" cleanOnRoleRecycle="false" />
-       </LocalResources>
-       <Endpoints>
-          <InternalEndpoint name="OrleansSiloEndpoint" protocol="tcp" port="11111" />
-          <InternalEndpoint name="OrleansProxyEndpoint" protocol="tcp" port="30000" />
-        </Endpoints>
-      </WorkerRole>
-
+``` xml
+<WorkerRole name="OrleansAzureSilos" vmsize="Large">
+  <Imports>
+    <Import moduleName="Diagnostics" />
+  </Imports>
+  <ConfigurationSettings>
+    <Setting name="DataConnectionString" />
+  </ConfigurationSettings>
+  <LocalResources>
+    <LocalStorage name="LocalStoreDirectory" cleanOnRoleRecycle="false" />
+  </LocalResources>
+  <Endpoints>
+    <InternalEndpoint name="OrleansSiloEndpoint" protocol="tcp" port="11111" />
+    <InternalEndpoint name="OrleansProxyEndpoint" protocol="tcp" port="30000" />
+  </Endpoints>
+</WorkerRole>
+```
 
 That's it for the worker role hosting the Orleans runtime. However, when deploying to Azure, there is typically a front end of some sort, either a web site or a web service, since making the Orleans ports public is not a good idea. Therefore, the client configuration is configuration of the web or worker role (or web site) that sits in front of Orleans.
 
  Assuming that the frontend is a web role, a simple ClientConfiguration file should be used:
 
-    <ClientConfiguration xmlns="urn:orleans">
-	    <Tracing DefaultTraceLevel="Info" 
-                     TraceToConsole="true" 
-                     TraceToFile="{0}-{1}.log"
-                     WriteTraces="false"/>
-    </ClientConfiguration>
+``` xml
+<ClientConfiguration xmlns="urn:orleans">
+  <Tracing DefaultTraceLevel="Info" 
+           TraceToConsole="true" 
+           TraceToFile="{0}-{1}.log"
+           WriteTraces="false"/>
+</ClientConfiguration>
+```
 
  The web role needs the same connection string information as the worker role, in the service configuration file:
 
-      <Role name="WebRole">
-        <Instances count="2" />
-        <ConfigurationSettings>
-          <Setting name="DataConnectionString" value="<<see earlier comment>>" />
-          <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="<<see earlier comment>>" />
-        </ConfigurationSettings>
-      </Role>
+``` xml
+<Role name="WebRole">
+  <Instances count="2" />
+  <ConfigurationSettings>
+    <Setting name="DataConnectionString" value="<<see earlier comment>>" />
+    <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="<<see earlier comment>>" />
+  </ConfigurationSettings>
+</Role>
+```
 
  and in the service definition file:
 
-      <WebRole name="WebRole" vmsize="Large">
-        <Imports>
-          <Import moduleName="Diagnostics" />
-        </Imports>
-        <ConfigurationSettings>
-          <Setting name="DataConnectionString" />
-        </ConfigurationSettings>
-       <!-- There is additional web role data that has nothing to do with Orleans -->
-     </WebRole>
-
+``` xml
+<WebRole name="WebRole" vmsize="Large">
+  <Imports>
+    <Import moduleName="Diagnostics" />
+  </Imports>
+  <ConfigurationSettings>
+    <Setting name="DataConnectionString" />
+  </ConfigurationSettings>
+  <!-- There is additional web role data that has nothing to do with Orleans -->
+</WebRole>
+```


### PR DESCRIPTION
Pygments syntax highlighter also supports xml code (although in a kind of limited way). I added it for some documentation files. I've also normalized xml indentation in a few places (to use 2 spaces as it seems to be most frequently used value and it is a default setting in VS).

Example: https://ksuszka.github.io/orleans/Orleans-Configuration-Guide/Typical-Configurations