### PR TITLE
ZooKeeper 3.4.6 as a membership provider

### DIFF
--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -135,6 +135,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Chocolatey", "Chocolatey", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansTestingHost", "OrleansTestingHost\OrleansTestingHost.csproj", "{40EE3B00-D381-485F-9C69-FF706837DEED}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansZooKeeperUtils", "OrleansZooKeeperUtils\OrleansZooKeeperUtils.csproj", "{45918DD2-53D9-4B27-BC6B-17C197DBC645}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -193,6 +195,10 @@ Global
 		{40EE3B00-D381-485F-9C69-FF706837DEED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{40EE3B00-D381-485F-9C69-FF706837DEED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{40EE3B00-D381-485F-9C69-FF706837DEED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{45918DD2-53D9-4B27-BC6B-17C197DBC645}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45918DD2-53D9-4B27-BC6B-17C197DBC645}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45918DD2-53D9-4B27-BC6B-17C197DBC645}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45918DD2-53D9-4B27-BC6B-17C197DBC645}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -102,6 +102,37 @@ namespace Orleans.Runtime
             return discoveredAssemblyLocations;
         }
 
+        public static T LoadAndCreateInstance<T>(string assemblyName, TraceLogger logger) where T : class
+        {
+            var exeRoot = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var dirs = new Dictionary<string, SearchOption>
+            {
+                {exeRoot, SearchOption.TopDirectoryOnly}
+            };
+
+            AssemblyLoaderPathNameCriterion[] includeCriteria =
+            {
+                AssemblyLoaderCriteria.IncludeFileNames(new[] {assemblyName})
+            };
+            AssemblyLoaderReflectionCriterion[] loadCriteria =
+            {
+                AssemblyLoaderCriteria.LoadTypesAssignableFrom(typeof (T))
+            };
+
+            var discoveredAssemblyLocations = LoadAssemblies(dirs, includeCriteria, loadCriteria, logger);
+
+            if (discoveredAssemblyLocations.Count == 0)
+                throw new TypeLoadException("Type " + typeof(T).Name + " wasn't found");
+
+            if (discoveredAssemblyLocations.Count > 1)
+                throw new TypeLoadException("Type " + typeof(T).Name + " was found more than once");
+
+            var foundType =
+                TypeUtils.GetTypes(discoveredAssemblyLocations, type => typeof(T).IsAssignableFrom(type)).First();
+
+            return (T)Activator.CreateInstance(foundType, true);
+        }
+
         // this method is internal so that it can be accessed from unit tests, which only test the discovery
         // process-- not the actual loading of assemblies.
         internal static AssemblyLoader NewAssemblyLoader(

--- a/src/Orleans/AssemblyLoader/AssemblyLoaderCriteria.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoaderCriteria.cs
@@ -94,7 +94,7 @@ namespace Orleans.Runtime
             return ExcludeFileNames(SystemBinariesList);
         }
 
-        internal static AssemblyLoaderPathNameCriterion ExcludeFileNames(IEnumerable<string> list)
+        private static AssemblyLoaderPathNameCriterion GetFileNameCriterion(IEnumerable<string> list, bool includeList)
         {
             return
                 AssemblyLoaderPathNameCriterion.NewCriterion(
@@ -103,7 +103,7 @@ namespace Orleans.Runtime
                         var fileName = Path.GetFileName(pathName);
                         foreach (var i in list)
                         {
-                            if (String.Equals(fileName, i, StringComparison.OrdinalIgnoreCase))
+                            if (String.Equals(fileName, i, StringComparison.OrdinalIgnoreCase) ^ includeList)
                             {
                                 complaints = new string[] {"Assembly filename is excluded."};
                                 return false;
@@ -112,6 +112,16 @@ namespace Orleans.Runtime
                         complaints = null;
                         return true;
                     });
+        }
+
+        internal static AssemblyLoaderPathNameCriterion ExcludeFileNames(IEnumerable<string> list)
+        {
+            return GetFileNameCriterion(list, false);
+        }
+
+        internal static AssemblyLoaderPathNameCriterion IncludeFileNames(IEnumerable<string> list)
+        {
+            return GetFileNameCriterion(list, true);
         }
     }
 }

--- a/src/Orleans/AzureUtils/AzureGatewayListProvider.cs
+++ b/src/Orleans/AzureUtils/AzureGatewayListProvider.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Messaging;
+using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 
 
