### PR TITLE
MSSQL Script - Fields defaults and Updating IAmAlive without ETag

### DIFF
--- a/src/OrleansSQLUtils/Storage/OrleansRelationalExtensions.cs
+++ b/src/OrleansSQLUtils/Storage/OrleansRelationalExtensions.cs
@@ -830,7 +830,7 @@ namespace Orleans.SqlUtils
                 }
             }
 
-            string etag = Convert.ToBase64String(record.GetValue<byte[]>("ETag"));
+            string etag = Convert.ToBase64String(record.GetValueOrDefault("ETag", new byte[0]));
             int tableVersion = (int)record.GetValueOrDefault<long>("Version");
             string versionETag = Convert.ToBase64String(record.GetValueOrDefault<byte[]>("VersionETag"));
 


### PR DESCRIPTION
I'm currently completing the MySQL ADO Invariant implementation in Orleans.
This includes creating a complete MySQL setup script as available in MSSQL and adding relevant tests.
While converting *CreateOrleansTables_SqlServer.sql* to MySQL I came across what IMHO is a bug.
In current implementation, the **UpdateIAmAlivetimeKey** script updates the **ETag** field.
The **IAmAliveTime** is a purely informative field and isn't a part of the membership protocol.
This will cause silos to unnecessarily fail periodically when trying to update the membership table.
My solution is to use the MSSQL 2000 implementation for all versions of MSSQL, with the minor change of not updating the **ETag** in **UpdateIAmAlivetimeKey**.
@veikkoeeva what do you think?