### PR TITLE
Changed GrainRuntime.SiloIdentity to be a silo address and not silo name.

### DIFF
--- a/src/Orleans/Runtime/GrainRuntime.cs
+++ b/src/Orleans/Runtime/GrainRuntime.cs
@@ -7,21 +7,16 @@ namespace Orleans.Runtime
 {
     internal class GrainRuntime : IGrainRuntime
     {
-        private readonly string id;
-
-        public GrainRuntime(string id, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager)
+        public GrainRuntime(string siloId, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager)
         {
-            this.id = id;
+            SiloIdentity = siloId;
             GrainFactory = grainFactory;
             TimerRegistry = timerRegistry;
             ReminderRegistry = reminderRegistry;
             StreamProviderManager = streamProviderManager;
         }
 
-        public string SiloIdentity
-        {
-            get { return id; }
-        }
+        public string SiloIdentity { get; private set; }
 
         public IGrainFactory GrainFactory { get; private set; }
         

--- a/src/Orleans/Runtime/IActivationData.cs
+++ b/src/Orleans/Runtime/IActivationData.cs
@@ -36,9 +36,6 @@ namespace Orleans.Runtime
         Grain GrainInstance { get; }
         ActivationId ActivationId { get; }
         ActivationAddress Address { get; }
-        string IdentityString { get; }
-        string RuntimeIdentity { get;  }
-        void DeactivateOnIdle();
         void DelayDeactivation(TimeSpan timeSpan);
         IStorageProvider StorageProvider { get; }
         IDisposable RegisterTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period);

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -305,21 +305,6 @@ namespace Orleans.Runtime
         public ActivationId ActivationId { get { return Address.Activation; } }
 
         public ActivationAddress Address { get; private set; }
-        
-        public string IdentityString
-        {
-            get { return Grain.ToDetailedString(); }
-        }
-
-        public string RuntimeIdentity
-        {
-            get { return Silo.ToLongString(); }
-        }
-
-        public void DeactivateOnIdle()
-        {
-            RuntimeClient.Current.DeactivateOnIdle(ActivationId);
-        }
 
         public IDisposable RegisterTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
         {

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -170,12 +170,6 @@ namespace Orleans.Runtime
                 TraceLogger.Initialize(nodeConfig);
 
             config.OnConfigChange("Defaults/Tracing", () => TraceLogger.Initialize(nodeConfig, true), false);
-
-            grainFactory = new GrainFactory();
-            grainRuntime = new GrainRuntime(name, grainFactory, 
-                new TimerRegistry(), 
-                new ReminderRegistry(), 
-                new StreamProviderManager());
             
             LimitManager.Initialize(nodeConfig);
             ActivationData.Init(config);
@@ -230,6 +224,13 @@ namespace Orleans.Runtime
                 mc.InstallGateway(nodeConfig.ProxyGatewayEndpoint);
             
             messageCenter = mc;
+
+            grainFactory = new GrainFactory();
+            grainRuntime = new GrainRuntime(SiloAddress.ToLongString(), grainFactory,
+                new TimerRegistry(),
+                new ReminderRegistry(),
+                new StreamProviderManager());
+
 
             // Now the router/directory service
             // This has to come after the message center //; note that it then gets injected back into the message center.;

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -208,6 +208,7 @@ namespace Orleans.Runtime
             AppDomain.CurrentDomain.UnhandledException +=
                 (obj, ev) => DomainUnobservedExceptionHandler(obj, (Exception)ev.ExceptionObject);
 
+            grainFactory = new GrainFactory();
             typeManager = new GrainTypeManager(here.Address.Equals(IPAddress.Loopback), grainFactory);
 
             // Performance metrics
@@ -225,7 +226,7 @@ namespace Orleans.Runtime
             
             messageCenter = mc;
 
-            grainFactory = new GrainFactory();
+            // GrainRuntime can be created only here, after messageCenter was created.
             grainRuntime = new GrainRuntime(SiloAddress.ToLongString(), grainFactory,
                 new TimerRegistry(),
                 new ReminderRegistry(),


### PR DESCRIPTION
Changed GrainRuntime.SiloIdentity to be a silo address and not silo name.
It used to be silo address and not silo name before the DI change, which accidently changed it.
Also remove some redundantly exposed properties on IActivationData.