### PR TITLE
Remove requirement for [StorageProvider] on stateful grains

### DIFF
--- a/src/ClientGenerator/NamespaceGenerator.cs
+++ b/src/ClientGenerator/NamespaceGenerator.cs
@@ -293,9 +293,6 @@ namespace Orleans.CodeGeneration
 
             if (persistentInterface!=null)
             {
-                if (!sourceType.GetCustomAttributes(typeof (StorageProviderAttribute)).Any())
-                    ReportError(String.Format("No StorageProvider attribute specified for grain class {0}", sourceType.FullName));
-                    
                 if (!persistentInterface.IsInterface)
                 {
                     hasStateClass = false;

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -581,16 +581,11 @@ namespace Orleans.Runtime
         {
             var grainTypeName = data.GrainInstanceType.FullName;
 
+            // Get the storage provider name, using the default if not specified.
             var attrs = data.GrainInstanceType.GetCustomAttributes(typeof(StorageProviderAttribute), true);
-            var attr = attrs.Length > 0 ? attrs[0] as StorageProviderAttribute : null;
-            if (attr == null)
-            {
-                var errMsg = string.Format("No storage providers specified for grain type {0}", grainTypeName);
-                logger.Error(ErrorCode.Provider_CatalogNoStorageProvider_3, errMsg);
-                throw new BadProviderConfigException(errMsg);
-            }
+            var attr = attrs.FirstOrDefault() as StorageProviderAttribute;
+            var storageProviderName = attr != null ? attr.ProviderName : Constants.DEFAULT_STORAGE_PROVIDER_NAME;
 
-            var storageProviderName = attr.ProviderName;
             IStorageProvider provider;
             if (storageProviderManager == null || storageProviderManager.GetNumLoadedProviders() == 0)
             {

--- a/src/OrleansTestingHost/OrleansConfigurationForTesting.xml
+++ b/src/OrleansTestingHost/OrleansConfigurationForTesting.xml
@@ -3,6 +3,7 @@
   <Globals>
     <StorageProviders>
       <Provider Type="Orleans.Storage.MemoryStorage" Name="MemoryStore" />
+      <Provider Type="Orleans.Storage.MemoryStorage" Name="Default" />
       <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" />-->
     </StorageProviders>
     <SeedNode Address="localhost" Port="22222"/>

--- a/src/TestGrains/SimplePersistentGrain.cs
+++ b/src/TestGrains/SimplePersistentGrain.cs
@@ -46,7 +46,6 @@ namespace UnitTests.Grains
     /// <summary>
     /// A simple grain that allows to set two arguments and then multiply them.
     /// </summary>
-    [StorageProvider(ProviderName = "MemoryStore")]
     public class SimplePersistentGrain : Grain<SimplePersistentGrain_State>, ISimplePersistentGrain
     {
         private Guid version;


### PR DESCRIPTION
Currently, adding `[StorageProvider]` to a grain is equivalent to adding `[StorageProvider(ProviderName = "Default")]` to that grain. The provider named "Default" will be used in either case.

This change removes the requirement for `[StorageProvider]` on a grain altogether: a grain with no`StorageProviderAttribute` is treated identically to a grain with a default `[StorageProvider]`.