### PR TITLE
Remove static collections from AsynchAgent. 

### DIFF
--- a/src/Orleans/Messaging/GatewayClientReceiver.cs
+++ b/src/Orleans/Messaging/GatewayClientReceiver.cs
@@ -38,6 +38,7 @@ namespace Orleans.Messaging
         private readonly IncomingMessageBuffer buffer;
 
         internal GatewayClientReceiver(GatewayConnection gateway)
+            : base(gateway.Address.ToString())
         {
             gatewayConnection = gateway;
             OnFault = FaultBehavior.RestartOnFault;

--- a/src/Orleans/Runtime/AsynchAgent.cs
+++ b/src/Orleans/Runtime/AsynchAgent.cs
@@ -22,11 +22,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using Orleans.Runtime;
 
 namespace Orleans.Runtime
 {
@@ -50,9 +46,6 @@ namespace Orleans.Runtime
         internal protected ThreadTrackingStatistic threadTracking;
 #endif
 
-        static protected readonly Dictionary<Type, int> SequenceNumbers = new Dictionary<Type, int>();
-        static private readonly object classLockable = new object();
-
         public ThreadState State { get; private set; }
         internal string Name { get; private set; }
         internal int ManagedThreadId { get { return t==null ? -1 : t.ManagedThreadId;  } } 
@@ -61,14 +54,6 @@ namespace Orleans.Runtime
         {
             Cts = new CancellationTokenSource();
             var thisType = GetType();
-            int n = 0;
-
-            lock (classLockable)
-            {
-                SequenceNumbers.TryGetValue(thisType, out n);
-                n++;
-                SequenceNumbers[thisType] = n;
-            }
             
             type = thisType.Namespace + "." + thisType.Name;
             if (type.StartsWith("Orleans.", StringComparison.Ordinal))
@@ -77,11 +62,11 @@ namespace Orleans.Runtime
             }
             if (!string.IsNullOrEmpty(nameSuffix))
             {
-                Name = type + "." + nameSuffix + "/" + n;
+                Name = type + "/" + nameSuffix;
             }
             else
             {
-                Name = type + "/" + n;
+                Name = type;
             }
 
             Lockable = new object();
@@ -96,24 +81,12 @@ namespace Orleans.Runtime
                 threadTracking = new ThreadTrackingStatistic(Name);
             }
 #endif
-
             t = new Thread(AgentThreadProc) { IsBackground = true, Name = this.Name };
         }
 
-        protected AsynchAgent() : this(null)
+        protected AsynchAgent()
+            : this(null)
         {
-        }
-
-        protected int GetThreadTypeSequenceNumber()
-        {
-            var thisType = GetType();
-            int n;
-
-            lock (classLockable)
-            {
-                SequenceNumbers.TryGetValue(thisType, out n);
-            }
-            return n;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]

--- a/src/OrleansRuntime/Scheduler/WorkerPoolThread.cs
+++ b/src/OrleansRuntime/Scheduler/WorkerPoolThread.cs
@@ -93,8 +93,8 @@ namespace Orleans.Runtime.Scheduler
 
         internal readonly int WorkerThreadStatisticsNumber;
 
-        internal WorkerPoolThread(WorkerPool gtp, OrleansTaskScheduler sched, bool system = false)
-            : base(system ? "System" : null)
+        internal WorkerPoolThread(WorkerPool gtp, OrleansTaskScheduler sched, int threadNumber, bool system = false)
+            : base((system ? "System." : "") + threadNumber)
         {
             pool = gtp;
             scheduler = sched;


### PR DESCRIPTION
Remove static collections from AsynchAgent. 
Fix thread names allocation to ensure unique thread names.
On the path of solving #467.