### PR TITLE
Add a config option to start silos with pulling agents stopped.

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -1037,6 +1037,13 @@ namespace Orleans
         PersistentStreamPullingManager_10 = PersistentStreamPullingManagerBase + 10,
         PersistentStreamPullingManager_11 = PersistentStreamPullingManagerBase + 11,
         PersistentStreamPullingManager_12 = PersistentStreamPullingManagerBase + 12,
+        PersistentStreamPullingManager_Starting         = PersistentStreamPullingManagerBase + 13,
+        PersistentStreamPullingManager_Stopping         = PersistentStreamPullingManagerBase + 14,
+        PersistentStreamPullingManager_Started          = PersistentStreamPullingManagerBase + 15,
+        PersistentStreamPullingManager_Stopped          = PersistentStreamPullingManagerBase + 16,
+        PersistentStreamPullingManager_AlreadyStarted   = PersistentStreamPullingManagerBase + 17,
+        PersistentStreamPullingManager_AlreadyStopped   = PersistentStreamPullingManagerBase + 18,
+
 
         StreamProviderBase = Runtime + 3600,
         StreamProvider_FailedToUnsubscribeFromPubSub = StreamProviderBase + 1,

--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -186,16 +186,5 @@ namespace Orleans.Providers
             return null;
         }
 
-        public Task StartPullingAgents(
-            string streamProviderName,
-            StreamQueueBalancerType balancerType,
-            IQueueAdapterFactory adapterFactory,
-            IQueueAdapter queueAdapter,
-            TimeSpan getQueueMsgsTimerPeriod,
-            TimeSpan initQueueTimeout,
-            TimeSpan maxEventDeliveryTime)
-        {        
-            return TaskDone.Done;
-        }
     }
 }

