### PR TITLE
Remove static dependency on OrleansCodeGenerator in OrleansRuntime

### DIFF
--- a/src/NuGet/Microsoft.Orleans.Client.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Client.nuspec
@@ -20,6 +20,7 @@
     <dependencies>
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansProviders" version="$version$" />
+      <dependency id="Microsoft.Orleans.OrleansCodeGenerator" version="$version$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
@@ -19,7 +19,6 @@
     <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
     <dependencies>
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
-      <dependency id="Microsoft.Orleans.OrleansCodeGenerator" version="$version$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/Microsoft.Orleans.Server.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Server.nuspec
@@ -23,6 +23,7 @@
       <dependency id="Microsoft.Orleans.OrleansHost" version="$version$" />
       <dependency id="Microsoft.Orleans.CounterControl" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansProviders" version="$version$" />
+      <dependency id="Microsoft.Orleans.OrleansCodeGenerator" version="$version$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Orleans/CodeGeneration/CodeGeneratorManager.cs
+++ b/src/Orleans/CodeGeneration/CodeGeneratorManager.cs
@@ -1,10 +1,38 @@
-﻿namespace Orleans.CodeGeneration
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace Orleans.CodeGeneration
 {
     using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Reflection;
 
     using Orleans.Runtime;
 
+    /// <summary>
+    /// Methods for invoking code generation.
+    /// </summary>
     internal static class CodeGeneratorManager
     {
         /// <summary>
@@ -15,7 +43,14 @@
         /// <summary>
         /// The runtime code generator.
         /// </summary>
-        private static readonly Lazy<IRuntimeCodeGenerator> CodeGeneratorInstance = new Lazy<IRuntimeCodeGenerator>(LoadCodeGenerator);
+        private static readonly Lazy<IRuntimeCodeGenerator> CodeGeneratorInstance =
+            new Lazy<IRuntimeCodeGenerator>(LoadCodeGenerator);
+
+        /// <summary>
+        /// The code generator cache.
+        /// </summary>
+        private static readonly Lazy<ICodeGeneratorCache> CodeGeneratorCacheInstance =
+            new Lazy<ICodeGeneratorCache>(LoadCodeGeneratorCache);
 
         /// <summary>
         /// The log.
@@ -23,8 +58,17 @@
         private static readonly TraceLogger Log = TraceLogger.GetLogger("CodeGenerator");
 
         /// <summary>
+        /// Empty generated assemblies.
+        /// </summary>
+        private static readonly ReadOnlyDictionary<string, byte[]> EmptyGeneratedAssemblies =
+            new ReadOnlyDictionary<string, byte[]>(new Dictionary<string, byte[]>());
+
+        /// <summary>
         /// Ensures code for the <paramref name="input"/> assembly has been generated and loaded.
         /// </summary>
+        /// <param name="input">
+        /// The input assembly.
+        /// </param>
         public static void GenerateAndCacheCodeForAssembly(Assembly input)
         {
             var codeGen = CodeGeneratorInstance.Value;
@@ -47,9 +91,48 @@
         }
 
         /// <summary>
+        /// Returns the collection of generated assemblies as pairs of target assembly name to raw assembly bytes.
+        /// </summary>
+        /// <returns>The collection of generated assemblies.</returns>
+        public static IDictionary<string, byte[]> GetGeneratedAssemblies()
+        {
+            var codeGen = CodeGeneratorCacheInstance.Value;
+            if (codeGen != null)
+            {
+                return codeGen.GetGeneratedAssemblies();
+            }
+
+            return EmptyGeneratedAssemblies;
+        }
+
+        /// <summary>
+        /// Adds a pre-generated assembly to the assembly cache.
+        /// </summary>
+        /// <param name="targetAssemblyName">
+        /// The name of the assembly the provided <paramref name="rawAssembly"/> targets.
+        /// </param>
+        /// <param name="generatedAssembly">
+        /// The generated assembly.
+        /// </param>
+        public static void AddGeneratedAssembly(string targetAssemblyName, byte[] generatedAssembly)
+        {
+            var codeGen = CodeGeneratorCacheInstance.Value;
+            if (codeGen != null)
+            {
+                codeGen.AddGeneratedAssembly(targetAssemblyName, generatedAssembly);
+            }
+            else
+            {
+                Log.Warn(
+                    ErrorCode.CodeGenDllMissing,
+                    "CodeGenerationManager.AddCachedAssembly called but no code geenrator has been loaded.");
+            }
+        }
+
+        /// <summary>
         /// Loads the code generator.
         /// </summary>
-        /// <returns>The laoded code generator.</returns>
+        /// <returns>The code generator.</returns>
         private static IRuntimeCodeGenerator LoadCodeGenerator()
         {
             var result = AssemblyLoader.TryLoadAndCreateInstance<IRuntimeCodeGenerator>(CodeGenAssemblyName, Log);
@@ -61,6 +144,15 @@
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Loads the code generator cache.
+        /// </summary>
+        /// <returns>The code generator cache, or <see langword="null"/> if none was loaded.</returns>
+        private static ICodeGeneratorCache LoadCodeGeneratorCache()
+        {
+            return CodeGeneratorInstance.Value as ICodeGeneratorCache;
         }
     }
 }

--- a/src/Orleans/CodeGeneration/ICodeGeneratorCache.cs
+++ b/src/Orleans/CodeGeneration/ICodeGeneratorCache.cs
@@ -1,0 +1,30 @@
+﻿namespace Orleans.CodeGeneration
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Methods for interacting with a cache for generated assemblies.
+    /// </summary>
+    public interface ICodeGeneratorCache
+    {
+        /// <summary>
+        /// Adds a pre-generated assembly.
+        /// </summary>
+        /// <param name="targetAssemblyName">
+        /// The name of the assembly the provided <paramref name="generatedAssembly"/> targets.
+        /// </param>
+        /// <param name="generatedAssembly">
+        /// The generated assembly.
+        /// </param>
+        void AddGeneratedAssembly(string targetAssemblyName, byte[] generatedAssembly);
+
+        /// <summary>
+        /// Returns the collection of generated assemblies as pairs of target assembly name to raw assembly bytes.
+        /// </summary>
+        /// <returns>The collection of generated assemblies.</returns>
+        /// <remarks>
+        /// The key of the returned dictionary is the name of the assembly which the value targets.
+        /// </remarks>
+        IDictionary<string, byte[]> GetGeneratedAssemblies();
+    }
+}

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Async\TaskExtensions.cs" />
     <Compile Include="CodeGeneration\CodeGeneratorManager.cs" />
     <Compile Include="CodeGeneration\GrainState.cs" />
