### PR TITLE
Refactored IMembershipTable and IReminderTable hierarchy to remove dependence on IGrain where not required.

### DIFF
--- a/src/Orleans/Runtime/IConsistentRingProviderForGrains.cs
+++ b/src/Orleans/Runtime/IConsistentRingProviderForGrains.cs
@@ -42,20 +42,21 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="observer">An observer interface to receive range change notifications.</param>
         /// <returns>bool value indicating that subscription succeeded or not.</returns>
-        bool SubscribeToRangeChangeEvents(IGrainRingRangeListener observer);
+        bool SubscribeToRangeChangeEvents(IAsyncRingRangeListener observer);
 
         /// <summary>
         /// Unsubscribe from receiving range change notifications
         /// </summary>
         /// <param name="observer">An observer interface to receive range change notifications.</param>
         /// <returns>bool value indicating that unsubscription succeeded or not</returns>
-        bool UnSubscribeFromRangeChangeEvents(IGrainRingRangeListener observer);
+        bool UnSubscribeFromRangeChangeEvents(IAsyncRingRangeListener observer);
     }
 
     // This has to be a separate interface, not polymorphic with IRingRangeListener,
     // since IRingRangeListener is implemented by SystemTarget and thus if it becomes grain interface 
     // it would need to be system target interface (with SiloAddress as first argument).
-    internal interface IGrainRingRangeListener : IGrain
+    // Renamed from IGrainRingRangeListener to IAsyncRingRangeListener and removed inheritance from IGrain.
+    internal interface IAsyncRingRangeListener
     {
         Task RangeChangeNotification(IRingRange old, IRingRange now);
     }

--- a/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
@@ -34,8 +34,9 @@ namespace Orleans
     /// <summary>
     /// Interface for Membership Table.
     /// </summary>
-    [Unordered]
-    public interface IMembershipTable : IGrain
+    //Removing the inheritance from IGrain since it is not applicable to all implementations of IMembershipTable. 
+    //Instead, creating a new interface IMembershipTableGrain which extends this one and will be used by the grain based implementation.    
+    public interface IMembershipTable
     {
         /// <summary>
         /// Initializes the membership table, will be called before all other methods
@@ -119,7 +120,16 @@ namespace Orleans
         /// <returns>Task representing the successful execution of this operation. </returns>
         Task UpdateIAmAlive(MembershipEntry entry);
     }
-    
+
+    /// <summary>
+    /// Membership table interface for grain based implementation.
+    /// </summary>
+    [Unordered]
+    public interface IMembershipTableGrain : IGrain, IMembershipTable
+    {
+        
+    }
+
     [Serializable]
     [Immutable]
     public class TableVersion

--- a/src/Orleans/SystemTargetInterfaces/IReminderTable.cs
+++ b/src/Orleans/SystemTargetInterfaces/IReminderTable.cs
@@ -35,8 +35,9 @@ namespace Orleans
     /// Azure Table, SQL, development emulator grain, and a mock implementation.
     /// Defined as a grain interface for the development emulator grain case.
     /// </summary>
-    [Unordered]
-    internal interface IReminderTable : IGrainWithIntegerKey
+    //Removing the inheritance from IGrain since it is not applicable to all implementations of IReminderTable. 
+    //Instead, creating a new interface IReminderTableGrain which extends this one and will be used by the grain based implementation.    
+    internal interface IReminderTable
     {
         Task Init(Guid serviceId, string deploymentId, string connectionString);
 
@@ -64,6 +65,15 @@ namespace Orleans
         Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag);
 
         Task TestOnlyClearTable();
+    }
+
+    /// <summary>
+    /// Reminder table interface for grain based implementation.
+    /// </summary>
+    [Unordered]
+    internal interface IReminderTableGrain : IGrainWithIntegerKey, IReminderTable
+    {
+        
     }
 
     internal class ReminderTableData

--- a/src/OrleansRuntime/ConsistentRing/EquallyDevidedRangeRingProvider.cs
+++ b/src/OrleansRuntime/ConsistentRing/EquallyDevidedRangeRingProvider.cs
@@ -32,7 +32,7 @@ namespace Orleans.Runtime.ConsistentRing
     internal class EquallyDevidedRangeRingProvider : IConsistentRingProviderForGrains, IRingRangeListener
     {
         private readonly IConsistentRingProvider ringProvider;
-        private readonly List<IGrainRingRangeListener> grainStatusListeners;
+        private readonly List<IAsyncRingRangeListener> grainStatusListeners;
         private readonly TraceLogger logger;
         private readonly int numSubRanges;
         private readonly int mySubRangeIndex;
@@ -46,7 +46,7 @@ namespace Orleans.Runtime.ConsistentRing
             ringProvider = provider;
             this.numSubRanges = numSubRanges;
             this.mySubRangeIndex = mySubRangeIndex;
-            grainStatusListeners = new List<IGrainRingRangeListener>();
+            grainStatusListeners = new List<IAsyncRingRangeListener>();
             ringProvider.SubscribeToRangeChangeEvents(this);
             logger = TraceLogger.GetLogger(typeof(EquallyDevidedRangeRingProvider).Name);
         }
