### PR TITLE
Remove statics from GrainFactory.

### DIFF
--- a/src/Orleans/Core/GrainClient.cs
+++ b/src/Orleans/Core/GrainClient.cs
@@ -58,7 +58,7 @@ namespace Orleans
 
         private static readonly object initLock = new Object();
 
-        private static IGrainFactory grainFactory;
+        private static GrainFactory grainFactory;
 
         //TODO: prevent client code from using this from inside a Grain
         public static IGrainFactory GrainFactory
@@ -68,6 +68,19 @@ namespace Orleans
                 if (!IsInitialized)
                 {
                     throw new OrleansException("You must initialize the Grain Client before accessing the GrainFactory");
+                }
+
+                return grainFactory;
+            }
+        }
+
+        internal static GrainFactory InternalGrainFactory
+        {
+            get
+            {
+                if (!IsInitialized)
+                {
+                    throw new OrleansException("You must initialize the Grain Client before accessing the InternalGrainFactory");
                 }
 
                 return grainFactory;

--- a/src/Orleans/Core/GrainExtensions.cs
+++ b/src/Orleans/Core/GrainExtensions.cs
@@ -70,7 +70,7 @@ namespace Orleans
                 throw new ArgumentNullException("grain", "Cannot pass null as an argument to AsReference");
             }
 
-            return GrainFactory.Cast<TGrainInterface>(grain.AsWeaklyTypedReference());
+            return RuntimeClient.Current.InternalGrainFactory.Cast<TGrainInterface>(grain.AsWeaklyTypedReference());
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Orleans
         /// <param name="grain">The grain to cast.</param>
         public static TGrainInterface Cast<TGrainInterface>(this IAddressable grain)
         {
-            return GrainFactory.Cast<TGrainInterface>(grain);
+            return RuntimeClient.Current.InternalGrainFactory.Cast<TGrainInterface>(grain);
         }
 
         internal static GrainId GetGrainId(IAddressable grain)

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -244,10 +244,10 @@ namespace Orleans
         #endregion
 
         #region Interface Casting
-        private static readonly ConcurrentDictionary<Type, Func<IAddressable, object>> casters
+        private readonly ConcurrentDictionary<Type, Func<IAddressable, object>> casters
             = new ConcurrentDictionary<Type, Func<IAddressable, object>>();
 
-        internal static TGrainInterface Cast<TGrainInterface>(IAddressable grain)
+        internal TGrainInterface Cast<TGrainInterface>(IAddressable grain)
         {
             var interfaceType = typeof(TGrainInterface);
             Func<IAddressable, object> caster;
@@ -269,10 +269,10 @@ namespace Orleans
 
         #region SystemTargets
 
-        private static readonly Dictionary<GrainId, Dictionary<SiloAddress, ISystemTarget>> typedSystemTargetReferenceCache =
+        private readonly Dictionary<GrainId, Dictionary<SiloAddress, ISystemTarget>> typedSystemTargetReferenceCache =
                     new Dictionary<GrainId, Dictionary<SiloAddress, ISystemTarget>>();
 
-        internal static TGrainInterface GetSystemTarget<TGrainInterface>(GrainId grainId, SiloAddress destination)
+        internal TGrainInterface GetSystemTarget<TGrainInterface>(GrainId grainId, SiloAddress destination)
             where TGrainInterface : ISystemTarget
         {
             Dictionary<SiloAddress, ISystemTarget> cache;

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -292,16 +292,16 @@ namespace Orleans.Messaging
             }
         }
 
-        public Task<GrainInterfaceMap> GetTypeCodeMap()
+        public Task<GrainInterfaceMap> GetTypeCodeMap(GrainFactory grainFactory)
         {
             var silo = GetLiveGatewaySiloAddress();
-            return GetTypeManager(silo).GetTypeCodeMap(silo);
+            return GetTypeManager(silo, grainFactory).GetTypeCodeMap(silo);
         }
 
-        public Task<Streams.ImplicitStreamSubscriberTable> GetImplicitStreamSubscriberTable()
+        public Task<Streams.ImplicitStreamSubscriberTable> GetImplicitStreamSubscriberTable(GrainFactory grainFactory)
         {
             var silo = GetLiveGatewaySiloAddress();
-            return GetTypeManager(silo).GetImplicitStreamSubscriberTable(silo);
+            return GetTypeManager(silo, grainFactory).GetImplicitStreamSubscriberTable(silo);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
@@ -396,9 +396,9 @@ namespace Orleans.Messaging
 
         #endregion
 
-        private ITypeManager GetTypeManager(SiloAddress destination)
+        private ITypeManager GetTypeManager(SiloAddress destination, GrainFactory grainFactory)
         {
-            return GrainFactory.GetSystemTarget<ITypeManager>(Constants.TypeManagerId, destination);
+            return grainFactory.GetSystemTarget<ITypeManager>(Constants.TypeManagerId, destination);
         }
 
         private SiloAddress GetLiveGatewaySiloAddress()

--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -154,7 +154,7 @@ namespace Orleans.Providers
                 }
             }
 
