### PR TITLE
ReSharper code cleanup settings

### DIFF
--- a/src/Build/GlobalAssemblyInfo.cs
+++ b/src/Build/GlobalAssemblyInfo.cs
@@ -1,3 +1,29 @@
+// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Reflection;
 
 [assembly: AssemblyCompany("Microsoft Corporation")]

--- a/src/ClientGenerator/CSharpCodeGenerator.cs
+++ b/src/ClientGenerator/CSharpCodeGenerator.cs
@@ -1,25 +1,28 @@
-/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
 using System.CodeDom;
@@ -27,7 +30,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-
 using Orleans.Runtime;
 
 namespace Orleans.CodeGeneration
@@ -160,7 +162,7 @@ namespace Orleans.CodeGeneration
             var invokerField = new CodeSnippetTypeMember(fieldImpl);
             factoryClass.Members.Add(invokerField);
 
-            var methodImpl = String.Format(@"
+            var methodImpl = string.Format(@"
         public async static System.Threading.Tasks.Task<{0}> CreateObjectReference({0} obj)
         {{
             if (methodInvoker == null) methodInvoker = new {2}();
@@ -169,7 +171,7 @@ namespace Orleans.CodeGeneration
             var createObjectReferenceMethod = new CodeSnippetTypeMember(methodImpl);
             factoryClass.Members.Add(createObjectReferenceMethod);
 
-            methodImpl = String.Format(@"
+            methodImpl = string.Format(@"
         public static System.Threading.Tasks.Task DeleteObjectReference({0} reference)
         {{
             return global::Orleans.Runtime.GrainReference.DeleteObjectReference(reference);
@@ -201,7 +203,7 @@ namespace Orleans.CodeGeneration
             try
             {{");
 
-            var interfaceSwitchBody = String.Empty;
+            var interfaceSwitchBody = string.Empty;
             foreach (int interfaceId in grainInterfaceInfo.Interfaces.Keys)
             {
                 InterfaceInfo interfaceInfo = grainInterfaceInfo.Interfaces[interfaceId];
@@ -231,7 +233,7 @@ namespace Orleans.CodeGeneration
 
         private string GetMethodDispatchSwitchForInterface(int interfaceId, InterfaceInfo interfaceInfo)
         {
-            string methodSwitchBody = String.Empty;
+            string methodSwitchBody = string.Empty;
 
             foreach (int methodId in interfaceInfo.Methods.Keys)
             {
@@ -313,7 +315,7 @@ namespace Orleans.CodeGeneration
             const string defaultCase = @"default: 
                             throw new NotImplementedException(""interfaceId=""+interfaceId+"",methodId=""+methodId);";
 
-            return String.Format(@"case {0}:  // {1}
+            return string.Format(@"case {0}:  // {1}
                         switch (methodId)
                         {{
 {2}                            {3}
@@ -332,11 +334,11 @@ namespace Orleans.CodeGeneration
             }
 
             var interfaces = new Dictionary<int, InterfaceInfo>(grainInterfaceInfo.Interfaces); // Copy, as we may alter the original collection in the loop below
-            var interfaceSwitchBody = String.Empty;
+            var interfaceSwitchBody = string.Empty;
 
             foreach (var kv in interfaces)
             {
-                var methodSwitchBody = String.Empty;
+                var methodSwitchBody = string.Empty;
                 int interfaceId = kv.Key;
                 InterfaceInfo interfaceInfo = kv.Value;
 
@@ -354,7 +356,7 @@ namespace Orleans.CodeGeneration
                     ", methodId, invokeGrainMethod);
                 }
 
-                interfaceSwitchBody += String.Format(@"
+                interfaceSwitchBody += string.Format(@"
                 case {0}:  // {1}
                     switch (methodId)
                     {{
@@ -379,7 +381,7 @@ namespace Orleans.CodeGeneration
             RecordReferencedNamespaceAndAssembly(iface.Type);
             var interfaceId = GrainInterfaceData.GetGrainInterfaceId(iface.Type);
             Action<string> add = codeFmt => factoryClass.Members.Add(
-                new CodeSnippetTypeMember(String.Format(codeFmt, iface.InterfaceTypeName)));
+                new CodeSnippetTypeMember(string.Format(codeFmt, iface.InterfaceTypeName)));
 
             bool isGuidCompoundKey = typeof(IGrainWithGuidCompoundKey).IsAssignableFrom(iface.Type);
             bool isLongCompoundKey = typeof(IGrainWithIntegerCompoundKey).IsAssignableFrom(iface.Type);
@@ -570,7 +572,7 @@ namespace Orleans.CodeGeneration
                 methodImpl = string.Format(@"
                     base.InvokeOneWayMethod({0}, {1} {2});",
                     methodId, 
-                    invokeArguments.Equals(string.Empty) ? "null" : String.Format("new object[] {{{0}}}", invokeArguments),
+                    invokeArguments.Equals(string.Empty) ? "null" : string.Format("new object[] {{{0}}}", invokeArguments),
                     optional);
             }
             else
@@ -580,7 +582,7 @@ namespace Orleans.CodeGeneration
                     methodImpl = string.Format(@"
                 return base.InvokeMethodAsync<object>({0}, {1} {2});",
                         methodId,
-                        invokeArguments.Equals(string.Empty) ? "null" : String.Format("new object[] {{{0}}}", invokeArguments),
+                        invokeArguments.Equals(string.Empty) ? "null" : string.Format("new object[] {{{0}}}", invokeArguments),
                         optional);
                 }
                 else
@@ -589,7 +591,7 @@ namespace Orleans.CodeGeneration
                 return base.InvokeMethodAsync<{0}>({1}, {2} {3});",
                         GetActualMethodReturnType(methodInfo.ReturnType, SerializeFlag.NoSerialize),
                         methodId,
-                        invokeArguments.Equals(string.Empty) ? "null" : String.Format("new object[] {{{0}}}", invokeArguments),
+                        invokeArguments.Equals(string.Empty) ? "null" : string.Format("new object[] {{{0}}}", invokeArguments),
                         optional);
                 }
             }

--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -1,25 +1,28 @@
-/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
 using System.CodeDom;
@@ -29,10 +32,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Text;
-
 using Orleans.CodeGeneration.Serialization;
 using Orleans.Runtime;
-
 
 namespace Orleans.CodeGeneration
 {
@@ -45,11 +46,11 @@ namespace Orleans.CodeGeneration
         [Serializable]
         internal class CodeGenOptions
         {
-            public bool ServerGen = false;
+            public bool ServerGen;
             public FileInfo InputLib;
             public FileInfo SigningKey;
 
-            public bool LanguageConflict = false;
+            public bool LanguageConflict;
             public Language? TargetLanguage;
 
             public List<string> ReferencedAssemblies = new List<string>();
@@ -464,7 +465,7 @@ namespace Orleans.CodeGeneration
             // add referrenced named spaces
             foreach (string referredNamespace in grainNamespace.ReferencedNamespaces)
                 if (referredNamespace != referenceNameSpace.Name)
-                    if (!String.IsNullOrEmpty(referredNamespace))
+                    if (!string.IsNullOrEmpty(referredNamespace))
                     {
                         referenceNameSpace.Imports.Add(new CodeNamespaceImport(referredNamespace));
                     }
@@ -613,7 +614,7 @@ namespace Orleans.CodeGeneration
                 foreach (string imp in options.Imports)
                     compilerParams.CompilerOptions += string.Format(" /imports:{0} ", imp);
 
-            compilerParams.CompilerOptions += string.Format(" /define:EXCLUDE_CODEGEN ");
+            compilerParams.CompilerOptions += " /define:EXCLUDE_CODEGEN ";
 
             using (CodeDomProvider codeProvider = CodeGeneratorBase.GetCodeProvider(options.TargetLanguage.Value, true))
             {
@@ -625,7 +626,7 @@ namespace Orleans.CodeGeneration
                 foreach (CompilerError error in results.Errors)
                 {
                     Console.WriteLine(error.ToString());
-                    errorsString += String.Format("{0} Line {1},{2} - {3} {4} -- {5}",
+                    errorsString += string.Format("{0} Line {1},{2} - {3} {4} -- {5}",
                         error.FileName,
                         error.Line,
                         error.Column,
@@ -634,7 +635,7 @@ namespace Orleans.CodeGeneration
                         error.ErrorText)
                     + Environment.NewLine;
                 }
-                String errMsg = String.Format(
+                string errMsg = string.Format(
                     "Error: ClientGenerator could not compile and generate " + options.TargetLanguage.Value
                     + " -- encountered " + results.Errors.Count + " compilation warnings/errors."
                     + Environment.NewLine + "ErrorList = "
@@ -676,7 +677,7 @@ namespace Orleans.CodeGeneration
                     string arg = a.Trim('"').Trim().Trim('"');
                     if (GrainClientGeneratorFlags.Verbose)
                         Console.WriteLine("Orleans-CodeGen - arg #{0}={1}", i++, arg);
-                    if (String.IsNullOrEmpty(arg) || String.IsNullOrWhiteSpace(arg))
+                    if (string.IsNullOrEmpty(arg) || string.IsNullOrWhiteSpace(arg))
                         continue;
 
                     if (arg.StartsWith("/"))

--- a/src/ClientGenerator/CodeGeneratorBase.cs
+++ b/src/ClientGenerator/CodeGeneratorBase.cs
@@ -1,25 +1,28 @@
-﻿/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+﻿// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
 using System.CodeDom;
@@ -32,7 +35,6 @@ using System.Reflection;
 using System.Text;
 using Microsoft.CSharp;
 using Microsoft.VisualBasic;
-
 using Orleans.Runtime;
 
 namespace Orleans.CodeGeneration
@@ -345,7 +347,7 @@ namespace Orleans.CodeGeneration
             {
                 var xFullName = TypeUtils.GetFullName(x.InterfaceType);
                 var yFullName = TypeUtils.GetFullName(y.InterfaceType);
-                return String.CompareOrdinal(xFullName, yFullName) == 0;
+                return string.CompareOrdinal(xFullName, yFullName) == 0;
             }
 
             public int GetHashCode(InterfaceInfo obj)

--- a/src/ClientGenerator/FSharpCodeGenerator.cs
+++ b/src/ClientGenerator/FSharpCodeGenerator.cs
@@ -1,33 +1,35 @@
-/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
 using System.CodeDom;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Linq;
-
 using Orleans.Runtime;
 
 namespace Orleans.CodeGeneration

--- a/src/ClientGenerator/NamespaceGenerator.cs
+++ b/src/ClientGenerator/NamespaceGenerator.cs
@@ -1,25 +1,28 @@
-﻿/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+﻿// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
 using System.CodeDom;
@@ -29,11 +32,8 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
-
 using Orleans.CodeGeneration.Serialization;
-using Orleans.Providers;
 using Orleans.Runtime;
-using Orleans.Storage;
 
 namespace Orleans.CodeGeneration
 {
@@ -47,7 +47,7 @@ namespace Orleans.CodeGeneration
         {
             SerializeArgument = 0,
             DeserializeResult = 1,
-            NoSerialize = 2,
+            NoSerialize = 2
         }
 
         private readonly HashSet<int> methodIdCollisionDetection;
@@ -298,11 +298,8 @@ namespace Orleans.CodeGeneration
                     hasStateClass = false;
                     return null;
                 }
-                else
-                {
-                    ConsoleText.WriteError(String.Format("Warning: Usage of grain state interfaces as type arguments for Grain<T> has been deprecated. " +
-                        "Define an equivalent class with automatic properties instead of the state interface for {0}.", sourceType.FullName));
-                }
+                ConsoleText.WriteError(string.Format("Warning: Usage of grain state interfaces as type arguments for Grain<T> has been deprecated. " +
+                                                     "Define an equivalent class with automatic properties instead of the state interface for {0}.", sourceType.FullName));
             }
 
             Dictionary<string, PropertyInfo> asyncProperties = GrainInterfaceData.GetPersistentProperties(persistentInterface)
@@ -561,7 +558,7 @@ namespace Orleans.CodeGeneration
                 if (genericArguments.Length == 1) 
                     return GetGenericTypeName(genericArguments[0], flag);
 
-                var errorMsg = String.Format("Unexpected number of arguments {0} for generic type {1} used as a return type. Only Type<T> are supported as generic return types of grain methods.", genericArguments.Length, type);
+                var errorMsg = string.Format("Unexpected number of arguments {0} for generic type {1} used as a return type. Only Type<T> are supported as generic return types of grain methods.", genericArguments.Length, type);
                 ReportError(errorMsg);
                 throw new ApplicationException(errorMsg);
             }
@@ -806,7 +803,7 @@ namespace Orleans.CodeGeneration
 
         private void RecordReferencedNamespaceAndAssembly(string nspace, string assembly)
         {
-            if (!String.IsNullOrEmpty((nspace)))
+            if (!string.IsNullOrEmpty((nspace)))
                 if (!ReferencedNamespaces.Contains(nspace) && ReferencedNamespace.Name != nspace)
                     ReferencedNamespaces.Add(nspace);
 

--- a/src/ClientGenerator/Program.cs
+++ b/src/ClientGenerator/Program.cs
@@ -1,27 +1,29 @@
-/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-
-﻿namespace Orleans.CodeGeneration
+﻿// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Orleans.CodeGeneration
 {
     public class Program
     {

--- a/src/ClientGenerator/Properties/AssemblyInfo.cs
+++ b/src/ClientGenerator/Properties/AssemblyInfo.cs
@@ -1,25 +1,28 @@
-/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/ClientGenerator/Serialization/SerializationGenerator.cs
+++ b/src/ClientGenerator/Serialization/SerializationGenerator.cs
@@ -1,32 +1,34 @@
-﻿/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+﻿// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
-using System.Collections.Generic;
 using System.CodeDom;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-
 using Orleans.Runtime;
 using Orleans.Serialization;
 
@@ -61,7 +63,7 @@ namespace Orleans.CodeGeneration.Serialization
             container.Imports.Add(new CodeNamespaceImport("System.Collections.Generic"));
             container.Imports.Add(new CodeNamespaceImport("System.Reflection"));
             container.Imports.Add(new CodeNamespaceImport("Orleans.Serialization"));
-            if (!String.IsNullOrEmpty(t.Namespace))
+            if (!string.IsNullOrEmpty(t.Namespace))
             {
                 container.Imports.Add(new CodeNamespaceImport(t.Namespace));
             }
@@ -527,8 +529,7 @@ namespace Orleans.CodeGeneration.Serialization
                 ser.Statements.Add(new CodeVariableDeclarationStatement(typeof(MethodInfo), "f",
                     new CodeMethodInvokeExpression(new CodeVariableReferenceExpression("t"), "GetMethod", new CodePrimitiveExpression("Serializer"))));
                 ser.Statements.Add(new CodeVariableDeclarationStatement(typeof(object[]), "args",
-                    new CodeArrayCreateExpression(typeof(object), new CodeExpression[] { new CodeArgumentReferenceExpression("input"), 
-                        new CodeArgumentReferenceExpression("stream"), new CodeArgumentReferenceExpression("expected")})));
+                    new CodeArrayCreateExpression(typeof(object), new CodeArgumentReferenceExpression("input"), new CodeArgumentReferenceExpression("stream"), new CodeArgumentReferenceExpression("expected"))));
                 ser.Statements.Add(new CodeMethodInvokeExpression(new CodeVariableReferenceExpression("f"), "Invoke", new CodePrimitiveExpression(),
                         new CodeVariableReferenceExpression("args")));
 
@@ -547,8 +548,7 @@ namespace Orleans.CodeGeneration.Serialization
                 deser.Statements.Add(new CodeVariableDeclarationStatement(typeof(MethodInfo), "f",
                     new CodeMethodInvokeExpression(new CodeVariableReferenceExpression("t"), "GetMethod", new CodePrimitiveExpression("Deserializer"))));
                 deser.Statements.Add(new CodeVariableDeclarationStatement(typeof(object[]), "args",
-                    new CodeArrayCreateExpression(typeof(object), new CodeExpression[] { new CodeArgumentReferenceExpression("expected"), 
-                        new CodeArgumentReferenceExpression("stream")})));
+                    new CodeArrayCreateExpression(typeof(object), new CodeArgumentReferenceExpression("expected"), new CodeArgumentReferenceExpression("stream"))));
                 deser.Statements.Add(new CodeMethodReturnStatement(
                     new CodeMethodInvokeExpression(new CodeVariableReferenceExpression("f"), "Invoke", new CodePrimitiveExpression(),
                         new CodeVariableReferenceExpression("args"))));
@@ -581,7 +581,7 @@ namespace Orleans.CodeGeneration.Serialization
         {
             public int Compare(FieldInfo x, FieldInfo y)
             {
-                return String.Compare(x.Name, y.Name, StringComparison.Ordinal);
+                return string.Compare(x.Name, y.Name, StringComparison.Ordinal);
             }
         }
 
@@ -602,10 +602,10 @@ namespace Orleans.CodeGeneration.Serialization
                 return true;
 
             if (hasCustomDeserializer)
-                throw new OrleansException(String.Format("Class {0} has a custom deserializer but no custom serializer", t));
+                throw new OrleansException(string.Format("Class {0} has a custom deserializer but no custom serializer", t));
 
             if (hasCustomSerializer)
-                throw new OrleansException(String.Format("Class {0} has a custom serializer but no custom deserializer", t));
+                throw new OrleansException(string.Format("Class {0} has a custom serializer but no custom deserializer", t));
 
             return false;
         }
@@ -617,7 +617,7 @@ namespace Orleans.CodeGeneration.Serialization
 
         private static void ImportFieldNamespaces(Type t, CodeNamespaceImportCollection imports)
         {
-            if (!String.IsNullOrEmpty(t.Namespace))
+            if (!string.IsNullOrEmpty(t.Namespace))
             {
                 imports.Add(new CodeNamespaceImport(t.Namespace));
             }

--- a/src/ClientGenerator/Serialization/SerializerGenerationManager.cs
+++ b/src/ClientGenerator/Serialization/SerializerGenerationManager.cs
@@ -1,33 +1,35 @@
-/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
-
-using Orleans.Serialization;
 using Orleans.Runtime;
+using Orleans.Serialization;
 
 namespace Orleans.CodeGeneration.Serialization
 {
@@ -146,7 +148,7 @@ namespace Orleans.CodeGeneration.Serialization
                 ConsoleText.WriteStatus("\ttype " + toGen.FullName + " in namespace " + toGen.Namespace + " defined in Assembly " + toGen.Assembly.GetName());
                 NamespaceGenerator typeNamespace;
 
-                string nspace = toGen.Namespace ?? String.Empty;
+                string nspace = toGen.Namespace ?? string.Empty;
                 if (!namespaceDictionary.TryGetValue(nspace, out typeNamespace))
                 {
                     if (extraNamespace == null)

--- a/src/ClientGenerator/Serialization/SerializerGenerationUtilities.cs
+++ b/src/ClientGenerator/Serialization/SerializerGenerationUtilities.cs
@@ -1,29 +1,31 @@
-/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
 using System.CodeDom;
-
 using Orleans.Serialization;
 
 namespace Orleans.CodeGeneration.Serialization

--- a/src/ClientGenerator/VBCodeGenerator.cs
+++ b/src/ClientGenerator/VBCodeGenerator.cs
@@ -1,25 +1,28 @@
-/*
-Project Orleans Cloud Service SDK ver. 1.0
- 
-Copyright (c) Microsoft Corporation
- 
-All rights reserved.
- 
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the ""Software""), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+// Project Orleans Cloud Service SDK ver. 1.0
+//  
+// Copyright (c) .NET Foundation
+// 
+// All rights reserved.
+//  
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
 using System.CodeDom;
@@ -27,7 +30,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-
 using Orleans.CodeGeneration.Serialization;
 using Orleans.Runtime;
 
@@ -161,7 +163,7 @@ End If", pair.Key, pair.Value);
             var invokerField = new CodeSnippetTypeMember(fieldImpl);
             factoryClass.Members.Add(invokerField);
 
-            var methodImpl = String.Format(@"
+            var methodImpl = string.Format(@"
         Public Shared Async Function CreateObjectReference(obj As {0}) As System.Threading.Tasks.Task(Of {0})       
             If methodInvoker Is Nothing Then : methodInvoker = New {2}() : End If
             Return {1}.Cast(Await Global.Orleans.Runtime.GrainReference.CreateObjectReference(obj, methodInvoker))
@@ -172,7 +174,7 @@ End If", pair.Key, pair.Value);
             var createObjectReferenceMethod = new CodeSnippetTypeMember(methodImpl);
             factoryClass.Members.Add(createObjectReferenceMethod);
 
-            methodImpl = String.Format(@"
+            methodImpl = string.Format(@"
         Public Shared Function DeleteObjectReference(reference As {0}) As System.Threading.Tasks.Task
             Return Global.Orleans.Runtime.GrainReference.DeleteObjectReference(reference)
         End Function",
@@ -195,11 +197,11 @@ End If", pair.Key, pair.Value);
 
             var interfaces = new Dictionary<int, InterfaceInfo>(grainInterfaceInfo.Interfaces); // Copy, as we may alter the original collection in the loop below
 
-            var interfaceSwitchBody = String.Empty;
+            var interfaceSwitchBody = string.Empty;
 
             foreach (var kv in interfaces)
             {
-                var methodSwitchBody = String.Empty;
+                var methodSwitchBody = string.Empty;
                 int interfaceId = kv.Key;
                 InterfaceInfo interfaceInfo = kv.Value;
 
@@ -218,7 +220,7 @@ End If", pair.Key, pair.Value);
                     , methodId, invokeGrainMethod);
                 }
 
-                interfaceSwitchBody += String.Format(@"
+                interfaceSwitchBody += string.Format(@"
                 Case {0}  ' {1}
                     Select methodId
                         {2}
@@ -255,7 +257,7 @@ End If", pair.Key, pair.Value);
             builder.Append(@"            Try
             ");
 
-            var interfaceSwitchBody = String.Empty;
+            var interfaceSwitchBody = string.Empty;
             foreach (int interfaceId in grainInterfaceInfo.Interfaces.Keys)
             {
                 InterfaceInfo interfaceInfo = grainInterfaceInfo.Interfaces[interfaceId];
@@ -282,7 +284,7 @@ End If", pair.Key, pair.Value);
 
         private string GetMethodDispatchSwitchForInterface(int interfaceId, InterfaceInfo interfaceInfo)
         {
-            var methodSwitchBody = String.Empty;
+            var methodSwitchBody = string.Empty;
 
             foreach (int methodId in interfaceInfo.Methods.Keys)
             {
@@ -365,7 +367,7 @@ Return System.Threading.Tasks.Task.FromResult(CObj(True))
             var defaultCase = @"                            Case Else 
                             Throw New NotImplementedException(""interfaceId=""+interfaceId+"",methodId=""+methodId)";
 
-            return String.Format(@"Case {0}  ' {1}
+            return string.Format(@"Case {0}  ' {1}
                         Select Case methodId
 {2}                            
 {3}
@@ -383,7 +385,7 @@ Return System.Threading.Tasks.Task.FromResult(CObj(True))
 
             Action<string> add = codeFmt =>
                 factoryClass.Members.Add(new CodeSnippetTypeMember(
-                     String.Format(codeFmt, FixupTypeName(interfaceName))));
+                     string.Format(codeFmt, FixupTypeName(interfaceName))));
 
             bool isGuidCompoundKey = typeof(IGrainWithGuidCompoundKey).IsAssignableFrom(iface.Type);
             bool isLongCompoundKey = typeof(IGrainWithIntegerCompoundKey).IsAssignableFrom(iface.Type);

--- a/src/Orleans.sln.DotSettings
+++ b/src/Orleans.sln.DotSettings
@@ -1,0 +1,30 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=OrleansCleanCodeSettings/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="OrleansCleanCodeSettings"&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;CSUpdateFileHeader&gt;True&lt;/CSUpdateFileHeader&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;/Profile&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">OrleansCleanCodeSettings</s:String>
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Project Orleans Cloud Service SDK ver. 1.0&#xD;
+ &#xD;
+Copyright (c) .NET Foundation&#xD;
+&#xD;
+All rights reserved.&#xD;
+ &#xD;
+MIT License&#xD;
+&#xD;
+Permission is hereby granted, free of charge, to any person obtaining a copy&#xD;
+of this software and associated documentation files (the "Software"), to deal&#xD;
+in the Software without restriction, including without limitation the rights&#xD;
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell&#xD;
+copies of the Software, and to permit persons to whom the Software is&#xD;
+furnished to do so, subject to the following conditions:&#xD;
+&#xD;
+The above copyright notice and this permission notice shall be included in all&#xD;
+copies or substantial portions of the Software.&#xD;
+&#xD;
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR&#xD;
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,&#xD;
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE&#xD;
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER&#xD;
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,&#xD;
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE&#xD;
+SOFTWARE.&#xD;
+</s:String>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
ReSharper Code Cleanup Settings

This is a first attempt to address some of the outstanding issues with code normalization / auto-cleanup that @attilah mentioned in PR #709 

> It is a habit that pushing Ctrl+K, Ctrl+D to reformat the code and since no solution level settings exists for the project it will be different for everyone. I'll try to not to reformat the code, but having a Resharper code formatting setting for the solution in place would help a lot for situations like this.

I could not find any specific guidance on a "best-practice" set of code cleanup settings for ReSharper, so this is my strawman best-guess to start some community discussion. :)

Feel free to chime in if you have any suggestions or experience about a good set of settings to use.

I also ran ReSharper code-cleanup on a small project using these settings [included as a separate commit], so that we have a concrete examples of what changes are involved.

_Specific changes_:

ReSharper Code Cleanup Settings

- Add (strawman) ReSharper code cleanup settings config file `Orleans.sln.DotSettings`.

- Added code header setting containing Orleans MIT license,
  using master copy of license text from https://github.com/dotnet/orleans/blob/master/LICENSE

Sample auto-cleanup run with new ReSharper code-cleanup settings.

- An example of running ReSharper code-auto-cleanup on the (small) CodeGen project with the new cleanup config from `Orleans.sln.DotSettings`, so that everyone can see what the changes / impact of the code-cleanup settings is likely to be.

Advice, guidance and suggestions from any ReSharper experts are most welcome :)