### PR TITLE
Multicore compilation switch added to build script

### DIFF
--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -31,7 +31,7 @@ set PROJ=%CMDHOME%\Orleans.sln
 SET CONFIGURATION=Debug
 SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
-"%MSBUILDEXE%" /p:Configuration=%CONFIGURATION% "%PROJ%"
+"%MSBUILDEXE%" /m /p:Configuration=%CONFIGURATION% "%PROJ%"
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD ok for %CONFIGURATION% %PROJ%
 
@@ -40,7 +40,7 @@ SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 SET CONFIGURATION=Release
 SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
-"%MSBUILDEXE%" /p:Configuration=%CONFIGURATION% "%PROJ%"
+"%MSBUILDEXE%" /m /p:Configuration=%CONFIGURATION% "%PROJ%"
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD ok for %CONFIGURATION% %PROJ%
 
@@ -53,13 +53,13 @@ set STEP=VSIX
 @REM Install Visual Studio SDK and uncomment the following lines 
 @REM to build Visual Studio project templates.
 @REM
-@REM "%MSBUILDEXE%" /p:Configuration=%CONFIGURATION% "%CMDHOME%\OrleansVSTools\OrleansVSTools.sln"
+@REM "%MSBUILDEXE%" /m /p:Configuration=%CONFIGURATION% "%CMDHOME%\OrleansVSTools\OrleansVSTools.sln"
 @REM xcopy /s /y %CMDHOME%\SDK\VSIX %OutDir%\VSIX\
 @REM @if ERRORLEVEL 1 GOTO :ErrorStop
 @REM @echo BUILD ok for VSIX package for %PROJ%
 
 set STEP=WIX
-"%MSBUILDEXE%" /p:Configuration=%CONFIGURATION% /p:OutputPath=. "%CMDHOME%\Build\OrleansSetup.wixproj"
+"%MSBUILDEXE%" /m /p:Configuration=%CONFIGURATION% /p:OutputPath=. "%CMDHOME%\Build\OrleansSetup.wixproj"
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD ok for WIX package for %PROJ%
 


### PR DESCRIPTION
This adds a multicore, /m, switch to MSBuild arguments.
Unscientific measurement indicates increased processor utilization and mildly
decreased compilation times (also MSBuild won't print a suggestion to add "/m" anymore).