### PR TITLE
DateTime2->DateTime and Adding constants for MySql

### DIFF
--- a/src/Orleans/RelationalStorage/DbExtensions.cs
+++ b/src/Orleans/RelationalStorage/DbExtensions.cs
@@ -72,10 +72,9 @@ namespace Orleans.Runtime.Storage.Relational
             { typeof(char?),    DbType.StringFixedLength },
             { typeof(Guid),     DbType.Guid },
             { typeof(Guid?),    DbType.Guid },
-            //It looks like DbType.DateTime2 works to both DATETIME and DATETIME2(7).
-            //Though there might be a hitch here, see at http://stackoverflow.com/questions/27596899/ado-net-datetime-sql-parameter-lose-accuracy.
-            { typeof(DateTime),     DbType.DateTime2 },
-            { typeof(DateTime?),    DbType.DateTime2 },
+            //Using DateTime for cross DB compatibility. The underlying DB table column type can be DateTime or DateTime2
+            { typeof(DateTime),     DbType.DateTime },
+            { typeof(DateTime?),    DbType.DateTime },
             { typeof(TimeSpan),     DbType.Time },
             { typeof(byte[]),       DbType.Binary },
             { typeof(TimeSpan?),        DbType.Time },

--- a/src/Orleans/RelationalStorage/OrleansRelationalExtensions.cs
+++ b/src/Orleans/RelationalStorage/OrleansRelationalExtensions.cs
@@ -1225,7 +1225,7 @@ namespace Orleans.Runtime.Storage.Relational
             var parameter = command.CreateParameter();
             parameter.ParameterName = "startTime";
             parameter.Value = EnsureSqlMinValue(startTime);
-            parameter.DbType = DbType.DateTime2;
+            parameter.DbType = DbType.DateTime;//Using DateTime for cross DB compatibility. The underlying DB table column type can be DateTime or DateTime2
             parameter.Direction = direction;
 
             return parameter;
@@ -1261,7 +1261,7 @@ namespace Orleans.Runtime.Storage.Relational
             var parameter = command.CreateParameter();
             parameter.ParameterName = "iAmAliveTime";
             parameter.Value = EnsureSqlMinValue(iAmAlive);
-            parameter.DbType = DbType.DateTime2;
+            parameter.DbType = DbType.DateTime;//Using DateTime for cross DB compatibility. The underlying DB table column type can be DateTime or DateTime2
             parameter.Direction = direction;
 
             return parameter;

--- a/src/Orleans/RelationalStorage/QueryConstantsBag.cs
+++ b/src/Orleans/RelationalStorage/QueryConstantsBag.cs
@@ -46,12 +46,17 @@ namespace Orleans.Runtime.Storage.Relational
             const string OrleansQueries = @"SELECT QueryKey, QueryText FROM OrleansQuery;";
             AddOrModifyQueryConstant(AdoNetInvariants.InvariantNameSqlServer, QueryKeys.OrleansQueriesKey, OrleansQueries);
             AddOrModifyQueryConstant(AdoNetInvariants.InvariantNameOracleDatabase, QueryKeys.OrleansQueriesKey, OrleansQueries);
+            AddOrModifyQueryConstant(AdoNetInvariants.InvariantNameMySql, QueryKeys.OrleansQueriesKey, OrleansQueries);
 
             //These are vendor specific constants that are likely never to change. This is the place to add them so that
             //they are readily available when needed.
             AddOrModifyQueryConstant(AdoNetInvariants.InvariantNameSqlServer, RelationalVendorConstants.StartEscapeIndicatorKey, "[");
             AddOrModifyQueryConstant(AdoNetInvariants.InvariantNameSqlServer, RelationalVendorConstants.StartEscapeIndicatorKey, "]");
             AddOrModifyQueryConstant(AdoNetInvariants.InvariantNameSqlServer, RelationalVendorConstants.ParameterIndicatorKey, "@");
+
+            AddOrModifyQueryConstant(AdoNetInvariants.InvariantNameMySql, RelationalVendorConstants.StartEscapeIndicatorKey, "`");
+            AddOrModifyQueryConstant(AdoNetInvariants.InvariantNameMySql, RelationalVendorConstants.StartEscapeIndicatorKey, "`");
+            AddOrModifyQueryConstant(AdoNetInvariants.InvariantNameMySql, RelationalVendorConstants.ParameterIndicatorKey, "@");
         }
 
 

