### PR TITLE
Add support for grain state classes

### DIFF
--- a/src/ClientGenerator/NamespaceGenerator.cs
+++ b/src/ClientGenerator/NamespaceGenerator.cs
@@ -31,7 +31,9 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Orleans.CodeGeneration.Serialization;
+using Orleans.Providers;
 using Orleans.Runtime;
+using Orleans.Storage;
 
 namespace Orleans.CodeGeneration
 {
@@ -281,18 +283,26 @@ namespace Orleans.CodeGeneration
             out bool hasStateClass)
         {
             var sourceType = grainInterfaceData.Type;
+
             stateClassName = FixupTypeName(stateClassName);
             CodeTypeParameterCollection genericTypeParams = grainInterfaceData.GenericTypeParams;
 
             Func<Type, bool> nonamespace = t => CurrentNamespace == t.Namespace || ReferencedNamespaces.Contains(t.Namespace);
 
             Type persistentInterface = GetPersistentInterface(sourceType);
-            if (persistentInterface!=null && !persistentInterface.IsInterface)
-            {
-                hasStateClass = false;
-                return null;
-            }
 
+            if (persistentInterface!=null)
+            {
+                if (!sourceType.GetCustomAttributes(typeof (StorageProviderAttribute)).Any())
+                    throw new BadProviderConfigException(
+                        String.Format("No StorageProvider attribute specified for grain class {0}", sourceType.FullName));
+
+                if (!persistentInterface.IsInterface)
+                {
+                    hasStateClass = false;
+                    return null;
+                }
+            }
 
             Dictionary<string, PropertyInfo> asyncProperties = GrainInterfaceData.GetPersistentProperties(persistentInterface)
                 .ToDictionary(p => p.Name.Substring(p.Name.LastIndexOf('.') + 1), p => p);

--- a/src/ClientGenerator/NamespaceGenerator.cs
+++ b/src/ClientGenerator/NamespaceGenerator.cs
@@ -287,6 +287,13 @@ namespace Orleans.CodeGeneration
             Func<Type, bool> nonamespace = t => CurrentNamespace == t.Namespace || ReferencedNamespaces.Contains(t.Namespace);
 
             Type persistentInterface = GetPersistentInterface(sourceType);
+            if (persistentInterface!=null && !persistentInterface.IsInterface)
+            {
+                hasStateClass = false;
+                return null;
+            }
+
+
             Dictionary<string, PropertyInfo> asyncProperties = GrainInterfaceData.GetPersistentProperties(persistentInterface)
                 .ToDictionary(p => p.Name.Substring(p.Name.LastIndexOf('.') + 1), p => p);
 

--- a/src/Orleans/CodeGeneration/GrainState.cs
+++ b/src/Orleans/CodeGeneration/GrainState.cs
@@ -126,7 +126,7 @@ namespace Orleans.CodeGeneration
             {
                 throw new NullReferenceException("No GrainInstance has been set up.");
             }
-            await grain.ReadStateAsync();
+            await grain.Storage.ReadStateAsync();
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Orleans.CodeGeneration
             {
                 throw new NullReferenceException("No GrainInstance has been set up.");
             }
-            await grain.WriteStateAsync();
+            await grain.Storage.WriteStateAsync();
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace Orleans.CodeGeneration
             {
                 throw new NullReferenceException("No GrainInstance has been set up.");
             }
-            await grain.ClearStateAsync();
+            await grain.Storage.ClearStateAsync();
         }
         #endregion
 

--- a/src/Orleans/CodeGeneration/GrainState.cs
+++ b/src/Orleans/CodeGeneration/GrainState.cs
@@ -125,7 +125,7 @@ namespace Orleans.CodeGeneration
             {
                 throw new NullReferenceException("No GrainInstance has been set up.");
             }
-            await grain.Storage.ReadStateAsync();
+            await grain.ReadStateAsync();
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace Orleans.CodeGeneration
             {
                 throw new NullReferenceException("No GrainInstance has been set up.");
             }
-            await grain.Storage.WriteStateAsync();
+            await grain.WriteStateAsync();
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Orleans.CodeGeneration
             {
                 throw new NullReferenceException("No GrainInstance has been set up.");
             }
-            await grain.Storage.ClearStateAsync();
+            await grain.ClearStateAsync();
         }
         #endregion
 

--- a/src/Orleans/CodeGeneration/GrainState.cs
+++ b/src/Orleans/CodeGeneration/GrainState.cs
@@ -118,7 +118,7 @@ namespace Orleans.CodeGeneration
         /// Async method to cause refresh of the current grain state data from backing store.
         /// Any previous contents of the grain state data will be overwritten.
         /// </summary>
