### PR TITLE
Static stream queue distribution

### DIFF
--- a/src/Orleans/Streams/PersistentStreams/StreamQueueBalancerType.cs
+++ b/src/Orleans/Streams/PersistentStreams/StreamQueueBalancerType.cs
@@ -28,7 +28,9 @@ namespace Orleans.Streams
     public enum StreamQueueBalancerType
     {
         ConsistentRingBalancer, // Stream queue balancer that uses consistent ring provider for load balancing
-        AzureDeploymentBalancer, // Stream queue balancer that uses azure deployment information and silo status for load balancing.  Requires silo running in azure.
-        StaticClusterDeploymentBalancer, // Stream queue balancer that uses cluster configuration to determin deployment information and silo status for load balancing.  Does not support dynamic changes to cluster configuration.
+        DynamicAzureDeploymentBalancer, // Stream queue balancer that uses azure deployment information and silo status for load balancing.  Requires silo running in azure.
+        StaticAzureDeploymentBalancer, // Stream queue balancer that uses azure deployment information and silo status for load balancing.  Requires silo running in azure.
+        DynamicClusterConfigDeploymentBalancer, // Stream queue balancer that uses cluster configuration to determin deployment information and silo status for load balancing.  Does not support dynamic changes to cluster configuration.
+        StaticClusterConfigDeploymentBalancer, // Stream queue balancer that uses cluster configuration to determin deployment information and silo status for load balancing.  Does not support dynamic changes to cluster configuration.
     }
 }

--- a/src/OrleansRuntime/Streams/QueueBalancer/BestFitBalancer.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/BestFitBalancer.cs
@@ -57,6 +57,8 @@ namespace Orleans.Streams
     {
         private readonly Dictionary<TBucket, List<TResource>> idealDistribution;
 
+        public Dictionary<TBucket, List<TResource>> IdealDistribution { get { return idealDistribution; } }
+
         /// <summary>
         /// Constructor.
         /// Initializes an ideal distribution to be used to aid in resource to bucket affinity.


### PR DESCRIPTION
Updated deployment based queue balancer to support not rebalancing queues when silos are unavailable.  This mode always uses the ideal distribution of queues, regardless of cluster state.

This PR also reduced the state stored in the deployment based queue balancer to make it more resilient to missing silo status updates.