### PR TITLE
Fixed a bug of double namespace in codegen.

### DIFF
--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -163,7 +163,18 @@ namespace Orleans.Runtime
 
         public static string GetParameterizedTemplateName(Type t, Func<Type, bool> fullName, bool applyRecursively = false, Language language = Language.CSharp)
         {
-            return t.IsGenericType ? GetParameterizedTemplateName(GetSimpleTypeName(t, fullName), t, applyRecursively, fullName, language) : t.FullName;
+            if (t.IsGenericType)
+            {
+                return GetParameterizedTemplateName(GetSimpleTypeName(t, fullName), t, applyRecursively, fullName, language);
+            }
+            else
+            {
+                if(fullName != null && fullName(t)==true)
+                {
+                    return t.FullName;
+                }
+            }
+            return t.Name;
         }
 
         public static string GetParameterizedTemplateName(string baseName, Type t, bool applyRecursively = false, Func<Type, bool> fullName = null, Language language = Language.CSharp)


### PR DESCRIPTION
Bug reported by @ReubenBond on gitter:

"Okay, someone tell me I'm tripping, but is the existing codegen emitting the namespace twice in string forms of the names? eg, GrainReferenceAttribute("Orleans.Storage.Orleans.Storage.IMemoryStorageGrain") and the InterfaceName property.

(check orleans.codegen.cs from the Orleans project for that particular ref)"