### PR TITLE
ZK MBR -  update ZooKeeperNetEx to 3.4.6.1004

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -21,7 +21,7 @@
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
       <dependency id="Newtonsoft.Json" version="5.0.8" />
-	  <dependency id="ZooKeeperNetEx" version="3.4.6.1001" />
+	  <dependency id="ZooKeeperNetEx" version="3.4.6.1004" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
+++ b/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
@@ -52,12 +52,14 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="ZooKeeperNetEx, Version=3.4.6.1002, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeperNetEx.3.4.6.1002\lib\net45\ZooKeeperNetEx.dll</HintPath>
+    <Reference Include="System.Xml" />
+    <Reference Include="ZooKeeperNetEx, Version=3.4.6.1004, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.6.1004\lib\net45\ZooKeeperNetEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/OrleansZooKeeperUtils/packages.config
+++ b/src/OrleansZooKeeperUtils/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
-  <package id="ZooKeeperNetEx" version="3.4.6.1002" targetFramework="net45" />
+  <package id="ZooKeeperNetEx" version="3.4.6.1004" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
**New Features**

* Support the new [dotnet](https://oren.codes/2015/07/29/targeting-net-core/) target for .NET Core
* Support .NET 4 