### PR TITLE
Feature: Per-Grain-class Request Interceptors

### DIFF
--- a/src/Orleans/CodeGeneration/IGrainMethodInvoker.cs
+++ b/src/Orleans/CodeGeneration/IGrainMethodInvoker.cs
@@ -17,11 +17,9 @@ namespace Orleans.CodeGeneration
         /// Invoker classes in generated code implement this method to provide a method call jump-table to map invoke data to a strongly typed call to the correct method on the correct interface.
         /// </summary>
         /// <param name="grain">Reference to the grain to be invoked.</param>
-        /// <param name="interfaceId">Interface id of the method to be called.</param>
-        /// <param name="methodId">Method id of the method to be called.</param>
-        /// <param name="arguments">Arguments to be passed to the method being invoked.</param>
+        /// <param name="request">The request being invoked.</param>
         /// <returns>Value promise for the result of the method invoke.</returns>
-        Task<object> Invoke(IAddressable grain, int interfaceId, int methodId, object[] arguments);
+        Task<object> Invoke(IAddressable grain, InvokeMethodRequest request);
     }
 
     /// <summary>
@@ -33,10 +31,8 @@ namespace Orleans.CodeGeneration
         /// Invoke a grain extension method.
         /// </summary>
         /// <param name="extension">Reference to the extension to be invoked.</param>
-        /// <param name="interfaceId">Interface id of the method to be called.</param>
-        /// <param name="methodId">Method id of the method to be called.</param>
-        /// <param name="arguments">Arguments to be passed to the method being invoked.</param>
+        /// <param name="request">The request being invoked.</param>
         /// <returns>Value promise for the result of the method invoke.</returns>
-        Task<object> Invoke(IGrainExtension extension, int interfaceId, int methodId, object[] arguments);
+        Task<object> Invoke(IGrainExtension extension, InvokeMethodRequest request);
     }
 }

--- a/src/Orleans/Core/IGrainInvokeInterceptor.cs
+++ b/src/Orleans/Core/IGrainInvokeInterceptor.cs
@@ -1,0 +1,12 @@
+namespace Orleans
+{
+    using System.Reflection;
+    using System.Threading.Tasks;
+
+    using Orleans.CodeGeneration;
+
+    public interface IGrainInvokeInterceptor
+    {
+        Task<object> Invoke(MethodInfo method, InvokeMethodRequest request, IGrainMethodInvoker invoker);
+    }
+}

