### PR TITLE
generate implicit subscription ids

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Providers\IProviderRuntime.cs" />
     <Compile Include="Statistics\ThreadCycleStopWatch.cs" />
     <Compile Include="Streams\PubSub\PubSubSubscriptionState.cs" />
+    <Compile Include="Streams\PubSub\SubscriptionMarker.cs" />
     <Compile Include="Streams\SimpleMessageStream\SimpleMessageStreamProducer.cs" />
     <Compile Include="Streams\PersistentAdapter\IBatchContainer.cs" />
     <Compile Include="Streams\PersistentAdapter\IQueueAdapter.cs" />

--- a/src/Orleans/Streams/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans/Streams/PubSub/ImplicitStreamSubscriberTable.cs
@@ -106,30 +106,78 @@ namespace Orleans.Streams
         /// <returns>true if the grain id describes an implicit subscriber of the stream described by the stream id.</returns>
         internal bool IsImplicitSubscriber(GrainId grainId, StreamId streamId)
         {
-            if (String.IsNullOrWhiteSpace(streamId.Namespace))
+            return HasImplicitSubscription(streamId.Namespace, grainId.GetTypeCode());
+        }
+
+        /// <summary>
+        /// Try to get the implicit subscriptionId.
+        /// If an implicit subscription exists, return a subscription Id that is unique per grain type, grainId, namespace combination.
+        /// </summary>
+        /// <param name="grainId"></param>
+        /// <param name="streamId"></param>
+        /// <param name="subscriptionId"></param>
+        /// <returns></returns>
+        internal bool TryGetImplicitSubscriptionGuid(GrainId grainId, StreamId streamId, out Guid subscriptionId)
+        {
+            subscriptionId = Guid.Empty;
+
+            if (!HasImplicitSubscription(streamId.Namespace, grainId.GetTypeCode()))
+            {
+                return false;
+            }
+
+            // make subscriptionId
+            subscriptionId = MakeSubscriptionGuid(grainId, streamId);
+
+            return true;
+        }
+
+        /// <summary>
+        // Create a subscriptionId that is unique per grainId, grainType, namespace combination.
+        /// </summary>
+        /// <param name="grainId"></param>
+        /// <param name="streamId"></param>
+        /// <returns></returns>
+        private Guid MakeSubscriptionGuid(GrainId grainId, StreamId streamId)
+        {
+            // first int in guid is grain type code
+            int grainIdTypeCode = grainId.GetTypeCode();
+
+            // next 2 shorts ing guid are from namespace hash
+            int namespaceHash = streamId.Namespace.GetHashCode();
+            byte[] namespaceHashByes = BitConverter.GetBytes(namespaceHash);
+            short s1 = BitConverter.ToInt16(namespaceHashByes, 0);
+            short s2 = BitConverter.ToInt16(namespaceHashByes, 2);
+
+            // Tailing 8 bytes of the guid are from the hash of the streamId Guid and a hash of the full streamId.
+
+            // get streamId guid hash code
+            int streamIdGuidHash = streamId.Guid.GetHashCode();
+            // get full streamId hash code
+            int streamIdHash = streamId.GetHashCode();
+
+            // build guid tailing 8 bytes from grainIdHash and the hash of the full streamId.
+            var tail = new List<byte>();
+            tail.AddRange(BitConverter.GetBytes(streamIdGuidHash));
+            tail.AddRange(BitConverter.GetBytes(streamIdHash));
+
+            // make guid.
+            // - First int is grain type
+            // - Two shorts from namespace hash
+            // - 8 byte tail from streamId Guid and full stream hash.
+            return SubscriptionMarker.MarkAsImplictSubscriptionId(new Guid(grainIdTypeCode, s1, s2, tail.ToArray()));
+        }
+
+        private bool HasImplicitSubscription(string streamNamespace, int grainIdTypeCode)
+        {
+            if (String.IsNullOrWhiteSpace(streamNamespace))
             {
                 return false;
             }
 
             HashSet<int> entry;
-            return table.TryGetValue(streamId.Namespace, out entry) && entry.Contains(grainId.GetTypeCode());
-        }
-
-        /// <summary>
-        /// Determines whether the specified subscription is an implicit subscriber of a given stream.
-        /// </summary>
-        /// <param name="subscriptionId">The subscription identifier.</param>
-        /// <param name="streamId">The stream identifier.</param>
-        /// <returns>true if the subscription id describes an implicit subscriber of the stream described by the stream id.</returns>
-        internal bool IsImplicitSubscriber(GuidId subscriptionId, StreamId streamId)
-        {
-            if (String.IsNullOrWhiteSpace(streamId.Namespace))
-            {
-                return false;
-            }
-
-            // TODO: Get from table once static subscriptionId generation is added. Until then, implicit subscriptionIds can be recognized by having the same value as the streamId.
-            return subscriptionId.Equals(GuidId.GetGuidId(streamId.Guid));
+            return (table.TryGetValue(streamNamespace, out entry) && // if we don't have implictit subscriptions for this namespace, fail out
+                    entry.Contains(grainIdTypeCode));                 // if we don't have an implicit subscription for this type of grain on this namespace, fail out
         }
 
         /// <summary>

