### PR TITLE
Removed a Primary column in Silo Instance table.

### DIFF
--- a/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
@@ -172,10 +172,10 @@ namespace Orleans
     {
         public SiloAddress SiloAddress { get; set; }
 
-        public string HostName { get; set; }              // Mandatory
-        public SiloStatus Status { get; set; }                // Mandatory
-        public int ProxyPort { get; set; }             // Optional
-        public bool IsPrimary { get; set; }            // Optional - should be depricated
+        public string HostName { get; set; }          
+        public SiloStatus Status { get; set; }          
+        public int ProxyPort { get; set; }             
+        public bool IsPrimary { get; set; }           
 
         public string RoleName { get; set; }              // Optional - only for Azure role
         public string InstanceName { get; set; }          // Optional - only for Azure role

--- a/src/OrleansRuntime/MembershipService/AzureBasedMembershipTable.cs
+++ b/src/OrleansRuntime/MembershipService/AzureBasedMembershipTable.cs
@@ -214,8 +214,7 @@ namespace Orleans.Runtime.MembershipService
             if (!string.IsNullOrEmpty(tableEntry.ProxyPort))
                 parse.ProxyPort = int.Parse(tableEntry.ProxyPort);
 
-            if (!string.IsNullOrEmpty(tableEntry.Primary))
-                parse.IsPrimary = bool.Parse(tableEntry.Primary);
+            parse.IsPrimary = false; // there are no primaries with in Azure table.
 
             int port = 0;
             if (!string.IsNullOrEmpty(tableEntry.Port))
@@ -280,7 +279,6 @@ namespace Orleans.Runtime.MembershipService
                 HostName = memEntry.HostName,
                 Status = memEntry.Status.ToString(),
                 ProxyPort = memEntry.ProxyPort.ToString(CultureInfo.InvariantCulture),
-                Primary = memEntry.IsPrimary.ToString(),
                 RoleName = memEntry.RoleName,
                 InstanceName = memEntry.InstanceName,
                 UpdateZone = memEntry.UpdateZone.ToString(CultureInfo.InvariantCulture),

--- a/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
+++ b/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
@@ -216,23 +216,6 @@ namespace UnitTests.StorageTests
         }
 
         [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
-        public void SiloInstanceTable_FindPrimarySiloEndpoint()
-        {
-            RegisterSiloInstance();
-
-            IPEndPoint primary = manager.FindPrimarySiloEndpoint();
-            Assert.IsNull(primary, "Primary silo should not be found before Silo.Activate");
-
-            manager.ActivateSiloInstance(myEntry);
-
-            primary = manager.FindPrimarySiloEndpoint();
-            Assert.IsNotNull(primary, "Primary silo should be found after Silo.Activate");
-
-            Assert.AreEqual(myEntry.Address, primary.Address.ToString(), "Primary silo address");
-            Assert.AreEqual(myEntry.Port, primary.Port.ToString(CultureInfo.InvariantCulture), "Primary silo port");
-        }
-
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void SiloAddress_ToFrom_RowKey()
         {
             string ipAddress = "1.2.3.4";
@@ -274,7 +257,6 @@ namespace UnitTests.StorageTests
 
                 HostName = myEndpoint.Address.ToString(),
                 ProxyPort = "30000",
-                Primary = true.ToString(),
 
                 RoleName = "MyRole",
                 InstanceName = "MyInstance",
@@ -310,7 +292,6 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(referenceEntry.HostName, entry.HostName, "HostName");
             //Assert.AreEqual(referenceEntry.Status, entry.Status, "Status");
             Assert.AreEqual(referenceEntry.ProxyPort, entry.ProxyPort, "ProxyPort");
-            Assert.AreEqual(referenceEntry.Primary, entry.Primary, "Primary");
             Assert.AreEqual(referenceEntry.RoleName, entry.RoleName, "RoleName");
             Assert.AreEqual(referenceEntry.InstanceName, entry.InstanceName, "InstanceName");
             Assert.AreEqual(referenceEntry.UpdateZone, entry.UpdateZone, "UpdateZone");

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -51,7 +51,7 @@
     <Reference Include="Microsoft.Data.Services.Client">
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.WindowsAzure.Configuration">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
@@ -137,4 +137,3 @@ call "$(SolutionDir)Build\PostBuild.cmd"
   </Target>
   -->
 </Project>
-


### PR DESCRIPTION
Removed a Primary column in Silo Instance table.
It was deprecated years ago, but never removed. Found it while writing documentation for Runtime table.
In Orleans, all silos are equal, but some are more equal than others.