### PR TITLE
Updating Step-by-Step documenation

### DIFF
--- a/Step-by-step-Tutorials/A-Service-is-a-Collection-of-Communicating-Actors.md
+++ b/Step-by-step-Tutorials/A-Service-is-a-Collection-of-Communicating-Actors.md
@@ -4,17 +4,22 @@ title: A Service is a Collection of Communicating Actors
 ---
 {% include JB/setup %}
 
-The previous tutorials all relied on interacting with a single actor from the client. In most real-world situations this is not what would be expected as actors are intended to be more or less as light-weight as objects and treated as such. Thus, you would no more find an application with just one actor type and one actor instance than you would expect to find a .NET application with one instance of one class.
+The previous tutorials all relied on interacting with a single actor from the client. 
+In most real-world situations this is not what would be expected as actors are intended to be more or less as light-weight as objects and treated as such. 
+Thus, you would no more find an application with just one actor type and one actor instance than you would expect to find a .NET application with one instance of one class.
 
- In this tutorial, we're going to construct multiple actors from a couple of classes with different communication interfaces. Not everything will be explained while putting together the application, we will go back and elaborate on a few things after we have it working.
+In this tutorial, we're going to construct multiple actors from a couple of classes with different communication interfaces. 
+Not everything will be explained while putting together the application, we will go back and elaborate on a few things after we have it working.
 
-Employees and Managers
+##Employees and Managers
 
 This example will use the relationship of employees and managers to demonstrate the concept of multiple actors - it's one we all understand and relate to.
 
- Start by creating a new solution with a silo host, a communications interface project and a grain implementation project as described in previous tutorials. Don't forget to add the necessary project-to-project references and make sure to add a build dependency on the implementation project so that it is built when the host project is built.
+Start by creating a new solution with a silo host, a communications interface project and a grain implementation project as described in previous tutorials. 
+Don't forget to add the necessary project-to-project references and make sure to add a build dependency on the implementation project so that it is built when the host project is built.
 
- Change the first interface to `IEmployee` and add an interface called `IManager`. Add a couple of methods to describe relationships and employment level:
+Change the first interface to `IEmployee` and add an interface called `IManager`. 
+Add a couple of methods to describe relationships and employment level:
 
 
 ``` csharp
@@ -40,12 +45,15 @@ public interface IManager : Orleans.IGrain
 ```
 
 
-Note that this looks a bit different to normal .NET interfaces: usually, you have a property with a setter and a getter, but when defining grain interfaces, you need to avoid using properties altogether, only methods are supported. This is because .NET property setters and getters aren't meant to do I/O.
+Note that this looks a bit different to normal .NET interfaces: usually, you have a property with a setter and a getter, but when defining grain interfaces, you need to avoid using properties altogether, only methods are supported. 
+This is because .NET property setters and getters aren't meant to do I/O.
 
-It is often possible to use traditional object-oriented design methodology with Orleans, but sometimes there are reasons for not doing so. In this case, we're choosing to not rely on inheritance when defining the Manager class, even though a Manager is clearly also an Employee. The reason for this will be explained when we discuss Orleans' support for  Declarative Persistence.
+It is often possible to use traditional object-oriented design methodology with Orleans, but sometimes there are reasons for not doing so. 
+In this case, we're choosing to not rely on inheritance when defining the `Manager` class, even though a `Manager` is clearly also an `Employee`. 
+The reason for this will be explained when we discuss Orleans' support for [Declarative Persistence](Declarative-Persistence).
 With these two interfaces as our starting point, the implementation classes are straight-forward to implement, as the interfaces are simple.
 
- Here's what it looks like:
+Here's what it looks like:
 
 ``` csharp
 public class Employee : Orleans.Grain, Interfaces.IEmployee
@@ -110,9 +118,10 @@ public class Manager : Orleans.Grain, IManager
 }
 ```
 
- A manager is expressed as an employee through composition: the manager grain has a reference to an grain representing its "employeeness." The role of ActivateAsync() will be explained later on; for now, you may consider it a constructor.
+A manager is expressed as an employee through composition: the manager grain has a reference to an grain representing its "employeeness." 
+The role of `OnActivateAsync()` will be explained later on; for now, you may consider it a constructor.
 
- In the client (Program.cs), we can add a few lines to create a couple of employees and their manager:
+In the client _(Program.cs)_, we can add a few lines to create a couple of employees and their manager:
 
 ``` csharp
 Orleans.OrleansClient.Initialize("DevTestClientConfiguration.xml");
@@ -144,9 +153,11 @@ Console.WriteLine("Orleans Silo is running.\nPress Enter to terminate...");
 Console.ReadLine();
 ```
 
- In the code we have seen so far, it is noteworthy that you can send grain references (interfaces) in messages. Thus, when a direct report is added to a manager, the manager can communicate directly with the employee without calling 'GetGrain().' This ability is essential in making the programming model a smooth transition from .NET.
+In the code we have seen so far, it is noteworthy that you can send grain references (interfaces) in messages. 
+Thus, when a direct report is added to a manager, the manager can communicate directly with the employee without calling `GetGrain()`. 
+This ability is essential in making the programming model a smooth transition from .NET.
 
- Let's add the ability for employees to send messages to each other:
+Let's add the ability for employees to send messages to each other:
 
 ``` csharp
 public interface IEmployee : Orleans.IGrain
@@ -183,20 +194,23 @@ public class Manager : Employee, IManager
     }
 ```
 
- Executing it, you should see something like this:
+Executing it, you should see something like this:
 
 ![Multiple Actors1.png](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810446)
 
- The use of a GUID to represent the name of a person leaves something for you to fix, as an exercise.
+The use of a GUID to represent the name of a person leaves something for you to fix, as an exercise.
 
 
-TaskDone.Done, used in the code above, is a convenience object defined by Orleans to allow code to succinctly return an already completed Task. 
+`TaskDone.Done`, used in the code above, is a convenience object defined by Orleans to allow code to succinctly return an already completed `Task`. 
 
-**Asynchrony Bites Us!**
+###Asynchrony Bites Us!
 
- In the image above, you may notice that the last message comes out after the request to press Enter -- why is that? All the client requests to add a direct report dutifully wait for the addition to finish, i.e. they are fully synchronous. The problem lies elsewhere -- in the implementation of AddDirectReport(), which doesn't wait for the greeting to be acknowledged. Such concurrency is often innocuous and sometimes beneficial, as long as we don't consider the risk of exceptions, which we always must.
+In the image above, you may notice that the last message comes out after the request to press Enter -- why is that? 
+All the client requests to add a direct report dutifully wait for the addition to finish, i.e. they are fully synchronous. 
+The problem lies elsewhere -- in the implementation of `AddDirectReport()`, which doesn't wait for the greeting to be acknowledged. 
+Such concurrency is often innocuous and sometimes beneficial, as long as we don't consider the risk of exceptions, which we always must.
 
- A correct version of the method would look like this:
+A correct version of the method would look like this:
 
 ``` csharp
 public async Task AddDirectReport(IEmployee employee)
@@ -209,16 +223,24 @@ public async Task AddDirectReport(IEmployee employee)
 
 ## The Life of an Actor
 
-Orleans actors are virtual, meaning that even though an actor logically exists, it may not be present in memory at a given point in time. In fact, Orleans takes this concept to an extreme by claiming that all actors exist at all time (past and present) and are never created or destroyed. An actor may be inactive, such as before the first time anyone refers to it or after the last use, but is never not existing.
+Orleans actors are virtual, meaning that even though an actor logically exists, it may not be present in memory at a given point in time. 
+In fact, Orleans takes this concept to an extreme by claiming that all actors exist at all time (past and present) and are never created or destroyed. 
+An actor may be inactive, such as before the first time anyone refers to it or after the last use, but is never not existing.
 
- While counter-intuitive and, frankly, strange to most of us with a object-oriented background, this notion actually removes a source of complexity from the system. An actor is either active (present in memory) or inactive, and that status can not be observed by a client. Actor activation is on-demand, just like virtual memory is mapped on demand to physical memory.
+While counter-intuitive and, frankly, strange to most of us with a object-oriented background, this notion actually removes a source of complexity from the system. 
+An actor is either active (present in memory) or inactive, and that status can not be observed by a client. 
+Actor activation is on-demand, just like virtual memory is mapped on demand to physical memory.
 
- Thus, the .NET object that holds the actor state is logically just a copy of the actor in memory while it is in the active state. Implementors of Orleans grains should refrain from writing constructors, even parameter-less ones, with any logic. That is simply the wrong way of thinking about them: grains are never created or destroyed, just moved from the inactive to the active state or vice versa.
+Thus, the .NET object that holds the actor state is logically just a copy of the actor in memory while it is in the active state. 
+Implementations of Orleans grains should refrain from having constructors, even parameter-less ones, with any logic. 
+That is simply the wrong way of thinking about them: grains are never created or destroyed, just moved from the inactive to the active state or vice versa.
 
- Therefore, the implementation should catch the activation event (a call to ActivateAsync()) and perform any initialization steps necessary there. It is guaranteed to be called before any method on the grain instance is called. In the Manager grain above, it was used to establish the reference to the Employee grain.
+Therefore, the implementation should catch the activation event (a call to `OnActivateAsync()`) and perform any initialization steps necessary there. 
+It is guaranteed to be called before any method on the grain instance is called. 
+In the `Manager` grain above, it was used to establish the reference to the Employee grain.
 
- There is also a DeactivateAsync() method, used more infrequently.
+There is also an `OnDeactivateAsync()` method, used more infrequently.
 
 ## Next
 
-Next up is a look at  [Concurrency](Concurrency ) in Orleans.
+Next up is a look at  [Concurrency](Concurrency) in Orleans.

--- a/Step-by-step-Tutorials/Actor-Identity.md
+++ b/Step-by-step-Tutorials/Actor-Identity.md
@@ -4,33 +4,44 @@ title: Actor Identity
 ---
 {% include JB/setup %}
 
-In object-oriented environments, the identity of an object is hard to distinguish from a reference to it. Thus, when an object is created using new, the reference you get back represents all aspects of its identity except those that map the object to some external entity that it represents.
+In object-oriented environments, the identity of an object is hard to distinguish from a reference to it. 
+Thus, when an object is created using new, the reference you get back represents all aspects of its identity except those that map the object to some external entity that it represents.
 
- In distributed systems, object references cannot represent instance identity, since references are typically limited to a single address space. That is certainly the case for .NET references. Furthermore, a virtual actor must have an identity regardless of whether it is active, so that we can activate it on demand. Therefore grains have a primary key. The primary key can be either a GUID (A Globally Unique Identifier) or a long integer.
+In distributed systems, object references cannot represent instance identity, since references are typically limited to a single address space. 
+That is certainly the case for .NET references. 
+Furthermore, a virtual actor must have an identity regardless of whether it is active, so that we can activate it on demand. 
+Therefore grains have a primary key. 
+The primary key can be either a GUID (A Globally Unique Identifier) or a long integer.
 
- The primary key is scoped to the grain type. Therefore, the complete identity of a grain is formed from the actor type and its key. 
+The primary key is scoped to the grain type. 
+Therefore, the complete identity of a grain is formed from the actor type and its key. 
 
- The caller of the grain decides whether a long or a GUID scheme should be used. In fact the underlying data is the same, so the schemes can be used interchangeably. When a long is used, a GUID is actually created, and padded with zeros.
+The caller of the grain decides whether a long or a GUID scheme should be used. 
+In fact the underlying data is the same, so the schemes can be used interchangeably. 
+When a long is used, a GUID is actually created, and padded with zeros.
 
- Situations that require a singleton grain instance, such as a dictionary or registry, benefit from using '0' (a valid GUID) as its key. This is merely a convention, but by adhering, it becomes clear at the call site that it is what is going on, as we saw in the first tutorial:
+Situations that require a singleton grain instance, such as a dictionary or registry, benefit from using `0` (a valid GUID) as its key. 
+This is merely a convention, but by adhering, it becomes clear at the call site that it is what is going on, as we saw in the first tutorial:
 
 ## Using GUIDs
 
-GUIDs are useful when there are several processes that could request a grain, such as a number of web servers in a web farm. You don't need to coordinate the allocation of keys, which could introduce a single point of failure in the system, or a system-side lock on a resource which could present a bottleneck. There is a very low chance of GUIDs colliding, so they would probably be the default choice when architecting an Orleans system. 
+GUIDs are useful when there are several processes that could request a grain, such as a number of web servers in a web farm. 
+You don't need to coordinate the allocation of keys, which could introduce a single point of failure in the system, or a system-side lock on a resource which could present a bottleneck. 
+There is a very low chance of GUIDs colliding, so they would probably be the default choice when architecting an Orleans system. 
 
- Referencing a grain by GUID in client code:
+Referencing a grain by GUID in client code:
 
 ``` csharp
 var grain = ExampleGrainFactor.GetGrain(Guid.NewGuid());
 ```
 
-Retrieving the primary key form grain code:
+Retrieving the primary key from grain code:
 
 ``` csharp
