### PR TITLE
Use version from Build\Version.txt for msi's product version.

### DIFF
--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -9,6 +9,16 @@ if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
 
 SET MSBUILDEXEDIR=%FrameworkDir%\%FrameworkVersion%
 SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe
+SET VERSION_FILE=%CMDHOME%\Build\Version.txt
+
+if EXIST "%VERSION_FILE%" (
+    @Echo Using version number from file %VERSION_FILE%
+    FOR /F "usebackq tokens=1,2,3,4 delims=." %%i in (`type %VERSION_FILE%`) do set PRODUCT_VERSION=%%i.%%j.%%k
+	@Echo PRODUCT_VERSION=%PRODUCT_VERSION%
+) else (
+    @Echo ERROR: Unable to read version number from file %VERSION_FILE%
+    SET PRODUCT_VERSION=1.0
+)
 
 set PROJ=%CMDHOME%\Orleans.sln
 

--- a/src/Build/GlobalAssemblyInfo.cs
+++ b/src/Build/GlobalAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyProduct("Orleans")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation 2015")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.7.0")]
+[assembly: AssemblyInformationalVersion("1.0.7.0")]

--- a/src/Build/OrleansSetup.wixproj
+++ b/src/Build/OrleansSetup.wixproj
@@ -32,7 +32,8 @@
       <SDKDir>$(BuildRoot)\SDK</SDKDir>
       <DocsDir>$(BuildRoot)\Documentation</DocsDir>
       <OrleansDir>$(BuildRoot)</OrleansDir>
-      <ProductVersion>1.0</ProductVersion>
+      <ProductVersion>$(PRODUCT_VERSION)</ProductVersion>
+      <ProductVersion Condition="'$(ProductVersion)'==''">1.0</ProductVersion>
       <SchemaVersion>2.0</SchemaVersion>
       <OutputType>Package</OutputType>
       <DefineSolutionProperties>false</DefineSolutionProperties>

--- a/src/NuGet/CreateOrleansPackages.bat
+++ b/src/NuGet/CreateOrleansPackages.bat
@@ -22,12 +22,18 @@ if "%BASE_PATH%" == "." (
 )
 @echo Using binary drop location directory %BASE_PATH%
 
-if EXIST "%VERSION%" (
-    @Echo Using version number from file %VERSION%
-    FOR /F "usebackq tokens=1,2,3,4 delims=." %%i in (`type %VERSION%`) do set VERSION=%%i.%%j.%%k
+if "%PRODUCT_VERSION%" == "" (
+
+  if EXIST "%VERSION%" (
+      @Echo Using version number from file %VERSION%
+      FOR /F "usebackq tokens=1,2,3,4 delims=." %%i in (`type %VERSION%`) do set VERSION=%%i.%%j.%%k
+  ) else (
+      @Echo ERROR: Unable to read version number from file %VERSION%
+      GOTO Usage
+  )
 ) else (
-    @Echo ERROR: Unable to read version number from file %VERSION%
-    GOTO Usage
+    set VERSION=%PRODUCT_VERSION%
+	@Echo Using version number %VERSION% from %%PRODUCT_VERSION%%
 )
 
 @echo CreateOrleansNugetPackages: Version = %VERSION% -- Drop location = %BASE_PATH%


### PR DESCRIPTION
Also, manually updated AssemblyFileVersion and AssemblyInformationalVersion (but not AssemblyVersion) in GlobalAssemblyInfo.cs to 1.0.7.

This is to address https://github.com/dotnet/orleans/issues/430.