### PR TITLE
ZK MBR - update ZooKeeperNetEx to 3.4.6.1002

### DIFF
--- a/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
+++ b/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
@@ -56,8 +56,8 @@
       <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="ZooKeeperNetEx, Version=3.4.6.0, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeperNetEx.3.4.6.1001\lib\net45\ZooKeeperNetEx.dll</HintPath>
+    <Reference Include="ZooKeeperNetEx, Version=3.4.6.1002, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.6.1002\lib\net45\ZooKeeperNetEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
+++ b/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
@@ -326,12 +326,13 @@ namespace Orleans.Runtime.Host
                 logger = traceLogger;
             }
 
-            public override void process(WatchedEvent @event)
+            public override Task process(WatchedEvent @event)
             {
                 if (logger.IsVerbose)
                 {
                     logger.Verbose(@event.ToString());
                 }
+                return TaskDone.Done;
             }
         }
     }

--- a/src/OrleansZooKeeperUtils/packages.config
+++ b/src/OrleansZooKeeperUtils/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ZooKeeperNetEx" version="3.4.6.1001" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="ZooKeeperNetEx" version="3.4.6.1002" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Improvements :
* Watcher interface method returns Task
* Taking better care of disposables
* Globalization of all strings
* Added async Recipes. [Nuget available](https://www.nuget.org/packages/ZooKeeperNetEx.Recipes)
* Support both .NET 4.5 and .NET 4.6 in nuget packages
* Published code & pdb & xml doc files with the nuget packages. go [here](http://www.symbolsource.org/Public/Home/VisualStudio) for instructions.