### PR TITLE
Fixed a bug in client GW registration protocol.

### DIFF
--- a/src/Orleans/IDs/ActivationId.cs
+++ b/src/Orleans/IDs/ActivationId.cs
@@ -69,9 +69,17 @@ namespace Orleans.Runtime
             return FindOrCreate(grain.Key);
         }
 
-        internal static ActivationId GetActivationId(GrainId grain)
+        public static ActivationId GetClientGWActivation(GrainId grain, SiloAddress location)
         {
-            return FindOrCreate(grain.Key);
+            if (!grain.IsClient)
+                throw new ArgumentException("ClientGW activation IDs can only be created for system grains");
+
+            // Construct a unique and deterministic ActivationId based on GrainId and SiloAddress.
+            string stringToHash = grain.ToParsableString() + location.Endpoint + location.Generation.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            Guid hash = Utils.CalculateGuidHash(stringToHash);
+            UniqueKey key = UniqueKey.NewKey(hash);
+
+            return FindOrCreate(key);
         }
 
         internal static ActivationId GetActivationId(UniqueKey key)

--- a/src/Orleans/IDs/ActivationId.cs
+++ b/src/Orleans/IDs/ActivationId.cs
@@ -72,7 +72,7 @@ namespace Orleans.Runtime
         public static ActivationId GetClientGWActivation(GrainId grain, SiloAddress location)
         {
             if (!grain.IsClient)
-                throw new ArgumentException("ClientGW activation IDs can only be created for system grains");
+                throw new ArgumentException("ClientGW activation IDs can only be created for client grains");
 
             // Construct a unique and deterministic ActivationId based on GrainId and SiloAddress.
             string stringToHash = grain.ToParsableString() + location.Endpoint + location.Generation.ToString(System.Globalization.CultureInfo.InvariantCulture);

--- a/src/Orleans/Utils/Utils.cs
+++ b/src/Orleans/Utils/Utils.cs
@@ -224,7 +224,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="text">The string to hash.</param>
         /// <returns>An integer hash for the string.</returns>
-        public static Guid CalculateGuidHash(string text)
+        internal static Guid CalculateGuidHash(string text)
         {
             SHA256 sha = SHA256.Create(); // This is one implementation of the abstract class SHA1.
             byte[] hash = new byte[16];

--- a/src/Orleans/Utils/Utils.cs
+++ b/src/Orleans/Utils/Utils.cs
@@ -219,6 +219,32 @@ namespace Orleans.Runtime
             return hash;
         }
 
+        /// <summary>
+        /// Calculates a Guid hash value based on the consistent identity a string.
+        /// </summary>
+        /// <param name="text">The string to hash.</param>
+        /// <returns>An integer hash for the string.</returns>
+        public static Guid CalculateGuidHash(string text)
+        {
+            SHA256 sha = SHA256.Create(); // This is one implementation of the abstract class SHA1.
+            byte[] hash = new byte[16];
+            try
+            {
+                byte[] data = Encoding.Unicode.GetBytes(text);
+                byte[] result = sha.ComputeHash(data);
+                for (int i = 0; i < result.Length; i ++)
+                {
+                    byte tmp =  (byte)(hash[i % 16] ^ result[i]);
+                    hash[i%16] = tmp;
+                }
+            }
+            finally
+            {
+                sha.Dispose();
+            }
+            return new Guid(hash);
+        }
+
         public static bool TryFindException(Exception original, Type targetType, out Exception target)
         {
             if (original.GetType() == targetType)


### PR DESCRIPTION
When a client connects to a silo GW, GW registers his own address as a fake "activation" in the grain directory for this client GrainId. That is used later on to find the GW that is proxying for this client to send observer and stream messages to it. If client connects to multiples GW, each has to register as a different activation, so we can send observer notifications via different GWs. 

The bug was in the way we calculate activation id for this "fake GW activation", which caused all GWs to use the same activation id. As a result, only one GW would be used to send observer notifications to this client, potentially reducing reliability and throughput for this client.
The fix generates a unique deterministic activation id for each client GrainId and GW silo address pair.