-public override Task ActivateAsync()
+public override Task OnActivateAsync()
 {
     Guid primaryKey = this.GetPrimaryKey();
-    return base.ActivateAsync();
+    return base.OnActivateAsync();
 }
 ```
 
@@ -38,7 +49,7 @@ public override Task ActivateAsync()
 
 A long integer is also available, which would make sense if the grain is persisted to a relational database, where numerical indexes are preferred over GUIDs.
 
- Referencing a grain by GUID in client code:
+Referencing a grain by GUID in client code:
 
 ``` csharp
 var grain = ExampleGrainFactor.GetGrain(1);
@@ -47,10 +58,10 @@ var grain = ExampleGrainFactor.GetGrain(1);
 Retrieving the primary key form grain code:
 
 ``` csharp
-public override Task ActivateAsync()
+public override Task OnActivateAsync()
 {
     long primaryKey = this.GetPrimaryKeyLong();
-    return base.ActivateAsync();
+    return base.OnActivateAsync();
 }
 ```
 
@@ -58,7 +69,7 @@ public override Task ActivateAsync()
 
 If you have a system that doesn't fit well with either GUIDs or longs, you can opt for an extended primary key which allows you to use a string to reference a grain.
 
- You can mark a grain interface with an [ExtendedPrimaryKey] attribute like this:
+You can mark a grain interface with an `[ExtendedPrimaryKey]` attribute like this:
 
 ``` csharp
 [ExtendedPrimaryKey]
@@ -68,15 +79,16 @@ public interface IExampleGrain : Orleans.IGrain
 }
 ```
 
-In client code, this adds a second argument to the GetGrain method on the grain factory.
+In client code, this adds a second argument to the `GetGrain` method on the grain factory.
 
 ``` csharp
 var grain = ExampleGrainFactory.GetGrain(0, "a string!");
 ```
 
-Notice we still have a primary key, which can still be either a GUID or a long. We can choose to ignore this by setting the primary key to zero, or we can combine the primary key and secondary key together as a joined key.
+Notice we still have a primary key, which can still be either a GUID or a long. 
+We can choose to ignore this by setting the primary key to zero, or we can combine the primary key and secondary key together as a joined key.
 
- To access the extended key in the grain, we can call an overload on the  GetPrimaryKey method:
+To access the extended key in the grain, we can call an overload on the `GetPrimaryKey` method:
 
 ``` csharp
 public class ExampleGrain : Orleans.GrainBase, IExampleGrain
@@ -91,7 +103,7 @@ public class ExampleGrain : Orleans.GrainBase, IExampleGrain
 }
 ```
 
-The stock ticker example used in the  Interaction with Libraries and Services uses ExtendedPrimaryKey to activate grains representing different stock symbols.
+The stock ticker example used in the [Interaction with Libraries and Services](Interaction-with-Libraries-and-Services) uses `[ExtendedPrimaryKey]` to activate grains representing different stock symbols.
 
 ## Next
 

--- a/Step-by-step-Tutorials/Cloud-Deployment.md
+++ b/Step-by-step-Tutorials/Cloud-Deployment.md
@@ -7,46 +7,50 @@ title: Cloud Deployment
 ## Deploying Orleans to Windows Azure
 This walkthrough shows the steps required to deploy the sample created in the  [Front Ends for Orleans Services](Front-Ends-for-Orleans-Services) to Windows Azure Cloud Services.
 
- In Azure, one or more worker roles will be used to host the Orleans silos, and an Azure web role will act as the presentation layer for the application and client to the application grains running in the Orleans silos. 
+In Azure, one or more worker roles will be used to host the Orleans silos, and an Azure web role will act as the presentation layer for the application and client to the application grains running in the Orleans silos. 
 
- The same grain interfaces and implementation can run on both Windows Server and Windows Azure, so no special considerations are needed in order to be able to run your application in a Windows Azure hosting environment.
+The same grain interfaces and implementation can run on both Windows Server and Windows Azure, so no special considerations are needed in order to be able to run your application in a Windows Azure hosting environment.
 
- The  [Azure Web Sample] (https://orleans.codeplex.com/wikipage?title=Azure%20Web%20Sample&referringTitle=Cloud%20Deployment) sample app in the Orleans SDK provides a working example of how to run a web application with supporting Orleans silo cluster backend in an Azure hosted service, and the details are described below.
+The  [Azure Web Sample](https://orleans.codeplex.com/wikipage?title=Azure%20Web%20Sample&referringTitle=Cloud%20Deployment) sample app in the Orleans SDK provides a working example of how to run a web application with supporting Orleans silo cluster backend in an Azure hosted service, and the details are described below.
 
 ## Pre-requisites
 The following prerequisites are required:
+
 * Visual Studio 2013 
 * Orleans SDK 
 * [Windows Azure SDK v2.4](http://azure.microsoft.com/en-us/downloads/)
 
- For more info on installing and working with Windows Azure in general, see the Microsoft Developer Network (MSDN) web site: http://msdn.microsoft.com/en-us/windowsazure/ 
+For more info on installing and working with Windows Azure in general, see the Microsoft Developer Network (MSDN) web site: (http://msdn.microsoft.com/en-us/windowsazure/) 
 
 ## Create Azure Worker Role for Orleans Silos 
 Right click on your solution, and select 'Add | New Project...'.
 
- Choose the 'Windows Azure Cloud Service' project template:
+Choose the 'Windows Azure Cloud Service' project template:
 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815101)
 
- When prompted, select a new Worker Role to add to the project. This will bed used to host the Orleans Silos:
+When prompted, select a new 'Worker Role' to add to the project. 
+This will be used to host the Orleans Silos:
 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815102)
 
 ## Add project references for Orleans Silo binaries 
-Add references to the OrleansAzureSilos project for the required Orleans server library files. Copies of these files can be found in the .\Binaries\OrleansServer folder under the Orleans SDK.
+Add references to the `OrleansAzureSilo` project for the required Orleans server library files. 
+Copies of these files can be found in the _.\Binaries\OrleansServer_ folder under the Orleans SDK.
+
 * Orleans.dll 
 * OrleansAzureUtils.dll 
 * OrleansRuntime.dll 
-* OrleansProviders.dll (Only required if you your grains use the Declarative Persistence functionality.)
+* OrleansProviders.dll (Only required if you your grains use the [Declarative Persistence](Declarative-Persistence) functionality.)
 
- Note: All of these references MUST have Copy Local = `True` settings to ensure the necessary library DLLs get copied into the OrleansAzureSilos project output directory. 
+Note: All of these references MUST have _Copy Local = 'True'_ settings to ensure the necessary library DLLs get copied into the `OrleansAzureSilo` project output directory. 
 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815103)
 
 ## Configure Azure Worker Role for Orleans Silos 
 The Worker Role initialization class is a normal Azure worker role - it needs to inherit from the usual `Microsoft.WindowsAzure.ServiceRuntime.RoleEntryPoint` base class. 
 
- The worker role initialization class needs to create an instance of `Orleans.Host.Azure.OrleansAzureSilo` class, and call the appropriate Start/Run/Stop functions in the appropriate places:
+The worker role initialization class needs to create an instance of `Orleans.Host.Azure.OrleansAzureSilo` class, and call the appropriate `Start`/`Run`/`Stop` functions in the appropriate places:
 
 ``` csharp
 public class WorkerRole : RoleEntryPoint 
@@ -67,11 +71,12 @@ public class WorkerRole : RoleEntryPoint
 } 
 ```
 
- Then, in the ServiceDefinition.csdef file for this role, add some required configuration items used by the Orleans Azure hosting library to the WorkerRole configuration:
-* Add a ConfigurationSettings declaration named 'DataConnectionString' This is the Azure storage location where Orleans Azure hosting library will place / look for its silo instance table. 
-* Add a LocalStorage declaration named 'LocalStoreDirectory' This is the directory that will be used for any local cache directories. 
-* Add an InternalEndpoint declaration for a TCP endpoint named 'OrleansSiloEndpoint' 
-* Add an InternalEndpoint declaration for a TCP endpoint named 'OrleansProxyEndpoint' 
+Then, in the `ServiceDefinition.csdef` file for this role, add some required configuration items used by the Orleans Azure hosting library to the WorkerRole configuration:
+
+* Add a `ConfigurationSettings` declaration named 'DataConnectionString'. This is the Azure storage location where Orleans Azure hosting library will place / look for its silo instance table. 
+* Add a `LocalStorage` declaration named 'LocalStoreDirectory'. This is the directory that will be used for any local cache directories. 
+* Add an `InternalEndpoint` declaration for a TCP endpoint named 'OrleansSiloEndpoint' 
+* Add an `InternalEndpoint` declaration for a TCP endpoint named 'OrleansProxyEndpoint' 
 
 
     <ServiceDefinition ...>
@@ -90,17 +95,17 @@ public class WorkerRole : RoleEntryPoint
     </ServiceDefinition> 
 
 
- In the ServiceConfiguration.cscfg file for this role, add some required configuration items used by the Orleans Azure hosting library:
+In the _ServiceConfiguration.cscfg_ file for this role, add some required configuration items used by the Orleans Azure hosting library:
 
- Add a ConfigurationSettings definition for 'DataConnectionString'
+Add a `ConfigurationSettings` definition for 'DataConnectionString'
 
- This will be a normal Azure storage connection – either for the development storage emulator (only valid if running locally), or a full Azure storage account connection string for cloud-storage.
+This will be a normal Azure storage connection – either for the development storage emulator (only valid if running locally), or a full Azure storage account connection string for cloud-storage.
 
- In general, this connection string is likely to use the same configuration values as the `Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString` diagnostics connection string setting, but is not required to.
+In general, this connection string is likely to use the same configuration values as the `Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString` diagnostics connection string setting, but is not required to.
 
-http://msdn.microsoft.com/en-us/library/ee758697.aspx
+See the [Configure Azure Storage Connection Strings](http://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/) for more information.
 
- For example, to use local Developer Storage emulator (for local testing only)
+For example, to use local Developer Storage emulator (for local testing only)
 
 
     <ConfigurationSettings> 
@@ -108,7 +113,7 @@ http://msdn.microsoft.com/en-us/library/ee758697.aspx
     </ConfigurationSettings> 
 
 
- Or using an Azure cloud storage account:
+Or using an Azure cloud storage account:
 
 
     <ConfigurationSettings> 
@@ -117,52 +122,58 @@ http://msdn.microsoft.com/en-us/library/ee758697.aspx
 
 
 ## Changing DataConnectionString
-The "DataConnectionString" setting in ServiceDefinition.csdef is the default name use by the Orleans silo for the Azure table account connection string that will be used for Orleans system tables such as OrleanSiloInstances. 
+The "DataConnectionString" setting in `ServiceDefinition.csdef` is the default name use by the Orleans silo for the Azure table account connection string that will be used for Orleans system tables such as `OrleanSiloInstances`. 
 
- If you wish to use a different setting name for this value, then in the silo role initialization code set the property OrleansAzureSilo.DataConnectionConfigurationSettingName before the call to OrleansAzureSilo.Start
+If you wish to use a different setting name for this value, then in the silo role initialization code set the property `OrleansAzureSilo.DataConnectionConfigurationSettingName` before the call to `OrleansAzureSilo.Start(...)`
 
-Add your Orleans silo config file to Azure Worker Role for Orleans Silos 
-Add an OrleansConfiguration.xml file into your OrleansAzureSilos worker role project, along with any supporting libraries those grains need. The networking configuration information in OrleansConfiguration.xml will be overridden by values from the Azure role environment / configuration.
+Add your Orleans silo config file to Azure Worker Role for Orleans Silos. 
+Add an _OrleansConfiguration.xml_ file into your `OrleansAzureSilo` worker role project, along with any supporting libraries those grains need. 
+The networking configuration information in _OrleansConfiguration.xml_ will be overridden by values from the Azure role environment / configuration.
 
 
-Note: You MUST ensure this config file get copied into the OrleansAzureSilos project output directory, to ensure they get picked up by the Azure packaging tools. 
+Note: You MUST ensure this config file get copied into the `OrleansAzureSilo` project output directory, to ensure they get picked up by the Azure packaging tools. 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815104)
 
 ## Add your grain binaries to Azure Worker Role for Orleans Silos 
-Add the grain interfaces DLL and implementation classes DLL for the grains to he hosted in the Azure silo into the OrleansAzureSilos project, along with any supporting libraries those grains need.
+Add the grain interfaces DLL and implementation classes DLL for the grains to he hosted in the Azure silo into the `OrleansAzureSilo` project, along with any supporting libraries those grains need.
 
 
-Note: You MUST ensure that all the referenced binaries are copied into the OrleansAzureSilos project output directory, to ensure they get picked up by the Azure packaging tools.
+Note: You MUST ensure that all the referenced binaries are copied into the `OrleansAzureSilo` project output directory, to ensure they get picked up by the Azure packaging tools.
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815105)
 
 ## Running Orleans Client as Azure Web Role
 The user interface / presentation layer for your application will usually run as a Web Role in Azure.
 
