### PR TITLE
Cleanup client side stream producers automatically when Orleans client is uninitialized.

### DIFF
--- a/src/Orleans/Core/GrainClient.cs
+++ b/src/Orleans/Core/GrainClient.cs
@@ -228,8 +228,6 @@ namespace Orleans
                         isFullyInitialized = false;
                         grainFactory = new GrainFactory();
 
-                        ClientProviderRuntime.InitializeSingleton(grainFactory);
-
                         if (runtimeClient == null)
                         {
                             runtimeClient = new OutsideRuntimeClient(config, grainFactory);
@@ -285,12 +283,6 @@ namespace Orleans
                 catch (Exception) { }
 
                 RuntimeClient.Current = null;
-
-                try
-                {
-                    ClientProviderRuntime.UninitializeSingleton();
-                }
-                catch (Exception) { }
             }
             outsideRuntimeClient = null;
             grainFactory = null;

--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -40,7 +40,7 @@ namespace Orleans.Providers
         private readonly Dictionary<Type, Tuple<IGrainExtension, IAddressable>> caoTable;
         private readonly AsyncLock lockable;
 
-        private ClientProviderRuntime(IGrainFactory grainFactory) 
+        public ClientProviderRuntime(IGrainFactory grainFactory) 
         {
             caoTable = new Dictionary<Type, Tuple<IGrainExtension, IAddressable>>();
             lockable = new AsyncLock();
@@ -49,25 +49,14 @@ namespace Orleans.Providers
 
         public IGrainFactory GrainFactory { get; private set; }
 
-        public static ClientProviderRuntime Instance { get; private set; }
-
-        public static void InitializeSingleton(IGrainFactory grainFactory) 
-        {
-            if (Instance != null)
-            {
-                UninitializeSingleton();
-            }
-            Instance = new ClientProviderRuntime(grainFactory);
-        }
-
-        public static void StreamingInitialize(IGrainFactory grainFactory, ImplicitStreamSubscriberTable implicitStreamSubscriberTable) 
+        public void StreamingInitialize(ImplicitStreamSubscriberTable implicitStreamSubscriberTable) 
         {
             if (null == implicitStreamSubscriberTable)
             {
                 throw new ArgumentNullException("implicitStreamSubscriberTable");
             }
-            Instance.pubSub = new StreamPubSubImpl(new GrainBasedPubSubRuntime(grainFactory), implicitStreamSubscriberTable);
-            Instance.streamDirectory = new StreamDirectory();
+            pubSub = new StreamPubSubImpl(new GrainBasedPubSubRuntime(GrainFactory), implicitStreamSubscriberTable);
+            streamDirectory = new StreamDirectory();
         }
 
         public StreamDirectory GetStreamDirectory()
@@ -75,9 +64,14 @@ namespace Orleans.Providers
             return streamDirectory;
         }
 
-        public static void UninitializeSingleton()
+        public async Task Reset()
         {
-            Instance = null;
+            if (streamDirectory != null)
+            {
+                var tmp = streamDirectory;
+                streamDirectory = null; // null streamDirectory now, just to make sure we call cleanup only once, in all cases.
+                await tmp.Cleanup();
+            }
         }
 
         public Logger GetLogger(string loggerName)

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -58,6 +58,7 @@ namespace Orleans
         private bool listenForMessages;
         private CancellationTokenSource listeningCts;
 
+        private readonly ClientProviderRuntime clientProviderRuntime;
         private readonly StatisticsProviderManager statisticsProviderManager;
 
         internal ClientStatisticsManager ClientStatistics;
@@ -67,6 +68,7 @@ namespace Orleans
 
         // initTimeout used to be AzureTableDefaultPolicies.TableCreationTimeout, which was 3 min
         private static readonly TimeSpan initTimeout = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan resetTimeout = TimeSpan.FromMinutes(1);
 
         private const string BARS = "----------";
 
@@ -179,7 +181,8 @@ namespace Orleans
                     }
                 }
 
-                statisticsProviderManager = new StatisticsProviderManager("Statistics", ClientProviderRuntime.Instance);
+                clientProviderRuntime = new ClientProviderRuntime(grainFactory);
+                statisticsProviderManager = new StatisticsProviderManager("Statistics", clientProviderRuntime);
                 var statsProviderName = statisticsProviderManager.LoadProvider(config.ProviderConfigurations)
                     .WaitForResultWithThrow(initTimeout);
                 if (statsProviderName != null)
