### PR TITLE
Issue a compile time warning if a class implements IGrain but does not extend the base Grain or Grain<T> class.

### DIFF
--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -122,6 +122,19 @@ namespace Orleans.CodeGeneration
 
         public static GrainInterfaceData FromGrainClass(Type grainType, Language language)
         {
+            IEnumerable<string> grainViolations;
+            IEnumerable<string> systemTargetViolations;
+            if (!TypeUtils.IsConcreteGrainClass(grainType, out grainViolations, true) &&
+                !TypeUtils.IsSystemTargetClass(grainType, out systemTargetViolations, true))
+            {
+                List<string> violations = new List<string>();
+                if (grainViolations != null)
+                    violations.AddRange(grainViolations);
+                else if (systemTargetViolations != null)
+                    violations.AddRange(systemTargetViolations);
+
+                throw new RulesViolationException(String.Format("{0} implements IGrain but is not a concrete Grain Class (Hint: Extend the base Grain or Grain<T> class).", grainType.FullName), violations);
+            }
             var gi = new GrainInterfaceData(language) { Type = grainType };
             gi.DefineClassNames(false);
             return gi;
@@ -141,7 +154,7 @@ namespace Orleans.CodeGeneration
             return typeof (IAddressable).IsAssignableFrom(t);
         }
 
-        public static bool IsGrainReference(Type t)
+        public static bool IsAddressable(Type t)
         {
             return typeof(IAddressable).IsAssignableFrom(t);
         }

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -310,10 +310,20 @@ namespace Orleans.Runtime
             return !IsGeneratedType(type);
         }
 
-        public static bool IsSystemTargetClass(Type type)
+        internal static bool IsSystemTargetClass(Type type)
+        {
+            IEnumerable<string> violations;
+            return IsSystemTargetClass(type, out violations, false);
+        }
+
+        public static bool IsSystemTargetClass(Type type, out IEnumerable<string> violations, bool complain)
         {
             Type systemTargetType;
-            if (!TryResolveType("Orleans.Runtime.SystemTarget", out systemTargetType)) return false; 
+            violations = null;
+            if (!TryResolveType("Orleans.Runtime.SystemTarget", out systemTargetType)) {
+                //no need to add violation here, since it might be a Grain (or will be caught by the corresponding violation)
+                return false;
+            }
 
             var systemTargetInterfaceType = typeof(ISystemTarget);
             var systemTargetBaseInterfaceType = typeof(ISystemTargetBase);
@@ -324,22 +334,47 @@ namespace Orleans.Runtime
                 systemTargetBaseInterfaceType = ToReflectionOnlyType(systemTargetBaseInterfaceType);
             }
 
-            if (!systemTargetInterfaceType.IsAssignableFrom(type) || 
-                !systemTargetBaseInterfaceType.IsAssignableFrom(type) || 
-                !systemTargetType.IsAssignableFrom(type)) return false;
+            if (!systemTargetInterfaceType.IsAssignableFrom(type) ||
+                !systemTargetBaseInterfaceType.IsAssignableFrom(type) ||
+                !systemTargetType.IsAssignableFrom(type))
+            {
+                if (complain)
+                {
+                    violations = new string[] { String.Format("Class {0} extends IGrain but is not a concrete Grain class or a System Target. Hint: Extend from base Grain or Grain<T>.", type.FullName) };
+                }
+                return false;
+            }
 
             // exclude generated classes.
-            return !IsGeneratedType(type);
+            if (IsGeneratedType(type))
+            {
+                if (complain)
+                {
+                    violations = new string[] { String.Format("Ignoring {0}, as it is an auto-generated class.", type.FullName) };
+                }
+                return false;
+            }
+            return true;
         }
 
         public static bool IsConcreteGrainClass(Type type, out IEnumerable<string> complaints, bool complain)
         {
-            complaints = null;
-            if (!IsGrainClass(type)) return false;
-            if (!type.IsAbstract) return true;
+            var violations = new List<String>();
+            bool success = true;
+            if (!IsGrainClass(type))
+            {
+                violations.Add(string.Format("Class {0} extends IGrain but is not a concrete Grain class. Hint: Extend from base Grain or Grain<T>", type.FullName));
+                success = false;
+            }
 
-            complaints = complain ? new [] { string.Format("Grain type {0} is abstract and cannot be instantiated.", type.FullName) } : null;
-            return false;
+            if (type.IsAbstract)
+            {
+                violations.Add(string.Format("Grain type {0} is abstract and cannot be instantiated.", type.FullName));
+                success = false;
+            }
+
+            complaints = complain && !success ? violations.AsEnumerable() : null;
+            return success;
         }
 
         public static bool IsConcreteGrainClass(Type type, out IEnumerable<string> complaints)


### PR DESCRIPTION
Fixes #492. The fix validate during code generation (for grain implementations) if all grain classes extend Grain or Grain<T> base classes, otherwise issue a compile time warning.

As a result of the fix, there were some compile warning in the orleans runtime:
1. IReminderTable is marked as IGrain because one of the implementations (GrainBasedReminderTable) is a grain while others e.g. Azure, SQL based are not.
2. Similarly for IMembershipTable interface.
Refactored the code so that the base IReminderTable and IMembershipTable interfaces are not IGrain and created a IReminderTableGrain and IMembershipTableGrain interfaces which are used by the GrainBased classes.

There was also an interface:
internal interface IGrainRingRangeListener : IGrain
Need to confirm with @gabikliot  if this really needs be IGrain?
It seems like this is neither a Grain class nor a SystemTarget and hence need not be IGrain. If in future, Grain based implementation is required, we can follow a pattern as above to create that implementation.

