### PR TITLE
Renamed test category "Nightly" to "Functional"

### DIFF
--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{013DFD29-E1DB-4968-A67B-C2342E6F5B6E}"
 	ProjectSection(SolutionItems) = preProject
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Orleans.SDK.targets = Orleans.SDK.targets
 		SetupTestScript.cmd = SetupTestScript.cmd
 		Test.cmd = Test.cmd
+		TestAll.cmd = TestAll.cmd
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClientGenerator", "ClientGenerator\ClientGenerator.csproj", "{E782DD19-51F7-4F66-8217-BACAC33767E4}"

--- a/src/TestAll.cmd
+++ b/src/TestAll.cmd
@@ -17,4 +17,4 @@ cd "%CMDHOME%"
 
 set TEST_ARGS= /testcontainer:%OutDir%\Tester.dll /testcontainer:%OutDir%\TesterInternal.dll 
 
-"%MSTESTEXE%" %TEST_ARGS% /category:"BVT|Nightly"
+"%MSTESTEXE%" %TEST_ARGS% /category:"BVT|Functional"

--- a/src/Tester/ConcreteStateClassTests.cs
+++ b/src/Tester/ConcreteStateClassTests.cs
@@ -43,13 +43,13 @@ namespace UnitTests.General
         {
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task StateClassTests_StateClass()
         {
             await StateClassTests_Test("UnitTests.Grains.SimplePersistentGrain");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task StateClassTests_StateInterface()
         {
             await StateClassTests_Test("UnitTests.Grains.SimpleInterfacePersistentGrain");

--- a/src/Tester/GenericGrainTests.cs
+++ b/src/Tester/GenericGrainTests.cs
@@ -67,7 +67,7 @@ namespace UnitTests.General
 
         /// Can instantiate multiple concrete grain types that implement
         /// different specializations of the same generic interface
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceGetGrain()
         {
 
@@ -89,7 +89,7 @@ namespace UnitTests.General
         }
 
         /// Multiple GetGrain requests with the same id return the same concrete grain 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithGenericInterfaceMultiplicity()
         {
             var grainId = GetRandomGrainId();
@@ -104,7 +104,7 @@ namespace UnitTests.General
         }
 
         /// Can instantiate generic grain specializations
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_SimpleGenericGrainGetGrain()
         {
 
@@ -131,7 +131,7 @@ namespace UnitTests.General
         }
 
         /// Multiple GetGrain requests with the same id return the same generic grain specialization
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_SimpleGenericGrainMultiplicity()
         {
             var grainId = GetRandomGrainId();
@@ -148,7 +148,7 @@ namespace UnitTests.General
 
         /// If both a concrete implementation and a generic implementation of a 
         /// generic interface exist, prefer the concrete implementation.
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterface()
         {
             var grainOfDouble1 = GetGrain<ISimpleGenericGrain<double>>();
@@ -169,7 +169,7 @@ namespace UnitTests.General
         }
 
         /// Multiple GetGrain requests with the same id return the same concrete grain implementation
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_PreferConcreteGrainImplementationOfGenericInterfaceMultiplicity()
         {
             var grainId = GetRandomGrainId();
@@ -187,7 +187,7 @@ namespace UnitTests.General
         }
 
         /// Can instantiate concrete grains that implement multiple generic interfaces
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesGetGrain()
         {
             var grain1 = GetGrain<ISimpleGenericGrain<int>>();
@@ -208,7 +208,7 @@ namespace UnitTests.General
         }
 
         /// Multiple GetGrain requests with the same id and interface return the same concrete grain implementation
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesMultiplicity1()
         {
             var grainId = GetRandomGrainId();
@@ -228,7 +228,7 @@ namespace UnitTests.General
         }
 
         /// Multiple GetGrain requests with the same id and different interfaces return the same concrete grain implementation
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_ConcreteGrainWithMultipleGenericInterfacesMultiplicity2()
         {
             var grainId = GetRandomGrainId();
@@ -246,7 +246,7 @@ namespace UnitTests.General
             Assert.AreEqual("100", floatResult);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task GenericGrainTests_UseGenericFactoryInsideGrain()
         {
             var grainId = GetRandomGrainId();

--- a/src/Tester/ObserverTests.cs
+++ b/src/Tester/ObserverTests.cs
@@ -76,7 +76,7 @@ namespace UnitTests.General
             return random.Next();
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task ObserverTest_SimpleNotification()
         {
             var result = new AsyncResultHandle();
@@ -93,7 +93,7 @@ namespace UnitTests.General
             await GrainFactory.DeleteObjectReference<ISimpleGrainObserver>(reference);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task ObserverTest_SimpleNotification_GeneratedFactory()
         {
             var result = new AsyncResultHandle();
@@ -138,7 +138,7 @@ namespace UnitTests.General
             }
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task ObserverTest_DoubleSubscriptionSameReference()
         {
             var result = new AsyncResultHandle();
@@ -185,7 +185,7 @@ namespace UnitTests.General
             }
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task ObserverTest_SubscribeUnsubscribe()
         {
             var result = new AsyncResultHandle();
@@ -217,7 +217,7 @@ namespace UnitTests.General
         }
 
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task ObserverTest_Unsubscribe()
         {
             ISimpleObserverableGrain grain = GetGrain();
@@ -241,7 +241,7 @@ namespace UnitTests.General
             }
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task ObserverTest_DoubleSubscriptionDifferentReferences()
         {
             var result = new AsyncResultHandle();
@@ -275,7 +275,7 @@ namespace UnitTests.General
         }
 
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task ObserverTest_DeleteObject()
         {
             var result = new AsyncResultHandle();
@@ -304,7 +304,7 @@ namespace UnitTests.General
             result.Continue = true;
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         [ExpectedException(typeof(NotSupportedException))]
         public async Task ObserverTest_SubscriberMustBeGrainReference()
         {

--- a/src/Tester/SerializationTests.cs
+++ b/src/Tester/SerializationTests.cs
@@ -41,7 +41,7 @@ namespace UnitTests.General
             SerializationManager.InitializeForTesting();
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_JObject()
         {
             const string json = @"{ 

--- a/src/Tester/SimpleGrainTests.cs
+++ b/src/Tester/SimpleGrainTests.cs
@@ -58,14 +58,14 @@ namespace UnitTests.General
             StopAllSilos();
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task SimpleGrainGetGrain()
         {
             ISimpleGrain grain = GetSimpleGrain();
             int ignored = await grain.GetAxB();
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task SimpleGrainControlFlow()
         {
             ISimpleGrain grain = GetSimpleGrain();
@@ -80,7 +80,7 @@ namespace UnitTests.General
             Assert.AreEqual(6, await intPromise);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task SimpleGrainDataFlow()
         {
             ISimpleGrain grain = GetSimpleGrain();

--- a/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
@@ -65,35 +65,35 @@ namespace Tester.StreamingTests
             AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(AQStreamProviderName, DeploymentId, StorageTestConstants.DataConnectionString, logger).Wait();
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
         public async Task AQMultipleSubscriptionTest()
         {
             logger.Info("************************ AQMultipleSubscriptionTest *********************************");
             await runner.MultipleSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
         public async Task AQAddAndRemoveSubscriptionTest()
         {
             logger.Info("************************ AQAddAndRemoveSubscriptionTest *********************************");
             await runner.AddAndRemoveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
         public async Task AQResubscriptionTest()
         {
             logger.Info("************************ AQResubscriptionTest *********************************");
             await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
         public async Task AQResubscriptionAfterDeactivationTest()
         {
             logger.Info("************************ ResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
         public async Task AQActiveSubscriptionTest()
         {
             logger.Info("************************ AQActiveSubscriptionTest *********************************");

--- a/src/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/src/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -65,14 +65,14 @@ namespace Tester.StreamingTests
             StopAllSilos();
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSDeactivationTest()
         {
             logger.Info("************************ SMSDeactivationTest *********************************");
             await runner.DeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSDeactivationTest_ClientConsumer()
         {
             logger.Info("************************ SMSDeactivationTest *********************************");

--- a/src/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
@@ -57,35 +57,35 @@ namespace Tester.StreamingTests
             StopAllSilos();
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSMultipleSubscriptionTest()
         {
             logger.Info("************************ SMSMultipleSubscriptionTest *********************************");
             await runner.MultipleSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSAddAndRemoveSubscriptionTest()
         {
             logger.Info("************************ SMSAddAndRemoveSubscriptionTest *********************************");
             await runner.AddAndRemoveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSResubscriptionTest()
         {
             logger.Info("************************ SMSResubscriptionTest *********************************");
             await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSResubscriptionAfterDeactivationTest()
         {
             logger.Info("************************ ResubscriptionAfterDeactivationTest *********************************");
             await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSActiveSubscriptionTest()
         {
             logger.Info("************************ SMSActiveSubscriptionTest *********************************");

--- a/src/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/src/Tester/StreamingTests/SampleStreamingTests.cs
@@ -71,7 +71,7 @@ namespace Tester.StreamingTests
             }
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SampleStreamingTests_1()
         {
             logger.Info("************************ SampleStreamingTests_1 *********************************");
@@ -80,7 +80,7 @@ namespace Tester.StreamingTests
             await StreamingTests_Consumer_Producer(streamId, streamProvider);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SampleStreamingTests_2()
         {
             logger.Info("************************ SampleStreamingTests_2 *********************************");
@@ -89,7 +89,7 @@ namespace Tester.StreamingTests
             await StreamingTests_Producer_Consumer(streamId, streamProvider);
         }
 
-        [TestMethod, TestCategory( "Nightly" ), TestCategory("Streaming" )]
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming" )]
         public async Task SampleStreamingTests_3()
         {
             logger.Info("************************ SampleStreamingTests_3 *********************************" );
@@ -98,7 +98,7 @@ namespace Tester.StreamingTests
             await StreamingTests_Producer_InlineConsumer(streamId, streamProvider );
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SampleStreamingTests_4()
         {
             logger.Info("************************ SampleStreamingTests_4 *********************************");
@@ -107,7 +107,7 @@ namespace Tester.StreamingTests
             await StreamingTests_Consumer_Producer(streamId, streamProvider);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Streaming")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SampleStreamingTests_5()
         {
             logger.Info("************************ SampleStreamingTests_5 *********************************");

--- a/src/TesterInternal/General/Identifiertests.cs
+++ b/src/TesterInternal/General/Identifiertests.cs
@@ -51,7 +51,7 @@ namespace UnitTests.General
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void ID_IsSystem()
         {
             GrainId testGrain = Constants.DirectoryServiceId;
@@ -69,28 +69,28 @@ namespace UnitTests.General
             Assert.IsTrue(testActivation.IsSystem, "System activation ID is not flagged as a system ID");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         [ExpectedException(typeof(ArgumentNullException))]
         public void UniqueKeyKeyExtGrainCategoryDisallowsNullKeyExtension()
         {
             UniqueKey.NewKey(Guid.NewGuid(), category: UniqueKey.Category.KeyExtGrain, keyExt: null);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         [ExpectedException(typeof(ArgumentException))]
         public void UniqueKeyKeyExtGrainCategoryDisallowsEmptyKeyExtension()
         {
             UniqueKey.NewKey(Guid.NewGuid(), category: UniqueKey.Category.KeyExtGrain, keyExt: "");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         [ExpectedException(typeof(ArgumentException))]
         public void UniqueKeyKeyExtGrainCategoryDisallowsWhiteSpaceKeyExtension()
         {
             UniqueKey.NewKey(Guid.NewGuid(), category: UniqueKey.Category.KeyExtGrain, keyExt: " \t\n\r");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void UniqueKeySerializationShouldReproduceAnIdenticalObject()
         {
             {
@@ -123,7 +123,7 @@ namespace UnitTests.General
             }
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void ParsingUniqueKeyStringificationShouldReproduceAnIdenticalObject()
         {
             UniqueKey expected1 = UniqueKey.NewKey(Guid.NewGuid());
@@ -152,7 +152,7 @@ namespace UnitTests.General
         }
 
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void GrainIdShouldEncodeAndDecodePrimaryKeyGuidCorrectly()
         {
             const int repeat = 100;
@@ -165,7 +165,7 @@ namespace UnitTests.General
             }
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void GrainId_ToFromPrintableString()
         {
             Guid guid = Guid.NewGuid();
@@ -209,7 +209,7 @@ namespace UnitTests.General
             return output;
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")] 
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")] 
         public void UniqueTypeCodeDataShouldStore32BitsOfInformation()
         {
             const int expected = unchecked((int)0xfabccbaf);
@@ -222,7 +222,7 @@ namespace UnitTests.General
                 "UniqueKey.BaseTypeCode should store at least 32 bits of information.");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void UniqueKeysShouldPreserveTheirPrimaryKeyValueIfItIsGuid()
         {
             const int all32Bits = unchecked((int)0xffffffff);
@@ -255,7 +255,7 @@ namespace UnitTests.General
                 "UniqueKey objects should preserve the value of their key extension (Guid case #2).");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void UniqueKeysShouldPreserveTheirPrimaryKeyValueIfItIsLong()
         {
             const int all32Bits = unchecked((int)0xffffffff);
@@ -279,7 +279,7 @@ namespace UnitTests.General
                 "UniqueKey objects should preserve the value of their key extension (long case).");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void ID_HashCorrectness()
         {
             // This tests that our optimized Jenkins hash computes the same value as the reference implementation
@@ -298,7 +298,7 @@ namespace UnitTests.General
             }
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void ID_Interning_GrainID()
         {
             Guid guid = new Guid();
@@ -315,7 +315,7 @@ namespace UnitTests.General
             Assert.AreSame(gid2, gid3, "Should be same / intern'ed GrainId object");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void ID_Interning_string_equals()
         {
             Interner<string, string> interner = new Interner<string, string>();
@@ -333,7 +333,7 @@ namespace UnitTests.General
             Assert.AreEqual(r2, r3, "4: Should be equal");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void ID_Intern_derived_class()
         {
             Interner<int, A> interner = new Interner<int, A>();
@@ -365,7 +365,7 @@ namespace UnitTests.General
             Assert.AreSame(obj2, r5, "Interning should return previously cached instances of more derived object");
         }
 
-       [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+       [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void ID_Intern_FindOrCreate_derived_class()
         {
             Interner<int, A> interner = new Interner<int, A>();
@@ -397,7 +397,7 @@ namespace UnitTests.General
             Assert.AreSame(obj2, r5, "FindOrCreate return previously cached object");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void Interning_SiloAddress()
         {
             //string addrStr1 = "1.2.3.4@11111@1";
@@ -414,7 +414,7 @@ namespace UnitTests.General
             Assert.AreSame(a2, a3, "Should be same / intern'ed SiloAddress object");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void Interning_SiloAddress2()
         {
             SiloAddress a1 = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
@@ -423,7 +423,7 @@ namespace UnitTests.General
             Assert.AreNotSame(a1, a2, "Should not be same / intern'ed SiloAddress object");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void Interning_SiloAddress_Serialization()
         {
             SiloAddress a1 = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
@@ -434,7 +434,7 @@ namespace UnitTests.General
             Assert.AreSame(a1, a3, "Should be same / intern'ed SiloAddress object");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void GrainID_AsGuid()
         {
             string guidString = "0699605f-884d-4343-9977-f40a39ab7b2b";
@@ -461,7 +461,7 @@ namespace UnitTests.General
             Assert.AreNotEqual(guidString, grainIdKeyString, "GrainId.Key.ToString");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void SiloAddress_ToFrom_ParsableString()
         {
             string testName = TestContext.TestName;
@@ -497,7 +497,7 @@ namespace UnitTests.General
             return pkGuidString;
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Nightly"), TestCategory("Identifiers")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void GrainReference_Test1()
         {
             Guid guid = Guid.NewGuid();

--- a/src/TesterInternal/OrleansRuntime/Streams/BestFitBalancerTests.cs
+++ b/src/TesterInternal/OrleansRuntime/Streams/BestFitBalancerTests.cs
@@ -32,7 +32,7 @@ namespace UnitTests.OrleansRuntime.Streams
     [TestClass]
     public class BestFitBalancerTests
     {
-        [TestMethod, TestCategory("Nightly")]
+        [TestMethod, TestCategory("Functional")]
         public void IdealCaseMoreResourcesThanBucketsTest()
         {
             const int resourceCount = 99;
@@ -45,7 +45,7 @@ namespace UnitTests.OrleansRuntime.Streams
             ValidateBalance(buckets, resources, balancerResults, idealBalance);
         }
 
-        [TestMethod, TestCategory("Nightly")]
+        [TestMethod, TestCategory("Functional")]
         public void IdealCaseLessResourcesThanBucketsTest()
         {
             const int bucketCount = 99;
@@ -58,7 +58,7 @@ namespace UnitTests.OrleansRuntime.Streams
             ValidateBalance(buckets, resources, balancerResults, idealBalance);
         }
 
-        [TestMethod, TestCategory("Nightly")]
+        [TestMethod, TestCategory("Functional")]
         public void HalfBucketsActiveTest()
         {
             const int resourceCount = 99;
@@ -73,7 +73,7 @@ namespace UnitTests.OrleansRuntime.Streams
             ValidateBalance(activeBuckets, resources, balancerResults, idealBalance);
         }
 
-        [TestMethod, TestCategory("Nightly")]
+        [TestMethod, TestCategory("Functional")]
         public void OrderIrrelevantTest()
         {
             const int resourceCount = 99;

--- a/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
+++ b/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
@@ -97,7 +97,7 @@ namespace UnitTests.StorageTests
             }
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureMembership_ReadAll_0()
         {
             MembershipTableData data = await membership.ReadAll();
@@ -113,7 +113,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(0, ver, "Initial tabel version should be zero");
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureMembership_ReadRow_0()
         {
             MembershipTableData data = await membership.ReadRow(siloAddress);
@@ -131,7 +131,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(0, ver, "Initial tabel version should be zero");
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureMembership_ReadRow_1()
         {
             MembershipTableData data = await membership.ReadAll();
@@ -171,7 +171,7 @@ namespace UnitTests.StorageTests
             Assert.IsNotNull(MembershipEntry, "MembershipEntry should not be null");
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureMembership_ReadAll_1()
         {
             MembershipTableData data = await membership.ReadAll();

--- a/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureQueueDataManagerTests.cs
@@ -74,7 +74,7 @@ namespace UnitTests.StorageTests
             return manager;
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("AzureQueue")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("AzureQueue")]
         public async Task AQ_Standalone_1()
         {
             queueName = "Test-1-".ToLower() + Guid.NewGuid();
@@ -108,7 +108,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(0, await manager.GetApproximateMessageCount());
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("AzureQueue")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("AzureQueue")]
         public async Task AQ_Standalone_2()
         {
             queueName = "Test-2-".ToLower() + Guid.NewGuid();
@@ -139,7 +139,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(0, await manager.GetApproximateMessageCount());
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("AzureQueue")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("AzureQueue")]
         public async Task AQ_Standalone_3_Init_MultipleThreads()
         {
             queueName = "Test-4-".ToLower() + Guid.NewGuid();

--- a/src/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
@@ -64,7 +64,7 @@ namespace UnitTests.StorageTests
             PartitionKey = "PK-AzureTableDataManagerTests-" + Guid.NewGuid();
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureTableDataManager_CreateTableEntryAsync()
         {
             var data = GenerateNewData();
@@ -89,7 +89,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(data.StringData, tuple.Item1.StringData);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureTableDataManager_UpsertTableEntryAsync()
         {
             var data = GenerateNewData();
@@ -104,7 +104,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(data2.StringData, tuple.Item1.StringData);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureTableDataManager_UpdateTableEntryAsync()
         {
             var data = GenerateNewData();
@@ -156,7 +156,7 @@ namespace UnitTests.StorageTests
             }
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureTableDataManager_DeleteTableAsync()
         {
             var data = GenerateNewData();
@@ -197,7 +197,7 @@ namespace UnitTests.StorageTests
             Assert.IsNull(tuple);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureTableDataManager_MergeTableAsync()
         {
             var data = GenerateNewData();
@@ -241,7 +241,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual("NewData", tuple.Item1.StringData);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureTableDataManager_ReadSingleTableEntryAsync()
         {
             var data = GenerateNewData();
@@ -249,7 +249,7 @@ namespace UnitTests.StorageTests
             Assert.IsNull(tuple);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureTableDataManager_InsertTwoTableEntriesConditionallyAsync()
         {
             var data1 = GenerateNewData();
@@ -301,7 +301,7 @@ namespace UnitTests.StorageTests
             };
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task AzureTableDataManager_UpdateTwoTableEntriesConditionallyAsync()
         {
             var data1 = GenerateNewData();

--- a/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
@@ -42,7 +42,7 @@ namespace UnitTests.StorageTests
             }
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_IsRetriableHttpError()
         {
             Assert.IsTrue(AzureStorageUtils.IsRetriableHttpError((HttpStatusCode) 503, null));
@@ -57,7 +57,7 @@ namespace UnitTests.StorageTests
             Assert.IsFalse(AzureStorageUtils.IsRetriableHttpError((HttpStatusCode) 200, null));
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public void AzureTableErrorCode_IsContentionError()
         {
             Assert.IsTrue(AzureStorageUtils.IsContentionError(HttpStatusCode.PreconditionFailed));
@@ -74,7 +74,7 @@ namespace UnitTests.StorageTests
             Assert.IsFalse(AzureStorageUtils.IsContentionError((HttpStatusCode) 200));
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         [ExpectedException(typeof (ArgumentException))]
         public void AzureTableErrorCode_BadTableName()
         {

--- a/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
+++ b/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
@@ -79,21 +79,21 @@ namespace UnitTests.LivenessTests
 
         // Test methods 
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Liveness"), TestCategory("Azure")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Liveness"), TestCategory("Azure")]
         public async Task MT_Init_Azure()
         {
             var membership = await GetMemebershipTable_Azure();
             Assert.IsNotNull(membership, "Membership Table handler created");
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Liveness"), TestCategory("Azure")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Liveness"), TestCategory("Azure")]
         public async Task MT_ReadAll_Azure()
         {
             var membership = await GetMemebershipTable_Azure();
             await MembershipTable_ReadAll(membership);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Liveness"), TestCategory("Azure")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Liveness"), TestCategory("Azure")]
         public async Task MT_InsertRow_Azure()
         {
             var membership = await GetMemebershipTable_Azure();

--- a/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
+++ b/src/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
@@ -112,13 +112,13 @@ namespace UnitTests.StorageTests
             }
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public void SiloInstanceTable_Op_RegisterSiloInstance()
         {
             RegisterSiloInstance();
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public void SiloInstanceTable_Op_ActivateSiloInstance()
         {
             RegisterSiloInstance();
@@ -126,7 +126,7 @@ namespace UnitTests.StorageTests
             manager.ActivateSiloInstance(myEntry);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public void SiloInstanceTable_Op_UnregisterSiloInstance()
         {
             RegisterSiloInstance();
@@ -134,7 +134,7 @@ namespace UnitTests.StorageTests
             manager.UnregisterSiloInstance(myEntry);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task SiloInstanceTable_Op_CreateSiloEntryConditionally()
         {
             bool didInsert = await manager.TryCreateTableVersionEntryAsync()
@@ -143,7 +143,7 @@ namespace UnitTests.StorageTests
             Assert.IsTrue(didInsert, "Did insert");
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task SiloInstanceTable_Register_CheckData()
         {
             const string testName = "SiloInstanceTable_Register_CheckData";
@@ -164,7 +164,7 @@ namespace UnitTests.StorageTests
             logger.Info("End {0}", testName);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task SiloInstanceTable_Activate_CheckData()
         {
             RegisterSiloInstance();
@@ -185,7 +185,7 @@ namespace UnitTests.StorageTests
             CheckSiloInstanceTableEntry(myEntry, siloEntry);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public async Task SiloInstanceTable_Unregister_CheckData()
         {
             RegisterSiloInstance();
@@ -204,7 +204,7 @@ namespace UnitTests.StorageTests
             CheckSiloInstanceTableEntry(myEntry, siloEntry);
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public void SiloInstanceTable_FindAllGatewayProxyEndpoints()
         {
             RegisterSiloInstance();
@@ -222,7 +222,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(myEntry.ProxyPort, myGateway.Port.ToString(CultureInfo.InvariantCulture), "Gateway port");
         }
 
-        [TestMethod, TestCategory("Nightly"), TestCategory("Azure"), TestCategory("Storage")]
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
         public void SiloAddress_ToFrom_RowKey()
         {
             string ipAddress = "1.2.3.4";


### PR DESCRIPTION
Renamed test category "Nightly" to "Functional" to better reflect its purpose.
A rebased replacement for https://github.com/dotnet/orleans/pull/484.