### PR TITLE
Do not stop low priority system targets before providers are stopped.

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -732,7 +732,7 @@ namespace Orleans
         SchedulerWorkGroupShuttingDown          = SchedulerBase + 16,
         SchedulerNotEnqueuWorkWhenShutdown      = SchedulerBase + 17,
         SchedulerNotExecuteWhenShutdown         = SchedulerBase + 18,
-        SchedulerAppTurnsStopped                = SchedulerBase + 19,
+        SchedulerAppTurnsStopped_1              = SchedulerBase + 19,
         SchedulerWorkGroupStopping              = SchedulerBase + 20,
         SchedulerSkipWorkStopping               = SchedulerBase + 21,
         SchedulerSkipWorkCancelled              = SchedulerBase + 22,
@@ -745,6 +745,7 @@ namespace Orleans
         SchedulerTaskWaitIncomplete             = SchedulerBase + 29,
         SchedulerWorkerThreadExc                = SchedulerBase + 30,
         SchedulerQueueWorkItemWrongContext      = SchedulerBase + 31,
+        SchedulerAppTurnsStopped_2              = SchedulerBase + 32,
 
         GatewayBase                             = Runtime + 1300,
         GatewayClientOpenedSocket               = GatewayBase + 1,

--- a/src/Orleans/Runtime/ISchedulingContext.cs
+++ b/src/Orleans/Runtime/ISchedulingContext.cs
@@ -49,11 +49,18 @@ namespace Orleans.Runtime
             return context != null && context.ContextType != SchedulingContextType.SystemThread;
         }
 
-        internal static bool IsSystemContext(ISchedulingContext context)
+        internal static bool IsSystemPriorityContext(ISchedulingContext context)
         {
-            // System Context are either associated with the (null) context, system target or system thread.
+            // System Priorit Context are either associated with the (null) context, system target or regular (non low priority) system thread.
             // Both System targets, system thread and normal grains have OrleansContext instances, of the appropriate type (based on SchedulingContext.ContextType).
             return context == null || context.IsSystemPriorityContext;
+        }
+
+        internal static bool IsSystemContext(ISchedulingContext context)
+        {
+            // System Context are either associated with the (null) context, system target or any (low and high priority) system thread.
+            // Both System targets, system thread and normal grains have OrleansContext instances, of the appropriate type (based on SchedulingContext.ContextType).
+            return context == null || context.ContextType== SchedulingContextType.SystemTarget || context.ContextType == SchedulingContextType.SystemThread;
         }
     }
 }

--- a/src/Orleans/Statistics/StatisticsCollector.cs
+++ b/src/Orleans/Statistics/StatisticsCollector.cs
@@ -73,7 +73,7 @@ namespace Orleans.Runtime
 
         internal static bool ReportPerWorkItemStats(ISchedulingContext schedulingContext)
         {
-            return SchedulingUtils.IsSystemContext(schedulingContext) ? IsVerbose2 : IsVerbose3;
+            return SchedulingUtils.IsSystemPriorityContext(schedulingContext) ? IsVerbose2 : IsVerbose3;
         }
 
         //--------------------------------------//

--- a/src/OrleansRuntime/Scheduler/IWorkItem.cs
+++ b/src/OrleansRuntime/Scheduler/IWorkItem.cs
@@ -33,7 +33,7 @@ namespace Orleans.Runtime.Scheduler
         ISchedulingContext SchedulingContext { get; set; }
         TimeSpan TimeSinceQueued { get; }
         DateTime TimeQueued { get; set;  }
-        bool IsSystem { get; }
+        bool IsSystemPriority { get; }
         void Execute();
     }
 }

--- a/src/OrleansRuntime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/OrleansRuntime/Scheduler/OrleansTaskScheduler.cs
@@ -159,11 +159,12 @@ namespace Orleans.Runtime.Scheduler
 #if DEBUG
             if (logger.IsVerbose) logger.Verbose("StopApplicationTurns");
 #endif
-            RunQueue.RunDownApplication();
+            // Do not RunDown the application run queue, since it is still used by low priority system targets.
+
             applicationTurnsStopped = true;
             foreach (var group in workgroupDirectory.Values)
             {
-                if (!group.IsSystem)
+                if (!group.IsSystemGroup)
                     group.Stop();
             }
         }
@@ -187,10 +188,10 @@ namespace Orleans.Runtime.Scheduler
 #endif
             var context = contextObj as ISchedulingContext;
             var workItemGroup = GetWorkItemGroup(context);
-            if (applicationTurnsStopped && (workItemGroup != null) && !workItemGroup.IsSystem)
+            if (applicationTurnsStopped && (workItemGroup != null) && !workItemGroup.IsSystemGroup)
             {
                 // Drop the task on the floor if it's an application work item and application turns are stopped
-                logger.Warn(ErrorCode.SchedulerAppTurnsStopped, string.Format("Dropping Task {0} because applicaiton turns are stopped", task));
+                logger.Warn(ErrorCode.SchedulerAppTurnsStopped_2, string.Format("Dropping Task {0} because application turns are stopped", task));
                 return;
             }
 
