### PR TITLE
Need a different client config for testing client-side streams.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 Test/
+
+# Temporary working files
+**/pingme.txt

--- a/src/Tester/ClientConfigurationForStreamTesting.xml
+++ b/src/Tester/ClientConfigurationForStreamTesting.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ClientConfiguration xmlns="urn:orleans">
+  <Gateway Address="localhost" Port="40000"/>
+  <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
+    For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+    <TraceLevelOverride LogPrefix="Runtime" TraceLevel="Info" />
+    <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
+    <TraceLevelOverride LogPrefix="AssemblyLoader" TraceLevel="Warning" />
+  </Tracing>
+  <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
+  <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0"/>
+  <StreamProviders>
+    <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
+  </StreamProviders>
+</ClientConfiguration>

--- a/src/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/src/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -32,6 +32,7 @@ using UnitTests.Tester;
 namespace Tester.StreamingTests
 {
     [DeploymentItem("OrleansConfigurationForStreamingDeactivationUnitTests.xml")]
+    [DeploymentItem("ClientConfigurationForStreamTesting.xml")]
     [DeploymentItem("OrleansProviders.dll")]
     [TestClass]
     public class SMSDeactivationTests : UnitTestSiloHost
@@ -40,13 +41,19 @@ namespace Tester.StreamingTests
         private const string StreamNamespace = "SMSDeactivationTestsNamespace";
         private readonly DeactivationTestRunner runner;
 
+        private static readonly TestingSiloOptions siloOptions = new TestingSiloOptions
+        {
+            StartFreshOrleans = true,
+            StartSecondary = false,
+            SiloConfigFile = new FileInfo("OrleansConfigurationForStreamingDeactivationUnitTests.xml"),
+        };
+        private static readonly TestingClientOptions clientOptions = new TestingClientOptions
+        {
+            ClientConfigFile = new FileInfo("ClientConfigurationForStreamTesting.xml")
+        };
+
         public SMSDeactivationTests()
-            : base(new TestingSiloOptions
-            {
-                StartFreshOrleans = true,
-                StartSecondary = false,
-                SiloConfigFile = new FileInfo("OrleansConfigurationForStreamingDeactivationUnitTests.xml"),
-            })
+            : base(siloOptions, clientOptions)
         {
             runner = new DeactivationTestRunner(SMSStreamProviderName, GrainClient.Logger);
         }

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -111,6 +111,9 @@
       <Link>OrleansConfigurationForTesting.xml</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="ClientConfigurationForStreamTesting.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="OrleansConfigurationForStreamingDeactivationUnitTests.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Fixes bug in Nightly test suite introduced by PR #408 

Failure case was: SMSDeactivationTest_ClientConsumer