### PR TITLE
Instantiating grains that implement only generic interfaces

### DIFF
--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -169,6 +169,7 @@ namespace Orleans.Runtime
         private void AddToGrainInterfaceToClassMap(Type grainClass, IEnumerable<Type> grainInterfaces, bool isUnordered)
         {
             var grainClassCompleteName = TypeUtils.GetFullName(grainClass);
+            var isGenericGrainClass = grainClass.ContainsGenericParameters;
             var grainClassTypeCode = CodeGeneration.GrainInterfaceData.GetGrainClassTypeCode(grainClass);
             var placement = GrainTypeData.GetPlacementStrategy(grainClass);
 
@@ -178,8 +179,8 @@ namespace Orleans.Runtime
                 var ifaceName = TypeUtils.GetRawClassName(ifaceCompleteName);
                 var isPrimaryImplementor = IsPrimaryImplementor(grainClass, iface);
                 var ifaceId = CodeGeneration.GrainInterfaceData.GetGrainInterfaceId(iface);
-                grainInterfaceMap.AddEntry(ifaceId, iface, grainClassTypeCode, ifaceName, grainClassCompleteName, grainClass.Assembly.CodeBase,
-                    placement, isPrimaryImplementor);
+                grainInterfaceMap.AddEntry(ifaceId, iface, grainClassTypeCode, ifaceName, grainClassCompleteName, 
+                    grainClass.Assembly.CodeBase, isGenericGrainClass, placement, isPrimaryImplementor);
             }
 
             if (isUnordered)

--- a/src/TestGrainInterfaces/IGenericGrain.cs
+++ b/src/TestGrainInterfaces/IGenericGrain.cs
@@ -1,0 +1,38 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IGenericGrain<T, U> : IGrainWithIntegerKey
+    {
+        Task<U> Ping(T a);
+    }
+}

--- a/src/TestGrainInterfaces/ISimpleGenericGrain.cs
+++ b/src/TestGrainInterfaces/ISimpleGenericGrain.cs
@@ -1,0 +1,38 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface ISimpleGenericGrain<T> : IGrainWithIntegerKey
+    {
+        Task<T> Ping(T a);
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -46,8 +46,10 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IGenericGrain.cs" />
     <Compile Include="IMultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="ISampleStreamingGrain.cs" />
+    <Compile Include="ISimpleGenericGrain.cs" />
     <Compile Include="ISimpleObserverableGrain.cs" />
     <Compile Include="IObserverGrain.cs" />
     <Compile Include="ISimpleGrain.cs" />
@@ -95,4 +97,3 @@
   </Target> 
   -->
 </Project>
-

--- a/src/TestGrains/NonGenericGrainsForGenericInterface.cs
+++ b/src/TestGrains/NonGenericGrainsForGenericInterface.cs
@@ -1,0 +1,50 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    class NonGenericGrainForGenericInterfaceOfIntFloat : Grain, IGenericGrain<int, float>
+    {
+        public Task<float> Ping(int a)
+        {
+            return Task.FromResult(a + 1.0f);
+        }
+    }
+
+    class NonGenericGrainForGenericInterfaceOfIntString : Grain, IGenericGrain<int, string>
+    {
+        public Task<string> Ping(int a)
+        {
+            return Task.FromResult(Convert.ToString(a,10));
+        }
+    }
+}

--- a/src/TestGrains/SimpleGenericGrain.cs
+++ b/src/TestGrains/SimpleGenericGrain.cs
@@ -1,0 +1,42 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    class SimleGenericGrain<T> :Grain, ISimpleGenericGrain<T>
+    {
+        public Task<T> Ping(T a)
+        {
+            return Task.FromResult(a);
+        }
+    }
+}

--- a/src/TestGrains/SpecializedSimpleGenericGrain.cs
+++ b/src/TestGrains/SpecializedSimpleGenericGrain.cs
@@ -32,11 +32,11 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    class SimpleGenericGrain<T> :Grain, ISimpleGenericGrain<T>
+    class SpecializedSimpleGenericGrain : SimpleGenericGrain<double>
     {
-        public virtual Task<T> Ping(T a)
+        public override Task<double> Ping(double a)
         {
-            return Task.FromResult(a);
+            return base.Ping(a * 2.0);
         }
     }
 }

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="SpecializedSimpleGenericGrain.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orleans\Orleans.csproj">

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -50,7 +50,9 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SimpleGenericGrain.cs" />
     <Compile Include="MultipleSubscriptionConsumerGrain.cs" />
