### PR TITLE
Support ExtendedPrimaryKey GetGrain from generic Factory.

### DIFF
--- a/src/Orleans/CodeGeneration/GrainFactoryBase.cs
+++ b/src/Orleans/CodeGeneration/GrainFactoryBase.cs
@@ -213,7 +213,7 @@ namespace Orleans.CodeGeneration
             }
         }
 
-        private static void DisallowNullOrWhiteSpaceKeyExtensions(string keyExt)
+        internal static void DisallowNullOrWhiteSpaceKeyExtensions(string keyExt)
         {
             if (!string.IsNullOrWhiteSpace(keyExt)) return;
 

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -23,8 +23,8 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 ﻿using System;
 using System.Collections.Concurrent;
-
-using Orleans.Runtime;
+﻿using Orleans.CodeGeneration;
+﻿using Orleans.Runtime;
 
 namespace Orleans
 {
@@ -109,7 +109,7 @@ namespace Orleans
         public static TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithGuidCompoundKey
         {
-            Orleans.CodeGeneration.GrainFactoryBase.DisallowNullOrWhiteSpaceKeyExtensions(keyExtension);
+            GrainFactoryBase.DisallowNullOrWhiteSpaceKeyExtensions(keyExtension);
 
             return Cast<TGrainInterface>(
                 _MakeGrainReference(
@@ -129,7 +129,7 @@ namespace Orleans
         public static TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithGuidCompoundKey
         {
-            Orleans.CodeGeneration.GrainFactoryBase.DisallowNullOrWhiteSpaceKeyExtensions(keyExtension);
+            GrainFactoryBase.DisallowNullOrWhiteSpaceKeyExtensions(keyExtension);
 
             return Cast<TGrainInterface>(
                 _MakeGrainReference(

--- a/src/Orleans/IDs/TypeCodeMapper.cs
+++ b/src/Orleans/IDs/TypeCodeMapper.cs
@@ -30,6 +30,22 @@ namespace Orleans.Runtime
     /// </summary>
     internal static class TypeCodeMapper
     {
+        internal static int GetImplementationTypeCode(Type interfaceType, string grainClassNamePrefix = null)
+        {
+            int typeCode;
+            IGrainTypeResolver grainTypeResolver = RuntimeClient.Current.GrainTypeResolver;
+            if (!grainTypeResolver.TryGetGrainTypeCode(interfaceType, out typeCode, grainClassNamePrefix))
+            {
+                var loadedAssemblies = grainTypeResolver.GetLoadedGrainAssemblies();
+                throw new ArgumentException(
+                    String.Format("Cannot find a type code for an implementation class for grain interface: {0}{2}. Make sure the grain assembly was correctly deployed and loaded in the silo.{1}",
+                                  interfaceType,
+                                  String.IsNullOrEmpty(loadedAssemblies) ? String.Empty : String.Format(" Loaded grain assemblies: {0}", loadedAssemblies),
+                                  String.IsNullOrEmpty(grainClassNamePrefix) ? String.Empty : ", grainClassNamePrefix=" + grainClassNamePrefix));
+            }
+            return typeCode;
+        }
+
         internal static int GetImplementationTypeCode(int interfaceId, string grainClassNamePrefix = null)
         {
             int typeCode;
@@ -56,7 +72,7 @@ namespace Orleans.Runtime
 
         internal static GrainId ComposeGrainId(int baseTypeCode, Guid primaryKey, Type interfaceType, string keyExt = null)
         {
-            return GrainId.GetGrainId(ComposeGenericTypeCode(interfaceType, baseTypeCode),
+            return GrainId.GetGrainId(ComposeGenericTypeCode(interfaceType, baseTypeCode), 
                 primaryKey, keyExt);
         }
 

--- a/src/Orleans/Streams/PubSub/PubSubRuntime.cs
+++ b/src/Orleans/Streams/PubSub/PubSubRuntime.cs
@@ -78,12 +78,9 @@ namespace Orleans.Streams
 
         private static IPubSubRendezvousGrain GetRendezvousGrain(StreamId streamId)
         {
-            return (IPubSubRendezvousGrain)GrainClient.InvokeStaticMethodThroughReflection(
-                "Orleans",
-                "Orleans.Streams.PubSubRendezvousGrainFactory",
-                "GetGrain",
-                new Type[] { typeof(Guid), typeof(string) },
-                new object[] { streamId.Guid, streamId.ProviderName + "_" + streamId.Namespace });
+            return GrainFactory.GetGrain<IPubSubRendezvousGrain>(
+                primaryKey: streamId.Guid,
+                keyExtension: streamId.ProviderName + "_" + streamId.Namespace);
         }
 
         public GuidId CreateSubscriptionId(IAddressable requesterAddress, StreamId streamId)


### PR DESCRIPTION
Added 2 new overloads, as discussed in https://github.com/dotnet/orleans/pull/330
 
* Removed code duplication between GrainFactory and TypeCodeMapper (not clear why it was duplicated). More opportunities to cleanup exist there.

* Ported PubSubGrain to use the new factory method, which validated the approach.

* Interestingly, the compiler could not automatically pick the right overload. It got confused between IGrainWithGuidKey (Guid, string = null) and IGrainWithGuidCompoundKey (Guid, string, string=null) overload, since they have similar args (2nd arg is string). I had to help it with explicit arg names.