### PR TITLE
avoid NullReferenceException in FindAppDirectoryLocations()

### DIFF
--- a/src/OrleansAzureUtils/AzureConfigUtils.cs
+++ b/src/OrleansAzureUtils/AzureConfigUtils.cs
@@ -157,9 +157,12 @@ namespace Orleans.Runtime.Host
             }
 
             // Try using Server.MapPath to resolve for web roles running in IIS web apps
-            appRootPath = HttpContext.Current.Server.MapPath(@"~\");
-            if (appRootPath != null) 
-                yield return new DirectoryInfo(appRootPath);
+            if (HttpContext.Current != null)
+            {
+                appRootPath = HttpContext.Current.Server.MapPath(@"~\");
+                if (appRootPath != null)
+                    yield return new DirectoryInfo(appRootPath);
+            }
 
             // Try using HostingEnvironment.MapPath to resolve for web roles running in IIS Express
             // https://orleans.codeplex.com/discussions/547617


### PR DESCRIPTION
The code was throwing an exception in my client (a WorkerRole) because HttpContext.Current is null.

I think the fix is simple (just add a check for null). Since these directory locations are just a  best-effort search, there is no harm in excluding one of the locations.