### PR TITLE
Switched loading of plugin assemblies from Assembly.LoadFrom() to Assembly.Load()

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -106,38 +106,8 @@ namespace Orleans.Runtime
         {
             try
             {
-                var exeRoot = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                var dirs = new Dictionary<string, SearchOption>
-                {
-                    {exeRoot, SearchOption.TopDirectoryOnly}
-                };
-
-                AssemblyLoaderPathNameCriterion[] includeCriteria =
-                {
-                    AssemblyLoaderCriteria.IncludeFileNames(new[] {assemblyName})
-                };
-                AssemblyLoaderReflectionCriterion[] loadCriteria =
-                {
-                    AssemblyLoaderCriteria.LoadTypesAssignableFrom(typeof (T))
-                };
-
-                var discoveredAssemblyLocations = LoadAssemblies(dirs, includeCriteria, loadCriteria, logger);
-
-                if (discoveredAssemblyLocations.Count == 0)
-                {
-                    var error = String.Format(  "Failed to LoadAndCreateInstance for type {0} from assembly {1}. " +
-                                                "Make sure this assembly is in your current executing directory and the type is defined there.", 
-                                                typeof(T).FullName, assemblyName);
-                    throw new OrleansException(error);
-                }
-
-                if (discoveredAssemblyLocations.Count > 1)
-                {
-                    var error = String.Format("Type {0} was found more than once in assembly {1}.", typeof(T).FullName, assemblyName);
-                    throw new OrleansException(error);
-                }
-
-                var foundType = TypeUtils.GetTypes(discoveredAssemblyLocations, type => typeof (T).IsAssignableFrom(type)).First();
+                var assembly = Assembly.Load(assemblyName);
+                var foundType = TypeUtils.GetTypes(assembly, type => typeof (T).IsAssignableFrom(type)).First();
 
                 return (T) Activator.CreateInstance(foundType, true);
             }

--- a/src/Orleans/Runtime/Constants.cs
+++ b/src/Orleans/Runtime/Constants.cs
@@ -39,8 +39,8 @@ namespace Orleans.Runtime
         public const string MEMORY_STORAGE_PROVIDER_NAME = "MemoryStore";
         public const string DATA_CONNECTION_STRING_NAME = "DataConnectionString";
 
-        public const string ORLEANS_AZURE_UTILS_DLL = "OrleansAzureUtils.dll";
-        public const string ORLEANS_ZOOKEEPER_UTILS_DLL = "OrleansZooKeeperUtils.dll";
+        public const string ORLEANS_AZURE_UTILS_DLL = "OrleansAzureUtils";
+        public const string ORLEANS_ZOOKEEPER_UTILS_DLL = "OrleansZooKeeperUtils";
 
         public static readonly GrainId DirectoryServiceId = GrainId.GetSystemTargetGrainId(10);
         public static readonly GrainId DirectoryCacheValidatorId = GrainId.GetSystemTargetGrainId(11);


### PR DESCRIPTION
This is a fix for https://github.com/dotnet/orleans/issues/593.

Changed AssemblyLoader.LoadAndCreateInstance<T> to use Assembly.Load() instead of Assembly.LoadFrom() because of the assembly layout in ASP.NET where every such assembly is put in its own folder.