### PR TITLE
Instantiating grains that directly implement generic interfaces (+ tests)

### DIFF
--- a/src/Orleans/CodeGeneration/GrainFactoryBase.cs
+++ b/src/Orleans/CodeGeneration/GrainFactoryBase.cs
@@ -51,7 +51,7 @@ namespace Orleans.CodeGeneration
         {
             return
                 MakeGrainReference(
-                    baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, grainInterfaceType),
+                    implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType),
                     grainInterfaceType,
                     interfaceId,
                     grainClassNamePrefix);
@@ -74,7 +74,7 @@ namespace Orleans.CodeGeneration
         {
             return
                 MakeGrainReference(
-                    baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, grainInterfaceType),
+                    implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType),
                     grainInterfaceType,
                     interfaceId,
                     grainClassNamePrefix);
@@ -97,7 +97,7 @@ namespace Orleans.CodeGeneration
         {
             return
                 MakeGrainReference(
-                    baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, grainInterfaceType),
+                    implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType),
                     grainInterfaceType,
                     interfaceId,
                     grainClassNamePrefix);
@@ -124,7 +124,7 @@ namespace Orleans.CodeGeneration
 
             return
                 MakeGrainReference(
-                    baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, grainInterfaceType, keyExt),
+                    implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType, keyExt),
                     grainInterfaceType,
                     interfaceId,
                     grainClassNamePrefix);
@@ -151,14 +151,14 @@ namespace Orleans.CodeGeneration
 
             return
                 MakeGrainReference(
-                    baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, grainInterfaceType, keyExt),
+                    implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType, keyExt),
                     grainInterfaceType,
                     interfaceId,
                     grainClassNamePrefix);
         }
 
         internal static IAddressable MakeGrainReference_FromType(
-            Func<int, GrainId> getGrainId,
+            Func<GrainClassData, GrainId> getGrainId,
             Type interfaceType,
             string grainClassNamePrefix = null)
         {
@@ -167,13 +167,13 @@ namespace Orleans.CodeGeneration
             {
                 throw new ArgumentException("Cannot fabricate grain-reference for non-grain type: " + interfaceType.FullName);
             }
-            int grainTypeCode = TypeCodeMapper.GetImplementationTypeCode(interfaceType, grainClassNamePrefix);
-            GrainId grainId = getGrainId(grainTypeCode);
+            var implementation = TypeCodeMapper.GetImplementation(interfaceType, grainClassNamePrefix);
+            GrainId grainId = getGrainId(implementation);
             return GrainReference.FromGrainId(grainId, interfaceType.IsGenericType ? interfaceType.UnderlyingSystemType.FullName : null);
         }
 
         internal static IAddressable MakeGrainReference(
-            Func<int, GrainId> getGrainId,
+            Func<GrainClassData, GrainId> getGrainId,
             Type grainType,
             int interfaceId,
             string grainClassNamePrefix = null)
@@ -183,8 +183,8 @@ namespace Orleans.CodeGeneration
             {
                 throw new ArgumentException("Cannot fabricate grain-reference for non-grain type: " + grainType.FullName);
             }
-            int grainTypeCode = TypeCodeMapper.GetImplementationTypeCode(grainType, grainClassNamePrefix);
-            GrainId grainId = getGrainId(grainTypeCode);
+            var implementation = TypeCodeMapper.GetImplementation(grainType, grainClassNamePrefix);
+            GrainId grainId = getGrainId(implementation);
             return GrainReference.FromGrainId(grainId, 
                 grainType.IsGenericType ? grainType.UnderlyingSystemType.FullName : null);
         }

