### PR TITLE
Migrate to using grain state classes instead of interfaces

### DIFF
--- a/src/ClientGenerator/NamespaceGenerator.cs
+++ b/src/ClientGenerator/NamespaceGenerator.cs
@@ -301,6 +301,11 @@ namespace Orleans.CodeGeneration
                     hasStateClass = false;
                     return null;
                 }
+                else
+                {
+                    ConsoleText.WriteError(String.Format("Warning: Usage of grain state interfaces as type arguments for Grain<T> has been deprecated. " +
+                        "Define an equivalent class with automatic properties instead of the state interface for {0}.", sourceType.FullName));
+                }
             }
 
             Dictionary<string, PropertyInfo> asyncProperties = GrainInterfaceData.GetPersistentProperties(persistentInterface)

--- a/src/Orleans/CodeGeneration/GrainState.cs
+++ b/src/Orleans/CodeGeneration/GrainState.cs
@@ -42,8 +42,6 @@ namespace Orleans.CodeGeneration
     [Serializable]
     public abstract class GrainState : IGrainState
     {
-        private readonly string grainTypeName;
-
         /// <summary>
         /// This is used for serializing the state, so all base class fields must be here
         /// </summary>
@@ -109,8 +107,10 @@ namespace Orleans.CodeGeneration
         /// <param name="reference">The type of the associated grains that use this GrainState object. Used to initialize the <c>GrainType</c> property.</param>
         protected GrainState(string grainTypeFullName)
         {
-            grainTypeName = grainTypeFullName;
+            // TODO: remove after removing support for state interfaces
         }
+
+        protected GrainState() { }
 
         #region IGrainState storage operation methods
         /// <summary>

--- a/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -25,19 +25,19 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
+using Orleans.CodeGeneration;
 using Orleans.Runtime;
 
 namespace Orleans.Streams
 {
-    internal interface IPubSubGrainState : IGrainState
+    internal class PubSubGrainState : GrainState
     {
-        HashSet<PubSubPublisherState> Producers { get; set; }
-        HashSet<PubSubSubscriptionState> Consumers { get; set; }
+        public HashSet<PubSubPublisherState> Producers { get; set; }
+        public HashSet<PubSubSubscriptionState> Consumers { get; set; }
     }
 
     [Orleans.Providers.StorageProvider(ProviderName = "PubSubStore")]
-    internal class PubSubRendezvousGrain : Grain<IPubSubGrainState>, IPubSubRendezvousGrain
+    internal class PubSubRendezvousGrain : Grain<PubSubGrainState>, IPubSubRendezvousGrain
     {
         private Logger logger;
         private const bool DEBUG_PUB_SUB = false;

--- a/src/TestGrains/GenericGrains.cs
+++ b/src/TestGrains/GenericGrains.cs
@@ -29,17 +29,18 @@ using Orleans.Concurrency;
 using Orleans.Providers;
 using UnitTests.GrainInterfaces;
 using System.Globalization;
+using Orleans.CodeGeneration;
 
 namespace UnitTests.Grains
 {
-    public interface ISimpleGenericGrainState<T> : IGrainState
+    public class SimpleGenericGrainState<T> : GrainState
     {
-        T A { get; set; }
-        T B { get; set; }
+        public T A { get; set; }
+        public T B { get; set; }
     }
 
     [StorageProvider(ProviderName = "MemoryStore")]
-    public class SimpleGenericGrain1<T> : Grain<ISimpleGenericGrainState<T>>, ISimpleGenericGrain1<T>
+    public class SimpleGenericGrain1<T> : Grain<SimpleGenericGrainState<T>>, ISimpleGenericGrain1<T>
     {
         public Task<T> GetA()
         {
@@ -71,14 +72,14 @@ namespace UnitTests.Grains
         }
     }
 
-    public interface ISimpleGenericGrainUState<U> : IGrainState
+    public class SimpleGenericGrainUState<U> : GrainState
     {
-        U A { get; set; }
-        U B { get; set; }
+        public U A { get; set; }
+        public U B { get; set; }
     }
 
     [StorageProvider(ProviderName = "MemoryStore")]
-    public class SimpleGenericGrainU<U> : Grain<ISimpleGenericGrainUState<U>>, ISimpleGenericGrainU<U>
+    public class SimpleGenericGrainU<U> : Grain<SimpleGenericGrainUState<U>>, ISimpleGenericGrainU<U>
     {
         public Task<U> GetA()
         {
@@ -110,14 +111,14 @@ namespace UnitTests.Grains
         }
     }
 
-    public interface ISimpleGenericGrain2State<T, U> : IGrainState
+    public class SimpleGenericGrain2State<T, U> : GrainState
     {
-        T A { get; set; }
-        U B { get; set; }
+        public T A { get; set; }
+        public U B { get; set; }
     }
 
     [StorageProvider(ProviderName = "MemoryStore")]
-    public class SimpleGenericGrain2<T, U> : Grain<ISimpleGenericGrain2State<T, U>>, ISimpleGenericGrain2<T, U>
+    public class SimpleGenericGrain2<T, U> : Grain<SimpleGenericGrain2State<T, U>>, ISimpleGenericGrain2<T, U>
     {
         public Task<T> GetA()
         {
@@ -149,7 +150,6 @@ namespace UnitTests.Grains
         }
     }
 
-    //public class GenericGrainWithNoProperties<T> : GenericGrainWithNoPropertiesBase<T>
     public class GenericGrainWithNoProperties<T> : Grain, IGenericGrainWithNoProperties<T>
     {
         public Task<string> GetAxB(T a, T b)
@@ -166,9 +166,9 @@ namespace UnitTests.Grains
             return Task.FromResult(retValue);
         }
     }
-    public interface IGrainWithListFieldsState : IGrainState
+    public class IGrainWithListFieldsState : GrainState
     {
-        IList<string> Items { get; set; }
+        public IList<string> Items { get; set; }
     }
 
     [StorageProvider(ProviderName = "MemoryStore")]
@@ -193,13 +193,13 @@ namespace UnitTests.Grains
         }
     }
 
-    public interface IGenericGrainWithListFieldsState<T> : IGrainState
+    public class GenericGrainWithListFieldsState<T> : GrainState
     {
-        IList<T> Items { get; set; }
+        public IList<T> Items { get; set; }
     }
 
     [StorageProvider(ProviderName = "MemoryStore")]
-    public class GenericGrainWithListFields<T> : Grain<IGenericGrainWithListFieldsState<T>>, IGenericGrainWithListFields<T>
+    public class GenericGrainWithListFields<T> : Grain<GenericGrainWithListFieldsState<T>>, IGenericGrainWithListFields<T>
     {
         public override Task OnActivateAsync()
         {
@@ -221,33 +221,33 @@ namespace UnitTests.Grains
         }
     }
 
-    public interface IGenericReaderWriterState<T> : IGrainState
+    public class GenericReaderWriterState<T> : GrainState
     {
-        T Value { get; set; }
+        public T Value { get; set; }
     }
     
 
-    public interface IGenericReader2State<TOne, TTwo> : IGrainState
+    public class GenericReader2State<TOne, TTwo> : GrainState
     {
-        TOne Value1 { get; set; }
-        TTwo Value2 { get; set; }
+        public TOne Value1 { get; set; }
+        public TTwo Value2 { get; set; }
     }
-    public interface IGenericReaderWriterGrain2State<TOne, TTwo> : IGrainState
+    public class GenericReaderWriterGrain2State<TOne, TTwo> : GrainState
     {
-        TOne Value1 { get; set; }
-        TTwo Value2 { get; set; }
+        public TOne Value1 { get; set; }
+        public TTwo Value2 { get; set; }
     }
 
-    public interface IGenericReader3State<TOne, TTwo, TThree> : IGrainState
+    public class GenericReader3State<TOne, TTwo, TThree> : GrainState
     {
-        TOne Value1 { get; set; }
-        TTwo Value2 { get; set; }
-        TThree Value3 { get; set; }
+        public TOne Value1 { get; set; }
+        public TTwo Value2 { get; set; }
+        public TThree Value3 { get; set; }
     }
 
 
     [StorageProvider(ProviderName = "MemoryStore")]
-    public class GenericReaderWriterGrain1<T> : Grain<IGenericReaderWriterState<T>>, IGenericReaderWriterGrain1<T>
+    public class GenericReaderWriterGrain1<T> : Grain<GenericReaderWriterState<T>>, IGenericReaderWriterGrain1<T>
     {
         public Task SetValue(T value)
         {
@@ -262,7 +262,7 @@ namespace UnitTests.Grains
     }
 
     [StorageProvider(ProviderName = "MemoryStore")]
-    public class GenericReaderWriterGrain2<TOne, TTwo> : Grain<IGenericReaderWriterGrain2State<TOne, TTwo>>, IGenericReaderWriterGrain2<TOne, TTwo>
+    public class GenericReaderWriterGrain2<TOne, TTwo> : Grain<GenericReaderWriterGrain2State<TOne, TTwo>>, IGenericReaderWriterGrain2<TOne, TTwo>
     {
         public Task SetValue1(TOne value)
         {
@@ -287,7 +287,7 @@ namespace UnitTests.Grains
     }
 
     [StorageProvider(ProviderName = "MemoryStore")]
-    public class GenericReaderWriterGrain3<TOne, TTwo, TThree> : Grain<IGenericReader3State<TOne, TTwo, TThree>>, IGenericReaderWriterGrain3<TOne, TTwo, TThree>
+    public class GenericReaderWriterGrain3<TOne, TTwo, TThree> : Grain<GenericReader3State<TOne, TTwo, TThree>>, IGenericReaderWriterGrain3<TOne, TTwo, TThree>
     {
         public Task SetValue1(TOne value)
         {

--- a/src/TestGrains/SimplePersistentGrain.cs
+++ b/src/TestGrains/SimplePersistentGrain.cs
@@ -39,21 +39,8 @@ namespace UnitTests.Grains
 {
     public class SimplePersistentGrain_State : GrainState
     {
-        public SimplePersistentGrain_State()
-            : base(typeof(SimplePersistentGrain).FullName) 
-            // TODO: GrainState takes name of the grain type here, which is probably a mistake
-            // since multiple grain classes can use the same state object interface/class.
-            // Need to figure out the right story for mapping grain classes to storage entity types (tables).
-        {}
-
         public int A { get; set; }
         public int B { get; set; }
-    }
-
-    public interface ISimplePersistentGrain_State : IGrainState
-    {
-        int A { get; set; }
-        int B { get; set; }
     }
 
     /// <summary>
@@ -97,62 +84,6 @@ namespace UnitTests.Grains
         public Task<int> GetAxB()
         {
             return Task.FromResult(State.A*State.B);
-        }
-
-        public Task<int> GetAxB(int a, int b)
-        {
-            return Task.FromResult(a * b);
-        }
-
-        public Task<int> GetA()
-        {
-            return Task.FromResult(State.A);
-        }
-
-        public Task<Guid> GetVersion()
-        {
-            return Task.FromResult(version);
-        }
-    }
-
-    [StorageProvider(ProviderName = "MemoryStore")]
-    public class SimpleInterfacePersistentGrain : Grain<ISimplePersistentGrain_State>, ISimplePersistentGrain
-    {
-        private Guid version;
-
-        public override Task OnActivateAsync()
-        {
-            version = Guid.NewGuid();
-            return base.OnActivateAsync();
-        }
-        public Task SetA(int a)
-        {
-            State.A = a;
-            return WriteStateAsync();
-        }
-
-        public Task SetA(int a, bool deactivate)
-        {
-            if (deactivate)
-                DeactivateOnIdle();
-            return SetA(a);
-        }
-
-        public Task SetB(int b)
-        {
-            State.B = b;
-            return WriteStateAsync();
-        }
-
-        public Task IncrementA()
-        {
-            State.A++;
-            return WriteStateAsync();
-        }
-
-        public Task<int> GetAxB()
-        {
-            return Task.FromResult(State.A * State.B);
         }
 
         public Task<int> GetAxB(int a, int b)

--- a/src/Tester/ConcreteStateClassTests.cs
+++ b/src/Tester/ConcreteStateClassTests.cs
@@ -49,12 +49,6 @@ namespace UnitTests.General
             await StateClassTests_Test("UnitTests.Grains.SimplePersistentGrain");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
-        public async Task StateClassTests_StateInterface()
-        {
-            await StateClassTests_Test("UnitTests.Grains.SimpleInterfacePersistentGrain");
-        }
-
         private async Task StateClassTests_Test(string grainClass)
         {
             var x = rand.Next();


### PR DESCRIPTION
Converted  PubSubRendezvousGrain and all tests grains to use state classes instead of interfaces.
Added a compile time warning for usage of grain state interfaces.

The goal here is to deprecate grain state interfaces in 1.0.9, and then remove support for them and code generation of state classes in 1.0.10.