### PR TITLE
Fixes float statistics to culture invariant form

### DIFF
--- a/src/Orleans/Statistics/FloatValueStatistic.cs
+++ b/src/Orleans/Statistics/FloatValueStatistic.cs
@@ -23,6 +23,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Orleans.Runtime
@@ -137,7 +138,7 @@ namespace Orleans.Runtime
         public string GetValueString()
         {
             float current = GetCurrentValue();
-            return String.Format("{0:0.000}", current);
+            return String.Format(CultureInfo.InvariantCulture, "{0:0.000}", current);
         }
 
         public string GetDeltaString()


### PR DESCRIPTION
This fixes float statistics values to culture invariant form,
especially forces the decimal separator to be dot.
fixes decimal separator to use invariant culture separator

This is done to avoid problems when reading data from a storage
and it is converted back to floating point values.

Fixes #573.