### PR TITLE
Unsubscribe all client side stream consumers when Orleans client gracefully shuts down.

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -1022,6 +1022,7 @@ namespace Orleans
         Stream_ExtensionNotInstalled                = StreamProviderManagerBase + 5,
         Stream_ProducerIsDead                       = StreamProviderManagerBase + 6,
         StreamProvider_NoStreamForBatch             = StreamProviderManagerBase + 7,
+        StreamProvider_ConsumerFailedToUnregister   = StreamProviderManagerBase + 8,
 
         PersistentStreamPullingManagerBase = Runtime + 3500,
         PersistentStreamPullingManager_01 = PersistentStreamPullingManagerBase + 1,

--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -70,7 +70,7 @@ namespace Orleans.Providers
             {
                 var tmp = streamDirectory;
                 streamDirectory = null; // null streamDirectory now, just to make sure we call cleanup only once, in all cases.
-                await tmp.Cleanup();
+                await tmp.Cleanup(true, true);
             }
         }
 

--- a/src/Orleans/Streams/Internal/IInternalAsyncObservable.cs
+++ b/src/Orleans/Streams/Internal/IInternalAsyncObservable.cs
@@ -36,5 +36,13 @@ namespace Orleans.Streams
         Task UnsubscribeAsync(StreamSubscriptionHandle<T> handle);
 
         Task<IList<StreamSubscriptionHandle<T>>> GetAllSubscriptions();
+
+        Task Cleanup();
+    }
+
+        
+    internal interface IInternalAsyncBatchObserver<in T> : IAsyncBatchObserver<T>
+    {
+        Task Cleanup();
     }
 }

--- a/src/Orleans/Streams/Internal/IInternalStreamProvider.cs
+++ b/src/Orleans/Streams/Internal/IInternalStreamProvider.cs
@@ -21,7 +21,7 @@ namespace Orleans.Streams
 {
     internal interface IInternalStreamProvider : IStreamProviderImpl
     {
-        IAsyncBatchObserver<T> GetProducerInterface<T>(IAsyncStream<T> streamId);
+        IInternalAsyncBatchObserver<T> GetProducerInterface<T>(IAsyncStream<T> streamId);
         IInternalAsyncObservable<T> GetConsumerInterface<T>(IAsyncStream<T> streamId);
     }
 }

--- a/src/Orleans/Streams/Internal/IStreamControl.cs
+++ b/src/Orleans/Streams/Internal/IStreamControl.cs
@@ -32,9 +32,9 @@ namespace Orleans.Streams
     internal interface IStreamControl
     {
         /// <summary>
-        /// Perform cleanup functiuons for this stream.
+        /// Perform cleanup functions for this stream.
         /// </summary>
         /// <returns>Completion promise for the cleanup operstions for this stream.</returns>
-        Task Cleanup();
+        Task Cleanup(bool cleanupProducers = true, bool cleanupConsumers = false);
     }
 }

--- a/src/Orleans/Streams/Internal/IStreamControl.cs
+++ b/src/Orleans/Streams/Internal/IStreamControl.cs
@@ -35,6 +35,6 @@ namespace Orleans.Streams
         /// Perform cleanup functions for this stream.
         /// </summary>
         /// <returns>Completion promise for the cleanup operstions for this stream.</returns>
-        Task Cleanup(bool cleanupProducers = true, bool cleanupConsumers = false);
+        Task Cleanup(bool cleanupProducers, bool cleanupConsumers);
     }
 }

--- a/src/Orleans/Streams/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans/Streams/Internal/StreamConsumerExtension.cs
@@ -23,6 +23,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
@@ -94,6 +95,11 @@ namespace Orleans.Streams
             internal int GetObserverCountForStream(StreamId streamId)
             {
                 return localObserver != null && localObserver.StreamId.Equals(streamId) ? 1 : 0;
+            }
+
+            internal StreamSubscriptionHandleImpl<T> GetLocalObserver()
+            {
+                return localObserver;
             }
 
             public Task CompleteStream()
@@ -230,6 +236,13 @@ namespace Orleans.Streams
             return allStreamObservers.Values
                                      .OfType<ObserversCollection<T>>()
                                      .Aggregate(0, (count,o) => count + o.GetObserverCountForStream(streamId));
+        }
+
+        internal List<StreamSubscriptionHandleImpl<T>> GetAllStreamHandles<T>()
+        {
+            return allStreamObservers.Values
+                .OfType<ObserversCollection<T>>()
+                .Select(o => o.GetLocalObserver()).ToList();
         }
     }
 }

--- a/src/Orleans/Streams/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans/Streams/Internal/StreamConsumerExtension.cs
@@ -238,11 +238,13 @@ namespace Orleans.Streams
                                      .Aggregate(0, (count,o) => count + o.GetObserverCountForStream(streamId));
         }
 
