### PR TITLE
Best Fit Balancer - divisible resource fix

### DIFF
--- a/src/OrleansRuntime/Streams/QueueBalancer/BestFitBalancer.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/BestFitBalancer.cs
@@ -172,6 +172,11 @@ namespace Orleans.Streams
             var lowerResourceCountPerBucket = upperResourceCountPerBucket - 1;
             List<TResource>.Enumerator resourceEnumerator = resourceList.GetEnumerator();
             int bucketsToFillWithUpperResource = resourceList.Count % bucketList.Count;
+            // a bucketsToFillWithUpperResource of 0 indicates resources are evenly devisible, so fill them all with upper resource count
+            if (bucketsToFillWithUpperResource == 0)
+            {
+                bucketsToFillWithUpperResource = bucketList.Count;
+            }
             int bucketsFilledCount = 0;
             foreach (TBucket bucket in bucketList)
             {

--- a/src/TesterInternal/OrleansRuntime/Streams/BestFitBalancerTests.cs
+++ b/src/TesterInternal/OrleansRuntime/Streams/BestFitBalancerTests.cs
@@ -100,14 +100,34 @@ namespace UnitTests.OrleansRuntime.Streams
         [TestMethod, TestCategory("Functional")]
         public void IdealCaseResourcesDevisibleByBucketsTest()
         {
-            const int bucketCount = 100;
-            const int resourceCount = 10;
+            const int resourceCount = 100;
+            const int bucketCount = 10;
             var idealBalance = (int)Math.Floor((double)(resourceCount) / bucketCount);
             List<int> buckets = Enumerable.Range(0, bucketCount).ToList();
             List<int> resources = Enumerable.Range(0, resourceCount).ToList();
             var resourceBalancer = new BestFitBalancer<int, int>(buckets, resources);
             Dictionary<int, List<int>> balancerResults = resourceBalancer.GetDistribution(buckets);
             ValidateBalance(buckets, resources, balancerResults, idealBalance);
+        }
+
+        [TestMethod, TestCategory("Functional")]
+        public void IdealCaseRangedTest()
+        {
+            const int MaxResourceCount = 20;
+            const int MaxBucketCount = 20;
+
+            for (int resourceCount = 1; resourceCount <= MaxResourceCount; resourceCount++)
+            {
+                for (int bucketCount = 1; bucketCount <= MaxBucketCount; bucketCount++)
+                {
+                    var idealBalance = (int)Math.Floor((double)(resourceCount) / bucketCount);
+                    List<int> buckets = Enumerable.Range(0, bucketCount).ToList();
+                    List<int> resources = Enumerable.Range(0, resourceCount).ToList();
+                    var resourceBalancer = new BestFitBalancer<int, int>(buckets, resources);
+                    Dictionary<int, List<int>> balancerResults = resourceBalancer.GetDistribution(buckets);
+                    ValidateBalance(buckets, resources, balancerResults, idealBalance);
+                }
+            }
         }
 
         [TestMethod, TestCategory("Functional")]


### PR DESCRIPTION
Best Fit Balancer did not balance resources correctly when resource count was evenly divisible by silo count.

There was a bug in the test that let this slide through.
Balancer fixed, test fixed, more tests added.