@@ -34,26 +35,16 @@ namespace Orleans.AzureUtils
     internal class AzureGatewayListProvider : IGatewayListProvider
     {
         private OrleansSiloInstanceManager siloInstanceManager;
-        private readonly ClientConfiguration config;
-        private readonly object lockable;
-
-        private AzureGatewayListProvider(ClientConfiguration conf)
-        {
-            config = conf;
-            lockable = new object();
-        }
-
-        public static async Task<AzureGatewayListProvider> GetAzureGatewayListProvider(ClientConfiguration conf)
-        {
-            var provider = new AzureGatewayListProvider(conf)
-            {
-                siloInstanceManager = await OrleansSiloInstanceManager.GetManager(conf.DeploymentId, conf.DataConnectionString)
-            };
-            return provider;
-        }
+        private ClientConfiguration config;
+        private readonly object lockable = new object();
 
         #region Implementation of IGatewayListProvider
 
+        public async Task InitializeGatewayListProvider(ClientConfiguration conf, TraceLogger traceLogger)
+        {
+            config = conf;
+            siloInstanceManager = await OrleansSiloInstanceManager.GetManager(conf.DeploymentId, conf.DataConnectionString);
+        }
         // no caching
         public IList<Uri> GetGateways()
         {

--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -45,6 +45,7 @@ namespace Orleans.Runtime.Configuration
             None,               // 
             AzureTable,         // use Azure, requires SystemStore element
             SqlServer,          // use SQL, requires SystemStore element
+            ZooKeeper,          // use ZooKeeper, requires SystemStore element
             Config              // use Config based static list, requires Config element(s)
         }
 

--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -168,6 +168,10 @@ namespace Orleans.Runtime.Configuration
                 {
                     Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
                 }
+                else if (Globals.UseZooKeeperSystemStore)
+                {
+                    Globals.LivenessType = GlobalConfiguration.LivenessProviderType.ZooKeeper;
+                }
                 else
                 {
                     Globals.LivenessType = GlobalConfiguration.LivenessProviderType.MembershipTableGrain;

--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -573,7 +573,10 @@ namespace Orleans.Runtime.Configuration
                             if (!"None".Equals(sst, StringComparison.InvariantCultureIgnoreCase))
                             {
                                 LivenessType = (LivenessProviderType)Enum.Parse(typeof(LivenessProviderType), sst);
-                                SetReminderServiceType((ReminderServiceProviderType)Enum.Parse(typeof(ReminderServiceProviderType), sst));
+                                ReminderServiceProviderType reminderServiceProviderType;
+                                SetReminderServiceType(Enum.TryParse(sst, out reminderServiceProviderType)
+                                    ? reminderServiceProviderType
+                                    : ReminderServiceProviderType.ReminderTableGrain);
                             }
                         }
                         if (child.HasAttribute("ServiceId"))

--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -71,6 +71,9 @@ namespace Orleans.Runtime.Configuration
             /// <summary>SQL Server is used to store membership information. 
             /// This option can be used in production.</summary>
             SqlServer,
+            /// <summary>Apache ZooKeeper is used to store membership information. 
+            /// This option can be used in production.</summary>
+            ZooKeeper,
         }
 
         /// <summary>
@@ -193,7 +196,7 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public string DeploymentId { get; set; }
         /// <summary>
-        /// Connection string for Azure Storage or SQL Server.
+        /// Connection string for Azure Storage or SQL Server or Apache ZooKeeper.
         /// </summary>
         public string DataConnectionString { get; set; }
 
@@ -316,6 +319,19 @@ namespace Orleans.Runtime.Configuration
         }
 
         /// <summary>
+        /// Determines if ZooKeeper should be used for storage of Membership and Reminders info.
+        /// True if LivenessType is set to ZooKeeper, false otherwise.
+        /// </summary>
+        internal bool UseZooKeeperSystemStore
+        {
+            get
+            {
+                return !String.IsNullOrWhiteSpace(DataConnectionString) && (
+                    (LivenessEnabled && LivenessType == LivenessProviderType.ZooKeeper));
+            }
+        }
+
+        /// <summary>
         /// Determines if Azure Storage should be used for storage of Membership and Reminders info.
         /// True if either or both of LivenessType and ReminderServiceType are set to AzureTable, false otherwise.
         /// </summary>
@@ -324,7 +340,7 @@ namespace Orleans.Runtime.Configuration
             get
             {
                 return !String.IsNullOrWhiteSpace(DataConnectionString)
-                    && !UseSqlSystemStore;
+                       && !UseSqlSystemStore && !UseZooKeeperSystemStore;
             }
         }
 

--- a/src/Orleans/Messaging/GatewayProviderFactory.cs
+++ b/src/Orleans/Messaging/GatewayProviderFactory.cs
@@ -52,6 +52,10 @@ namespace Orleans.Messaging
                     listProvider = new SqlMembershipTable();
                     break;
 
+                case ClientConfiguration.GatewayProviderType.ZooKeeper:
+                    listProvider = AssemblyLoader.LoadAndCreateInstance<IGatewayListProvider>("OrleansZooKeeperUtils.dll", logger);
+                    break;
+
                 case ClientConfiguration.GatewayProviderType.Config:
                     listProvider = new StaticGatewayListProvider();
                     break;

