### PR TITLE
Fixed a bug in GW-client shutdown sequence that caused an occasional message from a client to shutting down silo to be dropped.

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -360,6 +360,7 @@ namespace Orleans
         Runtime_Error_100328 = Runtime + 328,
         Runtime_Error_100329 = Runtime + 329,
         Runtime_Error_100330 = Runtime + 330,
+        Runtime_Error_100331 = Runtime + 331,
 
         SiloBase                        = Runtime + 400,
         SiloStarting                    = SiloBase + 1,

--- a/src/Orleans/Messaging/GatewayClientReceiver.cs
+++ b/src/Orleans/Messaging/GatewayClientReceiver.cs
@@ -49,7 +49,7 @@ namespace Orleans.Messaging
         {
             if (gatewayConnection.MsgCenter.MessagingConfiguration.UseMessageBatching)
             {
-                RunBatch();
+                throw new OrleansException("UseMessageBatching is no longer supported for ClientReceiver.");
             }
             else
             {
@@ -86,125 +86,6 @@ namespace Orleans.Messaging
                 throw;
             }
         }
-
-        private void RunBatch()
-        {
-            /* Disable batching.  TODO: Remove or fix
-            try
-            {
-                var metaHeader = new byte[Message.LENGTH_META_HEADER];
-                var metaHeaderSegments = new List<ArraySegment<byte>> { new ArraySegment<byte>(metaHeader) };
-
-                while (!Cts.IsCancellationRequested)
-                {
-                    if (!FillBuffer(metaHeaderSegments, Message.LENGTH_META_HEADER))
-                    {
-                        continue;
-                    }
-
-                    var numberOfMessages = BitConverter.ToInt32(metaHeader, 0);
-                    var lengths = new byte[Message.LENGTH_HEADER_SIZE * numberOfMessages];
-                    var lengthSegments = new List<ArraySegment<byte>> { new ArraySegment<byte>(lengths) };
-
-                    if (!FillBuffer(lengthSegments, Message.LENGTH_HEADER_SIZE * numberOfMessages))
-                    {
-                        continue;
-                    }
-
-                    var headerLengths = new int[numberOfMessages];
-                    var bodyLengths = new int[numberOfMessages];
-                    var headerbodiesLength = 0;
-                    var headerbodies = new List<ArraySegment<byte>>();
-
-                    for (int i = 0; i < numberOfMessages; i++)
-                    {
-                        headerLengths[i] = BitConverter.ToInt32(lengths, i * 8);
-                        bodyLengths[i] = BitConverter.ToInt32(lengths, i * 8 + 4);
-                        headerbodiesLength += (headerLengths[i] + bodyLengths[i]);
-
-                        // We need to set the boundary of ArraySegment<byte>s to the same as the header/body boundary
-                        headerbodies.AddRange(BufferPool.GlobalPool.GetMultiBuffer(headerLengths[i]));
-                        headerbodies.AddRange(BufferPool.GlobalPool.GetMultiBuffer(bodyLengths[i]));
-                    }
-
-                    if (!FillBuffer(headerbodies, headerbodiesLength))
-                    {
-                        continue;
-                    }
-
-                    var lengthSoFar = 0;
-                    for (int i = 0; i < numberOfMessages; i++)
-                    {
-                        var header = ByteArrayBuilder.BuildSegmentListWithLengthLimit(headerbodies, lengthSoFar, headerLengths[i]);
-                        var body = ByteArrayBuilder.BuildSegmentListWithLengthLimit(headerbodies, lengthSoFar + headerLengths[i], bodyLengths[i]);
-                        lengthSoFar += (headerLengths[i] + bodyLengths[i]);
-
-                        var msg = new Message(header, body);
-
-                        MessagingStatisticsGroup.OnMessageReceive(msg, headerLengths[i], bodyLengths[i]);
-
-                        if (Log.IsVerbose3) Log.Verbose3("Received a message from gateway {0}: {1}", gatewayConnection.Address, msg);
-                        gatewayConnection.MsgCenter.QueueIncomingMessage(msg);
-                    }
-                    MessagingStatisticsGroup.OnMessageBatchReceive(SocketDirection.ClientToGateway, numberOfMessages, lengthSoFar);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Warn(ErrorCode.ProxyClientUnhandledExceptionWhileReceiving, String.Format("Unexpected/unhandled exception while receiving: {0}. Restarting gateway receiver for {1}.",
-                    ex, gatewayConnection.Address), ex);
-                throw;
-            }
-             */
-        }
-
-        /* Disable batching.  TODO: Remove or fix
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        private bool FillBuffer(List<ArraySegment<byte>> buffer, int length)
-        {
-            var offset = 0;
-
-            while (offset < length)
-            {
-                Socket socketCapture = null;
-                if (Cts.IsCancellationRequested)
-                {
-                    return false;
-                }
-
-                try
-                {
-                    if (gatewayConnection.Socket == null || !gatewayConnection.Socket.Connected)
-                    {
-                        gatewayConnection.Connect();
-                    }
-                    socketCapture = gatewayConnection.Socket;
-                    if (socketCapture != null && socketCapture.Connected)
-                    {
-                        var bytesRead = socketCapture.Receive(ByteArrayBuilder.BuildSegmentList(buffer, offset));
-                        if (bytesRead == 0)
-                        {
-                            throw new EndOfStreamException("Socket closed");
-                        }
-                        offset += bytesRead;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // Only try to reconnect if we're not shutting down
-                    if (Cts.IsCancellationRequested) return false;
-
-                    if (ex is SocketException)
-                    {
-                        Log.Warn(ErrorCode.Runtime_Error_100158, "Exception receiving from gateway " + gatewayConnection.Address);
-                    }
-                    gatewayConnection.MarkAsDisconnected(socketCapture);
-                    return false;
-                }
-            }
-            return true;
-        }
-         */
 
         private int FillBuffer(List<ArraySegment<byte>> buffer)
         {

--- a/src/Orleans/Messaging/GatewayClientReceiver.cs
+++ b/src/Orleans/Messaging/GatewayClientReceiver.cs
@@ -231,10 +231,7 @@ namespace Orleans.Messaging
                 // Only try to reconnect if we're not shutting down
                 if (Cts.IsCancellationRequested) return 0;
 
-                if (ex is SocketException)
-                {
-                    Log.Warn(ErrorCode.Runtime_Error_100158, "Exception receiving from gateway " + gatewayConnection.Address);
-                }
+                Log.Warn(ErrorCode.Runtime_Error_100158, String.Format("Exception receiving from gateway {0}: {1}", gatewayConnection.Address, ex.Message));
                 gatewayConnection.MarkAsDisconnected(socketCapture);
                 return 0;
             }

