### PR TITLE
Wrapped build paths with quotes

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,1 +1,1 @@
-%~dp0src\Build.cmd
+"%~dp0src\Build.cmd"

--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -9,7 +9,7 @@ if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
 
 SET MSBUILDEXEDIR=%FrameworkDir%\%FrameworkVersion%
 SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe
-SET VERSION_FILE=%CMDHOME%\Build\Version.txt
+SET VERSION_FILE="%CMDHOME%\Build\Version.txt"
 
 if EXIST "%VERSION_FILE%" (
     @Echo Using version number from file %VERSION_FILE%

--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -9,11 +9,11 @@ if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
 
 SET MSBUILDEXEDIR=%FrameworkDir%\%FrameworkVersion%
 SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe
-SET VERSION_FILE="%CMDHOME%\Build\Version.txt"
+SET VERSION_FILE=%CMDHOME%\Build\Version.txt
 
 if EXIST "%VERSION_FILE%" (
     @Echo Using version number from file %VERSION_FILE%
-    FOR /F "usebackq tokens=1,2,3,4 delims=." %%i in (`type %VERSION_FILE%`) do set PRODUCT_VERSION=%%i.%%j.%%k
+    FOR /F "usebackq tokens=1,2,3,4 delims=." %%i in (`type "%VERSION_FILE%"`) do set PRODUCT_VERSION=%%i.%%j.%%k
 	@Echo PRODUCT_VERSION=%PRODUCT_VERSION%
 ) else (
     @Echo ERROR: Unable to read version number from file %VERSION_FILE%


### PR DESCRIPTION
You should now be able to run Build.cmd from a path with spaces in it.

This is for #461 