### PR TITLE
Fix IsGrainInterface to not consider IGrainWith* interfaces as grain interfaces.

### DIFF
--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -140,7 +140,8 @@ namespace Orleans.CodeGeneration
                 return false;
             if (t == typeof(IGrainObserver) || t == typeof(IAddressable) || t == typeof(IGrainExtension))
                 return false;
-            if (t == typeof (IGrain))
+            if (t == typeof(IGrain) || t == typeof(IGrainWithGuidKey) || t == typeof(IGrainWithIntegerKey)
+                || t == typeof(IGrainWithGuidCompoundKey) || t == typeof(IGrainWithIntegerCompoundKey))
                 return false;
             if (t == typeof (ISystemTarget))
                 return false;


### PR DESCRIPTION
Currently IGrainWith* interfaces are counted as grain interfaces while IGrain is not. This is clearly wrong.