### PR TITLE
Optimized ContinueWith by using TaskContinuationOptions.ExecuteSynchronously in critical places.

### DIFF
--- a/src/Orleans/Async/TaskExtensions.cs
+++ b/src/Orleans/Async/TaskExtensions.cs
@@ -216,7 +216,7 @@ namespace Orleans
                     {
                         resolver.TrySetResult(t.Result);
                     }
-                });
+                }, TaskContinuationOptions.ExecuteSynchronously);
             }
             return resolver.Task;
         }

--- a/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
+++ b/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
@@ -69,7 +69,7 @@ namespace Orleans.Runtime.Scheduler
                     // Note: This runs for all outcomes of resultPromiseTask - both Success or Fault
                     activation.DecrementInFlightCount();
                     InsideRuntimeClient.Current.Dispatcher.OnActivationCompletedRequest(activation, message);
-                }).Ignore();
+                }, TaskContinuationOptions.ExecuteSynchronously).Ignore();
             }
             catch (Exception exc)
             {


### PR DESCRIPTION
Added 2 places to execute ContinueWith with TaskContinuationOptions.ExecuteSynchronously, following @ReubenBond advise in https://github.com/dotnet/orleans/issues/831#issuecomment-142753723.
This is expected to optimize performance, since each of those places is called once for every request (once on the silo and once on the client), and should have no semantics or correctness impact.

This PR does NOT fix neither #831 nor #847.
