### PR TITLE
Choco Build Cleanup

### DIFF
--- a/src/Chocolatey/CreateOrleansChocolateyPackage.bat
+++ b/src/Chocolatey/CreateOrleansChocolateyPackage.bat
@@ -3,7 +3,7 @@
 
 IF %1.==. GOTO Usage
 
-set CPACK_EXE=cpack.exe
+set CPACK_EXE=choco pack
 
 set BASE_PATH=%1
 set VERSION=%2
@@ -11,7 +11,7 @@ IF %2 == "" set VERSION=%~dp0..\Build\Version.txt
 
 @echo CreateOrleansChocolateyPackage running in directory =
 @cd
-@echo CreateOrleansChocolateyPackage version file = %VERSION% from base dir = %BASE_DIR% using cpack location = %CPACK_EXE%
+@echo CreateOrleansChocolateyPackage version file = %VERSION% from base dir = %BASE_DIR% using cpack exe = %CPACK_EXE%
 
 if "%BASE_PATH%" == "." (
 	if EXIST "Release" (
@@ -32,11 +32,12 @@ if EXIST "%VERSION%" (
 
 @echo CreateOrleansChocolateyPackage: Version = %VERSION% -- Drop location = %BASE_PATH%
 
-@set CPACK_PACK_OPTS= 
-@set CPACK_PACK_OPTS=%CPACK_PACK_OPTS% --verbose
+@set CPACK_PACK_OPTS= --Version=%VERSION%
+@REM @set CPACK_PACK_OPTS=%CPACK_PACK_OPTS% --verbose
 
 FOR %%G IN ("%~dp0*.nuspec") DO (
-  "%CPACK_EXE%" "%%G" --Version=%VERSION% %CPACK_PACK_OPTS%
+  @echo CPACK_CMD= %CPACK_EXE% "%%G" %CPACK_PACK_OPTS%
+  %CPACK_EXE% "%%G" %CPACK_PACK_OPTS%
   if ERRORLEVEL 1 EXIT /B 1
 )
 
@@ -45,5 +46,6 @@ GOTO EOF
 :Usage
 @ECHO Usage:
 @ECHO    CreateOrleansChocolateyPackage ^<Path to Orleans SDK folder^> ^<VersionFile^>
+EXIT /B -1
 
 :EOF

--- a/src/NuGet/CreateOrleansPackages.bat
+++ b/src/NuGet/CreateOrleansPackages.bat
@@ -32,11 +32,13 @@ if EXIST "%VERSION%" (
 
 @echo CreateOrleansNugetPackages: Version = %VERSION% -- Drop location = %BASE_PATH%
 
-@set NUGET_PACK_OPTS= -NoPackageAnalysis
-@set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -Verbosity detailed
+@set NUGET_PACK_OPTS= -Version %VERSION% 
+@set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -NoPackageAnalysis
+@set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -BasePath "%BASE_PATH%"
+@REM @set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -Verbosity detailed
 
 FOR %%G IN ("%~dp0*.nuspec") DO (
-  "%NUGET_EXE%" pack "%%G" -Version %VERSION% -BasePath "%BASE_PATH%" %NUGET_PACK_OPTS%
+  "%NUGET_EXE%" pack "%%G" %NUGET_PACK_OPTS%
   if ERRORLEVEL 1 EXIT /B 1
 )
 


### PR DESCRIPTION
- Use 'choco pack' to build Chocolatey pkg rather than 'cpack.exe' which gets confused with exe from cmake on some build servers.
- Show location of choco exe if found.
- VS variables %SolutionDir% and %TargetDir% already have trailing back slash.
- Tweak some progress messages for easier readability of build output.
- Version value was not being passed in correctly to Choco pack
- Give explicit exit codes form success (0) or print-usage (-1)

More Cleanup

- Reduce verbosity of nuget & choco pkg cmd
- Use different error code if Choco Pack fails rather than NuGet Pack cmd

- Fix choco pack --Version param passing.

BTW, this problem first showed up in my repo build stream on Appveyer.
https://ci.appveyor.com/project/jthelin/orleans

P.S. Looking at the Jenkins build logs, master build is actually failing at the moment due to problems finding cpack.exe above, but script does not return exit status correctly so Jenkins is reporting success.

Ref: http://dotnet-ci.cloudapp.net/view/dotnet_prtests/job/dotnet_orleans_prtest/315/console
```
C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.Common.targets(4291,5): error MSB3073: " exited with code 1. [d:\j\workspace\dotnet_orleans_prtest\src\TesterInternal\TesterInternal.csproj]

    0 Warning(s)
    2 Error(s)

Time Elapsed 00:00:58.78
===== Build FAILED for d:\j\workspace\dotnet_orleans_prtest\src\.\Orleans.sln -- Release with error 0 - CANNOT CONTINUE =====
```
