### PR TITLE
Add GrainLocator and GrainIdentifier properties to the Grain class.

### DIFF
--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Orleans.Core;
 using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Storage;
@@ -42,6 +43,12 @@ namespace Orleans
 
         internal IActivationData Data;
 
+        protected Grain()
+        {
+            GrainLocator = new GrainLocator();
+            Identifier = new GrainIdentifier(this);
+        }
+
         internal GrainReference GrainReference { get { return Data.GrainReference; } }
 
         /// <summary>
@@ -51,6 +58,8 @@ namespace Orleans
         {
             get { return Data.Identity; }
         }
+
+        
 
         /// <summary>
         /// String representation of grain's identity including type and primary key.
@@ -68,6 +77,10 @@ namespace Orleans
         {
             get { return Data.RuntimeIdentity; }
         }
+
+        public IGrainLocator GrainLocator { get; set; }
+
+        public IGrainIdentifier Identifier { get; set; }
 
         /// <summary>
         /// Registers a timer to send periodic callbacks to this grain.

--- a/src/Orleans/Core/GrainIdentifier.cs
+++ b/src/Orleans/Core/GrainIdentifier.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Core
+{
+    public class GrainIdentifier : IGrainIdentifier
+    {
+        private readonly Grain _grain;
+
+        public GrainIdentifier(Grain grain)
+        {
+            _grain = grain;
+        }
+
+        public Guid AsGuid()
+        {
+            return _grain.AsReference<IGrain>().GetPrimaryKey();
+        }
+
+        public long AsLong()
+        {
+            return _grain.AsReference<IGrainWithIntegerKey>().GetPrimaryKeyLong();
+        }
+
+        public string AsString()
+        {
+            return _grain.AsReference<IGrainWithStringKey>().GetPrimaryKeyString();
+        }
+    }
+}

--- a/src/Orleans/Core/GrainLocator.cs
+++ b/src/Orleans/Core/GrainLocator.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Orleans.Core
+{
+    class GrainLocator : IGrainLocator
+    {
+        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey
+        {
+            return GrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
+        }
+
+        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey
+        {
+            return GrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
+        }
+
+        public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithStringKey
+        {
+            return GrainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix);
+        }
+    }
+}

--- a/src/Orleans/Core/IGrainIdentifier.cs
+++ b/src/Orleans/Core/IGrainIdentifier.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Core
+{
+    public interface IGrainIdentifier
+    {
+        Guid AsGuid();
+
+        long AsLong();
+
+        string AsString();
+    }
+}

--- a/src/Orleans/Core/IGrainLocator.cs
+++ b/src/Orleans/Core/IGrainLocator.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Core
+{
+    public interface IGrainLocator
+    {
+        TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey;
+
+        TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey;
+
+        TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string grainClassNamePrefix = null) where TGrainInterface : IGrainWithStringKey;
+    }
+}

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -117,6 +117,10 @@
     <Compile Include="Configuration\LimitNames.cs" />
     <Compile Include="Configuration\LimitValue.cs" />
     <Compile Include="Core\Exceptions.cs" />
+    <Compile Include="Core\GrainIdentifier.cs" />
+    <Compile Include="Core\GrainLocator.cs" />
+    <Compile Include="Core\IGrainIdentifier.cs" />
+    <Compile Include="Core\IGrainLocator.cs" />
     <Compile Include="Core\IGrainState.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="IDs\GuidId.cs" />


### PR DESCRIPTION
Adding these two properties makes it possible to unittest a grain without starting a Silo.

Fixes #362 #48 