### PR TITLE
More details diagnostics in the Scheduler.

### DIFF
--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -80,7 +80,7 @@ namespace Orleans.Runtime
 
         Task<List<IGrainReminder>> GetReminders();
 
-        Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context);
+        Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context, string activityName);
 
         void Reset();
 

--- a/src/Orleans/Runtime/ISchedulingContext.cs
+++ b/src/Orleans/Runtime/ISchedulingContext.cs
@@ -37,6 +37,7 @@ namespace Orleans.Runtime
         SchedulingContextType ContextType { get; }
         string Name { get; }
         bool IsSystemPriorityContext { get; }
+        string DetailedStatus();
     }
 
     internal static class SchedulingUtils

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -844,7 +844,7 @@ namespace Orleans
             throw new InvalidOperationException("GetSiloStatus can only be called on the silo.");
         }
 
-        public async Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context)
+        public async Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context, string activityName)
         {
             await Task.Run(asyncFunction); // No grain context on client - run on .NET thread pool
         }

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -781,7 +781,7 @@ namespace Orleans.Runtime
                  State);
         }
 
-        internal string ToDetailedString(bool inludeRunning = false)
+        internal string ToDetailedString(bool includeExtraDetails = false)
         {
             return
                 String.Format(
@@ -797,7 +797,7 @@ namespace Orleans.Runtime
                     numRunning,                     // 8 NumRunning
                     GetIdleness(DateTime.UtcNow),   // 9 IdlenessTimeSpan
                     CollectionAgeLimit,             // 10 CollectionAgeLimit
-                    (inludeRunning && Running !=null) ? " CurrentlyExecuting=" + Running : "");  // 11: Running
+                    (includeExtraDetails && Running != null) ? " CurrentlyExecuting=" + Running : "");  // 11: Running
         }
 
         public string Name

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -762,7 +762,7 @@ namespace Orleans.Runtime
                 {
                     sb.AppendFormat("   Processing message: {0}", Running);
                 }
-                
+
                 if (waiting!=null && waiting.Count > 0)
                 {
                     sb.AppendFormat("   Messages queued within ActivationData: {0}", PrintWaitingQueue());
@@ -781,11 +781,11 @@ namespace Orleans.Runtime
                  State);
         }
 
-        internal string ToDetailedString()
+        internal string ToDetailedString(bool inludeRunning = false)
         {
             return
                 String.Format(
-                    "[Activation: {0}{1}{2}{3} State={4} NonReentrancyQueueSize={5} EnqueuedOnDispatcher={6} InFlightCount={7} NumRunning={8} IdlenessTimeSpan={9} CollectionAgeLimit={10}]",
+                    "[Activation: {0}{1}{2}{3} State={4} NonReentrancyQueueSize={5} EnqueuedOnDispatcher={6} InFlightCount={7} NumRunning={8} IdlenessTimeSpan={9} CollectionAgeLimit={10}{11}]",
                     Silo.ToLongString(),
                     Grain.ToDetailedString(),
                     ActivationId,
@@ -796,7 +796,8 @@ namespace Orleans.Runtime
                     InFlightCount,                  // 7 InFlightCount
                     numRunning,                     // 8 NumRunning
                     GetIdleness(DateTime.UtcNow),   // 9 IdlenessTimeSpan
-                    CollectionAgeLimit);            // 10 CollectionAgeLimit
+                    CollectionAgeLimit,             // 10 CollectionAgeLimit
+                    (inludeRunning && Running !=null) ? " CurrentlyExecuting=" + Running : "");  // 11: Running
         }
 
         public string Name

--- a/src/OrleansRuntime/Core/GrainTimer.cs
+++ b/src/OrleansRuntime/Core/GrainTimer.cs
@@ -109,7 +109,7 @@ namespace Orleans.Runtime
                 return;
             try
             {
-                await RuntimeClient.Current.ExecAsync(() => ForwardToAsyncCallback(state), context);
+                await RuntimeClient.Current.ExecAsync(() => ForwardToAsyncCallback(state), context, Name);
             }
             catch (InvalidSchedulingContextException exc)
             {

--- a/src/OrleansRuntime/Core/InsideGrainClient.cs
+++ b/src/OrleansRuntime/Core/InsideGrainClient.cs
@@ -633,10 +633,10 @@ namespace Orleans.Runtime
             return InternalGrainFactory.GetSystemTarget<IReminderService>(Constants.ReminderServiceId, destination);
         }
 
