### PR TITLE
Re-enabled check for minimal allowed Activation CG AgeLimit that was enabled only in DEBUG mode.

### DIFF
--- a/src/Orleans/Configuration/ConfigUtilities.cs
+++ b/src/Orleans/Configuration/ConfigUtilities.cs
@@ -458,13 +458,11 @@ namespace Orleans.Runtime.Configuration
             if (!xmlElement.HasAttribute("AgeLimit"))
                 throw new ArgumentException("The AgeLimit attribute is required for a <Deactivate/> element.");
             TimeSpan ageLimit = ParseTimeSpan(xmlElement.GetAttribute("AgeLimit"), "Invalid TimeSpan value for Deactivation.AgeLimit");
-#if DEBUG
             TimeSpan minAgeLimit = GlobalConfiguration.DEFAULT_COLLECTION_QUANTUM;
             if (ageLimit < minAgeLimit)
             {
                 throw new ArgumentException(string.Format("The AgeLimit attribute is required to be at least {0}.", minAgeLimit));
             }
-#endif
             return ageLimit;
         }
 


### PR DESCRIPTION
That was a fun one!
We had the check for minimal allowed Activation CG AgeLimit  when config is loaded (causing silo to fail to start early if misconfigured), but the check was performed only under DEBUG for some reason. As a result silo started misconfigured and was failing to activate new grains later on.