### PR TITLE
Revert "Replaced XmlTextWriter with XmlWriter.Create"

### DIFF
--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -144,12 +144,12 @@ namespace Orleans.Runtime.Configuration
 
         private static string WriteXml(XmlElement element)
         {
-            using(var sw = new StringWriter())
+            using(var text = new StringWriter())
             {
-                using(var xw = XmlWriter.Create(sw))
+                using(var xml = new XmlTextWriter(text))
                 { 
-                    element.WriteTo(xw);
-                    return sw.ToString();
+                    element.WriteTo(xml);
+                    return text.ToString();
                 }
             }
         }

--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -186,9 +186,9 @@ namespace Orleans.Runtime.Management
             }
             
             using(var sw = new StringWriter())
-            {
-                using(XmlWriter xw = XmlWriter.Create(sw))
-                {
+            { 
+                using(var xw = new XmlTextWriter(sw))
+                { 
                     document.WriteTo(xw);
                     var xml = sw.ToString();
                     // do first one, then all the rest to avoid spamming all the silos in case of a parameter error


### PR DESCRIPTION
This reverts commit 75dd8e1d26418cb97b506063b93ba0b1efa01c9b.

This commit broke functional tests. `text.ToString();` for some reason returns a empty string. Reverting the commit for now.