### PR TITLE
Fix #852 - record deserialized objects before deserialization has completed

### DIFF
--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -367,12 +367,18 @@ namespace Orleans.Serialization
         {
             var count = stream.ReadInt();
             var list = new List<T>(count);
+            var stack = new Stack<T>(count);
+            DeserializationContext.Current.RecordObject(stack);
             for (var i = 0; i < count; i++)
             {
                 list.Add((T)SerializationManager.DeserializeInner(typeof(T), stream));
             }
-            list.Reverse(); // NOTE: this is required to get things on the stack in the original order
-            var stack = new Stack<T>(list);
+
+            for (var i = count - 1; i >= 0; i--)
+            {
+                stack.Push(list[i]);
+            }
+
             return stack;
         }
 

--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -84,6 +84,8 @@ namespace Orleans.Serialization
         {
             var count = stream.ReadInt();
             var list = new List<T>(count);
+            DeserializationContext.Current.RecordObject(list);
+
             for (var i = 0; i < count; i++)
             {
                 list.Add((T)SerializationManager.DeserializeInner(typeof(T), stream));
@@ -151,6 +153,7 @@ namespace Orleans.Serialization
         {
             var count = stream.ReadInt();
             var list = new LinkedList<T>();
+            DeserializationContext.Current.RecordObject(list);
             for (var i = 0; i < count; i++)
             {
                 list.AddLast((T)SerializationManager.DeserializeInner(typeof(T), stream));
@@ -224,6 +227,7 @@ namespace Orleans.Serialization
                 (IEqualityComparer<T>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<T>), stream);
             var count = stream.ReadInt();
             var set = new HashSet<T>(comparer);
+            DeserializationContext.Current.RecordObject(set);
             for (var i = 0; i < count; i++)
             {
                 set.Add((T)SerializationManager.DeserializeInner(typeof(T), stream));
@@ -293,6 +297,7 @@ namespace Orleans.Serialization
         {
             var count = stream.ReadInt();
             var queue = new Queue<T>();
+            DeserializationContext.Current.RecordObject(queue);
             for (var i = 0; i < count; i++)
             {
                 queue.Enqueue((T)SerializationManager.DeserializeInner(typeof(T), stream));
@@ -432,6 +437,7 @@ namespace Orleans.Serialization
             var comparer = (IEqualityComparer<K>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<K>), stream);
             var count = stream.ReadInt();
             var dict = new Dictionary<K, V>(count, comparer);
+            DeserializationContext.Current.RecordObject(dict);
             for (var i = 0; i < count; i++)
             {
                 var key = (K)SerializationManager.DeserializeInner(typeof(K), stream);
@@ -478,6 +484,7 @@ namespace Orleans.Serialization
             var comparer = (IEqualityComparer<string>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<string>), stream);
             var count = stream.ReadInt();
             var dict = new Dictionary<string, object>(count, comparer);
+            DeserializationContext.Current.RecordObject(dict);
             for (var i = 0; i < count; i++)
             {
                 //stream.ReadFullTypeHeader(stringType); // Skip the type header, which will be string
@@ -542,6 +549,7 @@ namespace Orleans.Serialization
             var comparer = (IComparer<K>)SerializationManager.DeserializeInner(typeof(IComparer<K>), stream);
             var count = stream.ReadInt();
             var dict = new SortedDictionary<K, V>(comparer);
+            DeserializationContext.Current.RecordObject(dict);
             for (var i = 0; i < count; i++)
             {
                 var key = (K)SerializationManager.DeserializeInner(typeof(K), stream);
@@ -610,6 +618,7 @@ namespace Orleans.Serialization
             var comparer = (IComparer<K>)SerializationManager.DeserializeInner(typeof(IComparer<K>), stream);
             var count = stream.ReadInt();
             var list = new SortedList<K, V>(count, comparer);
+            DeserializationContext.Current.RecordObject(list);
             for (var i = 0; i < count; i++)
             {
                 var key = (K)SerializationManager.DeserializeInner(typeof(K), stream);

--- a/src/Orleans/Serialization/DeserializationContext.cs
+++ b/src/Orleans/Serialization/DeserializationContext.cs
@@ -27,12 +27,12 @@ using System.Runtime.Serialization;
 
 namespace Orleans.Serialization
 {
-    internal class DeserializationContext
+    public class DeserializationContext
     {
         [ThreadStatic]
         private static DeserializationContext ctx;
 
-        internal static DeserializationContext Current
+        public static DeserializationContext Current
         {
             get { return ctx ?? (ctx = new DeserializationContext()); }
         }
@@ -47,11 +47,19 @@ namespace Orleans.Serialization
         internal void Reset()
         {
             taggedObjects.Clear();
+            CurrentObjectOffset = 0;
         }
+
+        internal int CurrentObjectOffset { get; set; }
 
         internal void RecordObject(int offset, object obj)
         {
             taggedObjects[offset] = obj;
+        }
+
+        public void RecordObject(object obj)
+        {
+            taggedObjects[CurrentObjectOffset] = obj;
         }
 
         internal object FetchReferencedObject(int offset)

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1366,73 +1366,89 @@ namespace Orleans.Serialization
         /// <returns>Object of the required Type, rehydrated from the input stream.</returns>
         public static object DeserializeInner(Type expected, BinaryTokenStreamReader stream)
         {
-            var start = stream.CurrentPosition;
+            var previousOffset = DeserializationContext.Current.CurrentObjectOffset;
+            DeserializationContext.Current.CurrentObjectOffset = stream.CurrentPosition;
 
-            // NOTE: we don't check that the actual dynamic result implements the expected type. We'll allow a cast exception higher up to catch this.
-
-            SerializationTokenType token;
-            object result;
-            if (stream.TryReadSimpleType(out result, out token))
-                return result;
-
-            // Special serializations (reference, fallback)
-            if (token == SerializationTokenType.Reference)
+            try
             {
-                var offset = stream.ReadInt();
-                return DeserializationContext.Current.FetchReferencedObject(offset);
-            }
-            if (token == SerializationTokenType.Fallback)
-            {
-                var fallbackResult = FallbackDeserializer(stream);
-                DeserializationContext.Current.RecordObject(start, fallbackResult);
-                return fallbackResult;
-            }
+                // NOTE: we don't check that the actual dynamic result implements the expected type.
+                // We'll allow a cast exception higher up to catch this.
+                SerializationTokenType token;
+                object result;
+                if (stream.TryReadSimpleType(out result, out token))
+                {
+                    return result;
+                }
 
-            Type resultType;
-            if (token == SerializationTokenType.ExpectedType)
-            {
-                if (expected == null)
-                    throw new SerializationException("ExpectedType token encountered but no expected type provided");
+                // Special serializations (reference, fallback)
+                if (token == SerializationTokenType.Reference)
+                {
+                    var offset = stream.ReadInt();
+                    result = DeserializationContext.Current.FetchReferencedObject(offset);
+                    return result;
+                }
+                if (token == SerializationTokenType.Fallback)
+                {
+                    var fallbackResult = FallbackDeserializer(stream);
+                    DeserializationContext.Current.RecordObject(fallbackResult);
+                    return fallbackResult;
+                }
 
-                resultType = expected;
-            }
-            else if (token == SerializationTokenType.SpecifiedType)
-            {
-                resultType = stream.ReadSpecifiedTypeHeader();
-            }
-            else
-            {
-                throw new SerializationException("Unexpected token '" + token + "' introducing type specifier");
-            }
+                Type resultType;
+                if (token == SerializationTokenType.ExpectedType)
+                {
+                    if (expected == null)
+                    {
+                        throw new SerializationException("ExpectedType token encountered but no expected type provided");
+                    }
 
-            // Handle object, which is easy
-            if (resultType.TypeHandle.Equals(objectTypeHandle))
-                return new object();
+                    resultType = expected;
+                }
+                else if (token == SerializationTokenType.SpecifiedType)
+                {
+                    resultType = stream.ReadSpecifiedTypeHeader();
+                }
+                else
+                {
+                    throw new SerializationException("Unexpected token '" + token + "' introducing type specifier");
+                }
 
-            // Handle enums
-            if (resultType.IsEnum)
-            {
-                result = Enum.ToObject(resultType, stream.ReadInt());
-                return result;
+                // Handle object, which is easy
+                if (resultType.TypeHandle.Equals(objectTypeHandle))
+                {
+                    return new object();
+                }
+
+                // Handle enums
+                if (resultType.IsEnum)
+                {
+                    result = Enum.ToObject(resultType, stream.ReadInt());
+                    return result;
+                }
+
+                if (resultType.IsArray)
+                {
+                    result = DeserializeArray(resultType, stream);
+                    DeserializationContext.Current.RecordObject(result);
+                    return result;
+                }
+
+                var deser = GetDeserializer(resultType);
+                if (deser != null)
+                {
+                    result = deser(resultType, stream);
+                    DeserializationContext.Current.RecordObject(result);
+                    return result;
+                }
+
+                throw new SerializationException(
+                    "Unsupported type '" + resultType.OrleansTypeName()
+                    + "' encountered. Perhaps you need to mark it [Serializable] or define a custom serializer for it?");
             }
-
-            if (resultType.IsArray)
+            finally
             {
-                result = DeserializeArray(resultType, stream);
-                DeserializationContext.Current.RecordObject(start, result);
-                return result;
+                DeserializationContext.Current.CurrentObjectOffset = previousOffset;
             }
-
-            var deser = GetDeserializer(resultType);
-            if (deser != null)
-            {
-                result = deser(resultType, stream);
-                DeserializationContext.Current.RecordObject(start, result);
-                return result;
-            }
-
-            throw new SerializationException("Unsupported type '" + resultType.OrleansTypeName() + 
-                "' encountered. Perhaps you need to mark it [Serializable] or define a custom serializer for it?");
         }
 
         private static object DeserializeArray(Type resultType, BinaryTokenStreamReader stream)

--- a/src/TestGrainInterfaces/ICircularStateTestGrain.cs
+++ b/src/TestGrainInterfaces/ICircularStateTestGrain.cs
@@ -1,0 +1,32 @@
+﻿using Orleans;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace TestGrainInterfaces
+{
+    public interface ICircularStateTestGrain : IGrainWithGuidCompoundKey
+    {
+        Task<CircularTest1> GetState();
+    }
+
+    public class CircularStateTestState : GrainState
+    {
+        public CircularTest1 CircularTest1 { get; set; }
+    }
+
+    [Serializable]
+    public class CircularTest1
+    {
+        public CircularTest2 CircularTest2 { get; set; }
+    }
+    [Serializable]
+    public class CircularTest2
+    {
+        public CircularTest2()
+        {
+            CircularTest1List = new List<CircularTest1>();
+        }
+        public List<CircularTest1> CircularTest1List { get; set; }
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ICircularStateTestGrain.cs" />
     <Compile Include="IExceptionGrain.cs" />
     <Compile Include="IFaultableConsumerGrain.cs" />
     <Compile Include="IGeneratorTestDerivedDerivedGrain.cs" />
@@ -113,4 +114,3 @@
   </Target> 
   -->
 </Project>
-

--- a/src/TestGrains/CircularStateTestGrain.cs
+++ b/src/TestGrains/CircularStateTestGrain.cs
@@ -1,0 +1,24 @@
+﻿using Orleans;
+using System.Threading.Tasks;
+using TestGrainInterfaces;
+
+namespace TestGrains
+{
+    public class CircularStateTestGrain : Grain<CircularStateTestState>, ICircularStateTestGrain
+    {
+        public override async Task OnActivateAsync()
+        {
+            var c1 = new CircularTest1();
+            var c2 = new CircularTest2();
+            c2.CircularTest1List.Add(c1);
+            c1.CircularTest2 = c2;
+
+            State.CircularTest1 = c1;
+            await WriteStateAsync();
+        }
+        public Task<CircularTest1> GetState()
+        {
+            return Task.FromResult(State.CircularTest1);
+        }
+    }
+}

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CircularStateTestGrain.cs" />
     <Compile Include="ExceptionGrain.cs" />
     <Compile Include="FaultableConsumerGrain.cs" />
     <Compile Include="EventSourcing\PersonState.cs" />
@@ -124,4 +125,3 @@
   <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
   <!--End Orleans -->
 </Project>
-

--- a/src/Tester/GenericGrainTests.cs
+++ b/src/Tester/GenericGrainTests.cs
@@ -31,6 +31,7 @@ using Orleans.TestingHost;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
 using System.Collections.Generic;
+using TestGrainInterfaces;
 
 namespace UnitTests.General
 {
@@ -666,6 +667,14 @@ namespace UnitTests.General
             await Task.Delay(TimeSpan.FromSeconds(6));
             var s2 = await grain.GetLastValue();
             Assert.AreEqual(s1, s2);
+        }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Generics"), TestCategory("Serialization")]
+        public async Task Generic_CircularReferenceTest()
+        {
+            var grainId = Guid.NewGuid();
+            var grain = GrainFactory.GetGrain<ICircularStateTestGrain>(primaryKey: grainId, keyExtension: grainId.ToString("N"));
+            var c1 = await grain.GetState();
         }
     }
 }

--- a/src/Tester/SerializationTests.cs
+++ b/src/Tester/SerializationTests.cs
@@ -143,6 +143,7 @@ namespace UnitTests.General
             public static object Deserializer(System.Type expected, global::Orleans.Serialization.BinaryTokenStreamReader stream)
             {
                 TestTypeA result = new TestTypeA();
+                DeserializationContext.Current.RecordObject(result);
                 result.Collection = ((System.Collections.Generic.ICollection<TestTypeA>)(Orleans.Serialization.SerializationManager.DeserializeInner(typeof(System.Collections.Generic.ICollection<TestTypeA>), stream)));
                 return result;
             }
@@ -153,7 +154,6 @@ namespace UnitTests.General
             }
         }
 
-        [Ignore]
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_RecursiveSerialization()
         {

--- a/src/TesterInternal/General/BuiltInSerializerTests.cs
+++ b/src/TesterInternal/General/BuiltInSerializerTests.cs
@@ -1111,10 +1111,13 @@ namespace UnitTests.SerializerTests
             c2.CircularTest1List.Add(c1);
             c1.CircularTest2 = c2;
 
-            var deserialized = OrleansSerializationLoop(c1);
-            //Assert.AreEqual(c1, deserialized);
-            deserialized = OrleansSerializationLoop(c1, true);
-            Assert.AreEqual(c1, deserialized);
+            var deserialized = (CircularTest1)OrleansSerializationLoop(c1);
+            Assert.AreEqual(c1.CircularTest2.CircularTest1List.Count, deserialized.CircularTest2.CircularTest1List.Count);
+            Assert.AreEqual(deserialized, deserialized.CircularTest2.CircularTest1List[0]);
+
+            deserialized = (CircularTest1)OrleansSerializationLoop(c1, true);
+            Assert.AreEqual(c1.CircularTest2.CircularTest1List.Count, deserialized.CircularTest2.CircularTest1List.Count);
+            Assert.AreEqual(deserialized, deserialized.CircularTest2.CircularTest1List[0]);
         }
 
         [Serializable]

--- a/src/TesterInternal/General/BuiltInSerializerTests.cs
+++ b/src/TesterInternal/General/BuiltInSerializerTests.cs
@@ -1102,6 +1102,35 @@ namespace UnitTests.SerializerTests
                 ValidateArrayOfArrays<T>(expected[i], result[i], "Array of " + type + "[" + i + "][]");
             }
         }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Serialization")]
+        public void Serialize_CircularReference()
+        {
+            var c1 = new CircularTest1();
+            var c2 = new CircularTest2();
+            c2.CircularTest1List.Add(c1);
+            c1.CircularTest2 = c2;
+
+            var deserialized = OrleansSerializationLoop(c1);
+            //Assert.AreEqual(c1, deserialized);
+            deserialized = OrleansSerializationLoop(c1, true);
+            Assert.AreEqual(c1, deserialized);
+        }
+
+        [Serializable]
+        public class CircularTest1
+        {
+            public CircularTest2 CircularTest2 { get; set; }
+        }
+        [Serializable]
+        public class CircularTest2
+        {
+            public CircularTest2()
+            {
+                CircularTest1List = new List<CircularTest1>();                   
+            }
+            public List<CircularTest1> CircularTest1List { get; set; }
+        }
     }
 }
 


### PR DESCRIPTION
This fix for #852 is based on @gabikliot's suggestions in that thread.
I have also included @galvesribeiro's tests for that bug. @galvesribeiro's test uses generated code, unlike the existing `SerializationTests_RecursiveSerialization`. I am not sure if the latter should be kept given it needed to be modified to pass the test.