--- a/src/Orleans/Messaging/IGatewayListProvider.cs
+++ b/src/Orleans/Messaging/IGatewayListProvider.cs
@@ -23,14 +23,23 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
 
 namespace Orleans.Messaging
 {
     /// <summary>
     /// Interface that provides Orleans gateways information.
     /// </summary>
-    internal interface IGatewayListProvider
+    public interface IGatewayListProvider
     {
+        /// <summary>
+        /// Initializes the provider, will be called before all other methods
+        /// </summary>
+        /// <param name="clientConfiguration">the given client configuration</param>
+        /// <param name="traceLogger">the logger to be used by the provider</param>
+        Task InitializeGatewayListProvider(ClientConfiguration clientConfiguration, TraceLogger traceLogger);
         /// <summary>
         /// Returns the list of gateways (silos) that can be used by a client to connect to Orleans cluster.
         /// The Uri is in the form of: "gwy.tcp://IP:port/Generation". See Utils.ToGatewayUri and Utils.ToSiloAddress for more details about Uri format.

--- a/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 using Orleans.Concurrency;
+using Orleans.Runtime.Configuration;
 
 namespace Orleans
 {
@@ -34,8 +35,21 @@ namespace Orleans
     /// Interface for Membership Table.
     /// </summary>
     [Unordered]
-    internal interface IMembershipTable : IGrain
+    public interface IMembershipTable : IGrain
     {
+        /// <summary>
+        /// Initializes the membership table, will be called before all other methods
+        /// </summary>
+        /// <param name="globalConfiguration">the give global configuration</param>
+        /// <param name="tryInitTableVersion">whether an attempt will be made to init the underlying table</param>
+        /// <param name="traceLogger">the logger used by the membership table</param>
+        Task InitializeMembershipTable(GlobalConfiguration globalConfiguration, bool tryInitTableVersion, TraceLogger traceLogger);
+
+        /// <summary>
+        /// Deletes all table entries of the given deploymentId
+        /// </summary>
+        Task DeleteMembershipTableEntries(string deploymentId);
+
         /// <summary>
         /// Atomically reads the Membership Table information about a given silo.
         /// The returned MembershipTableData includes one MembershipEntry entry for a given silo and the 
@@ -108,7 +122,7 @@ namespace Orleans
     
     [Serializable]
     [Immutable]
-    internal class TableVersion
+    public class TableVersion
     {
         /// <summary>
         /// The version part of this TableVersion. Monotonically increasing number.
@@ -138,7 +152,7 @@ namespace Orleans
     }
 
     [Serializable]
-    internal class MembershipTableData
+    public class MembershipTableData
     {
         public IReadOnlyList<Tuple<MembershipEntry, string>> Members { get; private set; }
 
@@ -231,7 +245,7 @@ namespace Orleans
     }
 
     [Serializable]
-    internal class MembershipEntry
+    public class MembershipEntry
     {
         public SiloAddress SiloAddress { get; set; }
 

--- a/src/Orleans/Utils/Utils.cs
+++ b/src/Orleans/Utils/Utils.cs
@@ -34,7 +34,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// The Utils class contains a variety of utility methods for use in application and grain code.
     /// </summary>
-    internal static class Utils
+    public static class Utils
     {
         /// <summary>
         /// Returns a human-readable text string that describes an IEnumerable collection of objects.

--- a/src/OrleansRuntime/MembershipService/GrainBasedMembershipTable.cs
+++ b/src/OrleansRuntime/MembershipService/GrainBasedMembershipTable.cs
@@ -21,8 +21,10 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using System;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
+using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -31,6 +33,16 @@ namespace Orleans.Runtime.MembershipService
     {
         private InMemoryMembershipTable table;
         private TraceLogger logger;
+
+        public Task InitializeMembershipTable(GlobalConfiguration config, bool tryInitTableVersion, TraceLogger traceLogger)
+        {
+            throw new InvalidOperationException("This method should not be called directly");
+        }
+
+        public Task DeleteMembershipTableEntries(string deploymentId)
+        {
+            throw new InvalidOperationException("This method should not be called directly");
+        }
 
         public override Task OnActivateAsync()
         {

--- a/src/OrleansRuntime/MembershipService/MembershipFactory.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipFactory.cs
@@ -66,20 +66,27 @@ namespace Orleans.Runtime.MembershipService
             GlobalConfiguration.LivenessProviderType livenessType = config.LivenessType;
             if (livenessType.Equals(GlobalConfiguration.LivenessProviderType.MembershipTableGrain))
             {
-                membershipTable = GrainFactory.Cast<IMembershipTable>(GrainReference.FromGrainId(Constants.SystemMembershipTableId));
-            }
-            else if (livenessType.Equals(GlobalConfiguration.LivenessProviderType.SqlServer))
-            {
-                membershipTable = await SqlMembershipTable.GetMembershipTable(config, true);
-            }
-            else if (livenessType.Equals(GlobalConfiguration.LivenessProviderType.AzureTable))
-            {
-                membershipTable = await AzureBasedMembershipTable.GetMembershipTable(config, true);
+                membershipTable =
+                    GrainFactory.Cast<IMembershipTable>(GrainReference.FromGrainId(Constants.SystemMembershipTableId));
             }
             else
             {
-                throw new NotImplementedException("No membership table provider found for LivenessType=" + livenessType);
+                if (livenessType.Equals(GlobalConfiguration.LivenessProviderType.SqlServer))
+                {
+                    membershipTable = new SqlMembershipTable();
+                }
+                else if (livenessType.Equals(GlobalConfiguration.LivenessProviderType.AzureTable))
+                {
+                    membershipTable = new AzureBasedMembershipTable();
+                }
+                else
+                {
+                    throw new NotImplementedException("No membership table provider found for LivenessType=" +
+                                                      livenessType);
+                }
+                await membershipTable.InitializeMembershipTable(config, true, TraceLogger.GetLogger(membershipTable.GetType().Name));
             }
+
             return membershipTable;
         }
     }

--- a/src/OrleansRuntime/MembershipService/MembershipFactory.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipFactory.cs
@@ -79,6 +79,11 @@ namespace Orleans.Runtime.MembershipService
                 {
                     membershipTable = new AzureBasedMembershipTable();
                 }
+                else if (livenessType.Equals(GlobalConfiguration.LivenessProviderType.ZooKeeper))
+                {
+                    membershipTable = AssemblyLoader.LoadAndCreateInstance<IMembershipTable>(
+                        "OrleansZooKeeperUtils.dll", logger);
+                }
                 else
                 {
                     throw new NotImplementedException("No membership table provider found for LivenessType=" +

--- a/src/OrleansTestingHost/StorageTestConstants.cs
+++ b/src/OrleansTestingHost/StorageTestConstants.cs
@@ -141,5 +141,10 @@ namespace Orleans.TestingHost
                 Console.WriteLine("DB file is writeable {0}", dbFile.FullName);
             }
         }
+
+        public static string GetZooKeeperConnectionString()
+        {
+            return "127.0.0.1:2181";
+        }
     }
 }

--- a/src/OrleansZooKeeperUtils/MembershipSerializerSettings.cs
+++ b/src/OrleansZooKeeperUtils/MembershipSerializerSettings.cs
@@ -1,0 +1,107 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+
+namespace Orleans.Runtime.Host
+{
+    internal class MembershipSerializerSettings : JsonSerializerSettings
+    {
+        public static readonly MembershipSerializerSettings Instance = new MembershipSerializerSettings();
+
+        private MembershipSerializerSettings()
+        {
+            Converters.Add(new SiloAddressConverter());
+            Converters.Add(new MembershipEntryConverter());
+            Converters.Add(new StringEnumConverter());
+        }
+
+        private class MembershipEntryConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return (objectType == typeof(MembershipEntry));
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                MembershipEntry me = (MembershipEntry)value;
+                writer.WriteStartObject();
+                writer.WritePropertyName("SiloAddress"); serializer.Serialize(writer, me.SiloAddress);
+                writer.WritePropertyName("HostName"); writer.WriteValue(me.HostName);
+                writer.WritePropertyName("InstanceName"); writer.WriteValue(me.InstanceName);
+                writer.WritePropertyName("Status"); serializer.Serialize(writer, me.Status);
+                writer.WritePropertyName("ProxyPort"); writer.WriteValue(me.ProxyPort);
+                writer.WritePropertyName("StartTime"); writer.WriteValue(me.StartTime);
+                writer.WritePropertyName("SuspectTimes"); serializer.Serialize(writer, me.SuspectTimes);
+                writer.WriteEndObject();
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+                JsonSerializer serializer)
+            {
+                JObject jo = JObject.Load(reader);
+                return new MembershipEntry
+                {
+                    IsPrimary = true,
+                    SiloAddress = jo["SiloAddress"].ToObject<SiloAddress>(serializer),
+                    HostName = jo["HostName"].ToObject<string>(),
+                    InstanceName = jo["InstanceName"].ToObject<string>(),
+                    Status = jo["Status"].ToObject<SiloStatus>(serializer),
+                    ProxyPort = jo["ProxyPort"].Value<int>(),
+                    StartTime = jo["StartTime"].Value<DateTime>(),
+                    SuspectTimes = jo["SuspectTimes"].ToObject<List<Tuple<SiloAddress, DateTime>>>(serializer)
+                };
+            }
+        }
+
+        private class SiloAddressConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return (objectType == typeof(SiloAddress));
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                SiloAddress se = (SiloAddress)value;
+                writer.WriteStartObject();
+                writer.WritePropertyName("SiloAddress");
+                writer.WriteValue(se.ToParsableString());
+                writer.WriteEndObject();
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+                JsonSerializer serializer)
+            {
+                JObject jo = JObject.Load(reader);
+                string seStr = jo["SiloAddress"].ToObject<string>(serializer);
+                return SiloAddress.FromParsableString(seStr);
+            }
+        }
+    }
+}