- The Orleans.Host.Azure.Client.OrleansAzureClient utility class is the main mechanism for bootstrapping connection to the Orleans silo worker roles from an Azure Web Role. A few additional configuration steps are needed to make the OrleansAzureClient utility class work – see below for details.
+The `Orleans.Host.Azure.Client.OrleansAzureClient` utility class is the main mechanism for bootstrapping connection to the Orleans silo worker roles from an Azure Web Role. 
+A few additional configuration steps are needed to make the `OrleansAzureClient` utility class work – see below for details.
 
-**Create Azure Web Role for Orleans Client **
+###Create Azure Web Role for Orleans Client
+
 Using the Azure Tools for Visual Studio, create a normal Azure web role project.
 
- Any type of web role can be used as an Orleans client, and there are no specific naming requirements or conventions for this project.
+Any type of web role can be used as an Orleans client, and there are no specific naming requirements or conventions for this project.
 
- Add a web role to the solution:
+Add a web role to the solution:
 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815106)
 
-Add project references for Orleans Client binaries 
-Add references to the web role project for the required Orleans client library files. Copies of these files can be found in either  SDK-ROOT\Samples\References or  SDK-ROOT\Binaries\OrleansClient directories.
+Add project references for Orleans Client binaries. 
+Add references to the web role project for the required Orleans client library files. 
+Copies of these files can be found in either  _SDK-ROOT\Samples\References_ or  _SDK-ROOT\Binaries\OrleansClient_ directories.
+
 * Orleans.dll 
 * OrleansAzureUtils.dll
 
 
-Note: All of these references MUST have Copy Local = True settings to ensure the necessary library DLLs get copied into the web role project output directory. 
-08.png
+Note: All of these references MUST have _Copy Local = 'True'_ settings to ensure the necessary library DLLs get copied into the web role project output directory. 
 
-**Configure Azure Web Role to be an Orleans Client **
-In the ServiceDefinition.csdef file for this web role, add some required configuration items used by the Orleans Azure hosting library:
-* Add a ConfigurationSettings declaration named 'DataConnectionString'. 
+
+###Configure Azure Web Role to be an Orleans Client
+In the `ServiceDefinition.csdef` file for this web role, add some required configuration items used by the Orleans Azure hosting library:
+
+* Add a `ConfigurationSettings` declaration named 'DataConnectionString'. 
 This is the Azure storage location where Orleans Azure hosting library will place / look for its silo instance table. 
-* In addition, a http/s InputEndpoint will also need to be declared, just as for any other Azure web role config. 
+* In addition, a http/s `InputEndpoint` will also need to be declared, just as for any other Azure web role config. 
 
 
     <ServiceDefinition ...> 
@@ -187,14 +198,14 @@ This is the Azure storage location where Orleans Azure hosting library will plac
     </ServiceDefinition> 
 
 
- In the ServiceConfiguration.cscfg file for this role, add some required configuration items used by the Orleans Azure hosting library:
+In the _ServiceConfiguration.cscfg_ file for this role, add some required configuration items used by the Orleans Azure hosting library:
 
- Add a ConfigurationSettings definition for 'DataConnectionString'.
- This will be a normal Azure storage connection – either for the development storage emulator (if running locally), or a full Azure storage account connection string for cloud-storage.
+Add a `ConfigurationSettings` definition for 'DataConnectionString'.
+This will be a normal Azure storage connection – either for the development storage emulator (if running locally), or a full Azure storage account connection string for cloud-storage.
 
- This setting MUST match the DataConnectionString value used by the OrleansSiloWorker role in order for the client to discover and bootstrap the connection to the Orleans silos.
+This setting MUST match the `DataConnectionString` value used by the `OrleansSiloWorker` role in order for the client to discover and bootstrap the connection to the Orleans silos.
 
- For example, to use local Developer Storage emulator (for local testing only)
+For example, to use local Developer Storage emulator (for local testing only)
 
 
     <ServiceConfiguration ...>
@@ -209,7 +220,7 @@ This is the Azure storage location where Orleans Azure hosting library will plac
     </ServiceConfiguration> 
 
 
- Or using an Azure cloud storage account:
+Or using an Azure cloud storage account:
 
 
     <ServiceConfiguration ...> 
@@ -224,26 +235,25 @@ This is the Azure storage location where Orleans Azure hosting library will plac
     </ServiceConfiguration> 
 
 
-Add your Orleans client config file to Azure Web Role for Orleans Client 
-Add a ClientConfiguration.xml file into this project. The networking configuration information in ClientConfiguration.xml will be overridden by values from the Azure role environment / configuration.
-
+Add your Orleans client config file to Azure Web Role for Orleans Client. 
+Add a _ClientConfiguration.xml_ file into this project. 
+The networking configuration information in _ClientConfiguration.xml_ will be overridden by values from the Azure role environment / configuration.
 
 Note: You MUST ensure this config file get copied into the web role project output directory, to ensure they get picked up by the Azure packaging tools.
-09.png
 
-**Add your grain interface binaries to Azure Web Role for Orleans Client **
+
+###Add your grain interface binaries to Azure Web Role for Orleans Client
 Add the grain interfaces DLL for the application grains into this web role project. 
 
- Access to the DLL containing the grain implementation classes should not be required by the client web role. 
-
+Access to the DLL containing the grain implementation classes should not be required by the client web role. 
 
 Note: You MUST ensure that all the referenced binaries for grain interfaces and the generated proxy / factory libraries are copied into the web role project output directory, to ensure they get picked up by the Azure packaging tools.
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815108)
 
- The grain implementation DLLs should not be required by the client and so should not be referenced by the web role.
+The grain implementation DLLs should not be required by the client and so should not be referenced by the web role.
 
 ## Initialize Client Connection to Orleans Silos 
-It is recommended to bootstrap and initialize the client connection to the Orleans silo worker roles, to ensure a connection is set up before use – either in the Page_Load method for each .aspx page, or in Global.asax initialization methods. 
+It is recommended to bootstrap and initialize the client connection to the Orleans silo worker roles, to ensure a connection is set up before use – either in the `Page_Load` method for each _.aspx_ page, or in _Global.asax_ initialization methods. 
 
 ``` csharp
 protected void Page_Load(object sender, EventArgs e) 
@@ -258,11 +268,13 @@ protected void Page_Load(object sender, EventArgs e)
 } 
 ```
 
- Repeated calls to OrleansAzureClient.Initialize()  will return and do nothing if the Orleans client connection is already set up.
+Repeated calls to `OrleansAzureClient.Initialize()`  will return and do nothing if the Orleans client connection is already set up.
 
- An additional variant of OrleansAzureClient.Initialize(System.IO.FileInfo) allows a base client config file location to be specified explicitly. The internal endpoint addresses of the Orleans silo nodes will still be determined dynamically from the Orleans Silo instance table each silo node registers with. 
+An additional variant of `OrleansAzureClient.Initialize(System.IO.FileInfo)` allows a base client config file location to be specified explicitly. 
+The internal endpoint addresses of the Orleans silo nodes will still be determined dynamically from the Orleans Silo instance table each silo node registers with. 
 
- See the Orleans API docs for details of the various Initialize methods available.
+<!--TODO: Create link to Orleans API when the link is created/found-->
+See the Orleans API docs for details of the various `Initialize` methods available.
 
 ## Deploying to Azure
 The normal Azure deployment tools are used to deploy the application to Windows Azure – either into the local Azure Compute Emulator for local development / test (Press F5 to run), or into the Azure cloud hosting environment right click on the Cloud project and select 'Publish':

