### PR TITLE
update ZK nuget & minor fix to membership tests

### DIFF
--- a/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
+++ b/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
@@ -52,16 +52,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="ZooKeeperNetEx, Version=3.4.6.0, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeperNetEx.3.4.6-alpha17\lib\net45\ZooKeeperNetEx.dll</HintPath>
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.6.1001\lib\net45\ZooKeeperNetEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/OrleansZooKeeperUtils/packages.config
+++ b/src/OrleansZooKeeperUtils/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="ZooKeeperNetEx" version="3.4.6-alpha17" targetFramework="net45" />
+  <package id="ZooKeeperNetEx" version="3.4.6.1001" targetFramework="net45" />
 </packages>

--- a/src/TesterInternal/MembershipTests/MembershipTablePluginTests.cs
+++ b/src/TesterInternal/MembershipTests/MembershipTablePluginTests.cs
@@ -171,7 +171,6 @@ namespace UnitTests.MembershipTests
             Assert.IsNotNull(tableVer, "TableVersion should not be null");
             tableVer = tableVer.Next();
 
-            data = CreateMembershipEntryForTest();
             data.Status = SiloStatus.Active;
 
             logger.Info("Calling UpdateRow with Entry = {0} eTag = {1} New TableVersion={2}", data, eTag, tableVer);


### PR DESCRIPTION
changes in ZooKeeperNetEx:
* code is 100% CoreCLR compliant
* purely task based, removed usage of explicit threads
* fixed a bug with session shutdown
* improved "ZooKeeper.Using" implementation
* documented all public surface methods and classes
* removed dependency on log4net

also, fixed a minor bug in the membership tests, correct me if I'm wrong.