### PR TITLE
add ado invariant and reminders overrides to config

### DIFF
--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -29,6 +29,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Xml;
 using Orleans.Providers;
+using Orleans.Runtime.Storage.Relational;
 
 namespace Orleans.Runtime.Configuration
 {
@@ -84,7 +85,7 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public string DeploymentId { get; set; }
         /// <summary>
-        /// Specifies the connection string for azure storage account.
+        /// Specifies the connection string for the gateway provider.
         /// If the silos are deployed on Azure (run as workers roles), DataConnectionString may be specified via RoleEnvironment.GetConfigurationSettingValue("DataConnectionString");
         /// In such a case it is taken from there and passed to the silo automatically by the role via config.
         /// So if the silos are run as Azure roles and this config is specified via RoleEnvironment, 
@@ -93,6 +94,13 @@ namespace Orleans.Runtime.Configuration
         /// If not set at all, DevelopmentStorageAccount will be used.
         /// </summary>
         public string DataConnectionString { get; set; }
+
+        /// <summary>
+        /// When using ADO, identifies the underlying data provider for the gateway provider. This three-part naming syntax is also used when creating a new factory 
+        /// and for identifying the provider in an application configuration file so that the provider name, along with its associated 
+        /// connection string, can be retrieved at run time. https://msdn.microsoft.com/en-us/library/dd0w4a2z%28v=vs.110%29.aspx
+        /// </summary>
+        public string AdoInvariant { get; set; }
 
         public string CustomGatewayProviderAssemblyName { get; set; }
 
@@ -192,6 +200,8 @@ namespace Orleans.Runtime.Configuration
             DNSHostName = Dns.GetHostName();
             DeploymentId = Environment.UserName;
             DataConnectionString = "";
+            // Assume the ado invariant is for sql server storage if not explicitly specified
+            AdoInvariant = AdoNetInvariants.InvariantNameSqlServer;
 
             DefaultTraceLevel = Logger.Severity.Info;
             TraceLevelOverrides = new List<Tuple<string, Logger.Severity>>();
@@ -272,6 +282,14 @@ namespace Orleans.Runtime.Configuration
                                 {
                                     // Assume the connection string is for Azure storage if not explicitly specified
                                     GatewayProvider = GatewayProviderType.AzureTable;
+                                }
+                            }
+                            if (child.HasAttribute(Constants.ADO_INVARIANT_NAME))
+                            {
+                                AdoInvariant = child.GetAttribute(Constants.ADO_INVARIANT_NAME);
+                                if (String.IsNullOrWhiteSpace(AdoInvariant))
+                                {
+                                    throw new FormatException("SystemStore.AdoInvariant cannot be blank");
                                 }
                             }
                             break;

--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -29,6 +29,7 @@ using System.Text;
 using System.Net;
 using System.Xml;
 using Orleans.Providers;
+using Orleans.Runtime.Storage.Relational;
 using Orleans.Streams;
 using Orleans.Storage;
 
@@ -201,9 +202,42 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public string DeploymentId { get; set; }
         /// <summary>
-        /// Connection string for Azure Storage or SQL Server or Apache ZooKeeper.
+        /// Connection string for the underlying data provider for liveness & reminders. eg. Azure Storage, ZooKeeper, SQL Server, ect.
+        /// In order to override this value for reminders set <see cref="DataConnectionStringForReminders"/>
         /// </summary>
         public string DataConnectionString { get; set; }