--- a/src/OrleansProviders/SQLServer/CreateOrleansTables_SqlServer.sql
+++ b/src/OrleansProviders/SQLServer/CreateOrleansTables_SqlServer.sql
@@ -124,11 +124,11 @@ IF(NOT EXISTS(SELECT [Value] FROM [OrleansDatabaseInfo] WHERE Id = N'ProductName
 BEGIN
 	-- These table definitions are SQL Server 2005 and later. The differences are
 	-- the ETag is ROWVersion in SQL Server 2005 and later whereas in SQL Server 2000 UNIQUEIDENTIFIER is used
-	-- and SQL Server 2005 and later use DATETIME2(7) and associated functions whereas SQL Server uses DATETIME.
+	-- and SQL Server 2005 and later use DATETIME2 and associated functions whereas SQL Server uses DATETIME.
 	CREATE TABLE [OrleansMembershipVersionTable]
 	(
 		[DeploymentId] NVARCHAR(150) NOT NULL, 
-		[Timestamp] DATETIME2(7) NOT NULL, 
+		[Timestamp] DATETIME2(3) NOT NULL, 
 		[Version] BIGINT NOT NULL,		
 		[ETag] ROWVERSION NOT NULL,
     
@@ -151,8 +151,8 @@ BEGIN
 		[FaultZone] INT NULL,		
 		[SuspectingSilos] NVARCHAR(MAX) NULL, 
 		[SuspectingTimes] NVARCHAR(MAX) NULL, 
-		[StartTime] DATETIME2(7) NOT NULL, 
-		[IAmAliveTime] DATETIME2(7) NOT NULL,			
+		[StartTime] DATETIME2(3) NOT NULL, 
+		[IAmAliveTime] DATETIME2(3) NOT NULL,			
 		[ETag] ROWVERSION NOT NULL,
     
 		-- A refactoring note: This combination needs to be unique, currently enforced by making it a primary key.
@@ -166,7 +166,7 @@ BEGIN
 		[ServiceId] NVARCHAR(150) NOT NULL, 
 		[GrainId] NVARCHAR(150) NOT NULL, 
 		[ReminderName] NVARCHAR(150) NOT NULL,
-		[StartTime] DATETIME2(7) NOT NULL, 
+		[StartTime] DATETIME2(3) NOT NULL, 
 		[Period] INT NOT NULL,
 		[GrainIdConsistentHash] INT NOT NULL,
 		[ETag] ROWVERSION NOT NULL,
@@ -193,7 +193,7 @@ BEGIN
 	(
 		[DeploymentId] NVARCHAR(150) NOT NULL, 
 		[ClientId] NVARCHAR(150) NOT NULL, 
-		[Timestamp] DATETIME2(7) NOT NULL, 
+		[Timestamp] DATETIME2(3) NOT NULL, 
 		[Address] VARCHAR(45) NOT NULL, 
 		[HostName] NVARCHAR(150) NOT NULL, 
 		[CPU] FLOAT NOT NULL,
@@ -211,7 +211,7 @@ BEGIN
 	(
 		[DeploymentId] NVARCHAR(150) NOT NULL, 
 		[SiloId] NVARCHAR(150) NOT NULL, 
-		[Timestamp] DATETIME2(7) NOT NULL, 
+		[Timestamp] DATETIME2(3) NOT NULL, 
 		[Address] VARCHAR(45) NOT NULL, 
 		[Port] INT NOT NULL, 
 		[Generation] INT NOT NULL, 


### PR DESCRIPTION
While integrating MySql as a reminders provider I came across a problem with DateTime2.
This type is MS SQL specific. Some ADO providers like Oracle seems to be ok with it. Unfortunately, MySql doesn't handle that well. My solution is to replace DbType.DateTime2 with DbType.DateTime. The underlying DB table can have DateTime2 or DateTime column type, I tested this on SQL Server.
I am not a db expert, but it seems to me that this isn't a MySql specific issue, and also that some milliseconds precision loss is irrelevant in Orleans. I am sure @veikkoeeva can shed some light.

Currently, I've conveted only the reminders related script, so I wasn't sure if it's PR worthy. Also, I haven't added the constants needed for testing. I plan to provide the full script with all the testing constants in place, but that might be after I come back from my vacation to the US for a month :sunglasses: