### PR TITLE
Fixed stream consumer cursor reentrancy bug.

### DIFF
--- a/src/Orleans/Streams/PersistentStreams/QueueStreamDataStructures.cs
+++ b/src/Orleans/Streams/PersistentStreams/QueueStreamDataStructures.cs
@@ -26,12 +26,6 @@ using Orleans.Runtime;
 
 namespace Orleans.Streams
 {
-    [Serializable]
-    internal enum StreamConsumerDataState
-    {
-        Active, // Indicates that events are activly being delivered to this consumer.
-        Inactive, // Indicates that events are not activly being delivered to this consumers.  If adapter produces any events on this consumers stream, the agent will need begin delivering events
-    }
 
     [Serializable]
     internal class StreamConsumerData
@@ -39,10 +33,14 @@ namespace Orleans.Streams
         public GuidId SubscriptionId;
         public StreamId StreamId;
         public IStreamConsumerExtension StreamConsumer;
-        public StreamConsumerDataState State = StreamConsumerDataState.Inactive;
         public IQueueCacheCursor Cursor;
         public IStreamFilterPredicateWrapper Filter;
         public StreamSequenceToken LastToken;
+
+        public bool IsActive
+        {
+            get { return Cursor != null && Cursor.IsSet; }
+        }
 
         public StreamConsumerData(GuidId subscriptionId, StreamId streamId, IStreamConsumerExtension streamConsumer, IStreamFilterPredicateWrapper filter)
         {
@@ -50,6 +48,11 @@ namespace Orleans.Streams
             StreamId = streamId;
             StreamConsumer = streamConsumer;
             Filter = filter;
+        }
+
+        public override string ToString()
+        {
+            return "<StreamId:" + StreamId + ", SubscriptionId=" + SubscriptionId + ", IsActive=" + IsActive + ">";
         }
     }
 }

--- a/src/Orleans/Streams/PersistentStreams/StreamConsumerCollection.cs
+++ b/src/Orleans/Streams/PersistentStreams/StreamConsumerCollection.cs
@@ -94,7 +94,7 @@ namespace Orleans.Streams
             // 2) All consumer for that stream are currently inactive (that is, all cursors are inactive) - 
             //    meaning there is nothing for those consumers in the adapter cache.
             if (now - lastActivityTime < inactivityPeriod) return false;
-            return !queueData.Values.Any(data => data.State.Equals(StreamConsumerDataState.Active));
+            return !queueData.Values.Any(data => data.IsActive);
         }
     }
 }

--- a/src/Orleans/Streams/QueueAdapters/IQueueCacheCursor.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueCacheCursor.cs
@@ -49,5 +49,11 @@ namespace Orleans.Streams
         /// </summary>
         /// <returns></returns>
         bool MoveNext();
+
+        /// <summary>
+        /// Whether this cursor is currently set and points to a valid next data in the cache (meaning the cursor is Active).
+        /// </summary>
+        /// <returns></returns>
+        bool IsSet { get; }
     }
 }

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainer.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainer.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Streams;
 
@@ -98,8 +99,9 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         public override string ToString()
         {
-            return string.Format("[AzureQueueBatchContainer:Stream={0},#Items={1}]", StreamGuid, events.Count);
-            //return string.Format("[AzureBatch:#Items={0},Items{1}]", events.Count, Utils.EnumerableToString(events.Select((e, i) => String.Format("{0}-{1}", e, sequenceToken.CreateSequenceTokenForEvent(i)))));
+            //return string.Format("[AzureQueueBatchContainer:Stream={0},#Items={1}]", StreamGuid, events.Count);
+            return string.Format("[AzureBatch:#Items={0},SequenceToken={1},Items:{2}]", 
+                events.Count, SequenceToken, Utils.EnumerableToString(events.Select((e, i) => String.Format("{0}", e))));
         }
     }
 }

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
@@ -21,12 +21,12 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 using Orleans.AzureUtils;
-using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
 
