### PR TITLE
Changed GetGrain code gened code to use GrainFactory instead of GrainFactoryBase.

### DIFF
--- a/src/ClientGenerator/CSharpCodeGenerator.cs
+++ b/src/ClientGenerator/CSharpCodeGenerator.cs
@@ -390,17 +390,16 @@ namespace Orleans.CodeGeneration
 
             if (isLongCompoundKey)
             {
-                // the programmer has specified [ExtendedPrimaryKey] on the interface.
                 add(@"
                         public static {0} GetGrain(long primaryKey, string keyExt)
                         {{
-                            return Cast(global::Orleans.CodeGeneration.GrainFactoryBase.MakeKeyExtendedGrainReferenceInternal(typeof({0}), {1}, primaryKey, keyExt));
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey: primaryKey, keyExtension: keyExt);
                         }}");
 
                 add(@"
                         public static {0} GetGrain(long primaryKey, string keyExt, string grainClassNamePrefix)
                         {{
-                            return Cast(global::Orleans.CodeGeneration.GrainFactoryBase.MakeKeyExtendedGrainReferenceInternal(typeof({0}), {1}, primaryKey, keyExt, grainClassNamePrefix));
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey: primaryKey, keyExtension: keyExt, grainClassNamePrefix: grainClassNamePrefix);
                         }}");
             }
             else if (isGuidCompoundKey)
@@ -408,19 +407,64 @@ namespace Orleans.CodeGeneration
                 add(@"
                         public static {0} GetGrain(System.Guid primaryKey, string keyExt)
                         {{
-                            return Cast(global::Orleans.CodeGeneration.GrainFactoryBase.MakeKeyExtendedGrainReferenceInternal(typeof({0}), {1}, primaryKey, keyExt));
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey: primaryKey, keyExtension: keyExt);
                         }}");
 
                 add(@"
                         public static {0} GetGrain(System.Guid primaryKey, string keyExt, string grainClassNamePrefix)
                         {{
-                            return Cast(global::Orleans.CodeGeneration.GrainFactoryBase.MakeKeyExtendedGrainReferenceInternal(typeof({0}), {1}, primaryKey, keyExt,grainClassNamePrefix));
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey: primaryKey, keyExtension: keyExt, grainClassNamePrefix: grainClassNamePrefix);
                         }}");
             }
             else
             {
                 // the programmer has not specified [ExplicitPlacement] on the interface nor [ExtendedPrimaryKey].
-                if (isLongKey || isDefaultKey)
+                if (isLongKey)
+                {
+                    add(@"
+                        public static {0} GetGrain(long primaryKey)
+                        {{
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey);
+                        }}");
+
+                    add(@"
+                        public static {0} GetGrain(long primaryKey, string grainClassNamePrefix)
+                        {{
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey, grainClassNamePrefix);
+                        }}");
+                }
+
+                if (isGuidKey)
+                {
+                    add(@"
+                        public static {0} GetGrain(System.Guid primaryKey)
+                        {{
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey);
+                        }}");
+
+                    add(@"
+                        public static {0} GetGrain(System.Guid primaryKey, string grainClassNamePrefix)
+                        {{
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey, grainClassNamePrefix);
+                        }}");
+                }
+
+                if (isStringKey)
+                {
+                    add(@"
+                        public static {0} GetGrain(System.String primaryKey)
+                        {{
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey);
+                        }}");
+
+                    add(@"
+                        public static {0} GetGrain(System.String primaryKey, string grainClassNamePrefix)
+                        {{
+                            return global::Orleans.GrainFactory.GetGrain<{0}>(primaryKey, grainClassNamePrefix);
+                        }}");
+                }
+
+                if (isDefaultKey)
                 {
                     add(@"
                         public static {0} GetGrain(long primaryKey)
@@ -433,33 +477,16 @@ namespace Orleans.CodeGeneration
                         {{
                             return Cast(global::Orleans.CodeGeneration.GrainFactoryBase.MakeGrainReferenceInternal(typeof({0}), {1}, primaryKey, grainClassNamePrefix));
                         }}");
-                }
 
-                if (isGuidKey || isDefaultKey)
-                {
                     add(@"
                         public static {0} GetGrain(System.Guid primaryKey)
                         {{
                             return Cast(global::Orleans.CodeGeneration.GrainFactoryBase.MakeGrainReferenceInternal(typeof({0}), {1}, primaryKey));
                         }}");
 
+
                     add(@"
                         public static {0} GetGrain(System.Guid primaryKey, string grainClassNamePrefix)
-                        {{
-                            return Cast(global::Orleans.CodeGeneration.GrainFactoryBase.MakeGrainReferenceInternal(typeof({0}), {1}, primaryKey, grainClassNamePrefix));
-                        }}");
-                }
-
-                if (isStringKey)
-                {
-                    add(@"
-                        public static {0} GetGrain(System.String primaryKey)
-                        {{
-                            return Cast(global::Orleans.CodeGeneration.GrainFactoryBase.MakeGrainReferenceInternal(typeof({0}), {1}, primaryKey));
-                        }}");
-
-                    add(@"
-                        public static {0} GetGrain(System.String primaryKey, string grainClassNamePrefix)
                         {{
                             return Cast(global::Orleans.CodeGeneration.GrainFactoryBase.MakeGrainReferenceInternal(typeof({0}), {1}, primaryKey, grainClassNamePrefix));
                         }}");

--- a/src/Orleans/CodeGeneration/GrainFactoryBase.cs
+++ b/src/Orleans/CodeGeneration/GrainFactoryBase.cs
@@ -53,7 +53,6 @@ namespace Orleans.CodeGeneration
                 MakeGrainReference(
                     implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType),
                     grainInterfaceType,
-                    interfaceId,
                     grainClassNamePrefix);
         }
 
@@ -76,7 +75,6 @@ namespace Orleans.CodeGeneration
                 MakeGrainReference(
                     implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType),
                     grainInterfaceType,
-                    interfaceId,
                     grainClassNamePrefix);
         }
 
@@ -99,7 +97,6 @@ namespace Orleans.CodeGeneration
                 MakeGrainReference(
                     implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType),
                     grainInterfaceType,
-                    interfaceId,
                     grainClassNamePrefix);
         }
 
@@ -126,7 +123,6 @@ namespace Orleans.CodeGeneration
                 MakeGrainReference(
                     implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType, keyExt),
                     grainInterfaceType,
-                    interfaceId,
                     grainClassNamePrefix);
         }
 