--- a/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
+++ b/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{45918DD2-53D9-4B27-BC6B-17C197DBC645}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Orleans.Runtime.Host</RootNamespace>
+    <AssemblyName>OrleansZooKeeperUtils</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Build\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="MembershipSerializerSettings.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ZooKeeperBasedMembershipTable.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\Orleans.snk">
+      <Link>Orleans.snk</Link>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="ZooKeeperNetEx, Version=3.4.6.0, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.6-alpha12\lib\net45\ZooKeeperNetEx.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Orleans\Orleans.csproj">
+      <Project>{BC1BD60C-E7D8-4452-A21C-290AEC8E2E74}</Project>
+      <Name>Orleans</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/OrleansZooKeeperUtils/Properties/AssemblyInfo.cs
+++ b/src/OrleansZooKeeperUtils/Properties/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("OrleansZooKeeperUtils")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("97d67c10-e039-4fd9-ac8d-7c761ce491a6")]

--- a/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
+++ b/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
@@ -1,0 +1,286 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using org.apache.zookeeper;
+using org.apache.zookeeper.data;
+using Orleans.Messaging;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.Runtime.Host
+{
+    public class ZooKeeperBasedMembershipTable : IMembershipTable, IGatewayListProvider
+    {
+        private TraceLogger logger;
+
+        private const int ZOOKEEPER_CONNECTION_TIMEOUT = 2000;
+
+        private ZooKeeperWatcher watcher;
+
+        private string deploymentConnectionString;
+        private string deploymentPath;
+        private string rootConnectionString;
+        private TimeSpan maxStaleness;
+
+        public Task InitializeGatewayListProvider(ClientConfiguration config,TraceLogger traceLogger)
+        {
+            InitConfig(traceLogger,config.DataConnectionString, config.DeploymentId, config.GatewayListRefreshPeriod);
+            return TaskDone.Done;
+        }
+
+        private void InitConfig(TraceLogger traceLogger, string dataConnectionString, string deploymentId, TimeSpan maxStale)
+        {
+            watcher = new ZooKeeperWatcher(traceLogger);
+            logger = traceLogger;
+            deploymentPath = "/" + deploymentId;
+            deploymentConnectionString = dataConnectionString + deploymentPath;
+            rootConnectionString = dataConnectionString;
+            maxStaleness = maxStale;
+        }
+
+        public Task<MembershipTableData> ReadRow(SiloAddress siloAddress)
+        {
+            return UsingZookeeper(async zk =>
+            {
+                var getRowTask = GetRow(zk, siloAddress);
+                var getTableNodeTask = zk.getDataAsync("/", false);
+
+                List<Tuple<MembershipEntry, string>> rows = new List<Tuple<MembershipEntry, string>>(1);
+                try
+                {
+                    await Task.WhenAll(getRowTask, getTableNodeTask);
+                    rows.Add(await getRowTask);
+                }
+                catch (KeeperException.NoNodeException)
+                {
+                    //that's ok because orleans expects an empty list in case of a missing row
+                }
+
+                var tableVersion = ConvertToTableVersion((await getTableNodeTask).Stat);
+                return new MembershipTableData(rows, tableVersion);
+            });
+        }
+
+        public Task<MembershipTableData> ReadAll()
+        {
+            return UsingZookeeper(async zk =>
+            {
+                var childrenResult = await zk.getChildrenAsync("/", false);
+
+                var childrenTasks =
+                    childrenResult.Children.Select(child => GetRow(zk, SiloAddress.FromParsableString(child))).ToList();
+
+                var childrenTaskResults = await Task.WhenAll(childrenTasks);
+
+                var tableVersion = ConvertToTableVersion(childrenResult.Stat);
+
+                return new MembershipTableData(childrenTaskResults.ToList(), tableVersion);
+            });
+        }
+
+        public Task<bool> InsertRow(MembershipEntry entry, TableVersion tableVersion)
+        {
+            string rowPath = ConvertToRowPath(entry.SiloAddress);
+            string rowIAmAlivePath = ConvertToRowIAmAlivePath(entry.SiloAddress);
+            byte[] newRowData = Serialize(entry);
+            byte[] newRowIAmAliveData = Serialize(entry.IAmAliveTime);
+
+            int expectedTableVersion = tableVersion.Version - 1;
+
+            return TryTransaction(t => t
+                .setData("/", null, expectedTableVersion)
+                .create(rowPath, newRowData, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT)
+                .create(rowIAmAlivePath, newRowIAmAliveData, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT));
+        }
+
+        public Task<bool> UpdateRow(MembershipEntry entry, string etag, TableVersion tableVersion)
+        {
+            string rowPath = ConvertToRowPath(entry.SiloAddress);
+            string rowIAmAlivePath = ConvertToRowIAmAlivePath(entry.SiloAddress);
+            var newRowData = Serialize(entry);
+            var newRowIAmAliveData = Serialize(entry.IAmAliveTime);
+
+            int expectedTableVersion = tableVersion.Version - 1;
+            int expectedRowVersion = int.Parse(etag);
+
+            return TryTransaction(t => t
+                .setData("/", null, expectedTableVersion)
+                .setData(rowPath, newRowData, expectedRowVersion)
+                .setData(rowIAmAlivePath, newRowIAmAliveData, -1));
+        }
+
+        public Task UpdateIAmAlive(MembershipEntry entry)
+        {
+            string rowIAmAlivePath = ConvertToRowIAmAlivePath(entry.SiloAddress);
+            byte[] newRowIAmAliveData = Serialize(entry.IAmAliveTime);
+            return UsingZookeeper(zk => zk.setDataAsync(rowIAmAlivePath, newRowIAmAliveData, -1));
+        }
+
+        public async Task InitializeMembershipTable(GlobalConfiguration config, bool tryInitPath, TraceLogger traceLogger)
+        {
+            InitConfig(traceLogger, config.DataConnectionString, config.DeploymentId, config.TableRefreshTimeout);
+            // even if I am not the one who created the path, 
+            // try to insert an initial path if it is not already there,
+            // so we always have the path, before this silo starts working.
+            await UsingZookeeper(rootConnectionString, async zk =>
+            {
+                try
+                {
+                    await zk.createAsync(deploymentPath, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                    await zk.sync(deploymentPath);
+                    logger.Info("Created new deployment path.");
+                }
+                catch (KeeperException.NodeExistsException)
+                {
+                    logger.Verbose("Deployment path already exists.");
+                }
+            });
+        }
+
+        public IList<Uri> GetGateways()
+        {
+            return ReadAll().Result.Members.Select(entryWithTag => entryWithTag.Item1.SiloAddress.Endpoint.ToGatewayUri()).ToList();
+        }
+
+        public TimeSpan MaxStaleness
+        {
+            get { return maxStaleness; }
+        }
+
+        public bool IsUpdatable
+        {
+            get { return true; }
+        }
+
+        public Task DeleteMembershipTableEntries(string deploymentId)
+        {
+            string pathToDelete = "/" + deploymentId;
+            return UsingZookeeper(rootConnectionString, async zk =>
+            {
+                await ZKUtil.deleteRecursiveAsync(zk, pathToDelete);
+                await zk.sync(pathToDelete);
+            });
+        }
+
+        private async Task<bool> TryTransaction(Func<Transaction, Transaction> transactionFunc)
+        {
+            try
+            {
+                await UsingZookeeper(zk => transactionFunc(zk.transaction()).commitAsync());
+                return true;
+            }
+            catch (KeeperException e)
+            {
+                //these exceptions are thrown when the transaction fails to commit due to semantical reasons
+                if (e is KeeperException.NodeExistsException || e is KeeperException.NoNodeException ||
+                    e is KeeperException.BadVersionException)
+                {
+                    return false;
+                }
+                throw;
+            }
+        }
+
+        private static async Task<Tuple<MembershipEntry, string>> GetRow(ZooKeeper zk, SiloAddress siloAddress)
+        {
+            string rowPath = ConvertToRowPath(siloAddress);
+            string rowIAmAlivePath = ConvertToRowIAmAlivePath(siloAddress);
+
+            var rowDataTask = zk.getDataAsync(rowPath, false);
+            var rowIAmAliveDataTask = zk.getDataAsync(rowIAmAlivePath, false);
+
+            await Task.WhenAll(rowDataTask, rowIAmAliveDataTask);
+
+            MembershipEntry me = Deserialize<MembershipEntry>((await rowDataTask).Data);
+            me.IAmAliveTime = Deserialize<DateTime>((await rowIAmAliveDataTask).Data);
+
+            int rowVersion = (await rowDataTask).Stat.getVersion();
+
+            return new Tuple<MembershipEntry, string>(me, rowVersion.ToString());
+        }
+
+        private Task<T> UsingZookeeper<T>(Func<ZooKeeper, Task<T>> zkMethod)
+        {
+            return ZooKeeper.Using(deploymentConnectionString, ZOOKEEPER_CONNECTION_TIMEOUT, watcher, zkMethod);
+        }
+
+        private Task UsingZookeeper(string connectString, Func<ZooKeeper, Task> zkMethod)
+        {
+            return ZooKeeper.Using(connectString, ZOOKEEPER_CONNECTION_TIMEOUT, watcher, zkMethod);
+        }
+
+        private static string ConvertToRowPath(SiloAddress siloAddress)
+        {
+            return "/" + siloAddress.ToParsableString();
+        }
+
+        private static string ConvertToRowIAmAlivePath(SiloAddress siloAddress)
+        {
+            return ConvertToRowPath(siloAddress) + "/IAmAlive";
+        }
+
+        private static TableVersion ConvertToTableVersion(Stat stat)
+        {
+            int version = stat.getVersion();
+            return new TableVersion(version, version.ToString());
+        }
+
+        private static byte[] Serialize(object obj)
+        {
+            return
+                Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(obj, Formatting.None,
+                    MembershipSerializerSettings.Instance));
+        }
+
+        private static T Deserialize<T>(byte[] data)
+        {
+            return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(data), MembershipSerializerSettings.Instance);
+        }
+
+        /// <summary>
+        /// the state of every ZooKeeper client and its push notifications are published using watchers.
+        /// in orleans the watcher is only for debugging purposes
+        /// </summary>
+        private class ZooKeeperWatcher : Watcher
+        {
+            private readonly TraceLogger logger;
+            public ZooKeeperWatcher(TraceLogger traceLogger)
+            {
+                logger = traceLogger;
+            }
+
+            public override void process(WatchedEvent @event)
+            {
+                if (logger.IsVerbose)
+                {
+                    logger.Verbose(@event.ToString());
+                }
+            }
+        }
+    }
+}

