### PR TITLE
Coreclr compatibility:XmlTextWriter -> XmlWriter.Create

### DIFF
--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -144,12 +144,13 @@ namespace Orleans.Runtime.Configuration
 
         private static string WriteXml(XmlElement element)
         {
-            using(var text = new StringWriter())
+            using(var sw = new StringWriter())
             {
-                using(var xml = new XmlTextWriter(text))
+                using(var xw = XmlWriter.Create(sw))
                 { 
-                    element.WriteTo(xml);
-                    return text.ToString();
+                    element.WriteTo(xw);
+                    xw.Flush();
+                    return sw.ToString();
                 }
             }
         }

--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -187,9 +187,10 @@ namespace Orleans.Runtime.Management
             
             using(var sw = new StringWriter())
             { 
-                using(var xw = new XmlTextWriter(sw))
+                using(var xw = XmlWriter.Create(sw))
                 { 
                     document.WriteTo(xw);
+                    xw.Flush();
                     var xml = sw.ToString();
                     // do first one, then all the rest to avoid spamming all the silos in case of a parameter error
                     await GetSiloControlReference(silos[0]).UpdateConfiguration(xml);


### PR DESCRIPTION
#916. The reason of empty string being returned was missing call to flush. 