### PR TITLE
OMQ-SendMessage

### DIFF
--- a/src/OrleansRuntime/Messaging/IOutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/IOutboundMessageQueue.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.Messaging
         /// </summary>
         void Stop();
 
-        bool SendMessage(Message message);
+        void SendMessage(Message message);
 
         /// <summary>
         /// Current queue length


### PR DESCRIPTION
- The `SendMessage` method in `OutboundMessageQueue` is declared as returning a `bool`, but the returned value is always `true` and the returned value is never used anywhere.
Changing return type to `void` to avoid confusion.

- Throw NullArgumentException if SendMessage is every passed a null message [never happens in current code base], rather than silently ignore.

Replaces #586 