### PR TITLE
ZK MBR documentation,tweaks and new ZooKeeperNetEx

### DIFF
--- a/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
+++ b/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
@@ -61,7 +61,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="ZooKeeperNetEx, Version=3.4.6.0, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeperNetEx.3.4.6-alpha12\lib\net45\ZooKeeperNetEx.dll</HintPath>
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.6-alpha17\lib\net45\ZooKeeperNetEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
+++ b/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
@@ -23,6 +23,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -34,6 +35,26 @@ using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.Host
 {
+    /// <summary>
+    /// A Membership Table implementation using Apache Zookeeper 3.4.6 https://zookeeper.apache.org/doc/r3.4.6/
+    /// </summary>
+    /// <remarks>
+    /// A brief overview of ZK features used: The data is represented by a tree of nodes (similar to a file system). 
+    /// Every node is addressed by a path and can hold data as a byte array and has a version. When a node is created, 
+    /// its version is 0. Upon updates, the version is atomically incremented. An update can also be conditional on an 
+    /// expected current version. A transaction can hold several operations, which succeed or fail atomically.
+    /// when creating a zookeeper client, one can set a base path where all operations are relative to.
+    /// 
+    /// In this implementation:
+    /// Every Orleans deployment has a node   /UniqueDeploymentId
+    /// Every Silo's state is saved in        /UniqueDeploymentId/IP:Port@Gen
+    /// Every Silo's IAmAlive is saved in     /UniqueDeploymentId/IP:Port@Gen/IAmAlive
+    /// IAmAlive is saved in a separate node because its updates are unconditional.
+    /// 
+    /// a node's ZK version is its ETag:
+    /// the table version is the version of /UniqueDeploymentId
+    /// the silo entry version is the version of /UniqueDeploymentId/IP:Port@Gen
+    /// </remarks>
     public class ZooKeeperBasedMembershipTable : IMembershipTable, IGatewayListProvider
     {
         private TraceLogger logger;
@@ -42,25 +63,65 @@ namespace Orleans.Runtime.Host
 
         private ZooKeeperWatcher watcher;
 
+        /// <summary>
+        /// The deployment connection string. for eg. "192.168.1.1,192.168.1.2/DeploymentId"
+        /// </summary>
         private string deploymentConnectionString;
+        /// <summary>
+        /// the node name for this deployment. for eg. /DeploymentId
+        /// </summary>
         private string deploymentPath;
+        /// <summary>
+        /// The root connection string. for eg. "192.168.1.1,192.168.1.2"
+        /// </summary>
         private string rootConnectionString;
+
         private TimeSpan maxStaleness;
 
-        public Task InitializeGatewayListProvider(ClientConfiguration config,TraceLogger traceLogger)
+        public Task InitializeGatewayListProvider(ClientConfiguration config, TraceLogger traceLogger)
         {
-            InitConfig(traceLogger,config.DataConnectionString, config.DeploymentId, config.GatewayListRefreshPeriod);
+            InitConfig(traceLogger,config.DataConnectionString, config.DeploymentId);
+            maxStaleness = config.GatewayListRefreshPeriod;
             return TaskDone.Done;
         }
 
-        private void InitConfig(TraceLogger traceLogger, string dataConnectionString, string deploymentId, TimeSpan maxStale)
+        /// <summary>
+        /// Initializes the ZooKeeper based membership table.
+        /// </summary>
+        /// <param name="config">The configuration for this instance.</param>
+        /// <param name="tryInitPath">if set to true, we'll try to create a node named "/DeploymentId"</param>
+        /// <param name="traceLogger">The logger to be used by this instance</param>
+        /// <returns></returns>
+        public async Task InitializeMembershipTable(GlobalConfiguration config, bool tryInitPath, TraceLogger traceLogger)
+        {
+            InitConfig(traceLogger, config.DataConnectionString, config.DeploymentId);
+            // even if I am not the one who created the path, 
+            // try to insert an initial path if it is not already there,
+            // so we always have the path, before this silo starts working.
+            // note that when a zookeeper connection adds /DeploymentId to the connection string, the nodes are relative
+            await UsingZookeeper(rootConnectionString, async zk =>
+            {
+                try
+                {
+                    await zk.createAsync(deploymentPath, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                    await zk.sync(deploymentPath);
+                    //if we got here we know that we've just created the deployment path with version=0
+                    logger.Info("Created new deployment path: " + deploymentPath);
+                }
+                catch (KeeperException.NodeExistsException)
+                {
+                    logger.Verbose("Deployment path already exists: " + deploymentPath);
+                }
+            });
+        }
+
+        private void InitConfig(TraceLogger traceLogger, string dataConnectionString, string deploymentId)
         {
             watcher = new ZooKeeperWatcher(traceLogger);
             logger = traceLogger;
             deploymentPath = "/" + deploymentId;
             deploymentConnectionString = dataConnectionString + deploymentPath;
             rootConnectionString = dataConnectionString;
-            maxStaleness = maxStale;
         }
 
         public Task<MembershipTableData> ReadRow(SiloAddress siloAddress)
@@ -68,7 +129,7 @@ namespace Orleans.Runtime.Host
             return UsingZookeeper(async zk =>
             {
                 var getRowTask = GetRow(zk, siloAddress);
-                var getTableNodeTask = zk.getDataAsync("/", false);
+                var getTableNodeTask = zk.getDataAsync("/");//get the current table version
 
                 List<Tuple<MembershipEntry, string>> rows = new List<Tuple<MembershipEntry, string>>(1);
                 try
@@ -83,26 +144,26 @@ namespace Orleans.Runtime.Host
 
                 var tableVersion = ConvertToTableVersion((await getTableNodeTask).Stat);
                 return new MembershipTableData(rows, tableVersion);
-            });
+            }, true);
         }
 
         public Task<MembershipTableData> ReadAll()
         {
             return UsingZookeeper(async zk =>
             {
-                var childrenResult = await zk.getChildrenAsync("/", false);
+                var childrenResult = await zk.getChildrenAsync("/");//get all the child nodes (without the data)
 
-                var childrenTasks =
+                var childrenTasks = //get the data from each child node
                     childrenResult.Children.Select(child => GetRow(zk, SiloAddress.FromParsableString(child))).ToList();
 
                 var childrenTaskResults = await Task.WhenAll(childrenTasks);
 
-                var tableVersion = ConvertToTableVersion(childrenResult.Stat);
+                var tableVersion = ConvertToTableVersion(childrenResult.Stat);//this is the current table version
 
                 return new MembershipTableData(childrenTaskResults.ToList(), tableVersion);
-            });
+            }, true);
         }
