### PR TITLE
Add broken test for grain method task cancellation.

### DIFF
--- a/src/TestGrainInterfaces/IExceptionGrain.cs
+++ b/src/TestGrainInterfaces/IExceptionGrain.cs
@@ -1,0 +1,18 @@
+namespace UnitTests.GrainInterfaces
+{
+    using System.Threading.Tasks;
+
+    using Orleans;
+
+    /// <summary>
+    /// The ExceptionGrain interface.
+    /// </summary>
+    public interface IExceptionGrain : IGrainWithIntegerKey
+    {
+        /// <summary>
+        /// Returns a canceled <see cref="Task"/>.
+        /// </summary>
+        /// <returns>A canceled <see cref="Task"/>.</returns>
+        Task Cancelled();
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IExceptionGrain.cs" />
     <Compile Include="IFaultableConsumerGrain.cs" />
     <Compile Include="IJournaledPersonGrain.cs" />
     <Compile Include="IGenericInterfaces.cs" />

--- a/src/TestGrains/ExceptionGrain.cs
+++ b/src/TestGrains/ExceptionGrain.cs
@@ -1,0 +1,22 @@
+namespace UnitTests.Grains
+{
+    using System.Threading.Tasks;
+
+    using Orleans;
+
+    using UnitTests.GrainInterfaces;
+
+    public class ExceptionGrain : Grain, IExceptionGrain
+    {
+        /// <summary>
+        /// Returns a canceled <see cref="Task"/>.
+        /// </summary>
+        /// <returns>A canceled <see cref="Task"/>.</returns>
+        public Task Cancelled()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            tcs.TrySetCanceled();
+            return tcs.Task;
+        }
+    }
+}

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExceptionGrain.cs" />
     <Compile Include="FaultableConsumerGrain.cs" />
     <Compile Include="EventSourcing\PersonState.cs" />
     <Compile Include="GenericGrains.cs" />

--- a/src/Tester/ExceptionPropagationTests.cs
+++ b/src/Tester/ExceptionPropagationTests.cs
@@ -54,6 +54,7 @@ namespace UnitTests.General
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
+        [ExpectedException(typeof(Exception), AllowDerivedTypes = true)]
         public async Task TaskCancelationPropagation()
         {
             IExceptionGrain grain = this.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());

--- a/src/Tester/ExceptionPropagationTests.cs
+++ b/src/Tester/ExceptionPropagationTests.cs
@@ -1,0 +1,77 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans.TestingHost;
+using UnitTests.GrainInterfaces;
+using UnitTests.Tester;
+
+namespace UnitTests.General
+{
+    using System;
+
+    /// <summary>
+    /// Tests that exceptions are correctly propagated.
+    /// </summary>
+    [TestClass]
+    public class ExceptionPropagationTests : UnitTestSiloHost
+    {
+        public ExceptionPropagationTests()
+            : base(new TestingSiloOptions { StartPrimary = true, StartSecondary = false })
+        {
+        }
+
+        private static int GetRandomGrainId()
+        {
+            return random.Next();
+        }
+
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task TaskCancelationPropagation()
+        {
+            IExceptionGrain grain = this.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
+            var actualException = default(Exception);
+            try
+            {
+                await grain.Cancelled();
+            }
+            catch (Exception exception)
+            {
+                actualException = exception;
+            }
+
+            Assert.IsNotNull(actualException, "Expected grain call to throw a cancellation exception.");
+            Assert.IsTrue(actualException is AggregateException);
+            Assert.AreEqual(
+                typeof(TaskCanceledException),
+                ((AggregateException)actualException).InnerException.GetType());
+        }
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -103,6 +103,7 @@
     <Compile Include="SerializationTests.cs" />
     <Compile Include="RelationalUtilities\SqlTestsEnvironment.cs" />
     <Compile Include="DependencyInjectionGrainTests.cs" />
+    <Compile Include="ExceptionPropagationTests.cs" />
     <Compile Include="StatelessWorkerTests.cs" />
     <Compile Include="StreamingTests\AQSubscriptionMultiplicityTests.cs" />
     <Compile Include="StreamingTests\DeactivationTestRunner.cs" />


### PR DESCRIPTION
This tests that task cancellations are correctly propagated from grain methods to the caller.
Issue open in #847.