### PR TITLE
Delayed repartitioning of stream queues

### DIFF
--- a/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
+++ b/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
@@ -151,6 +151,9 @@ namespace Orleans.Streams
         public const string STREAM_PUBSUB_TYPE = "PubSubType";
         public const StreamPubSubType DEFAULT_STREAM_PUBSUB_TYPE = StreamPubSubType.ExplicitGrainBasedAndImplicit;
 
+        public const string SILO_MATURITY_PERIOD = "SiloMaturityPeriod";
+        public static readonly TimeSpan DEFAULT_SILO_MATURITY_PERIOD = TimeSpan.FromMinutes(2);
+
 
         public TimeSpan GetQueueMsgsTimerPeriod { get; private set; }
         public TimeSpan InitQueueTimeout { get; private set; }
@@ -158,6 +161,7 @@ namespace Orleans.Streams
         public TimeSpan StreamInactivityPeriod { get; private set; }
         public StreamQueueBalancerType BalancerType { get; private set; }
         public StreamPubSubType PubSubType { get; private set; }
+        public TimeSpan SiloMaturityPeriod { get; private set; }
 
 
         public PersistentStreamProviderConfig(IProviderConfiguration config)
@@ -197,17 +201,25 @@ namespace Orleans.Streams
             PubSubType = !config.Properties.TryGetValue(STREAM_PUBSUB_TYPE, out pubSubTypeString)
                 ? DEFAULT_STREAM_PUBSUB_TYPE
                 : (StreamPubSubType)Enum.Parse(typeof(StreamPubSubType), pubSubTypeString);
+
+            string immaturityPeriod;
+            if (!config.Properties.TryGetValue(SILO_MATURITY_PERIOD, out immaturityPeriod))
+                SiloMaturityPeriod = DEFAULT_SILO_MATURITY_PERIOD;
+            else
+                SiloMaturityPeriod = ConfigUtilities.ParseTimeSpan(immaturityPeriod,
+                    "Invalid time value for the " + SILO_MATURITY_PERIOD + " property in the provider config values.");
         }
 
         public override string ToString()
         {
-            return String.Format("{0}={1}, {2}={3}, {4}={5}, {6}={7}, {8}={9}, {10}={11}",
+            return String.Format("{0}={1}, {2}={3}, {4}={5}, {6}={7}, {8}={9}, {10}={11}, {12}={13}",
                 GET_QUEUE_MESSAGES_TIMER_PERIOD, GetQueueMsgsTimerPeriod,
                 INIT_QUEUE_TIMEOUT, InitQueueTimeout,
                 MAX_EVENT_DELIVERY_TIME, MaxEventDeliveryTime,
                 STREAM_INACTIVITY_PERIOD, StreamInactivityPeriod,
                 QUEUE_BALANCER_TYPE, BalancerType,
-                STREAM_PUBSUB_TYPE, PubSubType);
+                STREAM_PUBSUB_TYPE, PubSubType,
+                SILO_MATURITY_PERIOD, SiloMaturityPeriod);
         }
     }
 

--- a/src/OrleansRuntime/MembershipService/ISiloStatusOracle.cs
+++ b/src/OrleansRuntime/MembershipService/ISiloStatusOracle.cs
@@ -42,6 +42,11 @@ namespace Orleans.Runtime
         string SiloName { get; }
 
         /// <summary>
+        /// Silo Address of this silo.
+        /// </summary>
+        SiloAddress SiloAddress { get; }
+
+        /// <summary>
         /// Start this oracle. Will register this silo in the SiloDirectory with SiloStatus.Starting status.
         /// </summary>
         Task Start();

--- a/src/OrleansRuntime/MembershipService/MembershipOracle.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipOracle.cs
@@ -57,6 +57,7 @@ namespace Orleans.Runtime.MembershipService
         public SiloStatus CurrentStatus { get { return membershipOracleData.CurrentStatus; } } // current status of this silo.
 
         public string SiloName { get { return membershipOracleData.SiloName; } }
