### PR TITLE
Fixed a bug in ByteArrayBuilder about setting initial offset to -1 instead of 0

### DIFF
--- a/src/Orleans/Messaging/ByteArrayBuilder.cs
+++ b/src/Orleans/Messaging/ByteArrayBuilder.cs
@@ -65,7 +65,7 @@ namespace Orleans.Runtime
             pool = bufferPool;
             bufferSize = bufferPool.Size;
             completedBuffers = new List<ArraySegment<byte>>();
-            currentOffset = -1;
+            currentOffset = 0;
             completedLength = 0;
             currentBuffer = null;
         }
@@ -74,7 +74,7 @@ namespace Orleans.Runtime
         {
             pool.Release(ToBytes());
             currentBuffer = null;
-            currentOffset = -1;
+            currentOffset = 0;
         }
 
         public List<ArraySegment<byte>> ToBytes()


### PR DESCRIPTION
Issue https://github.com/dotnet/orleans/pull/843 exposed 2 bugs in the serializer related to cyclic data structures (data structure that has a cycle of references).
This PR fixes the first, minor bug: `ByteArrayBuilder`  used to [initialize currentOffset to -1] (https://github.com/dotnet/orleans/blob/master/src/Orleans/Messaging/ByteArrayBuilder.cs#L68), which caused the [`ByteArrayBuilder.Leght`](https://github.com/dotnet/orleans/blob/master/src/Orleans/Messaging/ByteArrayBuilder.cs#L120) property to be -1 as the the first object used in the [`SerializationContext.RecordObject`](https://github.com/dotnet/orleans/blob/master/src/Orleans/Serialization/SerializationContext.cs#L119).

As a result, the wrong offset (-1) was recorded when serializing cyclic data structure into a byte array.

This PR also moves some test helper function into `TestUtils`.