@@ -62,7 +62,7 @@ namespace Orleans.Runtime.ConsistentRing
             return equallyDevidedMultiRange.GetSubRange(mySubRangeIndex);
         }
 
-        public bool SubscribeToRangeChangeEvents(IGrainRingRangeListener observer)
+        public bool SubscribeToRangeChangeEvents(IAsyncRingRangeListener observer)
         {
             lock (grainStatusListeners)
             {
@@ -73,7 +73,7 @@ namespace Orleans.Runtime.ConsistentRing
             }
         }
 
-        public bool UnSubscribeFromRangeChangeEvents(IGrainRingRangeListener observer)
+        public bool UnSubscribeFromRangeChangeEvents(IAsyncRingRangeListener observer)
         {
             lock (grainStatusListeners)
             {
@@ -98,12 +98,12 @@ namespace Orleans.Runtime.ConsistentRing
 
             logger.Info("-NotifyLocal GrainRangeSubscribers about old {0} and new {1} increased? {2}.", oldSubRange.ToString(), newSubRange.ToString(), increased);
 
-            List<IGrainRingRangeListener> copy;
+            List<IAsyncRingRangeListener> copy;
             lock (grainStatusListeners)
             {
                 copy = grainStatusListeners.ToList();
             }
-            foreach (IGrainRingRangeListener listener in copy)
+            foreach (IAsyncRingRangeListener listener in copy)
             {
                 try
                 {

--- a/src/OrleansRuntime/MembershipService/GrainBasedMembershipTable.cs
+++ b/src/OrleansRuntime/MembershipService/GrainBasedMembershipTable.cs
@@ -29,7 +29,7 @@ using Orleans.Runtime.Configuration;
 namespace Orleans.Runtime.MembershipService
 {
     [Reentrant]
-    internal class GrainBasedMembershipTable : Grain, IMembershipTable
+    internal class GrainBasedMembershipTable : Grain, IMembershipTableGrain
     {
         private InMemoryMembershipTable table;
         private TraceLogger logger;

--- a/src/OrleansRuntime/MembershipService/MembershipFactory.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipFactory.cs
@@ -67,7 +67,7 @@ namespace Orleans.Runtime.MembershipService
             if (livenessType.Equals(GlobalConfiguration.LivenessProviderType.MembershipTableGrain))
             {
                 membershipTable =
-                    GrainFactory.Cast<IMembershipTable>(GrainReference.FromGrainId(Constants.SystemMembershipTableId));
+                    GrainFactory.Cast<IMembershipTableGrain>(GrainReference.FromGrainId(Constants.SystemMembershipTableId));
             }
             else
             {

--- a/src/OrleansRuntime/ReminderService/GrainBasedReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/GrainBasedReminderTable.cs
@@ -30,7 +30,7 @@ using Orleans.Concurrency;
 namespace Orleans.Runtime.ReminderService
 {
     [Reentrant]
-    internal class GrainBasedReminderTable : Grain, IReminderTable
+    internal class GrainBasedReminderTable : Grain, IReminderTableGrain
     {
         private InMemoryRemindersTable remTable;
         private TraceLogger logger;

--- a/src/OrleansRuntime/ReminderService/ReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/ReminderTable.cs
@@ -56,7 +56,7 @@ namespace Orleans.Runtime.ReminderService
                     return;
 
                 case GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain:
-                    Singleton = grainFactory.GetGrain<IReminderTable>(Constants.ReminderTableGrainId);
+                    Singleton = grainFactory.GetGrain<IReminderTableGrain>(Constants.ReminderTableGrainId);
                     return;
 
                 case GlobalConfiguration.ReminderServiceProviderType.MockTable:

--- a/src/OrleansRuntime/Streams/QueueBalancer/ConsistentRingQueueBalancer.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/ConsistentRingQueueBalancer.cs
@@ -29,7 +29,7 @@ using Orleans.Runtime;
 
 namespace Orleans.Streams
 {
-    internal class ConsistentRingQueueBalancer : IGrainRingRangeListener, IStreamQueueBalancer
+    internal class ConsistentRingQueueBalancer : IAsyncRingRangeListener, IStreamQueueBalancer
     {
         private readonly List<IStreamQueueBalanceListener> queueBalanceListeners = new List<IStreamQueueBalanceListener>();
         private readonly IConsistentRingStreamQueueMapper streamQueueMapper;


### PR DESCRIPTION
Refactoring IReminderTable and IMembershipTable interfaces to remove
dependce on IGrain interface. This cleans up the code so that only grain based implementations are marked as IGrain and others such as Azure or SQL are not. 
Also, removed IGrain inheritance for IGrainRingRangeListener since it no longer requires that and renamed it to IAsyncRingRangeListener.