### PR TITLE
Fixed handling of generic parameter names

### DIFF
--- a/src/ClientGenerator/CSharpCodeGenerator.cs
+++ b/src/ClientGenerator/CSharpCodeGenerator.cs
@@ -521,10 +521,9 @@ namespace Orleans.CodeGeneration
             foreach (var paramInfo in parameters)
             {
                 if (paramInfo.ParameterType.GetInterface("Orleans.Runtime.IAddressable") != null && !typeof(GrainReference).IsAssignableFrom(paramInfo.ParameterType))
-                    invokeArguments += string.Format("{0} is global::Orleans.Grain ? {0}.AsReference<{2}.{1}>() : {0}",
+                    invokeArguments += string.Format("{0} is global::Orleans.Grain ? {0}.AsReference<{1}>() : {0}",
                         GetParameterName(paramInfo),
-                        paramInfo.ParameterType.Name,
-                        paramInfo.ParameterType.Namespace);
+                        TypeUtils.GetFullName(paramInfo.ParameterType));
                 else
                     invokeArguments += GetParameterName(paramInfo);
 

--- a/src/ClientGenerator/VBCodeGenerator.cs
+++ b/src/ClientGenerator/VBCodeGenerator.cs
@@ -525,10 +525,9 @@ Return System.Threading.Tasks.Task.FromResult(CObj(True))
             foreach (ParameterInfo paramInfo in parameters)
             {
                 if (paramInfo.ParameterType.GetInterface("Orleans.Runtime.IAddressable") != null && !typeof(GrainReference).IsAssignableFrom(paramInfo.ParameterType))
-                    invokeArguments += string.Format("If(typeof({0}) is Global.Orleans.Grain, {0}.AsReference<{2}.{1}>(),{0})",
+                    invokeArguments += string.Format("If(typeof({0}) is Global.Orleans.Grain, {0}.AsReference<{1}>(),{0})",
                         GetParameterName(paramInfo),
-                        paramInfo.ParameterType.Name,
-                        paramInfo.ParameterType.Namespace);
+                        TypeUtils.GetFullName(paramInfo.ParameterType));
                 else
                     invokeArguments += GetParameterName(paramInfo);
 


### PR DESCRIPTION
Fixed handling of generic parameter names in the generated code that converts references to grain activation objects into grain references. This is a fix for https://github.com/dotnet/orleans/issues/287.