### PR TITLE
Removed schema initialization from table creation

### DIFF
--- a/src/OrleansAzureUtils/Storage/AzureTableDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/AzureTableDataManager.cs
@@ -93,10 +93,6 @@ namespace Orleans.AzureUtils
 
                 Logger.Info(ErrorCode.AzureTable_01, "{0} Azure storage table {1}", (didCreate ? "Created" : "Attached to"), TableName);
 
-                await InitializeTableSchemaFromEntity(tableRef);
-
-                Logger.Info(ErrorCode.AzureTable_36, "Initialized schema for Azure storage table {0}", TableName);
-
                 CloudTableClient tableOperationsClient = GetCloudTableOperationsClient();
                 tableReference = tableOperationsClient.GetTableReference(TableName);
             }
@@ -735,83 +731,6 @@ namespace Orleans.AzureUtils
                 Logger.Error(ErrorCode.AzureTable_18, String.Format("Error creating CloudTableCreationClient."), exc);
                 throw;
             }
-        }
-
-        // Based on: http://blogs.msdn.com/b/cesardelatorre/archive/2011/03/12/typical-issue-one-of-the-request-inputs-is-not-valid-when-working-with-the-wa-development-storage.aspx
-        private async Task InitializeTableSchemaFromEntity(CloudTable tableRef)
-        {
-            const string operation = "InitializeTableSchemaFromEntity";
-            var startTime = DateTime.UtcNow;
-
-            ITableEntity entity = new T();
-            entity.PartitionKey = Guid.NewGuid().ToString();
-            entity.RowKey = Guid.NewGuid().ToString();
-            Array.ForEach(
-                entity.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance),
-                p =>
-                {
-                    if ((p.Name == "PartitionKey") || (p.Name == "RowKey") || (p.Name == "Timestamp")) return;
-
-                    if (p.PropertyType == typeof(string))
-                    {
-                        p.SetValue(entity, Guid.NewGuid().ToString(),
-                                   null);
-                    }
-                    else if (p.PropertyType == typeof(DateTime))
-                    {
-                        p.SetValue(entity, startTime, null);
-                    }
-                });
-
-            try
-            {
-                // WAS:
-                // svc.AddObject(TableName, entity);
-                // SaveChangesOptions.None,
-
-                try
-                {
-                    await Task<TableResult>.Factory.FromAsync(
-                        tableRef.BeginExecute,
-                        tableRef.EndExecute,
-                        TableOperation.Insert(entity),
-                        null);
-                }
-                catch (Exception exc)
-                {
-                    CheckAlertWriteError(operation + "-Create", entity, null, exc);
-                    throw;
-                }
-
-                try
-                {
-                    // WAS:
-                    // svc.DeleteObject(entity);
-                    // SaveChangesOptions.None,
-
-                    await Task<TableResult>.Factory.FromAsync(
-                        tableRef.BeginExecute,
-                        tableRef.EndExecute,
-                        TableOperation.Delete(entity),
-                        null);
-                }
-                catch (Exception exc)
-                {
-                    CheckAlertWriteError(operation + "-Delete", entity, null, exc);
-                    throw;
-                }
-            }
-            finally
-            {
-                CheckAlertSlowAccess(startTime, operation);
-            }
-        }
-
-        private bool IsServerBusy(Exception exc)
-        {
-            bool serverBusy = AzureStorageUtils.IsServerBusy(exc);
-            if (serverBusy) numServerBusy.Increment();
-            return serverBusy;
         }
 
         private void CheckAlertWriteError(string operation, object data1, string data2, Exception exc)


### PR DESCRIPTION
This change removes schema initialization of azure tables.  
Earlier versions of azure table storage required schema initialization when using local developer storage.  This is no longer the case, and this schema initialization can leave junk in the table.  