### PR TITLE
Handle the case when Dns.GetHostName returns "localhost"

### DIFF
--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -440,6 +440,10 @@ namespace Orleans.Runtime.Configuration
                 if (String.IsNullOrEmpty(addrOrHost))
                 {
                     addrOrHost = Dns.GetHostName();
+
+                    // If for some reason we get "localhost" back. This seems to have happened to somebody.
+                    if (addrOrHost.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+                        return loopback;
                 }
 
                 var candidates = new List<IPAddress>();


### PR DESCRIPTION
Handle the case when Dns.GetHostName returns "localhost", which appears to have happened in https://orleans.codeplex.com/discussions/616249.