### PR TITLE
Add minimal example of PerSilo grains scenario.

### DIFF
--- a/src/TestGrainInterfaces/IPerSiloExampleGrains.cs
+++ b/src/TestGrainInterfaces/IPerSiloExampleGrains.cs
@@ -1,0 +1,68 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace TestGrainInterfaces
+{
+    /// <summary>
+    /// Grain interface for PerSilo Example Grain
+    /// </summary>
+    public interface IPartitionGrain : IGrainWithGuidKey
+    {
+        /// <summary> Start this partiton grain. </summary>
+        Task<PartitionInfo> Start();
+
+        /// <summary> Return the <c>PartitionInfo</c> for this partition. </summary>
+        Task<PartitionInfo> GetPartitionInfo();
+    }
+
+    /// <summary>
+    /// Manager for Partition Grains.
+    /// By convention, only Id=0 will be used, to ensure only single copy exists within the cluster.
+    /// </summary>
+    public interface IPartitionManager : IGrainWithIntegerKey
+    {
+        Task<IList<IPartitionGrain>> GetPartitions();
+        Task<IList<PartitionInfo>> GetPartitionInfos();
+        Task RegisterPartition(PartitionInfo partitonInfo, IPartitionGrain partitionGrain);
+        Task RemovePartition(PartitionInfo partitonInfo, IPartitionGrain partitionGrain);
+    }
+
+    [Serializable]
+    [DebuggerDisplay("PartitionInfo:{PartitionId}")]
+    public class PartitionInfo
+    {
+        public Guid PartitionId { get; set; }
+        public string SiloId { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("PartitionInfo:PartitionId={0},SiloId={1}", PartitionId, SiloId);
+        }
+    }
+}

--- a/src/TestGrainInterfaces/IPerSiloExampleGrains.cs
+++ b/src/TestGrainInterfaces/IPerSiloExampleGrains.cs
@@ -51,6 +51,7 @@ namespace TestGrainInterfaces
         Task<IList<PartitionInfo>> GetPartitionInfos();
         Task RegisterPartition(PartitionInfo partitonInfo, IPartitionGrain partitionGrain);
         Task RemovePartition(PartitionInfo partitonInfo, IPartitionGrain partitionGrain);
+        Task Broadcast(Func<IPartitionGrain, Task> asyncAction);
     }
 
     [Serializable]

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -51,6 +51,7 @@
     <Compile Include="IMultipleImplicitSubscriptionGrain.cs" />
     <Compile Include="IMultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="GrainInterfaceHierarchyIGrains.cs" />
+    <Compile Include="IPerSiloExampleGrains.cs" />
     <Compile Include="ISampleStreamingGrain.cs" />
     <Compile Include="ISimpleGenericGrain.cs" />
     <Compile Include="CodegenTestInterfaces.cs" />

