### PR TITLE
Stream event delivery data loss bug fix.

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -115,6 +115,7 @@
     <Compile Include="IDs\UniqueKey.cs" />
     <Compile Include="Core\IGrainFactory.cs" />
     <Compile Include="Runtime\IGrainRuntime.cs" />
+    <Compile Include="Streams\Internal\StreamDeliveryStartSequenceToken.cs" />
     <Compile Include="Streams\PersistentStreams\IDeploymentConfiguration.cs" />
     <Compile Include="Streams\PersistentStreams\NoOpStreamFailureHandler.cs" />
     <Compile Include="Streams\PersistentStreams\IStreamFailureHandler.cs" />

--- a/src/Orleans/Streams/Internal/StreamDeliveryStartSequenceToken.cs
+++ b/src/Orleans/Streams/Internal/StreamDeliveryStartSequenceToken.cs
@@ -1,0 +1,71 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+
+namespace Orleans.Streams.Internal
+{
+    [Serializable]
+    internal class StreamDeliveryStartSequenceToken : StreamSequenceToken
+    {
+        public StreamSequenceToken Token { get; private set; }
+
+        public StreamDeliveryStartSequenceToken(StreamSequenceToken token)
+        {
+            Token = token;
+        }
+
+        public override bool Equals(StreamSequenceToken other)
+        {
+            var token = other as StreamDeliveryStartSequenceToken;
+            if (token == null)
+                return false;
+
+            if (Token == null)
+                return token.Token == null;
+
+            return Token.Equals(token.Token);
+        }
+
+        public override int CompareTo(StreamSequenceToken other)
+        {
+            if (other == null)
+                return 1;
+
+            var token = other as StreamDeliveryStartSequenceToken;
+            if (token == null)
+                throw new ArgumentOutOfRangeException("other");
+
+            if (Token == null)
+                return token.Token == null ? 0: -1;
+
+            return Token.CompareTo(token.Token);
+        }
+
+        public static StreamSequenceToken GetToken(StreamSequenceToken token)
+        {
+            var deliveryStart = token as StreamDeliveryStartSequenceToken;
+            return (deliveryStart != null) ? deliveryStart.Token : token;
+        }
+    }
+}

--- a/src/Orleans/Streams/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamSubscriptionHandleImpl.cs
@@ -24,6 +24,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System;
 using System.Threading.Tasks;
 using Orleans.Runtime;
+using Orleans.Streams.Internal;
 
 namespace Orleans.Streams
 {
@@ -60,7 +61,7 @@ namespace Orleans.Streams
             this.observer = observer;
             this.streamImpl = streamImpl;
             this.filterWrapper = filterWrapper;
-            expectedToken = token;
+            expectedToken = token != null ? new StreamDeliveryStartSequenceToken(token) : null;
         }
 
         public void Invalidate()
@@ -99,13 +100,6 @@ namespace Orleans.Streams
                 await NextItem(itemTuple.Item1, itemTuple.Item2);
             }
 
-            // check again, in case the expectedToken was changed indiretly via ResumeAsync()
-            if (expectedToken != null)
-            {
-                if (!expectedToken.Equals(handshakeToken))
-                    return expectedToken;
-            }
-
             expectedToken = batch.SequenceToken;
 
             return null;
@@ -120,13 +114,6 @@ namespace Orleans.Streams
             }
 
             await NextItem(item, currentToken);
-
-            // check again, in case the expectedToken was changed indiretly via ResumeAsync()
-            if (expectedToken != null)
-            {
-                if (!expectedToken.Equals(handshakeToken))
-                    return expectedToken;
-            }
 
             expectedToken = currentToken;
 

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -28,6 +28,7 @@ using System.Threading.Tasks;
 
 using Orleans.Runtime;
 using Orleans.Concurrency;
+using Orleans.Streams.Internal;
 
 namespace Orleans.Streams
 {
@@ -270,7 +271,7 @@ namespace Orleans.Streams
                     if (requestedToken != null)
                     {
                         consumerData.SafeDisposeCursor(logger);
-                        consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId.Guid, consumerData.StreamId.Namespace, requestedToken);
+                        consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId.Guid, consumerData.StreamId.Namespace, StreamDeliveryStartSequenceToken.GetToken(requestedToken));
                     }
                     else
                     {
@@ -555,7 +556,7 @@ namespace Orleans.Streams
             {
                 consumerData.LastToken = newToken;
                 consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId.Guid,
-                    consumerData.StreamId.Namespace, newToken);
+                    consumerData.StreamId.Namespace, StreamDeliveryStartSequenceToken.GetToken(newToken));
             }
             else
             {


### PR DESCRIPTION
Since the handshakeToken is used as both the stream start token and the last event delivered token, the first and second events delivered in the stream will have the same handshakeToken.  If an exception is thrown during the second event delivery, and the grain rewinds the stream to the start token, the rewind will not be detected, because there is no difference in the handshake token. This scenario may lead to data loss.

Scenario elaboration:
Stream with events with sequence token ...3,4,5,6,...
1) Grain subscribes at sequence token 4.  Handshake 4
2) Grain stores sequence token 4 in case of error.
3) Agent publishes stream
    - Gets sequence token 4 from grain, and starts delivering events starting at sequence token 4.
4) First event delivered is event at sequence 4, with handshake 4
    -  Handshake passes (4=4), event processing succeeds, and handshake is set to 4.
5) Next event delivered is event at sequence 5, with handshake 4
    -  Handshake passes (4=4), processing event throws and error, and grain is deactivated.
6) Agent retries delivery of event at sequence 5, with handshake 4.
    - Grain activates, and resumes at sequence 4, handshake 4
    -  Handshake passes (4=4), event processing succeeds, and handshake is set to 5.
***** Data loss, since event at 4 was never processed by recovered grain.  Expected behavior is for the stream to redeliver event at sequence token 4.

To address this, we decorate the stream sequence token passed into the subscribe (or resume) with a StreamStartDeliveryToken to distinguish it from normal delivery tokens.  This token decoration is represented with StartToken(t) in the scenario below.

New Scenario elaboration:
Stream with events with sequence token ...,3,4,5,6,...
1) Grain subscribes at sequence token 4.  Handshake StartToken(4)
2) Grain stores sequence token 4 in case of error.
3) Agent publishes stream
    - Gets sequence token StartToken(4) from grain, and starts delivering events starting at sequence token 4.
4) First event delivered is event at sequence 4, with handshake StartToken(4)
    -  Handshake passes ((StartToken(4) = StartToken(4)), event processing succeeds, and handshake is set to 4.
5) Next event delivered is event at sequence 5, with handshake 4
    -  Handshake passes (4=4), processing event throws and error, and grain is deactivated.
6) Agent retries delivery of event at sequence 5, with handshake 4.
    - Grain activates, and resumes at sequence 4.  Handshake StartToken(4)
    - Handshake fails (4 != StartToken(4)), and StartToken(4) is returned to agent to reset stream delivery.
7) Agent resets cursor to start delivering events at 4, with handshake  StartToken(4)
8) Event delivered is event at sequence 4, with handshake StartToken(4)
    -  Handshake passes ((StartToken(4) = StartToken(4)), event processing succeeds, and handshake is set to 4.
9) Next event delivered is event at sequence 5, with handshake 4
    -  Handshake passes (4=4), event processing succeeds, and handshake is set to 5.
***** No data loss, since event at 4 was reprocessed by recovered grain.