### PR TITLE
ZK MBR - fix packaging and filter active gateways

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -21,6 +21,7 @@
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
       <dependency id="Newtonsoft.Json" version="5.0.8" />
+	  <dependency id="ZooKeeperNetEx" version="3.4.6.1001" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
+++ b/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
@@ -205,7 +205,13 @@ namespace Orleans.Runtime.Host
 
         public IList<Uri> GetGateways()
         {
-            return ReadAll().Result.Members.Select(entryWithTag => entryWithTag.Item1.SiloAddress.Endpoint.ToGatewayUri()).ToList();
+            return ReadAll().Result.Members.Select(e => e.Item1).
+                                            Where(m => m.Status == SiloStatus.Active && m.ProxyPort != 0).
+                                            Select(m =>
+                                            {
+                                                m.SiloAddress.Endpoint.Port = m.ProxyPort;
+                                                return m.SiloAddress.ToGatewayUri();
+                                            }).ToList();
         }
 
         public TimeSpan MaxStaleness

--- a/src/OrleansZooKeeperUtils/packages.config
+++ b/src/OrleansZooKeeperUtils/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ZooKeeperNetEx" version="3.4.6.1001" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR contains two fixes:
* ZK MBR - fix packaging
 * added ZooKeeperNetEx dependency to the OrleansZooKeeperUtils.nuspec
 * added Newtonsoft.Json to packages.config of OrleansZooKeeperUtils project
* ZK MBR - filter active gateways
 * filter only active gateways with ProxyPort !=0
 * replace Port with ProxyPort in returned SiloAddress