--- a/src/TestGrains/PerSiloExampleGrains.cs
+++ b/src/TestGrains/PerSiloExampleGrains.cs
@@ -1,0 +1,192 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Concurrency;
+using Orleans.Providers;
+using Orleans.Runtime;
+using TestGrainInterfaces;
+
+namespace TestGrains
+{
+    public interface PartitionManagerConfig : IGrainState
+    {
+        IDictionary<Guid, IPartitionGrain> Partitions { get; set; }
+        IDictionary<Guid, PartitionInfo> PartitionInfos { get; set; }
+    }
+
+    /// <summary>
+    /// Grain implemention for Partition Grains.
+    /// One partition grain is created per silo.
+    /// </summary>
+    [StatelessWorker(1)]
+    public class PartitionGrain : Grain, IPartitionGrain
+    {
+        PartitionInfo PartitionConfig { get; set; }
+
+        private Logger logger;
+
+        public override Task OnActivateAsync()
+        {
+            Guid pk = this.GetPrimaryKey();
+            string siloId = RuntimeIdentity;
+
+            logger = GetLogger(GetType().Name + "-" + pk);
+            logger.Info("Activate");
+
+            if (PartitionConfig == null)
+            {
+                PartitionConfig = new PartitionInfo
+                {
+                    PartitionId = pk,
+                    SiloId = siloId
+                };
+            }
+            return TaskDone.Done;
+        }
+
+        public Task<PartitionInfo> Start()
+        {
+            logger.Info("Start");
+            return Task.FromResult(PartitionConfig);
+        }
+
+        public Task<PartitionInfo> GetPartitionInfo()
+        {
+            return Task.FromResult(PartitionConfig);
+        }
+    }
+
+    /// <summary>
+    /// Grain implemention for Partition Manager Grain.
+    /// One partition manager grain is created per cluster.
+    /// By convention, only Id=0 will be used.
+    /// </summary>
+    [StorageProvider(ProviderName = "PartitionManagerStore")] // Note: Using MemoryStore for testing only.
+    public class PartitionManagerGrain : Grain<PartitionManagerConfig>, IPartitionManager
+    {
+        private Logger logger;
+
+        public override Task OnActivateAsync()
+        {
+            logger = GetLogger(GetType().Name);
+            logger.Info("Activate");
+
+            if (State.PartitionInfos == null)
+            {
+                State.PartitionInfos = new Dictionary<Guid, PartitionInfo>();
+            }
+            if (State.Partitions == null)
+            {
+                State.Partitions = new Dictionary<Guid, IPartitionGrain>();
+            }
+            // Don't need to write default init data back to store
+            return TaskDone.Done;
+        }
+
+        public Task<IList<IPartitionGrain>> GetPartitions()
+        {
+            IList<IPartitionGrain> partitions = State.Partitions.Values.ToList();
+            return Task.FromResult(partitions);
+        }
+
+        public Task<IList<PartitionInfo>> GetPartitionInfos()
+        {
+            IList<PartitionInfo> partitionInfos = State.PartitionInfos.Values.ToList();
+            return Task.FromResult(partitionInfos);
+        }
+
+        public async Task RegisterPartition(PartitionInfo partitionInfo, IPartitionGrain partitionGrain)
+        {
+            logger.Info("RegisterPartition {0} on silo {1}", partitionInfo.PartitionId, partitionInfo.SiloId);
+            Guid partitionId = partitionInfo.PartitionId;
+            State.Partitions[partitionId] = partitionGrain;
+            State.PartitionInfos[partitionId] = partitionInfo;
+            await WriteStateAsync();
+        }
+
+        public async Task RemovePartition(PartitionInfo partitionInfo, IPartitionGrain partitionGrain)
+        {
+            logger.Info("RemovePartition {0} on silo {1}", partitionInfo.PartitionId, partitionInfo.SiloId);
+            Guid partitionId = partitionInfo.PartitionId;
+            State.Partitions.Remove(partitionId);
+            State.PartitionInfos.Remove(partitionId);
+            await WriteStateAsync();
+        }
+    }
+
+    /// <summary>
+    /// App startup shim to bootstrap the partition grain in each silo.
+    /// </summary>
+    public class PartitionStartup : IBootstrapProvider
+    {
+        public string Name { get; private set; }
+        public Guid PartitionId { get; private set; }
+        public string HostId { get; private set; }
+
+        private IGrainFactory GrainFactory { get; set; }
+        private Logger logger;
+
+        /// <summary>
+        /// Bootstrap the partition grain in this silo.
+        /// </summary>
+        public async Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
+        {
+            logger = providerRuntime.GetLogger("Startup:" + name);
+            GrainFactory = providerRuntime.GrainFactory;
+
+            HostId = providerRuntime.SiloIdentity;
+
+            // Use different partition id value for each silo instance.
+            PartitionId = Guid.NewGuid();
+
+            Name = "Partition-" + PartitionId;
+
+            await StartPartition(PartitionId, HostId);
+        }
+
+        /// <summary>
+        /// Start the partition instance for this silo.
+        /// </summary>
+        /// <param name="partitionId">Id value for this partition.</param>
+        /// <param name="hostId">Id value for this host.</param>
+        /// <returns>Async Task to indicate when the partition startup operation is complete.</returns>
+        private async Task StartPartition(Guid partitionId, string hostId)
+        {
+            logger.Info("Creating partition grain id {0} on silo id {1}", partitionId, hostId);
+            IPartitionGrain partitionGrain = GrainFactory.GetGrain<IPartitionGrain>(partitionId);
+            PartitionInfo partitionInfo = await partitionGrain.Start();
+            logger.Info("Started partition grain {0} on this silo: {1}", partitionId, partitionInfo);
+
+            logger.Info("Registering partition grain {0} with partition manager", partitionId);
+            IPartitionManager partitionManager = GrainFactory.GetGrain<IPartitionManager>(0);
+            await partitionManager.RegisterPartition(partitionInfo, partitionGrain);
+
+            logger.Info("Partition grain {0} has been started on this silo", partitionId);
+        }
+    }
+}

