### PR TITLE
Refactoring tests to async-await

### DIFF
--- a/src/TestGrains/SimpleObserverableGrain.cs
+++ b/src/TestGrains/SimpleObserverableGrain.cs
@@ -52,33 +52,42 @@ namespace UnitTests.Grains
             return TaskDone.Done;
         }
 
-        public Task SetA(int a)
+        public async Task SetA(int a)
         {
             logger.Info("SetA={0}", a);
             A = a;
-            Task.Factory.StartNew(() =>
+
+            //If this were run with Task.Run there were no need for the added Unwrap call.
+            //However, Task.Run runs in Thread Pool and not in Orleans TaskScheduler, unlike Task.Factory.StartNew.
+            //See more at http://dotnet.github.io/orleans/Advanced-Concepts/External-Tasks-and-Grains.
+            //The extra task comes from the internal asynchronous lambda due to Task.Delay. For deeper
+            //insight, see at http://blogs.msdn.com/b/pfxteam/archive/2012/02/08/10265476.aspx.
+            await Task.Factory.StartNew(async () =>
             {
-                Thread.Sleep(EventDelay);
+                await Task.Delay(EventDelay);
                 RaiseStateUpdateEvent();
-            }).Ignore();
-            return TaskDone.Done;
+            }).Unwrap();            
         }
 
-        public Task SetB(int b)
+        public async Task SetB(int b)
         {
             this.B = b;
-            Task.Factory.StartNew(() =>
+
+            //If this were run with Task.Run there were no need for the added Unwrap call.
+            //However, Task.Run runs in Thread Pool and not in Orleans TaskScheduler, unlike Task.Factory.StartNew.
+            //See more at http://dotnet.github.io/orleans/Advanced-Concepts/External-Tasks-and-Grains.
+            //The extra task comes from the internal asynchronous lambda due to Task.Delay. For deeper
+            //insight, see at http://blogs.msdn.com/b/pfxteam/archive/2012/02/08/10265476.aspx.
+            await Task.Factory.StartNew(async () =>
             {
-                Thread.Sleep(EventDelay);
+                await Task.Delay(EventDelay);
                 RaiseStateUpdateEvent();
-            }).Ignore();
-            return TaskDone.Done;
+            }).Unwrap();            
         }
 
-        public Task IncrementA()
+        public async Task IncrementA()
         {
-            SetA(A + 1);
-            return TaskDone.Done;
+            await SetA(A + 1);            
         }
 
         public Task<int> GetAxB()

--- a/src/TestGrains/SimpleObserverableGrain.cs
+++ b/src/TestGrains/SimpleObserverableGrain.cs
@@ -58,7 +58,7 @@ namespace UnitTests.Grains
             A = a;
 
             //If this were run with Task.Run there were no need for the added Unwrap call.
-            //However, Task.Run runs in Thread Pool and not in Orleans TaskScheduler, unlike Task.Factory.StartNew.
+            //However, Task.Run runs in ThreadPool and not in Orleans TaskScheduler, unlike Task.Factory.StartNew.
             //See more at http://dotnet.github.io/orleans/Advanced-Concepts/External-Tasks-and-Grains.
             //The extra task comes from the internal asynchronous lambda due to Task.Delay. For deeper
             //insight, see at http://blogs.msdn.com/b/pfxteam/archive/2012/02/08/10265476.aspx.
@@ -74,7 +74,7 @@ namespace UnitTests.Grains
             this.B = b;
 
             //If this were run with Task.Run there were no need for the added Unwrap call.
-            //However, Task.Run runs in Thread Pool and not in Orleans TaskScheduler, unlike Task.Factory.StartNew.
+            //However, Task.Run runs in ThreadPool and not in Orleans TaskScheduler, unlike Task.Factory.StartNew.
             //See more at http://dotnet.github.io/orleans/Advanced-Concepts/External-Tasks-and-Grains.
             //The extra task comes from the internal asynchronous lambda due to Task.Delay. For deeper
             //insight, see at http://blogs.msdn.com/b/pfxteam/archive/2012/02/08/10265476.aspx.

--- a/src/Tester/ObserverTests.cs
+++ b/src/Tester/ObserverTests.cs
@@ -21,14 +21,13 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.TestingHost;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
 
