### PR TITLE
Added Silo.Shutdown call.

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -447,6 +447,7 @@ namespace Orleans
         Catalog_DeactivateStreamResources_Exception     = CatalogBase + 42,
         Catalog_FinishDeactivateActivation_Exception    = CatalogBase + 43,
         Catalog_FinishGrainDeactivateAndCleanupStreams_Exception = CatalogBase + 44,
+        Catalog_ShutdownActivations_DeactivateAll      = CatalogBase + 45,
 
         MembershipBase                         = Runtime + 600,
         MembershipCantWriteLivenessDisabled    = Runtime_Error_100225, // Backward compatability

--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -447,7 +447,7 @@ namespace Orleans
         Catalog_DeactivateStreamResources_Exception     = CatalogBase + 42,
         Catalog_FinishDeactivateActivation_Exception    = CatalogBase + 43,
         Catalog_FinishGrainDeactivateAndCleanupStreams_Exception = CatalogBase + 44,
-        Catalog_ShutdownActivations_DeactivateAll      = CatalogBase + 45,
+        Catalog_DeactivateAllActivations = CatalogBase + 45,
 
         MembershipBase                         = Runtime + 600,
         MembershipCantWriteLivenessDisabled    = Runtime_Error_100225, // Backward compatability

--- a/src/OrleansAzureUtils/AzureSilo.cs
+++ b/src/OrleansAzureUtils/AzureSilo.cs
@@ -242,7 +242,7 @@ namespace Orleans.Runtime.Host
         {
             logger.Info(ErrorCode.Runtime_Error_100290, "Stopping {0}", this.GetType().FullName);
             RoleEnvironment.Stopping -= HandleAzureRoleStopping;
-            host.StopOrleansSilo();
+            host.ShutdownOrleansSilo();
             logger.Info(ErrorCode.Runtime_Error_100291, "Orleans silo '{0}' shutdown.", host.Name);
         }
 
@@ -266,7 +266,7 @@ namespace Orleans.Runtime.Host
         {
             // Try to perform gracefull shutdown of Silo when we detect Azure role instance is being stopped
             logger.Info(ErrorCode.SiloStopping, "HandleAzureRoleStopping - starting to shutdown silo");
-            host.StopOrleansSilo();
+            host.ShutdownOrleansSilo();
         }
 
 		/// <summary>

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -772,6 +772,13 @@ namespace Orleans.Runtime
             }
         }
 
+        public Task ShutdownActivations_DeactivateAll()
+        {
+            logger.Info(ErrorCode.Catalog_ShutdownActivations_DeactivateAll, "ShutdownActivations_DeactivateAll.");
+            var activationsToShutdown = activations.Select(kv => kv.Value).ToList();
+            return ShutdownActivations_DirectShutdown(activationsToShutdown);
+        }
+
         /// <summary>
         /// Deletes activation immediately regardless of active transactions etc.
         /// For use by grain delete, transaction abort, etc.

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -168,7 +168,7 @@ namespace Orleans.Runtime
             if (list != null && list.Count > 0)
             {
                 if (logger.IsVerbose) logger.Verbose("CollectActivations{0}", list.ToStrings(d => d.Grain.ToString() + d.ActivationId));
-                await ShutdownActivation_Collector(list);
+                await DeactivateActivationsFromCollector(list);
             }
             long memAfter = GC.GetTotalMemory(false) / (1024 * 1024);
             watch.Stop();
@@ -655,9 +655,9 @@ namespace Orleans.Runtime
             return data != null;
         }
 
-        private Task ShutdownActivation_Collector(List<ActivationData> list)
+        private Task DeactivateActivationsFromCollector(List<ActivationData> list)
         {
-            logger.Info(ErrorCode.Catalog_ShutdownActivations_1, "ShutdownActivationCollector: total {0} to promptly Destroy.", list.Count);
+            logger.Info(ErrorCode.Catalog_ShutdownActivations_1, "DeactivateActivationsFromCollector: total {0} to promptly Destroy.", list.Count);
             CounterStatistic.FindOrCreate(StatisticNames.CATALOG_ACTIVATION_SHUTDOWN_VIA_COLLECTION).IncrementBy(list.Count);
             foreach (var activation in list)
             {
@@ -671,7 +671,7 @@ namespace Orleans.Runtime
 
         // To be called fro within Activation context.
         // Cannot be awaitable, since after DestroyActivation is done the activation is in Invalid state and cannot await any Task.
-        internal void ShutdownActivation_DeactivateOnIdle(ActivationData data)
+        internal void DeactivateActivationOnIdle(ActivationData data)
         {
             bool promptly = false;
             bool alreadBeingDestroyed = false;
@@ -695,8 +695,8 @@ namespace Orleans.Runtime
                     alreadBeingDestroyed = true;
                 }
             }
-            logger.Info(ErrorCode.Catalog_ShutdownActivations_2, 
-                "ShutdownActivationDeactivateOnIdle: 1 {0}.", promptly ? "promptly" : (alreadBeingDestroyed ? "already being destroyed or invalid" : "later when become idle"));
+            logger.Info(ErrorCode.Catalog_ShutdownActivations_2,
+                "DeactivateActivationOnIdle: 1 {0}.", promptly ? "promptly" : (alreadBeingDestroyed ? "already being destroyed or invalid" : "later when become idle"));
 
             CounterStatistic.FindOrCreate(StatisticNames.CATALOG_ACTIVATION_SHUTDOWN_VIA_DEACTIVATE_ON_IDLE).Increment();
             if (promptly)
@@ -712,11 +712,11 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="list"></param>
         /// <returns></returns>
-        internal async Task ShutdownActivations_DirectShutdown(List<ActivationData> list)
+        internal async Task DeactivateActivations(List<ActivationData> list)
         {
             if (list == null || list.Count == 0) return;
 
-            if (logger.IsVerbose) logger.Verbose("ShutdownActivations_DirectShutdown: {0} activations.", list.Count);
+            if (logger.IsVerbose) logger.Verbose("DeactivateActivations: {0} activations.", list.Count);
             List<ActivationData> destroyNow = null;
             List<MultiTaskCompletionSource> destroyLater = null;
             int alreadBeingDestroyed = 0;
@@ -758,7 +758,7 @@ namespace Orleans.Runtime
             int numDestroyNow = destroyNow == null ? 0 : destroyNow.Count;
             int numDestroyLater = destroyLater == null ? 0 : destroyLater.Count;
             logger.Info(ErrorCode.Catalog_ShutdownActivations_3,
-                "RequestShutdownActivation_DirectShutdown: total {0} to shutdown, out of them {1} promptly, {2} later when become idle and {3} are already being destroyed or invalid.",
+                "DeactivateActivations: total {0} to shutdown, out of them {1} promptly, {2} later when become idle and {3} are already being destroyed or invalid.",
                 list.Count, numDestroyNow, numDestroyLater, alreadBeingDestroyed);
             CounterStatistic.FindOrCreate(StatisticNames.CATALOG_ACTIVATION_SHUTDOWN_VIA_DIRECT_SHUTDOWN).IncrementBy(list.Count);
 
@@ -772,11 +772,11 @@ namespace Orleans.Runtime
             }
         }
 
