### PR TITLE
Made EventSequenceToken.NextSequenceNumber public

### DIFF
--- a/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
@@ -46,7 +46,7 @@ namespace Orleans.Providers.Streams.Common
             eventIndex = eventInd;
         }
 
-        internal EventSequenceToken NextSequenceNumber()
+        public EventSequenceToken NextSequenceNumber()
         {
             return new EventSequenceToken(sequenceNumber + 1, eventIndex);
         }


### PR DESCRIPTION
I need it in order to implement my own QueueCache solution.
Thanks.