-            var typedAddressable = Orleans.GrainFactory.Cast<TExtensionInterface>(addressable);
+            var typedAddressable = addressable.Cast<TExtensionInterface>();
             // we have to return the extension as well as the IAddressable because the caller needs to root the extension
             // to prevent it from being collected (the IAddressable uses a weak reference).
             return Tuple.Create(extension, typedAddressable);

--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -24,8 +24,6 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
-
 using Orleans.Storage;
 using Orleans.CodeGeneration;
 
@@ -36,6 +34,11 @@ namespace Orleans.Runtime
     /// </summary>
     internal interface IRuntimeClient
     {
+        /// <summary>
+        /// Grain Factory to get and cast grain references.
+        /// </summary>
+        GrainFactory InternalGrainFactory { get; }
+
         /// <summary>
         /// Provides client application code with access to an Orleans logger.
         /// </summary>

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -70,7 +70,12 @@ namespace Orleans
 
         private const string BARS = "----------";
 
-        private readonly IGrainFactory grainFactory;
+        private readonly GrainFactory grainFactory;
+
+        public GrainFactory InternalGrainFactory
+        {
+            get { return grainFactory; }
+        }
 
         /// <summary>
         /// Response timeout.
@@ -127,7 +132,7 @@ namespace Orleans
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "MessageCenter is IDisposable but cannot call Dispose yet as it lives past the end of this method call.")]
-        public OutsideRuntimeClient(ClientConfiguration cfg, IGrainFactory grainFactory, bool secondary = false)
+        public OutsideRuntimeClient(ClientConfiguration cfg, GrainFactory grainFactory, bool secondary = false)
         {
             this.grainFactory = grainFactory;
             this.clientId = GrainId.NewClientId();
@@ -221,7 +226,7 @@ namespace Orleans
 
         private void StreamingInitialize()
         {
-            var implicitSubscriberTable = transport.GetImplicitStreamSubscriberTable().Result;
+            var implicitSubscriberTable = transport.GetImplicitStreamSubscriberTable(grainFactory).Result;
             ClientProviderRuntime.StreamingInitialize(grainFactory, implicitSubscriberTable);
             var streamProviderManager = new Streams.StreamProviderManager();
             streamProviderManager
@@ -316,7 +321,7 @@ namespace Orleans
                     }
                 }
             );
-            grainInterfaceMap = transport.GetTypeCodeMap().Result;
+            grainInterfaceMap = transport.GetTypeCodeMap(grainFactory).Result;
             StreamingInitialize();
         }
 

--- a/src/Orleans/Streams/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans/Streams/PubSub/ImplicitStreamSubscriberTable.cs
@@ -251,7 +251,7 @@ namespace Orleans.Streams
         {
             GrainId grainId = GrainId.GetGrainId(implTypeCode, primaryKey);
             IAddressable addressable = GrainReference.FromGrainId(grainId);
-            return GrainFactory.Cast<IStreamConsumerExtension>(addressable);
+            return addressable.Cast<IStreamConsumerExtension>();
         }
 
         /// <summary>

--- a/src/OrleansManager/Program.cs
+++ b/src/OrleansManager/Program.cs
@@ -166,7 +166,7 @@ namespace OrleansManager
                 WriteStatus(string.Format("**Calling GetDetailedGrainReport({0}, {1})", silo, grainId));
                 try
                 {
-                    var siloControl = GrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, silo);
+                    var siloControl = GrainClient.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, silo);
                     DetailedGrainReport grainReport = siloControl.GetDetailedGrainReport(grainId).Result;
                     reports.Add(grainReport);
                 }
@@ -188,7 +188,7 @@ namespace OrleansManager
             var silo = GetSiloAddress();
             if (silo == null) return;
 
-            var directory = GrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, silo);
+            var directory = GrainClient.InternalGrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, silo);
 
             WriteStatus(string.Format("**Calling DeleteGrain({0}, {1}, {2})", silo, grainId, RETRIES));
             directory.DeleteGrain(grainId, RETRIES).Wait();
@@ -202,7 +202,7 @@ namespace OrleansManager
             var silo = GetSiloAddress();
             if (silo == null) return;
 
-            var directory = GrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, silo);
+            var directory = GrainClient.InternalGrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, silo);
   
             WriteStatus(string.Format("**Calling LookupGrain({0}, {1}, {2})", silo, grainId, RETRIES));
             Tuple<List<Tuple<SiloAddress, ActivationId>>, int> lookupResult = await directory.LookUp(grainId, RETRIES);

--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -311,7 +311,7 @@ namespace Orleans.Runtime.Management
 
         private ISiloControl GetSiloControlReference(SiloAddress silo)
         {
-            return Orleans.GrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, silo);
+            return InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, silo);
         }
     }
 }

--- a/src/OrleansRuntime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
+++ b/src/OrleansRuntime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
@@ -152,7 +152,7 @@ namespace Orleans.Runtime.GrainDirectory
 
                 router.CacheValidationsSent.Increment();
                 // Send all of the items in one large request
