### PR TITLE
Modified network receive to perform bulk receive.

### DIFF
--- a/src/Orleans/Messaging/GatewayClientReceiver.cs
+++ b/src/Orleans/Messaging/GatewayClientReceiver.cs
@@ -62,7 +62,7 @@ namespace Orleans.Messaging
             {
                 while (!Cts.IsCancellationRequested)
                 {
-                    int bytesRead = FillBuffer(buffer.RecieveBuffer);
+                    int bytesRead = FillBuffer(buffer.ReceiveBuffer);
                     if (bytesRead == 0)
                     {
                         continue;

--- a/src/Orleans/Messaging/GatewayClientReceiver.cs
+++ b/src/Orleans/Messaging/GatewayClientReceiver.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Project Orleans Cloud Service SDK ver. 1.0
  
 Copyright (c) Microsoft Corporation
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Sockets;
 using Orleans.Runtime;
-
+ 
 namespace Orleans.Messaging
 {
     /// <summary>
@@ -35,11 +35,13 @@ namespace Orleans.Messaging
     internal class GatewayClientReceiver : AsynchAgent
     {
         private readonly GatewayConnection gatewayConnection;
+        private readonly IncomingMessageBuffer buffer;
 
         internal GatewayClientReceiver(GatewayConnection gateway)
         {
             gatewayConnection = gateway;
             OnFault = FaultBehavior.RestartOnFault;
+            buffer = new IncomingMessageBuffer(Log, true); 
         }
 
         protected override void Run()
@@ -58,34 +60,22 @@ namespace Orleans.Messaging
         {
             try
             {
-                var lengths = new byte[Message.LENGTH_HEADER_SIZE];
-                var lengthSegments = new List<ArraySegment<byte>> { new ArraySegment<byte>(lengths) };
-
                 while (!Cts.IsCancellationRequested)
                 {
-                    if (!FillBuffer(lengthSegments, Message.LENGTH_HEADER_SIZE))
+                    int bytesRead = FillBuffer(buffer.RecieveBuffer);
+                    if (bytesRead == 0)
                     {
                         continue;
                     }
 
-                    var headerLength = BitConverter.ToInt32(lengths, 0);
-                    var header = BufferPool.GlobalPool.GetMultiBuffer(headerLength);
-                    var bodyLength = BitConverter.ToInt32(lengths, 4);
-                    var body = BufferPool.GlobalPool.GetMultiBuffer(bodyLength);
+                    buffer.UpdateReceivedData(bytesRead);
 
-                    if (!FillBuffer(header, headerLength))
+                    Message msg;
+                    while (buffer.TryDecodeMessage(out msg))
                     {
-                        continue;
+                        gatewayConnection.MsgCenter.QueueIncomingMessage(msg);
+                        if (Log.IsVerbose3) Log.Verbose3("Received a message from gateway {0}: {1}", gatewayConnection.Address, msg);
                     }
-                    if (!FillBuffer(body, bodyLength))
-                    {
-                        continue;
-                    }
-                    var msg = new Message(header, body);
-                    MessagingStatisticsGroup.OnMessageReceive(msg, headerLength, bodyLength);
-
-                    if (Log.IsVerbose3) Log.Verbose3("Received a message from gateway {0}: {1}", gatewayConnection.Address, msg);
-                    gatewayConnection.MsgCenter.QueueIncomingMessage(msg);
                 }
             }
             catch (Exception ex)
@@ -98,6 +88,7 @@ namespace Orleans.Messaging
 
         private void RunBatch()
         {
+            /* Disable batching.  TODO: Remove or fix
             try
             {
                 var metaHeader = new byte[Message.LENGTH_META_HEADER];
@@ -148,6 +139,7 @@ namespace Orleans.Messaging
                         lengthSoFar += (headerLengths[i] + bodyLengths[i]);
 
                         var msg = new Message(header, body);
+
                         MessagingStatisticsGroup.OnMessageReceive(msg, headerLengths[i], bodyLengths[i]);
 
                         if (Log.IsVerbose3) Log.Verbose3("Received a message from gateway {0}: {1}", gatewayConnection.Address, msg);
@@ -162,8 +154,10 @@ namespace Orleans.Messaging
                     ex, gatewayConnection.Address), ex);
                 throw;
             }
+             */
         }
 
+        /* Disable batching.  TODO: Remove or fix
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private bool FillBuffer(List<ArraySegment<byte>> buffer, int length)
         {
@@ -208,6 +202,42 @@ namespace Orleans.Messaging
                 }
             }
             return true;
+        }
+         */
+
+        private int FillBuffer(List<ArraySegment<byte>> buffer)
+        {
+            Socket socketCapture = null;
+            try
+            {
+                if (gatewayConnection.Socket == null || !gatewayConnection.Socket.Connected)
+                {
+                    gatewayConnection.Connect();
+                }
+                socketCapture = gatewayConnection.Socket;
+                if (socketCapture != null && socketCapture.Connected)
+                {
+                    var bytesRead = socketCapture.Receive(buffer);
+                    if (bytesRead == 0)
+                    {
+                        throw new EndOfStreamException("Socket closed");
+                    }
+                    return bytesRead;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Only try to reconnect if we're not shutting down
+                if (Cts.IsCancellationRequested) return 0;
+
+                if (ex is SocketException)
+                {
+                    Log.Warn(ErrorCode.Runtime_Error_100158, "Exception receiving from gateway " + gatewayConnection.Address);
+                }
+                gatewayConnection.MarkAsDisconnected(socketCapture);
+                return 0;
+            }
+            return 0;
         }
     }
 }

--- a/src/Orleans/Messaging/IncomingMessageBuffer.cs
+++ b/src/Orleans/Messaging/IncomingMessageBuffer.cs
@@ -1,0 +1,213 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Orleans.Runtime
+{
+    internal class IncomingMessageBuffer
+    {
+        public List<ArraySegment<byte>> RecieveBuffer
+        {
+            get { return ByteArrayBuilder.BuildSegmentList(readBuffer, recieveOffset); }
+        }
+
+        private const int Kb = 1024;
+        private const int DEFAULT_RECEIVE_BUFFER_SIZE = 128 * Kb; // 128k
+        private const int DEFAULT_MAX_SUSTAINED_RECEIVE_BUFFER_SIZE = DEFAULT_RECEIVE_BUFFER_SIZE * 8; // 1mg
+        private const int GROW_MAX_BLOCK_SIZE = 1024 * Kb; // 1mg
+        private readonly List<ArraySegment<byte>> readBuffer;
+        private readonly int maxSustainedBufferSize;
+        private int currentBufferSize;
+
+        private readonly byte[] lengthBuffer;
+
+        private int headerLength;
+        private int bodyLength;
+
+        private int recieveOffset;
+        private int decodeOffset;
+
+        private readonly bool supportForwarding;
+        private TraceLogger Log;
+
+        public IncomingMessageBuffer(TraceLogger logger, bool supportForwarding = false, int receiveBufferSize = DEFAULT_RECEIVE_BUFFER_SIZE, int maxSustainedReceiveBufferSize = DEFAULT_MAX_SUSTAINED_RECEIVE_BUFFER_SIZE)
+        {
+            Log = logger;
+            this.supportForwarding = supportForwarding;
+            currentBufferSize = receiveBufferSize;
+            maxSustainedBufferSize = maxSustainedReceiveBufferSize;
+            lengthBuffer = new byte[Message.LENGTH_HEADER_SIZE];
+            readBuffer = BufferPool.GlobalPool.GetMultiBuffer(currentBufferSize);
+            recieveOffset = 0;
+            decodeOffset = 0;
+            headerLength = 0;
+            bodyLength = 0;
+        }
+
+        public void UpdateReceivedData(int bytesRead)
+        {
+            recieveOffset += bytesRead;
+        }
+
+        public void Reset()
+        {
+            recieveOffset = 0;
+            decodeOffset = 0;
+            headerLength = 0;
+            bodyLength = 0;
+        }
+
+        public bool TryDecodeMessage(out Message msg)
+        {
+            msg = null;
+
+            // Is there enough read into the buffer to continue (at least read the lengths?)
+            if (recieveOffset - decodeOffset < KnownMessageSize())
+                return false;
+
+            // parse lengths if needed
+            if (headerLength == 0 || bodyLength == 0)
+            {
+                // get length segments
+                List<ArraySegment<byte>> lenghts = ByteArrayBuilder.BuildSegmentListWithLengthLimit(readBuffer, decodeOffset, Message.LENGTH_HEADER_SIZE);
+
+                // copy length segment to buffer
+                int lengthBufferoffset = 0;
+                foreach (ArraySegment<byte> seg in lenghts)
+                {
+                    Buffer.BlockCopy(seg.Array, seg.Offset, lengthBuffer, lengthBufferoffset, seg.Count);
+                    lengthBufferoffset += seg.Count;
+                }
+
+                // read lengths
+                headerLength = BitConverter.ToInt32(lengthBuffer, 0);
+                bodyLength = BitConverter.ToInt32(lengthBuffer, 4);
+            }
+
+            // If message is too big for default buffer size, grow
+            while (decodeOffset + KnownMessageSize() > currentBufferSize)
+            {
+                //TODO: Add configurable max message size for safety
+                //TODO: Review networking layer and add max size checks to all dictionaries, arrays, or other variable sized containers.
+                // double buffer size up to max grow block size, then only grow it in those intervals
+                int growBlockSize = Math.Min(currentBufferSize, GROW_MAX_BLOCK_SIZE);
+                readBuffer.AddRange(BufferPool.GlobalPool.GetMultiBuffer(growBlockSize));
+                currentBufferSize += growBlockSize;
+            }
+
+            // Is there enough read into the buffer to read full message
+            if (recieveOffset - decodeOffset < KnownMessageSize())
+                return false;
+
+            // decode header
+            int headerOffset = decodeOffset + Message.LENGTH_HEADER_SIZE;
+            List<ArraySegment<byte>> header = ByteArrayBuilder.BuildSegmentListWithLengthLimit(readBuffer, headerOffset, headerLength);
+
+            // decode body
+            int bodyOffset = headerOffset + headerLength;
+            List<ArraySegment<byte>> body = ByteArrayBuilder.BuildSegmentListWithLengthLimit(readBuffer, bodyOffset, bodyLength);
+
+            // need to maintain ownership of buffer, so if we are supporting forwarding we need to duplicate the body buffer.
+            if (supportForwarding)
+            {
+                body = DuplicateBuffer(body);
+            }
+
+            // build message
+            msg = new Message(header, body, !supportForwarding);
+            MessagingStatisticsGroup.OnMessageReceive(msg, headerLength, bodyLength);
+
+            if (headerLength + bodyLength > Message.LargeMessageSizeThreshold)
+            {
+                Log.Info(ErrorCode.Messaging_LargeMsg_Incoming, "Receiving large message Size={0} HeaderLength={1} BodyLength={2}. Msg={3}",
+                    headerLength + bodyLength, headerLength, bodyLength, msg.ToString());
+                if (Log.IsVerbose3) Log.Verbose3("Received large message {0}", msg.ToLongString());
+            }
+
+            // update parse recieveOffset and clear lengths
+            decodeOffset = bodyOffset + bodyLength;
+            headerLength = 0;
+            bodyLength = 0;
+
+            // drop buffers consumed in message and adjust parse recieveOffset
+            // TODO: This can be optimized further. Linked lists?
+            int consumedBytes = 0;
+            while (readBuffer.Count != 0)
+            {
+                ArraySegment<byte> seg = readBuffer[0];
+                if (seg.Count <= decodeOffset - consumedBytes)
+                {
+                    consumedBytes += seg.Count;
+                    readBuffer.Remove(seg);
+                    BufferPool.GlobalPool.Release(seg.Array);
+                }
+                else
+                {
+                    break;
+                }
+            }
+            decodeOffset -= consumedBytes;
+            recieveOffset -= consumedBytes;
+
+            if (consumedBytes != 0)
+            {
+                if (currentBufferSize <= maxSustainedBufferSize)
+                {
+                    readBuffer.AddRange(BufferPool.GlobalPool.GetMultiBuffer(consumedBytes));
+                }
+                else
+                {
+                    // shrink buffer to DEFAULT_MAX_SUSTAINED_RECEIVE_BUFFER_SIZE
+                    int backfillBytes = Math.Max(consumedBytes + maxSustainedBufferSize - currentBufferSize, 0);
+                    currentBufferSize -= consumedBytes;
+                    currentBufferSize += backfillBytes;
+                    if (backfillBytes > 0)
+                    {
+                        readBuffer.AddRange(BufferPool.GlobalPool.GetMultiBuffer(backfillBytes));
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private int KnownMessageSize()
+        {
+            return headerLength + bodyLength + Message.LENGTH_HEADER_SIZE;
+        }
+
+        private List<ArraySegment<byte>> DuplicateBuffer(List<ArraySegment<byte>> body)
+        {
+            var dupBody = new List<ArraySegment<byte>>(body.Count);
+            foreach (ArraySegment<byte> seg in body)
+            {
+                var dupSeg = new ArraySegment<byte>(BufferPool.GlobalPool.GetBuffer(), seg.Offset, seg.Count);
+                Buffer.BlockCopy(seg.Array, seg.Offset, dupSeg.Array, dupSeg.Offset, seg.Count);
+                dupBody.Add(dupSeg);
+            }
+            return dupBody;
+        }
+    }
+}

--- a/src/Orleans/Messaging/IncomingMessageBuffer.cs
+++ b/src/Orleans/Messaging/IncomingMessageBuffer.cs
@@ -28,9 +28,9 @@ namespace Orleans.Runtime
 {
     internal class IncomingMessageBuffer
     {
-        public List<ArraySegment<byte>> RecieveBuffer
+        public List<ArraySegment<byte>> ReceiveBuffer
         {
-            get { return ByteArrayBuilder.BuildSegmentList(readBuffer, recieveOffset); }
+            get { return ByteArrayBuilder.BuildSegmentList(readBuffer, receiveOffset); }
         }
 
         private const int Kb = 1024;
@@ -46,7 +46,7 @@ namespace Orleans.Runtime
         private int headerLength;
         private int bodyLength;
 
-        private int recieveOffset;
+        private int receiveOffset;
         private int decodeOffset;
 
         private readonly bool supportForwarding;
@@ -60,7 +60,7 @@ namespace Orleans.Runtime
             maxSustainedBufferSize = maxSustainedReceiveBufferSize;
             lengthBuffer = new byte[Message.LENGTH_HEADER_SIZE];
             readBuffer = BufferPool.GlobalPool.GetMultiBuffer(currentBufferSize);
-            recieveOffset = 0;
+            receiveOffset = 0;
             decodeOffset = 0;
             headerLength = 0;
             bodyLength = 0;
@@ -68,12 +68,12 @@ namespace Orleans.Runtime
 
         public void UpdateReceivedData(int bytesRead)
         {
-            recieveOffset += bytesRead;
+            receiveOffset += bytesRead;
         }
 
         public void Reset()
         {
-            recieveOffset = 0;
+            receiveOffset = 0;
             decodeOffset = 0;
             headerLength = 0;
             bodyLength = 0;
@@ -84,7 +84,7 @@ namespace Orleans.Runtime
             msg = null;
 
             // Is there enough read into the buffer to continue (at least read the lengths?)
-            if (recieveOffset - decodeOffset < KnownMessageSize())
+            if (receiveOffset - decodeOffset < KnownMessageSize())
                 return false;
 
             // parse lengths if needed
@@ -118,7 +118,7 @@ namespace Orleans.Runtime
             }
 
             // Is there enough read into the buffer to read full message
-            if (recieveOffset - decodeOffset < KnownMessageSize())
+            if (receiveOffset - decodeOffset < KnownMessageSize())
                 return false;
 
             // decode header
@@ -146,12 +146,12 @@ namespace Orleans.Runtime
                 if (Log.IsVerbose3) Log.Verbose3("Received large message {0}", msg.ToLongString());
             }
 
-            // update parse recieveOffset and clear lengths
+            // update parse receiveOffset and clear lengths
             decodeOffset = bodyOffset + bodyLength;
             headerLength = 0;
             bodyLength = 0;
 
-            // drop buffers consumed in message and adjust parse recieveOffset
+            // drop buffers consumed in message and adjust parse receiveOffset
             // TODO: This can be optimized further. Linked lists?
             int consumedBytes = 0;
             while (readBuffer.Count != 0)
@@ -169,7 +169,7 @@ namespace Orleans.Runtime
                 }
             }
             decodeOffset -= consumedBytes;
-            recieveOffset -= consumedBytes;
+            receiveOffset -= consumedBytes;
 
             if (consumedBytes != 0)
             {

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -124,6 +124,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="IDs\GuidId.cs" />
     <Compile Include="Messaging\GatewayManager.cs" />
+    <Compile Include="Messaging\IncomingMessageBuffer.cs" />
     <Compile Include="Messaging\RequestInvocationHistory.cs" />
     <Compile Include="Messaging\Response.cs" />
     <Compile Include="Providers\StorageProviderUtils.cs" />

--- a/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
-
 using Orleans.Messaging;
 
 namespace Orleans.Runtime.Messaging
@@ -521,183 +520,25 @@ namespace Orleans.Runtime.Messaging
 
         private class ReceiveCallbackContext
         {
-            private enum ReceivePhase
-            {
-                Lengths,
-                Header,
-                Body,
-                MetaHeader,
-                HeaderBodies
-            }
-
-            private ReceivePhase phase;
-            private byte[] lengthBuffer;
-            private readonly byte[] metaHeaderBuffer;
-            private List<ArraySegment<byte>> lengths;
-            private List<ArraySegment<byte>> header;
-            private List<ArraySegment<byte>> body;
-            private readonly List<ArraySegment<byte>> metaHeader;
-            private List<ArraySegment<byte>> headerBodies;
-            private int headerLength;
-            private int bodyLength;
-            private int[] headerLengths;
-            private int[] bodyLengths;
-            private int headerBodiesLength;
-            private int offset;
-            private readonly bool batchingMode;
-            private int numberOfMessages;
+            private readonly IncomingMessageBuffer _buffer;
 
             public Socket Sock { get; private set; }
             public EndPoint RemoteEndPoint { get; private set; }
             public IncomingMessageAcceptor IMA { get; private set; }
 
-            private List<ArraySegment<byte>> CurrentBuffer
-            {
-                get
-                {
-                    if (batchingMode)
-                    {
-                        switch (phase)
-                        {
-                            case ReceivePhase.MetaHeader:
-                                return metaHeader;
-                            case ReceivePhase.Lengths:
-                                return lengths;
-                            default:
-                                return headerBodies;
-                        }
-                    }
-
-                    switch (phase)
-                    {
-                        case ReceivePhase.Lengths:
-                            return lengths;
-                        case ReceivePhase.Header:
-                            return header;
-                        default:
-                            return body;
-                    }
-                }
-            }
-
-            private int CurrentLength
-            {
-                get
-                {
-                    if (batchingMode)
-                    {
-                        switch (phase)
-                        {
-                            case ReceivePhase.MetaHeader:
-                                return Message.LENGTH_META_HEADER;
-                            case ReceivePhase.Lengths:
-                                if (numberOfMessages == 0)
-                                {
-                                    IMA.Log.Info("Error: numberOfMessages must NOT be 0 here.");
-                                    return 0;
-                                }
-                                return Message.LENGTH_HEADER_SIZE * numberOfMessages;
-                            default:
-                                return headerBodiesLength;
-                        }
-                    }
-
-                    switch (phase)
-                    {
-                        case ReceivePhase.Lengths:
-                            return Message.LENGTH_HEADER_SIZE;
-                        case ReceivePhase.Header:
-                            return headerLength;
-                        default:
-                            return bodyLength;
-                    }
-                }
-            }
-
             public ReceiveCallbackContext(Socket sock, IncomingMessageAcceptor ima)
             {
-                batchingMode = ima.MessageCenter.MessagingConfiguration.UseMessageBatching;
-                if (batchingMode)
-                {
-                    phase = ReceivePhase.MetaHeader;
-                    Sock = sock;
-                    RemoteEndPoint = sock.RemoteEndPoint;
-                    IMA = ima;
-                    metaHeaderBuffer = new byte[Message.LENGTH_META_HEADER];
-                    metaHeader = new List<ArraySegment<byte>>() { new ArraySegment<byte>(metaHeaderBuffer) };
-                    // LengthBuffer and Lengths cannot be allocated here because the sizes varies in response to the number of received messages
-                    lengthBuffer = null;
-                    lengths = null;
-                    header = null;
-                    body = null;
-                    headerBodies = null;
-                    headerLengths = null;
-                    bodyLengths = null;
-                    headerBodiesLength = 0;
-                    numberOfMessages = 0;
-                    offset = 0;
-                }
-                else
-                {
-                    phase = ReceivePhase.Lengths;
-                    Sock = sock;
-                    RemoteEndPoint = sock.RemoteEndPoint;
-                    IMA = ima;
-                    lengthBuffer = new byte[Message.LENGTH_HEADER_SIZE];
-                    lengths = new List<ArraySegment<byte>>() { new ArraySegment<byte>(lengthBuffer) };
-                    header = null;
-                    body = null;
-                    headerLength = 0;
-                    bodyLength = 0;
-                    offset = 0;
-                }
-            }
-
-            private void Reset()
-            {
-                if (batchingMode)
-                {
-                    phase = ReceivePhase.MetaHeader;
-                    // MetaHeader MUST NOT set to null because it will be re-used.
-                    lengthBuffer = null;
-                    lengths = null;
-                    header = null;
-                    body = null;
-                    headerLengths = null;
-                    bodyLengths = null;
-                    headerBodies = null;
-                    headerBodiesLength = 0;
-                    numberOfMessages = 0;
-                    offset = 0;
-                }
-                else
-                {
-                    phase = ReceivePhase.Lengths;
-                    headerLength = 0;
-                    bodyLength = 0;
-                    offset = 0;
-                    header = null;
-                    body = null;
-                }
-            }
-
-            /// <summary>
-            /// Builds the list of buffer segments to pass to Socket.BeginReceive, based on the total list (CurrentBuffer)
-            /// and how much we've already filled in (Offset). We have to do this because the scatter/gather variant of
-            /// the BeginReceive API doesn't allow you to specify an offset into the list of segments.
-            /// To build the list, we walk through the complete buffer, skipping segments that we've already filled up; 
-            /// add the partial segment for whatever's left in the first unfilled buffer, and then add any remaining buffers.
-            /// </summary>
-            private List<ArraySegment<byte>> BuildSegmentList()
-            {
-                return ByteArrayBuilder.BuildSegmentList(CurrentBuffer, offset);
+                Sock = sock;
+                RemoteEndPoint = sock.RemoteEndPoint;
+                IMA = ima;
+                _buffer = new IncomingMessageBuffer(ima.Log);
             }
 
             public void BeginReceive(AsyncCallback callback)
             {
                 try
                 {
-                    Sock.BeginReceive(BuildSegmentList(), SocketFlags.None, callback, this);
+                    Sock.BeginReceive(_buffer.RecieveBuffer, SocketFlags.None, callback, this);
                 }
                 catch (Exception ex)
                 {
@@ -713,8 +554,8 @@ namespace Orleans.Runtime.Messaging
 
             public void ProcessReceivedBuffer(int bytes)
             {
-                offset += bytes;
-                if (offset < CurrentLength) return; // Nothing to do except start the next receive
+                if (bytes == 0)
+                    return;
 
 #if TRACK_DETAILED_STATS
                 ThreadTrackingStatistic tracker = null;
@@ -733,103 +574,14 @@ namespace Orleans.Runtime.Messaging
                     tracker.OnStartProcessing();
                 }
 #endif
-
                 try
                 {
-                    if (batchingMode)
+                    _buffer.UpdateReceivedData(bytes);
+
+                    Message msg;
+                    while (_buffer.TryDecodeMessage(out msg))
                     {
-                        switch (phase)
-                        {
-                            case ReceivePhase.MetaHeader:
-                                numberOfMessages = BitConverter.ToInt32(metaHeaderBuffer, 0);
-                                lengthBuffer = new byte[numberOfMessages * Message.LENGTH_HEADER_SIZE];
-                                lengths = new List<ArraySegment<byte>>() { new ArraySegment<byte>(lengthBuffer) };
-                                phase = ReceivePhase.Lengths;
-                                offset = 0;
-                                break;
-
-                            case ReceivePhase.Lengths:
-                                headerBodies = new List<ArraySegment<byte>>();
-                                headerLengths = new int[numberOfMessages];
-                                bodyLengths = new int[numberOfMessages];
-
-                                for (int i = 0; i < numberOfMessages; i++)
-                                {
-                                    headerLengths[i] = BitConverter.ToInt32(lengthBuffer, i * 8);
-                                    bodyLengths[i] = BitConverter.ToInt32(lengthBuffer, i * 8 + 4);
-                                    headerBodiesLength += (headerLengths[i] + bodyLengths[i]);
-
-                                    // We need to set the boundary of ArraySegment<byte>s to the same as the header/body boundary
-                                    headerBodies.AddRange(BufferPool.GlobalPool.GetMultiBuffer(headerLengths[i]));
-                                    headerBodies.AddRange(BufferPool.GlobalPool.GetMultiBuffer(bodyLengths[i]));
-                                }
-
-                                phase = ReceivePhase.HeaderBodies;
-                                offset = 0;
-                                break;
-
-                            case ReceivePhase.HeaderBodies:
-                                int lengtshSoFar = 0;
-
-                                for (int i = 0; i < numberOfMessages; i++)
-                                {
-                                    header = ByteArrayBuilder.BuildSegmentListWithLengthLimit(headerBodies, lengtshSoFar, headerLengths[i]);
-                                    body = ByteArrayBuilder.BuildSegmentListWithLengthLimit(headerBodies, lengtshSoFar + headerLengths[i], bodyLengths[i]);
-                                    lengtshSoFar += (headerLengths[i] + bodyLengths[i]);
-
-                                    var msg = new Message(header, body);
-                                    MessagingStatisticsGroup.OnMessageReceive(msg, headerLengths[i], bodyLengths[i]);
-
-                                    if (IMA.Log.IsVerbose3) IMA.Log.Verbose3("Received a complete message of {0} bytes from {1}", headerLengths[i] + bodyLengths[i], msg.SendingAddress);
-                                    if (headerLengths[i] + bodyLengths[i] > Message.LargeMessageSizeThreshold)
-                                    {
-                                        IMA.Log.Info(ErrorCode.Messaging_LargeMsg_Incoming, "Receiving large message Size={0} HeaderLength={1} BodyLength={2}. Msg={3}",
-                                            headerLengths[i] + bodyLengths[i], headerLengths[i], bodyLengths[i], msg.ToString());
-                                        if (IMA.Log.IsVerbose3) IMA.Log.Verbose3("Received large message {0}", msg.ToLongString());
-                                    }
-                                    IMA.HandleMessage(msg, Sock);
-                                }
-                                MessagingStatisticsGroup.OnMessageBatchReceive(IMA.SocketDirection, numberOfMessages, lengtshSoFar);
-
-                                Reset();
-                                break;
-                        }
-                    }
-                    else
-                    {
-                        // We've completed a buffer. What we do depends on which phase we were in
-                        switch (phase)
-                        {
-                            case ReceivePhase.Lengths:
-                                // Pull out the header and body lengths
-                                headerLength = BitConverter.ToInt32(lengthBuffer, 0);
-                                bodyLength = BitConverter.ToInt32(lengthBuffer, 4);
-                                header = BufferPool.GlobalPool.GetMultiBuffer(headerLength);
-                                body = BufferPool.GlobalPool.GetMultiBuffer(bodyLength);
-                                phase = ReceivePhase.Header;
-                                offset = 0;
-                                break;
-
-                            case ReceivePhase.Header:
-                                phase = ReceivePhase.Body;
-                                offset = 0;
-                                break;
-
-                            case ReceivePhase.Body:
-                                var msg = new Message(header, body);
-                                MessagingStatisticsGroup.OnMessageReceive(msg, headerLength, bodyLength);
-
-                                if (IMA.Log.IsVerbose3) IMA.Log.Verbose3("Received a complete message of {0} bytes from {1}", headerLength + bodyLength, msg.SendingAddress);
-                                if (headerLength + bodyLength > Message.LargeMessageSizeThreshold)
-                                {
-                                    IMA.Log.Info(ErrorCode.Messaging_LargeMsg_Incoming, "Receiving large message Size={0} HeaderLength={1} BodyLength={2}. Msg={3}",
-                                        headerLength + bodyLength, headerLength, bodyLength, msg.ToString());
-                                    if (IMA.Log.IsVerbose3) IMA.Log.Verbose3("Received large message {0}", msg.ToLongString());
-                                }
-                                IMA.HandleMessage(msg, Sock);
-                                Reset();
-                                break;
-                        }
+                        IMA.HandleMessage(msg, Sock);
                     }
                 }
                 catch (Exception exc)
@@ -839,15 +591,12 @@ namespace Orleans.Runtime.Messaging
                         // Log details of receive state machine
                         IMA.Log.Error(ErrorCode.MessagingProcessReceiveBufferException,
                             string.Format(
-                            "Exception trying to process {0} bytes from endpoint {1} at offset {2} in phase {3}"
-                            + " CurrentLength={4} HeaderLength={5} BodyLength={6}",
-                                bytes, RemoteEndPoint, offset, phase,
-                                CurrentLength, headerLength, bodyLength
-                            ),
+                            "Exception trying to process {0} bytes from endpoint {1}",
+                                bytes, RemoteEndPoint),
                             exc);
                     }
                     catch (Exception) { }
-                    Reset(); // Reset back to a hopefully good base state
+                    _buffer.Reset(); // Reset back to a hopefully good base state
 
                     throw;
                 }

--- a/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
@@ -538,7 +538,7 @@ namespace Orleans.Runtime.Messaging
             {
                 try
                 {
-                    Sock.BeginReceive(_buffer.RecieveBuffer, SocketFlags.None, callback, this);
+                    Sock.BeginReceive(_buffer.ReceiveBuffer, SocketFlags.None, callback, this);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Modified network receive code to perform bulk receive in order to reduce the number of socket receive system calls.

The original networking code made 3 socket receive calls per message.
This change modifies the receive code to perform a bulk socket read into a buffer, then parses all messages that were received.  This should greatly reduce the number of socket receive system calls.