### PR TITLE
Allow using streams inside Bootstrap provider

### DIFF
--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -23,10 +23,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Reflection;
 using System.Threading.Tasks;
-using Orleans.Core;
 using Orleans.Streams;
 
 using Orleans.Runtime;
@@ -100,7 +97,7 @@ namespace Orleans.Providers
             }
         }
 
-        public string ExecutingEntityIdentity()
+        public string ExecutingEntityName()
         {
             return RuntimeClient.Current.Identity;
         }
@@ -181,7 +178,7 @@ namespace Orleans.Providers
             return Task.Run(asyncFunc);
         }
 
-        public object GetCurrentSchedulingContext()
+        public ISchedulingContext GetCurrentSchedulingContext()
         {
             return null;
         }

--- a/src/Orleans/Providers/IBootstrapProvider.cs
+++ b/src/Orleans/Providers/IBootstrapProvider.cs
@@ -21,7 +21,6 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System.Threading.Tasks;
 using Orleans.Streams;
 
 namespace Orleans.Providers
@@ -31,6 +30,6 @@ namespace Orleans.Providers
     /// </summary>
     public interface IBootstrapProvider : IProvider
     {
-        Task SetStreamProviderManager(IStreamProviderManager streamProviderManager); 
+        void SetStreamProviderManager(IStreamProviderManager streamProviderManager); 
     }
 }

--- a/src/Orleans/Providers/IBootstrapProvider.cs
+++ b/src/Orleans/Providers/IBootstrapProvider.cs
@@ -21,12 +21,16 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-﻿namespace Orleans.Providers
+using System.Threading.Tasks;
+using Orleans.Streams;
+
+namespace Orleans.Providers
 {
     /// <summary>
     /// Marker interface to be implemented by any app bootstrap classes that want to be loaded and auto-run during silo startup
     /// </summary>
     public interface IBootstrapProvider : IProvider
     {
+        Task SetStreamProviderManager(IStreamProviderManager streamProviderManager); 
     }
 }

--- a/src/Orleans/Providers/ProviderLoader.cs
+++ b/src/Orleans/Providers/ProviderLoader.cs
@@ -94,7 +94,7 @@ namespace Orleans.Providers
             }
         }
         
