### PR TITLE
Cleaning up the code duplication in GrainFactory.

### DIFF
--- a/src/Orleans/CodeGeneration/GrainFactoryBase.cs
+++ b/src/Orleans/CodeGeneration/GrainFactoryBase.cs
@@ -157,6 +157,21 @@ namespace Orleans.CodeGeneration
                     grainClassNamePrefix);
         }
 
+        internal static IAddressable MakeGrainReference_FromType(
+            Func<int, GrainId> getGrainId,
+            Type interfaceType,
+            string grainClassNamePrefix = null)
+        {
+            CheckRuntimeEnvironmentSetup();
+            if (!GrainInterfaceData.IsGrainType(interfaceType))
+            {
+                throw new ArgumentException("Cannot fabricate grain-reference for non-grain type: " + interfaceType.FullName);
+            }
+            int grainTypeCode = TypeCodeMapper.GetImplementationTypeCode(interfaceType, grainClassNamePrefix);
+            GrainId grainId = getGrainId(grainTypeCode);
+            return GrainReference.FromGrainId(grainId, interfaceType.IsGenericType ? interfaceType.UnderlyingSystemType.FullName : null);
+        }
+
         internal static IAddressable MakeGrainReference(
             Func<int, GrainId> getGrainId,
             Type grainType,
@@ -168,9 +183,9 @@ namespace Orleans.CodeGeneration
             {
                 throw new ArgumentException("Cannot fabricate grain-reference for non-grain type: " + grainType.FullName);
             }
-            int grainTypeCode = TypeCodeMapper.GetImplementationTypeCode(interfaceId, grainClassNamePrefix);
+            int grainTypeCode = TypeCodeMapper.GetImplementationTypeCode(grainType, grainClassNamePrefix);
             GrainId grainId = getGrainId(grainTypeCode);
-            return GrainReference.FromGrainId(grainId,
+            return GrainReference.FromGrainId(grainId, 
                 grainType.IsGenericType ? grainType.UnderlyingSystemType.FullName : null);
         }
 

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -58,7 +58,7 @@ namespace Orleans
             where TGrainInterface : IGrainWithGuidKey
         {
             return Cast<TGrainInterface>(
-                _MakeGrainReference(
+                GrainFactoryBase.MakeGrainReference_FromType(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface)),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));
@@ -75,7 +75,7 @@ namespace Orleans
             where TGrainInterface : IGrainWithIntegerKey
         {
             return Cast<TGrainInterface>(
-                _MakeGrainReference(
+                GrainFactoryBase.MakeGrainReference_FromType(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface)),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));
@@ -92,7 +92,7 @@ namespace Orleans
             where TGrainInterface : IGrainWithStringKey
         {
             return Cast<TGrainInterface>(
-                _MakeGrainReference(
+                GrainFactoryBase.MakeGrainReference_FromType(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface)),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));
@@ -112,7 +112,7 @@ namespace Orleans
             GrainFactoryBase.DisallowNullOrWhiteSpaceKeyExtensions(keyExtension);
 
             return Cast<TGrainInterface>(
-                _MakeGrainReference(
+                GrainFactoryBase.MakeGrainReference_FromType(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface), keyExtension),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));
@@ -132,7 +132,7 @@ namespace Orleans
             GrainFactoryBase.DisallowNullOrWhiteSpaceKeyExtensions(keyExtension);
 
             return Cast<TGrainInterface>(
-                _MakeGrainReference(
+                GrainFactoryBase.MakeGrainReference_FromType(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface), keyExtension),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));
@@ -227,20 +227,6 @@ namespace Orleans
         }
         #endregion
 
-        private static IAddressable _MakeGrainReference(
-            Func<int, GrainId> getGrainId,
-            Type interfaceType,
-            string grainClassNamePrefix = null)
-        {
-            CheckRuntimeEnvironmentSetup();
-            if (!CodeGeneration.GrainInterfaceData.IsGrainType(interfaceType))
-            {
-                throw new ArgumentException("Cannot fabricate grain-reference for non-grain type: " + interfaceType.FullName);
-            }
-            GrainId grainId = getGrainId(TypeCodeMapper.GetImplementationTypeCode(interfaceType, grainClassNamePrefix));
-            return GrainReference.FromGrainId(grainId, interfaceType.IsGenericType ? interfaceType.UnderlyingSystemType.FullName : null);
-        }
-
         #region Interface Casting
         private static readonly ConcurrentDictionary<Type, Func<IAddressable, object>> casters
             = new ConcurrentDictionary<Type, Func<IAddressable, object>>();
@@ -319,20 +305,6 @@ namespace Orleans
             }
 
             return method.CreateDelegate(delegateType);
-        }
-
-        /// <summary>
-        /// Check the current runtime environment has been setup and initialized correctly.
-        /// Throws InvalidOperationException if current runtime environment is not initialized.
-        /// </summary>
-        private static void CheckRuntimeEnvironmentSetup()
-        {
-            if (RuntimeClient.Current == null)
-            {
-                var msg = "Orleans runtime environment is not set up (RuntimeClient.Current==null). If you are running on the client, perhaps you are missing a call to Client.Initialize(...) ? " +
-                            "If you are running on the silo, perhaps you are trying to send a message or create a grain reference not within Orleans thread or from within grain constructor?";
-                throw new InvalidOperationException(msg);
-            }
         }
         #endregion
     }


### PR DESCRIPTION
GrainFactory is a generic factory used to create grain references.
GrainFactoryBase is a base class used by all code generated concrete factories to create grain references.
Both factories are very similar.

The main logic is in method GrainFactory_MakeGrainReference which is almost identical to GrainFactoryBase.MakeGrainReference. Therefore:
1) I moved GrainFactory_MakeGrainReference into GrainFactoryBase and renamed to GrainFactoryBase.MakeGrainReference_FromType
2) The only difference now between GrainFactoryBase.MakeGrainReference_FromType and the old GrainFactoryBase.MakeGrainReference is that the former used the Interface Type while the latter used the Interface Id hash code.
3) But both ways are actually equivalent! Therefore, changed MakeGrainReference  to use the Type and not to use Interface Id. Now both function are 100% identical.

After this is merged, we can move to the next step of realizing https://github.com/dotnet/orleans/issues/141: getting rid of code gen for factories/GetGrain and Cast.
One step at a time.