--- a/src/Orleans/Messaging/GatewayConnection.cs
+++ b/src/Orleans/Messaging/GatewayConnection.cs
@@ -168,7 +168,7 @@ namespace Orleans.Messaging
                                 return;
 
                             MarkAsDisconnected(Socket); // clean up the socket before reconnecting.
-                            }
+                        }
                         if (lastConnect != new DateTime())
                         {
                             var millisecondsSinceLastAttempt = DateTime.UtcNow - lastConnect;
@@ -248,6 +248,7 @@ namespace Orleans.Messaging
 
         protected override void OnGetSendingSocketFailure(Message msg, string error)
         {
+            msg.TargetSilo = null; // clear previous destination!
             MsgCenter.SendMessage(msg);
         }
 

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -284,7 +284,7 @@ namespace Orleans.Messaging
         {
             if (msg.TargetSilo != null)
             {
-                RejectMessage(msg, "Target silo is unavailable");
+                RejectMessage(msg, String.Format("Target silo {0} is unavailable", msg.TargetSilo));
             }
             else
             {

--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -305,6 +305,15 @@ namespace Orleans.TestingHost
         }
 
         /// <summary>
+        /// Restart the default Primary and Secondary silos.
+        /// </summary>
+        public void StartSecondarySilo(TestingSiloOptions secondarySiloOptions, int instanceCounter)
+        {
+            secondarySiloOptions.PickNewDeploymentId = false;
+            Secondary = StartOrleansSilo(Silo.SiloType.Secondary, secondarySiloOptions, instanceCounter);
+        }
+
+        /// <summary>
         /// Do a semi-graceful Stop of the specified silo.
         /// </summary>
         /// <param name="instance">Silo to be stopped.</param>

--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -305,7 +305,8 @@ namespace Orleans.TestingHost
         }
 
         /// <summary>
-        /// Restart the default Primary and Secondary silos.
+        /// Start a Secondary silo with a given instanceCounter 
+        /// (allows to set the port number as before or new, depending on the scenario).
         /// </summary>
         public void StartSecondarySilo(TestingSiloOptions secondarySiloOptions, int instanceCounter)
         {

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ConcreteStateClassTests.cs" />
     <Compile Include="GenericGrainTests.cs" />
     <Compile Include="GrainInterfaceHierarchyTests.cs" />
+    <Compile Include="MembershipTests\LivenessTests.cs" />
     <Compile Include="ObserverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -73,7 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="General\Identifiertests.cs" />
-    <Compile Include="MembershipTests\LivenessTests.cs" />
     <Compile Include="OrleansRuntime\Streams\BestFitBalancerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">


### PR DESCRIPTION
Addressing an issue reported in http://orleans.codeplex.com/discussions/641601, where in a sequence of graceful shutdowns of silos a client would sometimes loose an occasional  message.
No messages should be lost in failure free scenarios, including graceful shutdowns.

Also, created a test scenario following the scenario sequence described in http://orleans.codeplex.com/discussions/641601 (test name `Liveness_Grain_5_ShutdownRestartZeroLoss`) and was able to repro the problem and validate the fix. Did not enable this test yet, due to some weirdness in the TestInitialize/TestCleanup sequence by MSTest. Will enable once we switch to NUint, as planned according to #575.