### PR TITLE
A fix to add missing commas to SQL clauses

### DIFF
--- a/src/OrleansProviders/SQLServer/CreateOrleansTables_SqlServer.sql
+++ b/src/OrleansProviders/SQLServer/CreateOrleansTables_SqlServer.sql
@@ -107,7 +107,7 @@ CREATE TABLE [OrleansQuery]
 (	
     [QueryKey] VARCHAR(64) NOT NULL,
     [QueryText] NVARCHAR(MAX) NOT NULL,
-    [Description] NVARCHAR(MAX) NOT NULL
+    [Description] NVARCHAR(MAX) NOT NULL,
 
 	CONSTRAINT OrleansQuery_Key PRIMARY KEY([QueryKey])
 );
@@ -1186,7 +1186,7 @@ VALUES
 	N'SET NOCOUNT ON;
 	SELECT
 		[Address],
-        [ProxyPort]
+        [ProxyPort],
 		[Generation]
       FROM
 		[MembershipReadAll]


### PR DESCRIPTION
Although omission of these commad do not cause a bugs,
it is nevertheless better to adhere to a stricter comma rules.