### PR TITLE
Show Compiler Errors in Visual Studio Error List

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -618,6 +618,7 @@ namespace Orleans.CodeGeneration
                 var errorsString = string.Empty;
                 foreach (CompilerError error in results.Errors)
                 {
+                    Console.WriteLine(error.ToString());
                     errorsString += String.Format("{0} Line {1},{2} - {3} {4} -- {5}",
                         error.FileName,
                         error.Line,


### PR DESCRIPTION
In Orleans 1.0.7, compiler generated errors no longer appear in the Visual Studio Error List -- only a generic ClientGenerator encountered compilation errors message is displayed, and one would need to parse the raw output to determine the source of the compilation error(s).

It looks like in c5f76715b78764a53f5416069d8419540af46d81, a Console.WriteLine of the raw compiler error string was removed. This patch is to add that back in, which Visual Studio will parse and display in the Error List window as expected. In general, the error reporting changes in that commit seem extraneous, as they display the same data as writing out the MSBuild formatted error string, but in a custom format which Visual Studio cannot parse. Can the team provide any background on this change?