### PR TITLE
Ensure codegen registers all assemblies before generating new code

### DIFF
--- a/src/Orleans/CodeGeneration/CodeGeneratorManager.cs
+++ b/src/Orleans/CodeGeneration/CodeGeneratorManager.cs
@@ -25,6 +25,9 @@
         /// <summary>
         /// Ensures code for the <paramref name="input"/> assembly has been generated and loaded.
         /// </summary>
+        /// <param name="input">
+        /// The input assembly.
+        /// </param>
         public static void GenerateAndCacheCodeForAssembly(Assembly input)
         {
             var codeGen = CodeGeneratorInstance.Value;

--- a/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
+++ b/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
@@ -123,7 +123,12 @@ namespace Orleans.CodeGenerator
                 {
                     source = source ?? GenerateSourceCode(code);
                     var errors = string.Join("\n", compilationResult.Diagnostics.Select(_ => _.ToString()));
-                    logger.Warn(ErrorCode.CodeGenCompilationFailed, "Compilation of assembly {0} failed with errors:\n{1}", assemblyName, errors, source);
+                    logger.Warn(
+                        ErrorCode.CodeGenCompilationFailed,
+                        "Compilation of assembly {0} failed with errors:\n{1}\nGenerated Source Code:\n{2}",
+                        assemblyName,
+                        errors,
+                        source);
                     throw new CodeGenerationException(errors);
                 }
                 


### PR DESCRIPTION
There was not a clearly defined order in the execution of the following:
* The AssemblyLoad hook which registers assemblies which have had their code generated at compile-time; and
* The AssemblyLoad hook which ensures that all assemblies have been passed to the code generator.

This fix removes the registration hook from `RoslynCodeGenerator` and registers assemblies just before considering them for code generation. The ordering is now more clearly defined and closer to being "obviously not deficient" rather than "not obviously deficient"

The fix also improves logging around failed code generation.