@@ -227,12 +230,12 @@ namespace Orleans
         private void StreamingInitialize()
         {
             var implicitSubscriberTable = transport.GetImplicitStreamSubscriberTable(grainFactory).Result;
-            ClientProviderRuntime.StreamingInitialize(grainFactory, implicitSubscriberTable);
+            clientProviderRuntime.StreamingInitialize(implicitSubscriberTable);
             var streamProviderManager = new Streams.StreamProviderManager();
             streamProviderManager
                 .LoadStreamProviders(
                     this.config.ProviderConfigurations,
-                    ClientProviderRuntime.Instance)
+                    clientProviderRuntime)
                 .Wait();
             CurrentStreamProviderManager = streamProviderManager;
         }
@@ -725,6 +728,13 @@ namespace Orleans
 
             Utils.SafeExecute(() =>
             {
+                if (clientProviderRuntime != null)
+                {
+                    clientProviderRuntime.Reset().WaitWithThrow(resetTimeout);
+                }
+            }, logger, "Client.clientProviderRuntime.Reset");
+            Utils.SafeExecute(() =>
+            {
                 if (StatisticsCollector.CollectThreadTimeTrackingStats)
                 {
                     incomingMessagesThreadTimeTracking.OnStopExecution();
@@ -740,13 +750,13 @@ namespace Orleans
 
             listenForMessages = false;
             Utils.SafeExecute(() =>
+            {
+                if (listeningCts != null)
                 {
-                    if (listeningCts != null)
-                    {
-                        listeningCts.Cancel();
-                    }
-                }, logger, "Client.Stop-ListeningCTS");
-            Utils.SafeExecute(() =>
+                    listeningCts.Cancel();
+                }
+            }, logger, "Client.Stop-ListeningCTS");
+        Utils.SafeExecute(() =>
             {
                 if (transport != null)
                 {
@@ -776,6 +786,14 @@ namespace Orleans
             try
             {
                 UnobservedExceptionsHandlerClass.ResetUnobservedExceptionHandler();
+            }
+            catch (Exception) { }
+            try
+            {
+                if (clientProviderRuntime != null)
+                {
+                    clientProviderRuntime.Reset().WaitWithThrow(resetTimeout);
+                }
             }
             catch (Exception) { }
             try

--- a/src/Orleans/Streams/Internal/StreamDirectory.cs
+++ b/src/Orleans/Streams/Internal/StreamDirectory.cs
@@ -32,7 +32,7 @@ namespace Orleans.Streams
     /// <summary>
     /// Stores all streams associated with a specific grain activation.
     /// </summary>
-    internal class StreamDirectory : IStreamControl
+    internal class StreamDirectory
     {
         private readonly ConcurrentDictionary<StreamId, object> allStreams;
 
@@ -46,7 +46,7 @@ namespace Orleans.Streams
             return allStreams.GetOrAdd(streamId, _ => streamCreator()) as IAsyncStream<T>;
         }
 
-        public async Task Cleanup()
+        internal async Task Cleanup()
         {
             var promises = new List<Task>();
             List<StreamId> streamIds = GetUsedStreamIds();

--- a/src/OrleansRuntime/Storage/StorageProviderManager.cs
+++ b/src/OrleansRuntime/Storage/StorageProviderManager.cs
@@ -113,10 +113,10 @@ namespace Orleans.Runtime.Storage
         }
 
         // used only for testing
-        internal Task LoadEmptyStorageProviders()
+        internal Task LoadEmptyStorageProviders(IProviderRuntime providerRtm)
         {
             storageProviderLoader = new ProviderLoader<IStorageProvider>();
-            providerRuntime = ClientProviderRuntime.Instance;
+            providerRuntime = providerRtm;
 
             storageProviderLoader.LoadProviders(new Dictionary<string, IProviderConfiguration>(), this);
             return storageProviderLoader.InitProviders(providerRuntime);


### PR DESCRIPTION
Make `ClientProviderRuntime` non-singleton, since there was really no need for that (also helps with # 467).
Properly initialize and reset `ClientProviderRuntime`  when `OutsideGrainClient` is uninitialized.
As part of `ClientProviderRuntime.Reset()` calls `StreamDirectory.Cleanup`. This will cause all client side producers to unsubscribe from the pub sub. 
That way old client side producers will be cleaned up from the pubsub, in a non-failure clean-shutdown case of Orleans client.