### PR TITLE
Exposed the SequenceNumber in the EventSequenceToken

### DIFF
--- a/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
@@ -51,6 +51,11 @@ namespace Orleans.Providers.Streams.Common
             return new EventSequenceToken(sequenceNumber + 1, eventIndex);
         }
 
+        public long GetSequenceNumber()
+        {
+            return sequenceNumber;
+        }
+
         public EventSequenceToken CreateSequenceTokenForEvent(int eventInd)
         {
             return new EventSequenceToken(sequenceNumber, eventInd);


### PR DESCRIPTION
We need this is well to implement our custom cache for our PersistentStreamProvider.