--- a/src/OrleansZooKeeperUtils/packages.config
+++ b/src/OrleansZooKeeperUtils/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="ZooKeeperNetEx" version="3.4.6-alpha12" targetFramework="net45" />
+</packages>

--- a/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
+++ b/src/TesterInternal/StorageTests/AzureMembershipTableTests.cs
@@ -82,8 +82,8 @@ namespace UnitTests.StorageTests
                 DataConnectionString = StorageTestConstants.DataConnectionString
             };
 
-            membership = AzureBasedMembershipTable.GetMembershipTable(config, true)
-                .WaitForResultWithThrow(timeout);
+            membership = new AzureBasedMembershipTable();
+            membership.InitializeMembershipTable(config, true, logger).WaitWithThrow(timeout);
         }
 
         // Use TestCleanup to run code after each test has run

--- a/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
+++ b/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
@@ -122,6 +122,27 @@ namespace UnitTests.LivenessTests
             await MembershipTable_InsertRow(membership);
         }
 
+        [TestMethod, TestCategory("Liveness"), TestCategory("ZooKeeper")]
+        public async Task MT_Init_ZooKeeper()
+        {
+            var membership = await GetMembershipTable_ZooKeeper();
+            Assert.IsNotNull(membership, "Membership Table handler created");
+        }
+
+        [TestMethod, TestCategory("Liveness"), TestCategory("ZooKeeper")]
+        public async Task MT_ReadAll_ZooKeeper()
+        {
+            var membership = await GetMembershipTable_ZooKeeper();
+            await MembershipTable_ReadAll(membership);
+        }
+
+        [TestMethod, TestCategory("Liveness"), TestCategory("ZooKeeper")]
+        public async Task MT_InsertRow_ZooKeeper()
+        {
+            var membership = await GetMembershipTable_ZooKeeper();
+            await MembershipTable_InsertRow(membership);
+        }
+
         // Test function methods
 
         private async Task<IMembershipTable> GetMemebershipTable_Azure()
