### PR TITLE
Add "Who is Using Orleans" page to gh-pages web site.

### DIFF
--- a/Who-Is-Using-Orleans.md
+++ b/Who-Is-Using-Orleans.md
@@ -1,0 +1,41 @@
+---
+layout: index
+title: Who Is Using Orleans?
+tagline: A partial list of some companies and projects that are using Orleans.
+---
+{% include JB/setup %}
+
+# Who Is Using Orleans?
+
+Orleans has been used extensively by several Microsoft projects and product groups, 
+most notably by 343 Industries as a platform for all of Halo 4 cloud services.
+
+There are various other internal projects at Microsoft which are using Orleans, but we are not able to talk publicly about many of those yet.
+
+There are many more companies and projects which are also using Orleans, and this page provides a partial list of some that we know about....
+
+Feel free to send us a pull request on GitHub to add your company / project to this list.
+
+
+## Companies
+
+This list is for companies that are using Orleans.
+
+Company|Link|Notes
+-------|----|-----
+Gassumo|<a href="http://gassumo.com" target="_blank">www.gassumo.com</a>|
+Microsoft|<a href="http://www.microsoft.com" target="_blank">www.microsoft.com</a>|
+Microsoft Research|<a href="http://research.microsoft.com" target="_blank">research.microsoft.com</a>|
+NašeÚkoly.CZ|<a href="http://naseukoly.cz" target="_blank">www.naseukoly.cz</a>|
+
+
+## Projects and Applications
+
+This list is for projects, websites and applications that are powered by Orleans, or provide extensions to Orleans.
+
+Wesbites/Apps|Link|Notes
+-------------|----|-----
+Halo 4 - 343 Industries|<a href="https://www.halowaypoint.com" target="_blank">https://www.halowaypoint.com</a>|
+Orleans-Contrib|<a href="https://github.com/OrleansContrib" target="_blank">OrleansContrib</a>|Community contribution projects, including Orleans Monitoring, Design Patterns, Storage Provider, etc.|
+Pegasus Mission|<a href="http://pegasusmission.com," target="_blank">http://pegasusmission.com</a>|[More Info](http://pegasusmission.com/2015/03/04/orleans-above-the-cloud-piraeus-overview/) and [here](https://github.com/dotnet/orleans/issues/99#issuecomment-74697629)|
+Sync.Today 2015|<a href="https://github.com/SyncToday/synctoday2015" target="_blank">Sync.Today 2015 Community Edition</a>|.NET Business Processes Automation Platform. More info [here](http://www.naseukoly.cz/home/synctoday)|

--- a/index.md
+++ b/index.md
@@ -67,8 +67,6 @@ Orleans [GitHub repository](https://github.com/dotnet/orleans).
 
 * **[Orleans Best Practices](http://research.microsoft.com/apps/pubs/default.aspx?id=244727)** - A collection of tips and trick to help design, build, and run an Orleans-based application.
 
-* **[PAD -- Performance Anomaly Detection in Multi-Server Distributed Systems](http://research.microsoft.com/apps/pubs/default.aspx?id=217109)**
-
 * The original **[Orleans Codeplex site](https://orleans.codeplex.com)** with documentation, samples and discussion forum . Now deprecated -- all source code, documentation and samples have now been migrated to GitHub.
 
 * **[Links](Links)** Blog posts, articles and other links about Orleans.

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ Orleans [GitHub repository](https://github.com/dotnet/orleans).
 
 * **[Orleans NuGet Packages](NuGets)**
 
-* **[What's new in Orleans?](What's-new-in-Orleans)** - Coverage of the new and changed features in the September refresh of the preview binaries.
+* **[What's new in Orleans?](What's-new-in-Orleans)** - Coverage of the new and changed features since the original September 2014 preview release.
 
 ## Introduction and Tutorials
 
@@ -45,26 +45,30 @@ Orleans [GitHub repository](https://github.com/dotnet/orleans).
 
 ## Community and Contributions
 
-* **[Orleans GitHub Repository](https://github.com/dotnet/orleans)**
+* **[Orleans GitHub Repository](https://github.com/dotnet/orleans)** Pull requests are always welcome!
 
-* **[Repository of community add-ons to Orleans](https://github.com/OrleansContrib)**
+* **[Orleans Community - Repository of community add-ons to Orleans](https://github.com/OrleansContrib)** Various community projects, including Orleans Monitoring, Design Patterns, Storage Provider, etc.
 
-* **[Orleans Virtual Meetups](https://github.com/OrleansContrib/meetups)**
+* **[Orleans Community - Virtual Meetups](https://github.com/OrleansContrib/meetups)**
 
-* **[Orleans Gitter Chat Forum](https://gitter.im/dotnet/orleans)**
+* **[Orleans Community - Gitter Chat Forum](https://gitter.im/dotnet/orleans)**
 
 * **[Ideas for Contributions](Ideas-for-Contributions)**
 
-* **[Student Projects](Student-Projects)**
+* **[Intern and Student Projects](Student-Projects)**
+
+* **[Who Is Using Orleans?](Who-Is-Using-Orleans)** A partial list of companies, projects and applications which are using Orleans.
 
 ## Other Documentation Resources
 
-* **[Orleans Best Practices](files/Orleans Best Practices.pptx)** - A collection of tips and trick to help design, build, and run an Orleans-based application.
+* **[Microsoft Research Project Orleans home page](http://research.microsoft.com/en-us/projects/orleans/)**
 
-* **[Latest Orleans technical report](http://research.microsoft.com/pubs/210931/Orleans-MSR-TR-2014-41.pdf)**
+* **[Orleans Technical Report - Distributed Virtual Actors for Programmability and Scalability](http://research.microsoft.com/apps/pubs/default.aspx?id=210931)**
 
-* **[Original Orleans Codeplex site](https://orleans.codeplex.com)** with documentation, samples and discussion forum (will be migrated here)
+* **[Orleans Best Practices](http://research.microsoft.com/apps/pubs/default.aspx?id=244727)** - A collection of tips and trick to help design, build, and run an Orleans-based application.
 
-* **[Microsoft Research project page](http://research.microsoft.com/en-us/projects/orleans/)**
+* **[PAD -- Performance Anomaly Detection in Multi-Server Distributed Systems](http://research.microsoft.com/apps/pubs/default.aspx?id=217109)**
 
-* **[Links](Links)**
+* The original **[Orleans Codeplex site](https://orleans.codeplex.com)** with documentation, samples and discussion forum . Now deprecated -- all source code, documentation and samples have now been migrated to GitHub.
+
+* **[Links](Links)** Blog posts, articles and other links about Orleans.


### PR DESCRIPTION
Add "Who is Using Orleans" page to gh-pages web site rather just text file in master branch.

Cleaned up some old links & text.

TODO: Delete old copy from master branch:
~/misc/Projects-Applications-and-Companies-Using-Orleans.md