+    <Compile Include="NonGenericGrainsForGenericInterface.cs" />
     <Compile Include="SampleStreamingGrain.cs" />
     <Compile Include="SimpleObserverableGrain.cs" />
     <Compile Include="ObserverGrain.cs" />
@@ -99,4 +101,3 @@
   <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
   <!--End Orleans -->
 </Project>
-

--- a/src/Tester/GenericGrainTests.cs
+++ b/src/Tester/GenericGrainTests.cs
@@ -90,5 +90,16 @@ namespace UnitTests.General
             Assert.AreEqual("1234", stringResult);
         }
 
+        /// If both a concrete implementation and a generic implementation of a 
+        /// generic interface exist, prefer the concrete implementation.
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterface()
+        {
+            var grainOfDouble = GetGrain<ISimpleGenericGrain<double>>();
+            var result = await grainOfDouble.Ping(4.0);
+
+            Assert.AreEqual(8.0, result);
+        }
+
     }
 }

--- a/src/Tester/GenericGrainTests.cs
+++ b/src/Tester/GenericGrainTests.cs
@@ -1,0 +1,94 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using UnitTests.GrainInterfaces;
+using UnitTests.Tester;
+
+namespace UnitTests.General
+{
+    /// <summary>
+    /// Unit tests for grains implementing generic interfaces
+    /// </summary>
+    [TestClass]
+    public class GenericGrainTests : UnitTestSiloHost
+    {
+
+        public GenericGrainTests()
+            : base(new UnitTestSiloOptions { StartPrimary = true, StartSecondary = false })
+        {
+        }
+
+        public static I GetGrain<I>() where I : IGrainWithIntegerKey 
+        {
+            return GrainFactory.GetGrain<I>(GetRandomGrainId());
+        }
+
+        private static int GetRandomGrainId()
+        {
+            return random.Next();
+        }
+
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        /// Can instantiate multiple non-generic grain types that implement
+        /// different specializations of the same generic interface
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_NonGenericGrainForGenericInterfaceGetGrain()
+        {
+
+            var grainOfIntFloat = GetGrain<IGenericGrain<int, float>>();
+            var grainOfIntString = GetGrain<IGenericGrain<int, string>>();
+
+            var floatResult = await grainOfIntFloat.Ping(0);
+            var stringResult = await grainOfIntString.Ping(1234);
+
+            Assert.AreEqual(1.0f, floatResult);
+            Assert.AreEqual("1234", stringResult); 
+        }
+
+        /// Can instantiate generic grain specializations
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_SimpleGenericGrainGetGrain()
+        {
+
+            var grainOfFloat = GetGrain<ISimpleGenericGrain<float>>();
+            var grainOfString = GetGrain<ISimpleGenericGrain<string>>();
+
+            var floatResult = await grainOfFloat.Ping(12.34f);
+            var stringResult = await grainOfString.Ping("1234");
+
+            Assert.AreEqual(12.34f, floatResult);
+            Assert.AreEqual("1234", stringResult);
+        }
+
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\TestConfigurationExtensions.cs" />
+    <Compile Include="GenericGrainTests.cs" />
     <Compile Include="ObserverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">


### PR DESCRIPTION
Fixes #338 

All tests in TestAll.cmd pass (and my grains now work, yay :-) ).

Notes:
* One can now instantiate *non-generic* grains that directly implement one or more generic interfaces
* For *generic* grain classes, the constraints that were already implied in the code still apply (i.e. the generic class must take the same generic arguments as the implemented generic interface)
 * note that I am unsure if that particular code path was ever hit - I think that scenario was also broken (I have not tested it, though).

Please review, especially the change to ```GrainClassData```. I have noticed that it is serializable and I have marked the newly introduced field as ```[NonSerialized]``` in an attempt to not break a rolling update scenario. I've followed what seems to be an existing pattern, but I am not in love with that particular bit - while it works (the relevant method is only called from the ```Catalog```), it feels quite brittle.