-        internal List<StreamSubscriptionHandleImpl<T>> GetAllStreamHandles<T>()
+        internal IList<StreamSubscriptionHandleImpl<T>> GetAllStreamHandles<T>()
         {
             return allStreamObservers.Values
                 .OfType<ObserversCollection<T>>()
-                .Select(o => o.GetLocalObserver()).ToList();
+                .Select(o => o.GetLocalObserver())
+                .Where(o => o != null)
+                .ToList();
         }
     }
 }

--- a/src/Orleans/Streams/Internal/StreamDirectory.cs
+++ b/src/Orleans/Streams/Internal/StreamDirectory.cs
@@ -46,7 +46,7 @@ namespace Orleans.Streams
             return allStreams.GetOrAdd(streamId, _ => streamCreator()) as IAsyncStream<T>;
         }
 
-        internal async Task Cleanup()
+        internal async Task Cleanup(bool cleanupProducers, bool cleanupConsumers)
         {
             var promises = new List<Task>();
             List<StreamId> streamIds = GetUsedStreamIds();
@@ -54,7 +54,7 @@ namespace Orleans.Streams
             {
                 IStreamControl streamControl = GetStreamControl(s);
                 if (streamControl != null)
-                    promises.Add(streamControl.Cleanup());
+                    promises.Add(streamControl.Cleanup(cleanupProducers, cleanupConsumers));
             }
             await Task.WhenAll(promises);
         }

--- a/src/Orleans/Streams/Internal/StreamImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamImpl.cs
@@ -39,7 +39,7 @@ namespace Orleans.Streams
         [NonSerialized]
         private IInternalStreamProvider                         provider;
         [NonSerialized]
-        private volatile IAsyncBatchObserver<T>                 producerInterface;
+        private volatile IInternalAsyncBatchObserver<T>         producerInterface;
         [NonSerialized]
         private IInternalAsyncObservable<T>                     consumerInterface;
         [NonSerialized]
@@ -85,16 +85,20 @@ namespace Orleans.Streams
             return GetConsumerInterface().SubscribeAsync(observer, token, filterFunc, filterData);
         }
 
-        public async Task Cleanup()
+        public async Task Cleanup(bool cleanupProducers, bool cleanupConsumers)
         {
             // Cleanup producers
-            if (producerInterface != null)
+            if (cleanupProducers && producerInterface != null)
             {
-                var producer = producerInterface as IStreamControl;
-                if (producer != null)
-                    await producer.Cleanup();
-                
+                await producerInterface.Cleanup();
                 producerInterface = null;
+            }
+
+            // Cleanup consumers
+            if (cleanupConsumers && consumerInterface != null)
+            {
+                await consumerInterface.Cleanup();
+                consumerInterface = null;
             }
         }
 

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProducer.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProducer.cs
@@ -27,7 +27,7 @@ using System.Threading.Tasks;
 
 namespace Orleans.Streams
 {
-    internal class PersistentStreamProducer<T> : IAsyncBatchObserver<T>
+    internal class PersistentStreamProducer<T> : IInternalAsyncBatchObserver<T>
     {
         private readonly StreamImpl<T> stream;
         private readonly IQueueAdapter queueAdapter;
@@ -72,6 +72,11 @@ namespace Orleans.Streams
         {
             // Maybe send a close message to the rendezvous?
             throw new NotImplementedException("OnErrorAsync is not implemented for now.");
+        }
+
+        public Task Cleanup()
+        {
+            return TaskDone.Done;
         }
     }
 }

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -122,7 +122,7 @@ namespace Orleans.Providers.Streams.Common
                 streamId, () => new StreamImpl<T>(streamId, this, IsRewindable));
         }
 
-        public IAsyncBatchObserver<T> GetProducerInterface<T>(IAsyncStream<T> stream)
+        IInternalAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> stream)
         {
             return new PersistentStreamProducer<T>((StreamImpl<T>)stream, providerRuntime, queueAdapter, IsRewindable);
         }

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
@@ -30,7 +30,7 @@ using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.SimpleMessageStream
 {
-    internal class SimpleMessageStreamProducer<T> : IAsyncBatchObserver<T>, IStreamControl
+    internal class SimpleMessageStreamProducer<T> : IInternalAsyncBatchObserver<T>
     {
         private readonly StreamImpl<T>                  stream;
         private readonly string                         streamProviderName;

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -65,7 +65,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                 () => new StreamImpl<T>(streamId, this, IsRewindable));
         }
 
-        public IAsyncBatchObserver<T> GetProducerInterface<T>(IAsyncStream<T> stream)
+        IInternalAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> stream)
         {
             return new SimpleMessageStreamProducer<T>((StreamImpl<T>)stream, Name, providerRuntime, fireAndForgetDelivery, IsRewindable);
         }

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -288,7 +288,7 @@ namespace Orleans.Runtime
                 return;
             }
 
-            await streamDirectory.Cleanup();
+            await streamDirectory.Cleanup(true, false);
         }
 
         #region IActivationData


### PR DESCRIPTION
This is a follow up work on #642.