### PR TITLE
Allow to send external control commands to providers

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Messaging\IncomingMessageBuffer.cs" />
     <Compile Include="Messaging\RequestInvocationHistory.cs" />
     <Compile Include="Messaging\Response.cs" />
+    <Compile Include="Providers\IControllable.cs" />
     <Compile Include="Providers\StorageProviderUtils.cs" />
     <Compile Include="Runtime\GrainRuntime.cs" />
     <Compile Include="Runtime\IAddressable.cs" />

--- a/src/Orleans/Providers/IControllable.cs
+++ b/src/Orleans/Providers/IControllable.cs
@@ -21,34 +21,21 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
+
 using System.Threading.Tasks;
-using Orleans.Runtime;
 
-namespace Orleans
+namespace Orleans.Providers
 {
-    internal interface ISiloControl : ISystemTarget
+    /// <summary>
+    /// A general interface for controllable components inside Orleans runtime.
+    /// </summary>
+    public interface IControllable
     {
-        Task Ping(string message);
-
-        Task SetSystemLogLevel(int traceLevel);
-        Task SetAppLogLevel(int traceLevel);
-        Task SetLogLevel(string logName, int traceLevel);
-
-        Task ForceGarbageCollection();
-        Task ForceActivationCollection(TimeSpan ageLimit);
-        Task ForceRuntimeStatisticsCollection();
-
-        Task<SiloRuntimeStatistics> GetRuntimeStatistics();
-        Task<List<Tuple<GrainId, string, int>>> GetGrainStatistics();
-        Task<SimpleGrainStatistic[]> GetSimpleGrainStatistics();
-        Task<DetailedGrainReport> GetDetailedGrainReport(GrainId grainId);
-
-        Task UpdateConfiguration(string configuration);
-
-        Task<int> GetActivationCount();
-
-        Task<object> SendControlCommandToProvider(string providerTypeFullName, string providerName, int command, object arg);
+        /// <summary>
+        /// A function to execute a control command.
+        /// </summary>
+        /// <param name="command">A serial number of the command.</param>
+        /// <param name="arg">An opaque command argument</param>
+        Task<object> ExecuteCommand(int command, object arg);
     }
 }

--- a/src/Orleans/Providers/StatisticsProviderManager.cs
+++ b/src/Orleans/Providers/StatisticsProviderManager.cs
@@ -72,6 +72,11 @@ namespace Orleans.Providers
             return statisticsProviderLoader.GetProvider(name, true);
         }
 
+        public IList<IProvider> GetProviders()
+        {
+            return statisticsProviderLoader.GetProviders();
+        }
+
         // used only for testing
         internal async Task LoadEmptyProviders()
         {

--- a/src/Orleans/Streams/Providers/StreamProviderManager.cs
+++ b/src/Orleans/Streams/Providers/StreamProviderManager.cs
@@ -22,6 +22,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System.Collections.Generic;
+using System.Linq;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
 using System.Threading.Tasks;
@@ -58,6 +59,11 @@ namespace Orleans.Streams
         public IEnumerable<IStreamProvider> GetStreamProviders()
         {
             return appStreamProviders.GetProviders();
+        }
+
+        public IList<IProvider> GetProviders()
+        {
+            return appStreamProviders.GetProviders().Cast<IProvider>().ToList();
         }
 
         public IProvider GetProvider(string name)

--- a/src/Orleans/SystemTargetInterfaces/IManagementGrain.cs
+++ b/src/Orleans/SystemTargetInterfaces/IManagementGrain.cs
@@ -110,7 +110,8 @@ namespace Orleans.Runtime
         /// <returns>Completion promise for this operation.</returns>
         Task<int> GetGrainActivationCount(GrainReference grainReference);
         Task<int> GetTotalActivationCount();
-
+        Task<object[]> SendControlCommandToProvider(string providerTypeFullName, string providerName, int command, object arg);
+        
         /// <summary>
         /// Update the configuration information dynamically. Only a subset of configuration information
         /// can be updated - will throw an error (and make no config changes) if you specify attributes

--- a/src/OrleansRuntime/Storage/StorageProviderManager.cs
+++ b/src/OrleansRuntime/Storage/StorageProviderManager.cs
@@ -70,6 +70,11 @@ namespace Orleans.Runtime.Storage
             return storageProviderLoader.GetNumLoadedProviders();
         }
 
+        public IList<IStorageProvider> GetProviders()
+        {
+            return storageProviderLoader.GetProviders();
+        }
+
         public Logger GetLogger(string loggerName)
         {
             return TraceLogger.GetLogger(loggerName, TraceLogger.LoggerType.Provider);

--- a/src/Tester/StreamingTests/PullingAgentManagementTests.cs
+++ b/src/Tester/StreamingTests/PullingAgentManagementTests.cs
@@ -1,0 +1,73 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using UnitTests.Tester;
+
+namespace UnitTests.StreamingTests
+{
+    [DeploymentItem("OrleansConfigurationForStreamingUnitTests.xml")]
+    [DeploymentItem("ClientConfigurationForStreamTesting.xml")]
+    [DeploymentItem("OrleansProviders.dll")]
+    [TestClass]
+    public class PullingAgentManagementTests : UnitTestSiloHost
+    {
+        private const string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AzureQueueProvider";
+        private readonly string AZURE_QUEUE_STREAM_PROVIDER_TYPE = typeof(AzureQueueStreamProvider).FullName;
+
+        public PullingAgentManagementTests()
+            : base(new TestingSiloOptions
+            {
+                StartFreshOrleans = true,
+                StartSecondary = true,
+                SiloConfigFile = new FileInfo("OrleansConfigurationForStreamingUnitTests.xml"),
+            },
+            new TestingClientOptions()
+            {
+                ClientConfigFile = new FileInfo("ClientConfigurationForStreamTesting.xml")
+            })
+        {
+        }
+
+        // Use ClassCleanup to run code after all tests in a class have run
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming")]
+        public async Task PullingAgent_ControlCmd_1()
+        {
+            var mgmt = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
+
+            await mgmt.SendControlCommandToProvider(AZURE_QUEUE_STREAM_PROVIDER_TYPE, AZURE_QUEUE_STREAM_PROVIDER_NAME, 1, "CommandArgs");
+        }
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -90,6 +90,7 @@
     <Compile Include="StatelessWorkerTests.cs" />
     <Compile Include="StreamingTests\AQSubscriptionMultiplicityTests.cs" />
     <Compile Include="StreamingTests\DeactivationTestRunner.cs" />
+    <Compile Include="StreamingTests\PullingAgentManagementTests.cs" />
     <Compile Include="StreamingTests\SampleStreamingTests.cs" />
     <Compile Include="SimpleGrainTests.cs" />
     <Compile Include="StreamingTests\SMSDeactivationTests.cs" />


### PR DESCRIPTION
Added IControllable interface for providers ().
Store all providers in the Silo, for fast lookup and retrieval.
Added an ability to send a command to a controllable provider via management grain and ISiloControl system target.
Made PersistentStreamProvider controllable.
Unit test.