### PR TITLE
Improve error reporting in codegen

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -336,7 +336,7 @@ namespace Orleans.CodeGeneration
                     catch (GrainInterfaceData.RulesViolationException rve)
                     {
                         foreach (var v in rve.Violations)
-                            ConsoleText.WriteError(string.Format("Error: {0}", v));
+                            NamespaceGenerator.ReportError(v);
 
                         success = false;
                     }
@@ -356,7 +356,7 @@ namespace Orleans.CodeGeneration
                         //Question: Should we instead throw compile errors?
                         //Question: What warning number should we use? Standard C# warning/error numbers are listed here: https://msdn.microsoft.com/en-us/library/ms228296(v=vs.90).aspx                        
                         foreach (var v in rve.Violations)
-                            ConsoleText.WriteUsage(string.Format("Warning CS0184 : {0}", v));
+                            NamespaceGenerator.ReportWarning(string.Format("CS0184 : {0}", v));
                     }
                 }
             }
@@ -813,7 +813,7 @@ namespace Orleans.CodeGeneration
 
                 if (!options.TargetLanguage.HasValue)
                 {
-                    ConsoleText.WriteError("Error: unable to determine source code language to use for code generation.");
+                    NamespaceGenerator.ReportError("Unable to determine source code language to use for code generation.");
                     return 2;
                 }
 
@@ -826,7 +826,7 @@ namespace Orleans.CodeGeneration
 
                 if (string.IsNullOrEmpty(options.CodeGenFile))
                 {
-                    ConsoleText.WriteError(string.Format("Error: no codegen file. Add a file '{0}' to your project",
+                    NamespaceGenerator.ReportError(string.Format("No codegen file. Add a file '{0}' to your project",
                         (options.TargetLanguage == Language.CSharp) ? Path.Combine("Properties", "orleans.codegen.cs") :
                         (options.TargetLanguage == Language.FSharp) ? Path.Combine("GeneratedFiles", "orleans.codegen.fs") 
                                                                     : Path.Combine("GeneratedFiles", "orleans.codegen.vb")));
@@ -873,7 +873,7 @@ namespace Orleans.CodeGeneration
             }
             catch (Exception ex)
             {
-                ConsoleText.WriteError("ERROR -- Code-gen FAILED -- ", ex);
+                NamespaceGenerator.ReportError("-- Code-gen FAILED -- ", ex);
                 return 3;
             }
         }

--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -124,11 +124,6 @@ namespace Orleans.CodeGeneration
                 // Call a method 
                 return generator.CreateGrainClient(options);
             }
