### PR TITLE
Turn down default verbosity of code-gen status logging.

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -78,7 +78,7 @@ namespace Orleans.CodeGeneration
         [Serializable]
         internal class GrainClientGeneratorFlags
         {
-            internal static bool Verbose = true;
+            internal static bool Verbose = false;
             internal static bool FailOnPathNotFound = false;
         }
 


### PR DESCRIPTION
Codegen puts way too much information in the build logs!