### PR TITLE
codegen for IGrain interface inherited methods

### DIFF
--- a/src/ClientGenerator/CodeGeneratorBase.cs
+++ b/src/ClientGenerator/CodeGeneratorBase.cs
@@ -131,7 +131,7 @@ namespace Orleans.CodeGeneration
             if (methodInfo.IsStatic || methodInfo.IsSpecialName || IsSpecialEventMethod(methodInfo))
                 return false; // Methods which are derived from base class or object class, or property getter/setter methods
 
-            return methodInfo.DeclaringType.IsInterface && typeof(IAddressable).IsAssignableFrom(methodInfo.DeclaringType);
+            return methodInfo.DeclaringType.IsInterface;
         }
         
         internal static CodeDomProvider GetCodeProvider(Language language, bool debug = false)

--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -146,7 +146,7 @@ namespace Orleans.CodeGeneration
             return typeof(IAddressable).IsAssignableFrom(t);
         }
         
-        public static MethodInfo[] GetMethods(Type grainType, bool bAllMethods = false)
+        public static MethodInfo[] GetMethods(Type grainType, bool bAllMethods = true)
         {
             var methodInfos = new List<MethodInfo>();
             GetMethodsImpl(grainType, grainType, methodInfos);
@@ -267,7 +267,7 @@ namespace Orleans.CodeGeneration
                     methodInfo.DeclaringType.GetInterfaceMap(i).TargetMethods.Contains(methodInfo)));
         }
 