@@ -132,6 +153,11 @@ namespace UnitTests.LivenessTests
         private async Task<IMembershipTable> GetMemebershipTable_SQL()
         {
             return await GetMembershipTable(GlobalConfiguration.LivenessProviderType.SqlServer);
+        }
+
+        private async Task<IMembershipTable> GetMembershipTable_ZooKeeper()
+        {
+            return await GetMembershipTable(GlobalConfiguration.LivenessProviderType.ZooKeeper);
         }
 
 
@@ -196,6 +222,11 @@ namespace UnitTests.LivenessTests
                 case GlobalConfiguration.LivenessProviderType.SqlServer:
                     config.DataConnectionString = StorageTestConstants.GetSqlConnectionString(TestContext.DeploymentDirectory);
                     membership = new SqlMembershipTable();
+                    break;
+
+                case GlobalConfiguration.LivenessProviderType.ZooKeeper:
+                    config.DataConnectionString = StorageTestConstants.GetZooKeeperConnectionString();
+                    membership = AssemblyLoader.LoadAndCreateInstance<IMembershipTable>("OrleansZooKeeperUtils.dll",logger);
                     break;
 
                 default:

--- a/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
+++ b/src/TesterInternal/StorageTests/MembershipTablePluginTests.cs
@@ -41,6 +41,7 @@ namespace UnitTests.LivenessTests
         public TestContext TestContext { get; set; }
         private static int counter;
         private static string hostName;
+        private static readonly TraceLogger logger = TraceLogger.GetLogger("MembershipTablePluginTests");
 
         [ClassInitialize]
         public static void ClassInitialize(TestContext testContext)
