### PR TITLE
Add Stream Filter tests from Functional Test Suite.

### DIFF
--- a/src/Clean.cmd
+++ b/src/Clean.cmd
@@ -1,0 +1,5 @@
+@ECHO .
+@ECHO Cleaning %CD%
+@ECHO .
+FOR /F "tokens=*" %%G IN ('DIR /B /AD /S bin') DO RMDIR /S /Q "%%G"
+FOR /F "tokens=*" %%G IN ('DIR /B /AD /S obj') DO RMDIR /S /Q "%%G"

--- a/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
+++ b/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
@@ -32,6 +32,8 @@ namespace Orleans.Streams
 
     /// <summary>
     /// This class is a [Serializable] function pointer to a static predicate method, used for stream filtering.
+    /// The predicate function / lamda is not directly serialized, only the class / method info details required to reconstruct the function reference on the other side.
+    /// Predicate filter functions must be staic (non-abstract) methods, so full class name and method name are sufficient info to rehydrate.
     /// </summary>
     [Serializable]
     internal class FilterPredicateWrapperData : IStreamFilterPredicateWrapper
@@ -41,29 +43,37 @@ namespace Orleans.Streams
         private string methodName;
         private string className;
 
+        private const string SER_FIELD_CLASS  = "ClassName";
+        private const string SER_FIELD_DATA   = "FilterData";
+        private const string SER_FIELD_METHOD = "MethodName";
+
         [NonSerialized]
         private StreamFilterPredicate predicateFunc;
 
         internal FilterPredicateWrapperData(object filterData, StreamFilterPredicate pred)
         {
+            CheckFilterPredicateFunc(pred); // Assert expected pre-conditions are always true.
+
             FilterData = filterData;
             predicateFunc = pred;
+
             DehydrateStaticFunc(pred);
         }
 
         #region ISerializable methods
         protected FilterPredicateWrapperData(SerializationInfo info, StreamingContext context)
         {
-            FilterData = info.GetValue("FilterData", typeof(object));
-            methodName = info.GetString("MethodName");
-            className = info.GetString("ClassName");
+            FilterData = info.GetValue(SER_FIELD_DATA, typeof(object));
+            methodName = info.GetString(SER_FIELD_METHOD);
+            className  = info.GetString(SER_FIELD_CLASS);
+
             predicateFunc = RehydrateStaticFuncion(className, methodName);
         }
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            info.AddValue("FilterData", FilterData);
-            info.AddValue("MethodName", methodName);
-            info.AddValue("ClassName", className);
+            info.AddValue(SER_FIELD_DATA,   FilterData);
+            info.AddValue(SER_FIELD_METHOD, methodName);
+            info.AddValue(SER_FIELD_CLASS,  className);
         }
         #endregion
 
@@ -78,24 +88,43 @@ namespace Orleans.Streams
 
         private static StreamFilterPredicate RehydrateStaticFuncion(string funcClassName, string funcMethodName)
         {
-            var funcClassType = CachedTypeResolver.Instance.ResolveType(funcClassName);
-            var method = funcClassType.GetMethod(funcMethodName);
-            return (StreamFilterPredicate)method.CreateDelegate(typeof(StreamFilterPredicate));
+            Type funcClassType = CachedTypeResolver.Instance.ResolveType(funcClassName);
+            MethodInfo method = funcClassType.GetMethod(funcMethodName);
+            StreamFilterPredicate pred = (StreamFilterPredicate) method.CreateDelegate(typeof(StreamFilterPredicate));
+#if DEBUG
+            CheckFilterPredicateFunc(pred); // Assert expected pre-conditions are always true.
+#endif
+            return pred;
         }
 
         private void DehydrateStaticFunc(StreamFilterPredicate pred)
         {
-            var method = pred.Method;
-
-            if (!CheckStaticFunc(method)) throw new ArgumentException("Filter function must be static and not abstract.");
-
+#if DEBUG
+            CheckFilterPredicateFunc(pred); // Assert expected pre-conditions are always true.
+#endif
+            MethodInfo method = pred.Method;
             className = method.DeclaringType.FullName;
             methodName = method.Name;
         }
 
-        private static bool CheckStaticFunc(MethodInfo method)
+        /// <summary>
+        /// Check that the user-supplied stream predicate function is valid.
+        /// Stream predicate functions must be static and not abstract.
+        /// </summary>
+        /// <param name="func"></param>
+        private static void CheckFilterPredicateFunc(StreamFilterPredicate predicate)
         {
-            return method.IsStatic && !method.IsAbstract;
+            if (predicate == null)
+            {
+                throw new ArgumentNullException("predicate", "Stream Filter predicate function must not be null.");
+            }
+
+            MethodInfo method = predicate.Method;
+
+            if (!method.IsStatic || method.IsAbstract)
+            {
+                throw new ArgumentException("Stream Filter predicate function must be static and not abstract.");
+            }
         }
 
         public override string ToString()

--- a/src/Test.cmd
+++ b/src/Test.cmd
@@ -1,20 +1,32 @@
-@REM NOTE: This script must be run from a Visual Studio command prompt window
-
 @setlocal
-@ECHO on
+@ECHO off
 
-SET CMDHOME=%~dp0.
+if .%TEST_CATEGORIES%. == .. set TEST_CATEGORIES="TestCategory=BVT"
+
+SET CONFIGURATION=Release
+
+SET CMDHOME=%~dp0
+@REM Remove trailing backslash \
+set CMDHOME=%CMDHOME:~0,-1%
+
 if "%FrameworkDir%" == "" set FrameworkDir=%WINDIR%\Microsoft.NET\Framework
 if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
 
-SET MSTESTEXEDIR=%VS120COMNTOOLS%..\IDE
-SET MSTESTEXE=%MSTESTEXEDIR%\MSTest.exe
-
-SET CONFIGURATION=Release
-SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
+SET VSIDEDIR=%VS120COMNTOOLS%..\IDE
+SET VSTESTEXEDIR=%VSIDEDIR%\CommonExtensions\Microsoft\TestWindow
+SET VSTESTEXE=%VSTESTEXEDIR%\VSTest.console.exe
 
 cd "%CMDHOME%"
