### PR TITLE
Fixed broken Json serialization of PubSub state classes.

### DIFF
--- a/src/Orleans/Streams/PubSub/PubSubPublisherState.cs
+++ b/src/Orleans/Streams/PubSub/PubSubPublisherState.cs
@@ -29,10 +29,11 @@ namespace Orleans.Streams
     [Serializable]
     internal class PubSubPublisherState : IEquatable<PubSubPublisherState>
     {
+        // IMPORTANT!!!!!
         // These fields have to be public non-readonly for JSonSerialization to work!
         // Implement ISerializable if changing any of them to readonly
         public StreamId Stream;
-        private GrainReference producerReference; // the field needs to be of a public type, otherwise we will not generate an Orleans serializer for that class.
+        public GrainReference producerReference; // the field needs to be of a public type, otherwise we will not generate an Orleans serializer for that class.
         public IStreamProducerExtension Producer { get { return producerReference as IStreamProducerExtension; } }
 
         // This constructor has to be public for JSonSerialization to work!

--- a/src/Orleans/Streams/PubSub/PubSubSubscriptionState.cs
+++ b/src/Orleans/Streams/PubSub/PubSubSubscriptionState.cs
@@ -35,13 +35,14 @@ namespace Orleans.Streams
             Faulted,
         }
 
+        // IMPORTANT!!!!!
         // These fields have to be public non-readonly for JSonSerialization to work!
         // Implement ISerializable if changing any of them to readonly
         public GuidId SubscriptionId;
         public StreamId Stream;
-        private GrainReference consumerReference; // the field needs to be of a public type, otherwise we will not generate an Orleans serializer for that class.
-        private object filterWrapper; // Serialized func info
-        private SubscriptionStates state;
+        public GrainReference consumerReference; // the field needs to be of a public type, otherwise we will not generate an Orleans serializer for that class.
+        public object filterWrapper; // Serialized func info
+        public SubscriptionStates state;
 
         public IStreamConsumerExtension Consumer { get { return consumerReference as IStreamConsumerExtension; } }
 

--- a/src/OrleansTestingHost/Extensions/TestConfigurationExtensions.cs
+++ b/src/OrleansTestingHost/Extensions/TestConfigurationExtensions.cs
@@ -63,7 +63,8 @@ namespace Orleans.TestingHost.Extensions
         {
             if (String.IsNullOrEmpty(@value)) return;
 
-            var providerConfigs = providerConfigurations.Where(kv => kv.Key.Equals(ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME))
+            var providerConfigs = providerConfigurations.Where(kv => kv.Key.Equals(ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME) ||
+                                                                    kv.Key.Equals(ProviderCategoryConfiguration.STORAGE_PROVIDER_CATEGORY_NAME))
                                                         .Select(kv => kv.Value)
                                                         .SelectMany(catagory => catagory.Providers.Values);
             foreach (IProviderConfiguration providerConfig in providerConfigs)


### PR DESCRIPTION
Json serialization of PubSub state classes was broken by mistake in #687 (as part of fixing Orleans's serialization). Reported in #752.