### PR TITLE
Fix bug in ClusterConfiguration(TextReader input) constructor

### DIFF
--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -68,7 +68,7 @@ namespace Orleans.Runtime.Configuration
         public IDictionary<string, NodeConfiguration> Overrides { get; private set; }
 
         private Dictionary<string, string> overrideXml;
-        private readonly Dictionary<string, List<Action>> listeners;
+        private readonly Dictionary<string, List<Action>> listeners = new Dictionary<string, List<Action>>();
         internal bool IsRunningAsUnitTest { get; set; }
 
         /// <summary>
@@ -76,7 +76,6 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public ClusterConfiguration()
         {
-            listeners = new Dictionary<string, List<Action>>();
             Init();
         }
 


### PR DESCRIPTION
Using the `ClusterConfiguration(TextReader input)` constructor would throw an exception at a later time because the `listeners` field only was initialized in the default constructor. Initialization of `listeners` has been moved to the field initializer.