### PR TITLE
Missing some project references required for package build.

### DIFF
--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -94,13 +94,29 @@
     <Compile Include="MembershipTests\ZookeeperMembershipTableTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\ClientGenerator\ClientGenerator.csproj">
+      <Project>{e782dd19-51f7-4f66-8217-bacac33767e4}</Project>
+      <Name>ClientGenerator</Name>
+    </ProjectReference>
     <ProjectReference Include="..\OrleansAzureUtils\OrleansAzureUtils.csproj">
       <Project>{792818ef-b3f8-4ce2-9886-4808713b15c4}</Project>
       <Name>OrleansAzureUtils</Name>
     </ProjectReference>
+    <ProjectReference Include="..\OrleansCounterControl\OrleansCounterControl.csproj">
+      <Project>{606b9647-cc0c-4058-bfbc-b5b7ed4f3c56}</Project>
+      <Name>OrleansCounterControl</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OrleansHost\OrleansHost.csproj">
+      <Project>{5c177f58-a40c-449f-8c2f-a2657f963edc}</Project>
+      <Name>OrleansHost</Name>
+    </ProjectReference>
     <ProjectReference Include="..\OrleansManager\OrleansManager.csproj">
       <Project>{60498b15-9700-4623-bda0-365238f2c1ad}</Project>
       <Name>OrleansManager</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj">
+      <Project>{0054db14-2a92-4cc0-959e-a2c51f5e65d4}</Project>
+      <Name>OrleansProviders</Name>
     </ProjectReference>
     <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj">
       <Project>{6ff2004c-cdf8-479c-bf27-c6bfe8ef93e0}</Project>
@@ -125,6 +141,10 @@
     <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj">
       <Project>{3972213f-189b-41d4-90fe-38d513c1106d}</Project>
       <Name>TestGrainInterfaces</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestGrains\TestGrains.csproj">
+      <Project>{eace28ae-f301-472a-b633-02b55434871b}</Project>
+      <Name>TestGrains</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Missing some project references in TesterInternal, which is the tailgate project that runs the PostBuild.cmd script to build the output packages.

- TesterInternal should contain project reference dependencies to all other project in the solution.