### PR TITLE
Wrong method signature for [TestInitialize] method.

### DIFF
--- a/src/TesterInternal/MembershipTests/ZookeeperMembershipTableTests.cs
+++ b/src/TesterInternal/MembershipTests/ZookeeperMembershipTableTests.cs
@@ -56,8 +56,6 @@ namespace UnitTests.MembershipTests
             TraceLogger.Initialize(new NodeConfiguration());        
         }
 
-        // Use TestInitialize to run code before running each test 
-        [TestInitialize]
         private async Task Initialize()
         {
             deploymentId = "test-" + Guid.NewGuid();


### PR DESCRIPTION
The Initialize method in ZookeeperMembershipTableTests is marked as [TestInitialize] method, but it is private.

The method is actually called explicitly at the beginning of each test case, so just remove [TestInitialize] attribute because we don't want / need test framework to call that method.

Failure mode:

Method UnitTests.MembershipTests.ZookeeperMembershipTableTests.Initialize has wrong signature.  The method should be marked public.