### PR TITLE
Change ExtendedPrimaryKey to IGrainWith Interface

### DIFF
--- a/src/ClientGenerator/VBCodeGenerator.cs
+++ b/src/ClientGenerator/VBCodeGenerator.cs
@@ -385,14 +385,15 @@ Return System.Threading.Tasks.Task.FromResult(CObj(True))
                 factoryClass.Members.Add(new CodeSnippetTypeMember(
                      String.Format(codeFmt, FixupTypeName(interfaceName), interfaceId)));
 
-            bool hasKeyExt = GrainInterfaceData.UsesPrimaryKeyExtension(iface.Type);
+            bool isGuidCompoundKey = typeof(IGrainWithGuidCompoundKey).IsAssignableFrom(iface.Type);
+            bool isLongCompoundKey = typeof(IGrainWithIntegerCompoundKey).IsAssignableFrom(iface.Type);
 
             bool isGuidKey = typeof(IGrainWithGuidKey).IsAssignableFrom(iface.Type);
             bool isLongKey = typeof(IGrainWithIntegerKey).IsAssignableFrom(iface.Type);
             bool isStringKey = typeof(IGrainWithStringKey).IsAssignableFrom(iface.Type);
             bool isDefaultKey = !(isGuidKey || isStringKey || isLongKey);
 
-            if (isDefaultKey && hasKeyExt)
+            if (isLongCompoundKey)
             {
                 // the programmer has specified [ExtendedPrimaryKey] on the interface.
                 add(
@@ -405,7 +406,9 @@ Return System.Threading.Tasks.Task.FromResult(CObj(True))
                         Public Shared Function GetGrain(primaryKey as System.Int64, keyExt as System.String, grainClassNamePrefix As System.String) As {0}
                             Return Cast(Global.Orleans.CodeGeneration.GrainFactoryBase.MakeKeyExtendedGrainReferenceInternal(GetType({0}), {1}, primaryKey, keyExt, grainClassNamePrefix))
                         End Function");
-
+            }
+            else if (isGuidCompoundKey)
+            {
                 add(
                     @"
                         Public Shared Function GetGrain(primaryKey As System.Guid, keyExt as System.String) As {0}

--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -304,11 +304,6 @@ namespace Orleans.CodeGeneration
             return Utils.CalculateIdHash(strMethodId.ToString());
         }
 
-        public static bool UsesPrimaryKeyExtension(Type grainIfaceType)
-        {
-            return HasAttribute<ExtendedPrimaryKeyAttribute>(grainIfaceType, inherit: false);
-        }
-
         public bool IsSystemTarget
         {
             get { return IsSystemTargetType(Type); }
@@ -555,27 +550,6 @@ namespace Orleans.CodeGeneration
             }
         }
 
-        private static int CountAttributes<T>(Type grainIfaceType, bool inherit)
-        {
-            return grainIfaceType.GetCustomAttributes(typeof (T), inherit).Length;
-        }
-
-        private static bool HasAttribute<T>(Type grainIfaceType, bool inherit)
-        {
-            switch (CountAttributes<T>(grainIfaceType, inherit))
-            {
-                case 0:
-                    return false;
-                case 1:
-                    return true;
-                default:
-                    throw new InvalidOperationException(string.Format(
-                        "More than one {0} cannot be specified for grain interface {1}",
-                        typeof (T).Name,
-                        grainIfaceType.Name));
-            }
-        }
-        
         private static int GetTypeCode(Type grainInterfaceOrClass)
         {
             var attrs = grainInterfaceOrClass.GetCustomAttributes(typeof(TypeCodeOverrideAttribute), false);

--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -223,17 +223,6 @@ namespace Orleans
         }
     }
 
-    /// <summary>
-    /// Used to make a grain interface as using extended keys.
-    /// </summary>
-    /// <remarks>
-    /// If a grain interface uses extended keys, then an additional set of grain reference 
-    /// factory methods will be generated which accept both primary and extended key parts.
-    /// </remarks>
-    [AttributeUsage(AttributeTargets.Interface)]
-    public sealed class ExtendedPrimaryKeyAttribute : Attribute
-    { }
-
     [AttributeUsage(AttributeTargets.Interface)]
     internal sealed class FactoryAttribute : Attribute
     {

--- a/src/Orleans/Core/IGrain.cs
+++ b/src/Orleans/Core/IGrain.cs
@@ -54,4 +54,18 @@ namespace Orleans
     public interface IGrainWithStringKey : IGrain
     {
     }
+
+    /// <summary>
+    /// Marker interface for grains with compound keys.
+    /// </summary>
+    public interface IGrainWithGuidCompoundKey : IGrain
+    {
+    }
+
+    /// <summary>
+    /// Marker interface for grains with compound keys.
+    /// </summary>
+    public interface IGrainWithIntegerCompoundKey : IGrain
+    {
+    }
 }

--- a/src/Orleans/Streams/PubSub/IPubSubRendezvousGrain.cs
+++ b/src/Orleans/Streams/PubSub/IPubSubRendezvousGrain.cs
@@ -27,8 +27,7 @@ using System.Collections.Generic;
 
 namespace Orleans.Streams
 {
-    [ExtendedPrimaryKey]
-    internal interface IPubSubRendezvousGrain : IGrain
+    internal interface IPubSubRendezvousGrain : IGrainWithGuidCompoundKey
     {
         Task<ISet<PubSubSubscriptionState>> RegisterProducer(StreamId streamId, IStreamProducerExtension streamProducer);
 


### PR DESCRIPTION
Removed the ExtendedPrimaryKeyAttribute class
and replaced it with a couple of IGrainWithCompoundKey
interfaces to unify the API and remove the inconsistency
with the new design.

Fix #326