### PR TITLE
Refactor .Result to .GetAwaiter().GetResult() to preserve stacktrace

### DIFF
--- a/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
+++ b/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
@@ -98,10 +98,12 @@ namespace Orleans.Runtime.MembershipService
         {
             if (logger.IsVerbose3) logger.Verbose3("SqlMembershipTable.GetGateways called.");
             try
-            {
-                //TODO: Refactor this to async.
+            {                
                 var query = queryConstants.GetConstant(database.InvariantName, QueryKeys.ActiveGatewaysQuery);
-                return database.ActiveGatewaysAsync(query, deploymentId).Result;
+
+                //The rationale for GetAwaiter().GetResult() instead of .Result
+                //is presented at https://github.com/aspnet/Security/issues/59.                
+                return database.ActiveGatewaysAsync(query, deploymentId).GetAwaiter().GetResult();
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
The rational is explained at https://github.com/aspnet/Security/issues/59.

"One last remark: you should avoid using Task.Result and Task.Wait as
much as possible as they always encapsulate the inner exception in an
AggregateException and replace the message by a generic one (One or
more errors occurred), which makes debugging harder. Even if the
synchronous version shouldn't be used that often, you should strongly
consider using Task.GetAwaiter().GetResult() instead."

This leaves aside another possibility to refactor, namely that of
making the interface method asynchronous.