### PR TITLE
Make GrainFactory static in TestingSiloHost

### DIFF
--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -77,7 +77,7 @@ namespace Orleans.TestingHost
 
         private static int InstanceCounter = 0;
 
-        public IGrainFactory GrainFactory { get; private set; }
+        public static IGrainFactory GrainFactory { get; private set; }
 
         public Logger logger 
         {

--- a/src/Tester/CodeGenTests/RuntimeCodeGenerationTests.cs
+++ b/src/Tester/CodeGenTests/RuntimeCodeGenerationTests.cs
@@ -55,7 +55,7 @@ namespace Tester.CodeGenTests
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public async Task RuntimeCodeGenTest()
         {
-            var grain = this.GrainFactory.GetGrain<IRuntimeCodeGenGrain<@event>>(Guid.NewGuid());
+            var grain = GrainFactory.GetGrain<IRuntimeCodeGenGrain<@event>>(Guid.NewGuid());
             var expected = new @event
             {
                 Id = Guid.NewGuid(),
@@ -76,7 +76,7 @@ namespace Tester.CodeGenTests
         public async Task RuntimeCodeGenNestedGenericTest()
         {
             const int Expected = 123985;
-            var grain = this.GrainFactory.GetGrain<INestedGenericGrain>(Guid.NewGuid());
+            var grain = GrainFactory.GetGrain<INestedGenericGrain>(Guid.NewGuid());
             
             var nestedGeneric = new NestedGeneric<int> { Payload = new NestedGeneric<int>.Nested { Value = Expected } };
             var actual = await grain.Do(nestedGeneric);

--- a/src/Tester/ExceptionPropagationTests.cs
+++ b/src/Tester/ExceptionPropagationTests.cs
@@ -56,7 +56,7 @@ namespace UnitTests.General
         [TestMethod, TestCategory("BVT"), TestCategory("Functional")]
         public async Task TaskCancelationPropagation()
         {
-            IExceptionGrain grain = this.GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
+            IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
             var actualException = default(Exception);
             try
             {


### PR DESCRIPTION
Commit by Maxim Terletsky <maxim@gigya-inc.com>
On branch: refs/heads/feature/MakingGrainFactoryStaticInTestingSiloHost
According to issue
https://github.com/dotnet/orleans/issues/962