+    <Compile Include="CodeGeneration\ICodeGeneratorCache.cs" />
     <Compile Include="CodeGeneration\IGrainMethodInvoker.cs" />
     <Compile Include="CodeGeneration\IRuntimeCodeGenerator.cs" />
     <Compile Include="CodeGeneration\ISourceCodeGenerator.cs" />

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -44,7 +44,7 @@ namespace Orleans.CodeGenerator
     /// <summary>
     /// Implements a code generator using the Roslyn C# compiler.
     /// </summary>
-    public class RoslynCodeGenerator : IRuntimeCodeGenerator, ISourceCodeGenerator
+    public class RoslynCodeGenerator : IRuntimeCodeGenerator, ISourceCodeGenerator, ICodeGeneratorCache
     {
         /// <summary>
         /// The compiled assemblies.
@@ -88,15 +88,15 @@ namespace Orleans.CodeGenerator
         /// <summary>
         /// Adds a pre-generated assembly.
         /// </summary>
-        /// <param name="assemblyName">
-        /// The name of the assembly the provided <paramref name="rawAssembly"/> targets.
+        /// <param name="targetAssemblyName">
+        /// The name of the assembly the provided <paramref name="generatedAssembly"/> targets.
         /// </param>
-        /// <param name="rawAssembly">
-        /// The raw assembly.
+        /// <param name="generatedAssembly">
+        /// The generated assembly.
         /// </param>
-        public static void AddCachedAssembly(string assemblyName, byte[] rawAssembly)
+        public void AddGeneratedAssembly(string targetAssemblyName, byte[] generatedAssembly)
         {
-            CompiledAssemblies.TryAdd(assemblyName, new GeneratedAssembly { RawBytes = rawAssembly });
+            CompiledAssemblies.TryAdd(targetAssemblyName, new GeneratedAssembly { RawBytes = generatedAssembly });
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Orleans.CodeGenerator
         /// Returns the collection of generated assemblies as pairs of target assembly name to raw assembly bytes.
         /// </summary>
         /// <returns>The collection of generated assemblies.</returns>
-        internal IDictionary<string, byte[]> GetGeneratedAssemblies()
+        public IDictionary<string, byte[]> GetGeneratedAssemblies()
         {
             return CompiledAssemblies.ToDictionary(_ => _.Key, _ => _.Value.RawBytes);
         }

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -69,7 +69,7 @@ namespace Orleans.Runtime
             var loader = new SiloAssemblyLoader();
 
             // Generate code for newly loaded assemblies.
-            CodeGenerator.RoslynCodeGenerator.Instance.GenerateAndLoadForAllAssemblies();
+            CodeGeneratorManager.GenerateAndCacheCodeForAllAssemblies();
 
             // (no more assemblies should be loaded into memory, so now is a good time to log all types registered with the serialization manager)
             SerializationManager.LogRegisteredTypes();

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -198,10 +198,6 @@
     <Compile Include="Streams\QueueBalancer\StreamQueueBalancerFactory.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\OrleansCodeGenerator\OrleansCodeGenerator.csproj">
-      <Project>{8d937706-f6da-4d33-b0a9-24a260bd3080}</Project>
-      <Name>OrleansCodeGenerator</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Orleans\Orleans.csproj">
       <Project>{BC1BD60C-E7D8-4452-A21C-290AEC8E2E74}</Project>
       <Name>Orleans</Name>

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -31,6 +31,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.CodeGeneration;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.ConsistentRing;
@@ -48,13 +49,8 @@ using Orleans.Storage;
 using Orleans.Streams;
 using Orleans.Timers;
 
-
 namespace Orleans.Runtime
 {
-    using System.Collections.ObjectModel;
-
-    using Orleans.CodeGeneration;
-    using Orleans.CodeGenerator;
 
     /// <summary>
     /// Orleans silo.
@@ -189,7 +185,7 @@ namespace Orleans.Runtime
             ActivationData.Init(config, nodeConfig);
             StatisticsCollector.Initialize(nodeConfig);
             
-            RoslynCodeGenerator.Instance.GenerateAndLoadForAllAssemblies();
+            CodeGeneratorManager.GenerateAndCacheCodeForAllAssemblies();
             SerializationManager.Initialize(globalConfig.UseStandardSerializer);
             initTimeout = globalConfig.MaxJoinAttemptTime;
             if (Debugger.IsAttached)
@@ -854,7 +850,7 @@ namespace Orleans.Runtime
             /// <param name="collection">The collection to populate.</param>
             public void UpdateGeneratedAssemblies(GeneratedAssemblies collection)
             {
-                var generatedAssemblies = RoslynCodeGenerator.Instance.GetGeneratedAssemblies();
+                var generatedAssemblies = CodeGeneratorManager.GetGeneratedAssemblies();
                 foreach (var asm in generatedAssemblies)
                 {
                     collection.Add(asm.Key, asm.Value);
@@ -994,7 +990,7 @@ namespace Orleans.Runtime
                 /// <param name="cachedAssembly">The generated assembly.</param>
                 public void AddCachedAssembly(string targetAssemblyName, byte[] cachedAssembly)
                 {
-                    RoslynCodeGenerator.AddCachedAssembly(targetAssemblyName, cachedAssembly);
+                    CodeGeneratorManager.AddGeneratedAssembly(targetAssemblyName, cachedAssembly);
                 }
             }
         }

--- a/src/Tester/CodeGenTests/RuntimeCodeGenerationTests.cs
+++ b/src/Tester/CodeGenTests/RuntimeCodeGenerationTests.cs
@@ -36,6 +36,7 @@ namespace Tester.CodeGenTests
     /// <summary>
     /// Tests runtime code generation.
     /// </summary>
+    [DeploymentItem("OrleansCodeGenerator.dll")]
     [TestClass]
     public class RuntimeCodeGenerationTests : UnitTestSiloHost
     {

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -161,6 +161,10 @@
       <Project>{792818ef-b3f8-4ce2-9886-4808713b15c4}</Project>
       <Name>OrleansAzureUtils</Name>
     </ProjectReference>
+    <ProjectReference Include="..\OrleansCodeGenerator\OrleansCodeGenerator.csproj">
+      <Project>{8d937706-f6da-4d33-b0a9-24a260bd3080}</Project>
+      <Name>OrleansCodeGenerator</Name>
+    </ProjectReference>
     <ProjectReference Include="..\OrleansCounterControl\OrleansCounterControl.csproj">
       <Project>{606b9647-cc0c-4058-bfbc-b5b7ed4f3c56}</Project>
       <Name>OrleansCounterControl</Name>


### PR DESCRIPTION
As the title suggests.

We can include OrleansCodeGenerator in one of the NuGet meta-packages to save the end-user the hassle/confusion of having to manually pull it in. Users who wish to use compile-time code generation then have the option of avoiding the Roslyn dependency altogether.