+        public SiloAddress SiloAddress { get { return membershipOracleData.MyAddress; } }
 
         internal MembershipOracle(Silo silo, IMembershipTable membershipTable)
             : base(Constants.MembershipOracleId, silo.SiloAddress)

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -254,7 +254,7 @@ namespace Orleans.Runtime.Providers
             PersistentStreamProviderConfig config)
         {
             IStreamQueueBalancer queueBalancer = StreamQueueBalancerFactory.Create(
-                config.BalancerType, streamProviderName, Silo.CurrentSilo.LocalSiloStatusOracle, Silo.CurrentSilo.OrleansConfig, this, adapterFactory.GetStreamQueueMapper());
+                config.BalancerType, streamProviderName, Silo.CurrentSilo.LocalSiloStatusOracle, Silo.CurrentSilo.OrleansConfig, this, adapterFactory.GetStreamQueueMapper(), config.SiloMaturityPeriod);
             var managerId = GrainId.NewSystemTargetGrainIdByTypeCode(Constants.PULLING_AGENTS_MANAGER_SYSTEM_TARGET_TYPE_CODE);
             var manager = new PersistentStreamPullingManager(managerId, streamProviderName, this, this.PubSub(config.PubSubType), adapterFactory, queueBalancer, config);
             this.RegisterSystemTarget(manager);

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingManager.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingManager.cs
@@ -53,6 +53,7 @@ namespace Orleans.Streams
         private readonly IQueueAdapterFactory adapterFactory;
         private PersistentStreamProviderState managerState;
         private readonly IDisposable queuePrintTimer;
+        private int NumberRunningAgents { get { return queuesToAgentsMap.Count; } }
 
         internal PersistentStreamPullingManager(
             GrainId id, 
@@ -261,7 +262,10 @@ namespace Orleans.Streams
             }
             if (agents.Count > 0)
             {
-                Log(ErrorCode.PersistentStreamPullingManager_08, "Took {0} new queues under my responsibility: {1}", agents.Count, Utils.EnumerableToString(agents, agent => agent.QueueId.ToString()));
+                Log(ErrorCode.PersistentStreamPullingManager_08, "Took {0} new queues. Now own {1} queues: {2}",
+                    agents.Count,
+                    NumberRunningAgents,
+                    Utils.EnumerableToString(queuesToAgentsMap.Values, agent => agent.QueueId.ToString()));
             }
         }
 
@@ -346,7 +350,7 @@ namespace Orleans.Streams
                     case PersistentStreamProviderCommand.GetAgentsState:
                         return managerState;
                     case PersistentStreamProviderCommand.GetNumberRunningAgents:
-                        return queuesToAgentsMap.Count;
+                        return NumberRunningAgents;
                     default:
                         throw new OrleansException(String.Format("PullingAgentManager does not support command {0}.", command));
                 }
@@ -354,8 +358,8 @@ namespace Orleans.Streams
             finally
             {
                 Log(ErrorCode.PersistentStreamPullingManager_15,
-                    String.Format("Done executing command {0}: commandSeqNumber = {1}, managerState = {2}.", 
-                    command, commandSeqNumber, managerState));
+                    String.Format("Done executing command {0}: commandSeqNumber = {1}, managerState = {2}, num running agents = {3}.", 
+                    command, commandSeqNumber, managerState, NumberRunningAgents));
             }
         }
 

