### PR TITLE
ZK MBR -  update ZooKeeperNetEx to 3.4.6.1005

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -21,7 +21,7 @@
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
       <dependency id="Newtonsoft.Json" version="5.0.8" />
-	  <dependency id="ZooKeeperNetEx" version="3.4.6.1004" />
+	  <dependency id="ZooKeeperNetEx" version="3.4.6.1005" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
+++ b/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
@@ -59,8 +59,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-    <Reference Include="ZooKeeperNetEx, Version=3.4.6.1004, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeperNetEx.3.4.6.1004\lib\net45\ZooKeeperNetEx.dll</HintPath>
+    <Reference Include="ZooKeeperNetEx, Version=3.4.6.1005, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.6.1005\lib\net45\ZooKeeperNetEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/OrleansZooKeeperUtils/packages.config
+++ b/src/OrleansZooKeeperUtils/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
-  <package id="ZooKeeperNetEx" version="3.4.6.1004" targetFramework="net45" />
+  <package id="ZooKeeperNetEx" version="3.4.6.1005" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This update removes redundant package dependencies from the .NETPlatform5.0 target platform.