### PR TITLE
Fixed a bug in  ByteArrayBuilder about setting initial offset to -1 instead of 0.

### DIFF
--- a/src/Orleans/Messaging/ByteArrayBuilder.cs
+++ b/src/Orleans/Messaging/ByteArrayBuilder.cs
@@ -65,7 +65,7 @@ namespace Orleans.Runtime
             pool = bufferPool;
             bufferSize = bufferPool.Size;
             completedBuffers = new List<ArraySegment<byte>>();
-            currentOffset = -1;
+            currentOffset = 0;
             completedLength = 0;
             currentBuffer = null;
         }
@@ -74,7 +74,7 @@ namespace Orleans.Runtime
         {
             pool.Release(ToBytes());
             currentBuffer = null;
-            currentOffset = -1;
+            currentOffset = 0;
         }
 
         public List<ArraySegment<byte>> ToBytes()

--- a/src/OrleansTestingHost/TestingUtils.cs
+++ b/src/OrleansTestingHost/TestingUtils.cs
@@ -22,7 +22,10 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
+using System.IO;
 using System.Net;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -96,6 +99,16 @@ namespace Orleans.TestingHost
             // We did not complete before the timeout, we fire and forget to ensure we observe any exceptions that may occur
             taskToComplete.Ignore();
             throw new TimeoutException(message);
+        }
+
+        public static T RoundTripDotNetSerializer<T>(T input)
+        {
+            IFormatter formatter = new BinaryFormatter();
+            MemoryStream stream = new MemoryStream(new byte[100000], true);
+            formatter.Serialize(stream, input);
+            stream.Position = 0;
+            T output = (T)formatter.Deserialize(stream);
+            return output;
         }
     }
 }

--- a/src/Tester/SerializationTests.cs
+++ b/src/Tester/SerializationTests.cs
@@ -31,6 +31,8 @@ using Orleans.CodeGeneration;
 using Orleans.Serialization;
 using UnitTests.GrainInterfaces;
 using System.Collections.Generic;
+using Orleans.TestingHost;
+using System.Runtime.Serialization;
 
 namespace UnitTests.General
 {
@@ -108,7 +110,8 @@ namespace UnitTests.General
             Assert.AreEqual(inputUnspecified.DateTime.Kind, outputUnspecified.DateTime.Kind);
         }
 
-        class TestTypeA
+        [Serializable]
+        internal class TestTypeA
         {
             public ICollection<TestTypeA> Collection { get; set; }
         }
@@ -150,15 +153,17 @@ namespace UnitTests.General
             }
         }
 
-		[Ignore]
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [ExpectedException(typeof(SerializationException))]
         public void SerializationTests_RecursiveSerialization()
         {
             TestTypeA input = new TestTypeA();
             input.Collection = new HashSet<TestTypeA>();
             input.Collection.Add(input);
 
-            TestTypeA output = SerializationManager.RoundTripSerializationForTesting(input);
+            TestTypeA output1 = TestingUtils.RoundTripDotNetSerializer(input);
+
+            TestTypeA output2 = SerializationManager.RoundTripSerializationForTesting(input);
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]

--- a/src/TesterInternal/General/Identifiertests.cs
+++ b/src/TesterInternal/General/Identifiertests.cs
@@ -32,6 +32,7 @@ using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using Orleans.TestingHost;
 
 namespace UnitTests.General
 {
@@ -522,10 +523,10 @@ namespace UnitTests.General
             GrainReference roundTripped = RoundTripGrainReferenceToKey(grainRef);
             Assert.AreEqual(grainRef, roundTripped, "GrainReference.ToKeyString");
 
-            roundTripped = RoundTripGrainReferenceOrleansSerializer(grainRef);
+            roundTripped = SerializationManager.RoundTripSerializationForTesting(grainRef);
             Assert.AreEqual(grainRef, roundTripped, "GrainReference.OrleansSerializer");
 
-            roundTripped = RoundTripGrainReferenceDotNetSerializer(grainRef);
+            roundTripped = TestingUtils.RoundTripDotNetSerializer(grainRef);
             Assert.AreEqual(grainRef, roundTripped, "GrainReference.DotNetSerializer");
         }
 