-
+       
         public Task<bool> InsertRow(MembershipEntry entry, TableVersion tableVersion)
         {
             string rowPath = ConvertToRowPath(entry.SiloAddress);
@@ -110,10 +171,10 @@ namespace Orleans.Runtime.Host
             byte[] newRowData = Serialize(entry);
             byte[] newRowIAmAliveData = Serialize(entry.IAmAliveTime);
 
-            int expectedTableVersion = tableVersion.Version - 1;
+            int expectedTableVersion = int.Parse(tableVersion.VersionEtag, CultureInfo.InvariantCulture);
 
             return TryTransaction(t => t
-                .setData("/", null, expectedTableVersion)
+                .setData("/", null, expectedTableVersion)//increments the version of node "/"
                 .create(rowPath, newRowData, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT)
                 .create(rowIAmAlivePath, newRowIAmAliveData, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT));
         }
@@ -125,41 +186,21 @@ namespace Orleans.Runtime.Host
             var newRowData = Serialize(entry);
             var newRowIAmAliveData = Serialize(entry.IAmAliveTime);
 
-            int expectedTableVersion = tableVersion.Version - 1;
-            int expectedRowVersion = int.Parse(etag);
+            int expectedTableVersion = int.Parse(tableVersion.VersionEtag, CultureInfo.InvariantCulture);
+            int expectedRowVersion = int.Parse(etag, CultureInfo.InvariantCulture);
 
             return TryTransaction(t => t
-                .setData("/", null, expectedTableVersion)
-                .setData(rowPath, newRowData, expectedRowVersion)
-                .setData(rowIAmAlivePath, newRowIAmAliveData, -1));
+                .setData("/", null, expectedTableVersion)//increments the version of node "/"
+                .setData(rowPath, newRowData, expectedRowVersion)//increments the version of node "/IP:Port@Gen"
+                .setData(rowIAmAlivePath, newRowIAmAliveData));
         }
 
         public Task UpdateIAmAlive(MembershipEntry entry)
         {
             string rowIAmAlivePath = ConvertToRowIAmAlivePath(entry.SiloAddress);
             byte[] newRowIAmAliveData = Serialize(entry.IAmAliveTime);
-            return UsingZookeeper(zk => zk.setDataAsync(rowIAmAlivePath, newRowIAmAliveData, -1));
-        }
-
-        public async Task InitializeMembershipTable(GlobalConfiguration config, bool tryInitPath, TraceLogger traceLogger)
-        {
-            InitConfig(traceLogger, config.DataConnectionString, config.DeploymentId, config.TableRefreshTimeout);
-            // even if I am not the one who created the path, 
-            // try to insert an initial path if it is not already there,
-            // so we always have the path, before this silo starts working.
-            await UsingZookeeper(rootConnectionString, async zk =>
-            {
-                try
-                {
-                    await zk.createAsync(deploymentPath, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-                    await zk.sync(deploymentPath);
-                    logger.Info("Created new deployment path.");
-                }
-                catch (KeeperException.NodeExistsException)
-                {
-                    logger.Verbose("Deployment path already exists.");
-                }
-            });
+            //update the data for IAmAlive unconditionally
+            return UsingZookeeper(zk => zk.setDataAsync(rowIAmAlivePath, newRowIAmAliveData));
         }
 
         public IList<Uri> GetGateways()
@@ -206,13 +247,18 @@ namespace Orleans.Runtime.Host
             }
         }
 
