### PR TITLE
Stateless worker ensure exact count

### DIFF
--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -67,7 +67,21 @@ namespace Orleans
         /// </summary>
         [AttributeUsage(AttributeTargets.Class)]
         public sealed class StatelessWorkerAttribute : Attribute
-        {
+        {            
+            /// <summary>
+            /// Maximal number of local StatelessWorkers in a single silo.
+            /// </summary>
+            public int MaxLocalWorkers { get; private set; }
+
+            public StatelessWorkerAttribute(int maxLocalWorkers)
+            {
+                MaxLocalWorkers = maxLocalWorkers;
+            }
+
+            public StatelessWorkerAttribute()
+            {
+                MaxLocalWorkers = -1;
+            }
         }
 
         /// <summary>

--- a/src/Orleans/Placement/GrainStrategy.cs
+++ b/src/Orleans/Placement/GrainStrategy.cs
@@ -48,10 +48,6 @@ namespace Orleans.Runtime
         /// </summary>
         public static PlacementStrategy ActivationCountBasedPlacement;
         /// <summary>
-        /// Use a local activation, create if not present or all busy
-        /// </summary>
-        public static PlacementStrategy StatelessWorkerPlacement;
-        /// <summary>
         /// Use a graph partitioning algorithm
         /// </summary>
         internal static PlacementStrategy GraphPartitionPlacement;
@@ -63,9 +59,6 @@ namespace Orleans.Runtime
             PreferLocalPlacement = Orleans.Runtime.PreferLocalPlacement.Singleton;
 
             ActivationCountBasedPlacement = Orleans.Runtime.ActivationCountBasedPlacement.Singleton;
-
-            StatelessWorkerPlacement = new StatelessWorkerPlacement(0);
-
         }
     }
 }

--- a/src/Orleans/Placement/StatelessWorkerPlacement.cs
+++ b/src/Orleans/Placement/StatelessWorkerPlacement.cs
@@ -30,8 +30,6 @@ namespace Orleans.Runtime
     {
         private static int defaultMaxActivationBankSize = Environment.ProcessorCount;
 
-        public int MinAvailable { get; private set; }
-
         public int MaxLocal { get; private set; }
 
         internal static void InitializeClass(int defMaxActivationBankSize)
@@ -43,26 +41,25 @@ namespace Orleans.Runtime
             defaultMaxActivationBankSize = defMaxActivationBankSize;
         }
 
-        internal StatelessWorkerPlacement(int minAvailable, int defaultMaxLocal = -1)
+        internal StatelessWorkerPlacement(int defaultMaxLocal = -1)
         {
-            MinAvailable = minAvailable;
             MaxLocal = defaultMaxLocal > 0 ? defaultMaxLocal : defaultMaxActivationBankSize;
         }
 
         public override string ToString()
         {
-            return String.Format("StatelessWorkerPlacement(min={0}, max={1})", MinAvailable, MaxLocal);
+            return String.Format("StatelessWorkerPlacement(max={1})", MaxLocal);
         }
 
         public override bool Equals(object obj)
         {
             var other = obj as StatelessWorkerPlacement;
-            return other != null && MinAvailable == other.MinAvailable && MaxLocal == other.MaxLocal;
+            return other != null && MaxLocal == other.MaxLocal;
         }
 
         public override int GetHashCode()
         {
-            return GetType().GetHashCode() + MinAvailable.GetHashCode() + MaxLocal.GetHashCode();
+            return GetType().GetHashCode() ^ MaxLocal.GetHashCode();
         }
     }
 