@@ -189,18 +190,19 @@ namespace UnitTests.LivenessTests
             {
                 case GlobalConfiguration.LivenessProviderType.AzureTable:
                     config.DataConnectionString = StorageTestConstants.DataConnectionString;
-                    membership = await AzureBasedMembershipTable.GetMembershipTable(config, true);
+                    membership = new AzureBasedMembershipTable();
                     break;
 
                 case GlobalConfiguration.LivenessProviderType.SqlServer:
                     config.DataConnectionString = StorageTestConstants.GetSqlConnectionString(TestContext.DeploymentDirectory);
-                    membership = await SqlMembershipTable.GetMembershipTable(config, true);
+                    membership = new SqlMembershipTable();
                     break;
 
                 default:
                     throw new NotImplementedException(membershipType.ToString());
             }
 
+            await membership.InitializeMembershipTable(config, true, TraceLogger.GetLogger(membership.GetType().Name));
             return membership;
         }
     }

--- a/src/TesterInternal/StorageTests/ZookeeperMembershipTableTests.cs
+++ b/src/TesterInternal/StorageTests/ZookeeperMembershipTableTests.cs
@@ -1,0 +1,212 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Host;
+using Orleans.TestingHost;
+
+
+namespace UnitTests.StorageTests
+{
+    /// <summary>
+    /// Tests for operation of Orleans SiloInstanceManager using ZookeeperStore - Requires access to external Zookeeper storage
+    /// </summary>
+    [TestClass]
+    public class ZookeeperMembershipTableTests
+    {
+        public TestContext TestContext { get; set; }
+
+        private string deploymentId;
+        private int generation;
+        private SiloAddress siloAddress;
+        private IMembershipTable membership;
+        private static readonly TimeSpan timeout = TimeSpan.FromMinutes(1);
+        private readonly TraceLogger logger;
+
+        //this is because mstest doesn't copy the referenced dll if not used in the project
+#pragma warning disable 169
+        private static readonly ZooKeeperBasedMembershipTable hackToMakeCopy = null;
+#pragma warning restore 169
+
+        public ZookeeperMembershipTableTests()
+        {
+            logger = TraceLogger.GetLogger("ZookeeperMembershipTableTests", TraceLogger.LoggerType.Application);
+        }
+
+        // Use ClassInitialize to run code before running the first test in the class
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            TraceLogger.Initialize(new NodeConfiguration());        
+        }
+
+        // Use TestInitialize to run code before running each test 
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            deploymentId = "test-" + Guid.NewGuid();
+            generation = SiloAddress.AllocateNewGeneration();
+            siloAddress = SiloAddress.NewLocalAddress(generation);
+
+            logger.Info("DeploymentId={0} Generation={1}", deploymentId, generation);
+
+            GlobalConfiguration config = new GlobalConfiguration
+            {
+                DeploymentId = deploymentId,
+                DataConnectionString = StorageTestConstants.GetZooKeeperConnectionString()
+            };
+            membership = AssemblyLoader.LoadAndCreateInstance<IMembershipTable>("OrleansZooKeeperUtils.dll", logger);
+            membership.InitializeMembershipTable(config, true, logger).WaitWithThrow(timeout);
+        }
+
+        // Use TestCleanup to run code after each test has run
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            if (membership != null && SiloInstanceTableTestConstants.DeleteEntriesAfterTest)
+            {
+                membership.DeleteMembershipTableEntries(deploymentId).Wait();
+                membership = null;
+            }
+        }
+
+        [TestMethod, TestCategory("Nightly"), TestCategory("ZooKeeper"), TestCategory("Storage")]
+        public async Task ZookeeperMembership_ReadAll_0()
+        {
+            MembershipTableData data = await membership.ReadAll();
+            TableVersion tableVersion = data.Version;
+            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", tableVersion, data);
+
+            Assert.AreEqual(0, data.Members.Count, "Number of records returned - no table version row");
+
+            string eTag = tableVersion.VersionEtag;
+            int ver = tableVersion.Version;
+
+            Assert.IsNotNull(eTag, "ETag should not be null");
+            Assert.AreEqual(0, ver, "Initial tabel version should be zero");
+        }
+
+        [TestMethod, TestCategory("Nightly"), TestCategory("ZooKeeper"), TestCategory("Storage")]
+        public async Task ZookeeperMembership_ReadRow_0()
+        {
+            MembershipTableData data = await membership.ReadRow(siloAddress);
+            TableVersion tableVersion = data.Version;
+            logger.Info("Membership.ReadRow returned VableVersion={0} Data={1}", tableVersion, data);
+
+            Assert.AreEqual(0, data.Members.Count, "Number of records returned - no table version row");
+
+            string eTag = tableVersion.VersionEtag;
+            int ver = tableVersion.Version;
+
+            logger.Info("Membership.ReadRow returned MembershipEntry ETag={0} TableVersion={1}", eTag, tableVersion);
+
+            Assert.IsNotNull(eTag, "ETag should not be null");
+            Assert.AreEqual(0, ver, "Initial tabel version should be zero");
+        }
+
+        [TestMethod, TestCategory("Nightly"), TestCategory("ZooKeeper"), TestCategory("Storage")]
+        public async Task ZookeeperMembership_ReadRow_1()
+        {
+            MembershipTableData data = await membership.ReadAll();
+            TableVersion tableVersion = data.Version;
+            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", tableVersion, data);
+
+            Assert.AreEqual(0, data.Members.Count, "Number of records returned - no table version row");
+
+            DateTime now = DateTime.UtcNow;
+            MembershipEntry entry = new MembershipEntry
+            {
+                SiloAddress = siloAddress,
+                StartTime = now,
+                Status = SiloStatus.Active,
+            };
+
+            TableVersion newTableVersion = tableVersion.Next();
+            bool ok = await membership.InsertRow(entry, newTableVersion);
+
+            Assert.IsTrue(ok, "InsertRow completed successfully");
+
+            data = await membership.ReadRow(siloAddress);
+            tableVersion = data.Version;
+            logger.Info("Membership.ReadRow returned VableVersion={0} Data={1}", tableVersion, data);
+
+            Assert.AreEqual(1, data.Members.Count, "Number of records returned - data row only");
+
+            Assert.IsNotNull(tableVersion.VersionEtag, "New version ETag should not be null");
+            Assert.AreNotEqual(newTableVersion.VersionEtag, tableVersion.VersionEtag, "New VersionEtag differetnfrom last");
+            Assert.AreEqual(newTableVersion.Version, tableVersion.Version, "New table version number");
+
+            MembershipEntry MembershipEntry = data.Members[0].Item1;
+            string eTag = data.Members[0].Item2;
+            logger.Info("Membership.ReadRow returned MembershipEntry ETag={0} Entry={1}", eTag, MembershipEntry);
+
+            Assert.IsNotNull(eTag, "ETag should not be null");
+            Assert.IsNotNull(MembershipEntry, "MembershipEntry should not be null");
+        }
+
+        [TestMethod, TestCategory("Nightly"), TestCategory("ZooKeeper"), TestCategory("Storage")]
+        public async Task ZookeeperMembership_ReadAll_1()
+        {
+            MembershipTableData data = await membership.ReadAll();
+            TableVersion tableVersion = data.Version;
+            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", tableVersion, data);
+
+            Assert.AreEqual(0, data.Members.Count, "Number of records returned - no table version row");
+
+            DateTime now = DateTime.UtcNow;
+            MembershipEntry entry = new MembershipEntry
+            {
+                SiloAddress = siloAddress,
+                StartTime = now,
+                Status = SiloStatus.Active,
+            };
+
+            TableVersion newTableVersion = tableVersion.Next();
+            bool ok = await membership.InsertRow(entry, newTableVersion);
+
+            Assert.IsTrue(ok, "InsertRow completed successfully");
+
+            data = await membership.ReadAll();
+            tableVersion = data.Version;
+            logger.Info("Membership.ReadAll returned VableVersion={0} Data={1}", tableVersion, data);
+
+            Assert.AreEqual(1, data.Members.Count, "Number of records returned - data row only");
+
+            Assert.IsNotNull(tableVersion.VersionEtag, "New version ETag should not be null");
+            Assert.AreNotEqual(newTableVersion.VersionEtag, tableVersion.VersionEtag, "New VersionEtag differetnfrom last");
+            Assert.AreEqual(newTableVersion.Version, tableVersion.Version, "New table version number");
+
+            MembershipEntry MembershipEntry = data.Members[0].Item1;
+            string eTag = data.Members[0].Item2;
+            logger.Info("Membership.ReadAll returned MembershipEntry ETag={0} Entry={1}", eTag, MembershipEntry);
+
+            Assert.IsNotNull(eTag, "ETag should not be null");
+            Assert.IsNotNull(MembershipEntry, "MembershipEntry should not be null");
+        }
+    }
+}

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -82,6 +82,7 @@
     <Compile Include="StorageTests\AzureTableDataManagerTests.cs" />
     <Compile Include="StorageTests\SiloInstanceTableManagerTests.cs" />
     <Compile Include="StorageTests\AzureQueueDataManagerTests.cs" />