@@ -225,11 +226,11 @@ namespace Orleans.Runtime.Scheduler
             }
 
             var workItemGroup = GetWorkItemGroup(context);
-            if (applicationTurnsStopped && (workItemGroup != null) && !workItemGroup.IsSystem)
+            if (applicationTurnsStopped && (workItemGroup != null) && !workItemGroup.IsSystemGroup)
             {
                 // Drop the task on the floor if it's an application work item and application turns are stopped
-                var msg = string.Format("Dropping work item {0} because applicaiton turns are stopped", workItem);
-                logger.Warn(ErrorCode.SchedulerAppTurnsStopped, msg);
+                var msg = string.Format("Dropping work item {0} because application turns are stopped", workItem);
+                logger.Warn(ErrorCode.SchedulerAppTurnsStopped_1, msg);
                 return;
             }
 

--- a/src/OrleansRuntime/Scheduler/WorkItemBase.cs
+++ b/src/OrleansRuntime/Scheduler/WorkItemBase.cs
@@ -46,9 +46,9 @@ namespace Orleans.Runtime.Scheduler
 
         public abstract void Execute();
 
-        public bool IsSystem
+        public bool IsSystemPriority
         {
-            get { return SchedulingUtils.IsSystemContext(this.SchedulingContext); }
+            get { return SchedulingUtils.IsSystemPriorityContext(this.SchedulingContext); }
         }
 
         public override string ToString()

--- a/src/OrleansRuntime/Scheduler/WorkItemGroup.cs
+++ b/src/OrleansRuntime/Scheduler/WorkItemGroup.cs
@@ -68,7 +68,12 @@ namespace Orleans.Runtime.Scheduler
 
         public ISchedulingContext SchedulingContext { get; set; }
 
-        public bool IsSystem
+        public bool IsSystemPriority
+        {
+            get { return SchedulingUtils.IsSystemPriorityContext(SchedulingContext); }
+        }
+
+        internal bool IsSystemGroup
         {
             get { return SchedulingUtils.IsSystemContext(SchedulingContext); }
         }
@@ -160,7 +165,7 @@ namespace Orleans.Runtime.Scheduler
             totalQueuingDelay = TimeSpan.Zero;
             quantumExpirations = 0;
             TaskRunner = new ActivationTaskScheduler(this);
-            log = IsSystem ? TraceLogger.GetLogger("Scheduler." + Name + ".WorkItemGroup", TraceLogger.LoggerType.Runtime) : appLogger;
+            log = IsSystemPriority ? TraceLogger.GetLogger("Scheduler." + Name + ".WorkItemGroup", TraceLogger.LoggerType.Runtime) : appLogger;
 
             if (StatisticsCollector.CollectShedulerQueuesStats)
             {
@@ -427,7 +432,7 @@ namespace Orleans.Runtime.Scheduler
         public override string ToString()
         {
             return String.Format("{0}WorkItemGroup:Name={1},WorkGroupStatus={2}",
-                IsSystem ? "System*" : "",
+                IsSystemGroup ? "System*" : "",
                 Name,
                 state);
         }

--- a/src/OrleansRuntime/Scheduler/WorkQueue.cs
+++ b/src/OrleansRuntime/Scheduler/WorkQueue.cs
@@ -64,7 +64,7 @@ namespace Orleans.Runtime.Scheduler
             try
             {
 #if PRIORITIZE_SYSTEM_TASKS
-                if (workItem.IsSystem)
+                if (workItem.IsSystemPriority)
                 {
     #if TRACK_DETAILED_STATS
                     if (StatisticsCollector.CollectShedulerQueuesStats)
@@ -177,13 +177,6 @@ namespace Orleans.Runtime.Scheduler
             sb.AppendLine("Main Queue:");
             foreach (var workItem in mainQueue)
                 sb.AppendFormat("  {0}", workItem).AppendLine();
-        }
-
-        public void RunDownApplication()
-        {
-#if PRIORITIZE_SYSTEM_TASKS
-            mainQueue.CompleteAdding();
-#endif
         }
 
         public void RunDown()


### PR DESCRIPTION
This is a bug fix to the bug reported in #930.

Explanation:
In the silo shutdown sequence we:
a) stop application
b) stop providers
c) stop the system
Pulling agents are used by the persistent stream providers. Those agents are implemented as "low priority system targets". That means they are just like regular system targets from all perspectives except that in the scheduler they are handled the same way as application (grains) - they have regular priority (they do not receive a special high priority treatment as regular system targets). It was done this way so that pulling agents could not starve the high priority system activities.

The bug was that when we stop application turns and all application work items groups in the scheduler, we also stop the low priority system targets. As a result, when later on as part of shutting down the stream providers we make a `Shutdown` call on the pulling agents, the scheduler was rejecting this call (it was rejecting the `Task` enqueued on that pulling agents), since pulling agents were already stopped.

The fix:
1) Rename `IsSystem` to  `IsSystemPriority` everywhere it was used to disambiguate and make it clear that indeed in those places we are interested to know what is the priority and not any other aspect of this scheduling context.
2) Add `IsSystemContext` to  scheduling context and `IsSystemGroup` to work item group to mean if they represents application vs. system (both high and low priority).
