### PR TITLE
Delete msgs from Azure Queue only after they have been delivered and processed.

### DIFF
--- a/src/Orleans/Streams/QueueAdapters/IQueueAdapterReceiver.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueAdapterReceiver.cs
@@ -47,6 +47,12 @@ namespace Orleans.Streams
         Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount);
 
         /// <summary>
+        /// Release messages from a message queue.
+        /// </summary>
+        /// <returns></returns>
+        Task ReleaseMessagesAsync(IList<IBatchContainer> messages);
+
+        /// <summary>
         /// Receiver is no longer used.  Shutdown and clean up.
         /// </summary>
         /// <returns></returns>

--- a/src/Orleans/Streams/QueueAdapters/IQueueAdapterReceiver.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueAdapterReceiver.cs
@@ -47,10 +47,11 @@ namespace Orleans.Streams
         Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount);
 
         /// <summary>
-        /// Release messages from a message queue.
+        /// Notifies the adapter receiver that the mesages were delivered to all consumers,
+        /// so the receiver can take an appropriate action (e.g., delete the messages from a message queue).
         /// </summary>
         /// <returns></returns>
-        Task ReleaseMessagesAsync(IList<IBatchContainer> messages);
+        Task MessagesDeliveredAsync(IList<IBatchContainer> messages);
 
         /// <summary>
         /// Receiver is no longer used.  Shutdown and clean up.

--- a/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
@@ -50,10 +50,11 @@ namespace Orleans.Streams
         void AddToCache(IList<IBatchContainer> messages);
 
         /// <summary>
-        /// Ask the cache if it has items that can be release from them underlying queue.
+        /// Ask the cache if it has items that can be purged from the cache 
+        /// (so that they can be subsequently released them the underlying queue).
         /// </summary>
-        /// <param name="messages"></param>
-        bool TryRelease(out IList<IBatchContainer> itemsToRelease);
+        /// <param name="purgedItems"></param>
+        bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems);
 
         /// <summary>
         /// Acquire a stream message cursor.  This can be used to retreave messages from the

--- a/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
@@ -50,6 +50,12 @@ namespace Orleans.Streams
         void AddToCache(IList<IBatchContainer> messages);
 
         /// <summary>
+        /// Ask the cache if it has items that can be release from them underlying queue.
+        /// </summary>
+        /// <param name="messages"></param>
+        bool TryRelease(out IList<IBatchContainer> itemsToRelease);
+
+        /// <summary>
         /// Acquire a stream message cursor.  This can be used to retreave messages from the
         ///   cache starting at the location indicated by the provided token.
         /// </summary>

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -107,7 +107,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             }
         }
 
-        public async Task ReleaseMessagesAsync(IList<IBatchContainer> messages)
+        public async Task MessagesDeliveredAsync(IList<IBatchContainer> messages)
         {
             try
             {

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -87,27 +87,34 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
         {
-            var queueRef = queue; // store direct ref, in case we are somehow asked to shutdown while we are receiving.
-            if (queueRef == null) return new List<IBatchContainer>();
             try
             {
-                int count = maxCount < 0 || maxCount == QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG ? 
+                int count = maxCount < 0 || maxCount == QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG ?
                     CloudQueueMessage.MaxNumberOfMessagesToPeek : Math.Min(maxCount, CloudQueueMessage.MaxNumberOfMessagesToPeek);
 
-                var task = queueRef.GetQueueMessages(count);
+                var task = queue.GetQueueMessages(count);
                 outstandingTask = task;
                 IEnumerable<CloudQueueMessage> messages = await task;
-                
+
                 List<IBatchContainer> azureQueueMessages = messages
                     .Select(msg => (IBatchContainer)AzureQueueBatchContainer.FromCloudQueueMessage(msg, lastReadMessage++)).ToList();
 
-                if (azureQueueMessages.Count == 0)
-                    return azureQueueMessages;
-
-                outstandingTask = Task.WhenAll(messages.Select(queueRef.DeleteQueueMessage));
-                await outstandingTask;
-
                 return azureQueueMessages;
+            }
+            finally
+            {
+                outstandingTask = null;
+            }
+        }
+
+        public async Task ReleaseMessagesAsync(IList<IBatchContainer> messages)
+        {
+            try
+            {
+                if (messages.Count == 0) return;
+                List<CloudQueueMessage> cloudQueueMessages = messages.Cast<AzureQueueBatchContainer>().Select(b => b.CloudQueueMessage).ToList();
+                outstandingTask = Task.WhenAll(cloudQueueMessages.Select(queue.DeleteQueueMessage));
+                await outstandingTask;
             }
             finally
             {

--- a/src/OrleansProviders/Streams/Common/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleQueueCache.cs
@@ -100,9 +100,9 @@ namespace Orleans.Providers.Streams.Common
         }
 
 
-        public virtual bool TryRelease(out IList<IBatchContainer> itemsToRelease)
+        public virtual bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
         {
-            itemsToRelease = null;
+            purgedItems = null;
             if (cachedMessages.Count == 0) return false; // empty cache
             if (cacheCursorHistogram.Count == 0) return false;  // no cursors yet - zero consumers basically yet.
             if (cacheCursorHistogram[0].NumCurrentCursors > 0) return false; // consumers are still active in the oldest bucket - fast path
@@ -114,7 +114,7 @@ namespace Orleans.Providers.Streams.Common
                 allItems.AddRange(items);
                 cacheCursorHistogram.RemoveAt(0); // remove the last bucket
             }
-            itemsToRelease = allItems;
+            purgedItems = allItems;
             return true;
         }
 

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -332,10 +332,10 @@ namespace Orleans.Streams
 
                     if (queueCache != null)
                     {
-                        IList<IBatchContainer> itemsToRelease;
-                        if (queueCache.TryRelease(out itemsToRelease))
+                        IList<IBatchContainer> purgedItems;
+                        if (queueCache.TryPurgeFromCache(out purgedItems))
                         {
-                            await rcvr.ReleaseMessagesAsync(itemsToRelease);
+                            await rcvr.MessagesDeliveredAsync(purgedItems);
                         }
                     }
 

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -330,6 +330,15 @@ namespace Orleans.Streams
                         CleanupPubSubCache(now);
                     }
 
+                    if (queueCache != null)
+                    {
+                        IList<IBatchContainer> itemsToRelease;
+                        if (queueCache.TryRelease(out itemsToRelease))
+                        {
+                            await rcvr.ReleaseMessagesAsync(itemsToRelease);
+                        }
+                    }
+
                     if (queueCache != null && queueCache.IsUnderPressure())
                     {
                         // Under back pressure. Exit the loop. Will attempt again in the next timer callback.


### PR DESCRIPTION
This fixes an old standing bug reported in #166 about Azure Queue stream provider not guaranteeing at-least-once delivery. The old code used to delete msgs from the queue after they have been pulled but before they have been delivered and processed.
This PR fixes that. Now the msg is retrieved from the queue, put in the cache, delivered to all stream consumers of that stream and only after all consumers have processed this msg it will be deleted from the underlying Azure Queue.
