### PR TITLE
OrleansCodeGenerator.dll not found during test runs.

### DIFF
--- a/src/Tester/UnitTestSiloHost.cs
+++ b/src/Tester/UnitTestSiloHost.cs
@@ -25,7 +25,6 @@ using System;
 using System.IO;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 
 namespace UnitTests.Tester
@@ -40,6 +39,7 @@ namespace UnitTests.Tester
     [DeploymentItem("ClientConfigurationForTesting.xml")]
     [DeploymentItem("TestGrainInterfaces.dll")]
     [DeploymentItem("TestGrains.dll")]
+    [DeploymentItem("OrleansCodeGenerator.dll")]
     public class UnitTestSiloHost : TestingSiloHost
     {
         public UnitTestSiloHost() // : base()


### PR DESCRIPTION
- Add missing `[DeploymentItem]` to ensure the `OrleansCodeGenerator.dll` assembly is shadow copied into the tests runtime directory.

Failure Mode:

```
[2015-11-08 05:55:09.462 GMT    19 WARNING 101722 CodeGenerator ] Could not load file or assembly 'OrleansCodeGenerator' or one of its dependencies.
The system cannot find the file specified.

Exc level 0: System.IO.FileNotFoundException: Could not load file or assembly 'OrleansCodeGenerator' or one of its dependencies.
The system cannot find the file specified.
   at System.Reflection.RuntimeAssembly._nLoad(AssemblyName fileName, String codeBase, Evidence assemblySecurity, RuntimeAssembly locationHint, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, Boolean forIntrospection, Boolean suppressSecurityChecks)
   at System.Reflection.RuntimeAssembly.InternalLoadAssemblyName(AssemblyName assemblyRef, Evidence assemblySecurity, RuntimeAssembly reqAssembly, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, Boolean forIntrospection, Boolean suppressSecurityChecks)
   at System.Reflection.Assembly.Load(AssemblyName assemblyRef)
   at Orleans.Runtime.AssemblyLoader.TryLoadAndCreateInstance[T](String assemblyName, TraceLogger logger)
      in c:\Depot\GitHub\orleans\src\Orleans\AssemblyLoader\AssemblyLoader.cs:line 109

[2015-11-08 05:55:09.463 GMT    19 WARNING 103806 CodeGenerator ] Code generator assembly (OrleansCodeGenerator.dll) not present.
```