### PR TITLE
Added Refresh to cache cursor to solve cursor reentrancy bug.

### DIFF
--- a/src/Orleans/Streams/QueueAdapters/IQueueCacheCursor.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueCacheCursor.cs
@@ -49,5 +49,11 @@ namespace Orleans.Streams
         /// </summary>
         /// <returns></returns>
         bool MoveNext();
+
+        /// <summary>
+        /// Refresh that cache cursor. Called when new data is added into a cache.
+        /// </summary>
+        /// <returns></returns>
+        void Refresh();
     }
 }

--- a/src/OrleansProviders/Streams/Common/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleQueueCache.cs
@@ -23,7 +23,6 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Orleans.Runtime;
 using Orleans.Streams;
 
@@ -90,7 +89,7 @@ namespace Orleans.Providers.Streams.Common
             CACHE_HISTOGRAM_MAX_BUCKET_SIZE = Math.Max(cacheSize / NUM_CACHE_HISTOGRAM_BUCKETS, 1); // we have 10 buckets
         }
 
-        public bool IsUnderPressure()
+        public virtual bool IsUnderPressure()
         {
             if (cachedMessages.Count == 0) return false; // empty cache
             if (Size < maxCacheSize) return false; // there is still space in cache
@@ -125,7 +124,7 @@ namespace Orleans.Providers.Streams.Common
             return cursor;
         }
 
-        private void InitializeCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken sequenceToken)
+        internal void InitializeCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken sequenceToken)
         {
             Log(logger, "InitializeCursor: {0} to sequenceToken {1}", cursor, sequenceToken);
            
@@ -273,7 +272,6 @@ namespace Orleans.Providers.Streams.Common
                 cacheCursorHistogram.Add(cacheBucket);
             }
 
-            cacheBucket.UpdateNumItems(1);
             // Add message to linked list
             var item = new SimpleQueueCacheItem
             {
@@ -283,6 +281,7 @@ namespace Orleans.Providers.Streams.Common
             };
 
             cachedMessages.AddFirst(new LinkedListNode<SimpleQueueCacheItem>(item));
+            cacheBucket.UpdateNumItems(1);
 
             if (Size > maxCacheSize)
             {

--- a/src/OrleansProviders/Streams/Common/SimpleQueueCacheCursor.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleQueueCacheCursor.cs
@@ -82,7 +82,7 @@ namespace Orleans.Providers.Streams.Common
             return current;
         }
 
-        public bool MoveNext()
+        public virtual bool MoveNext()
         {
             IBatchContainer next;
             while (cache.TryGetNextMessage(this, out next))
@@ -95,6 +95,14 @@ namespace Orleans.Providers.Streams.Common
 
             current = next;
             return true;
+        }
+
+        public virtual void Refresh()
+        {
+            if (!IsSet)
+            {
+                cache.InitializeCursor(this, SequenceToken);
+            }
         }
 
         private bool IsInStream(IBatchContainer batchContainer)


### PR DESCRIPTION
Stream consumer cursor (for persistent streams) has a field  State , which tracks if this cursor is active or not (Active means points to a valid data in the cache, Inactive means points outside the cache, waiting for the new data to arrive). That state field was updated in a different turn in the pulling agent from where the actual pointer into the cache was updated. As a result, due to interleaving of turns in the agent, we could get into a rare inconsistent situation, where the cursor will not be updated correctly.

Fixed by Refreshing the cursor state, to prevent the interleaving bug.
That is a different fix to the problem reported in  #759.
