### PR TITLE
Clarify usage scope of the [AlwaysInterleave] attribute.

### DIFF
--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -34,7 +34,7 @@ namespace Orleans
         /// that may significantly improve the performance of your application.
         /// </para>
         /// </summary>
-        [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+        [AttributeUsage(AttributeTargets.Method)]
         internal sealed class ReadOnlyAttribute : Attribute
         {
         }
@@ -67,7 +67,7 @@ namespace Orleans
         /// </summary>
         [AttributeUsage(AttributeTargets.Class)]
         public sealed class StatelessWorkerAttribute : Attribute
-        {            
+        {
             /// <summary>
             /// Maximal number of local StatelessWorkers in a single silo.
             /// </summary>
@@ -87,7 +87,11 @@ namespace Orleans
         /// <summary>
         /// The AlwaysInterleaveAttribute attribute is used to mark methods that can interleave with any other method type, including write (non ReadOnly) requests.
         /// </summary>
-        [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+        /// <remarks>
+        /// Note that this attribute is applied to method declaration in the grain interface, 
+        /// and not to the method in the implementation class itself.
+        /// </remarks>
+        [AttributeUsage(AttributeTargets.Method)]
         public sealed class AlwaysInterleaveAttribute : Attribute
         {
         }
@@ -247,7 +251,7 @@ namespace Orleans
             Both
         };
 
-        private readonly FactoryTypes factoryType = FactoryTypes.Grain;
+        private readonly FactoryTypes factoryType;
 
         public FactoryAttribute(FactoryTypes factoryType)
         {


### PR DESCRIPTION
- Clarify usage scope of the [AlwaysInterleave] attribute -- it is placed on methods in grain interface, not methods in implementation class.

- Remove attribute usage scopes of "Property". because properties in grain interfaces are no longer supported.