### PR TITLE
Fix bug with creation of duplicate filter

### DIFF
--- a/src/Orleans/Streams/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans/Streams/PubSub/ImplicitStreamPubSub.cs
@@ -51,7 +51,7 @@ namespace Orleans.Streams
             foreach (var kvp in implicitSubscriptions)
             {
                 GuidId subscriptionId = GuidId.GetGuidId(kvp.Key);
-                result.Add(new PubSubSubscriptionState(subscriptionId, streamId, kvp.Value, null));
+                result.Add(new PubSubSubscriptionState(subscriptionId, streamId, kvp.Value));
             }
             return Task.FromResult(result);
         }

--- a/src/Orleans/Streams/PubSub/PubSubSubscriptionState.cs
+++ b/src/Orleans/Streams/PubSub/PubSubSubscriptionState.cs
@@ -52,13 +52,11 @@ namespace Orleans.Streams
         public PubSubSubscriptionState(
             GuidId subscriptionId,
             StreamId streamId,
-            IStreamConsumerExtension streamConsumer,
-            IStreamFilterPredicateWrapper filterWrapper)
+            IStreamConsumerExtension streamConsumer)
         {
             SubscriptionId = subscriptionId;
             Stream = streamId;
             consumerReference = streamConsumer as GrainReference;
-            this.filterWrapper = filterWrapper;
             state = SubscriptionStates.Active;
         }
 

--- a/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -166,7 +166,7 @@ namespace Orleans.Streams
             PubSubSubscriptionState pubSubState = State.Consumers.FirstOrDefault(s => s.Equals(subscriptionId));
             if (pubSubState == null)
             {
-                pubSubState = new PubSubSubscriptionState(subscriptionId, streamId, streamConsumer, null);
+                pubSubState = new PubSubSubscriptionState(subscriptionId, streamId, streamConsumer);
                 State.Consumers.Add(pubSubState);
             }
 

--- a/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -166,7 +166,7 @@ namespace Orleans.Streams
             PubSubSubscriptionState pubSubState = State.Consumers.FirstOrDefault(s => s.Equals(subscriptionId));
             if (pubSubState == null)
             {
-                pubSubState = new PubSubSubscriptionState(subscriptionId, streamId, streamConsumer, filter);
+                pubSubState = new PubSubSubscriptionState(subscriptionId, streamId, streamConsumer, null);
                 State.Consumers.Add(pubSubState);
             }
 


### PR DESCRIPTION
The filter is passed to ctor and then added again by calling `AddFilter(filter)` few lines later. The logic inside `AddFilter()` happily creates `OrFilter` which now contains exact same filters, leading to filter called twice,