### PR TITLE
PubSubType public

### DIFF
--- a/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
+++ b/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
@@ -126,7 +126,7 @@ namespace Orleans.Streams
             TimeSpan maxEventDeliveryTime);
     }
 
-    internal enum StreamPubSubType
+    public enum StreamPubSubType
     {
         ExplicitGrainBasedAndImplicit,
         ExplicitGrainBasedOnly,


### PR DESCRIPTION
Now that pubsub type is configurable, types should be public