### PR TITLE
Code cleanup 05/05

### DIFF
--- a/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
@@ -148,7 +148,7 @@ namespace Orleans.Runtime.GrainDirectory
             cacheSuccesses = CounterStatistic.FindOrCreate(StatisticNames.DIRECTORY_LOOKUPS_CACHE_SUCCESSES);
             StringValueStatistic.FindOrCreate(StatisticNames.DIRECTORY_LOOKUPS_CACHE_HITRATIO, () =>
                 {
-                    long delta1 = 0, delta2 = 0;
+                    long delta1, delta2;
                     long curr1 = cacheSuccesses.GetCurrentValueAndDelta(out delta1);
                     long curr2 = cacheLookups.GetCurrentValueAndDelta(out delta2);
                     return String.Format("{0}, Delta={1}", 
@@ -459,13 +459,13 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 if (Seed == null)
                 {
-                    var grainName = String.Empty;
+                    string grainName;
                     if (!Constants.TryGetSystemGrainName(grain, out grainName))
                         grainName = "MembershipTableGrain";
                     
                     var errorMsg = grainName + " cannot run without Seed node - please check your silo configuration file and make sure it specifies a SeedNode element. " +
                         " Alternatively, you may want to use AzureTable for LivenessType.";
-                    throw new ArgumentException(errorMsg, "grain = " + grain.ToString());
+                    throw new ArgumentException(errorMsg, "grain = " + grain);
                 }
                 // Directory info for the membership table grain has to be located on the primary (seed) node, for bootstrapping
                 if (log.IsVerbose2) log.Verbose2("Silo {0} looked for a special grain {1}, returned {2}", MyAddress, grain, Seed);
@@ -577,7 +577,7 @@ namespace Orleans.Runtime.GrainDirectory
                     // Caching optimization:
                     // cache the result of a successfull RegisterActivation call, only if it is not a duplicate activation.
                     // this way next local lookup will find this ActivationAddress in the cache and we will save a full lookup!
-                    List<Tuple<SiloAddress, ActivationId>> cached = null;
+                    List<Tuple<SiloAddress, ActivationId>> cached;
                     if (!DirectoryCache.LookUp(address.Grain, out cached))
                     {
                         cached = new List<Tuple<SiloAddress, ActivationId>>(1);
@@ -710,7 +710,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public List<ActivationAddress> GetLocalCacheData(GrainId grain)
         {
-            List<Tuple<SiloAddress, ActivationId>> cached = null;
+            List<Tuple<SiloAddress, ActivationId>> cached;
             return DirectoryCache.LookUp(grain, out cached) ? 
                 cached.Select(elem => ActivationAddress.GetAddress(elem.Item1, grain, elem.Item2)).Where(addr => IsValidSilo(addr.Silo)).ToList() : 
                 null;

--- a/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
@@ -105,6 +105,8 @@ namespace Orleans.Runtime.GrainDirectory
         public async Task<Tuple<ActivationAddress, int>> RegisterSingleActivation(ActivationAddress address, int retries)
         {
             router.RegistrationsSingleActRemoteReceived.Increment();
+            if (logger.IsVerbose2) logger.Verbose2("Trying to register activation for grain. GrainId: {0}. ActivationId: {1}.", address.Grain, address.Activation);
+
             // validate that this grain should be stored in our partition
             SiloAddress owner = router.CalculateTargetSilo(address.Grain);
             if (owner == null)
@@ -123,7 +125,7 @@ namespace Orleans.Runtime.GrainDirectory
                 throw new OrleansException("Silo " + router.MyAddress + " is not the owner of the grain " +
                                                 address.Grain + " Owner=" + owner);
 
-            if (logger.IsVerbose2) logger.Verbose2("Retry " + retries + " RemoteGrainDirectory.RegisterSingleActivation for address=" + address + " at Owner=" + owner);
+            if (logger.IsVerbose2) logger.Verbose2("Retry {0} RemoteGrainDirectory.RegisterSingleActivation for address={1} at Owner={2}", retries, address, owner);
             PrepareForRetry(retries);
 
             await Task.Delay(RETRY_DELAY);
@@ -158,6 +160,7 @@ namespace Orleans.Runtime.GrainDirectory
             // validate that this request arrived correctly
             //logger.Assert(ErrorCode.Runtime_Error_100140, silo.Matches(router.MyAddress), "destination address != my address");
             //var result = new List<ActivationAddress>();
+            if (logger.IsVerbose2) logger.Verbose2("RegisterManySingleActivation Count={0}", addresses.Count);
 
             if (addresses.Count == 0)
                 return TaskDone.Done;
@@ -186,7 +189,7 @@ namespace Orleans.Runtime.GrainDirectory
             
             if (retries > 0)
             {
-                if (logger.IsVerbose2) logger.Verbose2("Retry " + retries + " RemoteGrainDirectory.Unregister for address=" + address + " at Owner=" + owner);
+                if (logger.IsVerbose2) logger.Verbose2("Retry {0} RemoteGrainDirectory.Unregister for address={1} at Owner={2}", retries, address, owner);
                 PrepareForRetry(retries);
 
                 await Task.Delay(RETRY_DELAY);
@@ -272,7 +275,7 @@ namespace Orleans.Runtime.GrainDirectory
             
             if (retries > 0)
             {
-                if (logger.IsVerbose2) logger.Verbose2("Retry " + retries + " RemoteGrainDirectory.DeleteGrain for Grain=" + grain + " at Owner=" + owner);
+                if (logger.IsVerbose2) logger.Verbose2("Retry {0} RemoteGrainDirectory.DeleteGrain for Grain={1} at Owner={2}", retries, grain, owner);
                 PrepareForRetry(retries);
 
                 await Task.Delay(RETRY_DELAY);

--- a/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
@@ -151,7 +151,6 @@ namespace Orleans.Runtime.Messaging
         {
             pingSender.Start();
             systemSender.Start();
-
         }
 
         public void Stop()

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -475,7 +475,7 @@ namespace Orleans.Runtime
                 }
                 if (logger.IsVerbose) { logger.Verbose("Message gateway service started successfully."); }
 
-                scheduler.QueueTask(clientRegistrar.Start, ((SystemTarget)clientRegistrar).SchedulingContext)
+                scheduler.QueueTask(clientRegistrar.Start, clientRegistrar.SchedulingContext)
                     .WaitWithThrow(initTimeout);
                 if (logger.IsVerbose) { logger.Verbose("Client registrar service started successfully."); }
 


### PR DESCRIPTION
Code cleanup

- Some minor code cleanup suggested by some internal code walkthroughs + ReSharper.

- The only significant change is likely to be Line 450 in IncomingMessageAcceptor.cs

Changed from: ``` msg.SendingGrain != Constants.SystemMembershipTableId ```
To: ``` !Constants.SystemMembershipTableId.Equals(msg.SendingGrain) ```

ReSharper pointed out a "possible unintended reference comparison" warning, and i think they are right.

Although GrainId's _should_ all be interned so ref-compare should / may work ok,
i think it safest to use .Equals comparison to ensure we really do get the semantics we expect.