--- a/src/Orleans/Placement/StatelessWorkerPlacement.cs
+++ b/src/Orleans/Placement/StatelessWorkerPlacement.cs
@@ -28,22 +28,24 @@ namespace Orleans.Runtime
     [Serializable]
     internal class StatelessWorkerPlacement : PlacementStrategy
     {
-        private static int defaultMaxActivationBankSize = Environment.ProcessorCount;
+        private static int defaultMaxStatelessWorkers = Environment.ProcessorCount;
 
         public int MaxLocal { get; private set; }
 
-        internal static void InitializeClass(int defMaxActivationBankSize)
+        internal static void InitializeClass(int defMaxStatelessWorkers)
         {
-            if (defMaxActivationBankSize < 1)
-                throw new ArgumentOutOfRangeException("defMaxActivationBankSize",
-                    "defMaxActivationBankSize must contain a value greater than zero.");
-            
-            defaultMaxActivationBankSize = defMaxActivationBankSize;
+            if (defMaxStatelessWorkers < 1)
+                throw new ArgumentOutOfRangeException("defMaxStatelessWorkers",
+                    "defMaxStatelessWorkers must contain a value greater than zero.");
+
+            defaultMaxStatelessWorkers = defMaxStatelessWorkers;
         }
 
-        internal StatelessWorkerPlacement(int defaultMaxLocal = -1)
+        internal StatelessWorkerPlacement(int maxLocal = -1)
         {
-            MaxLocal = defaultMaxLocal > 0 ? defaultMaxLocal : defaultMaxActivationBankSize;
+            // If maxLocal was not specified on the StatelessWorkerAttribute, 
+            // we will use the defaultMaxStatelessWorkers, which is System.Environment.ProcessorCount.
+            MaxLocal = maxLocal > 0 ? maxLocal : defaultMaxStatelessWorkers;
         }
 
         public override string ToString()

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -395,9 +395,6 @@ namespace Orleans.Runtime
 
         public PlacementStrategy PlacedUsing { get; private set; }
 
-        // currently, the only supported multi-activation grain is one using the StatelessWorkerPlacement strategy.
-        internal bool IsMultiActivationGrain { get { return PlacedUsing is StatelessWorkerPlacement; } }
-
         public Message Running { get; private set; }
 
         // the number of requests that are currently executing on this activation.
@@ -822,9 +819,9 @@ namespace Orleans.Runtime
 
         private string GetActivationInfoString()
         {
-            var multi = IsMultiActivationGrain ? " MultiActivationGrain" : String.Empty;
-            return GrainInstanceType == null ? multi : 
-                String.Format(" #GrainType={0}{1}", GrainInstanceType.FullName, multi);
+            var placement = PlacedUsing != null ? PlacedUsing.GetType().Name : String.Empty;
+            return GrainInstanceType == null ? placement :
+                String.Format(" #GrainType={0} Placement={1}", GrainInstanceType.FullName, placement);
         }
 
         #endregion

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -395,6 +395,10 @@ namespace Orleans.Runtime
 
         public PlacementStrategy PlacedUsing { get; private set; }
 
+        // currently, the only supported multi-activation grain is one using the StatelessWorkerPlacement strategy.
+        internal bool IsStatelessWorker { get { return PlacedUsing is StatelessWorkerPlacement; } }
+
+
         public Message Running { get; private set; }
 
         // the number of requests that are currently executing on this activation.

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -142,8 +142,16 @@ namespace Orleans.Runtime
                         throw new OrleansException(str, ex);
                     }
 
-                    logger.Warn(ErrorCode.Dispatcher_Intermediate_GetOrCreateActivation,
-                        String.Format("Intermediate warning for NonExistentActivation from Catalog.GetOrCreateActivation for message {0}", message), ex);
+                    if (nea.IsStatelessWorker)
+                    {
+                        if (logger.IsVerbose) logger.Verbose(ErrorCode.Dispatcher_Intermediate_GetOrCreateActivation,
+                           String.Format("Intermediate warning for StatelessWorker NonExistentActivation from Catalog.GetOrCreateActivation for message {0}", message), ex);
+                    }
+                    else
+                    {
+                        logger.Warn(ErrorCode.Dispatcher_Intermediate_GetOrCreateActivation,
+                            String.Format("Intermediate warning for NonExistentActivation from Catalog.GetOrCreateActivation for message {0}", message), ex);
+                    }
 
                     ActivationAddress nonExistentActivation = nea.NonExistentActivation;
 

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
@@ -41,8 +41,8 @@ namespace Orleans.Runtime
         internal Type StateObjectType { get; private set; }
         internal bool IsReentrant { get; private set; }
         internal bool IsStatelessWorker { get; private set; }