--- a/src/Orleans/Streams/PubSub/SubscriptionMarker.cs
+++ b/src/Orleans/Streams/PubSub/SubscriptionMarker.cs
@@ -1,0 +1,70 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+
+namespace Orleans.Streams
+{
+    /// <summary>
+    /// Mark a subscriptionId as either an implicit subscription Id, or a explicit subscription Id.
+    /// high bit of last byte in guild is the subscription type flag.
+    /// 1: implicit subscription
+    /// 0: explicit subscription
+    /// </summary>
+    internal static class SubscriptionMarker
+    {
+        internal static Guid MarkAsExplicitSubscriptionId(Guid subscriptionGuid)
+        {
+            return MarkSubscriptionGuid(subscriptionGuid, false);
+        }
+
+        internal static Guid MarkAsImplictSubscriptionId(Guid subscriptionGuid)
+        {
+            return MarkSubscriptionGuid(subscriptionGuid, true);
+        }
+
+        internal static bool IsImplicitSubscription(Guid subscriptionGuid)
+        {
+            byte[] guidBytes = subscriptionGuid.ToByteArray();
+            // return true if high bit of last byte is set
+            return guidBytes[guidBytes.Length - 1] == (byte)(guidBytes[guidBytes.Length - 1] | 0x80);
+        }
+
+        private static Guid MarkSubscriptionGuid(Guid subscriptionGuid, bool isImplicitSubscription)
+        {
+            byte[] guidBytes = subscriptionGuid.ToByteArray();
+            if (isImplicitSubscription)
+            {
+                // set high bit of last byte
+                guidBytes[guidBytes.Length - 1] = (byte)(guidBytes[guidBytes.Length - 1] | 0x80);
+            }
+            else
+            {
+                // clear high bit of last byte
+                guidBytes[guidBytes.Length - 1] = (byte)(guidBytes[guidBytes.Length - 1] & 0x7f);
+            }
+
+            return new Guid(guidBytes);
+        }
+    }
+}

--- a/src/TesterInternal/OrleansRuntime/Streams/SubscriptionMarkerTests.cs
+++ b/src/TesterInternal/OrleansRuntime/Streams/SubscriptionMarkerTests.cs
@@ -1,0 +1,59 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans.Streams;
+
+namespace UnitTests.OrleansRuntime.Streams
+{
+    [TestClass]
+    public class SubscriptionMarkerTests
+    {
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        public void MarkAsImplicitSubscriptionTest()
+        {
+            Guid guid = Guid.Empty;
+
+            Assert.IsFalse(SubscriptionMarker.IsImplicitSubscription(guid));
+
+            Guid markedGuid = SubscriptionMarker.MarkAsImplictSubscriptionId(guid);
+
+            Assert.IsTrue(SubscriptionMarker.IsImplicitSubscription(markedGuid));
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        public void MarkAsExplicitSubscriptionTest()
+        {
+            byte[] guidBytes = Enumerable.Range(0, 16).Select(i => (byte)0xff).ToArray();
+            var guid = new Guid(guidBytes);
+
+            Assert.IsTrue(SubscriptionMarker.IsImplicitSubscription(guid));
+
+            Guid markedGuid = SubscriptionMarker.MarkAsExplicitSubscriptionId(guid);
+
+            Assert.IsFalse(SubscriptionMarker.IsImplicitSubscription(markedGuid));
+        }
+    }
+}

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -51,7 +51,7 @@
     <Reference Include="Microsoft.Data.Services.Client">
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.WindowsAzure.Configuration">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -51,7 +51,7 @@
     <Reference Include="Microsoft.Data.Services.Client">
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.WindowsAzure.Configuration">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="General\Identifiertests.cs" />
     <Compile Include="OrleansRuntime\Streams\BestFitBalancerTests.cs" />
+    <Compile Include="OrleansRuntime\Streams\SubscriptionMarkerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>


### PR DESCRIPTION
Implicit subscription Ids are currently the same as the streamId's guid.  This will break if there is more than one grain configured to implicitly subscribe to a stream with the same namespace.  To solve this, we generate implicit subscription ids unique per streamId (Guid and namespace) + grainTypeCode combination.