+        /// <summary>
+        /// Reads the nodes /IP:Port@Gen and /IP:Port@Gen/IAmAlive (which together is one row)
+        /// </summary>
+        /// <param name="zk">The zookeeper instance used for the read</param>
+        /// <param name="siloAddress">The silo address.</param>
         private static async Task<Tuple<MembershipEntry, string>> GetRow(ZooKeeper zk, SiloAddress siloAddress)
         {
             string rowPath = ConvertToRowPath(siloAddress);
             string rowIAmAlivePath = ConvertToRowIAmAlivePath(siloAddress);
 
-            var rowDataTask = zk.getDataAsync(rowPath, false);
-            var rowIAmAliveDataTask = zk.getDataAsync(rowIAmAlivePath, false);
+            var rowDataTask = zk.getDataAsync(rowPath);
+            var rowIAmAliveDataTask = zk.getDataAsync(rowIAmAlivePath);
 
             await Task.WhenAll(rowDataTask, rowIAmAliveDataTask);
 
@@ -221,12 +267,12 @@ namespace Orleans.Runtime.Host
 
             int rowVersion = (await rowDataTask).Stat.getVersion();
 
-            return new Tuple<MembershipEntry, string>(me, rowVersion.ToString());
+            return new Tuple<MembershipEntry, string>(me, rowVersion.ToString(CultureInfo.InvariantCulture));
         }
 
-        private Task<T> UsingZookeeper<T>(Func<ZooKeeper, Task<T>> zkMethod)
+        private Task<T> UsingZookeeper<T>(Func<ZooKeeper, Task<T>> zkMethod, bool canBeReadOnly = false)
         {
-            return ZooKeeper.Using(deploymentConnectionString, ZOOKEEPER_CONNECTION_TIMEOUT, watcher, zkMethod);
+            return ZooKeeper.Using(deploymentConnectionString, ZOOKEEPER_CONNECTION_TIMEOUT, watcher, zkMethod, canBeReadOnly);
         }
 
         private Task UsingZookeeper(string connectString, Func<ZooKeeper, Task> zkMethod)
@@ -247,7 +293,7 @@ namespace Orleans.Runtime.Host
         private static TableVersion ConvertToTableVersion(Stat stat)
         {
             int version = stat.getVersion();
-            return new TableVersion(version, version.ToString());
+            return new TableVersion(version, version.ToString(CultureInfo.InvariantCulture));
         }
 
         private static byte[] Serialize(object obj)

--- a/src/OrleansZooKeeperUtils/packages.config
+++ b/src/OrleansZooKeeperUtils/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="ZooKeeperNetEx" version="3.4.6-alpha12" targetFramework="net45" />
+  <package id="ZooKeeperNetEx" version="3.4.6-alpha17" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
* Updated ZooKeeperNetEx. (the new version fixes several bugs that came up in testing)
* Only set maxStaleness for GatewayListProvider. from #530
* Use CultureInfo.InvariantCulture when converting ZK rowVersion to string eTag. from #530
* Added lots of documentation
* Using ETags instead of table versions.
* Some implementation tweaks, no logic was changed