-                var validator = GrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryCacheValidatorId, capture);
+                var validator = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryCacheValidatorId, capture);
                                 
                 router.Scheduler.QueueTask(async () =>
                 {

--- a/src/OrleansRuntime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/OrleansRuntime/GrainDirectory/GrainDirectoryPartition.cs
@@ -172,7 +172,7 @@ namespace Orleans.Runtime.GrainDirectory
                 foreach (var activation in activationsToDrop.Select(keyValuePair => ActivationAddress.GetAddress(keyValuePair.Value.SiloAddress, grain, keyValuePair.Key)))
                 {
                     list.Add(activation);
-                    GrainFactory.GetSystemTarget<ICatalog>(Constants.CatalogId, activation.Silo).
+                    InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<ICatalog>(Constants.CatalogId, activation.Silo).
                         DeleteActivations(list).Ignore();
 
                     list.Clear();

--- a/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
@@ -953,7 +953,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         internal IRemoteGrainDirectory GetDirectoryReference(SiloAddress silo)
         {
-            return GrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, silo);
+            return InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, silo);
         }
     }
 }

--- a/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
@@ -407,7 +407,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         private IRemoteGrainDirectory GetDirectoryReference(SiloAddress target)
         {
-            return GrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, target);
+            return InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, target);
         }
     }
 }

--- a/src/OrleansRuntime/MembershipService/MembershipFactory.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipFactory.cs
@@ -61,7 +61,8 @@ namespace Orleans.Runtime.MembershipService
             IMembershipTable membershipTable;
             if (livenessType.Equals(GlobalConfiguration.LivenessProviderType.MembershipTableGrain))
             {
-                membershipTable = GrainFactory.Cast<IMembershipTableGrain>(GrainReference.FromGrainId(Constants.SystemMembershipTableId));
+                membershipTable =
+                    GrainReference.FromGrainId(Constants.SystemMembershipTableId).Cast<IMembershipTableGrain>();
             }
             else if (livenessType.Equals(GlobalConfiguration.LivenessProviderType.SqlServer))
             {

--- a/src/OrleansRuntime/MembershipService/MembershipOracle.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipOracle.cs
@@ -1159,7 +1159,7 @@ namespace Orleans.Runtime.MembershipService
 
         private static IMembershipService GetOracleReference(SiloAddress silo)
         {
-            return GrainFactory.GetSystemTarget<IMembershipService>(Constants.MembershipOracleId, silo);
+            return InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IMembershipService>(Constants.MembershipOracleId, silo);
         }
     }
 }

--- a/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
+++ b/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
@@ -91,7 +91,7 @@ namespace Orleans.Runtime
                 {
                     try
                     {
-                        tasks.Add(GrainFactory.GetSystemTarget<IDeploymentLoadPublisher>(
+                        tasks.Add(InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IDeploymentLoadPublisher>(
                             Constants.DeploymentLoadPublisherSystemTargetId, siloAddress)
                             .UpdateRuntimeStatistics(silo.SiloAddress, myStats));
                     }
@@ -137,7 +137,7 @@ namespace Orleans.Runtime
                     foreach (var siloAddress in members)
                     {
                         var capture = siloAddress;
-                        Task task = GrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, capture)
+                        Task task = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, capture)
                                 .GetRuntimeStatistics()
                                 .ContinueWith((Task<SiloRuntimeStatistics> statsTask) =>
                                     {

--- a/src/OrleansRuntime/ReminderService/LocalReminderService.cs
+++ b/src/OrleansRuntime/ReminderService/LocalReminderService.cs
@@ -466,7 +466,7 @@ namespace Orleans.Runtime.ReminderService
                 Identity = new ReminderIdentity(entry.GrainRef, entry.ReminderName);
                 firstTickTime = entry.StartAt;
                 period = entry.Period;
-                remindable = GrainFactory.Cast<IRemindable>(entry.GrainRef);
+                remindable = entry.GrainRef.Cast<IRemindable>();
                 ETag = entry.ETag;
                 LocalSequenceNumber = -1;
             }

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -97,7 +97,7 @@ namespace Orleans.Runtime
         private readonly Catalog catalog;
         private readonly List<IHealthCheckParticipant> healthCheckParticipants;
         private readonly object lockable = new object();
-        private readonly IGrainFactory grainFactory;
+        private readonly GrainFactory grainFactory;
         private readonly IGrainRuntime grainRuntime;
         
         
@@ -258,7 +258,8 @@ namespace Orleans.Runtime
                 SiloAddress, 
                 config, 
                 RingProvider, 
-                typeManager);
+                typeManager,
+                grainFactory);
             messageCenter.RerouteHandler = InsideRuntimeClient.Current.RerouteMessage;
             messageCenter.SniffIncomingMessage = InsideRuntimeClient.Current.SniffIncomingMessage;
 


### PR DESCRIPTION
Make GrainFactory.Cast and GetSystemTarget non static.
Make caster collections inside GrainFactory non static.
Add IRuntimeClient.InternalGrainFactory to expose GrainFactory.GetSystemTarget
Switch to use IAddressable.Cast instead of Orleans.GrainFactory.Cast.

A step towards making GrainClient non static and allowing multiple grain clients to connect to multiple clusters. 