-        public async Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context)
+        public async Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context, string activityName)
         {
             // Schedule call back to grain context
-            await OrleansTaskScheduler.Instance.QueueTask(asyncFunction, context);
+            await OrleansTaskScheduler.Instance.QueueNamedTask(asyncFunction, context, activityName);
         }
 
         public void Reset()

--- a/src/OrleansRuntime/Core/SystemTarget.cs
+++ b/src/OrleansRuntime/Core/SystemTarget.cs
@@ -32,6 +32,7 @@ namespace Orleans.Runtime
     {
         private IGrainMethodInvoker lastInvoker;
         private readonly SchedulingContext schedulingContext;
+        private Message running;
         
         protected SystemTarget(GrainId grainId, SiloAddress silo) 
             : this(grainId, silo, false)
@@ -65,11 +66,13 @@ namespace Orleans.Runtime
 
         public void HandleNewRequest(Message request)
         {
+            running = request;
             InsideRuntimeClient.Current.Invoke(this, this, request).Ignore();
         }
 
         public void HandleResponse(Message response)
         {
+            running = response;
             InsideRuntimeClient.Current.ReceiveResponse(response);
         }
 
@@ -100,6 +103,11 @@ namespace Orleans.Runtime
                  Silo,
                  GrainId,
                  ActivationId);
+        }
+
+        public string ToDetailedString()
+        {
+            return String.Format("{0} CurrentlyExecuting={1}", ToString(), running != null ? running.ToString() : "null");
         }
     }
 }

--- a/src/OrleansRuntime/Scheduler/SchedulingContext.cs
+++ b/src/OrleansRuntime/Scheduler/SchedulingContext.cs
@@ -144,7 +144,7 @@ namespace Orleans.Runtime.Scheduler
                     return String.Format("DispatcherTarget{0}", DispatcherTarget);
 
                 default:
-                    return "";
+                    return ContextType.ToString();
             }
         }
         public string DetailedStatus()
@@ -161,7 +161,7 @@ namespace Orleans.Runtime.Scheduler
                     return String.Format("DispatcherTarget{0}", DispatcherTarget);
 
                 default:
-                    return "";
+                    return ContextType.ToString();
             }
         }
 
@@ -181,7 +181,7 @@ namespace Orleans.Runtime.Scheduler
                         return String.Format("DispatcherTarget{0}", DispatcherTarget);
 
                     default:
-                        return "";
+                        return ContextType.ToString();
                 }
             }
         }

--- a/src/OrleansRuntime/Scheduler/SchedulingContext.cs
+++ b/src/OrleansRuntime/Scheduler/SchedulingContext.cs
@@ -147,6 +147,23 @@ namespace Orleans.Runtime.Scheduler
                     return "";
             }
         }