--- a/src/OrleansRuntime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
@@ -22,7 +22,9 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Runtime;
@@ -38,17 +40,21 @@ namespace Orleans.Streams
     /// </summary>
     internal class DeploymentBasedQueueBalancer : ISiloStatusListener, IStreamQueueBalancer
     {
+        private readonly TimeSpan siloMaturityPeriod;
         private readonly ISiloStatusOracle siloStatusOracle;
         private readonly IDeploymentConfiguration deploymentConfig;
-        private readonly List<QueueId> allQueues;
+        private readonly ReadOnlyCollection<QueueId> allQueues;
         private readonly List<IStreamQueueBalanceListener> queueBalanceListeners;
-        private readonly string mySiloName;
+        private readonly ConcurrentDictionary<SiloAddress, bool> immatureSilos;
         private readonly bool isFixed;
+        private bool isStarting;
+
         
         public DeploymentBasedQueueBalancer(
             ISiloStatusOracle siloStatusOracle,
             IDeploymentConfiguration deploymentConfig,
             IStreamQueueMapper queueMapper,
+            TimeSpan maturityPeriod,
             bool isFixed)
         {
             if (siloStatusOracle == null)
@@ -66,13 +72,31 @@ namespace Orleans.Streams
 
             this.siloStatusOracle = siloStatusOracle;
             this.deploymentConfig = deploymentConfig;
-            allQueues = queueMapper.GetAllQueues().ToList();
+            allQueues = new ReadOnlyCollection<QueueId>(queueMapper.GetAllQueues().ToList());
             queueBalanceListeners = new List<IStreamQueueBalanceListener>();
-            mySiloName = this.siloStatusOracle.SiloName;
+            immatureSilos = new ConcurrentDictionary<SiloAddress, bool>();
             this.isFixed = isFixed;
+            siloMaturityPeriod = maturityPeriod;
+            isStarting = true;
 
             // register for notification of changes to silo status for any silo in the cluster
             this.siloStatusOracle.SubscribeToSiloStatusEvents(this);
+
+            // record all already active silos as already mature. 
+            // Even if they are not yet, they will be mature by the time I mature myself (after I become !isStarting).
+            foreach (var silo in siloStatusOracle.GetApproximateSiloStatuses(true).Keys.Where(s => !s.Equals(siloStatusOracle.SiloAddress)))
+            {
+                immatureSilos[silo] = false;     // record as mature
+            }
+
+            NotifyAfterStart().Ignore();
+        }
+
+        private async Task NotifyAfterStart()
+        {
+            await Task.Delay(siloMaturityPeriod);
+            isStarting = false;
+            await NotifyListeners();
         }
 
         /// <summary>
@@ -83,19 +107,64 @@ namespace Orleans.Streams
         /// <param name="status">new silo status</param>
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
         {
-            NotifyListeners().Ignore();
+            if (status.Equals(SiloStatus.Dead))
+            {
+                // just clean up garbage from immatureSilos.
+                bool ignore;
+                immatureSilos.TryRemove(updatedSilo, out ignore);
+            }
+            SiloStatusChangeNotification().Ignore();
+        }
+
+        private async Task SiloStatusChangeNotification()
+        {
+            List<Task> tasks = new List<Task>();
+            // look at all currently active silos not including myself
+            foreach (var silo in siloStatusOracle.GetApproximateSiloStatuses(true).Keys.Where(s => !s.Equals(siloStatusOracle.SiloAddress)))
+            {
+                bool ignore;
+                if (!immatureSilos.TryGetValue(silo, out ignore))
+                {
+                    tasks.Add(RecordImmatureSilo(silo));
+                }
+            }
+            if (!isStarting)
+            {
+                // notify, uncoditionaly, and deal with changes in GetMyQueues()
+                NotifyListeners().Ignore();
+            }
+            if (tasks.Count > 0)
+            {
+                await Task.WhenAll(tasks);
+                await NotifyListeners(); // notify, uncoditionaly, and deal with changes it in GetMyQueues()
+            }
+        }
+
+        private async Task RecordImmatureSilo(SiloAddress updatedSilo)
+        {
+            immatureSilos[updatedSilo] = true;      // record as immature
+            await Task.Delay(siloMaturityPeriod);
+            immatureSilos[updatedSilo] = false;     // record as mature
         }
 
         public IEnumerable<QueueId> GetMyQueues()
         {
             BestFitBalancer<string, QueueId> balancer = GetBalancer();
-            Dictionary<string, List<QueueId>> distribution = isFixed
+            bool useIdealDistribution = isFixed || isStarting;
+            Dictionary<string, List<QueueId>> distribution = useIdealDistribution
                 ? balancer.IdealDistribution
-                : balancer.GetDistribution(GetActiveSilos());
-            List<QueueId> queues;
-            if (distribution.TryGetValue(mySiloName, out queues))
+                : balancer.GetDistribution(GetActiveSilos(siloStatusOracle, immatureSilos));
+
+            List<QueueId> myQueues;
+            if (distribution.TryGetValue(siloStatusOracle.SiloName, out myQueues))
             {
-                return queues;
+                if (!useIdealDistribution)
+                {
+                    HashSet<QueueId> queuesOfImmatureSilos = GetQueuesOfImmatureSilos(siloStatusOracle, immatureSilos, balancer.IdealDistribution);
+                    // filter queues that belong to immature silos
+                    myQueues.RemoveAll(queue => queuesOfImmatureSilos.Contains(queue));
+                }
+                return myQueues;
             }
             return Enumerable.Empty<QueueId>();
         }
@@ -112,7 +181,6 @@ namespace Orleans.Streams
                 {
                     return false;
                 }
-                
                 queueBalanceListeners.Add(observer);
                 return true;
             }
