### PR TITLE
StreamReader correction for coreclr

### DIFF
--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -408,7 +408,7 @@ namespace Orleans.Runtime
         {
             FileInfo file = GetLogFile(logName);
             string logText;
-            using (var f = new StreamReader(file.FullName))
+            using (var f = new StreamReader(File.OpenRead(file.FullName)))
             {
                 logText = f.ReadToEnd();
             }


### PR DESCRIPTION
new StreamReader(string) is listed in the .NET Portability Report as none compatible; this change corrects this. 