@@ -153,11 +149,10 @@ namespace Orleans.CodeGeneration
                 MakeGrainReference(
                     implementation => TypeCodeMapper.ComposeGrainId(implementation, primaryKey, grainInterfaceType, keyExt),
                     grainInterfaceType,
-                    interfaceId,
                     grainClassNamePrefix);
         }
 
-        internal static IAddressable MakeGrainReference_FromType(
+        internal static IAddressable MakeGrainReference(
             Func<GrainClassData, GrainId> getGrainId,
             Type interfaceType,
             string grainClassNamePrefix = null)
@@ -170,23 +165,6 @@ namespace Orleans.CodeGeneration
             var implementation = TypeCodeMapper.GetImplementation(interfaceType, grainClassNamePrefix);
             GrainId grainId = getGrainId(implementation);
             return GrainReference.FromGrainId(grainId, interfaceType.IsGenericType ? interfaceType.UnderlyingSystemType.FullName : null);
-        }
-
-        internal static IAddressable MakeGrainReference(
-            Func<GrainClassData, GrainId> getGrainId,
-            Type grainType,
-            int interfaceId,
-            string grainClassNamePrefix = null)
-        {
-            CheckRuntimeEnvironmentSetup();
-            if (!GrainInterfaceData.IsGrainType(grainType))
-            {
-                throw new ArgumentException("Cannot fabricate grain-reference for non-grain type: " + grainType.FullName);
-            }
-            var implementation = TypeCodeMapper.GetImplementation(grainType, grainClassNamePrefix);
-            GrainId grainId = getGrainId(implementation);
-            return GrainReference.FromGrainId(grainId, 
-                grainType.IsGenericType ? grainType.UnderlyingSystemType.FullName : null);
         }
 
         /// <summary>

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -58,7 +58,7 @@ namespace Orleans
             where TGrainInterface : IGrainWithGuidKey
         {
             return Cast<TGrainInterface>(
-                GrainFactoryBase.MakeGrainReference_FromType(
+                GrainFactoryBase.MakeGrainReference(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface)),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));
@@ -75,7 +75,7 @@ namespace Orleans
             where TGrainInterface : IGrainWithIntegerKey
         {
             return Cast<TGrainInterface>(
-                GrainFactoryBase.MakeGrainReference_FromType(
+                GrainFactoryBase.MakeGrainReference(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface)),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));
@@ -92,7 +92,7 @@ namespace Orleans
             where TGrainInterface : IGrainWithStringKey
         {
             return Cast<TGrainInterface>(
-                GrainFactoryBase.MakeGrainReference_FromType(
+                GrainFactoryBase.MakeGrainReference(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface)),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));
@@ -112,7 +112,7 @@ namespace Orleans
             GrainFactoryBase.DisallowNullOrWhiteSpaceKeyExtensions(keyExtension);
 
             return Cast<TGrainInterface>(
-                GrainFactoryBase.MakeGrainReference_FromType(
+                GrainFactoryBase.MakeGrainReference(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface), keyExtension),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));
@@ -127,12 +127,12 @@ namespace Orleans
         /// <param name="grainClassNamePrefix">An optional class name prefix used to find the runtime type of the grain.</param>
         /// <returns></returns>
         public static TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string grainClassNamePrefix = null)
-            where TGrainInterface : IGrainWithGuidCompoundKey
+            where TGrainInterface : IGrainWithIntegerCompoundKey
         {
             GrainFactoryBase.DisallowNullOrWhiteSpaceKeyExtensions(keyExtension);
 
             return Cast<TGrainInterface>(
-                GrainFactoryBase.MakeGrainReference_FromType(
+                GrainFactoryBase.MakeGrainReference(
                     baseTypeCode => TypeCodeMapper.ComposeGrainId(baseTypeCode, primaryKey, typeof(TGrainInterface), keyExtension),
                     typeof(TGrainInterface),
                     grainClassNamePrefix));


### PR DESCRIPTION
Changed GetGrain code gened code to use GrainFactory instead of GrainFactoryBase.(so basically the gened code now looks like the generaic factory code written by application).

There is one gap with IGrain (BackwardCompat option instead of IGrainWithGuidKey) - the generic factory overload cannot distinguish between "where IGrain" and "where IGrainWithGuidKey", so had to still use GrainFactoryBase .
Solutions are either discontinue GetGrain(IGrain) or add another function GrainFactory.GetGrain_BackwardCompat_IGrain.

Also found a typo bug in GrainFactory and also removed more duplicate code from GrainFactoryBase .

This continues the work in https://github.com/dotnet/orleans/pull/346 on the path towards solving https://github.com/dotnet/orleans/issues/141.