@@ -88,9 +87,9 @@ namespace UnitTests.General
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(ObserverTest_SimpleNotification_Callback, result);
             ISimpleGrainObserver reference = await GrainFactory.CreateObjectReference<ISimpleGrainObserver>(this.observer1);
-            grain.Subscribe(reference).Wait();
-            grain.SetA(3).Wait();
-            grain.SetB(2).Wait();
+            await grain.Subscribe(reference);
+            await grain.SetA(3);
+            await grain.SetB(2);
 
             Assert.IsTrue(result.WaitForFinished(timeout), "Should not timeout waiting {0} for {1}", timeout, "SetB");
 
@@ -105,9 +104,9 @@ namespace UnitTests.General
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(ObserverTest_SimpleNotification_Callback, result);
             ISimpleGrainObserver reference = await SimpleGrainObserverFactory.CreateObjectReference(this.observer1);
-            grain.Subscribe(reference).Wait();
-            grain.SetA(3).Wait();
-            grain.SetB(2).Wait();
+            await grain.Subscribe(reference);
+            await grain.SetA(3);
+            await grain.SetB(2);
 
             Assert.IsTrue(result.WaitForFinished(timeout), "Should not timeout waiting {0} for {1}", timeout, "SetB");
 
@@ -150,8 +149,8 @@ namespace UnitTests.General
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(ObserverTest_DoubleSubscriptionSameReference_Callback, result);
             ISimpleGrainObserver reference = await GrainFactory.CreateObjectReference<ISimpleGrainObserver>(this.observer1);
-            grain.Subscribe(reference).Wait();
-            grain.SetA(1).Wait(); // Use grain
+            await grain.Subscribe(reference);
+            await grain.SetA(1); // Use grain
             try
             {
                 bool ok = grain.Subscribe(reference).Wait(timeout);
@@ -171,7 +170,7 @@ namespace UnitTests.General
                     Assert.Fail("Unexpected exception message: " + baseException);
                 }
             }
-            grain.SetA(2).Wait(); // Use grain
+            await grain.SetA(2); // Use grain
 
             Assert.IsFalse(result.WaitForFinished(timeout), "Should timeout waiting {0} for {1}", timeout, "SetA(2)");
 
@@ -198,11 +197,11 @@ namespace UnitTests.General
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(ObserverTest_SubscribeUnsubscribe_Callback, result);
             ISimpleGrainObserver reference = await GrainFactory.CreateObjectReference<ISimpleGrainObserver>(this.observer1);
-            grain.Subscribe(reference).Wait();
-            grain.SetA(5).Wait();
+            await grain.Subscribe(reference);
+            await grain.SetA(5);
             Assert.IsTrue(result.WaitForContinue(timeout), "Should not timeout waiting {0} for {1}", timeout, "SetA");
-            grain.Unsubscribe(reference).Wait();
-            grain.SetB(3).Wait();
+            await grain.Unsubscribe(reference);
+            await grain.SetB(3);
 
             Assert.IsFalse(result.WaitForFinished(timeout), "Should timeout waiting {0} for {1}", timeout, "SetB");
 
@@ -257,8 +256,8 @@ namespace UnitTests.General
             ISimpleGrainObserver reference1 = await GrainFactory.CreateObjectReference<ISimpleGrainObserver>(this.observer1);
             this.observer2 = new SimpleGrainObserver(ObserverTest_DoubleSubscriptionDifferentReferences_Callback, result);
             ISimpleGrainObserver reference2 = await GrainFactory.CreateObjectReference<ISimpleGrainObserver>(this.observer2);
-            grain.Subscribe(reference1).Wait();
-            grain.Subscribe(reference2).Wait();
+            await grain.Subscribe(reference1);
+            await grain.Subscribe(reference2);
             grain.SetA(6).Ignore();
 
             Assert.IsTrue(result.WaitForFinished(timeout), "Should not timeout waiting {0} for {1}", timeout, "SetA");
@@ -289,11 +288,11 @@ namespace UnitTests.General
             ISimpleObserverableGrain grain = GetGrain();
             this.observer1 = new SimpleGrainObserver(ObserverTest_DeleteObject_Callback, result);
             ISimpleGrainObserver reference = await GrainFactory.CreateObjectReference<ISimpleGrainObserver>(this.observer1);