--- a/Step-by-step-Tutorials/Concurrency.md
+++ b/Step-by-step-Tutorials/Concurrency.md
@@ -4,23 +4,29 @@ title: Concurrency
 ---
 {% include JB/setup %}
 
-Distributed applications are inherently concurrent, which leads to complexity. One of the things that makes the actor model special and productive is that it helps reduce some of the complexities of having to grapple with concurrency.
+Distributed applications are inherently concurrent, which leads to complexity. 
+One of the things that makes the actor model special and productive is that it helps reduce some of the complexities of having to grapple with concurrency.
 
 Actors accomplish this in two ways:
+
 * By providing single-threaded access to the internal state of an actor instance. 
 * By not sharing data between actor instances except via message-passing.
 
- In this tutorial, we will examine both of these aspects of the programming model.
+In this tutorial, we will examine both of these aspects of the programming model.
 
 ## Turn-based Execution
 
-The idea behind the single-threaded execution model for actors is that the invokers (remote) take turns "calling" its methods. Thus, a message coming to actor B from actor A will placed in a queue and the associated handler is invoked only when all prior messages have been serviced. 
+The idea behind the single-threaded execution model for actors is that the invokers (remote) take turns "calling" its methods.
+Thus, a message coming to actor B from actor A will placed in a queue and the associated handler is invoked only when all prior messages have been serviced. 
 
- This allows us to avoid all use of locks to protect actor state, as it is inherently protected against data races. However, it may also lead to problems when messages pass back and forth and the message graph forms cycles. If A sends a message to B from one of its methods and awaits its completion, and B sends a message to A, also awaiting its completion, the application will quickly lock up. 
+This allows us to avoid all use of locks to protect actor state, as it is inherently protected against data races. 
+However, it may also lead to problems when messages pass back and forth and the message graph forms cycles. 
+If A sends a message to B from one of its methods and awaits its completion, and B sends a message to A, also awaiting its completion, the application will quickly lock up. 
 
- To illustrate, let's go back to the code that was established in the tutorial on collections of actors and modify it to demonstrate how things can go bad by creating a trivial cycle in the messaging graph: when an employee receives a greeting, he sends another greeting back to the sender and waits for the acknowledgment. This will send a back-and-forth series of messages, until we get to 3. 
+To illustrate, let's go back to the code that was established in the tutorial on collections of actors and modify it to demonstrate how things can go bad by creating a trivial cycle in the messaging graph: when an employee receives a greeting, he sends another greeting back to the sender and waits for the acknowledgement. 
+This will send a back-and-forth series of messages, until we get to 3. 
 
- First create a class in the interface project which we'll use to send the greetings around:
+First create a class in the interface project which we'll use to send the greetings around:
 
 ``` csharp
 public class GreetingData
@@ -31,9 +37,10 @@ public class GreetingData
 }
 ```
 
-From will be the sender of the message (the ID of the grain), Message will be the message text, and Count will be the number of times the message has been sent back and forth. This stops us from getting a stack overflow.
+`From` will be the sender of the message (the ID of the grain), `Message` will be the message text, and `Count` will be the number of times the message has been sent back and forth. 
+This stops us from getting a stack overflow.
 
- We need to modify the arguments of Greeting on the Employee interface to :
+We need to modify the arguments of `Greeting` on the `IEmployee` interface to :
 
 
 ``` csharp
@@ -59,7 +66,7 @@ public async Task Greeting(GreetingData data)
 }
 ```
 
- We'll also update the Manager class, so it send the new message object:
+ We'll also update the `Manager` class, so it send the new message object:
 
 ``` csharp
 public async Task AddDirectReport(IEmployee employee)
@@ -72,9 +79,9 @@ public async Task AddDirectReport(IEmployee employee)
 }
 ```
 
- Now the Employee sends a message back to the manager, saying "Thanks!".
+Now the Employee sends a message back to the manager, saying "Thanks!".
 
- Let's add some simple client code to add a direct report to a manager:
+Let's add some simple client code to add a direct report to a manager:
 
 
 ``` csharp
@@ -83,7 +90,8 @@ var m1 = ManagerFactory.GetGrain(1);
 m1.AddDirectReport(e0);
 ```
 
- When we run this code, the first "Thanks!" greeting is received. However, when this message is responded to this we get a 30 second pause, then warnings appear in the log and we're told the grain is about to break it's promise.
+When we run this code, the first "Thanks!" greeting is received.
+However, when this message is responded to this we get a 30 second pause, then warnings appear in the log and we're told the grain is about to break it's promise.
 
     1 said: Welcome to my team!
     0 said: Thanks!
@@ -95,11 +103,16 @@ m1.AddDirectReport(e0);
     [2014-03-12 15:25:37.407 GMT    28      WARNING 100157  CallbackData    127.0.0.1:11111]        Response did  not arrive on time in 00:00:30 for message: Request S127.0.0.1:11111:132333898*grn/D9BB797F/00000001@afc70cb4->S127.0.0.1:11111:132333898*grn/D9BB797F/00000000@c24c4187 #15: MyGrainInterfaces1.IEmployee:Greeting(). Target History is: <S127.0.0.1:11111:132333898:*grn/D9BB797F/00000000:@c24c4187>. About to break its promise.
 
 
- An exception is then thrown in the client code.
+An exception is then thrown in the client code.
 
- We've created a deadlock. Grain 0 sends a message to grain 1. In that call grain 1 sends a message back to grain 0. However, grain 0 can't process it because it's awaiting the first message, so it gets queued. The await can't complete until the second message is returned, so we've entered a state that we can't escape from. Orleans waits for 30 seconds, then kills the request.
+We've created a deadlock. 
+Grain 0 sends a message to grain 1. 
+In that call grain 1 sends a message back to grain 0. 
+However, grain 0 can't process it because it's awaiting the first message, so it gets queued. 
+The await can't complete until the second message is returned, so we've entered a state that we can't escape from. 
+Orleans waits for 30 seconds, then kills the request.
 
- Orleans offers us a way to deal with this, by marking the grain [Reentrant], which means that additional calls may be made while the grain is waiting for a task to complete, resulting in interleaved execution.
+Orleans offers us a way to deal with this, by marking the grain `[Reentrant]`, which means that additional calls may be made while the grain is waiting for a task to complete, resulting in interleaved execution.
 
 
 ``` csharp
@@ -118,7 +131,7 @@ public class Employee : Orleans.Grain, Interfaces.IEmployee
 }  
 ```
 
- We see that the sample works, and Orleans is able to interleave the grain calls:
+We see that the sample works, and Orleans is able to interleave the grain calls:
 
  ```
  1 said: Welcome to my team!
@@ -127,20 +140,23 @@ public class Employee : Orleans.Grain, Interfaces.IEmployee
  0 said: Thanks!
  ```
 
-Messages
-Messages are simply data passed from one actor to, we just created the  GreetingData class to do just this.
+##Messages
+
+Messages are simply data passed from one actor to, we just created the `GreetingData` class to do just this.
 
 In .NET, most objects are created from a class of some sort and are passed around by reference, something that doesn't work well with concurrency, and definitely not with distribution. 
 
-When Orleans sends a message from one grain to another, it creates a deep copy of the object, and provides the copy to the second grain, and not the object stored in the first grain. This prohibits the mutation of state from one grain to another, one of the main tenants in the actor model is that state shouldn't be shared, and message passing is the only mechanism for exchanging data.
+When Orleans sends a message from one grain to another, it creates a deep copy of the object, and provides the copy to the second grain, and not the object stored in the first grain. 
+This prohibits the mutation of state from one grain to another, one of the main tenants in the actor model is that state shouldn't be shared, and message passing is the only mechanism for exchanging data.
 
 When the grains are in different silos, the object model is serialized to a binary format, and sent over the wire.
 
 However, this deep copy process is expensive, and if you promise not to modify the message, then for communication with grains within a silo, it's unnecessary.
 
