### PR TITLE
Avoid unnecessary use of TCS

### DIFF
--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -354,7 +354,6 @@ namespace Orleans.Runtime
                 return Task.FromResult(default(T));
             }
 
-            resultTask = OrleansTaskExtentions.ConvertTaskViaTcs(resultTask);
             return resultTask.Unbox<T>();
         }
 

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -388,7 +388,7 @@ namespace Orleans.Runtime
 
             bool isOneWayCall = ((options & InvokeMethodOptions.OneWay) != 0);
 
-            var resolver = isOneWayCall ? null : new TaskCompletionSource<object>();
+            var resolver = isOneWayCall ? null : new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             this.RuntimeClient.SendRequest(this, request, resolver, this.responseCallbackDelegate, debugContext, options, genericArguments);
             return isOneWayCall ? null : resolver.Task;
         }

--- a/test/DefaultCluster.Tests/SimpleGrainTests.cs
+++ b/test/DefaultCluster.Tests/SimpleGrainTests.cs
@@ -43,6 +43,19 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public void SimpleGrainControlFlow_Blocking()
+        {
+            ISimpleGrain grain = GetSimpleGrain();
+
+            // explicitly use .Wait() and .Result to make sure the client does not deadlock in these cases.
+            grain.SetA(2).Wait();
+            grain.SetB(3).Wait();
+
+            var result = grain.GetAxB().Result;
+            Assert.Equal(6, result);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
         public async Task SimpleGrainDataFlow()
         {
             ISimpleGrain grain = GetSimpleGrain();


### PR DESCRIPTION
Removes the unnecessary wrapping of a `TaskCompletionSource` into another `TaskCompletionSource`.

For some reason 1 test (`Generic_SimpleGrainControlFlow`) started deadlocking after the change (and ending in a `TimeoutException` after 30 seconds). The test was doing the wrong thing in the first place (blocking on `.Result`), nevertheless because the `OutsideRuntimeClient` executes the response callbacks in the same thread as where it is doing the message pump, then the `.Result` resulted in the message pump not running. I'm not sure why this was not the case before the change, so I'm worried that this could have breaking changes for people that were also doing blocking waits (albeit wrong).
This could be fixed by executing the callback inside a `Task.Run()` call, but that could bring bad perf implications for the people writing the code correctly and not blocking (although not sure if this path only occurs in unit tests or in an actual Orleans client, as that could be dangerous too if you are for example doing CPU intensive operations with the response, such as deserializing complex objects).

This PR is mainly a talking point, but it would be fine not to commit to master if the deadlocking I started seeing before my 2nd commit is a valid concern.
