### PR TITLE
Remove strong name left behind in [InternalsVisibleTo]

### DIFF
--- a/src/TestGrainInterfaces/Properties/AssemblyInfo.cs
+++ b/src/TestGrainInterfaces/Properties/AssemblyInfo.cs
@@ -39,4 +39,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("15F8D1EB-6A01-408B-81B0-6CF5FD0D190A")]
-[assembly: InternalsVisibleTo("TesterInternal, PublicKey=0024000004800000940000000602000000240000525341310004000001000100eb81539dc2728946d4860bad0fbc91ea23d7a835e00547aa4e9a7abf185535b564d29dbe77915b779951fef2f4b1ab39cc3a246cf572c7b217b5c892835a687eb22638183d66930039ff9fa6e7e71cb880f854fb76b884dfc905bf1f3c623abad7d4732c1ce62efff937155e352170831239acbe103a41ed363a90001d3108ca")]
+[assembly: InternalsVisibleTo("TesterInternal")]


### PR DESCRIPTION
This is a leftover from https://github.com/dotnet/orleans/pull/910.