### PR TITLE
Added direct link to Orleans NuGets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Orleans - Distributed Actor Model
 =======
 
 [![Build status](http://dotnet-ci.cloudapp.net/job/dotnet_orleans/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_orleans/)
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.Orleans.Core.svg?style=flat)](http://www.nuget.org/profiles/Orleans)
 
 Orleans is a framework that provides a straight-forward approach to building distributed high-scale computing applications, without the need to learn and apply complex concurrency or other scaling patterns. 
 It was created by [Microsoft Research][MSR-ProjectOrleans] and designed for use in the cloud. 


### PR DESCRIPTION
The image shows the latest version of Microsoft.Orleans.Core package, while the link points to all NuGets. Not sure if this is the right way. Maybe it would be better if the link pointed to Microsoft.Orleans.Core.

[Copied from https://github.com/Microsoft/bond/blob/master/README.md]