### PR TITLE
 Fixed AzureSilo config null reference exception

### DIFF
--- a/src/OrleansAzureUtils/Hosting/AzureSilo.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureSilo.cs
@@ -173,8 +173,8 @@ namespace Orleans.Runtime.Host
 
             // Always use Azure table for membership when running silo in Azure
             host.SetSiloLivenessType(GlobalConfiguration.LivenessProviderType.AzureTable);
-            if (config.Globals.ReminderServiceType == GlobalConfiguration.ReminderServiceProviderType.NotSpecified ||
-                config.Globals.ReminderServiceType == GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain)
+            if (host.Config.Globals.ReminderServiceType == GlobalConfiguration.ReminderServiceProviderType.NotSpecified ||
+                host.Config.Globals.ReminderServiceType == GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain)
             {
                 host.SetReminderServiceType(GlobalConfiguration.ReminderServiceProviderType.AzureTable);
             }


### PR DESCRIPTION
Host.Config is always loaded and is safe to use, config isnt safe in case using AzureSilo Start() method.