### PR TITLE
Best fit balancer ideal distribution fix

### DIFF
--- a/src/OrleansRuntime/Streams/QueueBalancer/BestFitBalancer.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/BestFitBalancer.cs
@@ -176,7 +176,7 @@ namespace Orleans.Streams
             foreach (TBucket bucket in bucketList)
             {
                 // if we've filled the first bucketsToFillWithUpperResource buckets with upperResourceCountPerBucket
-                //   resource , fill the rest with lowerResourceCountPerBucket
+                //   resources, fill the rest with lowerResourceCountPerBucket
                 int resourcesToAddToBucket = bucketsFilledCount < bucketsToFillWithUpperResource
                     ? upperResourceCountPerBucket
                     : lowerResourceCountPerBucket;

--- a/src/TesterInternal/OrleansRuntime/Streams/BestFitBalancerTests.cs
+++ b/src/TesterInternal/OrleansRuntime/Streams/BestFitBalancerTests.cs
@@ -46,9 +46,61 @@ namespace UnitTests.OrleansRuntime.Streams
         }
 
         [TestMethod, TestCategory("Functional")]
+        public void IdealCaseMoreResourcesThanBuckets2Test()
+        {
+            const int resourceCount = 100;
+            const int bucketCount = 30;
+            var idealBalance = (int)Math.Floor((double)(resourceCount) / bucketCount);
+            List<int> resources = Enumerable.Range(0, resourceCount).ToList();
+            List<int> buckets = Enumerable.Range(0, bucketCount).ToList();
+            var resourceBalancer = new BestFitBalancer<int, int>(buckets, resources);
+            Dictionary<int, List<int>> balancerResults = resourceBalancer.GetDistribution(buckets);
+            ValidateBalance(buckets, resources, balancerResults, idealBalance);
+        }
+
+        [TestMethod, TestCategory("Functional")]
         public void IdealCaseLessResourcesThanBucketsTest()
         {
             const int bucketCount = 99;
+            const int resourceCount = 10;
+            var idealBalance = (int)Math.Floor((double)(resourceCount) / bucketCount);
+            List<int> buckets = Enumerable.Range(0, bucketCount).ToList();
+            List<int> resources = Enumerable.Range(0, resourceCount).ToList();
+            var resourceBalancer = new BestFitBalancer<int, int>(buckets, resources);
+            Dictionary<int, List<int>> balancerResults = resourceBalancer.GetDistribution(buckets);
+            ValidateBalance(buckets, resources, balancerResults, idealBalance);
+        }
+
+        [TestMethod, TestCategory("Functional")]
+        public void IdealCaseLessResourcesThanBuckets2Test()
+        {
+            const int bucketCount = 100;
+            const int resourceCount = 30;
+            var idealBalance = (int)Math.Floor((double)(resourceCount) / bucketCount);
+            List<int> buckets = Enumerable.Range(0, bucketCount).ToList();
+            List<int> resources = Enumerable.Range(0, resourceCount).ToList();
+            var resourceBalancer = new BestFitBalancer<int, int>(buckets, resources);
+            Dictionary<int, List<int>> balancerResults = resourceBalancer.GetDistribution(buckets);
+            ValidateBalance(buckets, resources, balancerResults, idealBalance);
+        }
+
+        [TestMethod, TestCategory("Functional")]
+        public void IdealCaseResourcesMatchBucketsTest()
+        {
+            const int bucketCount = 100;
+            const int resourceCount = 100;
+            var idealBalance = (int)Math.Floor((double)(resourceCount) / bucketCount);
+            List<int> buckets = Enumerable.Range(0, bucketCount).ToList();
+            List<int> resources = Enumerable.Range(0, resourceCount).ToList();
+            var resourceBalancer = new BestFitBalancer<int, int>(buckets, resources);
+            Dictionary<int, List<int>> balancerResults = resourceBalancer.GetDistribution(buckets);
+            ValidateBalance(buckets, resources, balancerResults, idealBalance);
+        }
+
+        [TestMethod, TestCategory("Functional")]
+        public void IdealCaseResourcesDevisibleByBucketsTest()
+        {
+            const int bucketCount = 100;
             const int resourceCount = 10;
             var idealBalance = (int)Math.Floor((double)(resourceCount) / bucketCount);
             List<int> buckets = Enumerable.Range(0, bucketCount).ToList();


### PR DESCRIPTION
Initial Ideal distribution algorithm was naïve.  It assigned upper bound queues per silos until queues run out.  With 100 queues and 30 silos, upper bound would be 4.  With 4 queues per silo, we’d run out of queues after 25 silos.  This means 5 remaining silos would get 0 queues.

Ideal distribution now assigns upper bound of queues per silo to as many silos as it can, then the upper bound -1 to the rest.  This will produce a more even distribution.
