### PR TITLE
NotImplementedReminderTable to disable reminders

### DIFF
--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -93,6 +93,8 @@ namespace Orleans.Runtime.Configuration
             SqlServer,
             /// <summary>Used for benchmarking; it simply delays for a specified delay during each operation.</summary>
             MockTable,
+            /// <summary>Used to disable reminders. Throws a NotImplementedException when a grain upserts or removes reminders.</summary>
+            NotImplemented
         }
 
         /// <summary>
@@ -595,7 +597,7 @@ namespace Orleans.Runtime.Configuration
                                 ReminderServiceProviderType reminderServiceProviderType;
                                 SetReminderServiceType(Enum.TryParse(sst, out reminderServiceProviderType)
                                     ? reminderServiceProviderType
-                                    : ReminderServiceProviderType.ReminderTableGrain);
+                                    : ReminderServiceProviderType.NotImplemented);
                             }
                         }
                         if (child.HasAttribute("ServiceId"))

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -110,6 +110,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="ReminderService\MockReminderTable.cs" />
+    <Compile Include="ReminderService\NotImplementedReminderTable.cs" />
     <Compile Include="Scheduler\ITaskScheduler.cs" />
     <Compile Include="Storage\IStorageProviderManager.cs" />
     <Compile Include="Silo\SiloHost.cs" />

--- a/src/OrleansRuntime/ReminderService/NotImplementedReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/NotImplementedReminderTable.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.ReminderService
+{
+    internal class NotImplementedReminderTable:IReminderTable
+    {
+        private static readonly Task<ReminderTableData> emptyReminderTableDataTask = Task.FromResult(new ReminderTableData());
+        private static readonly Task<ReminderEntry> emptyReminderEntryTask = Task.FromResult(new ReminderEntry());
+
+        public Task Init(Guid serviceId, string deploymentId, string connectionString)
+        {
+            return TaskDone.Done;
+        }
+
+        public Task<ReminderTableData> ReadRows(GrainReference key)
+        {
+            return emptyReminderTableDataTask;
+        }
+
+        public Task<ReminderTableData> ReadRows(uint begin, uint end)
+        {
+            return emptyReminderTableDataTask;
+        }
+
+        public Task<ReminderEntry> ReadRow(GrainReference grainRef, string reminderName)
+        {
+            return emptyReminderEntryTask;
+        }
+
+        public Task<string> UpsertRow(ReminderEntry entry)
+        {
+            throw new NotImplementedException("Reminders are not supported when ReminderServiceProviderType=NotImplemented");
+        }
+
+        public Task<bool> RemoveRow(GrainReference grainRef, string reminderName, string eTag)
+        {
+            throw new NotImplementedException("Reminders are not supported when ReminderServiceProviderType=NotImplemented");
+        }
+
+        public Task TestOnlyClearTable()
+        {
+            return TaskDone.Done;
+        }
+    }
+}

--- a/src/OrleansRuntime/ReminderService/ReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/ReminderTable.cs
@@ -62,6 +62,9 @@ namespace Orleans.Runtime.ReminderService
                 case GlobalConfiguration.ReminderServiceProviderType.MockTable:
                     Singleton = new MockReminderTable(config.MockReminderTableTimeout);
                     return;
+                case GlobalConfiguration.ReminderServiceProviderType.NotImplemented:
+                    Singleton = new NotImplementedReminderTable();
+                    return;
             }
         }
 


### PR DESCRIPTION
When using ZooKeeper as a membership provider , the reminders provider is set to GrainBasedReminderTable (as a fallback). This seemed to work fine. But it doesn't.
The scenario:
1) 5 silos are started as secondary and are active in the same deployment. (named Silo1-Silo5)
2) all silos crash
3) Silo1 is restarted
4) Silo1 adds a suspected dead entry for Silo2-Silo5
5) Silo1 tries to get the grain for the GrainBasedReminderTable.
6) the hash result says that Silo3 knows where the GrainBasedReminderTable is.
7) Silo1 suspicion isn't enough to change the ring. 
8) Silo1 can't start its reminder service and crashes. This happens continuously until enough silos are started and the membership table reflects reality.

I've added a NotImplementedReminderTable reminder table implementation that just throws when reminders are used by grains. IMO this is much better than the fallback to GrainBasedReminderTable, which gives grains the illusion of persistent storage which in reality doesn't exist.