+
+        /// <summary>
+        /// When using ADO, identifies the underlying data provider for liveness & reminders. This three-part naming syntax is also used 
+        /// when creating a new factory and for identifying the provider in an application configuration file so that the provider name, 
+        /// along with its associated connection string, can be retrieved at run time. https://msdn.microsoft.com/en-us/library/dd0w4a2z%28v=vs.110%29.aspx
+        /// In order to override this value for reminders set <see cref="AdoInvariantForReminders"/> 
+        /// </summary>
+        public string AdoInvariant { get; set; }
+
+        /// <summary>
+        /// Set this property to override <see cref="DataConnectionString"/> for reminders.
+        /// </summary>
+        public string DataConnectionStringForReminders
+        {
+            get
+            {
+                return string.IsNullOrWhiteSpace(dataConnectionStringForReminders) ? DataConnectionString : dataConnectionStringForReminders;
+            }
+            set { dataConnectionStringForReminders = value; }
+        }
+
+        /// <summary>
+        /// Set this property to override <see cref="AdoInvariant"/> for reminders.
+        /// </summary>
+        public string AdoInvariantForReminders
+        {
+            get
+            {
+                return string.IsNullOrWhiteSpace(adoInvariantForReminders) ? AdoInvariant : adoInvariantForReminders;
+            }
+            set { adoInvariantForReminders = value; }
+        }
 
         internal TimeSpan CollectionQuantum { get; set; }
 
@@ -324,7 +358,7 @@ namespace Orleans.Runtime.Configuration
 
 
         /// <summary>
-        /// Determines if SqlServer should be used for storage of Membership and Reminders info.
+        /// Determines if ADO should be used for storage of Membership and Reminders info.
         /// True if either or both of LivenessType and ReminderServiceType are set to SqlServer, false otherwise.
         /// </summary>
         internal bool UseSqlSystemStore
@@ -394,6 +428,8 @@ namespace Orleans.Runtime.Configuration
         private const bool DEFAULT_USE_VIRTUAL_RING_BUCKETS = true;
         private const int DEFAULT_NUM_VIRTUAL_RING_BUCKETS = 30;
         private static readonly TimeSpan DEFAULT_MOCK_REMINDER_TABLE_TIMEOUT = TimeSpan.FromMilliseconds(50);
+        private string dataConnectionStringForReminders;
+        private string adoInvariantForReminders;
 
         internal GlobalConfiguration()
             : base(true)
@@ -417,6 +453,9 @@ namespace Orleans.Runtime.Configuration
             DeploymentId = Environment.UserName;
             DataConnectionString = "";
 
+            // Assume the ado invariant is for sql server storage if not explicitly specified
+            AdoInvariant = AdoNetInvariants.InvariantNameSqlServer;
+            
             CollectionQuantum = DEFAULT_COLLECTION_QUANTUM;
 
             CacheSize = DEFAULT_CACHE_SIZE;
@@ -477,7 +516,9 @@ namespace Orleans.Runtime.Configuration
             sb.AppendFormat("   SystemStore:").AppendLine();
             // Don't print connection credentials in log files, so pass it through redactment filter
             string connectionStringForLog = ConfigUtilities.RedactConnectionStringInfo(DataConnectionString);
-            sb.AppendFormat("      ConnectionString: {0}", connectionStringForLog).AppendLine();
+            sb.AppendFormat("      SystemStore ConnectionString: {0}", connectionStringForLog).AppendLine();
+            string remindersConnectionStringForLog = ConfigUtilities.RedactConnectionStringInfo(DataConnectionStringForReminders);
+            sb.AppendFormat("      Reminders ConnectionString: {0}", remindersConnectionStringForLog).AppendLine();
             sb.Append(Application.ToString()).AppendLine();
             sb.Append("   PlacementStrategy: ").AppendLine();
             sb.Append("      ").Append("   Default Placement Strategy: ").Append(DefaultPlacementStrategy).AppendLine();
@@ -651,6 +692,15 @@ namespace Orleans.Runtime.Configuration
                             {
                                 throw new FormatException("SystemStore.DataConnectionString cannot be blank");
                             }