--- a/src/OrleansManager/Program.cs
+++ b/src/OrleansManager/Program.cs
@@ -240,12 +240,12 @@ namespace OrleansManager
             if (Int32.TryParse(interfaceTypeCodeOrImplClassName, out interfaceTypeCodeDataLong))
             {
                 // parsed it as int, so it is an interface type code.
-                implementationTypeCode = TypeCodeMapper.GetImplementationTypeCode(interfaceTypeCodeDataLong);
+                implementationTypeCode = TypeCodeMapper.GetImplementation(interfaceTypeCodeDataLong).GrainTypeCode;
             }
             else
             {
                 // interfaceTypeCodeOrImplClassName is the implementation class name
-                implementationTypeCode = TypeCodeMapper.GetImplementationTypeCode(interfaceTypeCodeOrImplClassName);
+                implementationTypeCode = TypeCodeMapper.GetImplementation(interfaceTypeCodeOrImplClassName).GrainTypeCode;
             }
 
             var grainIdStr = args[1];

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -169,6 +169,7 @@ namespace Orleans.Runtime
         private void AddToGrainInterfaceToClassMap(Type grainClass, IEnumerable<Type> grainInterfaces, bool isUnordered)
         {
             var grainClassCompleteName = TypeUtils.GetFullName(grainClass);
+            var isGenericGrainClass = grainClass.ContainsGenericParameters;
             var grainClassTypeCode = CodeGeneration.GrainInterfaceData.GetGrainClassTypeCode(grainClass);
             var placement = GrainTypeData.GetPlacementStrategy(grainClass);
 
@@ -178,8 +179,8 @@ namespace Orleans.Runtime
                 var ifaceName = TypeUtils.GetRawClassName(ifaceCompleteName);
                 var isPrimaryImplementor = IsPrimaryImplementor(grainClass, iface);
                 var ifaceId = CodeGeneration.GrainInterfaceData.GetGrainInterfaceId(iface);
-                grainInterfaceMap.AddEntry(ifaceId, iface, grainClassTypeCode, ifaceName, grainClassCompleteName, grainClass.Assembly.CodeBase,
-                    placement, isPrimaryImplementor);
+                grainInterfaceMap.AddEntry(ifaceId, iface, grainClassTypeCode, ifaceName, grainClassCompleteName, 
+                    grainClass.Assembly.CodeBase, isGenericGrainClass, placement, isPrimaryImplementor);
             }
 
             if (isUnordered)

--- a/src/TestGrainInterfaces/IGenericGrain.cs
+++ b/src/TestGrainInterfaces/IGenericGrain.cs
@@ -1,0 +1,39 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IGenericGrain<T, U> : IGrainWithIntegerKey
+    {
+        Task SetT(T a);
+        Task<U> MapT2U();
+    }
+}

--- a/src/TestGrainInterfaces/ISimpleGenericGrain.cs
+++ b/src/TestGrainInterfaces/ISimpleGenericGrain.cs
@@ -1,0 +1,42 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface ISimpleGenericGrain<T> : IGrainWithIntegerKey
+    {
+        Task Set(T t);
+
+        Task Transform();
+
+        Task<T> Get();
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -46,8 +46,10 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IGenericGrain.cs" />
     <Compile Include="IMultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="ISampleStreamingGrain.cs" />
+    <Compile Include="ISimpleGenericGrain.cs" />
     <Compile Include="ISimpleObserverableGrain.cs" />
     <Compile Include="IObserverGrain.cs" />
     <Compile Include="ISimpleGrain.cs" />
@@ -95,4 +97,3 @@
   </Target> 
   -->
 </Project>
-

--- a/src/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
+++ b/src/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
@@ -1,0 +1,102 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    class ConcreteGrainWithGenericInterfaceOfIntFloat : Grain, IGenericGrain<int, float>
+    {
+        protected int T { get; set; }
+
+        public Task SetT(int t)
+        {
+            T = t;
+            return TaskDone.Done;
+        }
+
+        public Task<float> MapT2U()
+        {
+            return Task.FromResult((float)T);
+        }
+    }
+
+    class ConcreteGrainWithGenericInterfaceOfFloatString : Grain, IGenericGrain<float, string>
+    {
+        protected float T { get; set; }
+
+        public Task SetT(float t)
+        {
+            T = t;
+            return TaskDone.Done;
+        }
+
+        public Task<string> MapT2U()
+        {
+            return Task.FromResult(Convert.ToString(T));
+        }
+    }
+
+    class ConcreteGrainWith2GenericInterfaces: Grain, IGenericGrain<int, string>, ISimpleGenericGrain<int>
+    {
+        // IGenericGrain<int, string> methods:
+
+        protected int T { get; set; }
+
+        public Task SetT(int t)
+        {
+            T = t;
+            return TaskDone.Done;
+        }
+
+        public Task<string> MapT2U()
+        {
+            return Task.FromResult(Convert.ToString(T * 10, 10));
+        }
+
+        //ISimpleGenericGrain<int> methods:
+
+        public Task Set(int t)
+        {
+            return SetT(t);
+        }
+
+        public Task Transform()
+        {
+            T = T * 10;
+            return TaskDone.Done;
+        }
+
+        public Task<int> Get()
+        {
+            return Task.FromResult(T);
+        }
+    }
+}

