### PR TITLE
Repro for #378

### DIFF
--- a/src/TestGrainInterfaces/ISampleStreamingGrain.cs
+++ b/src/TestGrainInterfaces/ISampleStreamingGrain.cs
@@ -38,6 +38,7 @@ namespace UnitTests.SampleStreaming
         Task<int> GetNumberProduced();
 
         Task ClearNumberProduced();
+        Task Produce();
     }
 
     public interface ISampleStreaming_ConsumerGrain : IGrain

--- a/src/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/src/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -89,6 +89,7 @@ namespace TestGrains
 
         public async Task StopConsuming(StreamSubscriptionHandle<int> handle)
         {
+            logger.Info("StopConsuming");
             // unsubscribe
             await handle.UnsubscribeAsync();
 
@@ -115,6 +116,7 @@ namespace TestGrains
 
         public Task ClearNumberConsumed()
         {
+            logger.Info("ClearNumberConsumed");
             foreach (Counter count in consumedMessageCounts.Values)
             {
                 count.Clear();

--- a/src/TestGrains/SampleStreamingGrain.cs
+++ b/src/TestGrains/SampleStreamingGrain.cs
@@ -99,6 +99,7 @@ namespace UnitTests.SampleStreaming
 
         public Task<int> GetNumberProduced()
         {
+            logger.Info("GetNumberProduced");
             return Task.FromResult(numProducedItems);
         }
 

--- a/src/TestGrains/SampleStreamingGrain.cs
+++ b/src/TestGrains/SampleStreamingGrain.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams;
+using System.Runtime.CompilerServices;
 
 namespace UnitTests.SampleStreaming
 {
@@ -107,15 +108,21 @@ namespace UnitTests.SampleStreaming
             return TaskDone.Done;
         }
 
+        public Task Produce()
+        {
+            return Fire();
+        }
+
         private Task TimerCallback(object state)
         {
-            if (producerTimer != null)
-            {
-                numProducedItems++;
-                logger.Info("TimerCallback (item={0})", numProducedItems);
-                return producer.OnNextAsync(numProducedItems);
-            }
-            return TaskDone.Done;
+            return producerTimer != null? Fire(): TaskDone.Done;
+        }
+
+        private Task Fire([CallerMemberName] string caller = null)
+        {
+            numProducedItems++;
+            logger.Info("{0} (item={1})", caller, numProducedItems);
+            return producer.OnNextAsync(numProducedItems);
         }
     }
 

--- a/src/Tester/ClientConfigurationForUnitTests.xml
+++ b/src/Tester/ClientConfigurationForUnitTests.xml
@@ -10,4 +10,8 @@
   </Tracing>
   <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
   <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0"/>
+  <StreamProviders>
+    <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
+    <Provider Type="Orleans.Providers.Streams.AzureQueue.AzureQueueStreamProvider" Name="AzureQueueProvider"/>
+  </StreamProviders>
 </ClientConfiguration>

--- a/src/Tester/OrleansConfigurationForStreamingDeactivationUnitTests.xml
+++ b/src/Tester/OrleansConfigurationForStreamingDeactivationUnitTests.xml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <Application>
+      <Defaults>
+        <Deactivation AgeLimit="1m"/>
+      </Defaults>
+      <GrainType Type="TestGrains.MultipleSubscriptionConsumerGrain">
+        <Deactivation AgeLimit="2hr"/>
+      </GrainType>
+    </Application>
+    <StorageProviders>
+      <Provider Type="Orleans.Storage.MemoryStorage" Name="PubSubStore" NumStorageGrains="1"/>
+    </StorageProviders>
+    <StreamProviders>
+      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
+      <Provider Type="Orleans.Providers.Streams.AzureQueue.AzureQueueStreamProvider" Name="AzureQueueProvider"/>
+    </StreamProviders>
+    <SeedNode Address="localhost" Port="22222"/>
+    <Messaging ResponseTimeout="30s"/>
+  </Globals>
+  <Defaults>
+    <Networking Address="localhost" Port="22222"/>
+    <ProxyingGateway Address="localhost" Port="40000" />
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" BulkMessageLimit="1000">
+      <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
+    </Tracing>
+    <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
+  </Defaults>
+</OrleansConfiguration>
+
+

--- a/src/Tester/OrleansConfigurationForStreamingDeactivationUnitTests.xml
+++ b/src/Tester/OrleansConfigurationForStreamingDeactivationUnitTests.xml
@@ -17,7 +17,7 @@
       <Provider Type="Orleans.Providers.Streams.AzureQueue.AzureQueueStreamProvider" Name="AzureQueueProvider"/>
     </StreamProviders>
     <SeedNode Address="localhost" Port="22222"/>
-    <Messaging ResponseTimeout="30s"/>
+    <Messaging ResponseTimeout="1hr"/>
   </Globals>
   <Defaults>
     <Networking Address="localhost" Port="22222"/>

--- a/src/Tester/StreamingTests/PubSubDeactivationTestRunner.cs
+++ b/src/Tester/StreamingTests/PubSubDeactivationTestRunner.cs
@@ -1,0 +1,77 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans.Runtime;
+using Orleans.Streams;
+using TestGrainInterfaces;
+using UnitTests.SampleStreaming;
+using UnitTests.Tester;
+
+namespace Tester.StreamingTests
+{
+    class PubSubDeactivationTestRunner
+    {
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+        private readonly string streamProviderName;
+        private readonly Logger logger;
+
+        public PubSubDeactivationTestRunner(string streamProviderName, Logger logger)
+        {
+            if (string.IsNullOrWhiteSpace(streamProviderName))
+            {
+                throw new ArgumentNullException("streamProviderName");
+            }
+            this.streamProviderName = streamProviderName;
+            this.logger = logger;
+        }
+
+        public async Task DeactivationTest(Guid streamGuid, string streamNamespace)
+        {
+            // get producer and consumer
+            ISampleStreaming_ProducerGrain producer = SampleStreaming_ProducerGrainFactory.GetGrain(Guid.NewGuid());
+            IMultipleSubscriptionConsumerGrain consumer = MultipleSubscriptionConsumerGrainFactory.GetGrain(Guid.NewGuid());
+
+            Thread.Sleep(5000);
+
+            // subscribe (PubSubRendezvousGrain will have one consumer)
+            StreamSubscriptionHandle<int> subscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
+            // produce one message (PubSubRendezvousGrain will have one consumer and one producer)
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+            await producer.Produce();
+
+            Thread.Sleep(180000); // wait for the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain to be deactivated
+
+            // if the grains were deactivated during the same cycle, subsequent calls to the producer will hang:
+            var produceTask = producer.Produce();
+            var result = await Task.WhenAny(produceTask, Task.Delay(Timeout));
+
+            Assert.AreEqual(result, produceTask, "Deactivate succeeded");
+        }
+    }
+}

--- a/src/Tester/StreamingTests/PubSubDeactivationTestRunner.cs
+++ b/src/Tester/StreamingTests/PubSubDeactivationTestRunner.cs
@@ -27,11 +27,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams;
 using TestGrainInterfaces;
 using UnitTests.SampleStreaming;
 using UnitTests.Tester;
+
 
 namespace Tester.StreamingTests
 {
@@ -40,6 +42,22 @@ namespace Tester.StreamingTests
         private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
         private readonly string streamProviderName;
         private readonly Logger logger;
+
+        private class Counter
+        {
+            public int Value { get; private set; }
+
+            public Task Increment()
+            {
+                Value++;
+                return TaskDone.Done;
+            }
+
+            public void Clear()
+            {
+                Value = 0;
+            }
+        }
 
         public PubSubDeactivationTestRunner(string streamProviderName, Logger logger)
         {
@@ -61,17 +79,64 @@ namespace Tester.StreamingTests
 
             // subscribe (PubSubRendezvousGrain will have one consumer)
             StreamSubscriptionHandle<int> subscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
+
             // produce one message (PubSubRendezvousGrain will have one consumer and one producer)
             await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
             await producer.Produce();
 
+            var count = await consumer.GetNumberConsumed();
+            Assert.AreEqual(count[subscriptionHandle], 1, "Consumer grain has not received stream message");
+
             Thread.Sleep(180000); // wait for the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain to be deactivated
+            // deactivating PubSubRendezvousGrain and SampleStreaming_ProducerGrain during the same GC cycle causes a deadlock
 
-            // if the grains were deactivated during the same cycle, subsequent calls to the producer will hang:
-            var produceTask = producer.Produce();
-            var result = await Task.WhenAny(produceTask, Task.Delay(Timeout));
+            //confirm that the silo continues to operate despite the deactivation deadlock:
 
-            Assert.AreEqual(result, produceTask, "Deactivate succeeded");
+            // consumer grain AgeLimit is set to 2hr in configuration - should still be active and accessible:
+            count = await consumer.GetNumberConsumed();
+            Assert.AreEqual(count[subscriptionHandle], 1, "Consumer grain has been deactivated");
+
+            // resume producing after the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain grains have been deactivated:
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+            await producer.Produce();
+
+            // consumer grain should continue to receive stream messages despite deactivation hang:
+            count = await consumer.GetNumberConsumed();
+            Assert.AreEqual(count[subscriptionHandle], 2, "Consumer did not receive stream messages after PubSubRendezvousGrain and SampleStreaming_ProducerGrain reactivation");
         }
+        public async Task DeactivationTestWithClientGrain(Guid streamGuid, string streamNamespace)
+        {
+            // get producer and consumer
+            ISampleStreaming_ProducerGrain producer = SampleStreaming_ProducerGrainFactory.GetGrain(Guid.NewGuid());
+
+            var count = new Counter();
+            // get stream
+            IStreamProvider streamProvider = Orleans.GrainClient.GetStreamProvider(streamProviderName);
+            var stream = streamProvider.GetStream<int>(streamGuid, streamNamespace);
+            // subscribe
+            StreamSubscriptionHandle<int> handle = await stream.SubscribeAsync((e, t) => count.Increment());
+
+            Thread.Sleep(5000);
+
+            //// subscribe (PubSubRendezvousGrain will have one consumer)
+            //StreamSubscriptionHandle<int> subscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
+            // produce one message (PubSubRendezvousGrain will have one consumer and one producer)
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+            await producer.Produce();
+
+            Assert.AreEqual(count.Value, 1, "Client consumer grain has not received stream message");
+
+            Thread.Sleep(180000); // wait for the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain to be deactivated
+            // deactivating PubSubRendezvousGrain and SampleStreaming_ProducerGrain during the same GC cycle causes a deadlock
+
+            //confirm that the silo continues to operate despite the deactivation deadlock:
+
+            // resume producing after the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain grains have been deactivated:
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+            await producer.Produce();
+
+            Assert.AreEqual(count.Value, 2, "Client consumer grain did not receive stream messages after PubSubRendezvousGrain and SampleStreaming_ProducerGrain reactivation");
+        }
+
     }
 }

--- a/src/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/src/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -57,14 +57,14 @@ namespace Tester.StreamingTests
             StopAllSilos();
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Nightly"), TestCategory("Streaming")]
         public async Task SMSDeactivationTest()
         {
             logger.Info("************************ SMSDeactivationTest *********************************");
             await runner.DeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Nightly"), TestCategory("Streaming")]
         public async Task SMSDeactivationTestWithClientGrain()
         {
             logger.Info("************************ SMSDeactivationTest *********************************");

--- a/src/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/src/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -1,0 +1,67 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using UnitTests.Tester;
+
+namespace Tester.StreamingTests
+{
+    [DeploymentItem("OrleansConfigurationForStreamingDeactivationUnitTests.xml")]
+    [DeploymentItem("OrleansProviders.dll")]
+    [TestClass]
+    public class SMSDeactivationTests : UnitTestSiloHost
+    {
+        private const string SMSStreamProviderName = "SMSProvider";
+        private const string StreamNamespace = "SMSDeactivationTestsNamespace";
+        private readonly PubSubDeactivationTestRunner runner;
+
+        public SMSDeactivationTests()
+            : base(new UnitTestSiloOptions
+            {
+                StartFreshOrleans = true,
+                StartSecondary = false,
+                SiloConfigFile = new FileInfo("OrleansConfigurationForStreamingDeactivationUnitTests.xml"),
+            })
+        {
+            runner = new PubSubDeactivationTestRunner(SMSStreamProviderName, GrainClient.Logger);
+        }
+
+        // Use ClassCleanup to run code after all tests in a class have run
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        public async Task SMSDeactivationTest()
+        {
+            logger.Info("************************ SMSDeactivationTest *********************************");
+            await runner.DeactivationTest(Guid.NewGuid(), StreamNamespace);
+        }
+    }
+}

--- a/src/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/src/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -63,5 +63,13 @@ namespace Tester.StreamingTests
             logger.Info("************************ SMSDeactivationTest *********************************");
             await runner.DeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        public async Task SMSDeactivationTestWithClientGrain()
+        {
+            logger.Info("************************ SMSDeactivationTest *********************************");
+            await runner.DeactivationTestWithClientGrain(Guid.NewGuid(), StreamNamespace);
+        }
+
     }
 }

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -93,8 +93,10 @@
     <Compile Include="SerializationTests.cs" />
     <Compile Include="StorageTestConstants.cs" />
     <Compile Include="StreamingTests\AQSubscriptionMultiplicityTests.cs" />
+    <Compile Include="StreamingTests\PubSubDeactivationTestRunner.cs" />
     <Compile Include="StreamingTests\SampleStreamingTests.cs" />
     <Compile Include="SimpleGrainTests.cs" />
+    <Compile Include="StreamingTests\SMSDeactivationTests.cs" />
     <Compile Include="StreamingTests\SMSSubscriptionMultiplicityTests.cs" />
     <Compile Include="StreamingTests\SubscriptionMultiplicityTestRunner.cs" />
     <Compile Include="UnitTestSiloHostOptions.cs" />
@@ -109,6 +111,9 @@
     <Content Include="ClientConfigurationForUnitTests.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
+    </Content>
+    <Content Include="OrleansConfigurationForStreamingDeactivationUnitTests.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="OrleansConfigurationForStreamingUnitTests.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Repro for #378: Run ```SMSDeactivationTest```

Notes:

* The test is marked as BVT, but it takes 3+ minutes to execute - you may want to relegate it to nightly runs only
* I haven't created a similar test for the AQ streams - it's trivial to add one, though.
* The test shows that the deactivation cycle hangs and that subsequent calls to one of the grains involved in the deadlock hang. Adding more tests assessing the extent of the silo degradation may make sense (e.g. trying to activate an unrelated grain, etc.).
* I've observed that if one waits further (minutes?) the silo eventually commits suicide.