-            grain.Subscribe(reference).Wait();
-            grain.SetA(5).Wait();
+            await grain.Subscribe(reference);
+            await grain.SetA(5);
             Assert.IsTrue(result.WaitForContinue(timeout), "Should not timeout waiting {0} for {1}", timeout, "SetA");
             await GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
-            grain.SetB(3).Wait();
+            await grain.SetB(3);
 
             Assert.IsFalse(result.WaitForFinished(timeout), "Should timeout waiting {0} for {1}", timeout, "SetB");
         }
@@ -312,7 +311,7 @@ namespace UnitTests.General
 
         [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
         [ExpectedException(typeof(NotSupportedException))]
-        public void ObserverTest_SubscriberMustBeGrainReference()
+        public async Task ObserverTest_SubscriberMustBeGrainReference()
         {
             ResultHandle result = new ResultHandle();
 
@@ -320,7 +319,7 @@ namespace UnitTests.General
             this.observer1 = new SimpleGrainObserver(ObserverTest_SimpleNotification_Callback, result);
             ISimpleGrainObserver reference = this.observer1;
             // Should be: GrainFactory.CreateObjectReference<ISimpleGrainObserver>(obj);
-            grain.Subscribe(reference).Wait();
+            await grain.Subscribe(reference);
             // Not reached
         }
 

--- a/src/Tester/SimpleGrainTests.cs
+++ b/src/Tester/SimpleGrainTests.cs
@@ -71,18 +71,18 @@ namespace UnitTests.General
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
-        public void SimpleGrainControlFlow()
+        public async Task SimpleGrainControlFlow()
         {
             ISimpleGrain grain = GetSimpleGrain();
             
             Task setPromise = grain.SetA(2);
-            setPromise.Wait();
+            await setPromise;
 
             setPromise = grain.SetB(3);
-            setPromise.Wait();
+            await setPromise;
 
             Task<int> intPromise = grain.GetAxB();
-            Assert.AreEqual(6, intPromise.Result);
+            Assert.AreEqual(6, await intPromise);
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]

--- a/src/Tester/StreamingTests/DeactivationTestRunner.cs
+++ b/src/Tester/StreamingTests/DeactivationTestRunner.cs
@@ -83,7 +83,7 @@ namespace Tester.StreamingTests
             Assert.AreEqual(count[subscriptionHandle], 1, "Consumer grain has not received stream message");
 
             //TODO: trigger deactivation programmatically
-            Thread.Sleep(130000); // wait for the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain to be deactivated
+            await Task.Delay(TimeSpan.FromMilliseconds(130000)); // wait for the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain to be deactivated
 
             // deactivating PubSubRendezvousGrain and SampleStreaming_ProducerGrain during the same GC cycle causes a deadlock
             // resume producing after the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain grains have been deactivated:
@@ -113,7 +113,7 @@ namespace Tester.StreamingTests
             Assert.AreEqual(count.Value, 1, "Client consumer grain has not received stream message");
 
             //TODO: trigger deactivation programmatically
-            Thread.Sleep(130000); // wait for the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain to be deactivated
+            await Task.Delay(TimeSpan.FromMilliseconds(130000)); // wait for the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain to be deactivated
 
             // deactivating PubSubRendezvousGrain and SampleStreaming_ProducerGrain during the same GC cycle causes a deadlock
             // resume producing after the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain grains have been deactivated:

--- a/src/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/src/Tester/StreamingTests/SampleStreamingTests.cs
@@ -127,7 +127,7 @@ namespace Tester.StreamingTests
 
             await producer.StartPeriodicProducing();
 
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
 
             await producer.StopPeriodicProducing();
 
@@ -147,10 +147,10 @@ namespace Tester.StreamingTests
 
             await producer.StartPeriodicProducing();
 
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
 
             await producer.StopPeriodicProducing();
-            //int numProduced = producer.NumberProduced.Result;
+            //int numProduced = await producer.NumberProduced;
 
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, lastTry), _timeout);
 
@@ -168,10 +168,10 @@ namespace Tester.StreamingTests
 
             await producer.StartPeriodicProducing();
 
-            Thread.Sleep( 1000 );
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
 
             await producer.StopPeriodicProducing();