--- a/src/TestGrains/PerSiloExampleGrains.cs
+++ b/src/TestGrains/PerSiloExampleGrains.cs
@@ -56,7 +56,7 @@ namespace TestGrains
 
         public override async Task OnActivateAsync()
         {
-            logger = GetLogger(GetType().Name + "-" + partitionId);
+            logger = GetLogger(GetType().Name + "-" + this.GetPrimaryKey());
             logger.Info("Activate");
 
             partitionId = this.GetPrimaryKey();
@@ -75,7 +75,7 @@ namespace TestGrains
 
             logger.Info("Registering partition grain {0} on silo {1} with partition manager", partitionId, siloId);
             await partitionManager.RegisterPartition(PartitionConfig, me);
-            logger.Info("Partition grain {0} has been started on this silo", partitionId);
+            logger.Info("Partition grain {0} has been activated on this silo", partitionId);
         }
 
         public override async Task OnDeactivateAsync()
@@ -87,7 +87,7 @@ namespace TestGrains
 
         public Task<PartitionInfo> Start()
         {
-            logger.Info("Start");
+            logger.Info("Partition grain {0} has been started on this silo", partitionId);
             return Task.FromResult(PartitionConfig);
         }
 
@@ -110,7 +110,7 @@ namespace TestGrains
 
         public override Task OnActivateAsync()
         {
-            logger = GetLogger(GetType().Name);
+            logger = GetLogger(GetType().Name + this.GetPrimaryKey());
             logger.Info("Activate");
 
             if (State.PartitionInfos == null)

--- a/src/TestGrains/PerSiloExampleGrains.cs
+++ b/src/TestGrains/PerSiloExampleGrains.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Concurrency;
+using Orleans.Placement;
 using Orleans.Providers;
 using Orleans.Runtime;
 using TestGrainInterfaces;
@@ -43,7 +44,7 @@ namespace TestGrains
     /// Grain implemention for Partition Grains.
     /// One partition grain is created per silo.
     /// </summary>
-    [StatelessWorker(1)]
+    [PreferLocalPlacement]
     public class PartitionGrain : Grain, IPartitionGrain
     {
         PartitionInfo PartitionConfig { get; set; }

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -52,6 +52,7 @@
     <Compile Include="GenericGrains.cs" />
     <Compile Include="InitialStateGrain.cs" />
     <Compile Include="MultipleImplicitSubscriptionGrain.cs" />
+    <Compile Include="PerSiloExampleGrains.cs" />
     <Compile Include="SimpleGenericGrain.cs" />
     <Compile Include="MultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="ConcreteGrainsWithGenericInterfaces.cs" />

--- a/src/Tester/OrleansConfigurationForPerSiloGrainTesting.xml
+++ b/src/Tester/OrleansConfigurationForPerSiloGrainTesting.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <BootstrapProviders>
+      <Provider Type="TestGrains.PartitionStartup" Name="PartitionGrainStartup" />
+    </BootstrapProviders>
+    <StorageProviders>
+      <Provider Type="Orleans.Storage.MemoryStorage" Name="PartitionManagerStore" />
+    </StorageProviders>
+    <SeedNode Address="localhost" Port="22222"/>
+  </Globals>
+  <Defaults>
+    <Networking Address="localhost" Port="22222"/>
+    <ProxyingGateway Address="localhost" Port="40000" />
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log">
+       <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
+    </Tracing>
+  </Defaults>
+</OrleansConfiguration>
+
+

--- a/src/Tester/PerSiloExampleGrainTests.cs
+++ b/src/Tester/PerSiloExampleGrainTests.cs
@@ -1,0 +1,86 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.TestingHost;
+using TestGrainInterfaces;
+using UnitTests.Tester;
+
+namespace Tester
+{
+    [TestClass]
+    [DeploymentItem("OrleansConfigurationForPerSiloGrainTesting.xml")]
+    [DeploymentItem("ClientConfigurationForTesting.xml")]
+    [DeploymentItem("TestGrainInterfaces.dll")]
+    [DeploymentItem("TestGrains.dll")]
+    public class PerSiloExampleGrainTests : UnitTestSiloHost
+    {
+        private static readonly TestingSiloOptions siloOptions = new TestingSiloOptions
+        {
+            SiloConfigFile = new FileInfo("OrleansConfigurationForPerSiloGrainTesting.xml"),
+            PropagateActivityId = true
+        };
+
+        private static readonly TestingClientOptions clientOptions = new TestingClientOptions
+        {
+            ClientConfigFile = new FileInfo("ClientConfigurationForTesting.xml"),
+            PropagateActivityId = true
+        };
+
+        private int NumSilos { get; set; }
+
+        public PerSiloExampleGrainTests()
+            : base(siloOptions, clientOptions)
+        { }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            NumSilos = GetActiveSilos().Count();
+        }
+
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PerSilo")]
+        public async Task PerSiloGrainExample_Init()
+        {
+            // This tests just bootstraps the 2 default test silos, and checks that partition grains were created on each.
+            
+            IPartitionManager partitionManager = GrainClient.GrainFactory.GetGrain<IPartitionManager>(0);
+            IList<PartitionInfo> partitionInfos = await partitionManager.GetPartitionInfos();
+
+            Assert.AreEqual(NumSilos, partitionInfos.Count, " PartitionInfo list should return {0} values.", NumSilos);
+            Assert.AreNotEqual(partitionInfos[0].PartitionId, partitionInfos[1].PartitionId, "PartitionIds should be different.");
+        }
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -83,6 +83,7 @@
     <Compile Include="MembershipTests\LivenessTests.cs" />
     <Compile Include="MemoryStorageProviderTests.cs" />
     <Compile Include="ObserverTests.cs" />
+    <Compile Include="PerSiloExampleGrainTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
@@ -113,6 +114,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="ClientConfigurationForStreamTesting.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="OrleansConfigurationForPerSiloGrainTesting.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="OrleansConfigurationForStreamingDeactivationUnitTests.xml">

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -172,19 +172,8 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <!-- PostBuild.cmd script is platform specific, so for now we only want to run it on Windows -->
-    <PostBuildEvent>@echo Tester - Start Post-Build script
-
-set TEST_INPUT_DIR=$(TargetDir)TestInput
-if not exist "%25TEST_INPUT_DIR%25" ( mkdir "%25TEST_INPUT_DIR%25" )
-copy /y "$(ProjectDir)*.xml"  "%25TEST_INPUT_DIR%25\"
-
-if "$(BuildingInsideVisualStudio)" == "true" (
-  copy /y "$(SolutionDir)TestGrains\bin\$(ConfigurationName)\TestGrains.*"  "%25TEST_INPUT_DIR%25\"
-  copy /y "$(SolutionDir)TestGrainInterfaces\bin\$(ConfigurationName)\TestGrainInterfaces.*"  "%25TEST_INPUT_DIR%25\"
-) else (
-  copy /y "%25TargetDir%25TestGrains.*"  "%25TEST_INPUT_DIR%25\"
-  copy /y "%25TargetDir%25TestGrainInterfaces.*"  "%25TEST_INPUT_DIR%25\"
-)
+    <PostBuildEvent>
+@echo Tester - Start Post-Build script
 
 set SolutionDir=$(SolutionDir)
 set OutDir=$(OutDir)


### PR DESCRIPTION
- Add some minimal example code and scenario test case for implementing PerSilo grains using __`[StatelessWorker(1)]`__.

Implementation overview:

1. Grain class `TestGrains.PartitionGrain` is the PerSilo grain.
     It is annotated with `[StatelessWorker(1)]` attribute to __guarantee local placement and "no-roaming"__.

2. Grain class `TestGrains.PartitionManagerGrain` is the registry for the above PerSilo grains.
     Only GrainId = __0__ is used, so there will be a single instance of the Partition Manager in the cluster.

3. Class `TestGrains.PartitionStartup` is registered as a bootstrap provider in silo config.

4. During silo startup, the Orleans runtime calls `PartitionStartup.Init` on each silo, which:
4a. calls `PartitionGrain.Start` to create the local PerSilo grain instance on that silo.
4b. calls `PartitionManager.RegisterPartition` to declare that PerSilo grain with the registrar.

Xref: Discussion of Per-silo Grain feature request in issue #610