-        public static Dictionary<int, Type> GetRemoteInterfaces(Type type)
+        public static Dictionary<int, Type> GetRemoteInterfaces(Type type, bool checkIsGrainInterface = true)
         {
             var dict = new Dictionary<int, Type>();
 
@@ -275,7 +275,7 @@ namespace Orleans.CodeGeneration
                 dict.Add(ComputeInterfaceId(type), type);
 
             Type[] interfaces = type.GetInterfaces();
-            foreach (Type interfaceType in interfaces.Where(IsGrainInterface))
+            foreach (Type interfaceType in interfaces.Where(i => !checkIsGrainInterface || IsGrainInterface(i)))
                 dict.Add(ComputeInterfaceId(interfaceType), interfaceType);
 
             return dict;
@@ -518,7 +518,7 @@ namespace Orleans.CodeGeneration
         /// <param name="methodInfos">Accumulated </param>
         private static void GetMethodsImpl(Type grainType, Type serviceType, List<MethodInfo> methodInfos)
         {
-            Type[] iTypes = GetRemoteInterfaces(serviceType).Values.ToArray();
+            Type[] iTypes = GetRemoteInterfaces(serviceType, false).Values.ToArray();
             IEqualityComparer<MethodInfo> methodComparer = new MethodInfoComparer();
 
             foreach (Type iType in iTypes)

--- a/src/TestGrainInterfaces/GrainInterfaceHierarchyIGrains.cs
+++ b/src/TestGrainInterfaces/GrainInterfaceHierarchyIGrains.cs
@@ -3,17 +3,29 @@ using Orleans;
 
 namespace TestGrainInterfaces
 {
-    public interface GrainInterfaceHierarchyIGrains
+    public interface IDoSomething
     {
         Task<string> DoIt();
+
+        Task SetA(int a);
+
+        Task IncrementA();
+
+        Task<int> GetA();
     }
 
-    public interface IDoSomethingWithMoreGrain : GrainInterfaceHierarchyIGrains, IGrainWithIntegerKey
+    public interface IDoSomethingWithMoreGrain : IDoSomething, IGrainWithIntegerKey
     {
         Task<string> DoThat();
+
+        Task SetB(int a);
+
+        Task IncrementB();
+
+        Task<int> GetB();
     }
 
-    public interface IDoSomethingEmptyGrain : GrainInterfaceHierarchyIGrains, IGrainWithIntegerKey
+    public interface IDoSomethingEmptyGrain : IDoSomething, IGrainWithIntegerKey
     {
     }
 
@@ -28,6 +40,11 @@ namespace TestGrainInterfaces
 
     public interface IDoSomethingCombinedGrain : IDoSomethingWithMoreGrain, IDoSomethingWithMoreEmptyGrain
     {
+        Task SetC(int a);
+
+        Task IncrementC();
+
+        Task<int> GetC();
     }
 
 }

--- a/src/TestGrainInterfaces/GrainInterfaceHierarchyIGrains.cs
+++ b/src/TestGrainInterfaces/GrainInterfaceHierarchyIGrains.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using Orleans;
+
+namespace TestGrainInterfaces
+{
+    public interface GrainInterfaceHierarchyIGrains
+    {
+        Task<string> DoIt();
+    }
+
+    public interface IDoSomethingWithMoreGrain : GrainInterfaceHierarchyIGrains, IGrainWithIntegerKey
+    {
+        Task<string> DoThat();
+    }
+
+    public interface IDoSomethingEmptyGrain : GrainInterfaceHierarchyIGrains, IGrainWithIntegerKey
+    {
+    }
+
+    public interface IDoSomethingEmptyWithMoreGrain : IDoSomethingEmptyGrain
+    {
+        Task<string> DoMore();
+    }
+
+    public interface IDoSomethingWithMoreEmptyGrain : IDoSomethingEmptyWithMoreGrain
+    {
+    }
+
+    public interface IDoSomethingCombinedGrain : IDoSomethingWithMoreGrain, IDoSomethingWithMoreEmptyGrain
+    {
+    }
+
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="IGenericInterfaces.cs" />
     <Compile Include="IMultipleSubscriptionConsumerGrain.cs" />
+    <Compile Include="GrainInterfaceHierarchyIGrains.cs" />
     <Compile Include="ISampleStreamingGrain.cs" />
     <Compile Include="ISimpleGenericGrain.cs" />
     <Compile Include="ISimpleObserverableGrain.cs" />

--- a/src/TestGrains/GrainInterfaceHierarchyGrains.cs
+++ b/src/TestGrains/GrainInterfaceHierarchyGrains.cs
@@ -1,0 +1,79 @@
+﻿
+using System.Threading.Tasks;
+using Orleans;
+using TestGrainInterfaces;
+
+namespace TestGrains
+{
+    public class DoSomethingEmptyGrain : Grain, IDoSomethingEmptyGrain
+    {
+        public Task<string> DoIt()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+    }
+
+    public class DoSomethingEmptyWithMoreGrain : Grain, IDoSomethingEmptyWithMoreGrain
+    {
+        public Task<string> DoIt()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+
+        public Task<string> DoMore()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+    }
+
+    public class DoSomethingWithMoreGrain : Grain, IDoSomethingWithMoreGrain
+    {
+        public Task<string> DoIt()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+
+        public Task<string> DoThat()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+
+        public Task<string> DoMore()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+    }
+
+    public class DoSomethingWithMoreEmptyGrain : Grain, IDoSomethingWithMoreEmptyGrain
+    {
+        public Task<string> DoIt()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+
+        public Task<string> DoMore()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+    }
+
+
+
+    public class DoSomethingCombinedGrain : Grain, IDoSomethingCombinedGrain
+    {
+        public Task<string> DoIt()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+
+        public Task<string> DoMore()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+
+        public Task<string> DoThat()
+        {
+            return Task.FromResult(GetType().Name);
+        }
+    }
+}

--- a/src/TestGrains/GrainInterfaceHierarchyGrains.cs
+++ b/src/TestGrains/GrainInterfaceHierarchyGrains.cs
@@ -7,14 +7,35 @@ namespace TestGrains
 {
     public class DoSomethingEmptyGrain : Grain, IDoSomethingEmptyGrain
     {
+        private int A;
+
         public Task<string> DoIt()
         {
             return Task.FromResult(GetType().Name);
+        }
+
+        public Task SetA(int a)
+        {
+            A = a;
+            return TaskDone.Done;
+        }
+
+        public Task IncrementA()
+        {
+            A++;
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetA()
+        {
+            return Task.FromResult(A);
         }
     }
 
     public class DoSomethingEmptyWithMoreGrain : Grain, IDoSomethingEmptyWithMoreGrain
     {
+        private int A;
+
         public Task<string> DoIt()
         {
             return Task.FromResult(GetType().Name);
@@ -24,10 +45,30 @@ namespace TestGrains
         {
             return Task.FromResult(GetType().Name);
         }
+
+        public Task SetA(int a)
+        {
+            A = a;
+            return TaskDone.Done;
+        }
+
+        public Task IncrementA()
+        {
+            A++;
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetA()
+        {
+            return Task.FromResult(A);
+        }
     }
 
     public class DoSomethingWithMoreGrain : Grain, IDoSomethingWithMoreGrain
     {
+        private int A;
+        private int B;
+
         public Task<string> DoIt()
         {
             return Task.FromResult(GetType().Name);
@@ -37,18 +78,67 @@ namespace TestGrains
         {
             return Task.FromResult(GetType().Name);
         }
-
-        public Task<string> DoMore()
+        
+        public Task SetA(int a)
         {
-            return Task.FromResult(GetType().Name);
+            A = a;
+            return TaskDone.Done;
         }
+
+        public Task IncrementA()
+        {
+            A++;
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetA()
+        {
+            return Task.FromResult(A);
+        }
+
+        public Task SetB(int b)
+        {
+            B = b;
+            return TaskDone.Done;
+        }
+
+        public Task IncrementB()
+        {
+            B++;
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetB()
+        {
+            return Task.FromResult(B);
+        }
+
     }
 
     public class DoSomethingWithMoreEmptyGrain : Grain, IDoSomethingWithMoreEmptyGrain
     {
+        private int A;
+
         public Task<string> DoIt()
         {
             return Task.FromResult(GetType().Name);
+        }
+
+        public Task SetA(int a)
+        {
+            A = a;
+            return TaskDone.Done;
+        }
+
+        public Task IncrementA()
+        {
+            A++;
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetA()
+        {
+            return Task.FromResult(A);
         }
 
         public Task<string> DoMore()
@@ -61,6 +151,10 @@ namespace TestGrains
 
     public class DoSomethingCombinedGrain : Grain, IDoSomethingCombinedGrain
     {
+        private int A;
+        private int B;
+        private int C;
+
         public Task<string> DoIt()
         {
             return Task.FromResult(GetType().Name);
@@ -74,6 +168,57 @@ namespace TestGrains
         public Task<string> DoThat()
         {
             return Task.FromResult(GetType().Name);
+        }
+
+        public Task SetA(int a)
+        {
+            A = a;
+            return TaskDone.Done;
+        }
+
+        public Task IncrementA()
+        {
+            A++;
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetA()
+        {
+            return Task.FromResult(A);
+        }
+
+        public Task SetB(int b)
+        {
+            B = b;
+            return TaskDone.Done;
+        }
+
+        public Task IncrementB()
+        {
+            B++;
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetB()
+        {
+            return Task.FromResult(B);
+        }
+
+        public Task SetC(int c)
+        {
+            C = c;
+            return TaskDone.Done;
+        }
+
+        public Task IncrementC()
+        {
+            C++;
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetC()
+        {
+            return Task.FromResult(C);
         }
     }
 }

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -63,6 +63,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="SimplePersistentGrain.cs" />
+    <Compile Include="GrainInterfaceHierarchyGrains.cs" />
     <Compile Include="SpecializedSimpleGenericGrain.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tester/GrainInterfaceHierarchyTests.cs
+++ b/src/Tester/GrainInterfaceHierarchyTests.cs
@@ -17,7 +17,7 @@ namespace Tester
         {
         }
 
-        private T GetHierarchyGrain<T>() where T : GrainInterfaceHierarchyIGrains, IGrainWithIntegerKey
+        private T GetHierarchyGrain<T>() where T : IDoSomething, IGrainWithIntegerKey
         {
             return GrainFactory.GetGrain<T>(GetRandomGrainId());
         }
@@ -71,6 +71,44 @@ namespace Tester
             Assert.AreEqual(await doSomething.DoIt(), "DoSomethingCombinedGrain");
             Assert.AreEqual(await doSomething.DoMore(), "DoSomethingCombinedGrain");
             Assert.AreEqual(await doSomething.DoThat(), "DoSomethingCombinedGrain");
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task DoSomethingValidateSingleGrainTest()
+        {
+            var doSomethingEmptyGrain = GetHierarchyGrain<IDoSomethingEmptyGrain>();
+            var doSomethingEmptyWithMoreGrain = GetHierarchyGrain<IDoSomethingEmptyWithMoreGrain>();
+            var doSomethingWithMoreEmptyGrain = GetHierarchyGrain<IDoSomethingWithMoreEmptyGrain>();
+            var doSomethingWithMoreGrain = GetHierarchyGrain<IDoSomethingWithMoreGrain>();
+            var doSomethingCombinedGrain = GetHierarchyGrain<IDoSomethingCombinedGrain>();
+
+            await doSomethingEmptyGrain.SetA(10);
+            await doSomethingEmptyWithMoreGrain.SetA(10);
+            await doSomethingWithMoreEmptyGrain.SetA(10);
+            await doSomethingWithMoreGrain.SetA(10);
+            await doSomethingWithMoreGrain.SetB(10);
+            await doSomethingCombinedGrain.SetA(10);
+            await doSomethingCombinedGrain.SetB(10);
+            await doSomethingCombinedGrain.SetC(10);
+
+            await doSomethingEmptyGrain.IncrementA();
+            await doSomethingEmptyWithMoreGrain.IncrementA();
+            await doSomethingWithMoreEmptyGrain.IncrementA();
+            await doSomethingWithMoreGrain.IncrementA();
+            await doSomethingWithMoreGrain.IncrementB();
+            await doSomethingCombinedGrain.IncrementA();
+            await doSomethingCombinedGrain.IncrementB();
+            await doSomethingCombinedGrain.IncrementC();
+
+            Assert.AreEqual(await doSomethingEmptyGrain.GetA(), 11);
+            Assert.AreEqual(await doSomethingEmptyWithMoreGrain.GetA(), 11);
+            Assert.AreEqual(await doSomethingWithMoreEmptyGrain.GetA(), 11);
+            Assert.AreEqual(await doSomethingWithMoreGrain.GetA(), 11);
+            Assert.AreEqual(await doSomethingWithMoreGrain.GetB(), 11);
+            Assert.AreEqual(await doSomethingCombinedGrain.GetA(), 11);
+            Assert.AreEqual(await doSomethingCombinedGrain.GetB(), 11);
+            Assert.AreEqual(await doSomethingCombinedGrain.GetC(), 11);
+
         }
     }
 }

--- a/src/Tester/GrainInterfaceHierarchyTests.cs
+++ b/src/Tester/GrainInterfaceHierarchyTests.cs
@@ -1,0 +1,76 @@
+﻿
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.TestingHost;
+using TestGrainInterfaces;
+using UnitTests.Tester;
+
+namespace Tester
+{
+    [TestClass]
+    public class GrainInterfaceHierarchyTests : UnitTestSiloHost
+    {
+
+        public GrainInterfaceHierarchyTests()
+            : base(new TestingSiloOptions {StartPrimary = true, StartSecondary = false})
+        {
+        }
+
+        private T GetHierarchyGrain<T>() where T : GrainInterfaceHierarchyIGrains, IGrainWithIntegerKey
+        {
+            return GrainFactory.GetGrain<T>(GetRandomGrainId());
+        }
+
+        private static int GetRandomGrainId()
+        {
+            return random.Next();
+        }
+
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task DoSomethingGrainEmptyTest()
+        {
+            IDoSomethingEmptyGrain doSomething = GetHierarchyGrain<IDoSomethingEmptyGrain>();
+            Assert.AreEqual(await doSomething.DoIt(), "DoSomethingEmptyGrain");
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task DoSomethingGrainEmptyWithMoreTest()
+        {
+            IDoSomethingEmptyWithMoreGrain doSomething = GetHierarchyGrain<IDoSomethingEmptyWithMoreGrain>();
+            Assert.AreEqual(await doSomething.DoIt(), "DoSomethingEmptyWithMoreGrain");
+            Assert.AreEqual(await doSomething.DoMore(), "DoSomethingEmptyWithMoreGrain");
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task DoSomethingWithMoreEmptyGrainTest()
+        {
+            IDoSomethingWithMoreEmptyGrain doSomething = GetHierarchyGrain<IDoSomethingWithMoreEmptyGrain>();
+            Assert.AreEqual(await doSomething.DoIt(), "DoSomethingWithMoreEmptyGrain");
+            Assert.AreEqual(await doSomething.DoMore(), "DoSomethingWithMoreEmptyGrain");
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task DoSomethingWithMoreGrainTest()
+        {
+            IDoSomethingWithMoreGrain doSomething = GetHierarchyGrain<IDoSomethingWithMoreGrain>();
+            Assert.AreEqual(await doSomething.DoIt(), "DoSomethingWithMoreGrain");
+            Assert.AreEqual(await doSomething.DoThat(), "DoSomethingWithMoreGrain");
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task DoSomethingCombinedGrainTest()
+        {
+            IDoSomethingCombinedGrain doSomething = GetHierarchyGrain<IDoSomethingCombinedGrain>();
+            Assert.AreEqual(await doSomething.DoIt(), "DoSomethingCombinedGrain");
+            Assert.AreEqual(await doSomething.DoMore(), "DoSomethingCombinedGrain");
+            Assert.AreEqual(await doSomething.DoThat(), "DoSomethingCombinedGrain");
+        }
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <Compile Include="ConcreteStateClassTests.cs" />
     <Compile Include="GenericGrainTests.cs" />
+    <Compile Include="GrainInterfaceHierarchyTests.cs" />
     <Compile Include="ObserverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">


### PR DESCRIPTION
this is a small change in code, but big on implications. IMHO this should be the default.