-        public Task ShutdownActivations_DeactivateAll()
+        public Task DeactivateAllActivations()
         {
-            logger.Info(ErrorCode.Catalog_ShutdownActivations_DeactivateAll, "ShutdownActivations_DeactivateAll.");
+            logger.Info(ErrorCode.Catalog_DeactivateAllActivations, "DeactivateAllActivations.");
             var activationsToShutdown = activations.Select(kv => kv.Value).ToList();
-            return ShutdownActivations_DirectShutdown(activationsToShutdown);
+            return DeactivateActivations(activationsToShutdown);
         }
 
         /// <summary>
@@ -1183,7 +1183,7 @@ namespace Orleans.Runtime
                 // outside the lock.
                 if (activationsToShutdown.Count > 0)
                 {
-                    ShutdownActivations_DirectShutdown(activationsToShutdown).Ignore();
+                    DeactivateActivations(activationsToShutdown).Ignore();
                 }
             }
         }

--- a/src/OrleansRuntime/Core/InsideGrainClient.cs
+++ b/src/OrleansRuntime/Core/InsideGrainClient.cs
@@ -659,7 +659,7 @@ namespace Orleans.Runtime
             if (!Catalog.TryGetActivationData(id, out data)) return; // already gone
 
             data.ResetKeepAliveRequest(); // DeactivateOnIdle method would undo / override any current “keep alive” setting, making this grain immideately avaliable for deactivation.
-            Catalog.ShutdownActivation_DeactivateOnIdle(data);
+            Catalog.DeactivateActivationOnIdle(data);
         }
 
         #endregion

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -623,7 +623,7 @@ namespace Orleans.Runtime
                 if (gracefully)
                 {
                     // 3: Deactivate all grains
-                    SafeExecute(() => catalog.ShutdownActivations_DeactivateAll().WaitWithThrow(stopTimeout));
+                    SafeExecute(() => catalog.DeactivateAllActivations().WaitWithThrow(stopTimeout));
                 }
 
 

--- a/src/OrleansRuntime/Silo/SiloHost.cs
+++ b/src/OrleansRuntime/Silo/SiloHost.cs
@@ -227,6 +227,15 @@ namespace Orleans.Runtime.Host
             if (orleans != null) orleans.Stop();
         }
 
+        /// <summary>
+        /// Gracefully shutdown this silo.
+        /// </summary>
+        public void ShutdownOrleansSilo()
+        {
+            IsStarted = false;
+            if (orleans != null) orleans.Shutdown();
+        }
+
 		/// <summary>
 		/// Wait for this silo to shutdown.
 		/// </summary>
@@ -507,7 +516,7 @@ namespace Orleans.Runtime.Host
 		{
 			// Try to perform gracefull shutdown of Silo when we a cancellation request has been made
 			logger.Info(ErrorCode.SiloStopping, "External cancellation triggered, starting to shutdown silo.");
-			StopOrleansSilo();
+            ShutdownOrleansSilo();
 		}
 
         /// <summary>

--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -545,7 +545,7 @@ namespace Orleans.TestingHost
         {
             if (stopGracefully)
             {
-                try { if (instance.Silo != null) instance.Silo.Stop(); }
+                try { if (instance.Silo != null) instance.Silo.Shutdown(); }
                 catch (RemotingException re) { Console.WriteLine(re); /* Ignore error */ }
                 catch (Exception exc) { Console.WriteLine(exc); throw; }
             }


### PR DESCRIPTION
Call Silo.Shutdown  from Azure Orleans Silo host and regular Orleans Silo host Stop() methods.
Deactivate all grains in this silo properly upon Silo.Shutdown call.

This is a 2nd step towards Gracefull Shutdown, related to:
#381
#320 (comment)
http://orleans.codeplex.com/discussions/637820#post1425137
Continues the work in #413.

Still a bit more work is required, to properly unsure that silo does not accept any new grain requests after the grains were deactivated and before silo is fully dead (so that we don't reactivate some grains again). This PR definitely leaves us in a better state than before we Deactivated all grains, so I feel like it can be merged even before the next level of improvements is done.
