### PR TITLE
Cluster deployment queue balancer

### DIFF
--- a/src/Orleans/Streams/PersistentStreams/StreamQueueBalancerType.cs
+++ b/src/Orleans/Streams/PersistentStreams/StreamQueueBalancerType.cs
@@ -25,9 +25,10 @@ using System;
 
 namespace Orleans.Streams
 {
-    internal enum StreamQueueBalancerType
+    public enum StreamQueueBalancerType
     {
         ConsistentRingBalancer, // Stream queue balancer that uses consistent ring provider for load balancing
-        AzureDeploymentBasedBalancer, // Stream queue balancer that uses azure deployment information and silo status for load balancing.  Requires silo running in azure.
+        AzureDeploymentBalancer, // Stream queue balancer that uses azure deployment information and silo status for load balancing.  Requires silo running in azure.
+        StaticClusterDeploymentBalancer, // Stream queue balancer that uses cluster configuration to determin deployment information and silo status for load balancing.  Does not support dynamic changes to cluster configuration.
     }
 }

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -209,12 +209,12 @@
     <Compile Include="Core\InsideGrainClient.cs" />
     <Compile Include="GrainTypeManager\TypeManager.cs" />
     <Compile Include="Silo\Watchdog.cs" />
-    <Compile Include="Streams\QueueBalancer\AzureDelpoymentConfiguration.cs" />
+    <Compile Include="Streams\QueueBalancer\AzureDeploymentConfiguration.cs" />
     <Compile Include="Streams\QueueBalancer\BestFitBalancer.cs" />
     <Compile Include="Streams\QueueBalancer\StaticClusterDeploymentConfiguration.cs" />
     <Compile Include="Streams\QueueBalancer\ConsistentRingQueueBalancer.cs" />
     <Compile Include="Streams\QueueBalancer\DeploymentBasedQueueBalancer.cs" />
-    <Compile Include="Streams\QueueBalancer\IDelpoymentConfiguration.cs" />
+    <Compile Include="Streams\QueueBalancer\IDeploymentConfiguration.cs" />
     <Compile Include="Streams\QueueBalancer\StreamQueueBalancerFactory.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -211,6 +211,7 @@
     <Compile Include="Silo\Watchdog.cs" />
     <Compile Include="Streams\QueueBalancer\AzureDelpoymentConfiguration.cs" />
     <Compile Include="Streams\QueueBalancer\BestFitBalancer.cs" />
+    <Compile Include="Streams\QueueBalancer\StaticClusterDeploymentConfiguration.cs" />
     <Compile Include="Streams\QueueBalancer\ConsistentRingQueueBalancer.cs" />
     <Compile Include="Streams\QueueBalancer\DeploymentBasedQueueBalancer.cs" />
     <Compile Include="Streams\QueueBalancer\IDelpoymentConfiguration.cs" />
@@ -250,4 +251,3 @@
   <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
   <!--End Orleans -->
 </Project>
-

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -242,7 +242,7 @@ namespace Orleans.Runtime.Providers
             TimeSpan initQueueTimeout)
         {
             IStreamQueueBalancer queueBalancer = StreamQueueBalancerFactory.Create(
-                balancerType, streamProviderName, Silo.CurrentSilo.LocalSiloStatusOracle, this, queueAdapter.GetStreamQueueMapper());
+                balancerType, streamProviderName, Silo.CurrentSilo.LocalSiloStatusOracle, Silo.CurrentSilo.OrleansConfig, this, queueAdapter.GetStreamQueueMapper());
             var managerId = GrainId.NewSystemTargetGrainIdByTypeCode(Constants.PULLING_AGENTS_MANAGER_SYSTEM_TARGET_TYPE_CODE);
             var manager = new PersistentStreamPullingManager(managerId, streamProviderName, this, queueBalancer, getQueueMsgsTimerPeriod, initQueueTimeout);
             this.RegisterSystemTarget(manager);

--- a/src/OrleansRuntime/Streams/QueueBalancer/AzureDeploymentConfiguration.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/AzureDeploymentConfiguration.cs
@@ -29,7 +29,7 @@ namespace Orleans.Streams
     /// <summary>
     /// Deployment configuration that read cluster information from azure.
     /// </summary>
