### PR TITLE
OMQ-SendMessage

### DIFF
--- a/src/OrleansRuntime/Messaging/IOutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/IOutboundMessageQueue.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.Messaging
         /// </summary>
         void Stop();
 
-        bool SendMessage(Message message);
+        void SendMessage(Message message);
 
         /// <summary>
         /// Current queue length

--- a/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
@@ -72,21 +72,19 @@ namespace Orleans.Runtime.Messaging
             stopped = false;
         }
 
-        public bool SendMessage(Message msg)
+        public void SendMessage(Message msg)
         {
-            if (msg == null) return true;
+            if (msg == null) throw new ArgumentNullException("msg", "Can't send a null message.");
 
             if (stopped)
             {
                 logger.Info(ErrorCode.Runtime_Error_100112, "Message was queued for sending after outbound queue was stopped: {0}", msg);
-                return true;
             }
 
             // Don't process messages that have already timed out
             if (msg.IsExpired)
             {
                 msg.DropExpiredMessage(MessagingStatisticsGroup.Phase.Send);
-                return true;
             }
 
             if (!msg.ContainsMetadata(QUEUED_TIME_METADATA))
@@ -97,14 +95,13 @@ namespace Orleans.Runtime.Messaging
             // First check to see if it's really destined for a proxied client, instead of a local grain.
             if (messageCenter.IsProxying && messageCenter.TryDeliverToProxy(msg))
             {
-                return true;
+                return;
             }
 
             if (!msg.ContainsHeader(Message.Header.TARGET_SILO))
             {
                 logger.Error(ErrorCode.Runtime_Error_100113, "Message does not have a target silo: " + msg + " -- Call stack is: " + (new System.Diagnostics.StackTrace()));
                 messageCenter.SendRejection(msg, Message.RejectionTypes.Unrecoverable, "Message to be sent does not have a target silo");
-                return true;
             }
 
             if (Message.WriteMessagingTraces)
@@ -122,7 +119,6 @@ namespace Orleans.Runtime.Messaging
                 if (stopped)
                 {
                     logger.Info(ErrorCode.Runtime_Error_100115, "Message was queued for sending after outbound queue was stopped: {0}", msg);
-                    return true;
                 }
 
                 // Prioritize system messages
@@ -140,17 +136,17 @@ namespace Orleans.Runtime.Messaging
                     {
                         int index = Math.Abs(msg.TargetSilo.GetConsistentHashCode()) % senders.Length;
                         senders[index].Value.QueueRequest(msg);
-                    }
                         break;
+                    }
                 }
             }
-            return true;
         }
 
         public void Start()
         {
             pingSender.Start();
             systemSender.Start();
+            stopped = false;
         }
 
         public void Stop()
@@ -170,6 +166,7 @@ namespace Orleans.Runtime.Messaging
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1816:CallGCSuppressFinalizeCorrectly")]
         public void Dispose()
         {
+            stopped = true;
             foreach (var sender in senders)
             {
                 sender.Value.Stop();


### PR DESCRIPTION
- The `SendMessage` method in `OutboundMessageQueue` is declared as returning a `bool`, but the returned value is always `true` and the returned value is never used anywhere.
Changing return type to `void` to avoid confusion.

- Throw NullArgumentException if SendMessage is every passed a null message [never happens in current code base], rather than silently ignore.