+@cd
 
-set TEST_ARGS= /testcontainer:%OutDir%\Tester.dll /testcontainer:%OutDir%\TesterInternal.dll 
+SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
-"%MSTESTEXE%" %TEST_ARGS% /category:"BVT"
+set TESTS=%OutDir%\Tester.dll %OutDir%\TesterInternal.dll 
+@Echo Test assemblies = %TESTS%
+
+set TEST_ARGS= /Settings:%CMDHOME%\Local.testsettings
+set TEST_ARGS= %TEST_ARGS% /TestCaseFilter:%TEST_CATEGORIES%
+
+@echo on
+
+"%VSTESTEXE%" %TEST_ARGS% %TESTS%

--- a/src/TestAll.cmd
+++ b/src/TestAll.cmd
@@ -1,20 +1,16 @@
-@REM NOTE: This script must be run from a Visual Studio command prompt window
-
 @setlocal
-@ECHO on
+@ECHO off
 
-SET CMDHOME=%~dp0.
-if "%FrameworkDir%" == "" set FrameworkDir=%WINDIR%\Microsoft.NET\Framework
-if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
+SET CMDHOME=%~dp0
+@REM Remove trailing backslash \
+set CMDHOME=%CMDHOME:~0,-1%
 
-SET MSTESTEXEDIR=%VS120COMNTOOLS%..\IDE
-SET MSTESTEXE=%MSTESTEXEDIR%\MSTest.exe
+@REM Due to more of Windows .cmd script parameter passing quirks, we can't pass this value as cmdline argument, 
+@REM  so we need to pass it in through the back door as environment variable, scoped by setlocal
+set TEST_CATEGORIES="TestCategory=BVT|TestCategory=Functional"
 
-SET CONFIGURATION=Release
-SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
+@REM Note: We transfer _complete_ control to the Test.cmd script here because we don't use CALL.
 
-cd "%CMDHOME%"
+"%CMDHOME%\Test.cmd"
 
-set TEST_ARGS= /testcontainer:%OutDir%\Tester.dll /testcontainer:%OutDir%\TesterInternal.dll 
-
-"%MSTESTEXE%" %TEST_ARGS% /category:"BVT|Functional"
+@REM Note: Execution will NOT return here, and the exit code returned to the caller will be whatever the other script returned.

--- a/src/TestGrainInterfaces/IActivateDeactivateWatcherGrain.cs
+++ b/src/TestGrainInterfaces/IActivateDeactivateWatcherGrain.cs
@@ -1,0 +1,40 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IActivateDeactivateWatcherGrain : IGrainWithIntegerKey
+    {
+        Task<string[]> GetActivateCalls();
+        Task<string[]> GetDeactivateCalls();
+
+        Task Clear();
+
+        Task RecordActivateCall(string activation);
+        Task RecordDeactivateCall(string activation);
+    }
+}