-If you indicate to Orleans that you are not going to modify the object (i.e. it's immutable) then it can skip the deep copy step, and it will pass the object by reference. There's no way Orleans or C# can stop you from modifying the state, you have to be disciplined.
+If you indicate to Orleans that you are not going to modify the object (i.e. it's immutable) then it can skip the deep copy step, and it will pass the object by reference. 
+There's no way Orleans or C# can stop you from modifying the state, you have to be disciplined.
 
-Immutability is indicated with a the [Immutable] attribute on the class:
+Immutability is indicated with a the `[Immutable]` attribute on the class:
 
 ``` csharp
 [Immutable]

--- a/Step-by-step-Tutorials/Custom-Storage-Providers.md
+++ b/Step-by-step-Tutorials/Custom-Storage-Providers.md
@@ -7,16 +7,26 @@ title: Custom Storage Providers
 
 ## Writing a Custom Storage Provider
 
-In the tutorial on declarative actor storage, we looked at allowing grains to store their state in an Azure table using one of the built-in storage providers. While Azure is a great place to squirrel away your data, there are many alternatives. In fact, there are so many that there was no way to support them all. Instead, Orleans is designed to let you easily add support for your own form of storage by writing a storage provider.
+In the tutorial on declarative actor storage, we looked at allowing grains to store their state in an Azure table using one of the built-in storage providers. 
+While Azure is a great place to squirrel away your data, there are many alternatives. 
+In fact, there are so many that there was no way to support them all. 
+Instead, Orleans is designed to let you easily add support for your own form of storage by writing a storage provider.
 
- In this tutorial, we'll walk through how to write a simple file-based storage provider. A file system is not necessarily the best place to store data for grains, since it's so local, but it's an easy example to help us illustrate the principles.
+In this tutorial, we'll walk through how to write a simple file-based storage provider. 
+A file system is not necessarily the best place to store data for grains, since it's so local, but it's an easy example to help us illustrate the principles.
 
 ## Getting Started
-An Orleans storage provider is simply a class that implements IStorageProvider. It should be built into an assembly that is placed in the Orleans binaries folder. To move it there on build will require adding a bit of post-build event code.
+An Orleans storage provider is simply a class that implements `IStorageProvider`. 
+It should be built into an assembly that is placed in the Orleans binaries folder. 
+To move it there on build will require adding a bit of post-build event code.
 
- We'll start by creating the project -- it should be a regular .NET class library. Once the project is created, let's also rename the file Class1.cs to FileStorageProvider.cs. That should also prompt VS to rename the class we find inside. Next, we must add references to two Orleans runtime assemblies -- Orleans.dll and OrleansRuntime.dll. The former is found under the SDK installation directory $(OrleansSDK)\Binaries\OrleansClient, while the latter is under $(OrleansSDK)\Binaries\OrleansServer.
+We'll start by creating the project -- it should be a regular .NET class library. 
+Once the project is created, let's also rename the file _Class1.cs_ to _FileStorageProvider.cs_. 
+That should also prompt VS to rename the class we find inside. 
+Next, we must add references to two Orleans runtime assemblies -- _Orleans.dll_ and _OrleansRuntime.dll_. 
+The former is found under the SDK installation directory _$(OrleansSDK)\Binaries\OrleansClient_, while the latter is under _$(OrleansSDK)\Binaries\OrleansServer_.
 
- Edit the post-build events for the storage providers project to include the following lines:
+Edit the post-build events for the storage providers project to include the following lines:
 
       if exist "$(OrleansSDK)\LocalSilo" (
       copy /y StorageProviders.dll  "$(OrleansSDK)\LocalSilo\"
@@ -25,9 +35,12 @@ An Orleans storage provider is simply a class that implements IStorageProvider. 
 
 
 
- Assuming, of course, that your project is called 'StorageProviders.' The silo host project is set up to run out of the 'LocalSilo' folder under the SDK, and the storage provider assembly needs to be there in order to be found by Orleans. In fact, if you look at the silo host and grain collection projects, you will find similar post-build events code there.
+Assuming, of course, that your project is called `StorageProviders`. 
+The silo host project is set up to run out of the _LocalSilo_ folder under the SDK, and the storage provider assembly needs to be there in order to be found by Orleans. 
+In fact, if you look at the silo host and grain collection projects, you will find similar post-build events code there.
 
- Our storage provider should implement the interface 'Orleans.Storage.IStorageProvider.' With a little bit of massaging of the code, it should look something like this:
+Our storage provider should implement the interface `Orleans.Storage.IStorageProvider`. 
+With a little bit of massaging of the code, it should look something like this:
 
 ``` csharp
 using System;
@@ -80,7 +93,11 @@ namespace StorageProviders
 }
 ```
 
- The first thing we have to figure out is what data we need to provider through configuration. The name is a required property, but we will also need the path to the root directory for our file store. That is, in fact, the only piece of information we need, so we'll add a 'RootDirectory' string property and edit the configuration file as in the previous section. In doing so, it's critical to pay attention to the namespace and class name of the provider. Add this to the 'StorageProviders' element in the configuration file:
+The first thing we have to figure out is what data we need to provider through configuration. 
+The name is a required property, but we will also need the path to the root directory for our file store. 
+That is, in fact, the only piece of information we need, so we'll add a `RootDirectory` string property and edit the configuration file as in the previous section. 
+In doing so, it's critical to pay attention to the namespace and class name of the provider. 
+Add this to the `<StorageProviders>` element in the configuration file:
 
 
      <Provider Type="StorageProviders.FileStorageProvider"
@@ -88,10 +105,14 @@ namespace StorageProviders
               RootDirectory=".\Storage"/>
 
 
- Edit the Grain1.cs file to use this storage provider instead of the Azure provider, then set a breakpoint in the Init() method of the storage provider implementation class and start the silo. If you have followed the instructions, you should hit the breakpoint during silo initialization. There's no reason to go on debugging, since you will throw an exception right away.
+Edit the _Grain1.cs_ file to use this storage provider instead of the Azure provider, then set a breakpoint in the `Init()` method of the storage provider implementation class and start the silo. 
+If you have followed the instructions, you should hit the breakpoint during silo initialization. 
+There's no reason to go on debugging, since you will throw an exception right away.
 
 ## Initializing the Provider
-There are four major functions to implement in the provider -- Close() is the only one we won't need to do anything with. As you may have guessed, the starting point is the call to Init(), which provides us with the configuration data and a chance to get things set up properly. In our case, we'll want to set the properties and create the root directory if it doesn't already exist:
+There are four major functions to implement in the provider -- `Close()` is the only one we won't need to do anything with. 
+As you may have guessed, the starting point is the call to `Init()`, which provides us with the configuration data and a chance to get things set up properly. 
+In our case, we'll want to set the properties and create the root directory if it doesn't already exist:
 
 ``` csharp
 public Task Init(string name,
@@ -112,10 +133,15 @@ public Task Init(string name,
 }
 ```
 
- Run the program again. This time, you will still crahs, but in ReadStateAsync(). After running the code, you should find a 'Storage' directory under the $(OrleansSDK)\LocalSilo directory. Make sure you have set the project up to build on F5, or you may not see the edits take effect.
+Run the program again. 
+This time, you will still crash, but in `ReadStateAsync()`. 
+After running the code, you should find a _Storage_ directory under the _$(OrleansSDK)\LocalSilo_ directory. 
+Make sure you have set the project up to build on F5, or you may not see the edits take effect.
 
 ## Reading State
-To store data in the file system (or anywhere, really), we have to devise a convention that generates a unique name for each grain. This is easiest done by combining the state type name with the grain id, which combines the grain type and GUID creating a globally unique key. Thus, ReadStateAsync() (which, by the way, should be declared as an async method), starts like this:
+To store data in the file system (or anywhere, really), we have to devise a convention that generates a unique name for each grain. 
+This is easiest done by combining the state type name with the grain id, which combines the grain type and GUID creating a globally unique key. 
+Thus, `ReadStateAsync()` (which, by the way, should be declared as an async method), starts like this:
 
 
 ``` csharp
@@ -130,7 +156,11 @@ if (!fileInfo.Exists)
     return; 
 ```
 
- We also need to decide how the data will be stored. To make it easy to inspect the data outside of the application, we're going to use JSON. A more space-conscious design may use a binary serialization format, instead, it's entirely a choice of the provider designer's. The JSON serializer is found in the System.Web.Extensions assembly, which you now need to add to the project's references. Also, add a using clause to the top of the file: "using System.Web.Script.Serialization;"
+We also need to decide how the data will be stored. 
+To make it easy to inspect the data outside of the application, we're going to use JSON. 
+A more space-conscious design may use a binary serialization format, instead, it's entirely a choice of the provider designer's. 
+The JSON serializer is found in the `System.Web.Extensions` assembly, which you now need to add to the project's references. 
+Also, add a using clause to the top of the file: `using System.Web.Script.Serialization;`
 
 ``` csharp
 using (var stream = fileInfo.OpenText())
@@ -145,7 +175,7 @@ using (var stream = fileInfo.OpenText())
 ```
 
 ## Writing State
-The format decisions have already been made, so coding up the WriteStateAsync method should be straight-forward: serialize as JSON, construct the file name, then write to the file:
+The format decisions have already been made, so coding up the `WriteStateAsync` method should be straight-forward: serialize as JSON, construct the file name, then write to the file:
 
 
 ``` csharp
@@ -174,12 +204,18 @@ public async Task WriteStateAsync(string grainType, Orleans.GrainReference grain
 
 ## Putting it Together
 
-There's really just one thing left to do, and that is to test the thing. Run the application and let it get to the end, where the greetings are shown, and then terminate it. Under the LocalSilo\Storage directory, you should find a file called 0.Grain1State, and it should contain something very recognizable:
+There's really just one thing left to do, and that is to test the thing. 
+Run the application and let it get to the end, where the greetings are shown, and then terminate it. 
+Under the _LocalSilo\Storage_ directory, you should find a file called _0.Grain1State_, and it should contain something very recognizable:
 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810449)
 
- Run the application again, and you should see the same behavior as before, that is, the last greeting of the first session is remembered.
+Run the application again, and you should see the same behavior as before, that is, the last greeting of the first session is remembered.
 
 ## Clearing State
 
-The easiest method to write is the one that deletes grain state, which we didn't see any use of in the previous tutorial. In fact, we don't need it for our Hello World application, so we'll just leave its implementation as an exercise. It should do the obvious, i.e. delete the file.
+The easiest method to write is the one that deletes grain state, which we didn't see any use of in the previous tutorial. 
+In fact, we don't need it for our Hello World application, so we'll just leave its implementation as an exercise. 
+It should do the obvious, i.e. delete the file.
+
+[Back to Orleans Documenation homepage](../../)

--- a/Step-by-step-Tutorials/Front-Ends-for-Orleans-Services.md
+++ b/Step-by-step-Tutorials/Front-Ends-for-Orleans-Services.md
@@ -4,26 +4,29 @@ title: Front Ends for Orleans Services
 ---
 {% include JB/setup %}
 
-Exposing silo gateway ports as public endpoints of an Orleans cluster is not recommended. Instead, Orleans is intended to be fronted by your own API.
+Exposing silo gateway ports as public endpoints of an Orleans cluster is not recommended. 
+Instead, Orleans is intended to be fronted by your own API.
 
- Creating an HTTP API, or web application is a common scenario. Let's extend the Employee/Manager scenario from the  [Declarative-Persistence](Declarative-Persistence) walk-through to see what steps are required to publish grain data over HTTP.
+Creating an HTTP API, or web application is a common scenario. 
+Let's extend the Employee/Manager scenario from the  [Declarative-Persistence](Declarative-Persistence) walk-through to see what steps are required to publish grain data over HTTP.
 
-Creating the ASP.NET application
+##Creating the ASP.NET application
 First, you should add a new ASP.NET Web Application to your solution:
 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815096)
 
- Select the Web API template, although you could use MVC or Web Forms.
+Select the Web API template, although you could use MVC or Web Forms.
 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815097)
 
 ## Initializing Orleans
 
-Next, add a reference to the Orleans.dll file in the project references.
+Next, add a reference to the _Orleans.dll_ file in the project references.
 
- Now add the "DevTestClientConfiguration.xml" file used in the Orleans Host application to the root of the ASP.NET project.
+Now add the _DevTestClientConfiguration.xml_ file used in the Orleans Host application to the root of the ASP.NET project.
 
- As with the Orleans host we created earlier, we need to initialize Orleans. This is best done in the Global.asax.cs file like this:
+As with the Orleans host we created earlier, we need to initialize Orleans. 
+This is best done in the _Global.asax.cs_ file like this:
 
 ``` csharp
 namespace WebApplication1
@@ -43,17 +46,17 @@ Now when the ASP.NET application starts, it will initialize the Orleans Client.
 
 Now lets add a controller to the project, to receive HTTP requests, and call the grain code.
 
- Right click on the "Controllers" folder, and add a new "Web API 2 Controller - Empty":
+Right click on the "Controllers" folder, and add a new "Web API 2 Controller - Empty":
 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815098)
 
- Next, call the controller `EmployeeController`:
+Next, call the controller `EmployeeController`:
 
 ![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=815099)
 
- This will create a new empty controller called `EmployeeController`.
+This will create a new empty controller called `EmployeeController`.
 
- We can add a `Get` method to the controller, which we'll use to return the level of an Employee.
+We can add a `Get` method to the controller, which we'll use to return the level of an Employee.
 
 ``` csharp
 public class EmployeeController : ApiController
@@ -72,14 +75,13 @@ Note that the controller is asynchronous, and we can just pass back the `Task` w
 
 Now let's test the application. 
 
- Build the project, and start the local silo.
+Build the project, and start the local silo.
 
- Set the ASP.NET application as the startup project, and run the project.
+Set the ASP.NET application as the startup project, and run the project.
 
- If you navigate to the API URL (the number may be different on your project)...
+If you navigate to the API URL (the number may be different on your project)...
 
     http://localhost:6858/api/employee/3
-
 
 
  ...you should see the result returned from the grain:
@@ -88,7 +90,7 @@ Now let's test the application.
     <int xmlns="http://schemas.microsoft.com/2003/10/Serialization/">42</int>
 
 