-        [Obsolete("Use Grain.Storage.ReadStateAsync method instead.")]
+        [Obsolete("Use Grain.ReadStateAsync method instead.")]
         public async Task ReadStateAsync()
         {
             var grain = RuntimeClient.Current.CurrentActivationData.GrainInstance as Grain<IGrainState>;
@@ -132,7 +132,7 @@ namespace Orleans.CodeGeneration
         /// <summary>
         /// Async method to cause write of the current grain state data into backing store.
         /// </summary>
-        [Obsolete("Use Grain.Storage.WriteStateAsync method instead.")]
+        [Obsolete("Use Grain.WriteStateAsync method instead.")]
         public async Task WriteStateAsync()
         {
             var grain = RuntimeClient.Current.CurrentActivationData.GrainInstance as Grain<IGrainState>;
@@ -146,7 +146,7 @@ namespace Orleans.CodeGeneration
         /// <summary>
         /// Async method to cause write of the current grain state data into backing store.
         /// </summary>
-        [Obsolete("Use Grain.Storage.ClearStateAsync method instead.")]
+        [Obsolete("Use Grain.ClearStateAsync method instead.")]
         public async Task ClearStateAsync()
         {
             var grain = RuntimeClient.Current.CurrentActivationData.GrainInstance as Grain<IGrainState>;
@@ -192,7 +192,7 @@ namespace Orleans.CodeGeneration
         {
             if (values == null)
             {
-                ReesetProperties();
+                ResetProperties();
                 return;
             }
 
@@ -209,7 +209,7 @@ namespace Orleans.CodeGeneration
         /// <summary>
         /// Resets properties of the state object to their default values.
         /// </summary>
-        private void ReesetProperties()
+        private void ResetProperties()
         {
             var properties = this.GetType().GetProperties();
             foreach (var property in properties)

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -278,7 +278,7 @@ namespace Orleans
     /// Base class for a Grain with declared persistent state.
     /// </summary>
     /// <typeparam name="TGrainState">The interface of the persistent state object</typeparam>
-    public class Grain<TGrainState> : Grain, IStorage
+    public class Grain<TGrainState> : Grain
         where TGrainState : class, IGrainState
     {
 
@@ -313,17 +313,17 @@ namespace Orleans
             get { return base.GrainState as TGrainState; }
         }
 
-        public Task ClearStateAsync()
+        protected Task ClearStateAsync()
         {
             return Storage.ClearStateAsync();
         }
 
-        public Task WriteStateAsync()
+        protected Task WriteStateAsync()
         {
             return Storage.WriteStateAsync();
         }
 
-        public Task ReadStateAsync()
+        protected Task ReadStateAsync()
         {
             return Storage.ReadStateAsync();
         }

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -278,20 +278,20 @@ namespace Orleans
     public class Grain<TGrainState> : Grain, IStorage
         where TGrainState : class, IGrainState
     {
-        private IStorage stateStorageBridge;
+        private IStorage storage;
 
         private IStorage Storage
         {
             get
             {
-                if (stateStorageBridge == null)
+                if (storage == null) // Of storage has been injected via DI, we'll use it. Otherwise, we initialize here.
                 {
                     // Lazy create the storage bridge
                     IStorageProvider store = Data.StorageProvider;
                     string grainTypeName = Data.GrainTypeName;
-                    stateStorageBridge = new GrainStateStorageBridge<TGrainState>(grainTypeName, this, store);
+                    storage = new GrainStateStorageBridge<TGrainState>(grainTypeName, this, store);
                 }
-                return stateStorageBridge;
+                return storage;
             }
         }
         /// <summary>
@@ -313,6 +313,7 @@ namespace Orleans
         protected Grain(TGrainState state, IGrainIdentity identity, IGrainRuntime runtime) : this(identity, runtime)
         {
             GrainState = state;
+            storage = runtime.Storage;
         }
 
         protected Grain(IGrainIdentity identity, IGrainRuntime runtime)

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -298,7 +298,7 @@ namespace Orleans
         /// <param name="state"></param>
         /// <param name="identity"></param>
         /// <param name="runtime"></param>
-        protected Grain(TGrainState state, IGrainIdentity identity, IGrainRuntime runtime, IStorage storage) 
+        protected Grain(IGrainIdentity identity, IGrainRuntime runtime, TGrainState state, IStorage storage) 
             : base(identity, runtime)
         {
             GrainState = state;

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -271,12 +271,12 @@ namespace Orleans
     /// Base class for a Grain with declared persistent state.
     /// </summary>
     /// <typeparam name="TGrainState">The interface of the persistent state object</typeparam>
-    public class Grain<TGrainState> : Grain
+    public class Grain<TGrainState> : Grain, IStorage
         where TGrainState : class, IGrainState
     {
         private IStorage stateStorageBridge;
 
-        protected internal IStorage Storage
+        private IStorage Storage
         {
             get
             {
@@ -322,6 +322,21 @@ namespace Orleans
         protected TGrainState State
         {
             get { return base.GrainState as TGrainState; }
+        }
+
+        public Task ClearStateAsync()
+        {
+            return Storage.ClearStateAsync();
+        }
+
+        public Task WriteStateAsync()
+        {
+            return Storage.WriteStateAsync();
+        }
+
+        public Task ReadStateAsync()
+        {
+            return Storage.ReadStateAsync();
         }
     }
 }

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -25,7 +25,6 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Orleans.Core;
 using Orleans.Runtime;
@@ -275,6 +274,22 @@ namespace Orleans
     public class Grain<TGrainState> : Grain
         where TGrainState : class, IGrainState
     {
+        private IStorage stateStorageBridge;
+
+        protected internal IStorage Storage
+        {
+            get
+            {
+                if (stateStorageBridge == null)
+                {
+                    // Lazy create the storage bridge
+                    IStorageProvider store = Data.StorageProvider;
+                    string grainTypeName = Data.GrainTypeName;
+                    stateStorageBridge = new GrainStateStorageBridge<TGrainState>(grainTypeName, this, store);
+                }
+                return stateStorageBridge;
+            }
+        }
         /// <summary>
         /// This constructor should never be invoked. We expose it so that client code (subclasses of this class) do not have to add a constructor.
         /// Client code should use the GrainFactory to get a reference to a Grain.

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -40,7 +40,10 @@ namespace Orleans
     public abstract class Grain : IAddressable
     {
         private IGrainRuntime runtime;
+
         internal IGrainState GrainState { get; set; }
+
+        internal IStorage Storage { get; set; }
 
         // Do not use this directly because we currently don't provide a way to inject it;
         // any interaction with it will result in non unit-testable code. Any behaviour that can be accessed 
@@ -278,22 +281,7 @@ namespace Orleans
     public class Grain<TGrainState> : Grain, IStorage
         where TGrainState : class, IGrainState
     {
-        private IStorage storage;
 
-        private IStorage Storage
-        {
-            get
-            {
-                if (storage == null) // Of storage has been injected via DI, we'll use it. Otherwise, we initialize here.
-                {
-                    // Lazy create the storage bridge
-                    IStorageProvider store = Data.StorageProvider;
-                    string grainTypeName = Data.GrainTypeName;
-                    storage = new GrainStateStorageBridge<TGrainState>(grainTypeName, this, store);
-                }
-                return storage;
-            }
-        }
         /// <summary>
         /// This constructor should never be invoked. We expose it so that client code (subclasses of this class) do not have to add a constructor.
         /// Client code should use the GrainFactory to get a reference to a Grain.
@@ -310,15 +298,11 @@ namespace Orleans
         /// <param name="state"></param>
         /// <param name="identity"></param>
         /// <param name="runtime"></param>
-        protected Grain(TGrainState state, IGrainIdentity identity, IGrainRuntime runtime) : this(identity, runtime)
-        {
-            GrainState = state;
-            storage = runtime.Storage;
-        }
-
-        protected Grain(IGrainIdentity identity, IGrainRuntime runtime)
+        protected Grain(TGrainState state, IGrainIdentity identity, IGrainRuntime runtime, IStorage storage) 
             : base(identity, runtime)
         {
+            GrainState = state;
+            Storage = storage;
         }
 
         /// <summary>

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -25,9 +25,11 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Orleans.Core;
 using Orleans.Runtime;
+using Orleans.Storage;
 using Orleans.Streams;
 
 namespace Orleans
@@ -45,6 +47,8 @@ namespace Orleans
         // from within client code (including subclasses of this class), should be exposed through IGrainRuntime.
         // The better solution is to refactor this interface and make it injectable through the constructor.
         internal IActivationData Data;
+
+        internal GrainReference GrainReference { get { return Data.GrainReference; } }
 
         internal IGrainRuntime Runtime
         {

--- a/src/Orleans/Core/GrainStateStorageBridge.cs
+++ b/src/Orleans/Core/GrainStateStorageBridge.cs
@@ -1,0 +1,188 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// ﻿#define REREAD_STATE_AFTER_WRITE_FAILED
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Threading.Tasks;
+using Orleans.AzureUtils;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace Orleans.Core
+{
+    internal class GrainStateStorageBridge<TGrainState> : IStorage
+        where TGrainState : class, IGrainState
+    {
+        private readonly IStorageProvider store;
+        private readonly Grain<TGrainState> grain;
+        private readonly string grainTypeName;
+
+        internal GrainStateStorageBridge(string grainTypeName, Grain<TGrainState> grain, IStorageProvider store)
+        {
+            if (grainTypeName == null)
+            {
+                throw new ArgumentNullException("grainTypeName", "No grain type name supplied");
+            }
+            if (store == null)
+            {
+                throw new ArgumentNullException("store", "No storage provider supplied");
+            }
+            if (grain == null || grain.GrainState == null)
+            {
+                throw new ArgumentNullException("grain.GrainState", "No grain state object supplied");
+            }
+            this.grainTypeName = grainTypeName;
+            this.grain = grain;
+            this.store = store;
+        }
+
+        /// <summary>
+        /// Async method to cause refresh of the current grain state data from backing store.
+        /// Any previous contents of the grain state data will be overwritten.
+        /// </summary>
+        public async Task ReadStateAsync()
+        {
+            const string what = "ReadState";
+            Stopwatch sw = Stopwatch.StartNew();
+            GrainReference grainRef = grain.GrainReference;
+            try
+            {
+                await store.ReadStateAsync(grainTypeName, grainRef, grain.GrainState);
+                
+                StorageStatisticsGroup.OnStorageRead(store, grainTypeName, grainRef, sw.Elapsed);
+            }
+            catch (Exception exc)
+            {
+                StorageStatisticsGroup.OnStorageReadError(store, grainTypeName, grainRef);
+
+                string errMsg = MakeErrorMsg(what, exc);
+                store.Log.Error((int) ErrorCode.StorageProvider_ReadFailed, errMsg, exc);
+                throw new OrleansException(errMsg, exc);
+            }
+            finally
+            {
+                sw.Stop();
+            }
+        }
+
+        /// <summary>
+        /// Async method to cause write of the current grain state data into backing store.
+        /// </summary>
+        public async Task WriteStateAsync()
+        {
+            const string what = "WriteState";
+            Stopwatch sw = Stopwatch.StartNew();
+            GrainReference grainRef = grain.GrainReference;
+            Exception errorOccurred;
+            try
+            {
+                await store.WriteStateAsync(grainTypeName, grainRef, grain.GrainState);
+
+                StorageStatisticsGroup.OnStorageWrite(store, grainTypeName, grainRef, sw.Elapsed);
+                errorOccurred = null;
+            }
+            catch (Exception exc)
+            {
+                errorOccurred = exc;
+            }
+            // Note, we can't do this inside catch block above, because await is not permitted there.
+            if (errorOccurred != null)
+            {
+                StorageStatisticsGroup.OnStorageWriteError(store, grainTypeName, grainRef);
+
+                string errMsgToLog = MakeErrorMsg(what, errorOccurred);
+                store.Log.Error((int) ErrorCode.StorageProvider_WriteFailed, errMsgToLog, errorOccurred);
+                errorOccurred = new OrleansException(errMsgToLog, errorOccurred);
+
+#if REREAD_STATE_AFTER_WRITE_FAILED
+                // Force rollback to previously stored state
+                try
+                {
+                    sw.Restart();
+                    store.Log.Warn((int)ErrorCode.StorageProvider_ForceReRead, "Forcing re-read of last good state for grain Type={0}", grainTypeName);
+                    await store.ReadStateAsync(grainTypeName, grainRef, grain.GrainState);
+                    StorageStatisticsGroup.OnStorageRead(store, grainTypeName, grainRef, sw.Elapsed);
+                }
+                catch (Exception exc)
+                {
+                    StorageStatisticsGroup.OnStorageReadError(store, grainTypeName, grainRef);
+
+                    // Should we ignore this secondary error, and just return the original one?
+                    errMsgToLog = MakeErrorMsg("re-read state from store after write error", exc);
+                    errorOccurred = new OrleansException(errMsgToLog, exc);
+                }
+#endif
+            }
+            sw.Stop();
+            if (errorOccurred != null)
+            {
+                throw errorOccurred;
+            }
+        }
+
+        /// <summary>
+        /// Async method to cause write of the current grain state data into backing store.
+        /// </summary>
+        public async Task ClearStateAsync()
+        {
+            const string what = "ClearState";
+            Stopwatch sw = Stopwatch.StartNew();
+            GrainReference grainRef = grain.GrainReference;
+            try
+            {
+                // Clear (most likely Delete) state from external storage
+                await store.ClearStateAsync(grainTypeName, grainRef, grain.GrainState);
+                // Null out the in-memory copy of the state
+                grain.GrainState.SetAll(null);
+
+                // Update counters
+                StorageStatisticsGroup.OnStorageDelete(store, grainTypeName, grainRef, sw.Elapsed);
+            }
+            catch (Exception exc)
+            {
+                StorageStatisticsGroup.OnStorageDeleteError(store, grainTypeName, grainRef);
+
+                string errMsg = MakeErrorMsg(what, exc);
+                store.Log.Error((int) ErrorCode.StorageProvider_DeleteFailed, errMsg, exc);
+                throw new OrleansException(errMsg, exc);
+            }
+            finally
+            {
+                sw.Stop();
+            }
+        }
+
+        private string MakeErrorMsg(string what, Exception exc)
+        {
+            HttpStatusCode httpStatusCode;
+            string errorCode;
+            AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out errorCode, true);
+            GrainReference grainReference = grain.GrainReference;
+            return string.Format("Error from storage provider during {0} for grain Type={1} Pk={2} Id={3} Error={4}" + Environment.NewLine + " {5}",
+                what, grainTypeName, grainReference.GrainId.ToDetailedString(), grainReference, errorCode, TraceLogger.PrintException(exc));
+        }
+    }
+}

--- a/src/Orleans/Core/GrainStateStorageBridge.cs
+++ b/src/Orleans/Core/GrainStateStorageBridge.cs
@@ -40,7 +40,7 @@ namespace Orleans.Core
         private readonly Grain<TGrainState> grain;
         private readonly string grainTypeName;
 
-        internal GrainStateStorageBridge(string grainTypeName, Grain<TGrainState> grain, IStorageProvider store)
+        public GrainStateStorageBridge(string grainTypeName, Grain<TGrainState> grain, IStorageProvider store)
         {
             if (grainTypeName == null)
             {

--- a/src/Orleans/Core/GrainStateStorageBridge.cs
+++ b/src/Orleans/Core/GrainStateStorageBridge.cs
@@ -33,14 +33,13 @@ using Orleans.Storage;
 
 namespace Orleans.Core
 {
-    internal class GrainStateStorageBridge<TGrainState> : IStorage
-        where TGrainState : class, IGrainState
+    internal class GrainStateStorageBridge : IStorage
     {
         private readonly IStorageProvider store;
-        private readonly Grain<TGrainState> grain;
+        private readonly Grain grain;
         private readonly string grainTypeName;
 
-        public GrainStateStorageBridge(string grainTypeName, Grain<TGrainState> grain, IStorageProvider store)
+        public GrainStateStorageBridge(string grainTypeName, Grain grain, IStorageProvider store)
         {
             if (grainTypeName == null)
             {

--- a/src/Orleans/Core/IGrainState.cs
+++ b/src/Orleans/Core/IGrainState.cs
@@ -38,28 +38,6 @@ namespace Orleans
         string Etag { get; set; }
 
         /// <summary>
-        /// Async method to cause the current grain state data to be cleared and reset. 
-        /// This will usually mean the state record is deleted from backing store, but the specific behavior is defined by the storage provider instance configured for this grain.
-        /// If Etags do not match, then this operation will fail; Set Etag = <c>null</c> to indicate "always delete".
-        /// </summary>
-        [Obsolete("Use Grain.Storage.ClearStateAsync method instead.")]
-        Task ClearStateAsync();
-
-        /// <summary>
-        /// Async method to cause write of the current grain state data into backing store.
-        /// If Etags do not match, then this operation will fail; Set Etag = <c>null</c> to indicate "always overwrite".
-        /// </summary>
-        [Obsolete("Use Grain.Storage.WriteStateAsync method instead.")]
-        Task WriteStateAsync();
-
-        /// <summary>
-        /// Async method to cause refresh of the current grain state data from backing store.
-        /// Any previous contents of the grain state data will be overwritten.
-        /// </summary>
-        [Obsolete("Use Grain.Storage.ReadStateAsync method instead.")]
-        Task ReadStateAsync();
-
-        /// <summary>
         /// Return a snapshot of the current grain state data, as a Dictionary of Key-Value pairs.
         /// </summary>
         IDictionary<string, object> AsDictionary();

--- a/src/Orleans/Core/IStorage.cs
+++ b/src/Orleans/Core/IStorage.cs
@@ -25,7 +25,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 namespace Orleans.Core
 {
-    internal interface IStorage
+    public interface IStorage
     {
         /// <summary>
         /// Async method to cause the current grain state data to be cleared and reset. 

--- a/src/Orleans/Core/IStorage.cs
+++ b/src/Orleans/Core/IStorage.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Project Orleans Cloud Service SDK ver. 1.0
  
 Copyright (c) Microsoft Corporation
@@ -21,52 +21,29 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
-namespace Orleans
+namespace Orleans.Core
 {
-    /// <summary>
-    /// Base interface for interfaces that define persistent state properties of a grain.
-    /// </summary>
-    public interface IGrainState
+    public interface IStorage
     {
-        /// <summary>
-        /// Opaque value set by the storage provider representing an 'Etag' setting for the last time the state data was read from backing store.
-        /// </summary>
-        string Etag { get; set; }
-
         /// <summary>
         /// Async method to cause the current grain state data to be cleared and reset. 
         /// This will usually mean the state record is deleted from backing store, but the specific behavior is defined by the storage provider instance configured for this grain.
         /// If Etags do not match, then this operation will fail; Set Etag = <c>null</c> to indicate "always delete".
         /// </summary>
-        [Obsolete("Use Grain.Storage.ClearStateAsync method instead.")]
         Task ClearStateAsync();
 
         /// <summary>
         /// Async method to cause write of the current grain state data into backing store.
         /// If Etags do not match, then this operation will fail; Set Etag = <c>null</c> to indicate "always overwrite".
         /// </summary>
-        [Obsolete("Use Grain.Storage.WriteStateAsync method instead.")]
         Task WriteStateAsync();
 
         /// <summary>
         /// Async method to cause refresh of the current grain state data from backing store.
         /// Any previous contents of the grain state data will be overwritten.
         /// </summary>
-        [Obsolete("Use Grain.Storage.ReadStateAsync method instead.")]
         Task ReadStateAsync();
-
-        /// <summary>
-        /// Return a snapshot of the current grain state data, as a Dictionary of Key-Value pairs.
-        /// </summary>
-        IDictionary<string, object> AsDictionary();
-
-        /// <summary>
-        /// Update the current grain state data with the specified Dictionary of Key-Value pairs.
-        /// </summary>
-        void SetAll(IDictionary<string, object> values);
     }
 }

--- a/src/Orleans/Core/IStorage.cs
+++ b/src/Orleans/Core/IStorage.cs
@@ -25,7 +25,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 namespace Orleans.Core
 {
-    public interface IStorage
+    internal interface IStorage
     {
         /// <summary>
         /// Async method to cause the current grain state data to be cleared and reset. 

--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -967,6 +967,7 @@ namespace Orleans
         Provider_IgnoringExplicitSet            = ProviderManagerBase + 10,
         Provider_NotLoaded                      = ProviderManagerBase + 11,
         Provider_Manager_Already_Loaded         = ProviderManagerBase + 12,
+        Provider_CatalogNoStorageProvider_3     = ProviderManagerBase + 13,
 
         AzureQueueBase = Runtime + 3200,
         AzureQueue_01 = AzureQueueBase + 1,

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Configuration\LimitValue.cs" />
     <Compile Include="Core\Exceptions.cs" />
     <Compile Include="Core\GrainStateStorageBridge.cs" />
+    <Compile Include="Core\IGrainIdentity.cs" />
     <Compile Include="Core\IGrainState.cs" />
     <Compile Include="Core\IStorage.cs" />
     <Compile Include="GlobalSuppressions.cs" />

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -119,8 +119,9 @@
     <Compile Include="Configuration\LimitNames.cs" />
     <Compile Include="Configuration\LimitValue.cs" />
     <Compile Include="Core\Exceptions.cs" />
-    <Compile Include="Core\IGrainIdentity.cs" />
+    <Compile Include="Core\GrainStateStorageBridge.cs" />
     <Compile Include="Core\IGrainState.cs" />
+    <Compile Include="Core\IStorage.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="IDs\GuidId.cs" />
     <Compile Include="Messaging\GatewayManager.cs" />

--- a/src/Orleans/Runtime/GrainRuntime.cs
+++ b/src/Orleans/Runtime/GrainRuntime.cs
@@ -8,18 +8,15 @@ namespace Orleans.Runtime
     internal class GrainRuntime : IGrainRuntime
     {
         private readonly string id;
-        private readonly IGrainFactory grainFactory;
-        private readonly ITimerRegistry timerRegistry;
-        private readonly IReminderRegistry reminderRegistry;
-        private readonly IStreamProviderManager streamProviderManager;
 
-        public GrainRuntime(string id, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager)
+        public GrainRuntime(string id, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager, IStorage storage=null)
         {
             this.id = id;
-            this.grainFactory = grainFactory;
-            this.timerRegistry = timerRegistry;
-            this.reminderRegistry = reminderRegistry;
-            this.streamProviderManager = streamProviderManager;
+            GrainFactory = grainFactory;
+            TimerRegistry = timerRegistry;
+            ReminderRegistry = reminderRegistry;
+            StreamProviderManager = streamProviderManager;
+            Storage = storage;
         }
 
         public string SiloIdentity
@@ -27,26 +24,16 @@ namespace Orleans.Runtime
             get { return id; }
         }
 
-        public IGrainFactory GrainFactory
-        {
-            get { return grainFactory; }
-        }
+        public IGrainFactory GrainFactory { get; private set; }
+        
+        public ITimerRegistry TimerRegistry { get; private set; }
+        
+        public IReminderRegistry ReminderRegistry { get; private set; }
+        
+        public IStreamProviderManager StreamProviderManager { get; private set;}
 
-        public ITimerRegistry TimerRegistry
-        {
-            get { return timerRegistry; }
-        }
-
-        public IReminderRegistry ReminderRegistry
-        {
-            get { return reminderRegistry; }
-        }
-
-        public IStreamProviderManager StreamProviderManager
-        {
-            get { return streamProviderManager; }
-        }
-
+        public IStorage Storage { get; private set; }
+        
         public Logger GetLogger(string loggerName, TraceLogger.LoggerType logType)
         {
             return TraceLogger.GetLogger(loggerName, logType);

--- a/src/Orleans/Runtime/GrainRuntime.cs
+++ b/src/Orleans/Runtime/GrainRuntime.cs
@@ -9,14 +9,13 @@ namespace Orleans.Runtime
     {
         private readonly string id;
 
-        public GrainRuntime(string id, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager, IStorage storage=null)
+        public GrainRuntime(string id, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager)
         {
             this.id = id;
             GrainFactory = grainFactory;
             TimerRegistry = timerRegistry;
             ReminderRegistry = reminderRegistry;
             StreamProviderManager = streamProviderManager;
-            Storage = storage;
         }
 
         public string SiloIdentity
@@ -32,8 +31,6 @@ namespace Orleans.Runtime
         
         public IStreamProviderManager StreamProviderManager { get; private set;}
 
-        public IStorage Storage { get; private set; }
-        
         public Logger GetLogger(string loggerName, TraceLogger.LoggerType logType)
         {
             return TraceLogger.GetLogger(loggerName, logType);

--- a/src/Orleans/Runtime/IActivationData.cs
+++ b/src/Orleans/Runtime/IActivationData.cs
@@ -23,7 +23,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Threading.Tasks;
-using Orleans.Runtime;
+using Orleans.Storage;
 
 namespace Orleans.Runtime
 {
@@ -32,16 +32,15 @@ namespace Orleans.Runtime
     {
         GrainReference GrainReference { get; }
         GrainId Identity { get; }
+        string GrainTypeName { get; }
         Grain GrainInstance { get; }
         ActivationId ActivationId { get; }
         ActivationAddress Address { get; }
         string IdentityString { get; }
         string RuntimeIdentity { get;  }
-
-        // TODO: move this logic to the GrainRuntime
+        void DeactivateOnIdle();
         void DelayDeactivation(TimeSpan timeSpan);
-
-        // TODO: move this logic to the GrainRuntime
+        IStorageProvider StorageProvider { get; }
         IDisposable RegisterTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period);
     }
 }

--- a/src/Orleans/Runtime/IGrainRuntime.cs
+++ b/src/Orleans/Runtime/IGrainRuntime.cs
@@ -27,8 +27,6 @@ namespace Orleans.Runtime
 
         IStreamProviderManager StreamProviderManager { get; }
 
-        IStorage Storage { get; }
-
         Logger GetLogger(string loggerName, TraceLogger.LoggerType logType);
 
         void DeactivateOnIdle(Grain grain);

--- a/src/Orleans/Runtime/IGrainRuntime.cs
+++ b/src/Orleans/Runtime/IGrainRuntime.cs
@@ -27,6 +27,8 @@ namespace Orleans.Runtime
 
         IStreamProviderManager StreamProviderManager { get; }
 
+        IStorage Storage { get; }
+
         Logger GetLogger(string loggerName, TraceLogger.LoggerType logType);
 
         void DeactivateOnIdle(Grain grain);

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -232,6 +232,18 @@ namespace Orleans.Runtime
 
         #endregion
 
+        public string GrainTypeName
+        {
+            get
+            {
+                if (GrainInstanceType == null)
+                {
+                    throw new ArgumentNullException("GrainInstanceType", "GrainInstanceType has not been set.");
+                }
+                return GrainInstanceType.FullName;
+            }
+        }
+
         internal Type GrainInstanceType { get; private set; }
 
         internal void SetGrainInstance(Grain grainInstance)

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -577,13 +577,19 @@ namespace Orleans.Runtime
 
         private void SetupStorageProvider(ActivationData data)
         {
-            object[] attrs = data.GrainInstanceType.GetCustomAttributes(typeof(StorageProviderAttribute), true);
-            StorageProviderAttribute attr = attrs.Length > 0 ? attrs[0] as StorageProviderAttribute : null;
-            if (attr == null) return;
+            var grainTypeName = data.GrainInstanceType.FullName;
+
+            var attrs = data.GrainInstanceType.GetCustomAttributes(typeof(StorageProviderAttribute), true);
+            var attr = attrs.Length > 0 ? attrs[0] as StorageProviderAttribute : null;
+            if (attr == null)
+            {
+                var errMsg = string.Format("No storage providers specified for grain type {0}", grainTypeName);
+                logger.Error(ErrorCode.Provider_CatalogNoStorageProvider_3, errMsg);
+                throw new BadProviderConfigException(errMsg);
+            }
 
             var storageProviderName = attr.ProviderName;
             IStorageProvider provider;
-            var grainTypeName = data.GrainInstanceType.FullName;
             if (storageProviderManager == null || storageProviderManager.GetNumLoadedProviders() == 0)
             {
                 var errMsg = string.Format("No storage providers found loading grain type {0}", grainTypeName);

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -564,11 +564,7 @@ namespace Orleans.Runtime
                     var state = (GrainState)Activator.CreateInstance(stateObjectType);
                     state.InitState(null);
                     data.GrainInstance.GrainState = state;
-
-                    var bridgeType = typeof (GrainStateStorageBridge<>).MakeGenericType(stateObjectType);
-                    data.GrainInstance.Storage = (IStorage)Activator.CreateInstance(
-                        bridgeType, 
-                        new object[]{data.GrainTypeName, data.GrainInstance, data.StorageProvider});
+                    data.GrainInstance.Storage = new GrainStateStorageBridge(data.GrainTypeName, data.GrainInstance, data.StorageProvider);
                 }
             }
 

--- a/src/OrleansTestingHost/OrleansConfigurationForTesting.xml
+++ b/src/OrleansTestingHost/OrleansConfigurationForTesting.xml
@@ -2,7 +2,7 @@
 <OrleansConfiguration xmlns="urn:orleans">
   <Globals>
     <StorageProviders>
-      <!--<Provider Type="Orleans.Storage.MemoryStorage" Name="MemoryStore" />-->
+      <Provider Type="Orleans.Storage.MemoryStorage" Name="MemoryStore" />
       <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" />-->
     </StorageProviders>
     <SeedNode Address="localhost" Port="22222"/>

--- a/src/TestGrainInterfaces/ISimpleGrain.cs
+++ b/src/TestGrainInterfaces/ISimpleGrain.cs
@@ -41,8 +41,4 @@ namespace UnitTests.GrainInterfaces
         Task<int> GetAxB(int a, int b);
         Task<int> GetA();
     }
-
-    public interface ISimpleCLIGrain : ISimpleGrain
-    {
-    }
 }

--- a/src/TestGrainInterfaces/ISimplePersistentGrain.cs
+++ b/src/TestGrainInterfaces/ISimplePersistentGrain.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Project Orleans Cloud Service SDK ver. 1.0
  
 Copyright (c) Microsoft Corporation
@@ -22,23 +22,14 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
 
 namespace UnitTests.GrainInterfaces
 {
-    public interface ISimpleGrain : IGrainWithIntegerKey
+    public interface ISimplePersistentGrain : ISimpleGrain
     {
-        Task SetA(int a);
-        Task SetB(int b);
-        Task IncrementA();
-        Task<int> GetAxB();
-        Task<int> GetAxB(int a, int b);
-        Task<int> GetA();
+        Task SetA(int a, bool deactivate);
+        Task<Guid> GetVersion();
     }
 }

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ISimpleObserverableGrain.cs" />
     <Compile Include="IObserverGrain.cs" />
     <Compile Include="ISimpleGrain.cs" />
+    <Compile Include="ISimplePersistentGrain.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>

--- a/src/TestGrains/SimplePersistentGrain.cs
+++ b/src/TestGrains/SimplePersistentGrain.cs
@@ -1,0 +1,104 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+
+namespace UnitTests.Grains
+{
+    public class SimplePersistentGrain_State : IGrainState
+    {
+        public int IntProperty { get; set; }
+        public string StringProperty { get; set; }
+        public string Etag { get; set; }
+        public Task ClearStateAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteStateAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task ReadStateAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDictionary<string, object> AsDictionary()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetAll(IDictionary<string, object> values)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// A simple grain that allows to set two arguments and then multiply them.
+    /// </summary>
+    public class SimplePersistentGrain : Grain<SimplePersistentGrain_State>, ISimpleGrain
+    {
+        public Task SetA(int a)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SetB(int a)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task IncrementA()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<int> GetAxB()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<int> GetAxB(int a, int b)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<int> GetA()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/TestGrains/SimplePersistentGrain.cs
+++ b/src/TestGrains/SimplePersistentGrain.cs
@@ -50,6 +50,12 @@ namespace UnitTests.Grains
         public int B { get; set; }
     }
 
+    public interface ISimplePersistentGrain_State : IGrainState
+    {
+        int A { get; set; }
+        int B { get; set; }
+    }
+
     /// <summary>
     /// A simple grain that allows to set two arguments and then multiply them.
     /// </summary>
@@ -91,6 +97,62 @@ namespace UnitTests.Grains
         public Task<int> GetAxB()
         {
             return Task.FromResult(State.A*State.B);
+        }
+
+        public Task<int> GetAxB(int a, int b)
+        {
+            return Task.FromResult(a * b);
+        }
+
+        public Task<int> GetA()
+        {
+            return Task.FromResult(State.A);
+        }
+
+        public Task<Guid> GetVersion()
+        {
+            return Task.FromResult(version);
+        }
+    }
+
+    [StorageProvider(ProviderName = "MemoryStore")]
+    public class SimpleInterfacePersistentGrain : Grain<ISimplePersistentGrain_State>, ISimplePersistentGrain
+    {
+        private Guid version;
+
+        public override Task OnActivateAsync()
+        {
+            version = Guid.NewGuid();
+            return base.OnActivateAsync();
+        }
+        public Task SetA(int a)
+        {
+            State.A = a;
+            return WriteStateAsync();
+        }
+
+        public Task SetA(int a, bool deactivate)
+        {
+            if (deactivate)
+                DeactivateOnIdle();
+            return SetA(a);
+        }
+
+        public Task SetB(int b)
+        {
+            State.B = b;
+            return WriteStateAsync();
+        }
+
+        public Task IncrementA()
+        {
+            State.A++;
+            return WriteStateAsync();
+        }
+
+        public Task<int> GetAxB()
+        {
+            return Task.FromResult(State.A * State.B);
         }
 
         public Task<int> GetAxB(int a, int b)

--- a/src/TestGrains/SimplePersistentGrain.cs
+++ b/src/TestGrains/SimplePersistentGrain.cs
@@ -29,76 +29,83 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections;
 using Orleans;
+using Orleans.CodeGeneration;
+using Orleans.Providers;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 
 
 namespace UnitTests.Grains
 {
-    public class SimplePersistentGrain_State : IGrainState
+    public class SimplePersistentGrain_State : GrainState
     {
-        public int IntProperty { get; set; }
-        public string StringProperty { get; set; }
-        public string Etag { get; set; }
-        public Task ClearStateAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public SimplePersistentGrain_State()
+            : base(typeof(SimplePersistentGrain).FullName) 
+            // TODO: GrainState takes name of the grain type here, which is probably a mistake
+            // since multiple grain classes can use the same state object interface/class.
+            // Need to figure out the right story for mapping grain classes to storage entity types (tables).
+        {}
 
-        public Task WriteStateAsync()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task ReadStateAsync()
-        {
-            throw new NotImplementedException();
-        }
-
-        public IDictionary<string, object> AsDictionary()
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetAll(IDictionary<string, object> values)
-        {
-            throw new NotImplementedException();
-        }
+        public int A { get; set; }
+        public int B { get; set; }
     }
 
     /// <summary>
     /// A simple grain that allows to set two arguments and then multiply them.
     /// </summary>
-    public class SimplePersistentGrain : Grain<SimplePersistentGrain_State>, ISimpleGrain
+    [StorageProvider(ProviderName = "MemoryStore")]
+    public class SimplePersistentGrain : Grain<SimplePersistentGrain_State>, ISimplePersistentGrain
     {
+        private Guid version;
+
+        public override Task OnActivateAsync()
+        {
+            version = Guid.NewGuid();
+            return base.OnActivateAsync();
+        }
         public Task SetA(int a)
         {
-            throw new NotImplementedException();
+            State.A = a;
+            return WriteStateAsync();
         }
 
-        public Task SetB(int a)
+        public Task SetA(int a, bool deactivate)
         {
-            throw new NotImplementedException();
+            if(deactivate)
+                DeactivateOnIdle();
+            return SetA(a);
+        }
+
+        public Task SetB(int b)
+        {
+            State.B = b;
+            return WriteStateAsync();
         }
 
         public Task IncrementA()
         {
-            throw new NotImplementedException();
+            State.A++;
+            return WriteStateAsync();
         }
 
         public Task<int> GetAxB()
         {
-            throw new NotImplementedException();
+            return Task.FromResult(State.A*State.B);
         }
 
         public Task<int> GetAxB(int a, int b)
         {
-            throw new NotImplementedException();
+            return Task.FromResult(a * b);
         }
 
         public Task<int> GetA()
         {
-            throw new NotImplementedException();
+            return Task.FromResult(State.A);
+        }
+
+        public Task<Guid> GetVersion()
+        {
+            return Task.FromResult(version);
         }
     }
 }

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="SimplePersistentGrain.cs" />
     <Compile Include="SpecializedSimpleGenericGrain.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tester/ConcreteStateClassTests.cs
+++ b/src/Tester/ConcreteStateClassTests.cs
@@ -34,20 +34,31 @@ namespace UnitTests.General
     /// Summary description for SimpleGrain
     /// </summary>
     [TestClass]
-    public class ConcreteStateClassTests : UnitTestSiloHost
+    public class StateClassTests : UnitTestSiloHost
     {
-        Random rand = new Random();
+        private readonly Random rand = new Random();
 
-        public ConcreteStateClassTests()
+        public StateClassTests()
             : base(new TestingSiloOptions {StartPrimary = true, StartSecondary = false})
         {
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
-        public async Task ConcreteStateClassTests_1()
+        public async Task StateClassTests_StateClass()
+        {
+            await StateClassTests_Test("UnitTests.Grains.SimplePersistentGrain");
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task StateClassTests_StateInterface()
+        {
+            await StateClassTests_Test("UnitTests.Grains.SimpleInterfacePersistentGrain");
+        }
+
+        private async Task StateClassTests_Test(string grainClass)
         {
             var x = rand.Next();
-            var grain = GrainFactory.GetGrain<ISimplePersistentGrain>(x);
+            var grain = GrainFactory.GetGrain<ISimplePersistentGrain>(x, grainClass);
             var originalVersion = await grain.GetVersion();
             await grain.SetA(x, true); // deactivate grain after setting A
 

--- a/src/Tester/ConcreteStateClassTests.cs
+++ b/src/Tester/ConcreteStateClassTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Project Orleans Cloud Service SDK ver. 1.0
  
 Copyright (c) Microsoft Corporation
@@ -22,23 +22,39 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Orleans;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans.TestingHost;
+using UnitTests.GrainInterfaces;
+using UnitTests.Tester;
 
-namespace UnitTests.GrainInterfaces
+namespace UnitTests.General
 {
-    public interface ISimpleGrain : IGrainWithIntegerKey
+    /// <summary>
+    /// Summary description for SimpleGrain
+    /// </summary>
+    [TestClass]
+    public class ConcreteStateClassTests : UnitTestSiloHost
     {
-        Task SetA(int a);
-        Task SetB(int b);
-        Task IncrementA();
-        Task<int> GetAxB();
-        Task<int> GetAxB(int a, int b);
-        Task<int> GetA();
+        Random rand = new Random();
+
+        public ConcreteStateClassTests()
+            : base(new TestingSiloOptions {StartPrimary = true, StartSecondary = false})
+        {
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        public async Task ConcreteStateClassTests_1()
+        {
+            var x = rand.Next();
+            var grain = GrainFactory.GetGrain<ISimplePersistentGrain>(x);
+            var originalVersion = await grain.GetVersion();
+            await grain.SetA(x, true); // deactivate grain after setting A
+
+            var newVersion = await grain.GetVersion(); // get a new version from the new activation
+            Assert.AreNotEqual(originalVersion, newVersion);
+            var a = await grain.GetA();
+            Assert.AreEqual(x, a); // value of A survive deactivation and reactivation of the grain
+        }
     }
 }

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -82,6 +82,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConcreteStateClassTests.cs" />
     <Compile Include="GenericGrainTests.cs" />
     <Compile Include="ObserverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This is to allow passing a concrete grain state class as a type argument to Grain<T>. This was initially driven by the need to have a way to define custom logic of applying events to state for Event Sourcing - https://github.com/dotnet/orleans/issues/343. In addition this would allow us later to get rid of the codegen of state classes altogether.

This is a breaking change: `Read/Write/ClearStateAsync` methods got moved from `IGrainState` to `Grain<T>`, so that state classes don't have to implement them. Very easy to adjust existing code by simply removing `State.` in those statements. We may consider changing the methods to take a state object as an argument, but that's a separate decision to make, and it's not part of this change. This is only what @yevhen called "separating *unit-of-work* from *state*." Consider this just a first step in refactoring the state management story and adding support for Event Sourcing.
