### PR TITLE
Fix for issue #504 to allow Grain interface to extend from non-grain interfaces.

### DIFF
--- a/src/ClientGenerator/CodeGeneratorBase.cs
+++ b/src/ClientGenerator/CodeGeneratorBase.cs
@@ -125,9 +125,9 @@ namespace Orleans.CodeGeneration
         /// </summary>
         internal protected static bool IsGrainMethod(MethodInfo methodInfo, Type declaringType = null)
         {
-            var methodDeclaringGrainType = declaringType ?? methodInfo.DeclaringType;
-
             if (methodInfo == null) throw new ArgumentNullException("methodInfo", "Cannot inspect null method info");
+            
+            var methodDeclaringGrainType = declaringType ?? methodInfo.DeclaringType;
 
             // ignore static, event, or non-remote methods
             if (methodInfo.IsStatic || methodInfo.IsSpecialName || IsSpecialEventMethod(methodInfo))

--- a/src/ClientGenerator/CodeGeneratorBase.cs
+++ b/src/ClientGenerator/CodeGeneratorBase.cs
@@ -304,7 +304,7 @@ namespace Orleans.CodeGeneration
             private Dictionary<int, MethodInfo> GetGrainMethods()
             {
                 var grainMethods = new Dictionary<int, MethodInfo>();
-                foreach (var interfaceMethodInfo in GrainInterfaceData.GetMethods(InterfaceType))
+                foreach (var interfaceMethodInfo in GrainInterfaceData.GetGrainInterfaceMethods(InterfaceType, true))
                 {
                     ParameterInfo[] parameters = interfaceMethodInfo.GetParameters();
                     var args = new Type[parameters.Length];

--- a/src/ClientGenerator/CodeGeneratorBase.cs
+++ b/src/ClientGenerator/CodeGeneratorBase.cs
@@ -123,15 +123,17 @@ namespace Orleans.CodeGeneration
         /// <summary>
         /// Decide whether this method is a remote grain call method
         /// </summary>
-        internal protected static bool IsGrainMethod(MethodInfo methodInfo)
+        internal protected static bool IsGrainMethod(MethodInfo methodInfo, Type declaringType = null)
         {
+            var methodDeclaringGrainType = declaringType ?? methodInfo.DeclaringType;
+
             if (methodInfo == null) throw new ArgumentNullException("methodInfo", "Cannot inspect null method info");
 
             // ignore static, event, or non-remote methods
             if (methodInfo.IsStatic || methodInfo.IsSpecialName || IsSpecialEventMethod(methodInfo))
                 return false; // Methods which are derived from base class or object class, or property getter/setter methods
 
-            return methodInfo.DeclaringType.IsInterface && typeof(IAddressable).IsAssignableFrom(methodInfo.DeclaringType);
+            return methodDeclaringGrainType.IsInterface && typeof(IAddressable).IsAssignableFrom(methodDeclaringGrainType);
         }
         
         internal static CodeDomProvider GetCodeProvider(Language language, bool debug = false)
@@ -314,7 +316,7 @@ namespace Orleans.CodeGeneration
 
                     MethodInfo methodInfo = InterfaceType.GetMethod(interfaceMethodInfo.Name, args) ?? interfaceMethodInfo;
 
-                    if (IsGrainMethod(methodInfo))
+                    if (IsGrainMethod(methodInfo, InterfaceType))
                         grainMethods.Add(GrainInterfaceData.ComputeMethodId(methodInfo), methodInfo);
                 }
                 return grainMethods;

--- a/src/ClientGenerator/NamespaceGenerator.cs
+++ b/src/ClientGenerator/NamespaceGenerator.cs
@@ -252,7 +252,7 @@ namespace Orleans.CodeGeneration
             ReferencedNamespace.Imports.Add(new CodeNamespaceImport("System.IO"));
             ReferencedNamespace.Imports.Add(new CodeNamespaceImport("System.Collections.Generic"));
 
-            MethodInfo[] methods = GrainInterfaceData.GetMethods(interfaceData.Type);
+            MethodInfo[] methods = GrainInterfaceData.GetGrainInterfaceMethods(interfaceData.Type, true);
             AddMethods(methods, referenceClass, genericTypeParam, isObserver);
         }
 

--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -180,6 +180,12 @@ namespace Orleans.CodeGeneration
         /// <param name="bIncludeAllParentsMethods"></param>
         private static void GetInterfaceMethods(System.Type interfaceType, ref List<MethodInfo> methodInfos, bool bIncludeAllParentsMethods)
         {
+            if (!interfaceType.IsInterface)
+            {
+                throw new ArgumentException("Illegal argument: interfaceType. Must be an interface.");
+            }
+
+            //Default flags (BindingFlags.Public) for GetMethod works fine here given that interfaceType is an interface and not a class (Hence .Invoke and .Instance flags are not required).
             MethodInfo[] infos = interfaceType.GetMethods();
 
             IEqualityComparer<MethodInfo> methodComparer = new MethodInfoComparer();
@@ -192,7 +198,12 @@ namespace Orleans.CodeGeneration
                 var parentInterfaces = interfaceType.GetInterfaces();
                 foreach (var parent in parentInterfaces)
                 {
-                    GetInterfaceMethods(parent, ref methodInfos, bIncludeAllParentsMethods);
+                    //no need for recursion as .GetInterfaces() actually returns all parent interfaces at all levels.
+                    //GetInterfaceMethods(parent, ref methodInfos, bIncludeAllParentsMethods);
+                    infos = parent.GetMethods();
+                    foreach (var methodInfo in infos)
+                        if (!methodInfos.Contains(methodInfo, methodComparer))
+                            methodInfos.Add(methodInfo);        
                 }
             }
         }