- That's the basics in place, the rest of the API can be completed by adding the rest of the HTTP verbs.
+That's the basics in place, the rest of the API can be completed by adding the rest of the HTTP verbs.
 
 ## Next
 

--- a/Step-by-step-Tutorials/Interaction-with-Libraries-and-Services.md
+++ b/Step-by-step-Tutorials/Interaction-with-Libraries-and-Services.md
@@ -6,13 +6,13 @@ title: Interaction with Libraries and Services
 
 Code running in a grain is not prohibited from calling external systems or services, but the rule for always using asynchronous code must be maintained.
 
- In this sample we'll see how a grain can all out to an external service.
+In this sample we'll see how a grain can all out to an external service.
 
 ## Creating a Stock Grain
 
 For this sample, let's create a grain which maintains the current price for a stock.
 
-Create a grain interface project, and add an interface for an  IStockGrain:
+Create a grain interface project, and add an interface for an `IStockGrain`:
 
 ``` csharp
 public interface IStockGrain : Orleans.IGrainWithStringKey
@@ -21,22 +21,24 @@ public interface IStockGrain : Orleans.IGrainWithStringKey
 }
 ```
 
-Note, we've opted for an string-based key for our grain, which is useful since the ticker symbol makes a natural key. The 'IGrainWithStringKey' interface is new in the September refresh.
-Now add a grain implementation project, and add a reference to the interface project. Add a reference to `System.Net.Http`.
+Note, we've opted for an string-based key for our grain, which is useful since the ticker symbol makes a natural key. 
+The `IGrainWithStringKey` interface is new in the September refresh.
+Now add a grain implementation project, and add a reference to the interface project. 
+Add a reference to `System.Net.Http`.
 
- We'll implement the grain so it retrieves the price of the stock when it is activated:
+We'll implement the grain so it retrieves the price of the stock when it is activated:
 
 ``` csharp
 public class StockGrain : Orleans.Grain, IStockGrain
 {
     string price;
 
-    public override async Task ActivateAsync()
+    public override async Task OnActivateAsync()
     {
         string stock;
         this.GetPrimaryKey(out stock);
         await UpdatePrice(stock);
-        await base.ActivateAsync();
+        await base.OnActivateAsync();
     }
 
     async Task UpdatePrice(string stock)
@@ -44,7 +46,7 @@ public class StockGrain : Orleans.Grain, IStockGrain
         price = await GetPriceFromYahoo(stock);
     }
 
-    async Task<string: GetPriceFromYahoo(string stock)
+    async Task<string> GetPriceFromYahoo(string stock)
     {
         var uri = "http://download.finance.yahoo.com/d/quotes.csv?f=snl1c1p2&e=.csv&s=" + stock;
         using (var http = new HttpClient())
@@ -54,7 +56,7 @@ public class StockGrain : Orleans.Grain, IStockGrain
         }
     }
 
-    public Task<string: GetPrice()
+    public Task<string> GetPrice()
     {
         return Task.FromResult(price);
     }
@@ -62,7 +64,7 @@ public class StockGrain : Orleans.Grain, IStockGrain
 ```
 
 
- Next create some client code to connect to the Orleans Silo, and retrieve the grain state:
+Next create some client code to connect to the Orleans Silo, and retrieve the grain state:
 
 ``` csharp
 OrleansClient.Initialize("LocalConfiguration.xml");
@@ -75,40 +77,42 @@ Console.WriteLine(price);
 Console.ReadKey();
 ```
 
- When we start the local silo, and run the application, we should see the stock value written out
+When we start the local silo, and run the application, we should see the stock value written out
 
      "MSFT","Microsoft Corpora",37.70,-0.19,"-0.50%"
 
- Note that the extra text in the stock price is just the formatting that Yahoo! returned. 
+Note that the extra text in the stock price is just the formatting that Yahoo! returned. 
 
 ## Refreshing the value with a timer
 
 The problem with the grain as it stands is that the value of the stock will change, but the grain will maintain the same value for it's lifetime (an indefinite period of time).
 
- One way to fix this is to periodically refresh the price.
+One way to fix this is to periodically refresh the price.
 
- A traditional .NET timer is not suitable for running in a grain. Instead, Orleans provides it's own timer.
+A traditional .NET timer is not suitable for running in a grain. 
+Instead, Orleans provides it's own timer.
 
- Let's re-factor the ActivateAsync() method to introduce a timer which will call the UpdatePrice method in 1 minute, and then repeatedly every minute from then on, until the grain is deactivated:
+Let's re-factor the `OnActivateAsync()` method to introduce a timer which will call the `UpdatePrice` method in 1 minute, and then repeatedly every minute from then on, until the grain is deactivated:
 
 ``` csharp
-public override async Task ActivateAsync()
+public override async Task OnActivateAsync()
 {
     string stock;
     this.GetPrimaryKey(out stock);
     await UpdatePrice(stock);
 
-    var timer = RegisterAsyncTimer(
+    var timer = RegisterTimer(
         UpdatePrice,
         stock,
         TimeSpan.FromMinutes(1),
         TimeSpan.FromMinutes(1));
 
-    await base.ActivateAsync();
+    await base.OnActivateAsync();
 }
 ```
 
- We'll also have to slightly adjust the UpdatePrice method, as the stock argument must be an object rather than a string. We'll also add some logging so we can see what's happening:
+We'll also have to slightly adjust the `UpdatePrice` method, as the stock argument must be an object rather than a string. 
+We'll also add some logging so we can see what's happening:
 
 ``` csharp
 async Task UpdatePrice(object stock)
@@ -118,17 +122,23 @@ async Task UpdatePrice(object stock)
 }
 ```
 
-RegisterAsyncTimer() takes four arguments:
-* callback A function to call. 
-* state An object to pass as the first argument of the callback function (this can be null). 
-* dueTime The period to wait before starting the first call to  callback. 
-* period The period between subsequent calls to  callback.
+The `RegisterTimer` method takes four arguments:
+
+* `callback` - A function to call. 
+* `state` - An object to pass as the first argument of the callback function (this can be null). 
+* `dueTime` - The period to wait before starting the first call to `callback`. 
+* `period` - The period between subsequent calls to `callback`.
 
 
-Note: In our sample we're passing the stock name as the  state argument when we register the timer. This means the stock name is presented to the UpdatePrice method as the argument. Alternative we could set state to be null, and read the stock name from inside UpdatePrice using GetPrimaryKey.
-The method returns an IOrleansTimer which is disposable and can be used to stop the timer. It's a good idea to hold on to a reference to this in case you need to stop the timer.
+Note: In our sample we're passing the stock name as the  state argument when we register the timer.
+This means the stock name is presented to the `UpdatePrice` method as the argument. 
+Alternative we could set state to be `null`, and read the stock name from inside `UpdatePrice` using `GetPrimaryKey`.
+The method returns an `IOrleansTimer` which is disposable and can be used to stop the timer. 
+It's a good idea to hold on to a reference to this in case you need to stop the timer.
 
- Now when we run the sample, the grain is activated, the timer gets registered and every minute the price is updated for us:
+Now when we run the sample, the grain is activated, the timer gets registered and every minute the price is updated for us:
+
+    "MSFT","Microsoft Corpora",37.70,-0.19,"-0.50%"
 
     "MSFT","Microsoft Corpora",37.70,-0.19,"-0.50%"
 
@@ -136,17 +146,16 @@ The method returns an IOrleansTimer which is disposable and can be used to stop 
 
     "MSFT","Microsoft Corpora",37.70,-0.19,"-0.50%"
 
-    "MSFT","Microsoft Corpora",37.70,-0.19,"-0.50%"
 
 
-
- Orleans is acting as an automatically refreshing cache. Whenever a stock grain is queried Orleans will provide the latest price it has, without having to make a call to the stock web service.
+Orleans is acting as an automatically refreshing cache.
+Whenever a stock grain is queried Orleans will provide the latest price it has, without having to make a call to the stock web service.
 
 ## Parallelization
 
 Running code in a single threaded execution model, does not prohibit you from await several tasks at once (or in parallel).
 
- Let's add a new function to retrieve the graph data for a stock:
+Let's add a new function to retrieve the graph data for a stock:
 
 ``` csharp
 async Task<string> GetYahooGraphData(string stock)
@@ -162,7 +171,7 @@ async Task<string> GetYahooGraphData(string stock)
 }
 ```
 
- We'll also add a new field to the grain to store this information:
+We'll also add a new field to the grain to store this information:
 
 ``` csharp
 string graphData;
@@ -180,7 +189,9 @@ async Task UpdatePrice(object stock)
 }
 ```
 
-However, by doing this we're waiting for the price from Yahoo, and after that's complete we request the graph data. This is inefficient, as we could be doing these at the same time. Fortunately, Task has a convenient  WhenAll method which allows us to await multiple tasks at once, allowing these tasks to complete in parallel.
+However, by doing this we're waiting for the price from Yahoo, and after that's complete we request the graph data. 
+This is inefficient, as we could be doing these at the same time. 
+Fortunately, `Task` has a convenient `WhenAll` method which allows us to await multiple tasks at once, allowing these tasks to complete in parallel.
 
 
 ``` csharp
@@ -200,26 +211,28 @@ async Task UpdatePrice(object stock)
 }
 ```
 
-Note: The Result of a Task will block execution if the task hasn't completed. This should be avoided in Orleans, tasks should always be awaited before Result is read.
+Note: The `Result` of a `Task` will block execution if the task hasn't completed. 
+This should be avoided in Orleans, tasks should always be awaited before `Result` is read.
 
 Note: When a large number of asynchronous actions need to happen simultaneously you can collect the tasks in a `List<Task<T>>` and present this to `Task.WhenAll`.
 
 ## External Tasks
 
-It's tempting to use the Parallel Task Library for executing parallel tasks in Orleans, but TPL uses the .NET thread pool to dispatch tasks. This is prohibited within grain code.
+It's tempting to use the [Task Parallel Library](https://msdn.microsoft.com/en-us/library/dd460717) _"TPL"_ for executing parallel tasks in Orleans, but TPL uses the .NET thread pool to dispatch tasks. This is prohibited within grain code.
 
- Orleans has it's own task scheduler which provides the single threaded execution model used within grains. It's important that when running tasks the Orleans scheduler is used, and not the .NET thread pool.
+Orleans has it's own task scheduler which provides the single threaded execution model used within grains. 
+It's important that when running tasks the Orleans scheduler is used, and not the .NET thread pool.
 
- Should your grain code require a sub-task to be created, you should use  Task.Factory.StartNew:
+Should your grain code require a sub-task to be created, you should use `Task.Factory.StartNew`:
 
 ``` csharp
 await Task.Factory.StartNew(() =>{ /* logic */ });
 ```
 
 
- This technique will use the current task scheduler, which will be the Orleans scheduler.
+This technique will use the current task scheduler, which will be the Orleans scheduler.
 
- You should avoid using Task.Run, which always uses the .NET thread pool, and therefore will not run in the single-threaded execution model.
+You should avoid using `Task.Run`, which always uses the .NET thread pool, and therefore will not run in the single-threaded execution model.
 
 ## Next 
 

