### PR TITLE
Make sure we handle all in flight requests correctly when silo is shutting down.

### DIFF
--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -473,18 +473,6 @@ namespace Orleans.Runtime
             }
         }
 
-        public bool IsUsable
-        {
-            get
-            {
-                if (State == ActivationState.Create) return false;
-                if (State == ActivationState.Activating) return false;
-                if (State == ActivationState.Deactivating) return false;
-                if (State == ActivationState.Invalid) return false;
-                return true;
-            }
-        }
-
         /// <summary>
         /// Insert in a FIFO order
         /// </summary>

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -350,7 +350,7 @@ namespace Orleans.Runtime
                     return result;
                 }
                 
-                if (newPlacement)
+                if (newPlacement && !SiloStatusOracle.CurrentStatus.IsTerminating())
                 {
                     // create a dummy activation that will queue up messages until the real data arrives
                     PlacementStrategy placement;

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -727,7 +727,7 @@ namespace Orleans.Runtime
             if (logger.IsVerbose) logger.Verbose("DeactivateActivations: {0} activations.", list.Count);
             List<ActivationData> destroyNow = null;
             List<MultiTaskCompletionSource> destroyLater = null;
-            int alreadBeingDestroyed = 0;
+            int alreadyBeingDestroyed = 0;
             foreach (var d in list)
             {
                 var activationData = d; // capture
@@ -758,7 +758,7 @@ namespace Orleans.Runtime
                     }
                     else
                     {
-                        alreadBeingDestroyed++;
+                        alreadyBeingDestroyed++;
                     }
                 }
             }
@@ -767,7 +767,7 @@ namespace Orleans.Runtime
             int numDestroyLater = destroyLater == null ? 0 : destroyLater.Count;
             logger.Info(ErrorCode.Catalog_ShutdownActivations_3,
                 "DeactivateActivations: total {0} to shutdown, out of them {1} promptly, {2} later when become idle and {3} are already being destroyed or invalid.",
-                list.Count, numDestroyNow, numDestroyLater, alreadBeingDestroyed);
+                list.Count, numDestroyNow, numDestroyLater, alreadyBeingDestroyed);
             CounterStatistic.FindOrCreate(StatisticNames.CATALOG_ACTIVATION_SHUTDOWN_VIA_DIRECT_SHUTDOWN).IncrementBy(list.Count);
 
             if (destroyNow != null && destroyNow.Count > 0)
@@ -1098,14 +1098,14 @@ namespace Orleans.Runtime
             return addresses != null;
         }
 
-        public List<SiloAddress> AllSilos
+        public List<SiloAddress> AllActiveSilos
         {
             get
             {
                 var result = SiloStatusOracle.GetApproximateSiloStatuses(true).Select(s => s.Key).ToList();
                 if (result.Count > 0) return result;
 
-                logger.Warn(ErrorCode.Catalog_GetApproximateSiloStatuses, "AllSilos SiloStatusOracle.GetApproximateSiloStatuses empty");
+                logger.Warn(ErrorCode.Catalog_GetApproximateSiloStatuses, "AllActiveSilos SiloStatusOracle.GetApproximateSiloStatuses empty");
                 return new List<SiloAddress> { LocalSilo };
             }
         }

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -123,22 +123,9 @@ namespace Orleans.Runtime
                 }
                 else // Request or OneWay
                 {
-                    if (SiloCanAcceptRequest(message))
-                    {
-                        ReceiveRequest(message, target);
-                    }
-                    else if (message.MayResend(config.Globals))
-                    {
-                        // Record that this message is no longer flowing through the system
-                        MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedError(message, "Redirecting");
-                        throw new NotImplementedException("RedirectRequest() is believed to be no longer necessary; please contact the Orleans team if you see this error.");
-                    }
-                    else
-                    {
-                        // Record that this message is no longer flowing through the system
-                        MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedError(message, "Rejecting");
-                        RejectMessage(message, Message.RejectionTypes.Transient, null, "Shutting down");
-                    }
+                    // Silo is always capable to accept a new request. It's up to the activation to handle its internal state.
+                    // If activation is shutting down, it will queue and later forward this request.
+                    ReceiveRequest(message, target);
                 }
             }
             catch (Exception ex)
@@ -258,15 +245,6 @@ namespace Orleans.Runtime
 
                 RuntimeClient.Current.ReceiveResponse(message);
             }
-        }
-
-        // Check if it is OK to receive a message to its current target activation. 
-        private bool SiloCanAcceptRequest(Message message)
-        {
-            if (Message.WriteMessagingTraces)
-                message.AddTimestamp(Message.LifecycleTag.TaskIncoming);
-
-            return !catalog.SiloStatusOracle.CurrentStatus.IsTerminating();
         }
 
         /// <summary>