-            //int numProduced = producer.NumberProduced.Result;
+            //int numProduced = await producer.NumberProduced;
 
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, lastTry), _timeout);
 

--- a/src/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/src/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -21,15 +21,14 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using TestGrainInterfaces;
 using UnitTests.SampleStreaming;
 
@@ -65,7 +64,7 @@ namespace Tester.StreamingTests
             await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
 
             await producer.StartPeriodicProducing();
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
             await producer.StopPeriodicProducing();
 
             // check
@@ -88,7 +87,7 @@ namespace Tester.StreamingTests
             StreamSubscriptionHandle<int> firstSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
 
             await producer.StartPeriodicProducing();
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
             await producer.StopPeriodicProducing();
 
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, 1, lastTry), Timeout);
@@ -101,7 +100,7 @@ namespace Tester.StreamingTests
             StreamSubscriptionHandle<int> secondSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
 
             await producer.StartPeriodicProducing();
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
             await producer.StopPeriodicProducing();
 
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, 2, lastTry), Timeout);
@@ -114,7 +113,7 @@ namespace Tester.StreamingTests
             await consumer.StopConsuming(firstSubscriptionHandle);
 
             await producer.StartPeriodicProducing();
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
             await producer.StopPeriodicProducing();
 
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, 1, lastTry), Timeout);
@@ -135,7 +134,7 @@ namespace Tester.StreamingTests
             StreamSubscriptionHandle<int> firstSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
 
             await producer.StartPeriodicProducing();
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
             await producer.StopPeriodicProducing();
 
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, 1, lastTry), Timeout);
@@ -146,7 +145,7 @@ namespace Tester.StreamingTests
             Assert.AreEqual(firstSubscriptionHandle, resumeHandle, "Handle matches");
 
             await producer.StartPeriodicProducing();
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
             await producer.StopPeriodicProducing();
 
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, 1, lastTry), Timeout);
@@ -167,7 +166,7 @@ namespace Tester.StreamingTests
             StreamSubscriptionHandle<int> firstSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
 
             await producer.StartPeriodicProducing();
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
             await producer.StopPeriodicProducing();
 
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, 1, lastTry), Timeout);
@@ -176,7 +175,7 @@ namespace Tester.StreamingTests
             await consumer.Deactivate();
 
             // make sure grain has time to deactivate.
-            Thread.Sleep(100);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
 
             // clear producer counts
             await producer.ClearNumberProduced();
@@ -187,7 +186,7 @@ namespace Tester.StreamingTests
             Assert.AreEqual(firstSubscriptionHandle, resumeHandle, "Handle matches");
 
             await producer.StartPeriodicProducing();
-            Thread.Sleep(1000);
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
             await producer.StopPeriodicProducing();
 
             await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, 1, lastTry), Timeout);

--- a/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
+++ b/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
@@ -86,7 +86,7 @@ namespace UnitTests.StorageTests
         {
             if (membership != null && SiloInstanceTableTestConstants.DeleteEntriesAfterTest)
             {
-                membership.DeleteMembershipTableEntries(deploymentId);
+                membership.DeleteMembershipTableEntries(deploymentId).Wait();
                 membership = null;
             }
         }

--- a/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
@@ -61,7 +61,7 @@ namespace UnitTests.StorageTests
         {
             AzureQueueDataManager manager = new AzureQueueDataManager(qName, DeploymentId, StorageTestConstants.DataConnectionString);
             await manager.InitQueueAsync();
-            return manager;
+            return await Task.FromResult(manager);
         }
 
         [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("AzureQueue")]

--- a/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
@@ -61,7 +61,7 @@ namespace UnitTests.StorageTests
         {
             AzureQueueDataManager manager = new AzureQueueDataManager(qName, DeploymentId, StorageTestConstants.DataConnectionString);
             await manager.InitQueueAsync();
-            return await Task.FromResult(manager);
+            return manager;
         }
 
         [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("AzureQueue")]


### PR DESCRIPTION
It would make sense to refactor all the code to be async-await too. Some of the testing code arguably is as it returns ``TaskDone.Done``, though using .Result and Wait() on the caller side making it more difficult to detect and pushes one into investigating in more detail. But not all code is asynchronous.