--- a/Step-by-step-Tutorials/My-First-Orleans-Application.md
+++ b/Step-by-step-Tutorials/My-First-Orleans-Application.md
@@ -3,29 +3,40 @@ layout: page
 title: My First Orleans Application
 ---
 
-In this tutorial, we will walk through the steps to get the simplest possible Orleans application up and running, the all-too-familiar "Hello World!". We're using VS 2013, but it works equally well with VS 2012.
+In this tutorial, we will walk through the steps to get the simplest possible Orleans application up and running, the all-too-familiar "Hello World!". 
+We're using VS 2013, but it works equally well with VS 2012.
 
- Before we start, there are three Orleans concepts that you will run into in this tutorial: that of a grain, a communication interface, and a silo.
+Before we start, there are three Orleans concepts that you will run into in this tutorial: that of a grain, a communication interface, and a silo.
 
-**Grains** form the core of the Orleans programming model - they are distributed virtual actors. Grains are .NET classes that derive from a particular base class. It is easy to think about actors as objects that get dynamically instantiated on different servers and can invoke each other. They are distributed because interactions with grains may happen across process and computer boundaries, virtual because a particular grain may not be loaded in memory when another component sends it a message. If not present, the grain will be activated on-demand.
+###Grains
+Grains form the core of the Orleans programming model - they are distributed virtual actors. 
+Grains are .NET classes that derive from a particular base class. 
+It is easy to think about actors as objects that get dynamically instantiated on different servers and can invoke each other. 
+They are distributed because interactions with grains may happen across process and computer boundaries, virtual because a particular grain may not be loaded in memory when another component sends it a message. 
+If not present, the grain will be activated on-demand.
 
-**Communication interfaces** describe how to communicate with grains. They are .NET interfaces extending a particular base interface.
+###Communication interfaces
+Communication interfaces describe how to communicate with grains. 
+They are .NET interfaces extending a particular base interface.
 
-**Silos** are containers of grains, potentially millions of grains in a single silo. Typically, you will run one silo per machine, but it sometimes make sense to run more than one on a single machine, when testing, for example.
+###Silos
+Silos are containers of grains, potentially millions of grains in a single silo. 
+Typically, you will run one silo per machine, but it sometimes make sense to run more than one on a single machine, when testing, for example.
 
 ## Getting Started
 
-After starting either Visual Studio 2012 or 2013, go to create a new project. Under "Visual C#," you should see the following:
+After starting either Visual Studio 2012 or 2013, go to create a new project. 
+Under "Visual C#," you should see the following:
 
 ![New DevTest 1.png](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810085)
 
- Choose the Orleans Dev/Test Host project type, create a directory for the solution, and create the project:
+Choose the "Orleans Dev/Test Host" project type, create a directory for the solution, and create the project:
 
 ![New DevTest 2.png](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810086)
 
- The project is just a console application populated with code that helps you host a silo in an environment that is "developer friendly," i.e. where everything runs in a single process.
+The project is just a console application populated with code that helps you host a silo in an environment that is "developer friendly," i.e. where everything runs in a single process.
 
- The main code does three things: it creates a silo in a separate app domain, initializes the Orleans client runtime, and waits for user input before terminating:
+The main code does three things: it creates a silo in a separate app domain, initializes the Orleans client runtime, and waits for user input before terminating:
 
 
 ``` csharp
@@ -51,19 +62,22 @@ static void Main(string[] args)
 
 ## Adding Some Grains
 
-At this point, we have everything we need except some actual Orleans-based code. Next we will create two more projects, one to hold the communication interface, and one to hold our grain. Separating the two is a best practice since the interface project is shared between the client and server-side, while the grains are implementation code and should be private to the server side.
+At this point, we have everything we need except some actual Orleans-based code. 
+Next we will create two more projects, one to hold the communication interface, and one to hold our grain. 
+Separating the two is a best practice since the interface project is shared between the client and server-side, while the grains are implementation code and should be private to the server side.
 
- In addition to the Dev/Test host, there are two more Orleans projects, and we should create one of each in our solution:
+In addition to the Dev/Test host, there are two more Orleans projects, and we should create one of each in our solution:
 
 ![New DevTest 4.png](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810088)
 
- Once you have them in your solution, make sure to add a reference to the grain interface project from each of the other projects: the host, which will contain our client code, and the grain collection project. 
+Once you have them in your solution, make sure to add a reference to the grain interface project from each of the other projects: the host, which will contain our client code, and the grain collection project. 
 
- Add a project dependency (not a project reference) on the grain collection to the host project, so that it is automatically (re-)built when starting the debugger.
+Add a project dependency (not a project reference) on the grain collection to the host project, so that it is automatically (re-)built when starting the debugger.
 
 ![New DevTest 7.png](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810091)
 
- Open the IGrain1.cs file and add a method 'SayHello()' to it. We should have something like this:
+Open the _IGrain1.cs_ file and add a method `SayHello()` to it. 
+We should have something like this:
 
 
 ``` csharp
@@ -74,10 +88,11 @@ public interface IGrain1 : Orleans.IGrain
 ```
 
 
-Note that we're relying on TPL tasks in the interface method's return type -- an essential means to achiving scalability in the lightweight Orleans programming model is to use asynchronous I/O everywhere, and Orleans forces you to do so. Use Task or Task<T> as the return type of all methods of communication interfaces.
-Next, we turn our attention to the grain implementation, which is found in Grain1.cs. The first thing to do is make sure that the interface it implements is the right one: it should be 'MyGrainInterfaces1.IGrain1,' unless you renamed the project and/or the interface in the previous step.
+Note that we're relying on TPL tasks in the interface method's return type -- an essential means to achieving scalability in the lightweight Orleans programming model is to use asynchronous I/O everywhere, and Orleans forces you to do so. 
+Use `Task` or `Task<T>` as the return type of all methods of communication interfaces.
+Next, we turn our attention to the grain implementation, which is found in _Grain1.cs_. The first thing to do is make sure that the interface it implements is the right one: it should be `MyGrainInterfaces1.IGrain1`, unless you renamed the project and/or the interface in the previous step.
 
- Then, we ask VS to generate the method stub for the one interface method we defined earlier:
+Then, we ask VS to generate the method stub for the one interface method we defined earlier:
 
 ``` csharp
 public Task<string> SayHello()
@@ -87,7 +102,8 @@ public Task<string> SayHello()
 ```
 
 
- We're finally ready to add the much-anticipated "Hello World!" code. Just return the string as the contents of a Task:
+We're finally ready to add the much-anticipated "Hello World!" code. 
+Just return the string as the contents of a Task:
 
 
 ``` csharp
@@ -97,7 +113,9 @@ public Task<string> SayHello()
 }
 ```
 
- OK, we're nearly done. All we need is a bit of client code, which we will return to Program.cs in order to add. In place of the comment following the call to OrleansClient.Initialize(), add these two lines:
+OK, we're nearly done. 
+All we need is a bit of client code, which we will return to _Program.cs_ in order to add. 
+In place of the comment following the call to `OrleansClient.Initialize()`, add these two lines:
 
 
 ``` csharp
@@ -106,11 +124,16 @@ public Task<string> SayHello()
 ```
 
 
- That's it! Hit F5, let the silo initialization code take its time. This will take a few seconds, maybe as much as ten, and there will be a lot of log messages printed. At the very end, you should see the printout of the greeting.
+That's it! 
+Hit F5, let the silo initialization code take its time. 
+This will take a few seconds, maybe as much as ten, and there will be a lot of log messages printed. 
+At the very end, you should see the printout of the greeting.
 
 ![New DevTest 6.png](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810090)
 
- These are the essential steps to create and run Orleans-based code: define communication interfaces, implement them using grain classes, and write some client code to communicate with the grains in order to test them. In a realistic production environment, the grain code would be deployed in a silo hosted by Windows Azure or Windows Server and the client would most likely be a Web site or service using Orleans for the backend logic. However, that is just about making different configuration choices - the code in the simplified environment is the same as in the production environment.
+These are the essential steps to create and run Orleans-based code: define communication interfaces, implement them using grain classes, and write some client code to communicate with the grains in order to test them. 
+In a realistic production environment, the grain code would be deployed in a silo hosted by Windows Azure or Windows Server and the client would most likely be a Web site or service using Orleans for the backend logic. 
+However, that is just about making different configuration choices - the code in the simplified environment is the same as in the production environment.
 
 
 ## Next

--- a/Step-by-step-Tutorials/Running-in-a-Stand-alone-Silo.md
+++ b/Step-by-step-Tutorials/Running-in-a-Stand-alone-Silo.md
@@ -5,19 +5,22 @@ title: Running in a Stand-Alone Silo
 {% include JB/setup %}
 
 
-In the [first tutorial](), we got a very simple "Hello World!" Orleans application running in the simplest possible environment, a dev/test host where everything is running in one process, which makes starting and stopping it really easy. For most of your initial development of grain-based applications and services, that environment will be ideal.
+In the [first tutorial](My-First-Orleans-Application), we got a very simple "Hello World!" Orleans application running in the simplest possible environment, a dev/test host where everything is running in one process, which makes starting and stopping it really easy. 
+For most of your initial development of grain-based applications and services, that environment will be ideal.
 
- However, one thing that is hard to test in such an environment is what happens when the client and server do not get started and stopped at the same time. Often, state is maintained on the server across client sessions, something that is hard to model using the single-process setup.
+However, one thing that is hard to test in such an environment is what happens when the client and server do not get started and stopped at the same time. 
+Often, state is maintained on the server across client sessions, something that is hard to model using the single-process setup.
 
- Therefore, what we're going to do now is modify the solution we finished up with in the first tutorial and make it just a bit more like a production environment, running the server and client code in different processes.
+Therefore, what we're going to do now is modify the solution we finished up with in the first tutorial and make it just a bit more like a production environment, running the server and client code in different processes.
 
 ## Getting Started
 
-The first thing we need to do is get the grain code running in a silo that is in a separate process and prevent it from being started by the code in Program.cs.
+The first thing we need to do is get the grain code running in a silo that is in a separate process and prevent it from being started by the code in _Program.cs_.
 
- To do the latter, remove the code that starts the silo in its own app domain, as well as the code that shuts it down at the end.
+To do the latter, remove the code that starts the silo in its own app domain, as well as the code that shuts it down at the end.
 
- One consequence of not running the silo from the same process is that the client code has to wait for the silo to be ready to accept incoming requests. Rather than adding some clever backoff-retry code, here we simply expect you to wait for the silo to start, then hit 'Enter' in the client console window when the silo is advertising its readiness.
+One consequence of not running the silo from the same process is that the client code has to wait for the silo to be ready to accept incoming requests. 
+Rather than adding some clever backoff-retry code, here we simply expect you to wait for the silo to start, then hit 'Enter' in the client console window when the silo is advertising its readiness.
 
  This is the result:
 
@@ -31,15 +34,22 @@ static void Main(string[] args)
 }
 ```
 