+        public string DetailedStatus()
+        {
+            switch (ContextType)
+            {
+                case SchedulingContextType.Activation:
+                    return Activation.ToDetailedString(true);
+
+                case SchedulingContextType.SystemTarget:
+                    return SystemTarget.ToDetailedString();
+
+                case SchedulingContextType.SystemThread:
+                    return String.Format("DispatcherTarget{0}", DispatcherTarget);
+
+                default:
+                    return "";
+            }
+        }
 
         public string Name 
         {

--- a/src/OrleansRuntime/Scheduler/WorkItemGroup.cs
+++ b/src/OrleansRuntime/Scheduler/WorkItemGroup.cs
@@ -32,7 +32,7 @@ using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.Scheduler
 {
-    [DebuggerDisplay("WorkItemGroup State={state} WorkItemCount={WorkItemCount} Context={SchedulingContext.Name}")]
+    [DebuggerDisplay("WorkItemGroup Name={Name} State={state}")]
     internal class WorkItemGroup : IWorkItem
     {
         private enum WorkGroupStatus
@@ -426,7 +426,7 @@ namespace Orleans.Runtime.Scheduler
 
         public override string ToString()
         {
-            return String.Format("{0}WorkItemGroup:Name={1},State={2}",
+            return String.Format("{0}WorkItemGroup:Name={1},WorkGroupStatus={2}",
                 IsSystem ? "System*" : "",
                 Name,
                 state);
@@ -440,14 +440,21 @@ namespace Orleans.Runtime.Scheduler
                 sb.Append(this);
                 sb.AppendFormat(". Currently QueuedWorkItems={0}; Total EnQueued={1}; Total processed={2}; Quantum expirations={3}; ",
                     WorkItemCount, totalItemsEnQueued, totalItemsProcessed, quantumExpirations);
-                if (AverageQueueLenght != 0)
+                Utils.SafeExecute(() =>
                 {
-                    sb.AppendFormat("average queue length at enqueue: {0}; ", AverageQueueLenght);
-                    if (!totalQueuingDelay.Equals(TimeSpan.Zero))
-                        sb.AppendFormat("average queue delay: {0}ms; ", totalQueuingDelay.Divide(totalItemsProcessed).TotalMilliseconds);
-                }
+                    if (AverageQueueLenght != 0)
+                    {
+                        sb.AppendFormat("average queue length at enqueue: {0}; ", AverageQueueLenght);
+                        if (!totalQueuingDelay.Equals(TimeSpan.Zero))
+                            sb.AppendFormat("average queue delay: {0}ms; ",
+                                totalQueuingDelay.Divide(totalItemsProcessed).TotalMilliseconds);
+                    }
+                });
                 sb.AppendFormat("TaskRunner={0}; ", TaskRunner);
-                sb.AppendFormat("SchedulingContext={0}", SchedulingContext);
+                if (SchedulingContext != null)
+                {
+                    sb.AppendFormat("Detailed SchedulingContext=<{0}>", SchedulingContext.DetailedStatus());
+                }
                 return sb.ToString();
             }
         }

--- a/src/OrleansRuntime/Scheduler/WorkItemGroup.cs
+++ b/src/OrleansRuntime/Scheduler/WorkItemGroup.cs
@@ -440,16 +440,16 @@ namespace Orleans.Runtime.Scheduler
                 sb.Append(this);
                 sb.AppendFormat(". Currently QueuedWorkItems={0}; Total EnQueued={1}; Total processed={2}; Quantum expirations={3}; ",
                     WorkItemCount, totalItemsEnQueued, totalItemsProcessed, quantumExpirations);
-                Utils.SafeExecute(() =>
+         
+                if (AverageQueueLenght != 0)
                 {
-                    if (AverageQueueLenght != 0)
+                    sb.AppendFormat("average queue length at enqueue: {0}; ", AverageQueueLenght);
+                    if (!totalQueuingDelay.Equals(TimeSpan.Zero) && totalItemsProcessed > 0)
                     {
-                        sb.AppendFormat("average queue length at enqueue: {0}; ", AverageQueueLenght);
-                        if (!totalQueuingDelay.Equals(TimeSpan.Zero))
-                            sb.AppendFormat("average queue delay: {0}ms; ",
-                                totalQueuingDelay.Divide(totalItemsProcessed).TotalMilliseconds);
+                        sb.AppendFormat("average queue delay: {0}ms; ", totalQueuingDelay.Divide(totalItemsProcessed).TotalMilliseconds);
                     }
-                });
+                }
+                
                 sb.AppendFormat("TaskRunner={0}; ", TaskRunner);
                 if (SchedulingContext != null)
                 {

--- a/src/OrleansRuntime/Scheduler/WorkerPoolThread.cs
+++ b/src/OrleansRuntime/Scheduler/WorkerPoolThread.cs
@@ -75,21 +75,38 @@ namespace Orleans.Runtime.Scheduler
             }
         }
 
-        internal string GetThreadStatus()
+        internal string GetThreadStatus(bool detailed)
         {
             // Take status snapshot before checking status, to avoid race
             Task task = currentTask;
             IWorkItem workItem = currentWorkItem;
 
-            if (task != null)
-                return string.Format("Executing Task Id={0} Status={1} for {2} on WorkItem={3} (executing work item for {4})",
-                    task.Id, task.Status, Utils.Since(currentTaskStarted), currentWorkItem, Utils.Since(currentWorkItemStarted));
+            if (task != null) 
+                return string.Format("Executing Task Id={0} Status={1} for {2} on {3}.",
+                    task.Id, task.Status, Utils.Since(currentTaskStarted), GetWorkItemStatus(detailed));
 
             if (workItem != null)
-                return string.Format("Executing Work Item {0} for {1}", workItem, Utils.Since(currentWorkItemStarted));
+                return string.Format("Executing {0}.", GetWorkItemStatus(detailed));
 
             var becomeIdle = currentWorkItemStarted < currentTaskStarted ? currentTaskStarted : currentWorkItemStarted;
             return string.Format("Idle for {0}", Utils.Since(becomeIdle));
+        }
+
+        private string GetWorkItemStatus(bool detailed)
+        {
+            IWorkItem workItem = currentWorkItem;
+            if (workItem == null) return String.Empty;
+
+            string str = string.Format("WorkItem={0} Executing for {1}. ", workItem, Utils.Since(currentWorkItemStarted));
+            if (detailed && workItem.ItemType == WorkItemType.WorkItemGroup)
+            {
+                WorkItemGroup group = workItem as WorkItemGroup;
+                if (group != null)
+                {
+                    str += string.Format("WorkItemGroup Details: {0}", group.DumpStatus());
+                }
+            }
+            return str;
         }
 
         internal readonly int WorkerThreadStatisticsNumber;
