### PR TITLE
Serialization code optimizations

### DIFF
--- a/src/ClientGenerator/CSharpCodeGenerator.cs
+++ b/src/ClientGenerator/CSharpCodeGenerator.cs
@@ -569,26 +569,28 @@ namespace Orleans.CodeGeneration
             if (methodInfo.ReturnType == typeof(void))
             {
                 methodImpl = string.Format(@"
-                base.InvokeOneWayMethod({0}, new object[] {{{1}}} {2});",
-                methodId, invokeArguments, optional);
+                    base.InvokeOneWayMethod({0}, {1} {2});",
+                    methodId, 
+                    invokeArguments.Equals(string.Empty) ? "null" : String.Format("new object[] {{{0}}}", invokeArguments),
+                    optional);
             }
             else
             {
                 if (methodInfo.ReturnType == typeof(Task))
                 {
                     methodImpl = string.Format(@"
-                return base.InvokeMethodAsync<object>({0}, new object[] {{{1}}} {2});",
+                return base.InvokeMethodAsync<object>({0}, {1} {2});",
                         methodId,
-                        invokeArguments,
+                        invokeArguments.Equals(string.Empty) ? "null" : String.Format("new object[] {{{0}}}", invokeArguments),
                         optional);
                 }
                 else
                 {
                     methodImpl = string.Format(@"
-                return base.InvokeMethodAsync<{0}>({1}, new object[] {{{2}}} {3});",
+                return base.InvokeMethodAsync<{0}>({1}, {2} {3});",
                         GetActualMethodReturnType(methodInfo.ReturnType, SerializeFlag.NoSerialize),
                         methodId,
-                        invokeArguments,
+                        invokeArguments.Equals(string.Empty) ? "null" : String.Format("new object[] {{{0}}}", invokeArguments),
                         optional);
                 }
             }

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -320,9 +320,13 @@ namespace Orleans.Runtime
         /// </summary>
         protected async Task<T> InvokeMethodAsync<T>(int methodId, object[] arguments, InvokeMethodOptions options = InvokeMethodOptions.None, SiloAddress silo = null)
         {
-            CheckForGrainArguments(arguments);
-
-            var argsDeepCopy = (object[])SerializationManager.DeepCopy(arguments);
+            object[] argsDeepCopy = null;
+            if (arguments != null)
+            {
+                CheckForGrainArguments(arguments);
+                argsDeepCopy = (object[])SerializationManager.DeepCopy(arguments);
+            }
+            
             var request = new InvokeMethodRequest(this.InterfaceId, methodId, argsDeepCopy);
 
             if (IsUnordered)

--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -1237,10 +1237,13 @@ namespace Orleans.Serialization
 
             stream.Write(request.InterfaceId);
             stream.Write(request.MethodId);
-            stream.Write(request.Arguments.Length);
-            foreach (var arg in request.Arguments)
+            stream.Write(request.Arguments != null ? request.Arguments.Length : 0);
+            if (request.Arguments != null)
             {
-                SerializationManager.SerializeInner(arg, stream, null);
+                foreach (var arg in request.Arguments)
+                {
+                    SerializationManager.SerializeInner(arg, stream, null);
+                }
             }
         }
 
@@ -1250,11 +1253,15 @@ namespace Orleans.Serialization
             int mid = stream.ReadInt();
 
             int argCount = stream.ReadInt();
-            var args = new object[argCount];
+            object[] args = null;
 
-            for (var i = 0; i < argCount; i++)
+            if (argCount > 0)
             {
-                args[i] = SerializationManager.DeserializeInner(null, stream);
+                args = new object[argCount];
+                for (var i = 0; i < argCount; i++)
+                {
+                    args[i] = SerializationManager.DeserializeInner(null, stream);
+                }
             }
 
             return new InvokeMethodRequest(iid, mid, args);
@@ -1264,10 +1271,14 @@ namespace Orleans.Serialization
         {
             var request = (InvokeMethodRequest)original;
 
-            var args = new object[request.Arguments.Length];
-            for (var i = 0; i < request.Arguments.Length; i++)
+            object[] args = null;
+            if (request.Arguments != null)
             {
-                args[i] = SerializationManager.DeepCopyInner(request.Arguments[i]);
+                args = new object[request.Arguments.Length];
+                for (var i = 0; i < request.Arguments.Length; i++)
+                {
+                    args[i] = SerializationManager.DeepCopyInner(request.Arguments[i]);
+                }
             }
 
             var result = new InvokeMethodRequest(request.InterfaceId, request.MethodId, args);

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -764,12 +764,6 @@ namespace Orleans.Serialization
 
         private static object DeepCopierHelper(Type t, object original)
         {
-            if (t.IsOrleansShallowCopyable())
-            {
-                // Simple value types and immutables have already been deep-copied sufficiently
-                return original;
-            }
-
             // Arrays are all that's left. 
             // Handling arbitrary-rank arrays is a bit complex, but why not?
             var originalArray = original as Array;

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -769,6 +769,11 @@ namespace Orleans.Serialization
             var originalArray = original as Array;
             if (originalArray != null)
             {
+                if (originalArray.Rank == 1 && originalArray.GetLength(0) == 0)
+                {
+                    // A common special case - empty one dimentional array
+                    return originalArray;
+                }
                 // A common special case
                 if ((original is byte[]) && (originalArray.Rank == 1))
                 {

--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -65,8 +65,12 @@ namespace Orleans.Serialization
                 t == typeof (Immutable<>))
                 return true;
 
-            if (t.GetCustomAttributes(typeof (ImmutableAttribute), false).Length > 0)
-                return true;
+            var attributes = t.GetCustomAttributesData();
+            if (attributes != null && attributes.Count > 0)
+            {
+                if(attributes.Any(attr => attr.AttributeType == (typeof (ImmutableAttribute))))
+                    return true;
+            }
 
             if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof (Immutable<>))
                 return true;

--- a/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
@@ -61,6 +61,7 @@ namespace Orleans
     }
     
     [Serializable]
+    [Immutable]
     internal class TableVersion
     {
         public int Version { get; private set; }


### PR DESCRIPTION
Implemented a number of optimizations in the serialization code:
1) Removed a duplicate call to IsOrleansShallowCopyable
2) Optimized grain methods with zero args to code gen null instead of zero size object array, which speeds up a bunch of code paths.
3) Optimized t.GetCustomAttributes(typeof (ImmutableAttribute)) to use t.GetCustomAttributesData.