-
-        
+   
+     
         public GrainTypeData(Type type, Type stateObjectType)
         {
             Type = type;
@@ -110,7 +110,10 @@ namespace Orleans.Runtime
 
             if (GetPlacementStrategy<StatelessWorkerAttribute>(
                 grainClass,
-                _ => GrainStrategy.StatelessWorkerPlacement, 
+                (StatelessWorkerAttribute attr) =>
+                {
+                    return new StatelessWorkerPlacement(attr.MaxLocalWorkers);
+                },
                 out placement))
             {
                 return placement;

--- a/src/OrleansRuntime/Placement/StatelessWorkerDirector.cs
+++ b/src/OrleansRuntime/Placement/StatelessWorkerDirector.cs
@@ -30,7 +30,7 @@ namespace Orleans.Runtime.Placement
 {
     internal class StatelessWorkerDirector : PlacementDirector
     {
-        private readonly SafeRandom random = new SafeRandom();
+        internal static readonly SafeRandom Random = new SafeRandom();
 
         internal override Task<PlacementResult> OnSelectActivation(
             PlacementStrategy strategy, GrainId target, IPlacementContext context)
@@ -60,7 +60,7 @@ namespace Orleans.Runtime.Placement
 
             if (local.Count >= placement.MaxLocal)
             {
-                var id = local[local.Count == 1 ? 0 : random.Next(local.Count)].ActivationId;
+                var id = local[local.Count == 1 ? 0 : Random.Next(local.Count)].ActivationId;
                 return Task.FromResult(PlacementResult.IdentifySelection(ActivationAddress.GetAddress(context.LocalSilo, target, id)));
             }
 

--- a/src/OrleansRuntime/Placement/StatelessWorkerDirector.cs
+++ b/src/OrleansRuntime/Placement/StatelessWorkerDirector.cs
@@ -30,7 +30,7 @@ namespace Orleans.Runtime.Placement
 {
     internal class StatelessWorkerDirector : PlacementDirector
     {
-        internal static readonly SafeRandom Random = new SafeRandom();
+        private static readonly SafeRandom random = new SafeRandom();
 
         internal override Task<PlacementResult> OnSelectActivation(
             PlacementStrategy strategy, GrainId target, IPlacementContext context)
@@ -40,7 +40,6 @@ namespace Orleans.Runtime.Placement
 
             // If there are available (not busy with a request) activations, it returns the first one.
             // If all are busy and the number of local activations reached or exceeded MaxLocal, it randomly returns one of them.
-            // If all are busy but was told to returnAny, also randomly returns one of them.
             // Otherwise, it requests creation of a new activation.
             List<ActivationData> local;
 
@@ -60,7 +59,7 @@ namespace Orleans.Runtime.Placement
 
             if (local.Count >= placement.MaxLocal)
             {
-                var id = local[local.Count == 1 ? 0 : Random.Next(local.Count)].ActivationId;
+                var id = local[local.Count == 1 ? 0 : random.Next(local.Count)].ActivationId;
                 return Task.FromResult(PlacementResult.IdentifySelection(ActivationAddress.GetAddress(context.LocalSilo, target, id)));
             }
 
@@ -72,6 +71,11 @@ namespace Orleans.Runtime.Placement
             var grainType = context.GetGrainTypeName(grain);
             return Task.FromResult(
                 PlacementResult.SpecifyCreation(context.LocalSilo, strategy, grainType));
+        }
+
+        internal static ActivationData PickRandom(List<ActivationData> local)
+        {
+             return local[local.Count == 1 ? 0 : random.Next(local.Count)];
         }
     }
 }

--- a/src/TestGrainInterfaces/IStatelessWorkerGrain.cs
+++ b/src/TestGrainInterfaces/IStatelessWorkerGrain.cs
@@ -1,0 +1,36 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IStatelessWorkerGrain : IGrainWithIntegerKey
+    {
+        Task LongCall();
+        Task<Tuple<Guid, List<Tuple<DateTime, DateTime>>>> GetCallStats();
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -52,6 +52,7 @@
     <Compile Include="ISampleStreamingGrain.cs" />
     <Compile Include="ISimpleGenericGrain.cs" />
     <Compile Include="CodegenTestInterfaces.cs" />
+    <Compile Include="IStatelessWorkerGrain.cs" />
     <Compile Include="ISimpleObserverableGrain.cs" />
     <Compile Include="IObserverGrain.cs" />
     <Compile Include="ISimpleGrain.cs" />

--- a/src/TestGrains/StatelessWorkerGrain.cs
+++ b/src/TestGrains/StatelessWorkerGrain.cs
@@ -1,0 +1,96 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections;
+using Orleans;
+using Orleans.Concurrency;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+
+namespace UnitTests.Grains
+{
+    [StatelessWorker(12)]
+    public class StatelessWorkerGrain : Grain, IStatelessWorkerGrain
+    {
+        private Guid activationGuid;
+        private readonly List<Tuple<DateTime, DateTime>> calls = new List<Tuple<DateTime, DateTime>>();
+        private Logger logger;
+        private static HashSet<Guid> allActivationIds = new HashSet<Guid>();
+
+        public override Task OnActivateAsync()
+        {
+            activationGuid = Guid.NewGuid();
+            logger = GetLogger(String.Format("{0}", activationGuid));
+            logger.Info("Activate.");
+            return TaskDone.Done;
+        }
+
+        public Task LongCall()
+        {
+            int count = 0;
+            lock (allActivationIds)
+            {
+                if (!allActivationIds.Contains(activationGuid))
+                {
+                    allActivationIds.Add(activationGuid);
+                }
+                count = allActivationIds.Count;
+            }
+            DateTime start = DateTime.UtcNow;
+            TaskCompletionSource<bool> resolver = new TaskCompletionSource<bool>();
+            RegisterTimer(TimerCallback, resolver, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(-1));
+            return resolver.Task.ContinueWith(
+                (_) =>
+                {
+                    DateTime stop = DateTime.UtcNow;
+                    calls.Add(new Tuple<DateTime, DateTime>(start, stop));
+                    logger.Info(((stop - start).TotalMilliseconds).ToString());
+                    logger.Info("Start {0}, stop {1}, duration {2}. #act {3}", TraceLogger.PrintDate(start), TraceLogger.PrintDate(stop), (stop - start), count);
+                });
+        }
+
+        private static Task TimerCallback(object state)
+        {
+            ((TaskCompletionSource<bool>)state).SetResult(true);
+            return TaskDone.Done;
+        }
+
+
+        public Task<Tuple<Guid, List<Tuple<DateTime, DateTime>>>> GetCallStats()
+        {
+            Thread.Sleep(200);
+            lock (allActivationIds)
+            {
+                logger.Info("# allActivationIds {0}: {1}", allActivationIds.Count, Utils.EnumerableToString(allActivationIds));
+            }
+            return Task.FromResult(new Tuple<Guid, List<Tuple<DateTime, DateTime>>>(activationGuid, calls));
+        }
+    }
+}

--- a/src/TestGrains/StatelessWorkerGrain.cs
+++ b/src/TestGrains/StatelessWorkerGrain.cs
@@ -36,7 +36,7 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    [StatelessWorker(12)]
+    [StatelessWorker(1)]
     public class StatelessWorkerGrain : Grain, IStatelessWorkerGrain
     {
         private Guid activationGuid;

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -55,6 +55,7 @@
     <Compile Include="MultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="ConcreteGrainsWithGenericInterfaces.cs" />
     <Compile Include="SampleStreamingGrain.cs" />
+    <Compile Include="StatelessWorkerGrain.cs" />
     <Compile Include="SimpleObserverableGrain.cs" />
     <Compile Include="ObserverGrain.cs" />
     <Compile Include="SimpleGrain.cs" />

--- a/src/Tester/StatelessWorkerTests.cs
+++ b/src/Tester/StatelessWorkerTests.cs
@@ -1,0 +1,103 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.TestingHost;
+using UnitTests.GrainInterfaces;
+using UnitTests.Tester;
+using Orleans.Runtime;
+
+
+namespace UnitTests.General
+{
+    [TestClass]
+    public class StatelessWorkerTests : UnitTestSiloHost
+    {
+        private const int maxLocalActivations = 10;
+        private readonly int ExpectedMaxLocalActivations = System.Environment.ProcessorCount;
+
+        public StatelessWorkerTests()
+            : base(new TestingSiloOptions { StartFreshOrleans = true, StartSecondary = false })
+        {
+        }
+
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("StatelessWorker")]
+        public async Task StatelessWorker()
+        {
+            IStatelessWorkerGrain grain = GrainClient.GrainFactory.GetGrain<IStatelessWorkerGrain>(0);
+            List<Task> promises = new List<Task>();
+
+            for (int i = 0; i < maxLocalActivations; i++)
+                promises.Add(grain.LongCall()); // trigger activation of 10 local activations
+            await Task.WhenAll(promises);
+
+            await Task.Delay(2000);
+
+            promises.Clear();
+            var stopwatch = Stopwatch.StartNew();
+
+            for (int i = 0; i < 50; i++)
+                promises.Add(grain.LongCall()); // send 50 requests to 10 activations
+            await Task.WhenAll(promises);
+
+            stopwatch.Stop();
+
+            //Assert.IsTrue(stopwatch.Elapsed > TimeSpan.FromSeconds(19.5), "50 requests with a 2 second processing time shouldn't take less than 20 seconds on 10 activations. But it took " + stopwatch.Elapsed);
+
+            promises.Clear();
+            for (int i = 0; i < 20; i++)
+                promises.Add(grain.GetCallStats());  // gather stats
+            await Task.WhenAll(promises);
+
+            HashSet<Guid> activations = new HashSet<Guid>();
+            foreach (var promise in promises)
+            {
+                Tuple<Guid, List<Tuple<DateTime, DateTime>>> response = await (Task<Tuple<Guid, List<Tuple<DateTime, DateTime>>>>)promise;
+
+                if (activations.Contains(response.Item1))
+                    continue; // duplicate response from the same activation
+
+                activations.Add(response.Item1);
+
+                logger.Info(" {0}: Activation {1}", activations.Count, response.Item1);
+                int count = 1;
+                foreach (Tuple<DateTime, DateTime> call in response.Item2)
+                    logger.Info("\t{0}: {1} - {2}", count++, TraceLogger.PrintDate(call.Item1), TraceLogger.PrintDate(call.Item2));
+            }
+
+            //Assert.IsTrue(activations.Count < ExpectedMaxLocalActivations, "activations.Count = " + activations.Count + " but expected no more than " + ExpectedMaxLocalActivations);
+        }
+    }
+}

--- a/src/Tester/StatelessWorkerTests.cs
+++ b/src/Tester/StatelessWorkerTests.cs
@@ -39,7 +39,7 @@ namespace UnitTests.General
     [TestClass]
     public class StatelessWorkerTests : UnitTestSiloHost
     {
-        private readonly int ExpectedMaxLocalActivations = 3;//System.Environment.ProcessorCount;
+        private readonly int ExpectedMaxLocalActivations = 1; // System.Environment.ProcessorCount;
 
         public StatelessWorkerTests()
             : base(new TestingSiloOptions { StartFreshOrleans = true, StartSecondary = false })
@@ -58,8 +58,8 @@ namespace UnitTests.General
             IStatelessWorkerGrain grain = GrainClient.GrainFactory.GetGrain<IStatelessWorkerGrain>(0);
             List<Task> promises = new List<Task>();
 
-            for (int i = 0; i < ExpectedMaxLocalActivations * 2; i++)
-                promises.Add(grain.LongCall()); // trigger activation of 10 local activations
+            for (int i = 0; i < ExpectedMaxLocalActivations * 3; i++)
+                promises.Add(grain.LongCall()); // trigger activation of ExpectedMaxLocalActivations local activations
             await Task.WhenAll(promises);
 
             await Task.Delay(2000);

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -87,6 +87,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="SerializationTests.cs" />
+    <Compile Include="StatelessWorkerTests.cs" />
     <Compile Include="StreamingTests\AQSubscriptionMultiplicityTests.cs" />
     <Compile Include="StreamingTests\DeactivationTestRunner.cs" />
     <Compile Include="StreamingTests\SampleStreamingTests.cs" />


### PR DESCRIPTION
Stateless worker placement was not guaranteeing that we never go above the exact specified number of  stateless worker activations in a single silo. We could sometimes overshoot, due to a race between lookup and multiple concurrent activate calls. This was especially bad when stateless worker count of "1" was specified.
This fix fixes the issue, by essentially re-using the DuplicateActivation logic to deal with races between concurrent activate attempts.