### PR TITLE
Added storage emulator auto-start before any tests are run

### DIFF
--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Extensions\TestConfigurationExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AsyncResultHandle.cs" />
+    <Compile Include="StorageEmulator.cs" />
     <Compile Include="StorageTestConstants.cs" />
     <Compile Include="SiloHandle.cs" />
     <Compile Include="TestingClientOptions.cs" />

--- a/src/OrleansTestingHost/StorageEmulator.cs
+++ b/src/OrleansTestingHost/StorageEmulator.cs
@@ -1,0 +1,209 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+
+namespace Orleans.TestingHost
+{
+    /// <summary>
+    /// A wrapper on Azure Storage Emulator.
+    /// </summary>
+    /// <remarks>It might be tricky to implement this as a <see cref="IDisposable">IDisposable</see>, isolated, autonomous instance, 
+    /// see at <see href="http://azure.microsoft.com/en-us/documentation/articles/storage-use-emulator/">Use the Azure Storage Emulator for Development and Testing</see>
+    /// for pointers.</remarks>
+    public static class StorageEmulator
+    {
+        /// <summary>
+        /// The storage emulator process name. One way to enumerate running process names is
+        /// Get-Process | Format-Table Id, ProcessName -autosize. If there were multiple storage emulator
+        /// processes running, they would named WASTOR~1, WASTOR~2, ... WASTOR~n.
+        /// </summary>
+        private const string storageEmulatorProcessName = "WAStorageEmulatorx";
+
+
+        /// <summary>
+        /// Is the storage emulator already started.
+        /// </summary>
+        /// <returns></returns>
+        public static bool IsStarted()
+        {
+            return GetStorageEmulatorProcess() != null;
+        }
+
+
+        /// <summary>
+        /// Checks if the storage emulator exists, i.e. is installed.
+        /// </summary>
+        public static bool Exists
+        {
+            get
+            {
+                return File.Exists(GetStorageEmulatorPath());
+            }
+        }
+
+
+        /// <summary>
+        /// Storage Emulator help.
+        /// </summary>
+        /// <returns>Storage emulator help.</returns>
+        public static string Help()
+        {
+            string help = "Error happened. Has StorageEmulator.Start() been called?";
+            if(IsStarted())
+            {
+                //This process handle returns immediately.
+                using(var process = Process.Start(CreateProcessArguments("help")))
+                {
+                    process.WaitForExit();
+                    help = string.Empty;
+                    while(!process.StandardOutput.EndOfStream)
+                    {
+                        help += process.StandardOutput.ReadLine();
+                    }
+                }
+            }
+
+            return help;
+        }
+
+
+        /// <summary>
+        /// Tries to start the storage emulator.
+        /// </summary>
+        /// <returns><em>TRUE</em> if the process was started sucessfully. <em>FALSE</em> otherwise.</returns>
+        public static bool TryStart()
+        {
+            bool isSuccess = StorageEmulator.Exists;
+            if(!IsStarted())
+            {
+                //This process handle returns immediately.
+                using(var process = Process.Start(CreateProcessArguments("start")))
+                {
+                    process.WaitForExit();
+                    isSuccess = process.ExitCode == 0;
+                }
+            }
+
+            return isSuccess;
+        }
+
+
+        /// <summary>
+        /// Starts the storage emulator if not already started.
+        /// </summary>
+        /// <returns><em>TRUE</em> if the process was stopped succesfully or was already started. <em>FALSE</em> otherwise.</returns>
+        public static bool Start()
+        {
+            bool isSuccess = true;
+            if(!IsStarted())
+            {
+                //This process handle returns immediately.
+                using(var process = Process.Start(CreateProcessArguments("start")))
+                {
+                    process.WaitForExit();
+                    isSuccess = process.ExitCode == 0;
+                }
+            }
+
+            return isSuccess;
+        }
+
+
+        /// <summary>
+        /// Stops the storage emulator if started.
+        /// </summary>
+        /// <returns><em>TRUE</em> if the process was stopped succesfully or was already stopped. <em>FALSE</em> otherwise.</returns>
+        public static bool Stop()
+        {
+            bool isSuccess = true;
+            if(IsStarted())
+            {
+                //This process handle returns immediately.
+                using(var process = Process.Start(CreateProcessArguments("stop")))
+                {
+                    process.WaitForExit();
+                    isSuccess = process.ExitCode == 0;
+                }
+            }
+
+            return isSuccess;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="ProcessStartInfo">ProcessStartInfo</see> to be used as an argument
+        /// to other operations in this class.
+        /// </summary>
+        /// <param name="arguments">The arguments.</param>
+        /// <returns>A new <see cref="ProcessStartInfo">ProcessStartInfo</see> that has the given arguments.</returns>
+        private static ProcessStartInfo CreateProcessArguments(string arguments)
+        {
+            return new ProcessStartInfo(GetStorageEmulatorPath())
+            {
+                WindowStyle = ProcessWindowStyle.Hidden,
+                ErrorDialog = true,
+                LoadUserProfile = true,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                Arguments = arguments
+            };
+        }
+
+
+        /// <summary>
+        /// Queries the storage emulator process from the system.
+        /// </summary>
+        /// <returns></returns>
+        private static Process GetStorageEmulatorProcess()
+        {
+            return Process.GetProcessesByName(storageEmulatorProcessName).FirstOrDefault();
+        }
+        
+                
+        /// <summary>
+        /// Returns a full path to the storage emulator executable, including the executable name and file extension.
+        /// </summary>
+        /// <returns>A full path to the storage emulator executable.</returns>
+        private static string GetStorageEmulatorPath()
+        {
+            return Path.Combine(GetProgramFilesBasePath(), @"Microsoft SDKs\Azure\Storage Emulator\WAStorageEmulator.exe");
+        }
+
+
+        /// <summary>
+        /// Determines the Program Files base directory.
+        /// </summary>
+        /// <returns>The Program files base directory.</returns>
+        private static string GetProgramFilesBasePath()
+        {
+            return Environment.Is64BitOperatingSystem ? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        }
+    }
+}

--- a/src/TestGrainInterfaces/ISimpleBootstrapGrain.cs
+++ b/src/TestGrainInterfaces/ISimpleBootstrapGrain.cs
@@ -1,0 +1,36 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using Orleans;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestGrainInterfaces
+{
+    interface ISimpleBootstrapGrain: IGrain
+    {
+    }
+}

--- a/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
+++ b/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
@@ -58,6 +58,12 @@ namespace UnitTests.StorageTests
         public static void ClassInitialize(TestContext testContext)
         {
             TraceLogger.Initialize(new NodeConfiguration());
+
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if(!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }            
         }
 
         // Use TestInitialize to run code before running each test 

--- a/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
@@ -49,6 +49,16 @@ namespace UnitTests.StorageTests
             logger = TraceLogger.GetLogger("AzureQueueDataManagerTests", TraceLogger.LoggerType.Application);
         }
 
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if(!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }
+        }
+
         [TestCleanup]
         public void TestCleanup()
         {

--- a/src/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
@@ -40,6 +40,16 @@ namespace UnitTests.StorageTests
         private string PartitionKey;
         private UnitTestAzureTableDataManager manager;
 
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if(!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }
+        }
+
         [TestInitialize]
         public void TestInitialize()
         {

--- a/src/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
@@ -45,6 +45,16 @@ namespace UnitTests.StorageTests
             return new UnitTestAzureTableData("JustData", PartitionKey, "RK-" + Guid.NewGuid());
         }
 
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if(!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }
+        }
+
         [TestInitialize]
         public void TestInitialize()
         {
@@ -66,12 +76,12 @@ namespace UnitTests.StorageTests
                 await manager.CreateTableEntryAsync(data2);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.Conflict, exc.RequestInformation.HttpStatusCode, "Creating an already existing entry.");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.Conflict, httpStatusCode);
                 Assert.AreEqual("EntityAlreadyExists", restStatus);
             }