--- a/src/TestGrainInterfaces/IStreamLifecycleTestGrains.cs
+++ b/src/TestGrainInterfaces/IStreamLifecycleTestGrains.cs
@@ -1,0 +1,63 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Threading.Tasks;
+
+using Orleans;
+using Orleans.Streams;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IStreamLifecycleConsumerGrain : IGrainWithGuidKey
+    {
+        Task<int> GetReceivedCount();
+        Task<int> GetErrorsCount();
+
+        Task Ping();
+        Task BecomeConsumer(Guid streamId, string streamNamespace, string providerName);
+        Task RemoveConsumer(Guid streamId, string streamNamespace, string providerName, StreamSubscriptionHandle<int> consumerHandle);
+        Task ClearGrain();
+    }
+
+    public interface IFilteredStreamConsumerGrain : IStreamLifecycleConsumerGrain
+    {
+        Task BecomeConsumer(Guid streamId, string streamNamespace, string providerName, bool sendEvensOnly);
+        Task SubscribeWithBadFunc(Guid streamId, string streamNamespace, string providerName);
+    }
+
+    public interface IStreamLifecycleProducerGrain : IGrainWithGuidKey
+    {
+        Task<int> GetSendCount();
+        Task<int> GetErrorsCount();
+
+        Task Ping();
+
+        Task BecomeProducer(Guid streamId, string streamNamespace, string providerName);
+        Task ClearGrain();
+
+        Task DoDeactivateNoClose();
+
+        Task SendItem(int item);
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{3972213F-189B-41D4-90FE-38D513C1106D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>TestGrainInterfaces</RootNamespace>
+    <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
     <AssemblyName>TestGrainInterfaces</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ICircularStateTestGrain.cs" />
+    <Compile Include="IActivateDeactivateWatcherGrain.cs" />
     <Compile Include="IExceptionGrain.cs" />
     <Compile Include="IFaultableConsumerGrain.cs" />
     <Compile Include="IGeneratorTestDerivedDerivedGrain.cs" />
@@ -68,6 +69,7 @@
     <Compile Include="ISimpleGrain.cs" />
     <Compile Include="ISimplePersistentGrain.cs" />
     <Compile Include="ILivenessTestGrain.cs" />
+    <Compile Include="IStreamLifecycleTestGrains.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>

--- a/src/TestGrains/ActivateDeactivateWatcherGrain.cs
+++ b/src/TestGrains/ActivateDeactivateWatcherGrain.cs
@@ -1,0 +1,70 @@
+/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    internal class ActivateDeactivateWatcherGrain : Grain, IActivateDeactivateWatcherGrain
+    {
+        private Logger logger;
+
+        private readonly List<string> activationCalls = new List<string>();
+        private readonly List<string> deactivationCalls = new List<string>();
+
+        public Task<string[]> GetActivateCalls() { return Task.FromResult(activationCalls.ToArray()); }
+        public Task<string[]> GetDeactivateCalls() { return Task.FromResult(deactivationCalls.ToArray()); }
+
+        public override Task OnActivateAsync()
+        {
+            this.logger = GetLogger();
+            return base.OnActivateAsync();
+        }
+
+        public Task Clear()
+        {
+            if (logger.IsVerbose) logger.Verbose("Clear");
+            activationCalls.Clear();
+            deactivationCalls.Clear();
+            return TaskDone.Done;
+        }
+        public Task RecordActivateCall(string activation)
+        {
+            if (logger.IsVerbose) logger.Verbose("RecordActivateCall: " + activation);
+            activationCalls.Add(activation);
+            return TaskDone.Done;
+        }
+
+        public Task RecordDeactivateCall(string activation)
+        {
+            if (logger.IsVerbose) logger.Verbose("RecordDeactivateCall: " + activation);
+            deactivationCalls.Add(activation);
+            return TaskDone.Done;
+        }
+    }
+}

--- a/src/TestGrains/StreamLifecycleTestGrains.cs
+++ b/src/TestGrains/StreamLifecycleTestGrains.cs
@@ -1,0 +1,458 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#define COUNT_ACTIVATE_DEACTIVATE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    public class StreamLifecycleTestGrainState : GrainState
+    {
+        // For producer and consumer 
+        // -- only need to store this because of how we run our unit tests against multiple providers
+        public string StreamProviderName { get; set; }
+
+        // For producer only.
+        public IAsyncStream<int> Stream { get; set; }
+        public bool IsProducer { get; set; }
+        public int NumMessagesSent { get; set; }
+        public int NumErrors { get; set; }
+
+        // For consumer only.
+        public HashSet<StreamSubscriptionHandle<int>> ConsumerSubscriptionHandles { get; set; }
+
+        public override void SetAll(IDictionary<string, object> values)
+        {
+            base.SetAll(values);
+            if(ConsumerSubscriptionHandles == null)
+                ConsumerSubscriptionHandles = new HashSet<StreamSubscriptionHandle<int>>();
+        }
+    }
+
+    public class StreamLifecycleTestGrainBase : Grain<StreamLifecycleTestGrainState>
+    {
+        protected Logger logger;
+        protected string _lastProviderName;
+        protected IStreamProvider _streamProvider;
+
+#if COUNT_ACTIVATE_DEACTIVATE
+        private IActivateDeactivateWatcherGrain watcher;
+#endif
+
+        protected Task RecordActivate()
+        {
+#if COUNT_ACTIVATE_DEACTIVATE
+            watcher = GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(0);
+            return watcher.RecordActivateCall(IdentityString);
+#else
+            return TaskDone.Done;
+#endif
+        }
+
+        protected Task RecordDeactivate()
+        {
+#if COUNT_ACTIVATE_DEACTIVATE
+            return watcher.RecordDeactivateCall(IdentityString);
+#else
+            return TaskDone.Done;
+#endif
+        }
+
+        protected void InitStream(Guid streamId, string streamNamespace, string providerToUse)
+        {
+            if (streamId == null) throw new ArgumentNullException("streamId", "Can't have null stream id");
+            if (streamNamespace == null) throw new ArgumentNullException("streamNamespace", "Can't have null stream namespace values");
+            if (providerToUse == null) throw new ArgumentNullException("providerToUse", "Can't have null stream provider name");
+
+            if (State.Stream != null && State.Stream.Guid != streamId)
+            {
+                if (logger.IsVerbose) logger.Verbose("Stream already exists for StreamId={0} StreamProvider={1} - Resetting", State.Stream, providerToUse);
+
+                // Note: in this test, we are deliberately not doing Unsubscribe consumers, just discard old stream and let auto-cleanup functions do their thing.
+                State.ConsumerSubscriptionHandles.Clear();
+                State.IsProducer = false;
+                State.NumMessagesSent = 0;
+                State.NumErrors = 0;
+                State.Stream = null;
+            }
+
+            if (logger.IsVerbose) logger.Verbose("InitStream StreamId={0} StreamProvider={1}", streamId, providerToUse);
+
+            if (providerToUse != _lastProviderName)
+            {
+                _streamProvider = GetStreamProvider(providerToUse);
+                _lastProviderName = providerToUse;
+            }
+            IAsyncStream<int> stream = _streamProvider.GetStream<int>(streamId, streamNamespace);
+            State.Stream = stream;
+            State.StreamProviderName = providerToUse;
+
+            if (logger.IsVerbose) logger.Verbose("InitStream returning with Stream={0} with ref type = {1}", State.Stream, State.Stream.GetType().FullName);
+        }
+    }
+
+    [Orleans.Providers.StorageProvider(ProviderName = "MemoryStore")]
+    public class StreamLifecycleConsumerGrain : StreamLifecycleTestGrainBase, IStreamLifecycleConsumerGrain
+    {
+        protected IDictionary<StreamSubscriptionHandle<int>, MyStreamObserver<int>> Observers { get; set; }
+
+        public override async Task OnActivateAsync()
+        {
+            logger = GetLogger(GetType().Name + "-" + IdentityString);
+            if (logger.IsVerbose) logger.Verbose("OnActivateAsync");
+
+            await RecordActivate();
+
+            if (Observers == null)
+            {
+                Observers = new Dictionary<StreamSubscriptionHandle<int>, MyStreamObserver<int>>();
+            }
+
+            if (State.Stream != null && State.StreamProviderName != null)
+            {
+                if (State.ConsumerSubscriptionHandles.Count > 0)
+                {
+                    var handles = State.ConsumerSubscriptionHandles.ToArray();
+                    logger.Info("ReconnectConsumerHandles SubscriptionHandles={0} Grain={1}", Utils.EnumerableToString(handles), this.AsReference<IStreamLifecycleConsumerGrain>());
+                    foreach (var handle in handles)
+                    {
+                        var observer = new MyStreamObserver<int>(logger);
+                        StreamSubscriptionHandle<int> subsHandle = await handle.ResumeAsync(observer);
+                        Observers.Add(subsHandle, observer);
+                    }
+                }
+            }
+            else
+            {
+                if (logger.IsVerbose) logger.Verbose("Not conected to stream yet.");
+            }
+        }
+        public override async Task OnDeactivateAsync()
+        {
+            if (logger.IsVerbose) logger.Verbose("OnDeactivateAsync");
+            await RecordDeactivate();
+        }
+
+        public Task<int> GetReceivedCount()
+        {
+            int numReceived = Observers.Sum(o => o.Value.NumItems);
+            if (logger.IsVerbose) logger.Verbose("ReceivedCount={0}", numReceived);
+            return Task.FromResult(numReceived);
+        }
+        public Task<int> GetErrorsCount()
+        {
+            int numErrors = Observers.Sum(o => o.Value.NumErrors);
+            if (logger.IsVerbose) logger.Verbose("ErrorsCount={0}", numErrors);
+            return Task.FromResult(numErrors);
+        }
+
+        public Task Ping()
+        {
+            logger.Info("Ping");
+            return TaskDone.Done;
+        }
+
+        public virtual async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
+        {
+            if (logger.IsVerbose) logger.Verbose("BecomeConsumer StreamId={0} StreamProvider={1} Grain={2}", streamId, providerToUse, this.AsReference<IStreamLifecycleConsumerGrain>());
+            InitStream(streamId, streamNamespace, providerToUse);
+            var observer = new MyStreamObserver<int>(logger);
+            var subsHandle = await State.Stream.SubscribeAsync(observer);
+            State.ConsumerSubscriptionHandles.Add(subsHandle);
+            Observers.Add(subsHandle, observer);
+            await WriteStateAsync();
+        }
+
+        public async Task RemoveConsumer(Guid streamId, string streamNamespace, string providerName, StreamSubscriptionHandle<int> subsHandle)
+        {
+            if (logger.IsVerbose) logger.Verbose("RemoveConsumer StreamId={0} StreamProvider={1}", streamId, providerName);
+            if (State.ConsumerSubscriptionHandles.Count == 0) throw new InvalidOperationException("Not a Consumer");
+            await subsHandle.UnsubscribeAsync();
+            Observers.Remove(subsHandle);
+            State.ConsumerSubscriptionHandles.Remove(subsHandle);
+            await WriteStateAsync();
+        }
+
+        public async Task ClearGrain()
+        {
+            logger.Info("ClearGrain");
+            var subsHandles = State.ConsumerSubscriptionHandles.ToArray();
+            foreach (var handle in subsHandles)
+            {
+                await handle.UnsubscribeAsync();
+            }
+            State.ConsumerSubscriptionHandles.Clear();
+            State.Stream = null;
+            State.IsProducer = false;
+            Observers.Clear();
+            await ClearStateAsync();
+        }
+    }
+
+    [Orleans.Providers.StorageProvider(ProviderName = "MemoryStore")]
+    public class FilteredStreamConsumerGrain : StreamLifecycleConsumerGrain, IFilteredStreamConsumerGrain
+    {
+        private static Logger _logger;
+
+        private const Int32 FilterDataOdd = 1;
+        private const Int32 FilterDataEven = 2;
+
+        public override Task BecomeConsumer(Guid streamId, string streamNamespace, string providerName)
+        {
+            throw new InvalidOperationException("Should not be calling unfiltered BecomeConsumer method on " + GetType());
+        }
+        public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerName, bool sendEvensOnly)
+        {
+            _logger = logger;
+            if (logger.IsVerbose)
+                logger.Verbose("BecomeConsumer StreamId={0} StreamProvider={1} Filter={2} Grain={3}",
+                streamId, providerName, sendEvensOnly, this.AsReference<IFilteredStreamConsumerGrain>());
+            InitStream(streamId, streamNamespace, providerName);
+
+            var observer = new MyStreamObserver<int>(logger);
+
+            StreamFilterPredicate filterFunc;
+            object filterData;
+            if (sendEvensOnly)
+            {
+                filterFunc = FilterIsEven;
+                filterData = FilterDataEven;
+            }
+            else
+            {
+                filterFunc = FilterIsOdd;
+                filterData = FilterDataOdd;
+            }
+
+            var subsHandle = await State.Stream.SubscribeAsync(observer, null, filterFunc, filterData);
+
+            State.ConsumerSubscriptionHandles.Add(subsHandle);
+            Observers.Add(subsHandle, observer);
+            await WriteStateAsync();
+        }
+
+        public async Task SubscribeWithBadFunc(Guid streamId, string streamNamespace, string providerName)
+        {
+            logger.Info("SubscribeWithBadFunc StreamId={0} StreamProvider={1}Grain={2}",
+                streamId, providerName, this.AsReference<IFilteredStreamConsumerGrain>());
+
+            InitStream(streamId, streamNamespace, providerName);
+
+            var observer = new MyStreamObserver<int>(logger);
+
+            StreamFilterPredicate filterFunc = BadFunc;
+
+            // This next call should fail because func is not static
+            await State.Stream.SubscribeAsync(observer, null, filterFunc);
+        }
+
+        public static bool FilterIsEven(IStreamIdentity stream, object filterData, object item)
+        {
+            if (!FilterDataEven.Equals(filterData))
+            {
+                throw new Exception("Should have got the correct filter data passed in, but got: " + filterData);
+            }
+            Int32 val = (int) item;
+            bool result = val % 2 == 0;
+            if (_logger != null) _logger.Info("FilterIsEven(Stream={0},FilterData={1},Item={2}) Filter = {3}", stream, filterData, item, result);
+            return result;
+        }
+        public static bool FilterIsOdd(IStreamIdentity stream, object filterData, object item)
+        {
+            if (!FilterDataOdd.Equals(filterData))
+            {
+                throw new Exception("Should have got the correct filter data passed in, but got: " + filterData);
+            }
+            Int32 val = (int) item;
+            bool result = val % 2 == 1;
+            if (_logger != null) _logger.Info("FilterIsOdd(Stream={0},FilterData={1},Item={2}) Filter = {3}", stream, filterData, item, result);
+            return result;
+        }
+        // Function is not static, so cannot be used as a filter predicate function.
+        public bool BadFunc(IStreamIdentity stream, object filterData, object item)
+        {
+            return true;
+        }
+    }
+
+    [Orleans.Providers.StorageProvider(ProviderName = "MemoryStore")]
+    public class StreamLifecycleProducerGrain : StreamLifecycleTestGrainBase, IStreamLifecycleProducerGrain
+    {
+        public override async Task OnActivateAsync()
+        {
+            logger = GetLogger(GetType().Name + "-" + IdentityString);
+            if (logger.IsVerbose) logger.Verbose("OnActivateAsync");
+
+            await RecordActivate();
+
+            if (State.Stream != null && State.StreamProviderName != null)
+            {
+                if (logger.IsVerbose) logger.Verbose("Reconnected to stream {0}", State.Stream);
+            }
+            else
+            {
+                if (logger.IsVerbose) logger.Verbose("Not connected to stream yet.");
+            }
+        }
+        public override async Task OnDeactivateAsync()
+        {
+            if (logger.IsVerbose) logger.Verbose("OnDeactivateAsync");
+            await RecordDeactivate();
+        }
+
+        public Task<int> GetSendCount()
+        {
+            int result = State.NumMessagesSent;
+            if (logger.IsVerbose) logger.Verbose("GetSendCount={0}", result);
+            return Task.FromResult(result);
+        }
+
+        public Task<int> GetErrorsCount()
+        {
+            int result = State.NumErrors;
+            if (logger.IsVerbose) logger.Verbose("GetErrorsCount={0}", result);
+            return Task.FromResult(result);
+        }
+
+        public Task Ping()
+        {
+            logger.Info("Ping");
+            return TaskDone.Done;
+        }
+
+        public async Task SendItem(int item)
+        {
+            if (!State.IsProducer || State.Stream == null) throw new InvalidOperationException("Not a Producer");
+            if (logger.IsVerbose) logger.Verbose("SendItem Item={0}", item);
+            Exception error = null;
+            try
+            {
+                await State.Stream.OnNextAsync(item);
+
+                if (logger.IsVerbose) logger.Verbose("Successful SendItem " + item);
+                State.NumMessagesSent++;
+            }
+            catch (Exception exc)
+            {
+                logger.Error(0, "Error from SendItem " + item, exc);
+                State.NumErrors++;
+                error = exc;
+            }
+            await WriteStateAsync(); // Update counts in persisted state
+
+            if (error != null)
+            {
+                throw new AggregateException(error);
+            }
+            if (logger.IsVerbose) logger.Verbose("Finished SendItem for Item={0}", item);
+        }
+
+        public async Task BecomeProducer(Guid streamId, string streamNamespace, string providerName)
+        {
+            if (logger.IsVerbose) logger.Verbose("BecomeProducer StreamId={0} StreamProvider={1}", streamId, providerName);
+            InitStream(streamId, streamNamespace, providerName);
+            State.IsProducer = true;
+
+            // Send an initial message to ensure we are properly initialized as a Producer.
+            await State.Stream.OnNextAsync(0);
+            State.NumMessagesSent++;
+            await WriteStateAsync();
+            if (logger.IsVerbose) logger.Verbose("Finished BecomeProducer for StreamId={0} StreamProvider={1}", streamId, providerName);
+        }
+
+        public async Task ClearGrain()
+        {
+            logger.Info("ClearGrain");
+            State.IsProducer = false;
+            State.Stream = null;
+            await ClearStateAsync();
+        }
+
+        public async Task DoDeactivateNoClose()
+        {
+            if (logger.IsVerbose) logger.Verbose("DoDeactivateNoClose");
+
+            State.IsProducer = false;
+            State.Stream = null;
+            await WriteStateAsync();
+
+            if (logger.IsVerbose) logger.Verbose("Calling DeactivateOnIdle");
+            base.DeactivateOnIdle();
+        }
+    }
+
+    [Serializable]
+    public class MyStreamObserver<T> : IAsyncObserver<T>
+    {
+        internal int NumItems { get; private set; }
+        internal int NumErrors { get; private set; }
+
+        private readonly Logger logger;
+
+        internal MyStreamObserver(Logger logger)
+        {
+            this.logger = logger;
+        }
+
+        public Task OnNextAsync(T item, StreamSequenceToken token)
+        {
+            NumItems++;
+
+            if (logger != null && logger.IsVerbose)
+            {
+                logger.Verbose("Received OnNextAsync - Item={0} - Total Items={1} Errors={2}", item, NumItems, NumErrors);
+            }
+
+            return TaskDone.Done;
+        }
+
+        public Task OnCompletedAsync()
+        {
+            if (logger != null)
+            {
+                logger.Info("Receive OnCompletedAsync - Total Items={0} Errors={1}", NumItems, NumErrors);
+            }
+            return TaskDone.Done;
+        }
+
+        public Task OnErrorAsync(Exception ex)
+        {
+            NumErrors++;
+
+            if (logger != null)
+            {
+                logger.Warn(1, "Received OnErrorAsync - Exception={0} - Total Items={1} Errors={2}", ex, NumItems, NumErrors);
+            }
+
+            return TaskDone.Done;
+        }
+    }
+}

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{EACE28AE-F301-472A-B633-02B55434871B}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>TestGrains</RootNamespace>
+    <RootNamespace>UnitTests.Grains</RootNamespace>
     <AssemblyName>TestGrains</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CircularStateTestGrain.cs" />