-        public async Task InjectStreamProviderManagerToBootstrapProvider(IStreamProviderManager streamProviderManager)  
+        public void InjectStreamProviderManagerToBootstrapProvider(IStreamProviderManager streamProviderManager)  
         {  
             Dictionary<string, IBootstrapProvider> copy;  
             lock (providers)  
@@ -106,7 +106,7 @@ namespace Orleans.Providers
                 string name = provider.Key;  
                 try  
                 {
-                    await provider.Value.SetStreamProviderManager(streamProviderManager);  
+                    provider.Value.SetStreamProviderManager(streamProviderManager);  
                 }  
                 catch (Exception exc)  
                 {  

--- a/src/Orleans/Streams/Internal/IInternalStreamProvider.cs
+++ b/src/Orleans/Streams/Internal/IInternalStreamProvider.cs
@@ -21,6 +21,7 @@ namespace Orleans.Streams
 {
     internal interface IInternalStreamProvider : IStreamProviderImpl
     {
+        IStreamProviderRuntime StreamProviderRuntime { get; }
         IAsyncBatchObserver<T> GetProducerInterface<T>(IAsyncStream<T> streamId);
         IInternalAsyncObservable<T> GetConsumerInterface<T>(IAsyncStream<T> streamId);
     }

--- a/src/Orleans/Streams/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans/Streams/Internal/StreamConsumerExtension.cs
@@ -130,7 +130,7 @@ namespace Orleans.Streams
 
             try
             {
-                if (logger.IsVerbose) logger.Verbose("{0} AddObserver for stream {1}", providerRuntime.ExecutingEntityIdentity(), stream);
+                if (logger.IsVerbose) logger.Verbose("{0} AddObserver for stream {1}", providerRuntime.ExecutingEntityName(), stream);
 
                 // Note: The caller [StreamConsumer] already handles locking for Add/Remove operations, so we don't need to repeat here.
                 IStreamObservers obs = allStreamObservers.GetOrAdd(subscriptionId, new ObserversCollection<T>());
@@ -141,7 +141,7 @@ namespace Orleans.Streams
             catch (Exception exc)
             {
                 logger.Error((int)ErrorCode.StreamProvider_AddObserverException, String.Format("{0} StreamConsumerExtension.AddObserver({1}) caugth exception.", 
-                    providerRuntime.ExecutingEntityIdentity(), stream), exc);
+                    providerRuntime.ExecutingEntityName(), stream), exc);
                 throw;
             }
         }
@@ -173,7 +173,7 @@ namespace Orleans.Streams
                 return observers.DeliverItem(item.Value, token);
 
             logger.Warn((int)(ErrorCode.StreamProvider_NoStreamForItem), "{0} got an item for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
-                providerRuntime.ExecutingEntityIdentity(), subscriptionId);
+                providerRuntime.ExecutingEntityName(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...
             return TaskDone.Done;
@@ -189,7 +189,7 @@ namespace Orleans.Streams
                 return observers.DeliverBatch(batch.Value);
 
             logger.Warn((int)(ErrorCode.StreamProvider_NoStreamForBatch), "{0} got an item for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
-                providerRuntime.ExecutingEntityIdentity(), subscriptionId);
+                providerRuntime.ExecutingEntityName(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...
             return TaskDone.Done;
@@ -204,7 +204,7 @@ namespace Orleans.Streams
                 return observers.CompleteStream();
 
             logger.Warn((int)(ErrorCode.StreamProvider_NoStreamForItem), "{0} got a Complete for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
-                providerRuntime.ExecutingEntityIdentity(), subscriptionId);
+                providerRuntime.ExecutingEntityName(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...
             return TaskDone.Done;
@@ -219,7 +219,7 @@ namespace Orleans.Streams
                 return observers.ErrorInStream(exc);
 
             logger.Warn((int)(ErrorCode.StreamProvider_NoStreamForItem), "{0} got an Error for subscription {1}, but I don't have any subscriber for that stream. Dropping on the floor.",
-                providerRuntime.ExecutingEntityIdentity(), subscriptionId);
+                providerRuntime.ExecutingEntityName(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...
             return TaskDone.Done;

--- a/src/Orleans/Streams/Internal/StreamImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamImpl.cs
@@ -146,7 +146,7 @@ namespace Orleans.Streams
             var context = GetStreamProviderRuntime().GetCurrentSchedulingContext();
             if (context != null && !context.ContextType.Equals(SchedulingContextType.Activation))
             {
-                throw new OrleansException(String.Format("Attemping to {0} on a stream not from within Grain context.", caller));
+                throw new OrleansException(String.Format("Attempting to {0} on a stream from outside a Grain context.", caller));
             }
         }
 

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -122,7 +122,12 @@ namespace Orleans.Providers.Streams.Common
                 streamId, () => new StreamImpl<T>(streamId, this, IsRewindable));
         }
 
-        public IAsyncBatchObserver<T> GetProducerInterface<T>(IAsyncStream<T> stream)
+        IStreamProviderRuntime IInternalStreamProvider.StreamProviderRuntime
+        {
+            get { return providerRuntime; }
+        }
+
+        IAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> stream)
         {
             return new PersistentStreamProducer<T>((StreamImpl<T>)stream, providerRuntime, queueAdapter, IsRewindable);
         }

--- a/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
+++ b/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
@@ -39,7 +39,7 @@ namespace Orleans.Streams
         /// Just for logging purposes.
         /// </summary>
         /// <param name="handler"></param>
-        string ExecutingEntityIdentity();
+        string ExecutingEntityName();
 
         SiloAddress ExecutingSiloAddress { get; }
 
@@ -96,7 +96,7 @@ namespace Orleans.Streams
         /// <param name="asyncFunc"></param>
         Task InvokeWithinSchedulingContextAsync(Func<Task> asyncFunc, object context);
 
-        object GetCurrentSchedulingContext();
+        ISchedulingContext GetCurrentSchedulingContext();
 
         /// <summary>
         /// Start the pulling agents for a given persistent stream provider.

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
@@ -73,7 +73,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         internal void AddSubscribers(StreamId streamId, ICollection<PubSubSubscriptionState> newSubscribers)
         {
-            if (logger.IsVerbose) logger.Verbose("{0} AddSubscribers {1} for stream {2}", providerRuntime.ExecutingEntityIdentity(), Utils.EnumerableToString(newSubscribers), streamId);
+            if (logger.IsVerbose) logger.Verbose("{0} AddSubscribers {1} for stream {2}", providerRuntime.ExecutingEntityName(), Utils.EnumerableToString(newSubscribers), streamId);
             
             StreamConsumerExtensionCollection consumers;
             if (remoteConsumers.TryGetValue(streamId, out consumers))
@@ -145,7 +145,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         {
             if (logger.IsVerbose)
             {
-                logger.Verbose("{0} AddSubscriber {1} for stream {2}", providerRuntime.ExecutingEntityIdentity(), streamConsumer, streamId);
+                logger.Verbose("{0} AddSubscriber {1} for stream {2}", providerRuntime.ExecutingEntityName(), streamConsumer, streamId);
             }
 
             StreamConsumerExtensionCollection consumers;
@@ -165,7 +165,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         {
             if (logger.IsVerbose)
             {
-                logger.Verbose("{0} RemoveSubscription {1}", providerRuntime.ExecutingEntityIdentity(),
+                logger.Verbose("{0} RemoveSubscription {1}", providerRuntime.ExecutingEntityName(),
                     subscriptionId);
             }
 

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -65,7 +65,12 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                 () => new StreamImpl<T>(streamId, this, IsRewindable));
         }
 
-        public IAsyncBatchObserver<T> GetProducerInterface<T>(IAsyncStream<T> stream)
+        IStreamProviderRuntime IInternalStreamProvider.StreamProviderRuntime 
+        {
+            get { return providerRuntime; }
+        }
+
+        IAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> stream)
         {
             return new SimpleMessageStreamProducer<T>((StreamImpl<T>)stream, Name, providerRuntime, fireAndForgetDelivery, IsRewindable);
         }

--- a/src/Orleans/SystemTargetInterfaces/ISystemTarget.cs
+++ b/src/Orleans/SystemTargetInterfaces/ISystemTarget.cs
@@ -21,6 +21,8 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using System;
+using System.Threading.Tasks;
 using Orleans.Runtime;
 
 using Orleans.CodeGeneration;
@@ -51,5 +53,16 @@ namespace Orleans
     internal interface IInvokable
     {
         IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType = null);
+        bool TryAddExtension(IGrainExtensionMethodInvoker invoker, IGrainExtension extension);
+        void RemoveExtension(IGrainExtension extension);
+        bool TryGetExtensionHandler(Type extensionType, out IGrainExtension result);
+    }
+
+    // Runtime component that supports using streams from within it (SystemTarget and ActivationData)
+    internal interface IStreamable
+    {
+        Streams.StreamDirectory GetStreamDirectory();
+        bool IsUsingStreams { get; }
+        Task DeactivateStreamResources();
     }
 }

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -39,115 +39,8 @@ namespace Orleans.Runtime
     /// MUST lock this object for any concurrent access
     /// Consider: compartmentalize by usage, e.g., using separate interfaces for data for catalog, etc.
     /// </summary>
