### PR TITLE
Silo runtime identity

### DIFF
--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -98,6 +98,14 @@ namespace Orleans.Providers
             }
         }
 
+        public string SiloIdentity
+        {
+            get
+            {
+                throw new InvalidOperationException("Cannot access SiloIdentity from client.");
+            }
+        }
+
         public string ExecutingEntityIdentity()
         {
             return RuntimeClient.Current.Identity;

--- a/src/Orleans/Providers/IProviderRuntime.cs
+++ b/src/Orleans/Providers/IProviderRuntime.cs
@@ -55,6 +55,12 @@ namespace Orleans.Providers
         Guid ServiceId { get; }
 
         /// <summary>
+        /// A unique identifier for the current silo.
+        /// There is no semantic content to this string, but it may be useful for logging.
+        /// </summary>
+        string SiloIdentity { get; }
+
+        /// <summary>
         /// Factory for getting references to grains.
         /// </summary>
         IGrainFactory GrainFactory { get; }

--- a/src/Orleans/Providers/StatisticsProviderManager.cs
+++ b/src/Orleans/Providers/StatisticsProviderManager.cs
@@ -99,5 +99,10 @@ namespace Orleans.Providers
         {
             get { return runtime.ServiceId; }
         }
+
+        public string SiloIdentity
+        {
+            get { return runtime.SiloIdentity; }
+        }
     }
 }

--- a/src/Orleans/Runtime/GrainRuntime.cs
+++ b/src/Orleans/Runtime/GrainRuntime.cs
@@ -7,14 +7,17 @@ namespace Orleans.Runtime
 {
     internal class GrainRuntime : IGrainRuntime
     {
-        public GrainRuntime(string siloId, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager)
+        public GrainRuntime(Guid serviceId, string siloId, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager)
         {
+            ServiceId = serviceId;
             SiloIdentity = siloId;
             GrainFactory = grainFactory;
             TimerRegistry = timerRegistry;
             ReminderRegistry = reminderRegistry;
             StreamProviderManager = streamProviderManager;
         }
+
+        public Guid ServiceId { get; private set; }
 
         public string SiloIdentity { get; private set; }
 

--- a/src/Orleans/Runtime/IGrainRuntime.cs
+++ b/src/Orleans/Runtime/IGrainRuntime.cs
@@ -14,6 +14,14 @@ namespace Orleans.Runtime
     public interface IGrainRuntime
     {
         /// <summary>
+        /// Provides the ServiceId this cluster is running as.
+        /// ServiceId's are intended to be long lived Id values for a particular service which will remain constant 
+        /// even if the service is started / redeployed multiple times during its operations life.
+        /// </summary>
+        /// <returns>ServiceID Guid for this service.</returns>
+        Guid ServiceId { get; }
+
+        /// <summary>
         /// A unique identifier for the current silo.
         /// There is no semantic content to this string, but it may be useful for logging.
         /// </summary>

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -102,6 +102,7 @@ namespace Orleans.Runtime
         
         
         internal readonly string Name;
+        internal readonly string SiloIdentity;
         internal ClusterConfiguration OrleansConfig { get; private set; }
         internal GlobalConfiguration GlobalConfig { get { return globalConfig; } }
         internal NodeConfiguration LocalConfig { get { return nodeConfig; } }
@@ -225,8 +226,13 @@ namespace Orleans.Runtime
             
             messageCenter = mc;
 
+            SiloIdentity = SiloAddress.ToLongString();
+
             // GrainRuntime can be created only here, after messageCenter was created.
-            grainRuntime = new GrainRuntime(SiloAddress.ToLongString(), grainFactory,
+            grainRuntime = new GrainRuntime(
+                globalConfig.ServiceId,
+                SiloIdentity, 
+                grainFactory,
                 new TimerRegistry(),
                 new ReminderRegistry(),
                 new StreamProviderManager());
@@ -397,7 +403,7 @@ namespace Orleans.Runtime
             // Set up an execution context for this thread so that the target creation steps can use asynch values.
             RuntimeContext.InitializeMainThread();
 
-            SiloProviderRuntime.Initialize(GlobalConfig, grainFactory);
+            SiloProviderRuntime.Initialize(GlobalConfig, SiloIdentity, grainFactory);
             statisticsProviderManager = new StatisticsProviderManager("Statistics", SiloProviderRuntime.Instance);
             string statsProviderName =  statisticsProviderManager.LoadProvider(GlobalConfig.ProviderConfigurations)
                 .WaitForResultWithThrow(initTimeout);

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -43,14 +43,16 @@ namespace Orleans.Runtime.Providers
         private ImplicitStreamSubscriberTable implicitStreamSubscriberTable;
         public IGrainFactory GrainFactory { get; private set; }
         public Guid ServiceId { get; private set; }
+        public string SiloIdentity { get; private set; }
 
         private SiloProviderRuntime()
         {
         }
 
-        internal static void Initialize(GlobalConfiguration config, IGrainFactory grainFactory)
+        internal static void Initialize(GlobalConfiguration config, string siloIdentity, IGrainFactory grainFactory)
         {
             Instance.ServiceId = config.ServiceId;
+            Instance.SiloIdentity = siloIdentity;
             Instance.GrainFactory = grainFactory;
         }
 

--- a/src/OrleansRuntime/Storage/StorageProviderManager.cs
+++ b/src/OrleansRuntime/Storage/StorageProviderManager.cs
@@ -80,6 +80,11 @@ namespace Orleans.Runtime.Storage
             get { return providerRuntime.ServiceId; }
         }
 
+        public string SiloIdentity
+        {
+            get { return providerRuntime.SiloIdentity; }
+        }
+
         public IGrainFactory GrainFactory { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
Silo runtime identity - align runtime id values exposed to sub-components through IProviderRuntime and IGrainRuntime

Currently slightly different facets of "runtime identity" information is exposed in the `IProviderRuntime` and `IGrainRuntime` interfaces.

This change set is to normalize that so that both interfaces contain the same set of runtime identity info - both `Guid ServiceId` and `string SiloIdentity`.

Main changes are:

- Add `SiloIdentity` property to `IProviderRuntime` interface [it already contains `ServiceId`]

- Add `ServiceId` property to `IGrainRuntime` interface [it already contains `SiloIdentity`]