### PR TITLE
Do not ever collect activations of memory storage grains.

### DIFF
--- a/src/OrleansProviders/Storage/MemoryStorageGrain.cs
+++ b/src/OrleansProviders/Storage/MemoryStorageGrain.cs
@@ -21,6 +21,7 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -42,6 +43,7 @@ namespace OrleansProviders.Storage
         public override Task OnActivateAsync()
         {
             grainStore = new Dictionary<string, GrainStateStore>();
+            base.DelayDeactivation(TimeSpan.FromDays(10 * 365)); // Delay Deactivation for MemoryStorageGrain virtually indefinitely.
             return TaskDone.Done;
         }
 


### PR DESCRIPTION
Memory storage grains are only to be used for testing. If activation GC is set to a short period of time, those grain will also be collected, potentially leading to wrong test results. They should be viewed as "fake system grains".