+    <Compile Include="ActivateDeactivateWatcherGrain.cs" />
     <Compile Include="ExceptionGrain.cs" />
     <Compile Include="FaultableConsumerGrain.cs" />
     <Compile Include="EventSourcing\PersonState.cs" />
@@ -91,6 +92,7 @@
     <Compile Include="GrainInterfaceHierarchyGrains.cs" />
     <Compile Include="LivenessTestGrain.cs" />
     <Compile Include="SpecializedSimpleGenericGrain.cs" />
+    <Compile Include="StreamLifecycleTestGrains.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OrleansEventSourcing\OrleansEventSourcing.csproj">

--- a/src/Tester/OrleansConfigurationForStreamingTesting_SMS.xml
+++ b/src/Tester/OrleansConfigurationForStreamingTesting_SMS.xml
@@ -7,7 +7,6 @@
     </StorageProviders>
     <StreamProviders>
       <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>
-      <Provider Type="Orleans.Providers.Streams.AzureQueue.AzureQueueStreamProvider" Name="AzureQueueProvider"/>
     </StreamProviders>
     <SeedNode Address="localhost" Port="22222"/>
     <Messaging ResponseTimeout="30s"/>

--- a/src/Tester/StreamingTests/StreamFilteringTests.cs
+++ b/src/Tester/StreamingTests/StreamFilteringTests.cs
@@ -396,6 +396,7 @@ namespace Tester.StreamingTests
         {
         }
 