@@ -171,17 +188,16 @@ namespace Orleans.Runtime.Scheduler
                             try
                             {
                                 RuntimeContext.SetExecutionContext(todo.SchedulingContext, scheduler);
+                                CurrentWorkItem = todo;
+#if TRACK_DETAILED_STATS
                                 if (todo.ItemType != WorkItemType.WorkItemGroup)
                                 {
-                                    // for WorkItemGroup we will track CurrentWorkItem inside WorkItemGroup. 
-                                    CurrentWorkItem = todo;
-#if TRACK_DETAILED_STATS
                                     if (StatisticsCollector.CollectTurnsStats)
                                     {
                                         SchedulerStatisticsGroup.OnThreadStartsTurnExecution(WorkerThreadStatisticsNumber, todo.SchedulingContext);
                                     }
-#endif
                                 }
+#endif
                                 todo.Execute();
                             }
                             catch (ThreadAbortException ex)
@@ -320,7 +336,7 @@ namespace Orleans.Runtime.Scheduler
             return String.Format("<{0}, ManagedThreadId={1}, {2}>",
                 Name,
                 ManagedThreadId,
-                GetThreadStatus());
+                GetThreadStatus(false));
         }
 
         internal void CheckForLongTurns()
@@ -340,7 +356,7 @@ namespace Orleans.Runtime.Scheduler
             // only create a new thread once per slow thread!
             Log.Warn(ErrorCode.SchedulerTurnTooLong2, string.Format(
                 "Worker pool thread {0} (ManagedThreadId={1}) has been busy for long time: {2}; creating a new worker thread",
-                Name, ManagedThreadId, GetThreadStatus()));
+                Name, ManagedThreadId, GetThreadStatus(true)));
             Cts.Cancel();
             pool.CreateNewThread();
             // Consider: mark the activation running a long turn to reduce it's time quantum
@@ -352,7 +368,7 @@ namespace Orleans.Runtime.Scheduler
 
             Log.Error(ErrorCode.SchedulerTurnTooLong, string.Format(
                 "Worker pool thread {0} (ManagedThreadId={1}) has been busy for long time: {2}",
-                Name, ManagedThreadId, GetThreadStatus()));
+                Name, ManagedThreadId, GetThreadStatus(true)));
             return false;
         }
 

--- a/src/OrleansRuntime/Scheduler/WorkerPoolThread.cs
+++ b/src/OrleansRuntime/Scheduler/WorkerPoolThread.cs
@@ -377,12 +377,10 @@ namespace Orleans.Runtime.Scheduler
             if (CurrentTask != null)
             {
                 return Utils.Since(currentTaskStarted) > OrleansTaskScheduler.TurnWarningLengthThreshold;
-            }else
-            {
-                // If there is no active Task, check current wokr item, if any.
-                bool frozenWorkItem = CurrentWorkItem != null && Utils.Since(currentWorkItemStarted) > OrleansTaskScheduler.TurnWarningLengthThreshold;
-                return frozenWorkItem;
-            }
+            } 
+            // If there is no active Task, check current wokr item, if any.
+            bool frozenWorkItem = CurrentWorkItem != null && Utils.Since(currentWorkItemStarted) > OrleansTaskScheduler.TurnWarningLengthThreshold;
+            return frozenWorkItem;
         }
     }
 }


### PR DESCRIPTION
Capture correctly executing work item for all workitem in the worker thread (used to capture only non work item groups).
Print more details of `WorkItemGroup` status (`DumpStatus()`), available via `SchedulingContext.DetailedStatus()`:
* for activation data: detailed status report, including currently executing request.
* for system target: detailed status report, including currently executing request.
* for timers: timer name (needed to pipe timer name via scheduler to `ClosureWorkItem`).