### PR TITLE
QueueCacheMissException #844 Fix

### DIFF
--- a/src/OrleansProviders/Streams/Common/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleQueueCache.cs
@@ -162,11 +162,11 @@ namespace Orleans.Providers.Streams.Common
             }
 
             var cursor = new SimpleQueueCacheCursor(this, streamGuid, streamNamespace, logger);
-            InitializeCursor(cursor, token);
+            InitializeCursor(cursor, token, true);
             return cursor;
         }
 
-        internal void InitializeCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken sequenceToken, bool bestEffort = false)
+        internal void InitializeCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken sequenceToken, bool enforceSequenceToken)
         {
             Log(logger, "InitializeCursor: {0} to sequenceToken {1}", cursor, sequenceToken);
            
@@ -195,7 +195,7 @@ namespace Orleans.Providers.Streams.Common
             // Check to see if offset is too old to be in cache
             if (sequenceToken.Older(lastMessage.Value.SequenceToken))
             {
-                if (!bestEffort)
+                if (enforceSequenceToken)
                 {
                     // throw cache miss exception
                     throw new QueueCacheMissException(sequenceToken, cachedMessages.Last.Value.SequenceToken, cachedMessages.First.Value.SequenceToken);
@@ -242,7 +242,7 @@ namespace Orleans.Providers.Streams.Common
             //if not set, try to set and then get next
             if (!cursor.IsSet)
             {
-                InitializeCursor(cursor, cursor.SequenceToken, true);
+                InitializeCursor(cursor, cursor.SequenceToken, false);
                 return cursor.IsSet && TryGetNextMessage(cursor, out batch);
             }
 

--- a/src/OrleansProviders/Streams/Common/SimpleQueueCacheCursor.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleQueueCacheCursor.cs
@@ -101,7 +101,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (!IsSet)
             {
-                cache.InitializeCursor(this, SequenceToken);
+                cache.InitializeCursor(this, SequenceToken, true);
             }
         }
 

--- a/src/OrleansProviders/Streams/Common/SimpleQueueCacheCursor.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleQueueCacheCursor.cs
@@ -101,7 +101,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (!IsSet)
             {
-                cache.InitializeCursor(this, SequenceToken, true);
+                cache.InitializeCursor(this, SequenceToken, false);
             }
         }
 

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -461,13 +461,17 @@ namespace Orleans.Streams
                     consumerData.Cursor == null) return;
                 
                 consumerData.State = StreamConsumerDataState.Active;
-                while (consumerData.Cursor != null && consumerData.Cursor.MoveNext())
+                while (consumerData.Cursor != null)
                 {
                     IBatchContainer batch = null;
                     Exception exceptionOccured = null;
                     try
                     {
                         Exception ignore;
+                        if (!consumerData.Cursor.MoveNext())
+                        {
+                            break;
+                        }
                         batch = consumerData.Cursor.GetCurrent(out ignore);
                     }
                     catch (Exception exc)

--- a/src/TestGrainInterfaces/IMultipleSubscriptionConsumerGrain.cs
+++ b/src/TestGrainInterfaces/IMultipleSubscriptionConsumerGrain.cs
@@ -39,7 +39,7 @@ namespace UnitTests.GrainInterfaces
 
         Task<IList<StreamSubscriptionHandle<int>>> GetAllSubscriptions(Guid streamId, string streamNamespace, string providerToUse);
 
-        Task<Dictionary<StreamSubscriptionHandle<int>, int>> GetNumberConsumed();
+        Task<Dictionary<StreamSubscriptionHandle<int>, Tuple<int,int>>> GetNumberConsumed();
 
         Task ClearNumberConsumed();
 

--- a/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
@@ -106,5 +106,13 @@ namespace UnitTests.StreamingTests
             logger.Info("************************ AQActiveSubscriptionTest *********************************");
             await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
+        public async Task AQTwoIntermitentStreamTest()
+        {
+            logger.Info("************************ AQTwoIntermitentStreamTest *********************************");
+            await runner.TwoIntermitentStreamTest(Guid.NewGuid());
+        }
+        
     }
 }


### PR DESCRIPTION
The cache cursor for the first stream is becoming inactive while there is data still being delivered on the second stream. Since data is being delivered on the second stream the cache is moving forward in time and when we try to refresh the cache cursor for the first stream, it is older than any of the data in the cache, so it throws a cache miss.

When we refresh a cursor, if it's token is no longer in the cache, we start from the oldest data in the cache.