### PR TITLE
Add building of symbols NuGets

### DIFF
--- a/src/NuGet/CreateOrleansPackages.bat
+++ b/src/NuGet/CreateOrleansPackages.bat
@@ -39,7 +39,7 @@ if "%PRODUCT_VERSION%" == "" (
 @echo CreateOrleansNugetPackages: Version = %VERSION% -- Drop location = %BASE_PATH%
 
 @set NUGET_PACK_OPTS= -Version %VERSION% 
-@set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -NoPackageAnalysis
+@set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -NoPackageAnalysis -Symbols
 @set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -BasePath "%BASE_PATH%"
 @REM @set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -Verbosity detailed
 

--- a/src/NuGet/Microsoft.Orleans.Client.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Client.nuspec
@@ -24,6 +24,7 @@
   </metadata>
   <files>
     <file src="ClientConfiguration.xml" target="content" />
+    <file src="Configuration\OrleansConfiguration.xsd" target="tools\client" />
     <file src="ClientInstall.ps1" target="tools\install.ps1" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.Core.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Core.nuspec
@@ -20,6 +20,7 @@
   </metadata>
   <files>
     <file src="Orleans.dll" target="lib\net45" />
-	<file src="Orleans.xml" target="lib\net45" />
+    <file src="Orleans.pdb" target="lib\net45" />
+	  <file src="Orleans.xml" target="lib\net45" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
+++ b/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
@@ -25,6 +25,7 @@
   </metadata>
   <files>
     <file src="OrleansCounterControl.exe" target="lib\net45" />
+    <file src="OrleansCounterControl.pdb" target="lib\net45" />
     <file src="OrleansCounterControl.exe.config" target="lib\net45" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -28,6 +28,7 @@
   </metadata>
   <files>
     <file src="OrleansAzureUtils.dll" target="lib\net45" />
+    <file src="OrleansAzureUtils.pdb" target="lib\net45" />
     <file src="OrleansAzureUtils.xml" target="lib\net45" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
@@ -24,6 +24,7 @@
   </metadata>
   <files>
     <file src="OrleansHost.exe" target="lib\net45" />
+    <file src="OrleansHost.pdb" target="lib\net45" />
     <file src="OrleansHost.exe.config" target="lib\net45" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
@@ -23,6 +23,7 @@
   </metadata>
   <files>
     <file src="OrleansManager.exe" target="lib\net45" />
+    <file src="OrleansManager.pdb" target="lib\net45" />
     <file src="OrleansManager.exe.config" target="lib\net45" />
     <file src="ClientConfiguration.xml" target="lib\net45" />
   </files>

--- a/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
@@ -23,6 +23,7 @@
   </metadata>
   <files>
     <file src="OrleansProviders.dll" target="lib\net45" />
+    <file src="OrleansProviders.pdb" target="lib\net45" />
     <file src="SQLServer\CreateOrleansTables_SqlServer.sql" target="lib\net45\SQLServer" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
@@ -23,5 +23,6 @@
   </metadata>
   <files>
     <file src="OrleansRuntime.dll" target="lib\net45" />
+    <file src="OrleansRuntime.pdb" target="lib\net45" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -26,5 +26,6 @@
   </metadata>
   <files>
     <file src="OrleansZooKeeperUtils.dll" target="lib\net45" />
+    <file src="OrleansZooKeeperUtils.pdb" target="lib\net45" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.Templates.Grains.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Templates.Grains.nuspec
@@ -29,8 +29,10 @@
     <file src="Orleans.Grains.props" target="build\Microsoft.Orleans.Templates.Grains.props" />
 
     <file src="ClientGenerator.exe" target="tools" />
+    <file src="ClientGenerator.pdb" target="tools" />
     <file src="ClientGenerator.exe.config" target="tools" />
     <file src="Orleans.dll" target="tools" />
+    <file src="Orleans.pdb" target="tools" />
 
     <file src="EmptyFile.cs" target="content\Properties\orleans.codegen.cs" />
   </files>

--- a/src/NuGet/Microsoft.Orleans.Templates.Interfaces.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Templates.Interfaces.nuspec
@@ -29,8 +29,10 @@
     <file src="Orleans.Interfaces.props" target="build\Microsoft.Orleans.Templates.Interfaces.props" />
         
     <file src="ClientGenerator.exe" target="tools" />
+    <file src="ClientGenerator.pdb" target="tools" />
     <file src="ClientGenerator.exe.config" target="tools" />
     <file src="Orleans.dll" target="tools" />
+    <file src="Orleans.pdb" target="tools" />
 
     <file src="EmptyFile.cs" target="content\Properties\orleans.codegen.cs" />
   </files>

--- a/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
@@ -24,6 +24,7 @@
   </metadata>
   <files>
     <file src="OrleansTestingHost.dll" target="lib\net45" />
+    <file src="OrleansTestingHost.pdb" target="lib\net45" />
     
     <file src="ClientConfigurationForTesting.xml" target="content" />
     <file src="OrleansConfigurationForTesting.xml" target="content" />


### PR DESCRIPTION
These will let us easily build and publish NuGets with symbols to SymbolSource.org.

I added OrleansConfiguration.xsd to the Client package because it was failing to build as is for no obvious reason. It won't hurt to have the xsd in the Client package I think.