### PR TITLE
Set Reminder Type to Disabled in case of Zookeper System store.

### DIFF
--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -192,6 +192,10 @@ namespace Orleans.Runtime.Configuration
                 {
                     Globals.SetReminderServiceType(GlobalConfiguration.ReminderServiceProviderType.AzureTable);
                 }
+                else if (Globals.UseZooKeeperSystemStore)
+                {
+                    Globals.SetReminderServiceType(GlobalConfiguration.ReminderServiceProviderType.Disabled);
+                }
                 else
                 {
                     Globals.SetReminderServiceType(GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain);

--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -93,6 +93,8 @@ namespace Orleans.Runtime.Configuration
             SqlServer,
             /// <summary>Used for benchmarking; it simply delays for a specified delay during each operation.</summary>
             MockTable,
+            /// <summary>Reminder Service is disabled.</summary>
+            Disabled,
         }
 
         /// <summary>
@@ -595,7 +597,7 @@ namespace Orleans.Runtime.Configuration
                                 ReminderServiceProviderType reminderServiceProviderType;
                                 SetReminderServiceType(Enum.TryParse(sst, out reminderServiceProviderType)
                                     ? reminderServiceProviderType
-                                    : ReminderServiceProviderType.ReminderTableGrain);
+                                    : ReminderServiceProviderType.Disabled);
                             }
                         }
                         if (child.HasAttribute("ServiceId"))

--- a/src/OrleansRuntime/Core/InsideGrainClient.cs
+++ b/src/OrleansRuntime/Core/InsideGrainClient.cs
@@ -694,11 +694,13 @@ namespace Orleans.Runtime
 
         private void CheckValidReminderServiceType(string doingWhat)
         {
-            if (Config.Globals.ReminderServiceType.Equals(GlobalConfiguration.ReminderServiceProviderType.NotSpecified))
+            var remType = Config.Globals.ReminderServiceType;
+            if (remType.Equals(GlobalConfiguration.ReminderServiceProviderType.NotSpecified) ||
+                remType.Equals(GlobalConfiguration.ReminderServiceProviderType.Disabled))
             {
                 throw new InvalidOperationException(
                     string.Format("Cannot {0} when ReminderServiceProviderType is {1}",
-                    doingWhat, GlobalConfiguration.ReminderServiceProviderType.NotSpecified));
+                    doingWhat, remType));
             }
         }
 


### PR DESCRIPTION
Disable Reminders if ZK is used for system store.
This is instead of #535.
As opposite to #535, this code will throw earlier, on the caller, if reminders are used from the grain when running with ZK system store.