-            catch (Exception ex)
-            {
-                ConsoleText.WriteError("ERROR -- Client code-gen FAILED -- Exception caught -- ", ex);
-                throw;
-            }
             finally
             {
                 if (appDomain != null)

--- a/src/ClientGenerator/NamespaceGenerator.cs
+++ b/src/ClientGenerator/NamespaceGenerator.cs
@@ -294,9 +294,8 @@ namespace Orleans.CodeGeneration
             if (persistentInterface!=null)
             {
                 if (!sourceType.GetCustomAttributes(typeof (StorageProviderAttribute)).Any())
-                    throw new BadProviderConfigException(
-                        String.Format("No StorageProvider attribute specified for grain class {0}", sourceType.FullName));
-
+                    ConsoleText.WriteError(String.Format("Error: No StorageProvider attribute specified for grain class {0}", sourceType.FullName));
+                    
                 if (!persistentInterface.IsInterface)
                 {
                     hasStateClass = false;
@@ -725,7 +724,7 @@ namespace Orleans.CodeGeneration
             int methodId = GrainInterfaceData.ComputeMethodId(methodInfo);
             if (methodIdCollisionDetection.Contains(methodId))
             {
-                ReportErrorAndThrow(string.Format("Collision detected for method {0}, declaring type {1}, consider renaming method name",
+                ReportError(string.Format("Collision detected for method {0}, declaring type {1}, consider renaming method name",
                     methodInfo.Name, methodInfo.DeclaringType.FullName));
             }
             else
@@ -741,10 +740,9 @@ namespace Orleans.CodeGeneration
 
         #region utility methods
 
-        private static void ReportErrorAndThrow(string errorMsg)
+        private static void ReportError(string errorMsg)
         {
-            ConsoleText.WriteError("Orleans code generator found error: " + errorMsg);
-            throw new OrleansException(errorMsg);
+            ConsoleText.WriteError("Error: Orleans code generator found error " + errorMsg);
         }
 
         private void AddFactoryMethods(GrainInterfaceData si, CodeTypeDeclaration factoryClass)

--- a/src/ClientGenerator/NamespaceGenerator.cs
+++ b/src/ClientGenerator/NamespaceGenerator.cs
@@ -294,7 +294,7 @@ namespace Orleans.CodeGeneration
             if (persistentInterface!=null)
             {
                 if (!sourceType.GetCustomAttributes(typeof (StorageProviderAttribute)).Any())
-                    ConsoleText.WriteError(String.Format("Error: No StorageProvider attribute specified for grain class {0}", sourceType.FullName));
+                    ReportError(String.Format("No StorageProvider attribute specified for grain class {0}", sourceType.FullName));
                     
                 if (!persistentInterface.IsInterface)
                 {
@@ -560,7 +560,7 @@ namespace Orleans.CodeGeneration
                     return GetGenericTypeName(genericArguments[0], flag);
 
                 var errorMsg = String.Format("Unexpected number of arguments {0} for generic type {1} used as a return type. Only Type<T> are supported as generic return types of grain methods.", genericArguments.Length, type);
-                ConsoleText.WriteError(errorMsg);
+                ReportError(errorMsg);
                 throw new ApplicationException(errorMsg);
             }
 
@@ -740,10 +740,34 @@ namespace Orleans.CodeGeneration
 
         #region utility methods
 
-        private static void ReportError(string errorMsg)
+        /// <summary>
+        /// Makes errors visible in VS and MSBuild by prefixing error message with "Error"
+        /// </summary>
+        /// <param name="errorMsg">Error message</param>
+        internal static void ReportError(string errorMsg)
         {
-            ConsoleText.WriteError("Error: Orleans code generator found error " + errorMsg);
+            ConsoleText.WriteError("Error: Orleans code generator found error: " + errorMsg);
         }
+
+        /// <summary>
+        /// Makes errors visible in VS and MSBuild by prefixing error message with "Error"
+        /// </summary>
+        /// <param name="errorMsg">Error message</param>
+        /// <param name="exc">Exception associated with the error</param>
+        internal static void ReportError(string errorMsg, Exception exc)
+        {
+            ConsoleText.WriteError("Error: Orleans code generator found error: " + errorMsg, exc);
+        }
+
+        /// <summary>
+        /// Makes warnings visible in VS and MSBuild by prefixing error message with "Warning"
+        /// </summary>
+        /// <param name="warning">Warning message</param>
+        internal static void ReportWarning(string warning)
+        {
+            ConsoleText.WriteWarning("Warning: " + warning);
+        }
+        
 
         private void AddFactoryMethods(GrainInterfaceData si, CodeTypeDeclaration factoryClass)
         {

--- a/src/ClientGenerator/Serialization/SerializerGenerationManager.cs
+++ b/src/ClientGenerator/Serialization/SerializerGenerationManager.cs
@@ -75,7 +75,7 @@ namespace Orleans.CodeGeneration.Serialization
                     processedTypes.Contains(def) || typeof (IAddressable).IsAssignableFrom(def)) return;
 
                 if (def.Namespace.Equals("System") || def.Namespace.StartsWith("System."))
-                    ConsoleText.WriteError("System type " + def.Name + " requires a serializer.");
+                    ConsoleText.WriteWarning("System type " + def.Name + " requires a serializer.");
                 else
                     typesToProcess.Add(def);
 
@@ -87,8 +87,8 @@ namespace Orleans.CodeGeneration.Serialization
 
             if (t.Namespace.Equals("System") || t.Namespace.StartsWith("System."))
             {
-                ConsoleText.WriteError("System type " + t.Name + " may require a custom serializer for optimal performance.");
-                ConsoleText.WriteError("If you use arguments of this type a lot, consider asking the Orleans team to build a custom serializer for it.");
+                ConsoleText.WriteWarning("System type " + t.Name + " may require a custom serializer for optimal performance. " +
+                    "If you use arguments of this type a lot, consider asking the Orleans team to build a custom serializer for it.");
                 return;
             }
 

--- a/src/Orleans/Logging/ConsoleText.cs
+++ b/src/Orleans/Logging/ConsoleText.cs
@@ -45,6 +45,13 @@ namespace Orleans.Runtime
             WriteLine(ConsoleColor.Red, logMsg);
         }
 
+        public static void WriteWarning(string msg)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine(msg);
+            Console.ResetColor();
+        }
+
         public static void WriteStatus(string msg)
         {
             WriteLine(ConsoleColor.Green, msg);


### PR DESCRIPTION
Report "no StorageProvider attribute" as an error.
Remove duplicate reporting of errors.
Report an error and don't throw.