-    internal class AzureDelpoymentConfiguration : IDelpoymentConfiguration
+    internal class AzureDeploymentConfiguration : IDeploymentConfiguration
     {
         public List<string> GetAllSiloInstanceNames()
         {

--- a/src/OrleansRuntime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
@@ -39,7 +39,7 @@ namespace Orleans.Streams
     internal class DeploymentBasedQueueBalancer : ISiloStatusListener, IStreamQueueBalancer
     {
         private readonly ISiloStatusOracle siloStatusOracle;
-        private readonly IDelpoymentConfiguration deploymentConfig;
+        private readonly IDeploymentConfiguration deploymentConfig;
         private readonly IStreamQueueMapper streamQueueMapper;
         private readonly List<IStreamQueueBalanceListener> queueBalanceListeners;
         private readonly string mySiloName;
@@ -49,7 +49,7 @@ namespace Orleans.Streams
 
         public DeploymentBasedQueueBalancer(
             ISiloStatusOracle siloStatusOracle,
-            IDelpoymentConfiguration deploymentConfig,
+            IDeploymentConfiguration deploymentConfig,
             IStreamQueueMapper queueMapper)
         {
             if (siloStatusOracle == null)

--- a/src/OrleansRuntime/Streams/QueueBalancer/IDeploymentConfiguration.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/IDeploymentConfiguration.cs
@@ -28,7 +28,7 @@ namespace Orleans.Streams
     /// <summary>
     /// Interface for accessing the deployment configuration.
     /// </summary>
-    internal interface IDelpoymentConfiguration
+    internal interface IDeploymentConfiguration
     {
         /// <summary>
         /// Get the silo instance names for all configured silos

--- a/src/OrleansRuntime/Streams/QueueBalancer/StaticClusterDeploymentConfiguration.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/StaticClusterDeploymentConfiguration.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.Streams
+{
+    /// <summary>
+    /// Deployment configuration that reads from orleans cluster configuration
+    /// </summary>
+    internal class StaticClusterDeploymentConfiguration : IDelpoymentConfiguration
+    {
+        private readonly ClusterConfiguration _clusterConfiguration;
+
+        public StaticClusterDeploymentConfiguration(ClusterConfiguration clusterConfiguration)
+        {
+            if (clusterConfiguration == null)
+            {
+                throw new ArgumentNullException("clusterConfiguration");
+            }
+            _clusterConfiguration = clusterConfiguration;
+        }
+
+        public List<string> GetAllSiloInstanceNames()
+        {
+            return _clusterConfiguration.Overrides.Keys.ToList();
+        }
+    }
+}

--- a/src/OrleansRuntime/Streams/QueueBalancer/StaticClusterDeploymentConfiguration.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/StaticClusterDeploymentConfiguration.cs
@@ -8,7 +8,7 @@ namespace Orleans.Streams
     /// <summary>
     /// Deployment configuration that reads from orleans cluster configuration
     /// </summary>
-    internal class StaticClusterDeploymentConfiguration : IDelpoymentConfiguration
+    internal class StaticClusterDeploymentConfiguration : IDeploymentConfiguration
     {
         private readonly ClusterConfiguration _clusterConfiguration;
 

--- a/src/OrleansRuntime/Streams/QueueBalancer/StreamQueueBalancerFactory.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/StreamQueueBalancerFactory.cs
@@ -80,12 +80,12 @@ namespace Orleans.Streams
                 }
                 case StreamQueueBalancerType.AzureDeploymentBalancer:
                 {
-                    IDelpoymentConfiguration deploymentConfiguration = new AzureDelpoymentConfiguration();
+                    IDeploymentConfiguration deploymentConfiguration = new AzureDeploymentConfiguration();
                     return new DeploymentBasedQueueBalancer(siloStatusOracle, deploymentConfiguration, queueMapper);
                 }
                 case StreamQueueBalancerType.StaticClusterDeploymentBalancer:
                 {
-                    IDelpoymentConfiguration deploymentConfiguration = new StaticClusterDeploymentConfiguration(clusterConfiguration);
+                    IDeploymentConfiguration deploymentConfiguration = new StaticClusterDeploymentConfiguration(clusterConfiguration);
                     return new DeploymentBasedQueueBalancer(siloStatusOracle, deploymentConfiguration, queueMapper);
                 }
                 default:

--- a/src/OrleansRuntime/Streams/QueueBalancer/StreamQueueBalancerFactory.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/StreamQueueBalancerFactory.cs
@@ -23,6 +23,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
 
 namespace Orleans.Streams
 {
@@ -37,6 +38,7 @@ namespace Orleans.Streams
         /// <param name="balancerType">queue balancer type to create</param>
         /// <param name="strProviderName">name of requesting stream provider</param>
         /// <param name="siloStatusOracle">membership services interface.</param>
+        /// <param name="clusterConfiguration">cluster configuration</param>
         /// <param name="runtime">stream provider runtime environment to run in</param>
         /// <param name="queueMapper">queue mapper of requesting stream provider</param>
         /// <returns>Constructed stream queue balancer</returns>
@@ -44,6 +46,7 @@ namespace Orleans.Streams
             StreamQueueBalancerType balancerType,
             string strProviderName,
             ISiloStatusOracle siloStatusOracle,
+            ClusterConfiguration clusterConfiguration,
             IStreamProviderRuntime runtime,
             IStreamQueueMapper queueMapper)
         {
@@ -54,6 +57,10 @@ namespace Orleans.Streams
             if (siloStatusOracle == null)
             {
                 throw new ArgumentNullException("siloStatusOracle");
+            }
+            if (clusterConfiguration == null)
+            {
+                throw new ArgumentNullException("clusterConfiguration");
             }
             if (runtime == null)
             {
@@ -71,9 +78,14 @@ namespace Orleans.Streams
                     IConsistentRingProviderForGrains ringProvider = runtime.GetConsistentRingProvider(0, 1);
                     return new ConsistentRingQueueBalancer(ringProvider, queueMapper);
                 }
-                case StreamQueueBalancerType.AzureDeploymentBasedBalancer:
+                case StreamQueueBalancerType.AzureDeploymentBalancer:
                 {
                     IDelpoymentConfiguration deploymentConfiguration = new AzureDelpoymentConfiguration();
+                    return new DeploymentBasedQueueBalancer(siloStatusOracle, deploymentConfiguration, queueMapper);
+                }
+                case StreamQueueBalancerType.StaticClusterDeploymentBalancer:
+                {
+                    IDelpoymentConfiguration deploymentConfiguration = new StaticClusterDeploymentConfiguration(clusterConfiguration);
                     return new DeploymentBasedQueueBalancer(siloStatusOracle, deploymentConfiguration, queueMapper);
                 }
                 default:


### PR DESCRIPTION
Added new type of deployment configuration for DeploymentBasedQueueBalancer, StaticClusterDeploymentConfiguration.

Added new queue balancer type, StaticClusterDeploymentBalancer, which uses cluster configuration to balance queues.

Made queue balancer types public so stream provider configurations can set them.