### PR TITLE
[RegisterSerializer] - Register method must be public static void.

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -565,7 +565,7 @@ namespace Orleans.Serialization
                             {
                                 logger.Warn(
                                     ErrorCode.SerMgr_MissingRegisterMethod,
-                                    "Type {0} from assembly {1} has the RegisterSerializer attribute but no Register static method",
+                                    "Type {0} from assembly {1} has the RegisterSerializer attribute but no public static void Register method",
                                     type.Name,
                                     assembly.GetName().Name);
                             }

--- a/src/Tester/SerializationTests.cs
+++ b/src/Tester/SerializationTests.cs
@@ -166,7 +166,7 @@ namespace UnitTests.General
             TestTypeA output2 = SerializationManager.RoundTripSerializationForTesting(input);
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
         public void SerializationTests_JObject_Example1()
         {
             const string json = @"{ 
@@ -216,7 +216,7 @@ namespace UnitTests.General
             }
         }
         
-        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
         public void SerializationTests_Json_InnerTypes_TypeNameHandling()
         {
             var original = new RootType();
@@ -235,7 +235,7 @@ namespace UnitTests.General
             Console.WriteLine("Done OK.");
         }
 
-        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
         public void SerializationTests_Json_InnerTypes_NoTypeNameHandling()
         {
             var original = new RootType();
@@ -302,7 +302,7 @@ namespace UnitTests.General
                 return JsonConvert.DeserializeObject(str, expected);
             }
 
-            private static void Register()
+            public static void Register()
             {
                 foreach (var type in new[]
                     {


### PR DESCRIPTION
SerializationManager - The Register method must be public static void.

- Classes marked with a `[RegisterSerializer]` attribute need to provide a `public static void Register()` method.

- The test code for `JsonSerializationExample2` class incorrectly had `private` Register() method, so this PR fixes that (SerializationTests.cs line 305).

Failure Mode:

```
[2015-11-08 04:31:06.643 GMT    15 WARNING 102402 SerializationManager ] Type JsonSerializationExample2 from assembly Tester has the RegisterSerializer attribute but no Register static method
```

- The SerializationManager error message printed in the silo log [above] is slightly ambiguous because it does not mention that the `Register()` method needs to be `public`, so fixed that to be more explicit and clear.

- Added "JSON" tag to the JSON serializer test cases, for easier discovery.