### PR TITLE
Storage connection string test fix

### DIFF
--- a/src/Tester/StorageTestConstants.cs
+++ b/src/Tester/StorageTestConstants.cs
@@ -48,7 +48,7 @@ namespace UnitTests.Tester
 
         private const string DEFAULT_STORAGE_DATA_CONNECTION_STRING = "UseDevelopmentStorage=true";
 
-        public static void Init()
+        static StorageTestConstants()
         {
             if (DataConnectionString != null)
             {

--- a/src/Tester/StorageTestConstants.cs
+++ b/src/Tester/StorageTestConstants.cs
@@ -29,7 +29,7 @@ using Orleans.Runtime.Configuration;
 
 namespace UnitTests.Tester
 {
-    public class StorageTestConstants
+    public static class StorageTestConstants
     {
         // In order to specify your own Azure Storage DataConnectionString you should:
         // 1) Create a file named OrleansTestStorageKey.txt and put one line with your storage key there, without "", like this:

--- a/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
@@ -51,12 +51,6 @@ namespace Tester.StreamingTests
             runner = new SubscriptionMultiplicityTestRunner(AQStreamProviderName, GrainClient.Logger);
         }
 
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            StorageTestConstants.Init();
-        }
-
         // Use ClassCleanup to run code after all tests in a class have run
         [ClassCleanup]
         public static void MyClassCleanup()

--- a/src/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/src/Tester/StreamingTests/SampleStreamingTests.cs
@@ -54,13 +54,6 @@ namespace Tester.StreamingTests
         {
         }
 
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            StorageTestConstants.Init();
-        }
-
         // Use ClassCleanup to run code after all tests in a class have run
         [ClassCleanup]
         public static void MyClassCleanup()

--- a/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
+++ b/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
@@ -53,6 +53,13 @@ namespace UnitTests.StorageTests
             logger = TraceLogger.GetLogger("AzureMembershipTableTests", TraceLogger.LoggerType.Application);
         }
 
+        // Use ClassInitialize to run code before running the first test in the class
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            TraceLogger.Initialize(new NodeConfiguration());
+        }
+
         // Use TestInitialize to run code before running each test 
         [TestInitialize]
         public void TestInitialize()

--- a/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
+++ b/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
@@ -53,14 +53,6 @@ namespace UnitTests.StorageTests
             logger = TraceLogger.GetLogger("AzureMembershipTableTests", TraceLogger.LoggerType.Application);
         }
 
-        // Use ClassInitialize to run code before running the first test in the class
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            TraceLogger.Initialize(new NodeConfiguration());
-            StorageTestConstants.Init();
-        }
-
         // Use TestInitialize to run code before running each test 
         [TestInitialize]
         public void TestInitialize()

--- a/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
@@ -49,13 +49,6 @@ namespace UnitTests.StorageTests
             logger = TraceLogger.GetLogger("AzureQueueDataManagerTests", TraceLogger.LoggerType.Application);
         }
 
-        // Use ClassInitialize to run code before running the first test in the class
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            StorageTestConstants.Init();
-        }
-
         [TestCleanup]
         public void TestCleanup()
         {

--- a/src/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
@@ -40,13 +40,6 @@ namespace UnitTests.StorageTests
         private string PartitionKey;
         private UnitTestAzureTableDataManager manager;
 
-        // Use ClassInitialize to run code before running the first test in the class
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            StorageTestConstants.Init();
-        }
-
         [TestInitialize]
         public void TestInitialize()
         {

--- a/src/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
@@ -45,13 +45,6 @@ namespace UnitTests.StorageTests
             return new UnitTestAzureTableData("JustData", PartitionKey, "RK-" + Guid.NewGuid());
         }
 
-        // Use ClassInitialize to run code before running the first test in the class
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            StorageTestConstants.Init();
-        }
-
         [TestInitialize]
         public void TestInitialize()
         {

--- a/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
+++ b/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
@@ -51,7 +51,6 @@ namespace UnitTests.LivenessTests
             var cfg = new ClusterConfiguration();
             cfg.LoadFromFile("OrleansConfigurationForUnitTests.xml");
             TraceLogger.Initialize(cfg.GetConfigurationForNode("Primary"));
-            StorageTestConstants.Init();
 
             TraceLogger.AddTraceLevelOverride("AzureTableDataManager", Logger.Severity.Verbose3);
             TraceLogger.AddTraceLevelOverride("OrleansSiloInstanceManager", Logger.Severity.Verbose3);

--- a/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
+++ b/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
@@ -67,6 +67,13 @@ namespace UnitTests.StorageTests
             logger = TraceLogger.GetLogger("SiloInstanceTableManagerTests", TraceLogger.LoggerType.Application);
         }
 
+        // Use ClassInitialize to run code before running the first test in the class
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            TraceLogger.Initialize(new NodeConfiguration());
+        }
+
         // Use TestInitialize to run code before running each test 
         [TestInitialize]
         public void TestInitialize()

--- a/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
+++ b/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
@@ -67,14 +67,6 @@ namespace UnitTests.StorageTests
             logger = TraceLogger.GetLogger("SiloInstanceTableManagerTests", TraceLogger.LoggerType.Application);
         }
 
-        // Use ClassInitialize to run code before running the first test in the class
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            TraceLogger.Initialize(new NodeConfiguration());
-            StorageTestConstants.Init();
-        }
-
         // Use TestInitialize to run code before running each test 
         [TestInitialize]
         public void TestInitialize()


### PR DESCRIPTION
Fixed streaming tests that were failing due to connection string initialization issues.
Resolved by moved StorageTestConstants initialization to static initializer.