@@ -103,12 +113,12 @@ namespace UnitTests.StorageTests
                 await manager.UpdateTableEntryAsync(data, AzureStorageUtils.ANY_ETAG);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.NotFound, exc.RequestInformation.HttpStatusCode, "Update before insert.");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.NotFound, httpStatusCode);
                 Assert.AreEqual(StorageErrorCodeStrings.ResourceNotFound, restStatus);
             }
@@ -134,12 +144,12 @@ namespace UnitTests.StorageTests
                 string eTag3 = await manager.UpdateTableEntryAsync(data3.Clone(), eTag1);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.PreconditionFailed, exc.RequestInformation.HttpStatusCode, "Wrong eTag");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.PreconditionFailed, httpStatusCode);
                 Assert.IsTrue(restStatus == TableErrorCodeStrings.UpdateConditionNotSatisfied
                             || restStatus == StorageErrorCodeStrings.ConditionNotMet, restStatus);
@@ -155,12 +165,12 @@ namespace UnitTests.StorageTests
                 await manager.DeleteTableEntryAsync(data, AzureStorageUtils.ANY_ETAG);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.NotFound, exc.RequestInformation.HttpStatusCode, "Delete before create.");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.NotFound, httpStatusCode);
                 Assert.AreEqual(StorageErrorCodeStrings.ResourceNotFound, restStatus);
             }
