### PR TITLE
PubSubRendezvousGrain: always execute AddSubscriber continuation

### DIFF
--- a/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -230,7 +230,7 @@ namespace Orleans.Streams
                                     throw exc;
                                 }
                             }
-                        }, TaskContinuationOptions.OnlyOnFaulted);
+                        }, TaskContinuationOptions.ExecuteSynchronously);
                     tasks.Add(addSubscriberPromise);
                 }
 


### PR DESCRIPTION
`PubSubRendezvousGrain`'s continuation of `AddSubscriber` will be cancelled in the success case, which causes an exception when it is awaited below. This is not affecting tests currently because of #847.

This PR removes the `OnlyOnFaulted` condition from that continuation and adds `ExecuteSynchronously` for good measure.