### PR TITLE
Fixed a bug of MemoryStorageProvider does not respect grain state default constructor upon initialization.

### DIFF
--- a/src/OrleansProviders/Storage/MemoryStorage.cs
+++ b/src/OrleansProviders/Storage/MemoryStorage.cs
@@ -134,7 +134,10 @@ namespace Orleans.Storage
             string id = HierarchicalKeyStore.MakeStoreKey(keys);
             IMemoryStorageGrain storageGrain = GetStorageGrain(id);
             IDictionary<string, object> state = await storageGrain.ReadStateAsync(STATE_STORE_NAME, id);
-            grainState.SetAll(state);
+            if (state != null)
+            {
+                grainState.SetAll(state);
+            }
         }
 
         /// <summary> Write state data function for this storage provider. </summary>

--- a/src/TestGrains/InitialStateGrain.cs
+++ b/src/TestGrains/InitialStateGrain.cs
@@ -16,11 +16,6 @@ namespace UnitTests.Grains
     }
     public class InitialStateGrain : Grain<Initialized_State>, IInitialStateGrain
     {
-        public override Task OnActivateAsync()
-        {
-            return TaskDone.Done;
-        }
-
         public Task<List<string>> GetNames()
         {
             return Task.FromResult(State.Names);

--- a/src/TestGrains/InitialStateGrain.cs
+++ b/src/TestGrains/InitialStateGrain.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Orleans;
 using UnitTests.GrainInterfaces;
+
 namespace UnitTests.Grains
 {
     public class Initialized_State : GrainState
@@ -17,6 +16,11 @@ namespace UnitTests.Grains
     }
     public class InitialStateGrain : Grain<Initialized_State>, IInitialStateGrain
     {
+        public override Task OnActivateAsync()
+        {
+            return TaskDone.Done;
+        }
+
         public Task<List<string>> GetNames()
         {
             return Task.FromResult(State.Names);

--- a/src/Tester/MemoryStorageProviderTests.cs
+++ b/src/Tester/MemoryStorageProviderTests.cs
@@ -4,12 +4,13 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
+
 namespace UnitTests.StorageTests
 {
     [TestClass]
     public class MemoryStorageProviderTests : UnitTestSiloHost
     {
-        [TestMethod]
+        [TestMethod, TestCategory("Functional")]
         public async Task MemoryStorageProvider_RestoreStateTest()
         {
             var grainWithState = GrainClient.GrainFactory.GetGrain<IInitialStateGrain>(0);

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -81,6 +81,7 @@
     <Compile Include="GenericGrainTests.cs" />
     <Compile Include="GrainInterfaceHierarchyTests.cs" />
     <Compile Include="MembershipTests\LivenessTests.cs" />
+    <Compile Include="MemoryStorageProviderTests.cs" />
     <Compile Include="ObserverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -87,7 +87,6 @@
     <Compile Include="StorageTests\AzureTableErrorCodeTests.cs" />
     <Compile Include="MembershipTests\AzureMembershipTableTests.cs" />
     <Compile Include="MembershipTests\MembershipTablePluginTests.cs" />
-    <Compile Include="StorageTests\MemoryStorageProviderTests.cs" />
     <Compile Include="StorageTests\UnitTestAzureTableDataManager.cs" />
     <Compile Include="StorageTests\AzureTableDataManagerTests.cs" />
     <Compile Include="StorageTests\SiloInstanceTableManagerTests.cs" />


### PR DESCRIPTION
Fixed  a bug reported in #696 and reproduced in #697.
Moved the test from TesterInternal to Tester.