### PR TITLE
Allow multiple implicit subscriptions

### DIFF
--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -281,7 +281,7 @@ namespace Orleans
         }
     }
 
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple=true)]
     public sealed class ImplicitStreamSubscriptionAttribute : Attribute
     {
         internal string Namespace { get; private set; }

--- a/src/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/src/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -68,6 +68,11 @@ namespace UnitTests.GrainInterfaces
             bool ret = set1.SetEquals(set2);
             return ret;
         }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 
     [Serializable]
@@ -89,6 +94,11 @@ namespace UnitTests.GrainInterfaces
                 return false;
             }
             return Id.Equals(actual.Id) && Equals(Something, actual.Something);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 }

--- a/src/TestGrainInterfaces/IMultipleImplicitSubscriptionGrain.cs
+++ b/src/TestGrainInterfaces/IMultipleImplicitSubscriptionGrain.cs
@@ -1,0 +1,34 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IMultipleImplicitSubscriptionGrain : IGrainWithGuidKey
+    {
+        Task<Tuple<int, int>> GetCounters();
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="IFaultableConsumerGrain.cs" />
     <Compile Include="IGenericInterfaces.cs" />
+    <Compile Include="IMultipleImplicitSubscriptionGrain.cs" />
     <Compile Include="IMultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="GrainInterfaceHierarchyIGrains.cs" />
     <Compile Include="ISampleStreamingGrain.cs" />

--- a/src/TestGrains/MultipleImplicitSubscriptionGrain.cs
+++ b/src/TestGrains/MultipleImplicitSubscriptionGrain.cs
@@ -1,0 +1,73 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+
+    [ImplicitStreamSubscription("red")]
+    [ImplicitStreamSubscription("blue")]
+    public class MultipleImplicitSubscriptionGrain : Grain, IMultipleImplicitSubscriptionGrain
+    {
+        private Logger logger;
+        private IAsyncStream<int> redStream, blueStream;
+        private int redCounter, blueCounter;
+
+        public override async Task OnActivateAsync()
+        {
+            logger = base.GetLogger("MultipleImplicitSubscriptionGrain " + base.IdentityString);
+            logger.Info("OnActivateAsync");
+
+            var streamProvider = GetStreamProvider("SMSProvider");
+            redStream = streamProvider.GetStream<int>(this.GetPrimaryKey(), "red");
+            blueStream = streamProvider.GetStream<int>(this.GetPrimaryKey(), "blue");
+
+            await redStream.SubscribeAsync(
+                (e, t) =>
+                {
+                    logger.Info("Received a red event {0}", e);
+                    redCounter++;
+                    return TaskDone.Done;
+                });
+
+            await blueStream.SubscribeAsync(
+                (e, t) =>
+                {
+                    logger.Info("Received a blue event {0}", e);
+                    blueCounter++;
+                    return TaskDone.Done;
+                });
+        }
+
+        public Task<Tuple<int, int>> GetCounters()
+        {
+            return Task.FromResult(new Tuple<int, int>(redCounter, blueCounter));
+        }
+    }
+}

--- a/src/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/src/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -1,3 +1,26 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="FaultableConsumerGrain.cs" />
     <Compile Include="GenericGrains.cs" />
+    <Compile Include="MultipleImplicitSubscriptionGrain.cs" />
     <Compile Include="SimpleGenericGrain.cs" />
     <Compile Include="MultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="ConcreteGrainsWithGenericInterfaces.cs" />


### PR DESCRIPTION
By mistake ImplicitStreamSubscriptionAttribute doesn't have AllowMultiple=true set. This adds it and also adds a test for two implicit stream subscriptions on a grain class.