### PR TITLE
Fix alternate folder code for when trace file folder does not exist.

### DIFF
--- a/src/Orleans/Configuration/ConfigUtilities.cs
+++ b/src/Orleans/Configuration/ConfigUtilities.cs
@@ -203,19 +203,19 @@ namespace Orleans.Runtime.Configuration
             }
             else
             {
-                string traceFileDir = null;
-                string traceFileName = Path.GetFileName(config.TraceFilePattern);
-                string[] dirLocations = { Path.GetDirectoryName(config.TraceFilePattern), "appdir", "." };
-                foreach (var d in dirLocations)
+                string traceFileDir = Path.GetDirectoryName(config.TraceFilePattern);
+                if (!Directory.Exists(traceFileDir))
                 {
-                    if (!Directory.Exists(d)) continue;
-
-                    traceFileDir = d;
-                    break;
-                }
-                if (traceFileDir != null && !Directory.Exists(traceFileDir))
-                {
-                    config.TraceFilePattern = Path.Combine(traceFileDir, traceFileName);
+                    string traceFileName = Path.GetFileName(config.TraceFilePattern);
+                    string[] alternateDirLocations = { "appdir", "." };
+                    foreach (var d in alternateDirLocations)
+                    {
+                        if (Directory.Exists(d))
+                        {
+                            config.TraceFilePattern = Path.Combine(d, traceFileName);
+                            break;
+                        }
+                    }
                 }
                 config.TraceFileName = String.Format(config.TraceFilePattern, nodeName, timestamp.ToUniversalTime().ToString(dateFormat), Dns.GetHostName());
             }


### PR DESCRIPTION
The existing code had a bug on Line 216.  The `!Directory.Exists(traceFileDir)` clause would never be true since to even set the traceFileDir on line 213 `Directory.Exists(traceFileDir)` must be true.

I also cleaned up the code to be more readable in my opinion showing intent by only performing the search if the original folder is not found.

Now when the trace file does not exist, it will fall back on an "appdir" subdirectory if it exists, and finally the current directory.