--- a/src/Orleans/Core/InvocationMethodInfoMap.cs
+++ b/src/Orleans/Core/InvocationMethodInfoMap.cs
@@ -1,0 +1,90 @@
+namespace Orleans
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    using Orleans.CodeGeneration;
+
+    internal class InvocationMethodInfoMap
+    {
+        private readonly ConcurrentDictionary<Type, ConcurrentDictionary<int, IReadOnlyDictionary<int, MethodInfo>>> implementations =
+            new ConcurrentDictionary<Type, ConcurrentDictionary<int, IReadOnlyDictionary<int, MethodInfo>>>();
+
+        /// <summary>
+        /// Returns the <see cref="MethodInfo"/> for the specified implementation and invocation request.
+        /// </summary>
+        /// <param name="implementationType">The type of the implementation.</param>
+        /// <param name="request">The invocation request.</param>
+        /// <returns>The <see cref="MethodInfo"/> for the specified implementation and invocation request.</returns>
+        public MethodInfo GetMethodInfo(Type implementationType, InvokeMethodRequest request)
+        {
+            var implementation = this.implementations.GetOrAdd(
+                implementationType,
+                _ => new ConcurrentDictionary<int, IReadOnlyDictionary<int, MethodInfo>>());
+
+            IReadOnlyDictionary<int, MethodInfo> interfaceMap;
+            if (!implementation.TryGetValue(request.InterfaceId, out interfaceMap))
+            {
+                // Get the interface mapping for the current implementation.
+                var interfaces = GrainInterfaceData.GetRemoteInterfaces(implementationType);
+                Type interfaceType;
+                if (!interfaces.TryGetValue(request.InterfaceId, out interfaceType))
+                {
+                    // The specified type does not implement the provided interface.
+                    return null;
+                }
+
+                // Create a mapping between the interface and the implementation.
+                interfaceMap = implementation.GetOrAdd(
+                    request.InterfaceId,
+                    _ => MapInterfaceToImplementation(interfaceType, implementationType));
+            }
+
+            // Attempt to retrieve the implementation's MethodInfo.
+            MethodInfo result;
+            interfaceMap.TryGetValue(request.MethodId, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Maps the provided <paramref name="interfaceType"/> to the provided <paramref name="implementationType"/>.
+        /// </summary>
+        /// <param name="interfaceType">The interface type.</param>
+        /// <param name="implementationType">The implementation type.</param>
+        /// <returns>The mapped interface.</returns>
+        private static IReadOnlyDictionary<int, MethodInfo> MapInterfaceToImplementation(
+            Type interfaceType,
+            Type implementationType)
+        {
+            var interfaceMapping = implementationType.GetInterfaceMap(interfaceType);
+
+            // Map the interface methods to implementation methods.
+            var interfaceMethods = GrainInterfaceData.GetMethods(interfaceType);
+            return interfaceMethods.ToDictionary(
+                GrainInterfaceData.ComputeMethodId,
+                interfaceMethod => GetImplementingMethod(interfaceMethod, interfaceMapping));
+        }
+
+        /// <summary>
+        /// Returns the <see cref="MethodInfo"/> of implementation of <paramref name="interfaceMethod"/>.
+        /// </summary>
+        /// <param name="interfaceMethod">The interface method.</param>
+        /// <param name="implementation">The implementation.</param>
+        /// <returns>The <see cref="MethodInfo"/> of implementation of <paramref name="interfaceMethod"/>.</returns>
+        private static MethodInfo GetImplementingMethod(MethodInfo interfaceMethod, InterfaceMapping implementation)
+        {
+            for (var i = 0; i < implementation.InterfaceMethods.Length; i++)
+            {
+                if (implementation.InterfaceMethods[i] == interfaceMethod)
+                {
+                    return implementation.TargetMethods[i];
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -91,6 +91,8 @@
     <Compile Include="CodeGeneration\SkipCodeGenerationAttribute.cs" />
     <Compile Include="CodeGeneration\IGrainState.cs" />
     <Compile Include="CodeGeneration\TypeFormattingOptions.cs" />
+    <Compile Include="Core\IGrainInvokeInterceptor.cs" />
+    <Compile Include="Core\InvocationMethodInfoMap.cs" />
     <Compile Include="Core\IStatefulGrain.cs" />
     <Compile Include="Providers\DefaultServiceProvider.cs" />
     <Compile Include="Serialization\IExternalSerializer.cs" />

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -444,11 +444,7 @@ namespace Orleans
                     {
                         // exceptions thrown within this scope are not considered to be thrown from user code
                         // and not from runtime code.
-                        var resultPromise = objectData.Invoker.Invoke(
-                            targetOb,
-                            request.InterfaceId,
-                            request.MethodId,
-                            request.Arguments);
+                        var resultPromise = objectData.Invoker.Invoke(targetOb, request);
                         if (resultPromise != null) // it will be null for one way messages
                         {
                             resultObject = await resultPromise;

--- a/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
+++ b/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
@@ -199,7 +199,7 @@ namespace Orleans.CodeGenerator
         /// </returns>
         public static SwitchSectionSyntax[] GenerateGrainInterfaceAndMethodSwitch(
             Type grainType,
-            IdentifierNameSyntax methodIdArgument,
+            ExpressionSyntax methodIdArgument,
             Func<MethodInfo, StatementSyntax[]> generateMethodHandler)
         {
             var interfaces = GrainInterfaceData.GetRemoteInterfaces(grainType);

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -103,15 +103,15 @@ namespace Orleans.Runtime
             /// <param name="methodId"></param>
             /// <param name="arguments"></param>
             /// <returns></returns>
-            public Task<object> Invoke(IAddressable grain, int interfaceId, int methodId, object[] arguments)
+            public Task<object> Invoke(IAddressable grain, InvokeMethodRequest request)
             {
-                if (extensionMap == null || !extensionMap.ContainsKey(interfaceId))
+                if (extensionMap == null || !extensionMap.ContainsKey(request.InterfaceId))
                     throw new InvalidOperationException(
-                        String.Format("Extension invoker invoked with an unknown inteface ID:{0}.", interfaceId));
+                        String.Format("Extension invoker invoked with an unknown inteface ID:{0}.", request.InterfaceId));
 
-                var invoker = extensionMap[interfaceId].Item2;
-                var extension = extensionMap[interfaceId].Item1;
-                return invoker.Invoke(extension, interfaceId, methodId, arguments);
+                var invoker = extensionMap[request.InterfaceId].Item2;
+                var extension = extensionMap[request.InterfaceId].Item1;
+                return invoker.Invoke(extension, request);
             }
 
             public bool IsExtensionInstalled(int interfaceId)

--- a/src/OrleansRuntime/Core/InsideGrainClient.cs
+++ b/src/OrleansRuntime/Core/InsideGrainClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
@@ -32,6 +32,8 @@ namespace Orleans.Runtime
         private readonly ILocalGrainDirectory directory;
         private readonly List<IDisposable> disposables;
         private readonly ConcurrentDictionary<CorrelationId, CallbackData> callbacks;
+        
+        private readonly InvocationMethodInfoMap invocationMethodInfoMap = new InvocationMethodInfoMap();
         public TimeSpan ResponseTimeout { get; private set; }
         private readonly GrainTypeManager typeManager;
         private GrainInterfaceMap grainInterfaceMap;
@@ -361,7 +363,18 @@ namespace Orleans.Runtime
 
                         throw exc;
                     }
-                    resultObject = await invoker.Invoke(target, request.InterfaceId, request.MethodId, request.Arguments);
+
+                    // If the target has an interceptor, invoke that instead.
+                    var intercepted = target as IGrainInvokeInterceptor;
+                    if (intercepted != null)
+                    {
+                        var methodInfo = this.invocationMethodInfoMap.GetMethodInfo(target.GetType(), request);
+                        resultObject = await intercepted.Invoke(methodInfo, request, invoker);
+                    }
+                    else
+                    {
+                        resultObject = await invoker.Invoke(target, request);
+                    }
                 }
                 catch (Exception exc1)
                 {

--- a/src/TestGrainInterfaces/IMethodInterceptionGrain.cs
+++ b/src/TestGrainInterfaces/IMethodInterceptionGrain.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests.GrainInterfaces
+{
+    using Orleans;
+    public interface IMethodInterceptionGrain : IGrainWithIntegerKey
+    {
+        Task<string> One();
+        Task<string> Echo(string someArg);
+        Task<string> NotIntercepted();
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -62,6 +62,7 @@
     <Compile Include="IGeneratorTestDerivedGrain1.cs" />
     <Compile Include="IGeneratorTestDerivedGrain2.cs" />
     <Compile Include="IGeneratorTestGrain.cs" />
+    <Compile Include="IMethodInterceptionGrain.cs" />
     <Compile Include="IJournaledPersonGrain.cs" />
     <Compile Include="IGeneratedEventCollectorGrain.cs" />
     <Compile Include="IGeneratedEventReporterGrain.cs" />

--- a/src/TestGrains/MethodInterceptionGrain.cs
+++ b/src/TestGrains/MethodInterceptionGrain.cs
@@ -1,0 +1,60 @@
+﻿using System.Threading.Tasks;
+
+namespace UnitTests.Grains
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.InteropServices;
+
+    using Orleans;
+    using Orleans.CodeGeneration;
+    using Orleans.Runtime;
+
+    using UnitTests.GrainInterfaces;
+    public class MethodInterceptionGrain : Grain, IMethodInterceptionGrain, IGrainInvokeInterceptor
+    {
+        public async Task<object> Invoke(MethodInfo methodInfo, InvokeMethodRequest request, IGrainMethodInvoker invoker)
+        {
+            if (methodInfo.Name == "One" && methodInfo.GetParameters().Length == 0)
+            {
+                return "intercepted one with no args";
+            }
+
+            var result = await invoker.Invoke(this, request);
+
+            // To prove that the MethodInfo is from the implementation and not the interface,
+            // we check for this attribute which is only present on the implementation. This could be
+            // done in a simpler fashion, but this demonstrates a potential usage scenario.
+            var shouldMessWithResult = methodInfo.GetCustomAttribute<MessWithResultAttribute>();
+            var resultString = result as string;
+            if (shouldMessWithResult != null && resultString !=null)
+            {
+                result = string.Concat(resultString.Reverse());
+            }
+
+            return result;
+        }
+
+        public Task<string> One()
+        {
+            throw new InvalidOperationException("Not allowed to actually invoke this method!");
+        }
+
+        [MessWithResult]
+        public Task<string> Echo(string someArg)
+        {
+            return Task.FromResult(someArg);
+        }
+
+        public Task<string> NotIntercepted()
+        {
+            return Task.FromResult("not intercepted");
+        }
+
+        [AttributeUsage(AttributeTargets.Method)]
+        public class MessWithResultAttribute : Attribute
+        {
+        }
+    }
+}

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -76,6 +76,7 @@
     <Compile Include="GenericGrains.cs" />
     <Compile Include="GetGrainGrains.cs" />
     <Compile Include="InitialStateGrain.cs" />
+    <Compile Include="MethodInterceptionGrain.cs" />
     <Compile Include="KeyExtensionTestGrain.cs" />
     <Compile Include="MultipleImplicitSubscriptionGrain.cs" />
     <Compile Include="EventSourcing\JournaledPersonGrain.cs" />

--- a/src/Tester/MethodInterceptionTests.cs
+++ b/src/Tester/MethodInterceptionTests.cs
@@ -1,0 +1,33 @@
+﻿namespace Tester
+{
+    using System.Threading.Tasks;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using Orleans;
+    using Orleans.Runtime;
+
+    using UnitTests.GrainInterfaces;
+    using UnitTests.Tester;
+
+    [TestClass]
+    public class MethodInterceptionTests : HostedTestClusterEnsureDefaultStarted
+    {
+        [TestMethod, TestCategory("Functional"), TestCategory("MethodInterception")]
+        public async Task GrainMethodInterceptionTest()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<IMethodInterceptionGrain>(0);
+            var result = await grain.One();
+            Assert.AreEqual("intercepted one with no args", result, "Method invocation should have been intercepted");
+
+            result = await grain.Echo("stao erom tae");
+            Assert.AreEqual(
+                "eat more oats",
+                result,
+                "Grain interceptors should receive the MethodInfo of the implementation, not the interface.");
+
+            result = await grain.NotIntercepted();
+            Assert.AreEqual("not intercepted", result);
+        }
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -124,6 +124,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MethodInterceptionTests.cs" />
     <Compile Include="OrleansTestingBase.cs" />
     <Compile Include="SerializationTests\DeepCopyTests.cs" />
     <Compile Include="StreamingTests\EHImplicitSubscriptionStreamRecoveryTests.cs" />


### PR DESCRIPTION
This feature allows users to override `Grain.Invoke(InvokeMethodRequest request, IGrainMethodInvoker invoker)` in order to perform request interception on a per-Grain-class level.

As requested by @yevhen in #749.

Example:
```C#
public class InterceptRequestGrain : Grain, ISomeGrain 
{
  protected override Task<object> Invoke(InvokeMethodRequest request, IGrainMethodInvoker invoker)
  {
    RequestContext.Set("InterceptedValue", 74);
    return base.Invoke(request, invoker);
  }

  // Other methods...
}
```