### PR TITLE
Move GrainState and IGrainFactory to the root Orleans namespace 

### DIFF
--- a/src/Orleans/CodeGeneration/GrainState.cs
+++ b/src/Orleans/CodeGeneration/GrainState.cs
@@ -33,9 +33,8 @@ using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Storage;
 
-namespace Orleans.CodeGeneration
+namespace Orleans
 {
-
     /// <summary>
     /// Base class for generated grain state classes.
     /// </summary>

--- a/src/Orleans/Core/IGrainFactory.cs
+++ b/src/Orleans/Core/IGrainFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace Orleans.Core
+namespace Orleans
 {
     public interface IGrainFactory
     {


### PR DESCRIPTION
Both GrainState and IGrainFacttory are supposed to be used in common scenarios now, and having then in sub-namespaces creates unnecessary friction through lower discoverability and the need for extra using statements.