### PR TITLE
Remove activation from the ActivationCollector early upon call to DeactivateActivationOnIdle.

### DIFF
--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -256,7 +256,7 @@ namespace Orleans.Runtime
                 GrainInstanceType = grainInstance.GetType();
 
                 // Don't ever collect system grains or reminder table grain or memory store grains.
-                bool doNotCollect = typeof(IReminderTable).IsAssignableFrom(GrainInstanceType) || typeof(IMemoryStorageGrain).IsAssignableFrom(GrainInstanceType);
+                bool doNotCollect = typeof(IReminderTableGrain).IsAssignableFrom(GrainInstanceType) || typeof(IMemoryStorageGrain).IsAssignableFrom(GrainInstanceType);
                 if (doNotCollect)
                 {
                     this.collector = null;

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -891,7 +891,7 @@ namespace Orleans.Runtime
         public Task DeactivateAllActivations()
         {
             logger.Info(ErrorCode.Catalog_DeactivateAllActivations, "DeactivateAllActivations.");
-            var activationsToShutdown = activations.Select(kv => kv.Value).ToList();
+            var activationsToShutdown = activations.Where(kv => !kv.Value.IsExemptFromCollection).Select(kv => kv.Value).ToList();
             return DeactivateActivations(activationsToShutdown);
         }
 

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -795,6 +795,7 @@ namespace Orleans.Runtime
                 {
                     // Change the ActivationData state here, since we're about to give up the lock.
                     data.PrepareForDeactivation(); // Don't accept any new messages
+                    ActivationCollector.TryCancelCollection(data);
                     if (!data.IsCurrentlyExecuting)
                     {
                         promptly = true;
@@ -843,6 +844,7 @@ namespace Orleans.Runtime
                     {
                         // Change the ActivationData state here, since we're about to give up the lock.
                         activationData.PrepareForDeactivation(); // Don't accept any new messages
+                        ActivationCollector.TryCancelCollection(activationData);
                         if (!activationData.IsCurrentlyExecuting)
                         {
                             if (destroyNow == null)


### PR DESCRIPTION
Usually, activation is removed from the `ActivationCollector` when the collector itself decides to deactivate it (based on the idle period).
But there are also the cases of `DeactivateActivationOnIdle` called by grain code itself or bulk deactivation in the shutdown scenario. In those cases we mark the activation as `ActivationState.Deactivating`, do the whole multi step deactivation process and only at the end remove this activation from the collector [here](https://github.com/dotnet/orleans/blob/master/src/OrleansRuntime/Catalog/Catalog.cs#L346). 

This could cause [this warning](https://github.com/dotnet/orleans/blob/master/src/OrleansRuntime/Catalog/ActivationCollector.cs#L246) to fire in the ActivationCollector, catching a race when the collector finds an activation which is already `Deactivating`, thus violating `ActivationCollector`'s invariant that it only holds Active activation. The race was benign and did not cause any damage (the activation was deactivated correctly and later removed from the collector), but we would still like to maintain the invariant, to be able to catch any other bugs in the future.
This fix therefore removes the activation from ActivationCollector early on, upon the call to DeactivateActivationOnIdle.