--- a/src/TestGrains/SimpleGenericGrain.cs
+++ b/src/TestGrains/SimpleGenericGrain.cs
@@ -1,0 +1,55 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    class SimpleGenericGrain<T> :Grain, ISimpleGenericGrain<T>
+    {
+        protected T Value { get; set; }
+
+        public virtual Task Set(T t)
+        {
+            Value = t;
+            return TaskDone.Done;
+        }
+
+        public virtual Task Transform()
+        {
+            return TaskDone.Done;
+        }
+
+        public Task<T> Get()
+        {
+            return Task.FromResult(Value);
+        }
+    }
+}

--- a/src/TestGrains/SpecializedSimpleGenericGrain.cs
+++ b/src/TestGrains/SpecializedSimpleGenericGrain.cs
@@ -1,0 +1,43 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    class SpecializedSimpleGenericGrain : SimpleGenericGrain<double>
+    {
+        public override Task Transform()
+        {
+            Value = Value * 2.0;
+            return TaskDone.Done;
+        }
+    }
+}

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -50,7 +50,9 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SimpleGenericGrain.cs" />
     <Compile Include="MultipleSubscriptionConsumerGrain.cs" />
+    <Compile Include="ConcreteGrainsWithGenericInterfaces.cs" />
     <Compile Include="SampleStreamingGrain.cs" />
     <Compile Include="SimpleObserverableGrain.cs" />
     <Compile Include="ObserverGrain.cs" />
@@ -60,6 +62,7 @@
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="SpecializedSimpleGenericGrain.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orleans\Orleans.csproj">
@@ -99,4 +102,3 @@
   <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
   <!--End Orleans -->
 </Project>
-

