### PR TITLE
Remove confusing dependencies on Azure SDK

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
@@ -19,10 +19,6 @@
     <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
     <dependencies>
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
-      
-      <dependency id="WindowsAzure.Storage" version="4.2.0.0" />
-      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" />
-      <dependency id="Newtonsoft.Json" version="5.0.8" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -40,33 +40,8 @@
     <WarningsAsErrors>4014</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Edm">
-      <HintPath>..\packages\Microsoft.Data.Edm.5.6.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Data.OData">
-      <HintPath>..\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Data.Services.Client">
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Configuration">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage">
-      <HintPath>..\packages\WindowsAzure.Storage.4.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Streams\Common\SimpleQueueCache.cs" />

--- a/src/OrleansProviders/packages.config
+++ b/src/OrleansProviders/packages.config
@@ -1,10 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="4.2.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hi guys!

I've started cleaning up references to Azure SDK after upgraded to 1.0.9. You did a great job on consolidating azure dependencies to only OrleansAzureUtils.dll. While working on the upgrade I've noticed that OrleansProviders package still have references to Azure SDK. Thus this PR!

Yevhen