@@ -533,25 +534,6 @@ namespace UnitTests.General
         {
             string str = input.ToKeyString();
             GrainReference output = GrainReference.FromKeyString(str);
-            return output;
-        }
-
-        private GrainReference RoundTripGrainReferenceOrleansSerializer(GrainReference input)
-        {
-            BinaryTokenStreamWriter writer = new BinaryTokenStreamWriter();
-            GrainReference.SerializeGrainReference(input, writer, typeof(GrainReference));
-            BinaryTokenStreamReader reader = new BinaryTokenStreamReader(writer.ToBytes());
-            GrainReference output = (GrainReference)GrainReference.DeserializeGrainReference(typeof(GrainReference), reader);
-            return output;
-        }
-
-        private GrainReference RoundTripGrainReferenceDotNetSerializer(GrainReference input)
-        {
-            IFormatter formatter = new BinaryFormatter();
-            MemoryStream stream = new MemoryStream(new byte[1000], true);
-            formatter.Serialize(stream, input);
-            stream.Position = 0;
-            GrainReference output = (GrainReference)formatter.Deserialize(stream);
             return output;
         }
     }

--- a/src/TesterInternal/OrleansRuntime/ExceptionsTests.cs
+++ b/src/TesterInternal/OrleansRuntime/ExceptionsTests.cs
@@ -28,6 +28,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using Orleans.TestingHost;
 
 namespace UnitTests.OrleansRuntime
 {
@@ -47,7 +48,7 @@ namespace UnitTests.OrleansRuntime
             SiloAddress primaryDirectoryForGrain = SiloAddress.NewLocalAddress(6789);
            
             Catalog.DuplicateActivationException original = new Catalog.DuplicateActivationException(activationAddress, primaryDirectoryForGrain);
-            Catalog.DuplicateActivationException output = RoundTripDotNetSerializer(original);
+            Catalog.DuplicateActivationException output = TestingUtils.RoundTripDotNetSerializer(original);
 
             Assert.AreEqual(original.Message, output.Message);
             Assert.AreEqual(original.ActivationToUse, output.ActivationToUse);
@@ -66,16 +67,6 @@ namespace UnitTests.OrleansRuntime
             Assert.AreEqual(original.Message, output.Message);
             Assert.AreEqual(original.ActivationToUse, output.ActivationToUse);
             Assert.AreEqual(original.PrimaryDirectoryForGrain, output.PrimaryDirectoryForGrain);
-        }
-
-        private static T RoundTripDotNetSerializer<T>(T input)
-        {
-            IFormatter formatter = new BinaryFormatter();
-            MemoryStream stream = new MemoryStream(new byte[10000], true);
-            formatter.Serialize(stream, input);
-            stream.Position = 0;
-            T output = (T)formatter.Deserialize(stream);
-            return output;
         }
     }
 }


### PR DESCRIPTION
Issue https://github.com/dotnet/orleans/pull/843 exposed 2 bugs in the serializer related to cyclic data structures (data structure that has a cycle of references).
This PR fixes the first, minor bug: `ByteArrayBuilder`  used to [initialize currentOffset to -1] (https://github.com/dotnet/orleans/blob/master/src/Orleans/Messaging/ByteArrayBuilder.cs#L68), which caused the [`ByteArrayBuilder.Leght`](https://github.com/dotnet/orleans/blob/master/src/Orleans/Messaging/ByteArrayBuilder.cs#L120) property to be -1 as the the first object used in the [`SerializationContext.RecordObject`](https://github.com/dotnet/orleans/blob/master/src/Orleans/Serialization/SerializationContext.cs#L119).

As a result, the wrong offset (-1) was recorded when serializing cyclic data structure into a byte array.

This PR also moves some test helper function into `TestUtils`.