-    internal class ActivationData : IActivationData, IInvokable
+    internal class ActivationData : IActivationData, IInvokable, IStreamable
     {
-        // This class is used for activations that have extension invokers. It keeps a dictionary of 
-        // invoker objects to use with the activation, and extend the default invoker
-        // defined for the grain class.
-        // Note that in all cases we never have more than one copy of an actual invoker;
-        // we may have a ExtensionInvoker per activation, in the worst case.
-        private class ExtensionInvoker : IGrainMethodInvoker
-        {
-            // Because calls to ExtensionInvoker are allways made within the activation context,
-            // we rely on the single-threading guarantee of the runtime and do not protect the map with a lock.
-            private Dictionary<int, Tuple<IGrainExtension, IGrainExtensionMethodInvoker>> extensionMap; // key is the extension interface ID
-            
-            /// <summary>
-            /// Try to add an extension for the specific interface ID.
-            /// Fail and return false if there is already an extension for that interface ID.
-            /// Note that if an extension invoker handles multiple interface IDs, it can only be associated
-            /// with one of those IDs when added, and so only conflicts on that one ID will be detected and prevented.
-            /// </summary>
-            /// <param name="invoker"></param>
-            /// <param name="handler"></param>
-            /// <returns></returns>
-            internal bool TryAddExtension(IGrainExtensionMethodInvoker invoker, IGrainExtension handler)
-            {
-                if (extensionMap == null)
-                {
-                    extensionMap = new Dictionary<int, Tuple<IGrainExtension, IGrainExtensionMethodInvoker>>(1);
-                }
-
-                if (extensionMap.ContainsKey(invoker.InterfaceId)) return false;
-
-                extensionMap.Add(invoker.InterfaceId, new Tuple<IGrainExtension, IGrainExtensionMethodInvoker>(handler, invoker));
-                return true;
-            }
-
-            /// <summary>
-            /// Removes all extensions for the specified interface id.
-            /// Returns true if the chained invoker no longer has any extensions and may be safely retired.
-            /// </summary>
-            /// <param name="extension"></param>
-            /// <returns>true if the chained invoker is now empty, false otherwise</returns>
-            public bool Remove(IGrainExtension extension)
-            {
-                int interfaceId = 0;
-
-                foreach(int iface in extensionMap.Keys)
-                    if (extensionMap[iface].Item1 == extension)
-                    {
-                        interfaceId = iface;
-                        break;
-                    }
-
-                if (interfaceId == 0) // not found
-                    throw new InvalidOperationException(String.Format("Extension {0} is not installed",
-                        extension.GetType().FullName));
-
-                extensionMap.Remove(interfaceId);
-                return extensionMap.Count == 0;
-            }
-
-            public bool TryGetExtensionHandler(Type extensionType, out IGrainExtension result)
-            {
-                result = null;
-
-                if (extensionMap == null) return false;
-
-                foreach (var ext in extensionMap.Values)
-                    if (extensionType == ext.Item1.GetType())
-                    {
-                        result = ext.Item1;
-                        return true;
-                    }
-
-                return false;
-            }
-
-            /// <summary>
-            /// Invokes the appropriate grain or extension method for the request interface ID and method ID.
-            /// First each extension invoker is tried; if no extension handles the request, then the base
-            /// invoker is used to handle the request.
-            /// The base invoker will throw an appropriate exception if the request is not recognized.
-            /// </summary>
-            /// <param name="grain"></param>
-            /// <param name="interfaceId"></param>
-            /// <param name="methodId"></param>
-            /// <param name="arguments"></param>
-            /// <returns></returns>
-            public Task<object> Invoke(IAddressable grain, int interfaceId, int methodId, object[] arguments)
-            {
-                if (extensionMap == null || !extensionMap.ContainsKey(interfaceId))
-                    throw new InvalidOperationException(
-                        String.Format("Extension invoker invoked with an unknown inteface ID:{0}.", interfaceId));
-
-                var invoker = extensionMap[interfaceId].Item2;
-                var extension = extensionMap[interfaceId].Item1;
-                return invoker.Invoke(extension, interfaceId, methodId, arguments);
-            }
-
-            public bool IsExtensionInstalled(int interfaceId)
-            {
-                return extensionMap != null && extensionMap.ContainsKey(interfaceId);
-            }
-
-            public int InterfaceId
-            {
-                get { return 0; } // 0 indicates an extension invoker that may have multiple intefaces inplemented by extensions.
-            }
-        }
-
         // This is the maximum amount of time we expect a request to continue processing
         private static TimeSpan maxRequestProcessingTime;
         private static NodeConfiguration nodeConfiguration;
@@ -193,6 +86,12 @@ namespace Orleans.Runtime
         private ExtensionInvoker extensionInvoker;
         public IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType=null)
         {
+            return GetInvoker(ref lastInvoker, ref extensionInvoker, interfaceId, genericGrainType);
+        }
+
+        public static IGrainMethodInvoker GetInvoker(ref IGrainMethodInvoker lastInvoker, ref ExtensionInvoker extensionInvoker, 
+            int interfaceId, string genericGrainType = null)
+        {
             // Return previous cached invoker, if applicable
             if (lastInvoker != null && interfaceId == lastInvoker.InterfaceId) // extension invoker returns InterfaceId==0, so this condition will never be true if an extension is installed
                 return lastInvoker;
@@ -207,7 +106,7 @@ namespace Orleans.Runtime
             return lastInvoker;
         }
 
