### PR TITLE
[CoreCLR port] Type -> TypeInfo 

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -535,6 +535,7 @@ namespace Orleans.CodeGeneration
             }
             catch (Exception ex)
             {
+                File.WriteAllText("error.txt", ex.Message + Environment.NewLine + ex.StackTrace);
                 Console.WriteLine("-- Code-gen FAILED -- \n{0}", TraceLogger.PrintException(ex));
                 return 3;
             }

--- a/src/Orleans/ApiPortabilityAnalysis.htm
+++ b/src/Orleans/ApiPortabilityAnalysis.htm
@@ -1,0 +1,798 @@
+<!DOCTYPE html><html xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+	<head>
+		<meta content="en-us" http-equiv="Content-Language" /><meta content="text/html; charset=utf-16" http-equiv="Content-Type" /><title _locID="PortabilityAnalysis0">
+			.NET Portability Report
+		</title><style>
+			/* Body style, for the entire document */
+body
+{
+    background: #F3F3F4;
+    color: #1E1E1F;
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    padding: 0;
+    margin: 0;
+}
+
+/* Header1 style, used for the main title */
+h1
+{
+    padding: 10px 0px 10px 10px;
+    font-size: 21pt;
+    background-color: #E2E2E2;
+    border-bottom: 1px #C1C1C2 solid; 
+    color: #201F20;
+    margin: 0;
+    font-weight: normal;
+}
+
+/* Header2 style, used for "Overview" and other sections */
+h2
+{
+    font-size: 18pt;
+    font-weight: normal;
+    padding: 15px 0 5px 0;
+    margin: 0;
+}
+
+/* Header3 style, used for sub-sections, such as project name */
+h3
+{
+    font-weight: normal;
+    font-size: 15pt;
+    margin: 0;
+    padding: 15px 0 5px 0;
+    background-color: transparent;
+}
+
+/* Color all hyperlinks one color */
+a
+{
+    color: #1382CE;
+}
+
+/* Table styles */ 
+table
+{
+    border-spacing: 0 0;
+    border-collapse: collapse;
+    font-size: 10pt;
+}
+
+table th
+{
+    background: #E7E7E8;
+    text-align: left;
+    text-decoration: none;
+    font-weight: normal;
+    padding: 3px 6px 3px 6px;
+}
+
+table td
+{
+    vertical-align: top;
+    padding: 3px 6px 5px 5px;
+    margin: 0px;
+    border: 1px solid #E7E7E8;
+    background: #F7F7F8;
+}
+
+/* Local link is a style for hyperlinks that link to file:/// content, there are lots so color them as 'normal' text until the user mouse overs */
+.localLink
+{
+    color: #1E1E1F;
+    background: #EEEEED;
+    text-decoration: none;
+}
+
+.localLink:hover
+{
+    color: #1382CE;
+    background: #FFFF99;
+    text-decoration: none;
+}
+
+/* Center text, used in the over views cells that contain message level counts */ 
+.textCentered
+{
+    text-align: center;
+}
+
+/* The message cells in message tables should take up all avaliable space */
+.messageCell
+{
+    width: 100%;
+}
+
+/* Padding around the content after the h1 */ 
+#content 
+{
+    padding: 0px 12px 12px 12px; 
+}
+
+/* The overview table expands to width, with a max width of 97% */ 
+#overview table
+{
+    width: auto;
+    max-width: 75%; 
+}
+
+/* The messages tables are always 97% width */
+#messages table
+{
+    width: 97%;
+}
+
+/* All Icons */
+.IconSuccessEncoded, .IconInfoEncoded, .IconWarningEncoded, .IconErrorEncoded
+{
+    min-width:18px;
+    min-height:18px; 
+    background-repeat:no-repeat;
+    background-position:center;
+}
+
+/* Success icon encoded */
+.IconSuccessEncoded
+{
+    /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+    /* [---XsltValidateInternal-Base64EncodedImage:IconSuccess#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABPElEQVR4Xp1Tv0vDUBi8FqeA4NpBcBLcWnQSApncOnTo4FSnjP0DsnXpH5CxiwbHDg4Zuj4oOEXiJgiC4FDcCkLWmIMc1Pfw+eMgQ77v3Xf3Pe51YKGqqisAEwCR1TIAsiAIblSo6xrdHeJR85Xle3mdmCQKb0PsfqyxxzM8K15HZADl/H5+sHpZwYfxyRjTs+kWwKBx8yoHd2mRiuzF8mkJniWH/13u3Fjrs/EdhsdDFHGB/DLXEJBDLh1MWPAhPo1BLB4WX5yQywHR+m3tVe/t97D52CB/ziG0nIgD/qDuYg8WuCcVZ2YGwlJ3YDugkpR/VNcAEx6GEKhERSr71FuO4YCM4XBdwKvecjIlkSnsO0Hyp/GxSeJAdzBKzpOtnPwyyiPdAZhpZptT04tU+zk7s8czeges//s5C5+CwqrR4/gw+AAAAABJRU5ErkJggg==);
+}
+
+/* Information icon encoded */
+.IconInfoEncoded
+{
+    /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+    /* [---XsltValidateInternal-Base64EncodedImage:IconInformation#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABHElEQVR4Xs2TsUoDQRRF7wwoziokjZUKadInhdhukR9YP8DMX1hYW+QvdsXa/QHBbcXC7W0CamWTQnclFutceIQJwwaWNLlwm5k5d94M76mmaeCrrmsLYOocY12FcxZFUeozCqKqqgYA8uevv1H6VuPxcwlfk5N92KHBxfFeCSAxxswlYAW/Xr989x/mv9gkhtyMDhcAxgzRsp7flj8B/HF1RsMXq+NZMkopaHe7lbKxQUEIGbKsYNoGn969060hZBkQex/W8oRQwsQaW2o3Ago2SVcJUzAgY3N0lTCZZm+zPS8HB51gMmS1DEYyOz9acKO1D8JWTlafKIMxdhvlfdyT94Vv5h7P8Ky7nQzACmhvKq3zk3PjW9asz9D/1oigecsioooAAAAASUVORK5CYII=);
+}
+
+/* Warning icon encoded */
+.IconWarningEncoded
+{
+    /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+    /* [---XsltValidateInternal-Base64EncodedImage:IconWarning#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAx0lEQVR4XpWSMQ7CMAxFf4xAyBMLCxMrO8dhaBcuwdCJS3RJBw7SA/QGTCxdWJgiQYWKXJWKIXHIlyw5lqr34tQgEOdcBsCOx5yZK3hCCKdYXneQkh4pEfqzLfu+wVDSyyzFoJjfz9NB+pAF+eizx2Vruts0k15mPgvS6GYvpVtQhB61IB/dk6AF6fS4Ben0uIX5odtFe8Q/eW1KvFeH4e8khT6+gm5B+t3juyDt7n0jpe+CANTd+oTUjN/U3yVaABnSUjFz/gFq44JaVSCXeQAAAABJRU5ErkJggg==);
+}
+
+/* Error icon encoded */
+.IconErrorEncoded
+{
+    /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+    /* [---XsltValidateInternal-Base64EncodedImage:IconError#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABQElEQVR4XqWTvUoEQRCE6wYPZUA80AfwAQz23uCMjA7MDRQEIzPBVEyNTQUFIw00vcQTTMzuAh/AxEQQT8HF/3G/oGGnEUGuoNnd6qoZuqltyKEsyzVJq5I6rnUp6SjGeGhESikzzlc1eL7opfuVbrqbU1Zw9NCgtQMaZpY0eNnaaL2fHusvTK5vKu7sjSS1Y4y3QUA6K3e3Mau5UFDyMP7tYF9o8cAHZv68vipoIJg971PZIZ5HiwdvYGGvFVFHmGmZ2MxwmQYPXubPl9Up0tfoMQGetXd6mRbvhBw+boZ6WF7Mbv1+GsHRk0fQmPAH1GfmZirbCfDJ61tw3Px8/8pZsPAG4jlVhcPgZ7adwNWBB68lkRQWFiTgFlbnLY3DGGM7izIJIyT/jjIvEJw6fdJTc6krDzh6aMwMP9bvDH4ADSsa9uSWVJkAAAAASUVORK5CYII=);
+}
+		</style>
+	</head><body>
+		<h1 _locid="PortabilityReport">
+			.NET Portability Report
+		</h1><div id="content">
+			<h2 _locid="SummaryTitle">
+				<a name="Summary"></a>Summary
+			</h2><div id="summary">
+				<table>
+					<tbody>
+						<tr>
+							<th>Assembly</th><th>.NET Core 5.0</th><th>.NET Core (Cross-platform) 5.0</th><th>.NET Framework 4.6.1</th><th>.NET Native 1.0</th><th>ASP.NET 5 1.0</th>
+						</tr><tr>
+							<td><strong><a href="#Orleans">Orleans</a></strong></td><td class="textCentered">93.47%</td><td class="textCentered">93.42%</td><td class="textCentered">100%</td><td class="textCentered">89.4%</td><td class="textCentered">93.47%</td>
+						</tr>
+					</tbody>
+				</table>
+			</div><div id="details">
+				<a name="Orleans"></a><h3>
+					Orleans
+				</h3><table>
+					<tbody>
+						<tr>
+							<th>Target type</th><th>.NET Core 5.0</th><th>.NET Core (Cross-platform) 5.0</th><th>.NET Framework 4.6.1</th><th>.NET Native 1.0</th><th>ASP.NET 5 1.0</th><th>Recommended changes</th>
+						</tr><tr>
+							<td>System.Net.NetworkInformation.UnicastIPAddressInformationCollection</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetEnumerator</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.AppDomain</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use object with finalizer stored in static variable, or use app-model specific unload notifications (e.g. Application.Suspending event for modern apps)</td>
+						</tr><tr>
+							<td style="padding-left:2em">add_DomainUnload(System.EventHandler)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use object with finalizer stored in static variable, or use app-model specific unload notifications (e.g. Application.Suspending event for modern apps)</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetAssemblies</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove usage</td>
+						</tr><tr>
+							<td style="padding-left:2em">remove_ReflectionOnlyAssemblyResolve(System.ResolveEventHandler)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">add_AssemblyLoad(System.AssemblyLoadEventHandler)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">add_AssemblyResolve(System.ResolveEventHandler)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove usage</td>
+						</tr><tr>
+							<td style="padding-left:2em">ApplyPolicy(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_CurrentDomain</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove usage</td>
+						</tr><tr>
+							<td style="padding-left:2em">ReflectionOnlyGetAssemblies</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">add_ReflectionOnlyAssemblyResolve(System.ResolveEventHandler)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Management.ManagementObjectSearcher</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Get</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Type</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsGenericTypeDefinition</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsGenericTypeDefinition</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsGenericTypeDefinition</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsGenericType</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsGenericType</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsVisible</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsVisible</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsValueType</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsValueType</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetMethod(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type[],System.Reflection.ParameterModifier[])</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use GetMethod(string, Type[]) to search for public methods by name and parameter type or filter the results of GetMethods(BindingFlags) using LINQ for other queries.</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsNestedFamily</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsNestedFamily</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsNotPublic</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsNotPublic</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetConstructor(System.Reflection.BindingFlags,System.Reflection.Binder,System.Type[],System.Reflection.ParameterModifier[])</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use GetConstructor(Type[]) to search for public constructors by parameter type or filter the results of GetConstructors(BindingFlags) using LINQ for other queries.</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsClass</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsClass</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsAbstract</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsAbstract</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsPrimitive</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsPrimitive</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Assembly</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().Assembly</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsInterface</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsInterface</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsEnum</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsEnum</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetInterfaceMap(System.Type)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">ReflectionOnlyGetType(System.String,System.Boolean,System.Boolean)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsNestedPrivate</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsNestedPrivate</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_BaseType</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().BaseType</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsSerializable</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsSerializable</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetTypeCode(System.Type)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use Type or RuntimeTypeHandle instead.</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsNestedPublic</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>.GetTypeInfo().IsNestedPublic</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_UnderlyingSystemType</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Module</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use System.Reflection.AssemblyExtensions.GetModules(),  iterate over returned collection.</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Reflection.Assembly</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetReferencedAssemblies</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetType(System.String,System.Boolean)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use Assembly.GetType(string), throw if you receive null return value.</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Location</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove usage</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetExecutingAssembly</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>typeof(CurrentType).GetTypeInfo().Assembly</td>
+						</tr><tr>
+							<td style="padding-left:2em">ReflectionOnlyLoadFrom(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">ReflectionOnlyLoad(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetCustomAttributes(System.Boolean)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">LoadFrom(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use AssemblyLoadContext</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetCallingAssembly</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_ReflectionOnly</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetEntryAssembly</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Security.Cryptography.RandomNumberGenerator</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetBytes(System.Byte[])</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Create</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Environment</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Do not use.  Choose action based feature availability, not OS / Platform</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_OSVersion</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Do not use.  Choose action based feature availability, not OS / Platform</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Version</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Do not use.  Choose action based feature availability, not OS / Platform</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetFolderPath(System.Environment.SpecialFolder,System.Environment.SpecialFolderOption)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_UserName</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.AssemblyLoadEventArgs</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_LoadedAssembly</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Activator</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">CreateInstance(System.Type,System.Boolean)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.ResolveEventArgs</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use AssemblyLoadContext</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Name</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use AssemblyLoadContext</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_RequestingAssembly</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.CorrelationManager</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">set_ActivityId(System.Guid)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_ActivityId</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.Sockets.Socket</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Connect(System.Net.EndPoint)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Send(System.Collections.Generic.IList{System.ArraySegment{System.Byte}})</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Disconnect(System.Boolean)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Receive(System.Collections.Generic.IList{System.ArraySegment{System.Byte}})</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">SetSocketOption(System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName,System.Boolean)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">EndReceive(System.IAsyncResult)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">BeginReceive(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.AsyncCallback,System.Object)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">set_LingerState(System.Net.Sockets.LingerOption)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Send(System.Byte[])</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.Dns</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetHostAddressesAsync(System.String)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetHostName</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Runtime.Serialization.Formatters.Binary.BinaryFormatter</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Serialize(System.IO.Stream,System.Object)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Deserialize(System.IO.Stream)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">set_Binder(System.Runtime.Serialization.SerializationBinder)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.Trace</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_CorrelationManager</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">TraceError(System.String,System.Object[])</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">TraceWarning(System.String)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Listeners</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">TraceError(System.String)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">TraceInformation(System.String)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Flush</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">WriteLine(System.String)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Management.ManagementObjectCollection.ManagementObjectEnumerator</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">MoveNext</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Current</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Runtime.Remoting.Messaging.CallContext</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">FreeNamedDataSlot(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">LogicalSetData(System.String,System.Object)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">LogicalGetData(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Threading.Thread</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_CurrentThread</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">set_Name(System.String)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Start(System.Object)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Sleep(System.TimeSpan)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_ManagedThreadId</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">ResetAbort</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>This is only reliable in SQL Server.  Elsewhere, don't use it.</td>
+						</tr><tr>
+							<td style="padding-left:2em">Abort(System.Object)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>This is only reliable in SQL Server.  Elsewhere, don't use it.</td>
+						</tr><tr>
+							<td style="padding-left:2em">set_IsBackground(System.Boolean)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.Threading.ParameterizedThreadStart)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.FileVersionInfo</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td>Currently there is no workaround, but we are working on it. Please check back.</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetVersionInfo(System.String)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td>Currently there is no workaround, but we are working on it. Please check back.</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_ProductVersion</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_FileVersion</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td>Currently there is no workaround, but we are working on it. Please check back.</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Threading.WaitCallback</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.Object,System.IntPtr)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.PerformanceCounterCategory</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetInstanceNames</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetCounters(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.Sockets.SocketOptionName</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Reflection.PropertyInfo</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use PropertyInfo.SetMethod property</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetSetMethod</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use PropertyInfo.SetMethod property</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Management.PropertyDataCollection</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Item(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.NetworkInformation.NetworkInterface</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetAllNetworkInterfaces</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetIPProperties</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Name</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_LoopbackInterfaceIndex</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_OperationalStatus</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.AssemblyLoadEventHandler</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.Object,System.IntPtr)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.Process</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use System.Diagnostics.Process.SafeHandle</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Handle</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use System.Diagnostics.Process.SafeHandle</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetCurrentProcess</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_ProcessName</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Id</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Security.Cryptography.SHA256</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Create</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Threading.ThreadPool</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Change code to not depend on the size of the ThreadPool for functionality.  Portable code needs to be able to run correctly on multiple different ThreadPool implementations, not all of which support this method.</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetMinThreads(System.Int32@,System.Int32@)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Change code to not depend on the size of the ThreadPool for functionality.  Portable code needs to be able to run correctly on multiple different ThreadPool implementations, not all of which support this method.</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetAvailableThreads(System.Int32@,System.Int32@)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetMaxThreads(System.Int32@,System.Int32@)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Change code to not depend on the size of the ThreadPool for functionality.  Portable code needs to be able to run correctly on multiple different ThreadPool implementations, not all of which support this method.</td>
+						</tr><tr>
+							<td style="padding-left:2em">QueueUserWorkItem(System.Threading.WaitCallback,System.Object)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.NetworkInformation.IPAddressInformation</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Address</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Runtime.Serialization.SerializationInfo</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>either 1) Delete Serialization info from exceptions (since this can't be remoted) or 2) Use a different serialization technology if not for exceptions.</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetValue(System.String,System.Type)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>either 1) Delete Serialization info from exceptions (since this can't be remoted) or 2) Use a different serialization technology if not for exceptions.</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetString(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove serialization constructors on custom Exception types</td>
+						</tr><tr>
+							<td style="padding-left:2em">AddValue(System.String,System.Object)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove serialization constructors on custom Exception types</td>
+						</tr><tr>
+							<td style="padding-left:2em">AddValue(System.String,System.Object,System.Type)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>either 1) Delete Serialization info from exceptions (since this can't be remoted) or 2) Use a different serialization technology if not for exceptions.</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetBoolean(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>either 1) Delete Serialization info from exceptions (since this can't be remoted) or 2) Use a different serialization technology if not for exceptions.</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.TraceListenerCollection</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Count</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetEnumerator</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Add(System.Diagnostics.TraceListener)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.ResolveEventHandler</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use AssemblyLoadContext</td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.Object,System.IntPtr)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use AssemblyLoadContext</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.DefaultTraceListener</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.MarshalByRefObject</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove usage: Remoting is no longer available</td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove usage</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Reflection.CustomAttributeData</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetCustomAttributes(System.Reflection.MemberInfo)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Security.Cryptography.HashAlgorithm</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">ComputeHash(System.Byte[])</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">Dispose</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Threading.ParameterizedThreadStart</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.Object,System.IntPtr)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Runtime.Serialization.SerializationBinder</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Management.ManagementObjectCollection</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetEnumerator</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Console</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">ResetColor</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">set_Title(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">WriteLine(System.String,System.Object,System.Object)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">set_ForegroundColor(System.ConsoleColor)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td>Currently there is no workaround, but we are working on it. Please check back.</td>
+						</tr><tr>
+							<td style="padding-left:2em">WriteLine(System.String,System.Object[])</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">WriteLine(System.String)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">WriteLine(System.String,System.Object)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Environment.SpecialFolder</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Environment.SpecialFolderOption</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.OperatingSystem</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Do not use.  Couple behavior to feature availability, not OS version or Platform.</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.NetworkInformation.IPInterfaceProperties</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_UnicastAddresses</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Exception</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove.  Getting rid of other usage of SerializationInfo will remove the need for this method.</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove.  Getting rid of other usage of SerializationInfo will remove the need for this method.</td>
+						</tr><tr>
+							<td style="padding-left:2em">GetType</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>False positive (GetType() from Object is sufficient)</td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Remove.  Ctor overload taking SerializationInfo is not applicable in new surface area</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.PerformanceCounter</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_RawValue</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_CounterName</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.String,System.String,System.String,System.Boolean)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.String,System.String,System.Boolean)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">NextValue</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.Sockets.LingerOption</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.Boolean,System.Int32)</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.Sockets.SocketOptionLevel</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.NetworkInformation.OperationalStatus</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.Sockets.SocketFlags</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.StackTrace</td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td>Currently there is no workaround, but we are working on it. Please check back.</td>
+						</tr><tr>
+							<td style="padding-left:2em">#ctor(System.Boolean)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Runtime.Serialization.ISerializable</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Reflection.ParameterModifier</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use an overload that does not take a ParameterModifier array.</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Reflection.AssemblyName</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetAssemblyName(System.String)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Reflection.Binder</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use an overload that does not take a Binder.</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Management.PropertyData</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Value</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Delegate</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use System.Reflection.RuntimeReflectionExtensions.GetMethodInfo</td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Method</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Use System.Reflection.RuntimeReflectionExtensions.GetMethodInfo</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Net.NetworkInformation.UnicastIPAddressInformation</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Management.ManagementBaseObject</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_Properties</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Threading.ThreadState</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.ConsoleTraceListener</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>useErrorStream ? new TextWriterTraceListener(Console.Error) : new TextWriterTraceListener(Console.Out)</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Runtime.Serialization.FormatterServices</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">GetUninitializedObject(System.Type)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Xml.XmlNode</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">SelectNodes(System.String,System.Xml.XmlNamespaceManager)</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.ConsoleColor</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td>Currently there is no workaround, but we are working on it. Please check back.</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.TraceListener</td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Diagnostics.DebuggableAttribute</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td style="padding-left:2em">get_IsJITTrackingEnabled</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Threading.ThreadAbortException</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td>Do not use: exception cannot be caught since it is not thrown by framework, never throw this type. Thread.Abort is only reliable in SQL Server.  Elsewhere, don't use it.</td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr><tr>
+							<td>System.Management.ManagementObject</td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td class="IconSuccessEncoded"></td><td class="IconErrorEncoded"></td><td class="IconErrorEncoded"></td><td></td>
+						</tr><tr>
+							<td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td><td>&nbsp</td>
+						</tr>
+					</tbody>
+				</table><a href="#Summary">Back to summary</a>
+			</div>

--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -111,8 +111,8 @@ namespace Orleans.Runtime
                     TypeUtils.GetTypes(
                         assembly,
                         type =>
-                        typeof(T).IsAssignableFrom(type) && !type.IsInterface
-                        && type.GetConstructor(Type.EmptyTypes) != null).FirstOrDefault();
+                        typeof(T).GetTypeInfo().IsAssignableFrom(type) && !type.GetTypeInfo().IsInterface
+                        && type.GetTypeInfo().GetConstructor(Type.EmptyTypes) != null).FirstOrDefault();
                 if (foundType == null)
                 {
                     return null;

--- a/src/Orleans/AssemblyLoader/AssemblyLoaderCriteria.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoaderCriteria.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace Orleans.Runtime
 {
@@ -65,7 +66,7 @@ namespace Orleans.Runtime
                         ignored = null;
                         foreach (var requiredType in requiredTypes)
                         {
-                            if (requiredType.IsAssignableFrom(type))
+                            if (requiredType.GetTypeInfo().IsAssignableFrom(type))
                             {
                                 //  we found a match! load the assembly.
                                 return true;

--- a/src/Orleans/CodeGeneration/GrainFactoryBase.cs
+++ b/src/Orleans/CodeGeneration/GrainFactoryBase.cs
@@ -23,6 +23,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using Orleans.Runtime;
+using System.Reflection;
 
 namespace Orleans.CodeGeneration
 {
@@ -46,7 +47,9 @@ namespace Orleans.CodeGeneration
             }
             var implementation = TypeCodeMapper.GetImplementation(interfaceType, grainClassNamePrefix);
             GrainId grainId = getGrainId(implementation);
-            return GrainReference.FromGrainId(grainId, interfaceType.IsGenericType ? interfaceType.UnderlyingSystemType.FullName : null);
+
+            var typeInfo = interfaceType.GetTypeInfo();
+            return GrainReference.FromGrainId(grainId, typeInfo.IsGenericType ? typeInfo.UnderlyingSystemType.FullName : null);
         }
 
         /// <summary>

--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -130,7 +130,7 @@ namespace Orleans.CodeGeneration
 
         public static bool IsGrainInterface(Type t)
         {
-            if (t.IsClass)
+            if (t.GetTypeInfo().IsClass)
                 return false;
             if (t == typeof(IGrainObserver) || t == typeof(IAddressable) || t == typeof(IGrainExtension))
                 return false;
@@ -140,7 +140,7 @@ namespace Orleans.CodeGeneration
             if (t == typeof (ISystemTarget))
                 return false;
 
-            return typeof (IAddressable).IsAssignableFrom(t);
+            return typeof (IAddressable).GetTypeInfo().IsAssignableFrom(t);
         }
 
         public static bool IsAddressable(Type t)
@@ -186,8 +186,9 @@ namespace Orleans.CodeGeneration
 
         public static bool IsTaskType(Type t)
         {
+            var typeInfo = t.GetTypeInfo();
             return t == typeof (Task)
-                || (t.IsGenericType && t.GetGenericTypeDefinition().FullName == "System.Threading.Tasks.Task`1");
+                || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition().FullName == "System.Threading.Tasks.Task`1");
         }
 
         /// <summary>
@@ -254,9 +255,10 @@ namespace Orleans.CodeGeneration
                     strMethodId.Append(",");
 
                 strMethodId.Append(info.ParameterType.Name);
-                if (info.ParameterType.IsGenericType)
+                var typeInfo = info.ParameterType.GetTypeInfo();
+                if (typeInfo.IsGenericType)
                 {
-                    Type[] args = info.ParameterType.GetGenericArguments();
+                    Type[] args = typeInfo.GetGenericArguments();
                     foreach (Type arg in args)
                         strMethodId.Append(arg.Name);
                 }
@@ -304,11 +306,12 @@ namespace Orleans.CodeGeneration
         private void DefineClassNames(bool client)
         {
             var typeNameBase = TypeUtils.GetSimpleTypeName(Type, t => false, language);
-            if (Type.IsInterface && typeNameBase.Length > 1 && typeNameBase[0] == 'I' && Char.IsUpper(typeNameBase[1]))
+            var typeInfo = Type.GetTypeInfo();
+            if (typeInfo.IsInterface && typeNameBase.Length > 1 && typeNameBase[0] == 'I' && Char.IsUpper(typeNameBase[1]))
                 typeNameBase = typeNameBase.Substring(1);
 
             Namespace = Type.Namespace;
-            IsGeneric = Type.IsGenericType;
+            IsGeneric = typeInfo.IsGenericType;
             if (IsGeneric)
             {
                 Name = TypeUtils.GetParameterizedTemplateName(Type, language: language);
@@ -369,7 +372,7 @@ namespace Orleans.CodeGeneration
                             GetParameterName(parameter), type.FullName, method.Name));
                     }
 
-                    if (parameter.ParameterType.IsByRef)
+                    if (parameter.ParameterType.GetTypeInfo().IsByRef)
                     {
                         success = false;
                         violations.Add(String.Format("Argument {0} of method {1}.{2} is an a reference parameter. Reference parameters are not allowed.",
@@ -440,8 +443,9 @@ namespace Orleans.CodeGeneration
                 ParameterInfo[] parms = x.GetParameters();
                 foreach (ParameterInfo info in parms)
                 {
-                    xString.Append(info.ParameterType.Name);
-                    if (info.ParameterType.IsGenericType)
+                    var typeInfo = info.ParameterType.GetTypeInfo();
+                    xString.Append(typeInfo.Name);
+                    if (typeInfo.IsGenericType)
                     {
                         Type[] args = info.ParameterType.GetGenericArguments();
                         foreach (Type arg in args)
@@ -453,7 +457,8 @@ namespace Orleans.CodeGeneration
                 foreach (ParameterInfo info in parms)
                 {
                     yString.Append(info.ParameterType.Name);
-                    if (info.ParameterType.IsGenericType)
+                    var typeInfo = info.ParameterType.GetTypeInfo();
+                    if (typeInfo.IsGenericType)
                     {
                         Type[] args = info.ParameterType.GetGenericArguments();
                         foreach (Type arg in args)
@@ -482,17 +487,20 @@ namespace Orleans.CodeGeneration
             Type[] iTypes = GetRemoteInterfaces(serviceType, false).Values.ToArray();
             IEqualityComparer<MethodInfo> methodComparer = new MethodInfoComparer();
 
+            var typeInfo = grainType.GetTypeInfo();
+
             foreach (Type iType in iTypes)
             {
                 var mapping = new InterfaceMapping();
-                if (grainType.IsClass)
+                
+                if (typeInfo.IsClass)
                     mapping = grainType.GetInterfaceMap(iType);
 
-                if (grainType.IsInterface || mapping.TargetType == grainType)
+                if (typeInfo.IsInterface || mapping.TargetType == grainType)
                 {
                     foreach (var methodInfo in iType.GetMethods())
                     {
-                        if (grainType.IsClass)
+                        if (typeInfo.IsClass)
                         {
                             var mi = methodInfo;
                             var match = mapping.TargetMethods.Any(info => methodComparer.Equals(mi, info) &&

--- a/src/Orleans/Configuration/ApplicationConfiguration.cs
+++ b/src/Orleans/Configuration/ApplicationConfiguration.cs
@@ -23,6 +23,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 using System.Xml;
 
@@ -388,15 +389,17 @@ namespace Orleans.Runtime.Configuration
                 logger.Error(ErrorCode.Loader_TypeLoadError_2, errStr);
                 throw new OrleansException(errStr);
             }
+            var typeInfo = type.GetTypeInfo();
             // postcondition: returned type must implement IGrain.
-            if (!typeof(IGrain).IsAssignableFrom(type))
+            if (!typeof(IGrain).GetTypeInfo().IsAssignableFrom(type))
             {
                 string errStr = String.Format("Type {0} must implement IGrain to be used Application configuration context.",type.FullName);
                 logger.Error(ErrorCode.Loader_TypeLoadError_3, errStr);
                 throw new OrleansException(errStr);
             }
             // postcondition: returned type must either be an interface or a class.
-            if (!type.IsInterface && !type.IsClass)
+            
+            if (!typeInfo.IsInterface && !typeInfo.IsClass)
             {
                 string errStr = String.Format("Type {0} must either be an interface or class used Application configuration context.",type.FullName);
                 logger.Error(ErrorCode.Loader_TypeLoadError_4, errStr);

--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -29,6 +29,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Xml;
 using Orleans.Providers;
+using System.Reflection;
 
 namespace Orleans.Runtime.Configuration
 {
@@ -372,13 +373,13 @@ namespace Orleans.Runtime.Configuration
         /// <param name="properties">Properties that will be passed to stream provider upon initialization</param>
         public void RegisterStreamProvider<T>(string providerName, IDictionary<string, string> properties = null) where T : Orleans.Streams.IStreamProvider
         {
-            Type providerType = typeof(T);
-            if (providerType.IsAbstract ||
-                providerType.IsGenericType ||
-                !typeof(Orleans.Streams.IStreamProvider).IsAssignableFrom(providerType))
+            Type providerTypeInfo = typeof(T).GetTypeInfo();
+            if (providerTypeInfo.IsAbstract ||
+                providerTypeInfo.IsGenericType ||
+                !typeof(Orleans.Streams.IStreamProvider).IsAssignableFrom(providerTypeInfo))
                 throw new ArgumentException("Expected non-generic, non-abstract type which implements IStreamProvider interface", "typeof(T)");
 
-            ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, providerType.FullName, providerName, properties);
+            ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, providerTypeInfo.FullName, providerName, properties);
         }
 
         /// <summary>

--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -31,6 +31,7 @@ using System.Xml;
 using Orleans.Providers;
 using Orleans.Streams;
 using Orleans.Storage;
+using System.Reflection;
 
 namespace Orleans.Runtime.Configuration
 {
@@ -821,13 +822,13 @@ namespace Orleans.Runtime.Configuration
         /// <param name="properties">Properties that will be passed to bootstrap provider upon initialization</param>
         public void RegisterBootstrapProvider<T>(string providerName, IDictionary<string, string> properties = null) where T : IBootstrapProvider
         {
-            Type providerType = typeof(T);
-            if (providerType.IsAbstract ||
-                providerType.IsGenericType ||
-                !typeof(IBootstrapProvider).IsAssignableFrom(providerType))
+            Type providerTypeInfo = typeof(T).GetTypeInfo();
+            if (providerTypeInfo.IsAbstract ||
+                providerTypeInfo.IsGenericType ||
+                !typeof(IBootstrapProvider).IsAssignableFrom(providerTypeInfo))
                 throw new ArgumentException("Expected non-generic, non-abstract type which implements IBootstrapProvider interface", "typeof(T)");
 
-            ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.BOOTSTRAP_PROVIDER_CATEGORY_NAME, providerType.FullName, providerName, properties);
+            ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.BOOTSTRAP_PROVIDER_CATEGORY_NAME, providerTypeInfo.FullName, providerName, properties);
         }
 
         /// <summary>
@@ -848,11 +849,13 @@ namespace Orleans.Runtime.Configuration
         /// <param name="providerName">Name of the stream provider</param>
         /// <param name="properties">Properties that will be passed to stream provider upon initialization</param>
         public void RegisterStreamProvider<T>(string providerName, IDictionary<string, string> properties = null) where T : Orleans.Streams.IStreamProvider
-        {
+        {            
             Type providerType = typeof(T);
-            if (providerType.IsAbstract ||
-                providerType.IsGenericType ||
-                !typeof(Orleans.Streams.IStreamProvider).IsAssignableFrom(providerType))
+
+            var providerTypeInfo = providerType.GetTypeInfo();
+            if (providerTypeInfo.IsAbstract ||
+                providerTypeInfo.IsGenericType ||
+                !typeof(Orleans.Streams.IStreamProvider).GetTypeInfo().IsAssignableFrom(providerType))
                 throw new ArgumentException("Expected non-generic, non-abstract type which implements IStreamProvider interface", "typeof(T)");
 
             ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, providerType.FullName, providerName, properties);
@@ -877,13 +880,13 @@ namespace Orleans.Runtime.Configuration
         /// <param name="properties">Properties that will be passed to storage provider upon initialization</param>
         public void RegisterStorageProvider<T>(string providerName, IDictionary<string, string> properties = null) where T : IStorageProvider
         {
-            Type providerType = typeof(T);
-            if (providerType.IsAbstract ||
-                providerType.IsGenericType ||
-                !typeof(IStorageProvider).IsAssignableFrom(providerType))
+            Type providerTypeInfo = typeof(T).GetTypeInfo();
+            if (providerTypeInfo.IsAbstract ||
+                providerTypeInfo.IsGenericType ||
+                !typeof(IStorageProvider).IsAssignableFrom(providerTypeInfo))
                 throw new ArgumentException("Expected non-generic, non-abstract type which implements IStorageProvider interface", "typeof(T)");
 
-            ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STORAGE_PROVIDER_CATEGORY_NAME, providerType.FullName, providerName, properties);
+            ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STORAGE_PROVIDER_CATEGORY_NAME, providerTypeInfo.FullName, providerName, properties);
         }
 
         /// <summary>

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -193,18 +193,19 @@ namespace Orleans
         private Task<TGrainObserverInterface> CreateObjectReferenceImpl<TGrainObserverInterface>(IAddressable obj)
         {
             var interfaceType = typeof(TGrainObserverInterface);
-            if (!interfaceType.IsInterface)
+            var interfaceTypeInfo = interfaceType.GetTypeInfo();
+            if (!interfaceTypeInfo.IsInterface)
             {
                 throw new ArgumentException(
                     string.Format(
                         "The provided type parameter must be an interface. '{0}' is not an interface.",
-                        interfaceType.FullName));
+                        interfaceTypeInfo.FullName));
             }
 
-            if (!interfaceType.IsInstanceOfType(obj))
+            if (!interfaceTypeInfo.IsInstanceOfType(obj))
             {
                 throw new ArgumentException(
-                    string.Format("The provided object must implement '{0}'.", interfaceType.FullName),
+                    string.Format("The provided object must implement '{0}'.", interfaceTypeInfo.FullName),
                     "obj");
             }
             
@@ -247,9 +248,10 @@ namespace Orleans
 
         private static IGrainMethodInvoker MakeInvoker(Type interfaceType)
         {
-            CodeGeneratorManager.GenerateAndCacheCodeForAssembly(interfaceType.Assembly);
-            var genericInterfaceType = interfaceType.IsConstructedGenericType
-                                           ? interfaceType.GetGenericTypeDefinition()
+            var typeInfo = interfaceType.GetTypeInfo(); 
+            CodeGeneratorManager.GenerateAndCacheCodeForAssembly(typeInfo.Assembly);
+            var genericInterfaceType = typeInfo.IsConstructedGenericType
+                                           ? typeInfo.GetGenericTypeDefinition()
                                            : interfaceType;
 
             // Try to find the correct IGrainMethodInvoker type for this interface.
@@ -259,9 +261,9 @@ namespace Orleans
                 return null;
             }
 
-            if (interfaceType.IsConstructedGenericType)
+            if (typeInfo.IsConstructedGenericType)
             {
-                invokerType = invokerType.MakeGenericType(interfaceType.GenericTypeArguments);
+                invokerType = invokerType.MakeGenericType(typeInfo.GenericTypeArguments);
             }
 
             return (IGrainMethodInvoker)Activator.CreateInstance(invokerType);
@@ -288,9 +290,10 @@ namespace Orleans
 
         private static GrainReferenceCaster MakeCaster(Type interfaceType)
         {
-            CodeGeneratorManager.GenerateAndCacheCodeForAssembly(interfaceType.Assembly);
-            var genericInterfaceType = interfaceType.IsConstructedGenericType
-                                           ? interfaceType.GetGenericTypeDefinition()
+            var typeInfo = interfaceType.GetTypeInfo();
+            CodeGeneratorManager.GenerateAndCacheCodeForAssembly(typeInfo.Assembly);
+            var genericInterfaceType = typeInfo.IsConstructedGenericType
+                                           ? typeInfo.GetGenericTypeDefinition()
                                            : interfaceType;
 
             // Try to find the correct GrainReference type for this interface.
@@ -301,9 +304,9 @@ namespace Orleans
                     string.Format("Cannot find generated GrainReference class for interface '{0}'", interfaceType));
             }
 
-            if (interfaceType.IsConstructedGenericType)
+            if (typeInfo.IsConstructedGenericType)
             {
-                grainReferenceType = grainReferenceType.MakeGenericType(interfaceType.GenericTypeArguments);
+                grainReferenceType = grainReferenceType.MakeGenericType(typeInfo.GenericTypeArguments);
             }
 
             // Get the grain reference constructor.

--- a/src/Orleans/Providers/ProviderTypeLoader.cs
+++ b/src/Orleans/Providers/ProviderTypeLoader.cs
@@ -83,7 +83,8 @@ namespace Orleans.Providers
 
         private void ProcessType(Type type)
         {
-            if (alreadyProcessed.Contains(type) || type.IsInterface || type.IsAbstract || !condition(type)) return;
+            var typeInfo = type.GetTypeInfo();
+            if (alreadyProcessed.Contains(type) || typeInfo.IsInterface || typeInfo.IsAbstract || !condition(type)) return;
 
             alreadyProcessed.Add(type);
             callback(type);

--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -429,7 +429,7 @@ namespace Orleans.Serialization
         {
             var dict = (Dictionary<K, V>)original;
             SerializationManager.SerializeInner(dict.Comparer.Equals(EqualityComparer<K>.Default) ? null : dict.Comparer,
-                                           stream, typeof (IEqualityComparer<K>));
+                                           stream, typeof(IEqualityComparer<K>));
             stream.Write(dict.Count);
             foreach (var pair in dict)
             {
@@ -979,7 +979,7 @@ namespace Orleans.Serialization
                 return new T?();
             }
 
-            var val = (T) SerializationManager.DeserializeInner(typeof (T), stream);
+            var val = (T)SerializationManager.DeserializeInner(typeof(T), stream);
             return new Nullable<T>(val);
         }
 
@@ -1014,7 +1014,7 @@ namespace Orleans.Serialization
 
         internal static void SerializeImmutable<T>(object original, BinaryTokenStreamWriter stream, Type expected)
         {
-            var obj = (Immutable<T>) original;
+            var obj = (Immutable<T>)original;
             SerializationManager.SerializeInner(obj.Value, stream, typeof(T));
         }
 
@@ -1032,7 +1032,7 @@ namespace Orleans.Serialization
         #endregion
 
         #endregion
-        
+
         #region Other System types
 
         #region TimeSpan
@@ -1099,7 +1099,7 @@ namespace Orleans.Serialization
 
         internal static void SerializeGuid(object obj, BinaryTokenStreamWriter stream, Type expected)
         {
-            var guid = (Guid) obj;
+            var guid = (Guid)obj;
             stream.Write(guid.ToByteArray());
         }
 
@@ -1148,7 +1148,7 @@ namespace Orleans.Serialization
 
         internal static void SerializeGrainId(object obj, BinaryTokenStreamWriter stream, Type expected)
         {
-            var id = (GrainId) obj;
+            var id = (GrainId)obj;
             stream.Write(id);
         }
 
@@ -1228,7 +1228,7 @@ namespace Orleans.Serialization
 
         internal static void SerializeCorrelationId(object obj, BinaryTokenStreamWriter stream, Type expected)
         {
-            var id = (CorrelationId) obj;
+            var id = (CorrelationId)obj;
             stream.Write(id);
         }
 
@@ -1368,15 +1368,15 @@ namespace Orleans.Serialization
                 genericArgs = t.GetGenericArguments();
             }
 
-            var genericCopier = typeof(BuiltInTypes).GetMethod(copierName, System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            var genericCopier = typeof(BuiltInTypes).GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == copierName).FirstOrDefault();
             var concreteCopier = genericCopier.MakeGenericMethod(genericArgs);
             var copier = (SerializationManager.DeepCopier)concreteCopier.CreateDelegate(typeof(SerializationManager.DeepCopier));
 
-            var genericSerializer = typeof(BuiltInTypes).GetMethod(serializerName, System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            var genericSerializer = typeof(BuiltInTypes).GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == serializerName).FirstOrDefault();
             var concreteSerializer = genericSerializer.MakeGenericMethod(genericArgs);
             var serializer = (SerializationManager.Serializer)concreteSerializer.CreateDelegate(typeof(SerializationManager.Serializer));
 
-            var genericDeserializer = typeof(BuiltInTypes).GetMethod(deserializerName, System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            var genericDeserializer = typeof(BuiltInTypes).GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == deserializerName).FirstOrDefault();
             var concreteDeserializer = genericDeserializer.MakeGenericMethod(genericArgs);
             var deserializer =
                 (SerializationManager.Deserializer)concreteDeserializer.CreateDelegate(typeof(SerializationManager.Deserializer));
@@ -1394,15 +1394,15 @@ namespace Orleans.Serialization
                 genericArgs = concreteType.GetGenericArguments();
             }
 
-            var genericCopier = definingType.GetMethod(copierName, System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            var genericCopier = definingType.GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == copierName).FirstOrDefault();
             var concreteCopier = genericCopier.MakeGenericMethod(genericArgs);
             var copier = (SerializationManager.DeepCopier)concreteCopier.CreateDelegate(typeof(SerializationManager.DeepCopier));
 
-            var genericSerializer = definingType.GetMethod(serializerName, System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            var genericSerializer = definingType.GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == serializerName).FirstOrDefault();
             var concreteSerializer = genericSerializer.MakeGenericMethod(genericArgs);
             var serializer = (SerializationManager.Serializer)concreteSerializer.CreateDelegate(typeof(SerializationManager.Serializer));
 
-            var genericDeserializer = definingType.GetMethod(deserializerName, System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            var genericDeserializer = definingType.GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == deserializerName).FirstOrDefault();
             var concreteDeserializer = genericDeserializer.MakeGenericMethod(genericArgs);
             var deserializer =
                 (SerializationManager.Deserializer)concreteDeserializer.CreateDelegate(typeof(SerializationManager.Deserializer));

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -396,7 +396,7 @@ namespace Orleans.Serialization
             var baseType = t.BaseType;
             while (baseType != null)
             {
-                if (baseType.IsAbstract)
+                if (baseType.GetTypeInfo().IsAbstract)
                     Register(baseType);
 
                 baseType = baseType.BaseType;
@@ -438,7 +438,7 @@ namespace Orleans.Serialization
             var baseType = t.BaseType;
             while (baseType != null)
             {
-                if (baseType.IsAbstract)
+                if (baseType.GetTypeInfo().IsAbstract)
                     Register(baseType);
 
                 baseType = baseType.BaseType;
@@ -454,7 +454,7 @@ namespace Orleans.Serialization
         {
             try
             {
-                if (type.IsGenericTypeDefinition)
+                if (type.GetTypeInfo().IsGenericTypeDefinition)
                 {
                     Register(
                         type,
@@ -514,13 +514,14 @@ namespace Orleans.Serialization
 
             try
             {
-                if (type.IsEnum)
+                var typeInfo = type.GetTypeInfo();
+                if (typeInfo.IsEnum)
                 {
                     Register(type);
                 }
                 else if (!systemAssembly)
                 {
-                    if (!type.IsInterface && !type.IsAbstract
+                    if (!typeInfo.IsInterface && !typeInfo.IsAbstract
                         && (type.Namespace == null
                             || (!type.Namespace.Equals("System", StringComparison.Ordinal)
                                 && !type.Namespace.StartsWith("System.", StringComparison.Ordinal))))
@@ -534,7 +535,7 @@ namespace Orleans.Serialization
                                     type.Name,
                                     assembly.GetName().Name);
 
-                            var register = type.GetMethod("Register");
+                            var register = type.GetMethod("Register", Type.EmptyTypes);
                             if (register != null)
                             {
                                 try
@@ -640,19 +641,20 @@ namespace Orleans.Serialization
                                         type.Name,
                                         assembly.GetName().Name);
                             }
-                            else if (!type.IsSerializable)
+                            else if (!type.GetTypeInfo().IsSerializable)
                             {
                                 // Comparers with no fields can be safely dealt with as just a type name
                                 var comparer = false;
-                                foreach (var iface in type.GetInterfaces())
-                                    if (iface.IsGenericType
-                                        && (iface.GetGenericTypeDefinition() == typeof(IComparer<>)
-                                            || iface.GetGenericTypeDefinition() == typeof(IEqualityComparer<>)))
+                                foreach (var iface in type.GetInterfaces()) {
+                                    var ifaceTypeInfo = iface.GetTypeInfo();
+                                    if (ifaceTypeInfo.IsGenericType
+                                        && (ifaceTypeInfo.GetGenericTypeDefinition() == typeof(IComparer<>)
+                                            || ifaceTypeInfo.GetGenericTypeDefinition() == typeof(IEqualityComparer<>)))
                                     {
                                         comparer = true;
                                         break;
                                     }
-
+                                }
                                 if (comparer && (type.GetFields().Length == 0)) Register(type);
                             }
                             else
@@ -799,7 +801,8 @@ namespace Orleans.Serialization
                 if (copiers.TryGetValue(t.TypeHandle, out copier))
                     return copier;
 
-                if (t.IsGenericType && copiers.TryGetValue(t.GetGenericTypeDefinition().TypeHandle, out copier))
+                var typeInfo = t.GetTypeInfo();
+                if (typeInfo.IsGenericType && copiers.TryGetValue(typeInfo.GetGenericTypeDefinition().TypeHandle, out copier))
                     return copier;
             }
 
@@ -901,10 +904,11 @@ namespace Orleans.Serialization
                 }
 
                 var et = t.GetElementType();
+                var etInfo = et.GetTypeInfo();
                 if (et.IsOrleansShallowCopyable())
                 {
                     // Only check the size for primitive types because otherwise Buffer.ByteLength throws
-                    if (et.IsPrimitive && Buffer.ByteLength(originalArray) > LARGE_OBJECT_LIMIT)
+                    if (etInfo.IsPrimitive && Buffer.ByteLength(originalArray) > LARGE_OBJECT_LIMIT)
                     {
                         logger.Info(ErrorCode.Ser_LargeObjectAllocated,
                             "Large {0} array of total byte size {1} is being copied. This will result in an allocation on the large object heap. " +
@@ -958,7 +962,7 @@ namespace Orleans.Serialization
 
             }
 
-            if (t.IsSerializable)
+            if (t.GetTypeInfo().IsSerializable)
                 return FallbackSerializationDeepCopy(original);
 
             throw new OrleansException("No copier found for object of type " + t.OrleansTypeName() + 
@@ -979,8 +983,9 @@ namespace Orleans.Serialization
             lock (serializers)
             {
                 Serializer ser;
-                return serializers.TryGetValue(t.TypeHandle, out ser)
-                       || (t.IsGenericType && serializers.TryGetValue(t.GetGenericTypeDefinition().TypeHandle, out ser));
+                var typeInfo = t.GetTypeInfo();
+                return serializers.TryGetValue(typeInfo.TypeHandle, out ser)
+                       || (typeInfo.IsGenericType && serializers.TryGetValue(typeInfo.GetGenericTypeDefinition().TypeHandle, out ser));
             }
         }
 
@@ -989,11 +994,12 @@ namespace Orleans.Serialization
             lock (serializers)
             {
                 Serializer ser;
-                if (serializers.TryGetValue(t.TypeHandle, out ser))
+                var typeInfo = t.GetTypeInfo();
+                if (serializers.TryGetValue(typeInfo.TypeHandle, out ser))
                     return ser;
 
-                if (t.IsGenericType)
-                    if (serializers.TryGetValue(t.GetGenericTypeDefinition().TypeHandle, out ser))
+                if (typeInfo.IsGenericType)
+                    if (serializers.TryGetValue(typeInfo.GetGenericTypeDefinition().TypeHandle, out ser))
                         return ser;
             }
 
@@ -1043,9 +1049,10 @@ namespace Orleans.Serialization
             }
 
             var t = obj.GetType();
+            var typeInfo = t.GetTypeInfo();
 
             // Enums are extra-special
-            if (t.IsEnum)
+            if (typeInfo.IsEnum)
             {
                 stream.WriteTypeHeader(t, expected);
                 stream.Write(Convert.ToInt32(obj));
@@ -1059,7 +1066,7 @@ namespace Orleans.Serialization
             // At this point, we're either an object or a non-trivial value type
 
             // Start by checking to see if we're a back-reference, and recording us for possible future back-references if not
-            if (!t.IsValueType)
+            if (!typeInfo.IsValueType)
             {
                 int reference = SerializationContext.Current.CheckObjectWhileSerializing(obj);
                 if (reference >= 0)
@@ -1071,7 +1078,7 @@ namespace Orleans.Serialization
             }
 
             // If we're simply a plain old unadorned, undifferentiated object, life is easy
-            if (t.TypeHandle.Equals(objectTypeHandle))
+            if (typeInfo.TypeHandle.Equals(objectTypeHandle))
             {
                 stream.Write(SerializationTokenType.SpecifiedType);
                 stream.Write(SerializationTokenType.Object);
@@ -1079,14 +1086,14 @@ namespace Orleans.Serialization
             }
 
             // Arrays get handled specially
-            if (t.IsArray)
+            if (typeInfo.IsArray)
             {
                 var et = t.GetElementType();
                 if (HasOrleansSerialization(et))
                 {
                     SerializeArray((Array)obj, stream, expected, et);
                 }
-                else if (et.IsSerializable)
+                else if (et.GetTypeInfo().IsSerializable)
                 {
                     FallbackSerializer(obj, stream);
                 }
@@ -1105,13 +1112,13 @@ namespace Orleans.Serialization
                 return;
             }
 
-            if (t.IsSerializable)
+            if (typeInfo.IsSerializable)
             {
                 FallbackSerializer(obj, stream);
                 return;
             }
 
-            if ((obj is Exception) && !t.IsSerializable)
+            if ((obj is Exception) && !typeInfo.IsSerializable)
             {
                 // Exceptions should always be serializable, and thus handled by the prior if.
                 // In case someone creates a non-serializable exception, though, we don't want to 
@@ -1133,10 +1140,12 @@ namespace Orleans.Serialization
         // We assume that all lower bounds are 0, since creating an array with lower bound !=0 is hard in .NET 4.0+
         private static void SerializeArray(Array array, BinaryTokenStreamWriter stream, Type expected, Type et)
         {
+            var etTypeInfo = et.GetTypeInfo();
+
             // First check for one of the optimized cases
             if (array.Rank == 1)
             {
-                if (et.TypeHandle.Equals(byteTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(byteTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.ByteArray);
@@ -1144,7 +1153,7 @@ namespace Orleans.Serialization
                     stream.Write((byte[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(boolTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(boolTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.BoolArray);
@@ -1152,7 +1161,7 @@ namespace Orleans.Serialization
                     stream.Write((bool[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(charTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(charTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.CharArray);
@@ -1160,7 +1169,7 @@ namespace Orleans.Serialization
                     stream.Write((char[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(shortTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(shortTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.ShortArray);
@@ -1168,7 +1177,7 @@ namespace Orleans.Serialization
                     stream.Write((short[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(intTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(intTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.IntArray);
@@ -1176,7 +1185,7 @@ namespace Orleans.Serialization
                     stream.Write((int[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(longTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(longTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.LongArray);
@@ -1184,7 +1193,7 @@ namespace Orleans.Serialization
                     stream.Write((long[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(ushortTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(ushortTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.UShortArray);
@@ -1192,7 +1201,7 @@ namespace Orleans.Serialization
                     stream.Write((ushort[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(uintTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(uintTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.UIntArray);
@@ -1200,7 +1209,7 @@ namespace Orleans.Serialization
                     stream.Write((uint[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(ulongTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(ulongTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.ULongArray);
@@ -1208,7 +1217,7 @@ namespace Orleans.Serialization
                     stream.Write((ulong[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(floatTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(floatTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.FloatArray);
@@ -1216,7 +1225,7 @@ namespace Orleans.Serialization
                     stream.Write((float[])array);
                     return;
                 }
-                if (et.TypeHandle.Equals(doubleTypeHandle))
+                if (etTypeInfo.TypeHandle.Equals(doubleTypeHandle))
                 {
                     stream.Write(SerializationTokenType.SpecifiedType);
                     stream.Write(SerializationTokenType.DoubleArray);
@@ -1419,14 +1428,15 @@ namespace Orleans.Serialization
                     return new object();
                 }
 
+                var resultTypeInfo = resultType.GetTypeInfo();
                 // Handle enums
-                if (resultType.IsEnum)
+                if (resultTypeInfo.IsEnum)
                 {
                     result = Enum.ToObject(resultType, stream.ReadInt());
                     return result;
                 }
 
-                if (resultType.IsArray)
+                if (resultTypeInfo.IsArray)
                 {
                     result = DeserializeArray(resultType, stream);
                     DeserializationContext.Current.RecordObject(result);

--- a/src/Orleans/Utils/Utils.cs
+++ b/src/Orleans/Utils/Utils.cs
@@ -411,7 +411,7 @@ namespace Orleans.Runtime
 
             MethodInfo method;
             method = argumentTypes == null
-                ? cl.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                ? cl.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).Where(m=>m.Name == methodName).FirstOrDefault()
                 : cl.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, argumentTypes, null);
 
             if (method == null)

--- a/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
@@ -65,8 +65,9 @@ namespace Orleans.CodeGenerator
         {
             var baseTypes = new List<BaseTypeSyntax> { SF.SimpleBaseType(typeof(IGrainMethodInvoker).GetTypeSyntax()) };
 
-            var genericTypes = grainType.IsGenericTypeDefinition
-                                   ? grainType.GetGenericArguments()
+            var grainTypeInfo = grainType.GetTypeInfo();
+            var genericTypes = grainTypeInfo.IsGenericTypeDefinition
+                                   ? grainTypeInfo.GetGenericArguments()
                                          .Select(_ => SF.TypeParameter(_.ToString()))
                                          .ToArray()
                                    : new TypeParameterSyntax[0];

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -71,8 +71,9 @@ namespace Orleans.CodeGenerator
         /// </returns>
         internal static TypeDeclarationSyntax GenerateClass(Type grainType, Action<Type> onEncounteredType)
         {
-            var genericTypes = grainType.IsGenericTypeDefinition
-                                   ? grainType.GetGenericArguments()
+            var grainTypeInfo = grainType.GetTypeInfo();
+            var genericTypes = grainTypeInfo.IsGenericTypeDefinition
+                                   ? grainTypeInfo.GetGenericArguments()
                                          .Select(_ => SF.TypeParameter(_.ToString()))
                                          .ToArray()
                                    : new TypeParameterSyntax[0];
@@ -282,7 +283,7 @@ namespace Orleans.CodeGenerator
 
             // Addressable arguments must be converted to references before passing.
             if (typeof(IAddressable).IsAssignableFrom(arg.ParameterType)
-                && (typeof(Grain).IsAssignableFrom(arg.ParameterType) || arg.ParameterType.IsInterface))
+                && (typeof(Grain).IsAssignableFrom(arg.ParameterType) || arg.ParameterType.GetTypeInfo().IsInterface))
             {
                 return
                     SF.ConditionalExpression(
@@ -353,9 +354,8 @@ namespace Orleans.CodeGenerator
         private static MethodDeclarationSyntax GenerateGetMethodNameMethod(Type grainType)
         {
             // Get the method with the correct type.
-            var method = typeof(GrainReference).GetMethod(
-                "GetMethodName",
-                BindingFlags.NonPublic | BindingFlags.Instance);
+            var method = typeof(GrainReference).GetMethods(
+                BindingFlags.NonPublic | BindingFlags.Instance).Where(m=>m.Name == "GetMethodName").FirstOrDefault();
 
             var methodDeclaration =
                 method.GetDeclarationSyntax()

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -308,9 +308,10 @@ namespace Orleans.CodeGenerator
             {
                 // The module containing the serializer.
                 var module = runtime ? null : type.Module;
+                var typeInfo = type.GetTypeInfo();
 
                 // Every type which is encountered must be considered for serialization.
-                if (!type.IsNested && !type.IsGenericParameter && type.IsSerializable)
+                if (!typeInfo.IsNested && !typeInfo.IsGenericParameter && typeInfo.IsSerializable)
                 {
                     // If a type was encountered which can be accessed, process it for serialization.
                     var isAccessibleForSerialization =

--- a/src/OrleansCodeGenerator/Utilities/SyntaxFactoryExtensions.cs
+++ b/src/OrleansCodeGenerator/Utilities/SyntaxFactoryExtensions.cs
@@ -243,10 +243,11 @@ namespace Orleans.CodeGenerator.Utilities
         /// </returns>
         public static TypeParameterConstraintClauseSyntax[] GetTypeConstraintSyntax(this Type genericTypeArgument)
         {
-            if (genericTypeArgument.IsGenericTypeDefinition)
+            var typeInfo = genericTypeArgument.GetTypeInfo();
+            if (typeInfo.IsGenericTypeDefinition)
             {
-                    var constraints = new List<TypeParameterConstraintClauseSyntax>();
-                foreach (var genericParameter in genericTypeArgument.GetGenericArguments())
+                var constraints = new List<TypeParameterConstraintClauseSyntax>();
+                foreach (var genericParameter in typeInfo.GetGenericArguments())
                 {
                     var parameterConstraints = new List<TypeParameterConstraintSyntax>();
                     var attributes = genericParameter.GenericParameterAttributes;

--- a/src/OrleansRuntime/GrainTypeManager/GenericGrainTypeData.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GenericGrainTypeData.cs
@@ -22,7 +22,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
-
+using System.Reflection;
 
 namespace Orleans.Runtime
 {
@@ -35,7 +35,7 @@ namespace Orleans.Runtime
         public GenericGrainTypeData(Type activationType, Type stateObjectType) :
             base(activationType, stateObjectType)
         {
-            if (!activationType.IsGenericTypeDefinition)
+            if (!activationType.GetTypeInfo().IsGenericTypeDefinition)
                 throw new ArgumentException("Activation type is not generic: " + activationType.Name);
 
             this.activationType = activationType;
@@ -46,7 +46,7 @@ namespace Orleans.Runtime
         {
             // Need to make a non-generic instance of the class to access the static data field. The field itself is independent of the instantiated type.
             var concreteActivationType = activationType.MakeGenericType(typeArgs);
-            var concreteStateObjectType = (stateObjectType != null && stateObjectType.IsGenericType) ? stateObjectType.GetGenericTypeDefinition().MakeGenericType(typeArgs) : stateObjectType;
+            var concreteStateObjectType = (stateObjectType != null && stateObjectType.GetTypeInfo().IsGenericType) ? stateObjectType.GetGenericTypeDefinition().MakeGenericType(typeArgs) : stateObjectType;
 
             return new GrainTypeData(concreteActivationType, concreteStateObjectType);
         }

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using Orleans.CodeGeneration;
 using Orleans.Runtime.Providers;
 using Orleans.Serialization;
+using System.Reflection;
 
 namespace Orleans.Runtime
 {
@@ -255,7 +256,7 @@ namespace Orleans.Runtime
             public InvokerData(Type invokerType)
             {
                 baseInvokerType = invokerType;
-                if(invokerType.IsGenericType)
+                if(invokerType.GetTypeInfo().IsGenericType)
                     cachedGenericInvokers = new Dictionary<string, IGrainMethodInvoker>();
             }
 

--- a/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
+++ b/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
@@ -94,13 +94,13 @@ namespace Orleans.Runtime
                 var parentType = grainType.BaseType;
                 while (parentType != typeof (Grain) && parentType != typeof(object))
                 {
-                    if (parentType.IsGenericType)
+                    if (parentType.GetTypeInfo().IsGenericType)
                     {
                         var definition = parentType.GetGenericTypeDefinition();
                         if (definition == typeof (Grain<>))
                         {
                             var stateArg = parentType.GetGenericArguments()[0];
-                            if (stateArg.IsClass)
+                            if (stateArg.GetTypeInfo().IsClass)
                             {
                                 grainStateType = stateArg;
                                 break;
@@ -144,7 +144,7 @@ namespace Orleans.Runtime
         /// </summary>
         private static GrainTypeData GetTypeData(Type grainType, Type stateObjectType)
         {
-            return grainType.IsGenericTypeDefinition ? 
+            return grainType.GetTypeInfo().IsGenericTypeDefinition ? 
                 new GenericGrainTypeData(grainType, stateObjectType) : 
                 new GrainTypeData(grainType, stateObjectType);
         }

--- a/src/TesterInternal/General/SerializationTests.cs
+++ b/src/TesterInternal/General/SerializationTests.cs
@@ -131,27 +131,28 @@ namespace UnitTests.General
         public GrainReference GetGrainReference<TGrainInterface>()
         {
             var grainType = typeof(TGrainInterface);
+            var typeInfo = grainType.GetTypeInfo();
 
-            if (typeof(TGrainInterface).IsGenericTypeDefinition)
+            if (typeInfo.IsGenericTypeDefinition)
             {
                 throw new ArgumentException("Cannot create grain reference for non-concrete grain type");
             }
 
-            if (typeof(TGrainInterface).IsConstructedGenericType)
+            if (typeInfo.IsConstructedGenericType)
             {
-                grainType = typeof(TGrainInterface).GetGenericTypeDefinition();
+                grainType = typeInfo.GetGenericTypeDefinition();
             }
 
-            var type = typeof(TGrainInterface).Assembly.DefinedTypes.First(
+            var type = typeInfo.Assembly.DefinedTypes.First(
                 _ =>
                 {
                     var attr = _.GetCustomAttribute<GrainReferenceAttribute>();
                     return attr != null && attr.GrainType == grainType;
                 }).AsType();
 
-            if (typeof(TGrainInterface).IsConstructedGenericType)
+            if (typeInfo.IsConstructedGenericType)
             {
-                type = type.MakeGenericType(typeof(TGrainInterface).GetGenericArguments());
+                type = type.MakeGenericType(typeInfo.GetGenericArguments());
             }
 
             var regularGrainId = GrainId.GetGrainIdForTesting(Guid.NewGuid());


### PR DESCRIPTION
Moved calls from Type -> TypeInfo to comply with CoreCLR API compatibility at #368

For now, just moved all calls made directly to Type.XXX to TypeInfo.XXX in order to be compatible with CoreCLR apis.

The idea was to keep current Orleans code as is, and only change what is necessary. Later on, I'll create another PR (after coreclr is fully supported on Orleans) and change all APIs that uses Type to use TypeInfo since everything from Type can be accessible from TypeInfo members. (refactor task)

Feedback is always welcome.