### PR TITLE
Azure Table Connection Init Error Handling

### DIFF
--- a/src/Orleans/AzureUtils/OrleansSiloInstanceManager.cs
+++ b/src/Orleans/AzureUtils/OrleansSiloInstanceManager.cs
@@ -149,7 +149,7 @@ namespace Orleans.AzureUtils
         private readonly AzureTableDataManager<SiloInstanceTableEntry> storage;
         private readonly TraceLogger logger;
 
-        private static readonly TimeSpan initTimeout = AzureTableDefaultPolicies.TableCreationTimeout;
+        internal static TimeSpan initTimeout = AzureTableDefaultPolicies.TableCreationTimeout;
 
         public string DeploymentId { get; private set; }
 
@@ -168,15 +168,18 @@ namespace Orleans.AzureUtils
             {
                 await instance.storage.InitTableAsync()
                     .WithTimeout(initTimeout);
-
             }
-            catch (TimeoutException)
+            catch (TimeoutException te)
             {
-                instance.logger.Fail(ErrorCode.AzureTable_32, String.Format("Unable to create or connect to the Azure table in {0}", initTimeout));
+                string errorMsg = String.Format("Unable to create or connect to the Azure table in {0}", initTimeout);
+                instance.logger.Error(ErrorCode.AzureTable_32, errorMsg, te);
+                throw new OrleansException(errorMsg, te);
             }
             catch (Exception ex)
             {
-                instance.logger.Fail(ErrorCode.AzureTable_33, String.Format("Exception trying to create or connect to the Azure table: {0}", ex));
+                string errorMsg = String.Format("Exception trying to create or connect to the Azure table: {0}", ex.Message);
+                instance.logger.Error(ErrorCode.AzureTable_33, errorMsg, ex);
+                throw new OrleansException(errorMsg, ex);
             }
             return instance;
         }