@@ -173,12 +183,12 @@ namespace UnitTests.StorageTests
                 await manager.DeleteTableEntryAsync(data, eTag1);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.NotFound, exc.RequestInformation.HttpStatusCode, "Deleting an already deleted item.");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.NotFound, httpStatusCode);
                 Assert.AreEqual(StorageErrorCodeStrings.ResourceNotFound, restStatus);
             }
@@ -196,12 +206,12 @@ namespace UnitTests.StorageTests
                 await manager.MergeTableEntryAsync(data, AzureStorageUtils.ANY_ETAG);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.NotFound, exc.RequestInformation.HttpStatusCode, "Merge before create.");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.NotFound, httpStatusCode);
                 Assert.AreEqual(StorageErrorCodeStrings.ResourceNotFound, restStatus);
             }
@@ -216,12 +226,12 @@ namespace UnitTests.StorageTests
                 await manager.MergeTableEntryAsync(data, eTag1);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.PreconditionFailed, exc.RequestInformation.HttpStatusCode, "Wrong eTag.");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.PreconditionFailed, httpStatusCode);
                 Assert.IsTrue(restStatus == TableErrorCodeStrings.UpdateConditionNotSatisfied
                             || restStatus == StorageErrorCodeStrings.ConditionNotMet, restStatus);
@@ -248,12 +258,12 @@ namespace UnitTests.StorageTests
             {
                 await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, AzureStorageUtils.ANY_ETAG);
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.NotFound, exc.RequestInformation.HttpStatusCode, "Upadte item 2 before created it.");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.NotFound, httpStatusCode);
                 Assert.AreEqual(StorageErrorCodeStrings.ResourceNotFound, restStatus);
             }
@@ -265,12 +275,12 @@ namespace UnitTests.StorageTests
                 await manager.InsertTwoTableEntriesConditionallyAsync(data1.Clone(), data2.Clone(), tuple.Item2);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.Conflict, exc.RequestInformation.HttpStatusCode, "Inserting an already existing item 1.");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.Conflict, httpStatusCode);
                 Assert.AreEqual("EntityAlreadyExists", restStatus);
             }
@@ -280,12 +290,12 @@ namespace UnitTests.StorageTests
                 await manager.InsertTwoTableEntriesConditionallyAsync(data1.Clone(), data2.Clone(), AzureStorageUtils.ANY_ETAG);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.Conflict, exc.RequestInformation.HttpStatusCode, "Inserting an already existing item 1 AND wring eTag");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.Conflict, httpStatusCode);
                 Assert.AreEqual("EntityAlreadyExists", restStatus);
             };
@@ -300,12 +310,12 @@ namespace UnitTests.StorageTests
             {
                 await manager.UpdateTwoTableEntriesConditionallyAsync(data1, AzureStorageUtils.ANY_ETAG, data2, AzureStorageUtils.ANY_ETAG);
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.NotFound, exc.RequestInformation.HttpStatusCode, "Update before insert.");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.NotFound, httpStatusCode);
                 Assert.AreEqual(StorageErrorCodeStrings.ResourceNotFound, restStatus);
             }
@@ -319,12 +329,12 @@ namespace UnitTests.StorageTests
                 await manager.UpdateTwoTableEntriesConditionallyAsync(data1, tuple1.Item1, data2, tuple1.Item2);
                 Assert.Fail("Should have thrown StorageException.");
             }