--- a/src/Tester/GenericGrainTests.cs
+++ b/src/Tester/GenericGrainTests.cs
@@ -1,0 +1,249 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using UnitTests.GrainInterfaces;
+using UnitTests.Tester;
+
+namespace UnitTests.General
+{
+    /// <summary>
+    /// Unit tests for grains implementing generic interfaces
+    /// </summary>
+    [TestClass]
+    public class GenericGrainTests : UnitTestSiloHost
+    {
+
+        public GenericGrainTests()
+            : base(new UnitTestSiloOptions { StartPrimary = true, StartSecondary = false })
+        {
+        }
+
+        public static I GetGrain<I>(int i) where I : IGrainWithIntegerKey
+        {
+            return GrainFactory.GetGrain<I>(i);
+        }
+
+        public static I GetGrain<I>() where I : IGrainWithIntegerKey 
+        {
+            return GrainFactory.GetGrain<I>(GetRandomGrainId());
+        }
+
+        private static int GetRandomGrainId()
+        {
+            return random.Next();
+        }
+
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        /// Can instantiate multiple concrete grain types that implement
+        /// different specializations of the same generic interface
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceGetGrain()
+        {
+
+            var grainOfIntFloat1 = GetGrain<IGenericGrain<int, float>>();
+            var grainOfIntFloat2 = GetGrain<IGenericGrain<int, float>>();
+            var grainOfFloatString = GetGrain<IGenericGrain<float, string>>();
+
+            await grainOfIntFloat1.SetT(123);
+            await grainOfIntFloat2.SetT(456);
+            await grainOfFloatString.SetT(789.0f);
+
+            var floatResult1 = await grainOfIntFloat1.MapT2U();
+            var floatResult2 = await grainOfIntFloat2.MapT2U();
+            var stringResult = await grainOfFloatString.MapT2U();
+
+            Assert.AreEqual(123f, floatResult1);
+            Assert.AreEqual(456f, floatResult2);
+            Assert.AreEqual("789", stringResult); 
+        }
+
+        /// Multiple GetGrain requests with the same id return the same concrete grain 
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceMultiplicity()
+        {
+            var grainId = GetRandomGrainId();
+
+            var grainRef1 = GetGrain<IGenericGrain<int, float>>(grainId);
+            await grainRef1.SetT(123);
+
+            var grainRef2 = GetGrain<IGenericGrain<int, float>>(grainId);
+            var floatResult = await grainRef2.MapT2U();
+
+            Assert.AreEqual(123f, floatResult);
+        }
+
+        /// Can instantiate generic grain specializations
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_SimpleGenericGrainGetGrain()
+        {
+
+            var grainOfFloat1 = GetGrain<ISimpleGenericGrain<float>>();
+            var grainOfFloat2 = GetGrain<ISimpleGenericGrain<float>>();
+            var grainOfString = GetGrain<ISimpleGenericGrain<string>>();
+
+            await grainOfFloat1.Set(1.2f);
+            await grainOfFloat2.Set(3.4f);
+            await grainOfString.Set("5.6");
+
+            // generic grain implementation does not change the set value:
+            await grainOfFloat1.Transform();
+            await grainOfFloat2.Transform();
+            await grainOfString.Transform();
+
+            var floatResult1 = await grainOfFloat1.Get();
+            var floatResult2 = await grainOfFloat2.Get();
+            var stringResult = await grainOfString.Get();
+
+            Assert.AreEqual(1.2f, floatResult1);
+            Assert.AreEqual(3.4f, floatResult2);
+            Assert.AreEqual("5.6", stringResult);
+        }
+
+        /// Multiple GetGrain requests with the same id return the same generic grain specialization
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_SimpleGenericGrainMultiplicity()
+        {
+            var grainId = GetRandomGrainId();
+
+            var grainRef1 = GetGrain<ISimpleGenericGrain<float>>(grainId);
+            await grainRef1.Set(1.2f);
+            await grainRef1.Transform();  // NOP for generic grain class
+
+            var grainRef2 = GetGrain<ISimpleGenericGrain<float>>(grainId);
+            var floatResult = await grainRef2.Get();
+
+            Assert.AreEqual(1.2f, floatResult);
+        }
+
+        /// If both a concrete implementation and a generic implementation of a 
+        /// generic interface exist, prefer the concrete implementation.
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterface()
+        {
+            var grainOfDouble1 = GetGrain<ISimpleGenericGrain<double>>();
+            var grainOfDouble2 = GetGrain<ISimpleGenericGrain<double>>();
+
+            await grainOfDouble1.Set(1.0);
+            await grainOfDouble2.Set(2.0);
+
+            // concrete implementation (SpecializedSimpleGenericGrain) doubles the set value:
+            await grainOfDouble1.Transform();
+            await grainOfDouble2.Transform();
+
+            var result1 = await grainOfDouble1.Get();
+            var result2 = await grainOfDouble2.Get();
+
+            Assert.AreEqual(2.0, result1);
+            Assert.AreEqual(4.0, result2);
+        }
+
+        /// Multiple GetGrain requests with the same id return the same concrete grain implementation
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterfaceMultiplicity()
+        {
+            var grainId = GetRandomGrainId();
+
+            var grainRef1 = GetGrain<ISimpleGenericGrain<double>>(grainId);
+            await grainRef1.Set(1.0);
+            await grainRef1.Transform();  // SpecializedSimpleGenericGrain doubles the value for generic grain class
+
+            // a second reference with the same id points to the same grain:
+            var grainRef2 = GetGrain<ISimpleGenericGrain<double>>(grainId);
+            await grainRef2.Transform();
+            var floatResult = await grainRef2.Get();
+
+            Assert.AreEqual(4.0f, floatResult);
+        }
+
+        /// Can instantiate concrete grains that implement multiple generic interfaces
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesGetGrain()
+        {
+            var grain1 = GetGrain<ISimpleGenericGrain<int>>();
+            var grain2 = GetGrain<ISimpleGenericGrain<int>>();
+
+            await grain1.Set(1);
+            await grain2.Set(2);
+
+            // ConcreteGrainWith2GenericInterfaces multiplies the set value by 10:
+            await grain1.Transform();
+            await grain2.Transform();
+
+            var result1 = await grain1.Get();
+            var result2 = await grain2.Get();
+
+            Assert.AreEqual(10, result1);
+            Assert.AreEqual(20, result2);
+        }
+
+        /// Multiple GetGrain requests with the same id and interface return the same concrete grain implementation
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesMultiplicity1()
+        {
+            var grainId = GetRandomGrainId();
+
+            var grainRef1 = GetGrain<ISimpleGenericGrain<int>>(grainId);
+            await grainRef1.Set(1);
+
+            // ConcreteGrainWith2GenericInterfaces multiplies the set value by 10:
+            await grainRef1.Transform();  
+
+            //A second reference to the interface will point to the same grain
+            var grainRef2 = GetGrain<ISimpleGenericGrain<int>>(grainId);
+            await grainRef2.Transform();
+            var floatResult = await grainRef2.Get();
+
+            Assert.AreEqual(100, floatResult);
+        }
+
+        /// Multiple GetGrain requests with the same id and different interfaces return the same concrete grain implementation
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesMultiplicity2()
+        {
+            var grainId = GetRandomGrainId();
+
+            var grainRef1 = GetGrain<ISimpleGenericGrain<int>>(grainId);
+            await grainRef1.Set(1);
+            await grainRef1.Transform();  // ConcreteGrainWith2GenericInterfaces multiplies the set value by 10:
+
+            // A second reference to a different interface implemented by ConcreteGrainWith2GenericInterfaces 
+            // will reference the same grain:
+            var grainRef2 = GetGrain<IGenericGrain<int, string>>(grainId);
+            // ConcreteGrainWith2GenericInterfaces returns a string representation of the current value multiplied by 10:
+            var floatResult = await grainRef2.MapT2U(); 
+
+            Assert.AreEqual("100", floatResult);
+        }
+
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\TestConfigurationExtensions.cs" />
+    <Compile Include="GenericGrainTests.cs" />
     <Compile Include="ObserverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">


### PR DESCRIPTION
Fixes #338, Replaces #342

Hi guys, this a one-commit version  of #342, with further changes and tests addressing a couple of edge cases. The one significant change from #342  is that I was forced to serialize the ```isGeneric``` field in  ```GrainClassData```. This is required so that the client can create the correct ```GrainId```. Otherwise trying to obtain references to different generic interfaces of the same grain creates one activation per generic interface - see the tests for details, more specifically ```GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesMultiplicity2```.
Another change is that the grain reference creation process now passes along an instance of ```GrainCassData``` instead of just the grain type code. This should be just fine, as ```GrainCassData``` can not be mutated (there is some internal caching going on, but that's not an issue).

In essence, with this change one can create grain classes that implement one or more generic interfaces and obtain grain references to those interfaces. This allows for a development  approach where one can define a small number of generic interfaces and then create grains that implement one or more of them, without the need for additional non-generic marker interfaces. Basically we get *type-safe* uniform interfaces.

And yes, writing tests helps :-) All tests pass, including 9 new ones.