@@ -53,6 +53,7 @@ namespace Orleans.Providers.Streams.AzureQueue
                 List<QueueId> allQueues = queueMapper.GetAllQueues().ToList();
 
                 if (logger != null) logger.Info("About to delete all {0} Stream Queues\n", allQueues.Count);
+                else Console.WriteLine("About to delete all {0} Stream Queues\n", allQueues.Count);
                 foreach (var queueId in allQueues)
                 {
                     var manager = new AzureQueueDataManager(queueId.ToString(), deploymentId, storageConnectionString);

--- a/src/OrleansProviders/Streams/Common/SimpleQueueCacheCursor.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleQueueCacheCursor.cs
@@ -43,7 +43,7 @@ namespace Orleans.Providers.Streams.Common
         internal LinkedListNode<SimpleQueueCacheItem> Element { get; private set; }
         internal StreamSequenceToken SequenceToken { get; private set; }
 
-        internal bool IsSet
+        public bool IsSet
         {
             get { return Element != null; }
         }

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -277,17 +277,20 @@ namespace Orleans.Streams
 
             data.LastToken = requestedToken;
 
+            bool startCursor = false;
             // if we have a new cursor, use it
             if (newCursor != null)
             {
                 data.Cursor = newCursor;
+                startCursor = true;
             } // else if we don't yet have a cursor, get a cursor at the end of the cash (null sequence token).
             else if (data.Cursor == null && queueCache != null)
             {
                 data.Cursor = queueCache.GetCacheCursor(streamId.Guid, streamId.Namespace, null);
+                startCursor = true;
             }
 
-            if (data.State == StreamConsumerDataState.Inactive)
+            if (startCursor)
                 RunConsumerCursor(data, filter).Ignore(); // Start delivering events if not actively doing so
         }
 
@@ -384,6 +387,7 @@ namespace Orleans.Streams
             var toRemove = pubSubCache.Where(pair => pair.Value.IsInactive(now, config.StreamInactivityPeriod))
                          .Select(pair => pair.Key)
                          .ToList();
+            if (logger.IsVerbose) logger.Verbose("CleanupPubSubCache: about to cleanup {0} entries", toRemove.Count);
             toRemove.ForEach(key => pubSubCache.Remove(key));
         }
 
@@ -412,7 +416,7 @@ namespace Orleans.Streams
             // if stream is already registered, just wake inactive consumers
             // get list of inactive consumers
             var inactiveStreamConsumers = streamData.AllConsumers()
-                .Where(consumer => consumer.State == StreamConsumerDataState.Inactive)
+                .Where(consumer => !consumer.IsActive)
                 .ToList();
 
             // for each inactive stream
@@ -424,11 +428,7 @@ namespace Orleans.Streams
         {
             try
             {
-                // double check in case of interleaving
-                if (consumerData.State == StreamConsumerDataState.Active ||
-                    consumerData.Cursor == null) return;
-                
-                consumerData.State = StreamConsumerDataState.Active;
+                if (logger.IsVerbose) logger.Verbose("RunConsumerCursor: consumerData={0}.", consumerData);
                 while (consumerData.Cursor != null && consumerData.Cursor.MoveNext())
                 {
                     IBatchContainer batch = null;
@@ -524,7 +524,7 @@ namespace Orleans.Streams
                         }
                     }
                 }
-                consumerData.State = StreamConsumerDataState.Inactive;
+                if (logger.IsVerbose) logger.Verbose("Ended RunConsumerCursor: consumerData={0}. Setting StreamConsumerDataState to Inactive.", consumerData);
             }
             catch (Exception exc)
             {


### PR DESCRIPTION
Stream consumer cursor (for persistent streams) has a field `State`, which tracks if this cursor is active or not (Active means points to a valid data in the cache, Inactive means points outside the cache, waiting for the new data to arrive). That state field was updated in a different turn in the pulling agent from where the actual pointer into the cache was updated. As a result, due to interleaving of turns in the agent, we could get into a rare inconsistent situation, where the cursor will not be updated correctly.
Fixed by removing the redundant `State` field and tracking the cursor state directly via its cache pointer state (less duplicate data to track).