+        [Ignore]
         [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
         public async Task AQ_Filter_Basic()
         {
@@ -404,6 +405,7 @@ namespace Tester.StreamingTests
             await Test_Filter_EvenOdd(true);
         }
 
+        [Ignore]
         [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
         public async Task AQ_Filter_EvenOdd()
         {
@@ -412,6 +414,7 @@ namespace Tester.StreamingTests
             await Test_Filter_EvenOdd();
         }
 
+        [Ignore]
         [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
         [ExpectedException(typeof(ArgumentException))]
         public async Task AQ_Filter_BadFunc()
@@ -429,6 +432,7 @@ namespace Tester.StreamingTests
             }
         }
 
+        [Ignore]
         [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
         public async Task AQ_Filter_TwoObsv_Different()
         {
@@ -437,6 +441,7 @@ namespace Tester.StreamingTests
             await Test_Filter_TwoObsv_Different();
         }
 
+        [Ignore]
         [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
         public async Task AQ_Filter_TwoObsv_Same()
         {

--- a/src/Tester/StreamingTests/StreamFilteringTests.cs
+++ b/src/Tester/StreamingTests/StreamFilteringTests.cs
@@ -1,0 +1,448 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Runtime.Configuration;
+using Orleans.TestingHost;
+using UnitTests.GrainInterfaces;
+using UnitTests.StreamingTests;
+using UnitTests.Tester;
+
+namespace Tester.StreamingTests
+{
+    [ExcludeFromCodeCoverage]
+    public abstract class StreamFilteringTestsBase : UnitTestSiloHost
+    {
+        public TestContext TestContext { get; set; }
+
+        protected Guid StreamId;
+        protected string StreamNamespace;
+        protected string streamProviderName;
+
+        private static readonly TimeSpan timeout = TimeSpan.FromSeconds(30);
+
+        public StreamFilteringTestsBase(TestingSiloOptions siloOptions, TestingClientOptions clientOptions)
+            : base(siloOptions, clientOptions)
+        {
+        }
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if (!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            logger.Info("TestInitialize - {0}", TestContext.TestName);
+            StreamId = Guid.NewGuid();
+            StreamNamespace = TestContext.TestName;
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            logger.Info("TestCleanup - {0} - Test completed: Outcome = {1}", TestContext.TestName, TestContext.CurrentTestOutcome);
+
+            if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
+            {
+                try
+                {
+                    logger.Info("TestCleanup - DeleteAllUsedAzureQueues {0}", streamProviderName);
+                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(
+                        streamProviderName, 
+                        DeploymentId,
+                        StorageTestConstants.DataConnectionString, 
+                        logger).Wait();
+                }
+                catch (Exception exc)
+                {
+                    if (logger != null)
+                        logger.Warn(0, "Ignoring error in TestCleanup from DeleteAllUsedAzureQueues {0}", exc);
+                }
+            }
+        }
+
+        // Test support functions
+
+        protected async Task Test_Filter_EvenOdd(bool allCheckEven = false)
+        {
+            streamProviderName.Should().NotBeNull("Stream provider name not set.");
+
+            // Consumers
+            const int numConsumers = 10;
+            var consumers = new IFilteredStreamConsumerGrain[numConsumers];
+            var promises = new List<Task>();
+            for (int loopCount = 0; loopCount < numConsumers; loopCount++)
+            {
+                IFilteredStreamConsumerGrain grain = GrainClient.GrainFactory.GetGrain<IFilteredStreamConsumerGrain>(Guid.NewGuid());
+                consumers[loopCount] = grain;
+
+                bool isEven = allCheckEven || loopCount % 2 == 0;
+                Task promise = grain.BecomeConsumer(StreamId, StreamNamespace, streamProviderName, isEven);
+                promises.Add(promise);
+            }
+            await Task.WhenAll(promises);
+
+            // Producer
+            IStreamLifecycleProducerGrain producer = GrainClient.GrainFactory.GetGrain<IStreamLifecycleProducerGrain>(Guid.NewGuid());
+            await producer.BecomeProducer(StreamId, StreamNamespace, streamProviderName);
+
+            if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
+            {
+                // Allow some time for messages to propagate through the system
+                await TestingUtils.WaitUntilAsync(async tryLast => await producer.GetSendCount() >= 1, timeout);
+            }
+
+            // Check initial counts
+            int[] counts = new int[numConsumers];
+            for (int i = 0; i < numConsumers; i++)
+            {
+                counts[i] = await consumers[i].GetReceivedCount();
+                Console.WriteLine("Baseline count = {0} for consumer {1}", counts[i], i);
+            }
+
+            // Get producer to send some messages
+            for (int round = 1; round <= 10; round++)
+            {
+                bool roundIsEven = round % 2 == 0;
+                await producer.SendItem(round);
+
+                if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
+                {
+                    // Allow some time for messages to propagate through the system
+                    await TestingUtils.WaitUntilAsync(async tryLast => await producer.GetSendCount() >= 2, timeout);
+                }
+
+                for (int i = 0; i < numConsumers; i++)
+                {
+                    bool indexIsEven = i % 2 == 0;
+                    int expected = counts[i];
+                    if (roundIsEven)
+                    {
+                        if (indexIsEven || allCheckEven) expected += 1;
+                    }
+                    else if (allCheckEven)
+                    {
+                        // No change to expected counts for odd rounds
+                    }
+                    else
+                    {
+                        if (!indexIsEven) expected += 1;
+                    }
+
+                    int count = await consumers[i].GetReceivedCount();
+                    Console.WriteLine("Received count = {0} in round {1} for consumer {2}", count, round, i);
+                    count.Should().Be(expected, "Expected count in round {0} for consumer {1}", round, i);
+                    counts[i] = expected; // Set new baseline
+                }
+            }
+        }
+
+        protected async Task Test_Filter_BadFunc()
+        {
+            streamProviderName.Should().NotBeNull("Stream provider name not set.");
+
+            Guid id = Guid.NewGuid();
+            IFilteredStreamConsumerGrain grain = GrainClient.GrainFactory.GetGrain<IFilteredStreamConsumerGrain>(id);
+            try
+            {
+                await grain.Ping();
+                await grain.SubscribeWithBadFunc(id, StreamNamespace, streamProviderName);
+            }
+            catch (AggregateException ae)
+            {
+                Exception exc = ae.GetBaseException();
+                Console.WriteLine("Got exception " + exc);
+                throw exc;
+            }
+        }
+
+        protected async Task Test_Filter_TwoObsv_Different()
+        {
+            streamProviderName.Should().NotBeNull("Stream provider name not set.");
+
+            Guid id1 = Guid.NewGuid();
+            Guid id2 = Guid.NewGuid();
+
+            // Same consumer grain subscribes twice, with two different filters
+            IFilteredStreamConsumerGrain consumer = GrainClient.GrainFactory.GetGrain<IFilteredStreamConsumerGrain>(id1);
+            await consumer.BecomeConsumer(StreamId, StreamNamespace, streamProviderName, true); // Even
+            await consumer.BecomeConsumer(StreamId, StreamNamespace, streamProviderName, false); // Odd
+
+            IStreamLifecycleProducerGrain producer = GrainClient.GrainFactory.GetGrain<IStreamLifecycleProducerGrain>(id2);
+            await producer.BecomeProducer(StreamId, StreamNamespace, streamProviderName);
+            int expectedCount = 1; // Producer always sends first message when it becomes active
+
+            await producer.SendItem(1);
+            expectedCount++; // One observer receives, the other does not.
+            if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
+            {
+                // Allow some time for messages to propagate through the system
+                await TestingUtils.WaitUntilAsync(async tryLast => await producer.GetSendCount() >= 2, timeout);
+            }
+            int count = await consumer.GetReceivedCount();
+            Console.WriteLine("Received count = {0} after first send for consumer {1}", count, consumer);
+            count.Should().Be(expectedCount, "Expected count after first send");
+
+            await producer.SendItem(2);
+            expectedCount++;
+            if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
+            {
+                // Allow some time for messages to propagate through the system
+                await TestingUtils.WaitUntilAsync(async tryLast => await producer.GetSendCount() >= 3, timeout);
+            }
+            count = await consumer.GetReceivedCount();
+            Console.WriteLine("Received count = {0} after second send for consumer {1}", count, consumer);
+            count.Should().Be(expectedCount, "Expected count after second send");
+
+            await producer.SendItem(3);
+            expectedCount++;
+            if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
+            {
+                // Allow some time for messages to propagate through the system
+                await TestingUtils.WaitUntilAsync(async tryLast => await producer.GetSendCount() >= 4, timeout);
+            }
+            count = await consumer.GetReceivedCount();
+            Console.WriteLine("Received count = {0} after third send for consumer {1}", count, consumer);
+            count.Should().Be(expectedCount, "Expected count after second send");
+        }
+
+        protected async Task Test_Filter_TwoObsv_Same()
+        {
+            streamProviderName.Should().NotBeNull("Stream provider name not set.");
+
+            Guid id1 = Guid.NewGuid();
+            Guid id2 = Guid.NewGuid();
+
+            // Same consumer grain subscribes twice, with two identical filters
+            IFilteredStreamConsumerGrain consumer = GrainClient.GrainFactory.GetGrain<IFilteredStreamConsumerGrain>(id1);
+            await consumer.BecomeConsumer(StreamId, StreamNamespace, streamProviderName, true); // Even
+            await consumer.BecomeConsumer(StreamId, StreamNamespace, streamProviderName, true); // Even
+
+            IStreamLifecycleProducerGrain producer = GrainClient.GrainFactory.GetGrain<IStreamLifecycleProducerGrain>(id2);
+            await producer.BecomeProducer(StreamId, StreamNamespace, streamProviderName);
+            int expectedCount = 2; // When Producer becomes active, it always sends first message to each subscriber
+
+            await producer.SendItem(1);
+            if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
+            {
+                // Allow some time for messages to propagate through the system
+                await TestingUtils.WaitUntilAsync(async tryLast => await producer.GetSendCount() >= 2, timeout);
+            }
+            int count = await consumer.GetReceivedCount();
+            Console.WriteLine("Received count = {0} after first send for consumer {1}", count, consumer);
+            count.Should().Be(expectedCount, "Expected count after first send");
+
+            await producer.SendItem(2);
+            expectedCount += 2;
+            if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
+            {
+                // Allow some time for messages to propagate through the system
+                await TestingUtils.WaitUntilAsync(async tryLast => await producer.GetSendCount() >= 3, timeout);
+            }
+            count = await consumer.GetReceivedCount();
+            Console.WriteLine("Received count = {0} after second send for consumer {1}", count, consumer);
+            count.Should().Be(expectedCount, "Expected count after second send");
+
+            await producer.SendItem(3);
+            if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
+            {
+                // Allow some time for messages to propagate through the system
+                await TestingUtils.WaitUntilAsync(async tryLast => await producer.GetSendCount() >= 4, timeout);
+            }
+            count = await consumer.GetReceivedCount();
+            Console.WriteLine("Received count = {0} after third send for consumer {1}", count, consumer);
+            count.Should().Be(expectedCount, "Expected count after second send");
+        }
+    }
+
+    [TestClass]
+    [DeploymentItem("OrleansConfigurationForStreamingTesting_SMS.xml")]
+    [DeploymentItem("ClientConfigurationForStreamTesting.xml")]
+    [DeploymentItem("OrleansProviders.dll")]
+    [ExcludeFromCodeCoverage]
+    public class StreamFilteringTests_SMS : StreamFilteringTestsBase
+    {
+        private static readonly TestingSiloOptions siloOptions = new TestingSiloOptions
+        {
+            StartFreshOrleans = true,
+            SiloConfigFile = new FileInfo("OrleansConfigurationForStreamingTesting_SMS.xml"),
+            LivenessType = GlobalConfiguration.LivenessProviderType.MembershipTableGrain,
+            ReminderServiceType = GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain
+        };
+
+        private static readonly TestingClientOptions clientOptions = new TestingClientOptions
+        {
+            ClientConfigFile = new FileInfo("ClientConfigurationForStreamTesting.xml")
+        };
+
+        public StreamFilteringTests_SMS()
+            : base(siloOptions, clientOptions)
+        {
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async Task SMS_Filter_Basic()
+        {
+            streamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
+
+            await Test_Filter_EvenOdd(true);
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async Task SMS_Filter_EvenOdd()
+        {
+            streamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
+
+            await Test_Filter_EvenOdd();
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task SMS_Filter_BadFunc()
+        {
+            streamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
+
+            try
+            {
+                await Test_Filter_BadFunc();
+            }
+            catch (ArgumentException ae)
+            {
+                Console.WriteLine("Got the expected exception type: {0}", ae);
+                throw;
+            }
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async Task SMS_Filter_TwoObsv_Different()
+        {
+            streamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
+
+            await Test_Filter_TwoObsv_Different();
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
+        public async Task SMS_Filter_TwoObsv_Same()
+        {
+            streamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
+
+            await Test_Filter_TwoObsv_Same();
+        }
+    }
+
+    [TestClass]
+    [DeploymentItem("OrleansConfigurationForStreamingUnitTests.xml")]
+    [DeploymentItem("ClientConfigurationForStreamTesting.xml")]
+    [DeploymentItem("OrleansProviders.dll")]
+    [ExcludeFromCodeCoverage]
+    public class StreamFilteringTests_AQ : StreamFilteringTestsBase
+    {
+        private static readonly TestingSiloOptions siloOptions = new TestingSiloOptions
+        {
+            StartFreshOrleans = true,
+            SiloConfigFile = new FileInfo("OrleansConfigurationForStreamingUnitTests.xml"),
+            LivenessType = GlobalConfiguration.LivenessProviderType.MembershipTableGrain,
+            ReminderServiceType = GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain
+        };
+
+        private static readonly TestingClientOptions clientOptions = new TestingClientOptions
+        {
+            ClientConfigFile = new FileInfo("ClientConfigurationForStreamTesting.xml")
+        };
+
+        public StreamFilteringTests_AQ()
+            : base(siloOptions, clientOptions)
+        {
+        }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
+        public async Task AQ_Filter_Basic()
+        {
+            streamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
+
+            await Test_Filter_EvenOdd(true);
+        }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
+        public async Task AQ_Filter_EvenOdd()
+        {
+            streamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
+
+            await Test_Filter_EvenOdd();
+        }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task AQ_Filter_BadFunc()
+        {
+            streamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
+
+            try
+            {
+                await Test_Filter_BadFunc();
+            }
+            catch (ArgumentException ae)
+            {
+                Console.WriteLine("Got the expected exception type: {0}", ae);
+                throw;
+            }
+        }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
+        public async Task AQ_Filter_TwoObsv_Different()
+        {
+            streamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
+
+            await Test_Filter_TwoObsv_Different();
+        }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
+        public async Task AQ_Filter_TwoObsv_Same()
+        {
+            streamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
+
+            await Test_Filter_TwoObsv_Same();
+        }
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -55,9 +55,14 @@
     <Reference Include="Bond.JSON">
       <HintPath>$(SolutionDir)packages\Bond.Runtime.CSharp.3.0.7\lib\net45\Bond.JSON.dll</HintPath>
     </Reference>
+    <Reference Include="FluentAssertions">
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core">
+      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(SolutionDir)packages\Microsoft.Data.Edm.5.6.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
@@ -98,6 +103,8 @@
       <HintPath>$(SolutionDir)packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeGenTests\GeneratorGrainTest.cs" />
@@ -129,6 +136,7 @@
     <Compile Include="MembershipTests\SilosStopTests.cs" />
     <Compile Include="StreamingTests\PullingAgentManagementTests.cs" />
     <Compile Include="StreamingTests\DelayedQueueRebalancingTests.cs" />
+    <Compile Include="StreamingTests\StreamFilteringTests.cs" />
     <Compile Include="StreamingTests\StreamTestsConstants.cs" />
     <Compile Include="StreamingTests\SampleStreamingTests.cs" />
     <Compile Include="SimpleGrainTests.cs" />
@@ -184,6 +192,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="OrleansConfigurationForStreaming4SilosUnitTests.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="OrleansConfigurationForStreamingTesting_SMS.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="OrleansConfigurationForStreamingUnitTests.xml">

--- a/src/Tester/packages.config
+++ b/src/Tester/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Bond.Runtime.CSharp" version="3.0.7" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />


### PR DESCRIPTION
Add StreamFilteringTests to GitHub test suite.

- Add StreamFilteringTests test cases from Orleans Functional test suite.

- Use FluentAssertions package for easier way to express expected outcomes in test cases.

- Changed default namespaces set in TestGrains.csproj and TestGrainInterfaces.csproj to match the current naming convention we use.