+                        }
+                        if (child.HasAttribute(Constants.ADO_INVARIANT_NAME))
+                        {
+                            var adoInvariant = child.GetAttribute(Constants.ADO_INVARIANT_NAME);
+                            if (String.IsNullOrWhiteSpace(adoInvariant))
+                            {
+                                throw new FormatException("SystemStore.AdoInvariant cannot be blank");
+                            }
+                            AdoInvariant = adoInvariant;
                         }
                         if (child.HasAttribute("MaxStorageBusyRetries"))
                         {

--- a/src/Orleans/Messaging/SqlMembershipTable.cs
+++ b/src/Orleans/Messaging/SqlMembershipTable.cs
@@ -46,9 +46,8 @@ namespace Orleans.Runtime.MembershipService
             deploymentId = config.DeploymentId;
 
             if (logger.IsVerbose3) logger.Verbose3("SqlMembershipTable.InitializeMembershipTable called.");
-                                                
-            //TODO: Orleans does not yet provide the type of database used (to, e.g., to load dlls), so SQL Server is assumed.
-            database = RelationalStorageUtilities.CreateGenericStorageInstance(AdoNetInvariants.InvariantNameSqlServer, config.DataConnectionString);
+
+            database = RelationalStorageUtilities.CreateGenericStorageInstance(config.AdoInvariant, config.DataConnectionString);
 
             //This initializes all of Orleans operational queries from the database using a well known view
             //and assumes the database with appropriate defintions exists already.
@@ -75,9 +74,7 @@ namespace Orleans.Runtime.MembershipService
 
             deploymentId = config.DeploymentId;            
             maxStaleness = config.GatewayListRefreshPeriod;
-
-            //TODO: Orleans does not yet provide the type of database used (to, e.g., to load dlls), so SQL Server is assumed.
-            database = RelationalStorageUtilities.CreateGenericStorageInstance(AdoNetInvariants.InvariantNameSqlServer, config.DataConnectionString);
+            database = RelationalStorageUtilities.CreateGenericStorageInstance(config.AdoInvariant, config.DataConnectionString);
 
             //This initializes all of Orleans operational queries from the database using a well known view
             //and assumes the database with appropriate defintions exists already.

--- a/src/Orleans/Runtime/Constants.cs
+++ b/src/Orleans/Runtime/Constants.cs
@@ -38,6 +38,7 @@ namespace Orleans.Runtime
         public const string DEFAULT_STORAGE_PROVIDER_NAME = "Default";
         public const string MEMORY_STORAGE_PROVIDER_NAME = "MemoryStore";
         public const string DATA_CONNECTION_STRING_NAME = "DataConnectionString";
+        public const string ADO_INVARIANT_NAME = "AdoInvariant";
 
         public const string ORLEANS_AZURE_UTILS_DLL = "OrleansAzureUtils";
         public const string ORLEANS_ZOOKEEPER_UTILS_DLL = "OrleansZooKeeperUtils";

--- a/src/Orleans/SystemTargetInterfaces/IReminderTable.cs
+++ b/src/Orleans/SystemTargetInterfaces/IReminderTable.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 using Orleans.Concurrency;
+using Orleans.Runtime.Configuration;
 
 
 namespace Orleans
@@ -37,7 +38,7 @@ namespace Orleans
     /// </summary>  
     public interface IReminderTable
     {
-        Task Init(Guid serviceId, string deploymentId, string connectionString);
+        Task Init(GlobalConfiguration config, TraceLogger traceLogger);
 
         Task<ReminderTableData> ReadRows(GrainReference key);
 

--- a/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
+++ b/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
@@ -24,23 +24,21 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Orleans.Runtime.Configuration;
 
 
 namespace Orleans.Runtime.ReminderService
 {
     internal class AzureBasedReminderTable : IReminderTable
     {
-        private readonly TraceLogger logger;
+        private TraceLogger logger;
         private RemindersTableManager remTableManager;
 
-        public AzureBasedReminderTable()
-        {
-            logger = TraceLogger.GetLogger("AzureReminderTable", TraceLogger.LoggerType.Runtime);
-        }
 
-        public async Task Init(Guid serviceId, string deploymentId, string connectionString)
+        public async Task Init(GlobalConfiguration config, TraceLogger logger)
         {
-            remTableManager = await RemindersTableManager.GetManager(serviceId, deploymentId, connectionString);
+            this.logger = logger;
+            remTableManager = await RemindersTableManager.GetManager(config.ServiceId, config.DeploymentId, config.DataConnectionStringForReminders);
         }
 
         #region Utility methods

--- a/src/OrleansProviders/SQLServer/SqlStatisticsPublisher.cs
+++ b/src/OrleansProviders/SQLServer/SqlStatisticsPublisher.cs
@@ -58,9 +58,13 @@ namespace Orleans.Providers.SqlServer
             Name = name;
             logger = providerRuntime.GetLogger("SqlStatisticsPublisher");
 
-            //TODO: Orleans does not yet provide the type of database used (to, e.g., to load dlls), so SQL Server is assumed.            
-            database = RelationalStorageUtilities.CreateGenericStorageInstance(AdoNetInvariants.InvariantNameSqlServer, config.Properties["ConnectionString"]);
-            queryConstants = await database.InitializeOrleansQueriesAsync();           
+            string adoInvariant = AdoNetInvariants.InvariantNameSqlServer;
+            if (config.Properties.ContainsKey("AdoInvariant"))
+                adoInvariant = config.Properties["AdoInvariant"];
+
+            database = RelationalStorageUtilities.CreateGenericStorageInstance(adoInvariant, config.Properties["ConnectionString"]);
+
+            queryConstants = await database.InitializeOrleansQueriesAsync(); 
         }
 
 
@@ -92,9 +96,9 @@ namespace Orleans.Providers.SqlServer
 
 
         async Task IClientMetricsDataPublisher.Init(ClientConfiguration config, IPAddress address, string clientId)
-        {
-            //TODO: Orleans does not yet provide the type of database used (to, e.g., to load dlls), so SQL Server is assumed.            
-            database = RelationalStorageUtilities.CreateGenericStorageInstance(AdoNetInvariants.InvariantNameSqlServer, config.DataConnectionString);            
+        {          
+            database = RelationalStorageUtilities.CreateGenericStorageInstance(config.AdoInvariant, config.DataConnectionString);
+            
             queryConstants = await database.InitializeOrleansQueriesAsync();
         }
 

--- a/src/OrleansRuntime/ReminderService/GrainBasedReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/GrainBasedReminderTable.cs
@@ -25,6 +25,7 @@ using System;
 using System.Threading.Tasks;
 
 using Orleans.Concurrency;
+using Orleans.Runtime.Configuration;
 
 
 namespace Orleans.Runtime.ReminderService
@@ -44,7 +45,7 @@ namespace Orleans.Runtime.ReminderService
             return TaskDone.Done;
         }
 
-        public Task Init(Guid serviceId, string deploymentId, string connectionString)
+        public Task Init(GlobalConfiguration config, TraceLogger logger)
         {
             return TaskDone.Done;
         }

--- a/src/OrleansRuntime/ReminderService/LocalReminderService.cs
+++ b/src/OrleansRuntime/ReminderService/LocalReminderService.cs
@@ -96,7 +96,7 @@ namespace Orleans.Runtime.ReminderService
             myRange = ring.GetMyRange();
             logger.Info(ErrorCode.RS_ServiceStarting, "Starting reminder system target on: {0} x{1,8:X8}, with range {2}", Silo, Silo.GetConsistentHashCode(), myRange);
 
-            await reminderTable.Init(config.ServiceId, config.DeploymentId, config.DataConnectionString).WithTimeout(initTimeout);
+            await reminderTable.Init(config,logger).WithTimeout(initTimeout);
             await ReadAndUpdateReminders();
             logger.Info(ErrorCode.RS_ServiceStarted, "Reminder system target started OK on: {0} x{1,8:X8}, with range {2}", Silo, Silo.GetConsistentHashCode(), myRange);
 

--- a/src/OrleansRuntime/ReminderService/MockReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/MockReminderTable.cs
@@ -23,6 +23,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Threading.Tasks;
+using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.ReminderService
 {
@@ -36,7 +37,7 @@ namespace Orleans.Runtime.ReminderService
             this.delay = delay;
         }
 
-        public Task Init(Guid serviceId, string deploymentId, string connectionString)
+        public Task Init(GlobalConfiguration config,TraceLogger logger)
         {
             return TaskDone.Done;
         }

--- a/src/OrleansRuntime/ReminderService/ReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/ReminderTable.cs
@@ -46,7 +46,7 @@ namespace Orleans.Runtime.ReminderService
                             serviceType));
 
                 case GlobalConfiguration.ReminderServiceProviderType.SqlServer:
-                    Singleton = new SqlReminderTable(config);
+                    Singleton = new SqlReminderTable();
                     return;
 
                 case GlobalConfiguration.ReminderServiceProviderType.AzureTable:

--- a/src/OrleansRuntime/ReminderService/SqlReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/SqlReminderTable.cs
@@ -37,26 +37,13 @@ namespace Orleans.Runtime.ReminderService
         private IRelationalStorage database;
         private QueryConstantsBag queryConstants;
 
-
-        public SqlReminderTable(GlobalConfiguration config)
+        public async Task Init(GlobalConfiguration config, TraceLogger logger)
         {
             serviceId = config.ServiceId.ToString();
             deploymentId = config.DeploymentId;
-            
-            //TODO: Orleans does not yet provide the type of database used (to, e.g., to load dlls), so SQL Server is assumed.
-            database = RelationalStorageUtilities.CreateGenericStorageInstance(AdoNetInvariants.InvariantNameSqlServer, config.DataConnectionString);
-            queryConstants = database.InitializeOrleansQueriesAsync().Result;
-        }
-
-        public Task Init(Guid serviceId, string deploymentId, string connectionString)
-        {
-            this.serviceId = serviceId.ToString();
-            this.deploymentId = deploymentId;
-
-            database = RelationalStorageUtilities.CreateGenericStorageInstance(AdoNetInvariants.InvariantNameSqlServer, connectionString);
-            queryConstants = database.InitializeOrleansQueriesAsync().Result;
-
-            return TaskDone.Done;
+            database = RelationalStorageUtilities.CreateGenericStorageInstance(config.AdoInvariantForReminders,
+                config.DataConnectionStringForReminders);
+            queryConstants = await database.InitializeOrleansQueriesAsync();
         }
 
 

--- a/src/OrleansRuntime/Silo/SiloHost.cs
+++ b/src/OrleansRuntime/Silo/SiloHost.cs
@@ -264,7 +264,7 @@ namespace Orleans.Runtime.Host
 
         /// <summary>
         /// Set the DeploymentId for this silo, 
-        /// as well as the Azure connection string to use the silo system data, 
+        /// as well as the connection string to use the silo system data, 
         /// such as the cluster membership table..
         /// </summary>
         /// <param name="deploymentId">DeploymentId this silo is part of.</param>

--- a/src/TesterInternal/RemindersTest/SqlRemindersTableTests.cs
+++ b/src/TesterInternal/RemindersTest/SqlRemindersTableTests.cs
@@ -81,11 +81,12 @@ namespace UnitTests.RemindersTest
             GlobalConfiguration config = new GlobalConfiguration
                                          {
                                              DeploymentId = deploymentId,
-                                             DataConnectionString = relationalStorage.ConnectionString
+                                             DataConnectionStringForReminders = relationalStorage.ConnectionString,
+                                             AdoInvariantForReminders =  relationalStorage.InvariantName
                                          };
 
-            var rmndr = new SqlReminderTable(config);
-            await rmndr.Init(serviceId, deploymentId, config.DataConnectionString).WithTimeout(timeout);
+            var rmndr = new SqlReminderTable();
+            await rmndr.Init(config, logger).WithTimeout(timeout);
             reminder = rmndr;
         }
 


### PR DESCRIPTION
This also solves #569.
Main changes :
* Kept the current defaults (SQL server as the default invariant name)
* Kept the current behavior when reading config from xml
* Changes in **GlobalConfiguration**
 * Added AdoInvariant
 * Added DataConnectionStringForReminders & AdoInvariantForReminders which, if set, overrides DataConnectionString & AdoInvariant only for reminders.
* Changes in **ClientConfiguration**
 *  Added AdoInvariant