### PR TITLE
Added a manual reset event that signals to silo to shut down

### DIFF
--- a/src/Orleans/Configuration/NodeConfiguration.cs
+++ b/src/Orleans/Configuration/NodeConfiguration.cs
@@ -241,6 +241,8 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public bool UseNagleAlgorithm { get; set; }
 
+        public string SiloShutdownEventName { get; set; }
+
         internal const string DEFAULT_NODE_NAME = "default";
         private static readonly TimeSpan DEFAULT_STATS_METRICS_TABLE_WRITE_PERIOD = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan DEFAULT_STATS_PERF_COUNTERS_WRITE_PERIOD = TimeSpan.FromSeconds(30);
@@ -384,6 +386,7 @@ namespace Orleans.Runtime.Configuration
             sb.Append("      ").AppendFormat("   .NET ServicePointManager - DefaultConnectionLimit={0} Expect100Continue={1} UseNagleAlgorithm={2}", DefaultConnectionLimit, Expect100Continue, UseNagleAlgorithm).AppendLine();
             sb.Append("   Load Shedding Enabled: ").Append(LoadSheddingEnabled).AppendLine();
             sb.Append("   Load Shedding Limit: ").Append(LoadSheddingLimit).AppendLine();
+            sb.Append("   SiloShutdownEventName: ").Append(SiloShutdownEventName).AppendLine();
             sb.Append("   Debug: ").AppendLine();
             sb.Append(ConfigUtilities.TraceConfigurationToString(this));
             sb.Append(ConfigUtilities.IStatisticsConfigurationToString(this));

--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -402,6 +402,10 @@ namespace Orleans
         SetReminderServiceType          = SiloBase + 38,
         SiloStartError                  = SiloBase + 39,
         SiloConfigDeprecated            = SiloBase + 40,
+        SiloShutdownEventName           = SiloBase + 41,
+        SiloShutdownEventCreated        = SiloBase + 42,
+        SiloShutdownEventOpened         = SiloBase + 43,
+        SiloShutdownEventReceived       = SiloBase + 44,
 
         CatalogBase                     = Runtime + 500,
         CatalogNonExistingActivation1   = CatalogBase + 1,


### PR DESCRIPTION
This is needed when a silo runs as a separate process and needs to be told to gracefully shutdown.