### PR TITLE
msbuild Orleans.sln

### DIFF
--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -20,6 +20,8 @@ if EXIST "%VERSION_FILE%" (
     SET PRODUCT_VERSION=1.0
 )
 
+if "%builduri%" == "" set builduri=Build.cmd
+
 set PROJ=%CMDHOME%\Orleans.sln
 
 @echo ===== Building %PROJ% =====

--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -122,14 +122,16 @@
   </PropertyGroup>
   <!-- Set path to ClientGenerator.exe -->
   <Choose>
-    <When Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <When Condition="'$(builduri)' != ''">
       <PropertyGroup>
-        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+	    <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+	    <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -237,14 +237,16 @@
   </PropertyGroup>
   <!-- Set path to ClientGenerator.exe -->
   <Choose>
-    <When Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <When Condition="'$(builduri)' != ''">
       <PropertyGroup>
-        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+	    <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+	    <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -78,14 +78,16 @@
   </PropertyGroup>
   <!-- Set path to ClientGenerator.exe -->
   <Choose>
-    <When Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <When Condition="'$(builduri)' != ''">
       <PropertyGroup>
-        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+	    <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+	    <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -88,14 +88,16 @@
   </PropertyGroup>
   <!-- Set path to ClientGenerator.exe -->
   <Choose>
-    <When Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <When Condition="'$(builduri)' != ''">
       <PropertyGroup>
-        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+	    <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+	    <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
- Fixes problems building Orleans.sln with msbuild directly, rather than using the Build.cmd script.

- This fix sets `builduri` variable in Build.cmd to mimic the way TFS build works when $TargetDir points to separate Binaries folder.
- All other situations (including Visual Studio build and running `msbuild Orleans.sln` directly from comment line) use in-tree per-project locations for $TargetDir, so need to look in $SolutionDir\ClientGenerator\bin\$Configuration to locate code-gen tool.