@@ -657,12 +635,10 @@ namespace Orleans.Runtime
 #endif
                 activation.ResetRunning(message);
 
-                if (catalog.SiloStatusOracle.CurrentStatus.IsTerminating()) return;
-
                 // ensure inactive callbacks get run even with transactions disabled
                 if (!activation.IsCurrentlyExecuting)
                     activation.RunOnInactive();
-                
+
                 // Run message pump to see if there is a new request arrived to be processed
                 RunMessagePump(activation);
             }
@@ -680,8 +656,8 @@ namespace Orleans.Runtime
                     "RunMessagePump {0}: Activation={1}", activation.ActivationId, activation.DumpStatus());
             }
 #endif
-            // don't run any messages until activation is ready
-            if (activation.State != ActivationState.Valid) return;
+            // don't run any messages if activation is not ready or deactivating
+            if (!activation.IsUsable) return;
 
             bool runLoop;
             do

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -306,7 +306,7 @@ namespace Orleans.Runtime
         /// <returns></returns>
         private bool ActivationMayAcceptRequest(ActivationData targetActivation, Message incoming)
         {
-            if (!targetActivation.IsUsable) return false;
+            if (!targetActivation.State.Equals(ActivationState.Valid)) return false;
             if (!targetActivation.IsCurrentlyExecuting) return true;
             return CanInterleave(targetActivation, incoming);
         }
@@ -657,7 +657,7 @@ namespace Orleans.Runtime
             }
 #endif
             // don't run any messages if activation is not ready or deactivating
-            if (!activation.IsUsable) return;
+            if (!activation.State.Equals(ActivationState.Valid)) return;
 
             bool runLoop;
             do

--- a/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
@@ -150,7 +150,7 @@ namespace Orleans.Runtime.Messaging
                     lock (targetActivation)
                     {
                         var target = targetActivation; // to avoid a warning about nulling targetActivation under a lock on it
-                        if (target.IsUsable)
+                        if (target.State.Equals(ActivationState.Valid))
                         {
                             var overloadException = target.CheckOverloaded(Log);
                             if (overloadException != null)

--- a/src/OrleansRuntime/Placement/IPlacementContext.cs
+++ b/src/OrleansRuntime/Placement/IPlacementContext.cs
@@ -42,7 +42,7 @@ namespace Orleans.Runtime.Placement
 
         bool LocalLookup(GrainId grain, out List<ActivationData> addresses);
 
-        List<SiloAddress> AllSilos { get; }
+        List<SiloAddress> AllActiveSilos { get; }
 
         SiloAddress LocalSilo { get; }
 

--- a/src/OrleansRuntime/Placement/RandomPlacementDirector.cs
+++ b/src/OrleansRuntime/Placement/RandomPlacementDirector.cs
@@ -60,7 +60,7 @@ namespace Orleans.Runtime.Placement
             PlacementStrategy strategy, GrainId grain, IPlacementContext context)
         {
             var grainType = context.GetGrainTypeName(grain);
-            var allSilos = context.AllSilos;
+            var allSilos = context.AllActiveSilos;
             return Task.FromResult(
                 PlacementResult.SpecifyCreation(allSilos[random.Next(allSilos.Count)], strategy, grainType));
         }

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -898,7 +898,7 @@ namespace Orleans.Runtime
                     continue;
                 }
 
-                if (all || activationData.IsUsable)
+                if (all || activationData.State.Equals(ActivationState.Valid))
                 {
                     sb.AppendLine(workItemGroup.DumpStatus());
                     sb.AppendLine(activationData.DumpStatus());


### PR DESCRIPTION
This is a 3rd step towards Gracefull Shutdown, related to:
#381
#320 (comment)
http://orleans.codeplex.com/discussions/637820#post1425137
Continues the work in #413.
Continues the work in #448.

Essentially, the silo was already largely handling this logic correctly. I merely simplified a couple of places, to make more clear what will actually happen. At a high level:
1) Once silo is shutting down, it first updates its membership state. This will cause all other silos not to place new activation on it, not to use this silo as grain directory and not as reminder service. This logic was already handled correctly before. No change.
2) Silo refuses to create any new activations, throws Non-existent activation and tries to forward the request. The activation will be placed on a different silo. This is a new bit added in this PR..
3) Silo starts to deactivate all activations. 
4) Any new requests that arrive to activations on that silo will be queued and after activation is deactivated, they will be forwarded to a new activation. There is no change in that logic.