@@ -142,20 +210,43 @@ namespace Orleans.Streams
             return new BestFitBalancer<string, QueueId>(allSiloNames, allQueues);
         }
 
-        private List<string> GetActiveSilos()
+        private static List<string> GetActiveSilos(ISiloStatusOracle siloStatusOracle, ConcurrentDictionary<SiloAddress, bool> immatureSilos)
         {
             var activeSiloNames = new List<string>();
-            foreach(var siloStatus in siloStatusOracle.GetApproximateSiloStatuses(true))
+            foreach (var kvp in siloStatusOracle.GetApproximateSiloStatuses(true))
             {
-                string siloName;
-                if (siloStatusOracle.TryGetSiloName(siloStatus.Key, out siloName))
+                bool immatureBit;
+                if (!(immatureSilos.TryGetValue(kvp.Key, out immatureBit) && immatureBit)) // if not immature now or any more
                 {
-                    activeSiloNames.Add(siloName);
+                    string siloName;
+                    if (siloStatusOracle.TryGetSiloName(kvp.Key, out siloName))
+                    {
+                        activeSiloNames.Add(siloName);
+                    }
                 }
             }
             return activeSiloNames;
         }
 
+        private static HashSet<QueueId> GetQueuesOfImmatureSilos(ISiloStatusOracle siloStatusOracle, 
+            ConcurrentDictionary<SiloAddress, bool> immatureSilos, 
+            Dictionary<string, List<QueueId>> idealDistribution)
+        {
+            HashSet<QueueId> queuesOfImmatureSilos = new HashSet<QueueId>();
+            foreach (var silo in immatureSilos.Where(s => s.Value)) // take only those from immature set that have their immature status bit set
+            {
+                string siloName;
+                if (siloStatusOracle.TryGetSiloName(silo.Key, out siloName))
+                {
+                    List<QueueId> queues;
+                    if (idealDistribution.TryGetValue(siloName, out queues))
+                    {
+                        queuesOfImmatureSilos.UnionWith(queues);
+                    }
+                }
+            }
+            return queuesOfImmatureSilos;
+        }
 
         private Task NotifyListeners()
         {

--- a/src/OrleansRuntime/Streams/QueueBalancer/StreamQueueBalancerFactory.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/StreamQueueBalancerFactory.cs
@@ -41,6 +41,7 @@ namespace Orleans.Streams
         /// <param name="clusterConfiguration">cluster configuration</param>
         /// <param name="runtime">stream provider runtime environment to run in</param>
         /// <param name="queueMapper">queue mapper of requesting stream provider</param>
+        /// <param name="siloMaturityPeriod">Maturity Period of a silo for queue rebalancing purposes</param>
         /// <returns>Constructed stream queue balancer</returns>
         public static IStreamQueueBalancer Create(
             StreamQueueBalancerType balancerType,
@@ -48,7 +49,8 @@ namespace Orleans.Streams
             ISiloStatusOracle siloStatusOracle,
             ClusterConfiguration clusterConfiguration,
             IStreamProviderRuntime runtime,
-            IStreamQueueMapper queueMapper)
+            IStreamQueueMapper queueMapper,
+            TimeSpan siloMaturityPeriod)
         {
             if (string.IsNullOrWhiteSpace(strProviderName))
             {
@@ -85,14 +87,14 @@ namespace Orleans.Streams
                     TraceLogger logger = TraceLogger.GetLogger(typeof(StreamQueueBalancerFactory).Name, TraceLogger.LoggerType.Runtime);
                     var wrapper = AssemblyLoader.LoadAndCreateInstance<IDeploymentConfiguration>(Constants.ORLEANS_AZURE_UTILS_DLL, logger);
                     isFixed = balancerType == StreamQueueBalancerType.StaticAzureDeploymentBalancer;
-                    return new DeploymentBasedQueueBalancer(siloStatusOracle, wrapper, queueMapper, isFixed);
+                    return new DeploymentBasedQueueBalancer(siloStatusOracle, wrapper, queueMapper, siloMaturityPeriod, isFixed);
                 }
                 case StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer:
                 case StreamQueueBalancerType.StaticClusterConfigDeploymentBalancer:
                 {
                     IDeploymentConfiguration deploymentConfiguration = new StaticClusterDeploymentConfiguration(clusterConfiguration);
                     isFixed = balancerType == StreamQueueBalancerType.StaticClusterConfigDeploymentBalancer;
-                    return new DeploymentBasedQueueBalancer(siloStatusOracle, deploymentConfiguration, queueMapper, isFixed);
+                    return new DeploymentBasedQueueBalancer(siloStatusOracle, deploymentConfiguration, queueMapper, siloMaturityPeriod, isFixed);
                 }
                 default:
                 {

--- a/src/Tester/OrleansConfigurationForStreaming4SilosUnitTests.xml
+++ b/src/Tester/OrleansConfigurationForStreaming4SilosUnitTests.xml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <StorageProviders>
+      <Provider Type="Orleans.Storage.MemoryStorage" Name="PubSubStore" NumStorageGrains="1"/>
+    </StorageProviders>
+    <StreamProviders>
+      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
+      <Provider Type="Orleans.Providers.Streams.AzureQueue.AzureQueueStreamProvider" Name="AzureQueueProvider"
+           QueueBalancerType="DynamicClusterConfigDeploymentBalancer" SiloMaturityPeriod="10s"/>
+    </StreamProviders>
+    <SeedNode Address="localhost" Port="22222"/>
+    <Messaging ResponseTimeout="30s"/>
+  </Globals>
+  <Defaults>
+    <Networking Address="localhost" Port="22222"/>
+    <ProxyingGateway Address="localhost" Port="40000" />
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" BulkMessageLimit="1000">
+      <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
+    </Tracing>
+    <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
+  </Defaults>
+  <Override Node="Primary">
+  </Override>
+  <Override Node="Secondary_1">
+  </Override>
+  <Override Node="Secondary_2">
+  </Override>
+  <Override Node="Secondary_3">
+  </Override>
+</OrleansConfiguration>
+
+

--- a/src/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/src/Tester/StreamingTests/SampleStreamingTests.cs
@@ -39,9 +39,7 @@ namespace UnitTests.StreamingTests
     [TestClass]
     public class SampleStreamingTests : UnitTestSiloHost
     {
-        private const string SMS_STREAM_PROVIDER_NAME = "SMSProvider";
-        private const string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AzureQueueProvider";
-        private const string StreamNamespace = "SampleStreamNamespace";
+        private const string StreamNamespace = "SampleStreamNamespace"; 
         private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(30);
 
         private Guid streamId;
@@ -70,9 +68,9 @@ namespace UnitTests.StreamingTests
         [TestCleanup]
         public void TestCleanup()
         {
-            if (streamProvider != null && streamProvider.Equals(AZURE_QUEUE_STREAM_PROVIDER_NAME))
+            if (streamProvider != null && streamProvider.Equals(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME))
             {
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(AZURE_QUEUE_STREAM_PROVIDER_NAME, DeploymentId, StorageTestConstants.DataConnectionString, logger).Wait();
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME, DeploymentId, StorageTestConstants.DataConnectionString, logger).Wait();
             }
         }
 
@@ -81,7 +79,7 @@ namespace UnitTests.StreamingTests
         {
             logger.Info("************************ SampleStreamingTests_1 *********************************");
             streamId = Guid.NewGuid();
-            streamProvider = SMS_STREAM_PROVIDER_NAME;
+            streamProvider = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
             await StreamingTests_Consumer_Producer(streamId, streamProvider);
         }
 
@@ -90,7 +88,7 @@ namespace UnitTests.StreamingTests
         {
             logger.Info("************************ SampleStreamingTests_2 *********************************");
             streamId = Guid.NewGuid();
-            streamProvider = SMS_STREAM_PROVIDER_NAME;
+            streamProvider = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
             await StreamingTests_Producer_Consumer(streamId, streamProvider);
         }
 
@@ -99,7 +97,7 @@ namespace UnitTests.StreamingTests
         {
             logger.Info("************************ SampleStreamingTests_3 *********************************" );
             streamId = Guid.NewGuid();
-            streamProvider = SMS_STREAM_PROVIDER_NAME;
+            streamProvider = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
             await StreamingTests_Producer_InlineConsumer(streamId, streamProvider );
         }
 
@@ -108,7 +106,7 @@ namespace UnitTests.StreamingTests
         {
             logger.Info("************************ SampleStreamingTests_4 *********************************");
             streamId = Guid.NewGuid();
-            streamProvider = AZURE_QUEUE_STREAM_PROVIDER_NAME;
+            streamProvider = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
             await StreamingTests_Consumer_Producer(streamId, streamProvider);
         }
 
@@ -117,7 +115,7 @@ namespace UnitTests.StreamingTests
         {
             logger.Info("************************ SampleStreamingTests_5 *********************************");
             streamId = Guid.NewGuid();
-            streamProvider = AZURE_QUEUE_STREAM_PROVIDER_NAME;
+            streamProvider = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
             await StreamingTests_Producer_Consumer(streamId, streamProvider);
         }
 
@@ -128,7 +126,7 @@ namespace UnitTests.StreamingTests
             streamId = Guid.NewGuid();
             const int nRedEvents = 5, nBlueEvents = 3;
 
-            var provider = GrainClient.GetStreamProvider(SMS_STREAM_PROVIDER_NAME);
+            var provider = GrainClient.GetStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
             var redStream = provider.GetStream<int>(streamId, "red");
             var blueStream = provider.GetStream<int>(streamId, "blue");
 

--- a/src/Tester/StreamingTests/StreamTestsConstants.cs
+++ b/src/Tester/StreamingTests/StreamTestsConstants.cs
@@ -1,0 +1,31 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace UnitTests.StreamingTests
+{
+    public class StreamTestsConstants
+    {
+        public const string SMS_STREAM_PROVIDER_NAME = "SMSProvider";
+        public const string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AzureQueueProvider";
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -97,6 +97,8 @@
     <Compile Include="StreamingTests\AQSubscriptionMultiplicityTests.cs" />
     <Compile Include="StreamingTests\DeactivationTestRunner.cs" />
     <Compile Include="StreamingTests\PullingAgentManagementTests.cs" />
+    <Compile Include="StreamingTests\DelayedQueueRebalancingTests.cs" />
+    <Compile Include="StreamingTests\StreamTestsConstants.cs" />
     <Compile Include="StreamingTests\SampleStreamingTests.cs" />
     <Compile Include="SimpleGrainTests.cs" />
     <Compile Include="StreamingTests\SMSDeactivationTests.cs" />
@@ -121,6 +123,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="OrleansConfigurationForStreamingDeactivationUnitTests.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="OrleansConfigurationForStreaming4SilosUnitTests.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="OrleansConfigurationForStreamingUnitTests.xml">


### PR DESCRIPTION
Implemented delayed repartitioning of queues in queue balancer. 

When silo start up, they divide the multiple streaming queues between themselves, by using a dynamic queue balancing algorithm. The algorithm assigns queue to silos such that:
1) every queue is assigned to exactly one silo.
2) the number of queues per silo are equal (up to rounding).
3) in case of silo failures or additions, queue are dynamically rebalanced to adhere to the above 2 conditions.
4) the number of queue responsibility reassignments is minimized such that we try to minimize movements of a queues from one silo to another to as less as possible.

The previous implementation tried to achieve all those goals, but was not doing a good job on the last requirement. Specifically, in the case of all silos staring at approximately the same time (usual startup scenario), there were quite a lot of responsibility reassignments, which causes churn and unnecessary queue responsibility transitions. This PR addresses this issue, buy further minimizing responsibility reassignment in the startup scenario.

