### PR TITLE
Ignore exceptions when getting endpoint on socket error.

### DIFF
--- a/src/OrleansRuntime/Messaging/Gateway.cs
+++ b/src/OrleansRuntime/Messaging/Gateway.cs
@@ -616,7 +616,11 @@ namespace Orleans.Runtime.Messaging
                     string remoteEndpoint = "";
                     if (!(exc is ObjectDisposedException))
                     {
-                        remoteEndpoint = sock.RemoteEndPoint.ToString();
+                        try
+                        {
+                            remoteEndpoint = sock.RemoteEndPoint.ToString();
+                        }
+                        catch (Exception){}
                     }
                     sendErrorStr = String.Format("Exception sending to client at {0}: {1}", remoteEndpoint, exc);
                     Log.Warn(ErrorCode.GatewayExceptionSendingToClient, sendErrorStr, exc);


### PR DESCRIPTION
Code assumed that exception thrown was something other than ObjectDisposedException, socket had not been disposed.  This is not a safe assumption.  Calling RemoteEndPoint on a disposed socket can throw, breaking us out of he expected error handling path, so we now ignore any exceptions from that call.