### PR TITLE
Fix instantiation of generic state objects

### DIFF
--- a/src/OrleansRuntime/GrainTypeManager/GenericGrainTypeData.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GenericGrainTypeData.cs
@@ -46,7 +46,7 @@ namespace Orleans.Runtime
         {
             // Need to make a non-generic instance of the class to access the static data field. The field itself is independent of the instantiated type.
             var concreteActivationType = activationType.MakeGenericType(typeArgs);
-            var concreteStateObjectType = (stateObjectType != null && stateObjectType.IsGenericType) ? stateObjectType.MakeGenericType(typeArgs) : stateObjectType;
+            var concreteStateObjectType = (stateObjectType != null && stateObjectType.IsGenericType) ? stateObjectType.GetGenericTypeDefinition().MakeGenericType(typeArgs) : stateObjectType;
 
             return new GrainTypeData(concreteActivationType, concreteStateObjectType);
         }

--- a/src/Tester/GenericGrainTests.cs
+++ b/src/Tester/GenericGrainTests.cs
@@ -523,7 +523,7 @@ namespace UnitTests.General
             Assert.AreEqual(msg4, received, "Echo");
         }
 
-        [TestMethod, TestCategory("Failures"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task Generic_Echo_Chain_5()
         {
             const string msg5 = "Hello from EchoGenericChainGrain-5";
@@ -534,7 +534,7 @@ namespace UnitTests.General
             Assert.AreEqual(msg5, received, "Echo");
         }
 
-        [TestMethod, TestCategory("Failures"), TestCategory("Generics")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task Generic_Echo_Chain_6()
         {
             const string msg6 = "Hello from EchoGenericChainGrain-6";


### PR DESCRIPTION
Call `stateObjectType.GetGenericTypeDefinition().MakeGenericType(typeArgs)` instead of `stateObjectType.MakeGenericType(typeArgs)`.

This bug surfaces in trying to migrate from generic grain state interfaces to generic state classes.