-            catch (StorageException exc)
+            catch(StorageException exc)
             {
                 Assert.AreEqual((int)HttpStatusCode.PreconditionFailed, exc.RequestInformation.HttpStatusCode, "Wrong eTag");
                 HttpStatusCode httpStatusCode;
                 string restStatus;
-                AzureStorageUtils.EvaluateException(exc, out  httpStatusCode, out restStatus, true);
+                AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus, true);
                 Assert.AreEqual(HttpStatusCode.PreconditionFailed, httpStatusCode);
                 Assert.IsTrue(restStatus == TableErrorCodeStrings.UpdateConditionNotSatisfied
                         || restStatus == StorageErrorCodeStrings.ConditionNotMet, restStatus);

--- a/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
@@ -21,21 +21,27 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans.AzureUtils;
+using Orleans.TestingHost;
 using System;
 using System.Net;
-using System.Data.Services.Client;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.WindowsAzure.Storage.Shared.Protocol;
-using Microsoft.WindowsAzure.Storage.Table.Protocol;
-using Orleans.Runtime;
-using Orleans.AzureUtils;
-using Microsoft.WindowsAzure.Storage;
 
 namespace UnitTests.StorageTests
 {
     [TestClass]
     public class AzureTableErrorCodeTests
     {
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if(!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }
+        }
+
         [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_IsRetriableHttpError()
         {

--- a/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
+++ b/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
@@ -56,6 +56,12 @@ namespace UnitTests.LivenessTests
 
             // Set shorter init timeout for these tests
             OrleansSiloInstanceManager.initTimeout = TimeSpan.FromSeconds(20);
+
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if(!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }
         }
 
         [ClassCleanup]
@@ -90,10 +96,10 @@ namespace UnitTests.LivenessTests
         [TestMethod, TestCategory("Nightly"), TestCategory("Liveness"), TestCategory("Azure")]
         public async Task MT_InsertRow_Azure()
         {
-            var membership = await GetMemebershipTable_Azure(); 
+            var membership = await GetMemebershipTable_Azure();
             await MembershipTable_InsertRow(membership);
         }
-        
+
         [TestMethod, TestCategory("Liveness"), TestCategory("SqlServer")]
         public async Task MT_Init_SqlServer()
         {
@@ -108,7 +114,7 @@ namespace UnitTests.LivenessTests
             await MembershipTable_ReadAll(membership);
         }
 
-        [TestMethod,TestCategory("Liveness"), TestCategory("SqlServer")]
+        [TestMethod, TestCategory("Liveness"), TestCategory("SqlServer")]
         public async Task MT_InsertRow_SqlServer()
         {
             var membership = await GetMemebershipTable_SQL();
@@ -175,11 +181,11 @@ namespace UnitTests.LivenessTests
         {
             string runId = Guid.NewGuid().ToString("N");
 
-            var config = new GlobalConfiguration {LivenessType = membershipType, DeploymentId = runId};
+            var config = new GlobalConfiguration { LivenessType = membershipType, DeploymentId = runId };
 
             IMembershipTable membership;
 
-            switch (membershipType)
+            switch(membershipType)
             {
                 case GlobalConfiguration.LivenessProviderType.AzureTable:
                     config.DataConnectionString = StorageTestConstants.DataConnectionString;

--- a/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
+++ b/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
@@ -72,6 +72,12 @@ namespace UnitTests.StorageTests
         public static void ClassInitialize(TestContext testContext)
         {
             TraceLogger.Initialize(new NodeConfiguration());
+
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if(!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }
         }
 
         // Use TestInitialize to run code before running each test 
@@ -93,7 +99,7 @@ namespace UnitTests.StorageTests
         [TestCleanup]
         public void TestCleanup()
         {
-            if (manager != null && SiloInstanceTableTestConstants.DeleteEntriesAfterTest)
+            if(manager != null && SiloInstanceTableTestConstants.DeleteEntriesAfterTest)
             {
                 TimeSpan timeout = SiloInstanceTableTestConstants.Timeout;
 


### PR DESCRIPTION
Currently the test start to fail some time after startup if the storage emulator is not on. This patch provides a thin, programmatic wrapper to start or stop Storage Emulator process and a class to start the emulator before any tests are run.

This looks like being a nice convenience feature, as noted at [PR #412](https://github.com/dotnet/orleans/pull/412#issuecomment-101672812).

This approach might be suitable for refactoring to check if other processes are on too (e.g. database engines) if dependency external libraries such as Fake is not desired.