--- a/src/Orleans/Streams/PersistentStreams/IPersistentStreamPullingAgent.cs
+++ b/src/Orleans/Streams/PersistentStreams/IPersistentStreamPullingAgent.cs
@@ -36,5 +36,7 @@ namespace Orleans.Streams
     internal interface IPersistentStreamPullingManager : ISystemTarget
     {
         Task Initialize(Immutable<IQueueAdapter> queueAdapter);
+        Task StartAgents();
+        Task StopAgents();
     }
 }

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -130,12 +130,11 @@ namespace Orleans.Providers.Streams.Common
 
         public async Task Start()
         {
-            if (providerRuntime.InSilo) 
+            if (queueAdapter.Direction.Equals(StreamProviderDirection.ReadOnly) ||
+                queueAdapter.Direction.Equals(StreamProviderDirection.ReadWrite))
             {
                 var siloRuntime = providerRuntime as ISiloSideStreamProviderRuntime;
-
-                if (queueAdapter.Direction.Equals(StreamProviderDirection.ReadOnly) ||
-                    queueAdapter.Direction.Equals(StreamProviderDirection.ReadWrite))
+                if (siloRuntime != null)
                 {
                     await siloRuntime.InitializePullingAgents(Name, balancerType, adapterFactory, queueAdapter, getQueueMsgsTimerPeriod, initQueueTimeout, maxEventDeliveryTime);
 

--- a/src/Orleans/Streams/Providers/IStreamProviderImpl.cs
+++ b/src/Orleans/Streams/Providers/IStreamProviderImpl.cs
@@ -29,5 +29,6 @@ namespace Orleans.Streams
     public interface IStreamProviderImpl : IStreamProvider, IProvider
     {
         Task Start();
+        Task Stop();
     }
 }

--- a/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
+++ b/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
@@ -97,7 +97,13 @@ namespace Orleans.Streams
         Task InvokeWithinSchedulingContextAsync(Func<Task> asyncFunc, object context);
 
         object GetCurrentSchedulingContext();
+    }
 
+        /// <summary>
+    /// Provider-facing interface for manager of streaming providers
+    /// </summary>
+    internal interface ISiloSideStreamProviderRuntime : IStreamProviderRuntime
+    {
         /// <summary>
         /// Start the pulling agents for a given persistent stream provider.
         /// </summary>
@@ -108,7 +114,7 @@ namespace Orleans.Streams
         /// <param name="getQueueMsgsTimerPeriod"></param>
         /// <param name="initQueueTimeout"></param>
         /// <returns></returns>
-        Task StartPullingAgents(
+        Task InitializePullingAgents(
             string streamProviderName,
             StreamQueueBalancerType balancerType,
             IQueueAdapterFactory adapterFactory,
@@ -116,6 +122,9 @@ namespace Orleans.Streams
             TimeSpan getQueueMsgsTimerPeriod,
             TimeSpan initQueueTimeout,
             TimeSpan maxEventDeliveryTime);
+
+        Task StartPullingAgents();
+        Task StopPullingAgents();
     }
 
     internal enum StreamPubSubType

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -57,6 +57,11 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             return TaskDone.Done;
         }
 
+        public Task Stop()
+        {
+            return TaskDone.Done;
+        }
+
         public IAsyncStream<T> GetStream<T>(Guid id, string streamNamespace)
         {
             var streamId = StreamId.GetStreamId(id, Name, streamNamespace);

--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -214,17 +214,6 @@ namespace Orleans.Runtime.Management
             return sum;
         }
 
-        private async Task ExecutePerSiloCall(string actionToLog, Func<ISiloControl, Task> action)
-        {
-            var silos = await GetHosts(true);
-            logger.Info("Executing {0} against {1}", actionToLog, Utils.EnumerableToString(silos.Keys));
-
-            var actionPromises = PerformPerSiloAction(silos.Keys.ToArray(),
-                s => action(GetSiloControlReference(s)));
-
-            await Task.WhenAll(actionPromises);
-        }
-
         private async Task<IMembershipTable> GetMembershipTable()
         {
             if (membershipTable == null)

--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -214,6 +214,16 @@ namespace Orleans.Runtime.Management
             return sum;
         }
 
+        private async Task ExecutePerSiloCall(string actionToLog, Func<ISiloControl, Task> action)
+        {
+            var silos = await GetHosts(true);
+            logger.Info("Executing {0} against {1}", actionToLog, Utils.EnumerableToString(silos.Keys));
+
+            var actionPromises = PerformPerSiloAction(silos.Keys.ToArray(),
+                s => action(GetSiloControlReference(s)));
+
+            await Task.WhenAll(actionPromises);
+        }
 
         private async Task<IMembershipTable> GetMembershipTable()
         {

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -34,13 +34,15 @@ using Orleans.Streams;
 
 namespace Orleans.Runtime.Providers
 {
-    internal class SiloProviderRuntime : IStreamProviderRuntime
+    internal class SiloProviderRuntime : ISiloSideStreamProviderRuntime
     { 
         private static volatile SiloProviderRuntime instance;
         private static readonly object syncRoot = new Object();
 
         private IStreamPubSub pubSub;
         private ImplicitStreamSubscriberTable implicitStreamSubscriberTable;
+        private IPersistentStreamPullingManager pullingAgentManager;
+
         public IGrainFactory GrainFactory { get; private set; }
         public Guid ServiceId { get; private set; }
         public string SiloIdentity { get; private set; }
@@ -231,7 +233,7 @@ namespace Orleans.Runtime.Providers
             return RuntimeContext.CurrentActivationContext;
         }
 
-        public async Task StartPullingAgents(
+        public Task InitializePullingAgents(
             string streamProviderName,
             StreamQueueBalancerType balancerType,
             IQueueAdapterFactory adapterFactory,
@@ -246,9 +248,19 @@ namespace Orleans.Runtime.Providers
             var manager = new PersistentStreamPullingManager(managerId, streamProviderName, this, adapterFactory, queueBalancer, getQueueMsgsTimerPeriod, initQueueTimeout, maxEventDeliveryTime);
             this.RegisterSystemTarget(manager);
             // Init the manager only after it was registered locally.
-            var managerGrainRef = manager.AsReference<IPersistentStreamPullingManager>();
+            pullingAgentManager = manager.AsReference<IPersistentStreamPullingManager>();
             // Need to call it as a grain reference though.
-            await managerGrainRef.Initialize(queueAdapter.AsImmutable());
+            return pullingAgentManager.Initialize(queueAdapter.AsImmutable());
+        }
+
+        public Task StartPullingAgents()
+        {
+            return pullingAgentManager.StartAgents();
+        }
+
+        public Task StopPullingAgents()
+        {
+            return pullingAgentManager.StopAgents();
         }
     }
 }


### PR DESCRIPTION
For low/zero downtime upgrade scenarios we need an ability to start a silo/cluster without starting its pulling agents, so that we can switch from old to new cluster and avoid parallel delivery of events by two sets of pulling agents in two clusters.

This is a first step towards controllable management of stream pulling agents, allowing to stop/start/resume/suspend them based on config or external command.
