### PR TITLE
Exposed the queueId data member with a new function: QueueId.GetNumericId

### DIFF
--- a/src/Orleans/IDs/QueueId.cs
+++ b/src/Orleans/IDs/QueueId.cs
@@ -100,6 +100,11 @@ namespace Orleans.Streams
             return uniformHashCache;
         }
 
+        public uint GetNumericId()
+        {
+            return queueId;            
+        }
+
         public override string ToString()
         {
             return String.Format("{0}-{1}", queueNamePrefix.ToLower(), queueId.ToString());


### PR DESCRIPTION
We need this for implementation of KafkaStreamProvider. In our implementation, we map each Queue to a certain Kafka topic partition. A partition is represented by a uint. In order to get which partition belongs to which Queue it is simplest for us to get the queueId value from QueueId which is also a uint, and as their inner ids were created sequentially so it perfectly matched to use it in order to get the right partition.