@@ -238,7 +249,11 @@ namespace Orleans.CodeGeneration
                 var parentInterfaces = interfaceType.GetInterfaces();
                 foreach (var parent in parentInterfaces)
                 {
-                    GetInterfaceProperties(parent, ref propertyInfos, bIncludeAllParentsMethods);
+                    //no need for recursion as .GetInterfaces() actually returns all parent interfaces at all levels.
+                    //GetInterfaceProperties(parent, ref propertyInfos, bIncludeAllParentsMethods);
+                    foreach (var propInfo in infos)
+                        if (!propertyInfos.Contains(propInfo, propertyComparator))
+                            propertyInfos.Add(propInfo);
                 }
             }
         }

--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -198,8 +198,6 @@ namespace Orleans.CodeGeneration
                 var parentInterfaces = interfaceType.GetInterfaces();
                 foreach (var parent in parentInterfaces)
                 {
-                    //no need for recursion as .GetInterfaces() actually returns all parent interfaces at all levels.
-                    //GetInterfaceMethods(parent, ref methodInfos, bIncludeAllParentsMethods);
                     infos = parent.GetMethods();
                     foreach (var methodInfo in infos)
                         if (!methodInfos.Contains(methodInfo, methodComparer))
@@ -249,8 +247,6 @@ namespace Orleans.CodeGeneration
                 var parentInterfaces = interfaceType.GetInterfaces();
                 foreach (var parent in parentInterfaces)
                 {
-                    //no need for recursion as .GetInterfaces() actually returns all parent interfaces at all levels.
-                    //GetInterfaceProperties(parent, ref propertyInfos, bIncludeAllParentsMethods);
                     infos = parent.GetProperties();
                     foreach (var propInfo in infos)
                         if (!propertyInfos.Contains(propInfo, propertyComparator))

--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -251,6 +251,7 @@ namespace Orleans.CodeGeneration
                 {
                     //no need for recursion as .GetInterfaces() actually returns all parent interfaces at all levels.
                     //GetInterfaceProperties(parent, ref propertyInfos, bIncludeAllParentsMethods);
+                    infos = parent.GetProperties();
                     foreach (var propInfo in infos)
                         if (!propertyInfos.Contains(propInfo, propertyComparator))
                             propertyInfos.Add(propInfo);

--- a/src/TestGrainInterfaces/ISimpleGrainWithMultiInheritance.cs
+++ b/src/TestGrainInterfaces/ISimpleGrainWithMultiInheritance.cs
@@ -13,6 +13,9 @@ namespace UnitTests.GrainInterfaces
 
     public interface ISimpleServiceInterfaceA
     {
+        //Test: Uncommenting this property should throw compile error during code generation since Properties are not supported on grain interfaces.
+        //int A { get; set; }
+
         Task SetA(int a);
 
         Task IncrementA();

--- a/src/TestGrainInterfaces/ISimpleGrainWithMultiInheritance.cs
+++ b/src/TestGrainInterfaces/ISimpleGrainWithMultiInheritance.cs
@@ -1,0 +1,47 @@
+﻿using Orleans;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface ISimpleServiceInterfaceNoParentMethods
+    {
+    }
+
+    public interface ISimpleServiceInterfaceA
+    {
+        Task SetA(int a);
+
+        Task IncrementA();
+
+        Task<int> GetA();
+
+        //Test: Uncommenting this function should throw compile error during code generation since non-async functions are not allowed up the hierarchy for a Grain interface.
+        //int DecrementA();
+    }
+
+    public interface ISimpleServiceInterfaceB : ISimpleServiceInterfaceA
+    {
+        Task SetB(int b);
+
+        Task IncrementB();
+
+        Task<int> GetB();
+    }
+
+    public interface ISimpleGrainWithMultiInheritanceNoParentMehods : IGrain, ISimpleServiceInterfaceNoParentMethods 
+    {
+        //Test: To check for null pointer exception in the client generator if there are no methods.
+        //Should compile without error/warnings.
+    }
+
+    public interface ISimpleGrainWithMultiInheritance : IGrainWithIntegerKey, ISimpleServiceInterfaceB
+    {
+        Task SetC(int c);
+        Task IncrementC();
+        Task<int> GetC();
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -49,6 +49,7 @@
     <Compile Include="IMultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="ISampleStreamingGrain.cs" />
     <Compile Include="ISimpleGenericGrain.cs" />
+    <Compile Include="ISimpleGrainWithMultiInheritance.cs" />
     <Compile Include="ISimpleObserverableGrain.cs" />
     <Compile Include="IObserverGrain.cs" />
     <Compile Include="ISimpleGrain.cs" />

--- a/src/TestGrains/SimpleGrainWithMultiInheritance.cs
+++ b/src/TestGrains/SimpleGrainWithMultiInheritance.cs
@@ -1,0 +1,87 @@
+﻿using Orleans;
+using Orleans.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnitTests.GrainInterfaces;
+namespace UnitTests.Grains
+{
+    class SimpleGrainWithMultiInheritanceNoParentMethods : Grain, ISimpleGrainWithMultiInheritanceNoParentMehods
+    {
+    }
+
+    class SimpleGrainWithMultiInheritance : Grain, ISimpleGrainWithMultiInheritance
+    {
+        protected Logger logger;
+        protected int A { get; set; }
+        protected int B { get; set; }
+        protected int C { get; set; }
+
+        public override Task OnActivateAsync()
+        {
+            logger = GetLogger(String.Format("{0}-{1}-{2}", typeof(SimpleGrainWithMultiInheritance).Name, base.IdentityString, base.RuntimeIdentity));
+            logger.Info("Activate.");
+            return TaskDone.Done;
+        }
+
+        public Task SetA(int a)
+        {
+            logger.Info("SetA={0}", a);
+            A = a;
+            return TaskDone.Done;
+        }
+
+        public Task SetB(int b)
+        {
+            this.B = b;
+            return TaskDone.Done;
+        }
+
+        public Task SetC(int c)
+        {
+            this.C = c;
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetA()
+        {
+            return Task.FromResult(A);
+        }
+
+        public Task<int> GetB()
+        {
+            return Task.FromResult(B);
+        }
+
+        public Task<int> GetC()
+        {
+            return Task.FromResult(C);
+        }
+
+        public Task IncrementA()
+        {
+            A = A + 1;
+            return TaskDone.Done;
+        }
+
+        public Task IncrementB()
+        {
+            B = B + 1;
+            return TaskDone.Done;
+        }
+
+        public Task IncrementC()
+        {
+            C = C + 1;
+            return TaskDone.Done;
+        }
+
+        public override Task OnDeactivateAsync()
+        {
+            logger.Info("OnDeactivateAsync.");
+            return TaskDone.Done;
+        }
+    }
+}

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GenericGrains.cs" />
+    <Compile Include="SimpleGrainWithMultiInheritance.cs" />
     <Compile Include="SimpleGenericGrain.cs" />
     <Compile Include="MultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="ConcreteGrainsWithGenericInterfaces.cs" />
@@ -105,4 +106,3 @@
   <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
   <!--End Orleans -->
 </Project>
-

--- a/src/Tester/SimpleGrainTests.cs
+++ b/src/Tester/SimpleGrainTests.cs
@@ -92,5 +92,24 @@ namespace UnitTests.General
 
             Assert.AreEqual(12, x);
         }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task SimpleGrainWithMultiInheritance()
+        {
+            ISimpleGrainWithMultiInheritance grain = GrainFactory.GetGrain<ISimpleGrainWithMultiInheritance>(GetRandomGrainId());
+            int A = 10;
+            int B = 20;
+            int C = 30;
+            await grain.SetA(A);
+            await grain.SetB(B);
+            await grain.SetC(C);
+            await grain.IncrementA();
+            await grain.IncrementB();
+            await grain.IncrementC();
+
+            Assert.AreEqual(A + 1, await grain.GetA());
+            Assert.AreEqual(B + 1, await grain.GetB());
+            Assert.AreEqual(C + 1, await grain.GetC());
+        }
     }
 }


### PR DESCRIPTION
This will allow a Grain Interface to extend from a non-grain interface and the code generator will generate methods for all
inherited functions. 

This is required when a generic service interface is implemented using both a grain based implementation and some non-grain (non-orleans) implementation.
One example of such requirement within the Orleans runtime is the IReminderTable. There are implementations using AzureTable, SQL and a Grain based one. While only the Grain implementation requires the interface to be IGrain, without this fix the base IReminderTable interface has to be IGrain, which is counter intuitive since Azure and SQL based implementations are not really grains.

The fix is to explicitly traverse the inheritance tree and gather methods/properties at each level. Same interface validation rules are applied to all the parent interfaces, which implies a Grain Interface can extend only those interfaces with async functions. The reason for such explicit traversal is the way .NET handles interface inheritance. See (http://stackoverflow.com/questions/10550970/how-to-do-proper-reflection-of-base-interface-methods, http://www.roxolan.com/2009/04/interface-inheritance-in-c.html)