+    <Compile Include="StorageTests\ZookeeperMembershipTableTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj">
@@ -91,6 +92,10 @@
     <ProjectReference Include="..\OrleansTestingHost\OrleansTestingHost.csproj">
       <Project>{40ee3b00-d381-485f-9c69-ff706837deed}</Project>
       <Name>OrleansTestingHost</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OrleansZooKeeperUtils\OrleansZooKeeperUtils.csproj">
+      <Project>{45918dd2-53d9-4b27-bc6b-17c197dbc645}</Project>
+      <Name>OrleansZooKeeperUtils</Name>
     </ProjectReference>
     <ProjectReference Include="..\Orleans\Orleans.csproj">
       <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>


### PR DESCRIPTION
You can now run Orleans with a zookeeper membership table:
```xml
<SystemStore
      DataConnectionString="192.168.1.1;192.168.1.2;192.168.1.3"
      DeploymentId="BestDeploymentEver"
      SystemStoreType="ZooKeeper"/>
```

For testing, please copy [ZooKeeper 3.4.6 release](http://www.apache.org/dyn/closer.cgi/zookeeper/) to some local folder. then go to "conf" folder and rename zoo_sample.cfg to zoo.cfg. then go to the bin folder and run zkServer.cmd. this runs the server at 127.0.0.1:2181, which is the default address for the tests.

While integrating I came across some issues:
my first instinct was to create an "OrleansZooKeeperUtils" project, but that created circular dependencies since IMembershipTable & IGatewayListProvider live in Orleans.dll. . so for now it's where the SqlMembershipTable, in the Orleans.dll. Also, the Orleans.csproj file contains hard coded references in the CodeGenToolReferences property, which i edited manually to allow compilation.

Also, my implementation doesn't include reminders. Which might be better implemented using a different DB, maybe MySQL.  As far as i can tell, ZooKeeper is **perfect** for implementing the membership table. but the reminders interface requires range queries, that aren't natural for ZooKeeper. So, for now, i had to fallback to grain in memory reminders(which i am aware is not a solution).

Obviously, this integration should be cleaner. now i'll need your help.