-        internal bool TryAddExtension(IGrainExtensionMethodInvoker invoker, IGrainExtension extension)
+        public bool TryAddExtension(IGrainExtensionMethodInvoker invoker, IGrainExtension extension)
         {
             if(extensionInvoker == null)
                 extensionInvoker = new ExtensionInvoker();
@@ -215,7 +114,7 @@ namespace Orleans.Runtime
             return extensionInvoker.TryAddExtension(invoker, extension);
         }
 
-        internal void RemoveExtension(IGrainExtension extension)
+        public void RemoveExtension(IGrainExtension extension)
         {
             if (extensionInvoker != null)
             {
@@ -226,7 +125,7 @@ namespace Orleans.Runtime
                 throw new InvalidOperationException("Grain extensions not installed.");
         }
 
-        internal bool TryGetExtensionHandler(Type extensionType, out IGrainExtension result)
+        public bool TryGetExtensionHandler(Type extensionType, out IGrainExtension result)
         {
             result = null;
             return extensionInvoker != null && extensionInvoker.TryGetExtensionHandler(extensionType, out result);
@@ -267,17 +166,17 @@ namespace Orleans.Runtime
         public IStorageProvider StorageProvider { get; set; }
 
         private Streams.StreamDirectory streamDirectory;
-        internal Streams.StreamDirectory GetStreamDirectory()
+        public Streams.StreamDirectory GetStreamDirectory()
         {
             return streamDirectory ?? (streamDirectory = new Streams.StreamDirectory());
         }
 
-        internal bool IsUsingStreams 
+        public bool IsUsingStreams 
         {
             get { return streamDirectory != null; }
         }
 
-        internal async Task DeactivateStreamResources()
+        public async Task DeactivateStreamResources()
         {
             if (streamDirectory == null) return; // No streams - Nothing to do.
             if (extensionInvoker == null) return; // No installed extensions - Nothing to do.

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -84,12 +84,12 @@ namespace Orleans.Runtime
         #region Method invocation
 
         private ExtensionInvoker extensionInvoker;
-        public IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType=null)
+        public IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType = null)
         {
             return GetInvoker(ref lastInvoker, ref extensionInvoker, interfaceId, genericGrainType);
         }
 
-        public static IGrainMethodInvoker GetInvoker(ref IGrainMethodInvoker lastInvoker, ref ExtensionInvoker extensionInvoker, 
+        internal static IGrainMethodInvoker GetInvoker(ref IGrainMethodInvoker lastInvoker, ref ExtensionInvoker extensionInvoker, 
             int interfaceId, string genericGrainType = null)
         {
             // Return previous cached invoker, if applicable

--- a/src/OrleansRuntime/Catalog/ExtensionInvoker.cs
+++ b/src/OrleansRuntime/Catalog/ExtensionInvoker.cs
@@ -1,0 +1,137 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.CodeGeneration;
+
+namespace Orleans.Runtime
+{
+    // This class is used for activations that have extension invokers. It keeps a dictionary of 
+    // invoker objects to use with the activation, and extend the default invoker
+    // defined for the grain class.
+    // Note that in all cases we never have more than one copy of an actual invoker;
+    // we may have a ExtensionInvoker per activation, in the worst case.
+    internal class ExtensionInvoker : IGrainMethodInvoker
+    {
+        // Because calls to ExtensionInvoker are allways made within the activation context,
+        // we rely on the single-threading guarantee of the runtime and do not protect the map with a lock.
+        private Dictionary<int, Tuple<IGrainExtension, IGrainExtensionMethodInvoker>> extensionMap; // key is the extension interface ID
+
+        /// <summary>
+        /// Try to add an extension for the specific interface ID.
+        /// Fail and return false if there is already an extension for that interface ID.
+        /// Note that if an extension invoker handles multiple interface IDs, it can only be associated
+        /// with one of those IDs when added, and so only conflicts on that one ID will be detected and prevented.
+        /// </summary>
+        /// <param name="invoker"></param>
+        /// <param name="handler"></param>
+        /// <returns></returns>
+        internal bool TryAddExtension(IGrainExtensionMethodInvoker invoker, IGrainExtension handler)
+        {
+            if (extensionMap == null)
+            {
+                extensionMap = new Dictionary<int, Tuple<IGrainExtension, IGrainExtensionMethodInvoker>>(1);
+            }
+
+            if (extensionMap.ContainsKey(invoker.InterfaceId)) return false;
+
+            extensionMap.Add(invoker.InterfaceId, new Tuple<IGrainExtension, IGrainExtensionMethodInvoker>(handler, invoker));
+            return true;
+        }
+
+        /// <summary>
+        /// Removes all extensions for the specified interface id.
+        /// Returns true if the chained invoker no longer has any extensions and may be safely retired.
+        /// </summary>
+        /// <param name="extension"></param>
+        /// <returns>true if the chained invoker is now empty, false otherwise</returns>
+        internal bool Remove(IGrainExtension extension)
+        {
+            int interfaceId = 0;
+
+            foreach (int iface in extensionMap.Keys)
+                if (extensionMap[iface].Item1 == extension)
+                {
+                    interfaceId = iface;
+                    break;
+                }
+
+            if (interfaceId == 0) // not found
+                throw new InvalidOperationException(String.Format("Extension {0} is not installed",
+                    extension.GetType().FullName));
+
+            extensionMap.Remove(interfaceId);
+            return extensionMap.Count == 0;
+        }
+
+        internal bool TryGetExtensionHandler(Type extensionType, out IGrainExtension result)
+        {
+            result = null;
+
+            if (extensionMap == null) return false;
+
+            foreach (var ext in extensionMap.Values)
+                if (extensionType == ext.Item1.GetType())
+                {
+                    result = ext.Item1;
+                    return true;
+                }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Invokes the appropriate grain or extension method for the request interface ID and method ID.
+        /// First each extension invoker is tried; if no extension handles the request, then the base
+        /// invoker is used to handle the request.
+        /// The base invoker will throw an appropriate exception if the request is not recognized.
+        /// </summary>
+        /// <param name="grain"></param>
+        /// <param name="interfaceId"></param>
+        /// <param name="methodId"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        public Task<object> Invoke(IAddressable grain, int interfaceId, int methodId, object[] arguments)
+        {
+            if (extensionMap == null || !extensionMap.ContainsKey(interfaceId))
+                throw new InvalidOperationException(
+                    String.Format("Extension invoker invoked with an unknown inteface ID:{0}.", interfaceId));
+
+            var invoker = extensionMap[interfaceId].Item2;
+            var extension = extensionMap[interfaceId].Item1;
+            return invoker.Invoke(extension, interfaceId, methodId, arguments);
+        }
+
+        internal bool IsExtensionInstalled(int interfaceId)
+        {
+            return extensionMap != null && extensionMap.ContainsKey(interfaceId);
+        }
+
+        public int InterfaceId
+        {
+            get { return 0; } // 0 indicates an extension invoker that may have multiple intefaces inplemented by extensions.
+        }
+    }
+}

--- a/src/OrleansRuntime/Core/BootstrapProviderManager.cs
+++ b/src/OrleansRuntime/Core/BootstrapProviderManager.cs
@@ -88,7 +88,7 @@ namespace Orleans.Runtime
                 providerLoader.LoadProviders(providers, this);
                 logger.Info(ErrorCode.SiloCallingProviderInit, "Calling Init for {0} classes", typeof(T).Name);
 
-                await providerLoader.InjectStreamProviderManagerToBootstrapProvider(streamProviderManager); 
+                providerLoader.InjectStreamProviderManagerToBootstrapProvider(streamProviderManager); 
 
                 // Await here to force any errors to show this method name in stack trace, for better diagnostics
                 await providerLoader.InitProviders(SiloProviderRuntime.Instance);

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -71,6 +71,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Catalog\ExtensionInvoker.cs" />
     <Compile Include="Catalog\ActivationState.cs" />
     <Compile Include="Counters\PerfCounterConfigData.cs" />
     <Compile Include="GrainTypeManager\GenericGrainTypeData.cs" />

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -500,7 +500,7 @@ namespace Orleans.Runtime
 
                 var bootstrapProviderManager = new BootstrapProviderManager();
                 scheduler.QueueTask(
-                    () => bootstrapProviderManager.LoadAppBootstrapProviders(GlobalConfig.ProviderConfigurations),
+                    () => bootstrapProviderManager.LoadAppBootstrapProviders(GlobalConfig.ProviderConfigurations, siloStreamProviderManager),
                     providerManagerSystemTarget.SchedulingContext)
                         .WaitWithThrow(initTimeout);
                 BootstrapProviders = bootstrapProviderManager.GetProviders(); // Data hook for testing & diagnotics

--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -522,6 +522,10 @@ namespace Orleans.TestingHost
             {
                 config.Globals.DataConnectionString = options.DataConnectionString;
             }
+            if (!String.IsNullOrEmpty(options.BootstrapProviderType))
+            {
+                config.Globals.RegisterBootstrapProvider(options.BootstrapProviderType, "TestBootstraper");
+            }
 
             config.AdjustForTestEnvironment();
 

--- a/src/OrleansTestingHost/TestingSiloOptions.cs
+++ b/src/OrleansTestingHost/TestingSiloOptions.cs
@@ -47,6 +47,7 @@ namespace Orleans.TestingHost
         public bool ParallelStart { get; set; }
         public GlobalConfiguration.ReminderServiceProviderType ReminderServiceType { get; set; }
         public string DataConnectionString { get; set; }
+        public string BootstrapProviderType { get; set; }
 
         public TestingSiloOptions()
         {
@@ -82,7 +83,7 @@ namespace Orleans.TestingHost
                 ReminderServiceType = ReminderServiceType,
                 DataConnectionString = DataConnectionString,
                 ParallelStart = ParallelStart,
-
+                BootstrapProviderType = BootstrapProviderType,
             };
         }
     }

--- a/src/Tester/OrleansConfigurationForStreamingUnitTests.xml
+++ b/src/Tester/OrleansConfigurationForStreamingUnitTests.xml
@@ -8,6 +8,9 @@
       <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
       <Provider Type="Orleans.Providers.Streams.AzureQueue.AzureQueueStreamProvider" Name="AzureQueueProvider"/>
     </StreamProviders>
+    <BootstrapProviders>
+      <Provider Type="UnitTests.StreamingTests.StreamBootstrapper" Name="bootstrap1" />
+    </BootstrapProviders>
     <SeedNode Address="localhost" Port="22222"/>
     <Messaging ResponseTimeout="30s"/>
   </Globals>

--- a/src/Tester/OrleansConfigurationForStreamingUnitTests.xml
+++ b/src/Tester/OrleansConfigurationForStreamingUnitTests.xml
@@ -8,9 +8,6 @@
       <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
       <Provider Type="Orleans.Providers.Streams.AzureQueue.AzureQueueStreamProvider" Name="AzureQueueProvider"/>
     </StreamProviders>
-    <BootstrapProviders>
-      <Provider Type="UnitTests.StreamingTests.StreamBootstrapper" Name="bootstrap1" />
-    </BootstrapProviders>
     <SeedNode Address="localhost" Port="22222"/>
     <Messaging ResponseTimeout="30s"/>
   </Globals>

--- a/src/Tester/StreamingTests/BootstrapProviderStreamingTests.cs
+++ b/src/Tester/StreamingTests/BootstrapProviderStreamingTests.cs
@@ -1,0 +1,88 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Providers;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using UnitTests.Tester;
+
+
+namespace UnitTests.StreamingTests
+{
+    [DeploymentItem("OrleansConfigurationForStreamingUnitTests.xml")]
+    [DeploymentItem("OrleansProviders.dll")]
+    [TestClass]
+    public class BootstrapProviderStreamingTests : UnitTestSiloHost
+    {        
+        public BootstrapProviderStreamingTests()
+            : base(new TestingSiloOptions
+            {
+                StartFreshOrleans = true,
+                StartSecondary = false,
+                SiloConfigFile = new FileInfo("OrleansConfigurationForStreamingUnitTests.xml"),
+            })
+        {
+        }
+
+        // Use ClassCleanup to run code after all tests in a class have run
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming")]
+        public void BootstrapProviderStreamingTests_JustLoad()
+        {
+            logger.Info("************************ BootstrapProviderStreamingTests_JustLoad *********************************");
+        }
+    }
+
+    public class StreamBootstrapper : IBootstrapProvider
+    {
+        private const string SMS_STREAM_PROVIDER_NAME = "SMSProvider";
+        private const string StreamNamespace = "SampleStreamNamespace";
+
+        private IStreamProviderManager _streamProviderManager;
+        public async Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
+        {
+            Name = name;
+            var pro = _streamProviderManager.GetProvider(SMS_STREAM_PROVIDER_NAME) as IStreamProvider;
+            //var str = pro.GetStream<int>(Guid.Empty, StreamNamespace);
+            //await str.OnNextAsync(23);
+            await TaskDone.Done;
+        }
+
+        public string Name { get; private set; }
+        public Task SetStreamProviderManager(IStreamProviderManager streamProviderManager)
+        {
+            _streamProviderManager = streamProviderManager;
+            return TaskDone.Done;
+        }
+    }
+}

--- a/src/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/src/Tester/StreamingTests/SampleStreamingTests.cs
@@ -38,9 +38,9 @@ namespace UnitTests.StreamingTests
     [TestClass]
     public class SampleStreamingTests : UnitTestSiloHost
     {
-        private const string SMS_STREAM_PROVIDER_NAME = "SMSProvider";
+        internal const string SMS_STREAM_PROVIDER_NAME = "SMSProvider";
         private const string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AzureQueueProvider";
-        private const string StreamNamespace = "SampleStreamNamespace";
+        internal const string StreamNamespace = "SampleStreamNamespace";
         private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(30);
 
         private Guid streamId;

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -93,6 +93,7 @@
     <Compile Include="SimpleGrainTests.cs" />
     <Compile Include="StreamingTests\SMSDeactivationTests.cs" />
     <Compile Include="StreamingTests\SMSSubscriptionMultiplicityTests.cs" />
+    <Compile Include="StreamingTests\BootstrapProviderStreamingTests.cs" />
     <Compile Include="StreamingTests\SubscriptionMultiplicityTestRunner.cs" />
     <Compile Include="UnitTestSiloHost.cs" />
   </ItemGroup>


### PR DESCRIPTION
Allow usage of streams inside Bootstrap provider:
Addresses: https://github.com/dotnet/orleans/issues/587

1) Inject StreamProvider manager into Bootstrap provider. Used the code https://github.com/osjimenez/orleans/commit/783df88432c2ab53dcaa9b18c296b171165da73b from @osjimenez.

2) Allow producing to the stream from within Bootstrap provider:
a) Producing to the stream should be allowed, just like sending grain method is.
b) Bootstrap provider is run from within a system target, and system targets did not support using streams.
c) Enabled using stream from with system targets.
d) Extracted code for installing grain extensions from activation data and generalized for system targets as well.
e) Generalized activation data and system targets with new internal interface IStreamable, that allows storing and using steams.
f) Generalized the code inside SiloProviderRuntime to correctly install grain extensions and use streams for system targets.

3) Explicitly dis-allow subscribing to the stream from within Bootstrap provider. Bootstrap provider should not be used for long term processing, only to kick something in.

4) Added new test BootstrapProviderStreamingTests 
