### PR TITLE
Improved logging in multiple places.

### DIFF
--- a/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
+++ b/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
@@ -288,6 +288,11 @@ namespace Orleans.AzureUtils
             }
         }
 
+        /// <summary>
+        /// Remove any characters that can't be used in Azure PartitionKey or RowKey values.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
         public static string SanitizeTableProperty(string key)
         {
             // Remove any characters that can't be used in Azure PartitionKey or RowKey values

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -728,7 +728,7 @@ namespace Orleans.Runtime
                 }
             }
             logger.Info(ErrorCode.Catalog_ShutdownActivations_2,
-                "DeactivateActivationOnIdle: 1 {0}.", promptly ? "promptly" : (alreadBeingDestroyed ? "already being destroyed or invalid" : "later when become idle"));
+                "DeactivateActivationOnIdle: {0} {1}.", data.ToString(), promptly ? "promptly" : (alreadBeingDestroyed ? "already being destroyed or invalid" : "later when become idle"));
 
             CounterStatistic.FindOrCreate(StatisticNames.CATALOG_ACTIVATION_SHUTDOWN_VIA_DEACTIVATE_ON_IDLE).Increment();
             if (promptly)

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -145,12 +145,12 @@ namespace Orleans.Runtime
                     if (nea.IsStatelessWorker)
                     {
                         if (logger.IsVerbose) logger.Verbose(ErrorCode.Dispatcher_Intermediate_GetOrCreateActivation,
-                           String.Format("Intermediate warning for StatelessWorker NonExistentActivation from Catalog.GetOrCreateActivation for message {0}", message), ex);
+                           String.Format("Intermediate StatelessWorker NonExistentActivation for message {0}", message), ex);
                     }
                     else
                     {
-                        logger.Warn(ErrorCode.Dispatcher_Intermediate_GetOrCreateActivation,
-                            String.Format("Intermediate warning for NonExistentActivation from Catalog.GetOrCreateActivation for message {0}", message), ex);
+                        logger.Info(ErrorCode.Dispatcher_Intermediate_GetOrCreateActivation,
+                            String.Format("Intermediate NonExistentActivation for message {0}", message), ex);
                     }
 
                     ActivationAddress nonExistentActivation = nea.NonExistentActivation;

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -45,6 +45,7 @@ using Orleans.Serialization;
 using Orleans.Storage;
 using Orleans.Streams;
 using Orleans.Timers;
+using System.Runtime;
 
 
 namespace Orleans.Runtime
@@ -195,8 +196,15 @@ namespace Orleans.Runtime
             }
             TraceLogger.MyIPEndPoint = here;
             logger = TraceLogger.GetLogger("Silo", TraceLogger.LoggerType.Runtime);
-            logger.Info(ErrorCode.SiloInitializing, "-------------- Initializing {0} silo on {1} at {2}, gen {3} --------------", siloType, nodeConfig.DNSHostName, here, generation);
-            logger.Info(ErrorCode.SiloInitConfig, "Starting silo {0} with runtime Version='{1}' Config= " + Environment.NewLine + "{2}", name, RuntimeVersion.Current, config.ToString(name));
+
+            logger.Info(ErrorCode.SiloGcSetting, "Silo starting with GC settings: ServerGC={0} GCLatencyMode={1}", GCSettings.IsServerGC, Enum.GetName(typeof(GCLatencyMode), GCSettings.LatencyMode));
+            if (!GCSettings.IsServerGC || !GCSettings.LatencyMode.Equals(GCLatencyMode.Batch))
+                logger.Warn(ErrorCode.SiloGcWarning, "Note: Silo not running with ServerGC turned on or with GCLatencyMode.Batch enabled - recommend checking app config : <configuration>-<runtime>-<gcServer enabled=\"true\"> and <configuration>-<runtime>-<gcConcurrent enabled=\"false\"/>");
+
+            logger.Info(ErrorCode.SiloInitializing, "-------------- Initializing {0} silo on host {1} MachineName {2} at {3}, gen {4} --------------",
+                siloType, nodeConfig.DNSHostName, Environment.MachineName, here, generation);
+            logger.Info(ErrorCode.SiloInitConfig, "Starting silo {0} with runtime Version='{1}' .NET version='{2}' Is .NET 4.5={3} OS version='{4}' Config= " + Environment.NewLine + "{5}",
+                name, RuntimeVersion.Current, Environment.Version, ConfigUtilities.IsNet45OrNewer(), Environment.OSVersion, config.ToString(name));
 
             if (keyStore != null)
             {

--- a/src/OrleansRuntime/Silo/SiloHost.cs
+++ b/src/OrleansRuntime/Silo/SiloHost.cs
@@ -143,14 +143,6 @@ namespace Orleans.Runtime.Host
             try
             {
                 if (!ConfigLoaded) LoadOrleansConfig();
-
-                logger.Info( ErrorCode.SiloInitializing, "Initializing Silo {0} on host={1} CPU count={2} running .NET version='{3}' Is .NET 4.5={4} OS version='{5}'",
-                    Name, Environment.MachineName, Environment.ProcessorCount, Environment.Version, ConfigUtilities.IsNet45OrNewer(), Environment.OSVersion);
-
-                logger.Info(ErrorCode.SiloGcSetting, "Silo running with GC settings: ServerGC={0} GCLatencyMode={1}", GCSettings.IsServerGC, Enum.GetName(typeof(GCLatencyMode), GCSettings.LatencyMode));
-                if (!GCSettings.IsServerGC)
-                    logger.Warn(ErrorCode.SiloGcWarning, "Note: Silo not running with ServerGC turned on - recommend checking app config : <configuration>-<runtime>-<gcServer enabled=\"true\"> and <configuration>-<runtime>-<gcConcurrent enabled=\"false\"/>");
-                
                 orleans = new Silo(Name, Type, Config);
             }
             catch (Exception exc)


### PR DESCRIPTION
Changed `NonExistentActivation`  from `Warning` to `Info`.
More details in` DeactivateActivationOnIdle` logging.
Move preamble logging from `SiloHost` to `Silo` object, so works always for all hosts.
Warn upon `!GCSettings.LatencyMode.Equals(GCLatencyMode.Batch))`