- If you set the grain collection project as a startup project and hit F5, you will notice that it's started and hosted by a silo called "OrleansHost." This is a ready-made host executable intended for running Orleans code on Windows Server (Azure has a different host). It is also useful for development purposes. If you set both the grain collection project and the the host project as startup projects, you will see two windows come up:
+If you set the grain collection project as a startup project and hit F5, you will notice that it's started and hosted by a silo called "OrleansHost." 
+This is a ready-made host executable intended for running Orleans code on Windows Server (Azure has a different host). 
+It is also useful for development purposes. If you set both the grain collection project and the the host project as startup projects, you will see two windows come up:
 
 ![Standalone 1.png](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810442)
 
- This allows us to debug the grains in their own process, while keeping the client code in its own process. If you let the client make its request, then terminate it using 'Enter' when asked, you should see only the client process windows disappear. The debugging session won't end, because the grains are still being debugged in the OrleansHost.exe process. To start the client again, you will have to use the right-button context menu in the Solution Explorer to get it started.
+This allows us to debug the grains in their own process, while keeping the client code in its own process. 
+If you let the client make its request, then terminate it using 'Enter' when asked, you should see only the client process windows disappear. 
+The debugging session won't end, because the grains are still being debugged in the _OrleansHost.exe_ process. 
+To start the client again, you will have to use the right-button context menu in the Solution Explorer to get it started.
 
 ## Keeping Things Around
 
-To demonstrate keeping state around across client sessions, let's modify the 'SayHello()' method to take a string argument. Then, we will have our grain save each string it is sent and return the last one. Only at the first greeting will we see something we didn't send to the grain from the client.
+To demonstrate keeping state around across client sessions, let's modify the `SayHello()` method to take a string argument. 
+Then, we will have our grain save each string it is sent and return the last one. 
+Only at the first greeting will we see something we didn't send to the grain from the client.
 
 ``` csharp
 private string text = "Hello World!";
@@ -63,19 +73,25 @@ Console.WriteLine(hello.SayHello("Third").Result);
 Console.WriteLine(hello.SayHello("Fourth").Result);
 ```
 
- What we would expect to see here is four greetings, the first of which is "Hello World!" Let's check it out:
+What we would expect to see here is four greetings, the first of which is "Hello World!". 
+Let's check it out:
 
 ![Standalone 2.png](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810443)
 
- Terminate the client (make sure it's just the client, we need the grain host to stay up) and restart it using the context menu. There's no reason to wait for the silo now, since it's already running. Here's what we get:
+Terminate the client (make sure it's just the client, we need the grain host to stay up) and restart it using the context menu. 
+There's no reason to wait for the silo now, since it's already running. 
+Here's what we get:
 
 ![Standalone 3.png](http://download-codeplex.sec.s-msft.com/Download?ProjectName=orleans&DownloadId=810444)
 
- Still four greetings, but instead of "Hello World!" the first greeting is the last one from our previous client session. In other words, the grain in the silo kept some state around for us.
+Still four greetings, but instead of "Hello World!" the first greeting is the last one from our previous client session. 
+In other words, the grain in the silo kept some state around for us.
 
 ## Next
 
-So far, we've only seen one single grain type and a single instance of that type. It has served to keep things simple for the purpose of explaining how the environment works, but it is not typical of Orleans code. In the next tutorial, we will see something more realistic.
+So far, we've only seen one single grain type and a single instance of that type. 
+It has served to keep things simple for the purpose of explaining how the environment works, but it is not typical of Orleans code. 
+In the next tutorial, we will see something more realistic.
 
 [Actor Identity](Actor-Identity)
 

--- a/Step-by-step-Tutorials/index.md
+++ b/Step-by-step-Tutorials/index.md
@@ -4,7 +4,8 @@ title: Step by Step Tutorials
 ---
 {% include JB/setup %}
 
-The collection of technology walkthrough tutorials found here is intended to introduce you to the features of this exciting technology, spanning the programming model, its configuration, deployment, and customization. They build on each other, so it is best to go through them in the order outlined below.
+The collection of technology walkthrough tutorials found here is intended to introduce you to the features of this exciting technology, spanning the programming model, its configuration, deployment, and customization. 
+They build on each other, so it is best to go through them in the order outlined below.
 
 Each walkthrough is focused narrowly on just a couple of specific concepts in isolation from the scenarios that motivate your using Orleans in the first place, they are intended to teach you the mechanics of Orleans, not to explain when or why you should be using them.
 
@@ -14,15 +15,18 @@ This walkthrough shows you how to create a "Hello World" application using Orlea
 
 ## [Running in a Stand-Alone Silo](Running-in-a-Stand-alone-Silo)
 
-In this walkthrough, the simple "Hello World" application is modified to use a more typical environment for services: separate processes for the client and service code. It is still a development and debugging environment, simpler than a production configuration, which would involve multiple processes on multiple computers.
+In this walkthrough, the simple "Hello World" application is modified to use a more typical environment for services: separate processes for the client and service code. 
+It is still a development and debugging environment, simpler than a production configuration, which would involve multiple processes on multiple computers.
 
 ## [Actor Identity](Actor-Identity)
 
-Actors are a lot like regular objects, but there are a couple of quirks that make them different. One is the notion of actor identity, which surfaces in Orleans in the form of grains' primary keys.
+Actors are a lot like regular objects, but there are a couple of quirks that make them different. 
+One is the notion of actor identity, which surfaces in Orleans in the form of grains' primary keys.
 
 ## [A Service is a Collection of Communicating Actors](A-Service-is-a-Collection-of-Communicating-Actors)
 
-The previous examples used only a single actor type and instance to demonstrate their concepts. In almost all real systems, this is the opposite of what you would want to do; actors are intended to be as light-weight as objects and you would expect hundreds of thousands or millions of them to be active on a single system simultaneously, with as potentially billions waiting inactive in persistent store.
+The previous examples used only a single actor type and instance to demonstrate their concepts.
+In almost all real systems, this is the opposite of what you would want to do; actors are intended to be as light-weight as objects and you would expect hundreds of thousands or millions of them to be active on a single system simultaneously, with as potentially billions waiting inactive in persistent store.
 
 This walkthrough explains the actor lifecycle and identity, how actors are activated and deactivated.
 
@@ -30,19 +34,27 @@ This walkthrough explains the actor lifecycle and identity, how actors are activ
 
 What distinguishes the actor model from most other (distributed) object models is that it enforces a specific set of rules for concurrent access to state, allowing it to be free of data races by exchanging data between actors using message-passing and only allowing a single thread of execution to access each actor's internal state at any given point in time.
 
- On the other hand, there are many situations where data races are not a risk, and the single-threaded model is too conservative. Further, single-threaded execution can cause other problems, such as deadlocks. Orleans offers a few tools that allow developers to control this behavior, explained in this walkthrough.
+On the other hand, there are many situations where data races are not a risk, and the single-threaded model is too conservative. 
+Further, single-threaded execution can cause other problems, such as deadlocks. 
+Orleans offers a few tools that allow developers to control this behavior, explained in this walkthrough.
 
 ## [Interaction with Libraries and Services](Interaction-with-Libraries-and-Services)
 
-Applications using Orleans are regular .NET applications, and can interact freely with other .NET components. In order to not undermine the scalability inherent in the actor model, programmers have to take care to follow a few rules, mostly related to using asynchronous APIs whenever they are available. This walkthrough demonstrates the basic principles.
+Applications using Orleans are regular .NET applications, and can interact freely with other .NET components. 
+In order to not undermine the scalability inherent in the actor model, programmers have to take care to follow a few rules, mostly related to using asynchronous APIs whenever they are available. 
+This walkthrough demonstrates the basic principles.
 
 ## [Declarative Persistence](Declarative-Persistence)
 
-Actors are often transient, i.e., their state lives only for a short period of time, or is reconstructible at will from other actors. In many circumstances, however, actor state needs to persist for longer periods of time and be stored in an external database of some sort. Orleans offers the developer flexible options on where to store actor state, and this walkthrough will introduce the simplest way to deal with long-lived actor state: declaratively.
+Actors are often transient, i.e., their state lives only for a short period of time, or is reconstructible at will from other actors. 
+In many circumstances, however, actor state needs to persist for longer periods of time and be stored in an external database of some sort. 
+Orleans offers the developer flexible options on where to store actor state, and this walkthrough will introduce the simplest way to deal with long-lived actor state: declaratively.
 
 ## [Front Ends for Orleans Services](Front-Ends-for-Orleans-Services)
 
-Many Orleans services will be private and available only to front-end services that rely on the Orleans-based code as one of several backend services. In some circumstances, what is needed is to put a thin HTTP layer in front of the backend service, essentially making the Orleans service itself publically available via HTTP. In this walkthrough, the steps of producing a think HTTP layer based on ASP.NET Web API is described.
+Many Orleans services will be private and available only to front-end services that rely on the Orleans-based code as one of several backend services.
+In some circumstances, what is needed is to put a thin HTTP layer in front of the backend service, essentially making the Orleans service itself publically available via HTTP. 
+In this walkthrough, the steps of producing a think HTTP layer based on ASP.NET Web API is described.
 
 ## [Cloud Deployment](Cloud-Deployment)
 
@@ -50,8 +62,11 @@ The next walkthrough demonstrates how to get your Orleans application deployed i
 
 ## [On-Premise Deployment](On-Premise-Deployment)
 
-Orleans applications can be deployed both on your server equipment as well as in the cloud. In this walkthrough, you will see how to set up an on premise cluster and deploy your application to it.
+Orleans applications can be deployed both on your server equipment as well as in the cloud. 
+In this walkthrough, you will see how to set up an on premise cluster and deploy your application to it.
 
 ## [Custom Storage Providers](Custom-Storage-Providers)
 
-Defining your own storage provider is the easiest way to extend the persistence choices of your Orleans application. While Orleans comes with a couple of storage providers in the box, they are not intended to be the only choices or constrain you unnecessarily. Therefore, the library offers a way to extend the set of storage providers to include This walkthrough demonstrates how to extend the choices by building a storage provider based on regular files.
+Defining your own storage provider is the easiest way to extend the persistence choices of your Orleans application. 
+While Orleans comes with a couple of storage providers in the box, they are not intended to be the only choices or constrain you unnecessarily. 
+Therefore, the library offers a way to extend the set of storage providers to include This walkthrough demonstrates how to extend the choices by building a storage provider based on regular files.


### PR DESCRIPTION
Made the following changes to the Step-by-step documentation

 * Consistent treatment of file names, folder names and paths. All in italic eg _../Dir/file.ext_ as per [GitHub help](https://help.github.com/articles/create-a-repo/)
 * Consistent marking up of inline code e.g. `Employee`
 * Consolidated on straight quotes (" & ') not curled quotes (“..” & ‘..’). i.e instead of ‘y’, now 'y' and instead of “Version: 2.0”, now "Version: 2.0"
 * Keys to be quoted  e.g. "AttributeValue". 
 * Use H3 \### style heading instead of \** bold headings
 * Added home link on last page
 * Marked missing links to API documentation with a TODO comment
 * Made the usage of GUID to consistently use the upper case variant (not guid or Guid)
 * Corrected table layouts
 * Fixed missing/broken links
 * Corrected legacy usage of API e.g `ActivateSync` to `OnActivateAsync()`
 * Consistent usage of one line per sentence.