--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -218,6 +218,8 @@ namespace Orleans.Runtime
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public static void Initialize(ITraceConfiguration config, bool configChange = false)
         {
+            if (config == null) throw new ArgumentNullException("config", "No logger config data provided.");
+
             lock (lockable)
             {
                 if (IsInitialized && !configChange) return; // Already initialized

--- a/src/OrleansRuntime/ReminderService/RemindersTableManager.cs
+++ b/src/OrleansRuntime/ReminderService/RemindersTableManager.cs
@@ -111,15 +111,20 @@ namespace Orleans.Runtime.ReminderService
             try
             {
                 singleton.Logger.Info("Creating RemindersTableManager for service id {0} and deploymentId {1}.", serviceId, deploymentId);
-                await singleton.InitTableAsync().WithTimeout(initTimeout);
+                await singleton.InitTableAsync()
+                    .WithTimeout(initTimeout);
             }
-            catch (TimeoutException)
+            catch (TimeoutException te)
             {
-                singleton.Logger.Fail(ErrorCode.AzureTable_38, String.Format("Unable to create or connect to the Azure table in {0}", initTimeout));
+                string errorMsg = String.Format("Unable to create or connect to the Azure table in {0}", initTimeout);
+                singleton.Logger.Error(ErrorCode.AzureTable_38, errorMsg, te);
+                throw new OrleansException(errorMsg, te);
             }
             catch (Exception ex)
             {
-                singleton.Logger.Fail(ErrorCode.AzureTable_39, String.Format("Exception trying to create or connect to the Azure table: {0}", ex));
+                string errorMsg = String.Format("Exception trying to create or connect to the Azure table: {0}", ex.Message);
+                singleton.Logger.Error(ErrorCode.AzureTable_39, errorMsg, ex);
+                throw new OrleansException(errorMsg, ex);
             }
             return singleton;
         }


### PR DESCRIPTION
- Don't crash silo process (eg mstest agent process) if unable to connect to Azure table -- return exception back to caller for logging and handling.
  [See failure mode below found in Windows Application Error Log]
- Add check for null config object passed to Logger.Initialize
- Use shorter initialization timeout during Azure MT test cases -- don't need to wait a full 2 minutes before each of those test cases report failure.

Failure Mode from Windows Application Error Log:
```
Application: QTAgent.exe
Framework Version: v4.0.30319
Description: The application requested process termination through System.Environment.FailFast(string message).
Message: Unrecoverable failure: Exception trying to create or connect to the Azure table: Microsoft.WindowsAzure.Storage.StorageException:
Unable to connect to the remote server
---> System.Net.WebException: Unable to connect to the remote server
---> System.Net.Sockets.SocketException: No connection could be made because the target machine actively refused it 127.0.0.1:10002
   at System.Net.Sockets.Socket.EndConnect(IAsyncResult asyncResult)
   at System.Net.ServicePoint.ConnectSocketInternal(Boolean connectFailure, Socket s4, Socket s6, Socket& socket, IPAddress& address, ConnectSocketState state, IAsyncResult asyncResult, Exception& exception)
   --- End of inner exception stack trace ---
   at System.Net.HttpWebRequest.EndGetResponse(IAsyncResult asyncResult)
   at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndGetResponse[T](IAsyncResult getResponseResult)
   --- End of inner exception stack trace ---
   at Microsoft.WindowsAzure.Storage.Core.Util.StorageAsyncResult`1.End()
   at Microsoft.WindowsAzure.Storage.Table.CloudTable.EndCreateIfNotExists(IAsyncResult asyncResult)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Orleans.AzureUtils.AzureTableDataManager`1.<InitTableAsync>d__0.MoveNext() in e:\Depot\GitHub\orleans\src\Orleans\AzureUtils\AzureTableDataManager.cs:line 111
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Orleans.OrleansTaskExtentions.<WithTimeout>d__6.MoveNext() in e:\Depot\GitHub\orleans\src\Orleans\Async\TaskExtensions.cs:line 127
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Orleans.AzureUtils.OrleansSiloInstanceManager.<GetManager>d__0.MoveNext() in e:\Depot\GitHub\orleans\src\Orleans\AzureUtils\OrleansSiloInstanceManager.cs:line 169
Request Information
RequestID:
RequestDate:
StatusMessage:

Stack:
   at System.Environment.FailFast(System.String)
   at Orleans.Runtime.TraceLogger.Fail(Orleans.ErrorCode, System.String)
   at Orleans.AzureUtils.OrleansSiloInstanceManager+<GetManager>d__0.MoveNext()
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run()
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(System.Action, Boolean, System.Threading.Tasks.Task ByRef)
   at System.Threading.Tasks.Task.FinishContinuations()
   at System.Threading.Tasks.Task.Finish(Boolean)
   at System.Threading.Tasks.Task`1[[System.Threading.Tasks.VoidTaskResult, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TrySetException(System.Object)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[System.Threading.Tasks.VoidTaskResult, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].SetException(System.Exception)
   at Orleans.OrleansTaskExtentions+<WithTimeout>d__6.MoveNext()
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run()
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(System.Action, Boolean, System.Threading.Tasks.Task ByRef)
   at System.Threading.Tasks.Task.FinishContinuations()
   at System.Threading.Tasks.Task`1[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TrySetResult(System.__Canon)
   at System.Threading.Tasks.TaskFactory+CompleteOnInvokePromise.Invoke(System.Threading.Tasks.Task)
   at System.Threading.Tasks.Task.FinishContinuations()
   at System.Threading.Tasks.Task.Finish(Boolean)
   at System.Threading.Tasks.Task`1[[System.Threading.Tasks.VoidTaskResult, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TrySetException(System.Object)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[System.Threading.Tasks.VoidTaskResult, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].SetException(System.Exception)
   at Orleans.AzureUtils.AzureTableDataManager`1+<InitTableAsync>d__0[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].MoveNext()
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run()
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(System.Action, Boolean, System.Threading.Tasks.Task ByRef)
   at System.Threading.Tasks.Task.FinishContinuations()
   at System.Threading.Tasks.Task.Finish(Boolean)
   at System.Threading.Tasks.Task`1[[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TrySetException(System.Object)
   at System.Threading.Tasks.TaskFactory`1[[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].FromAsyncCoreLogic(System.IAsyncResult, System.Func`2<System.IAsyncResult,Boolean>, System.Action`1<System.IAsyncResult>, System.Threading.Tasks.Task`1<Boolean>, Boolean)
   at System.Threading.Tasks.TaskFactory`1+<>c__DisplayClass9[[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].<FromAsyncImpl>b__5(System.IAsyncResult)
   at Microsoft.WindowsAzure.Storage.Table.CloudTable.CreateIfNotExistHandler(System.IAsyncResult)
   at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndOperation[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]](Microsoft.WindowsAzure.Storage.Core.Executor.ExecutionState`1<System.__Canon>)
   at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndGetResponse[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]](System.IAsyncResult)
   at System.Net.LazyAsyncResult.Complete(IntPtr)
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
   at System.Net.ContextAwareResult.Complete(IntPtr)
   at System.Net.HttpWebRequest.SetResponse(System.Exception)
   at System.Net.ConnectionReturnResult.SetResponses(System.Net.ConnectionReturnResult)
   at System.Net.Connection.CompleteConnectionWrapper(System.Object, System.Object)
   at System.Net.PooledStream.ConnectionCallback(System.Object, System.Exception, System.Net.Sockets.Socket, System.Net.IPAddress)
   at System.Net.ServicePoint.ConnectSocketCallback(System.IAsyncResult)
   at System.Net.LazyAsyncResult.Complete(IntPtr)
   at System.Net.ContextAwareResult.Complete(IntPtr)
   at System.Net.Sockets.BaseOverlappedAsyncResult.CompletionPortCallback(UInt32, UInt32, System.Threading.NativeOverlapped*)
   at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32, UInt32, System.Threading.NativeOverlapped*)
```