### PR TITLE
Grain activation local cache threading fix 

### DIFF
--- a/src/OrleansRuntime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/OrleansRuntime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -70,13 +70,14 @@ namespace Orleans.Runtime.GrainDirectory
         {
         }
 
-        public bool LookUp(GrainId key, out TValue result)
+        public bool LookUp(GrainId key, out TValue result, out int version)
         {
             result = default(TValue);
+            version = default(int);
             return false;
         }
 
-        public List<Tuple<GrainId, TValue, int>> KeyValues
+        public IReadOnlyList<Tuple<GrainId, TValue, int>> KeyValues
         {
             get { return EmptyList; }
         }

--- a/src/OrleansRuntime/GrainDirectory/IGrainDirectoryCache.cs
+++ b/src/OrleansRuntime/GrainDirectory/IGrainDirectoryCache.cs
@@ -52,16 +52,33 @@ namespace Orleans.Runtime.GrainDirectory
         void Clear();
 
         /// <summary>
-        /// Lookups the cached value by the given key.
+        /// Looks uo the cached value and version by the given key
         /// </summary>
         /// <param name="key">key for the lookup</param>
         /// <param name="result">value if the key is found, undefined otherwise</param>
+        /// <param name="version">version of cached value if the key is found, undefined otherwise</param>
         /// <returns>true iff the the given key is in the cache</returns>
-        bool LookUp(GrainId key, out TValue result);
+        bool LookUp(GrainId key, out TValue result, out int version);
 
         /// <summary>
         /// Returns list of key-value-version tuples stored currently in the cache.
         /// </summary>
-        List<Tuple<GrainId, TValue, int>> KeyValues { get; }
+        IReadOnlyList<Tuple<GrainId, TValue, int>> KeyValues { get; }
+    }
+
+    internal static class GrainDirectoryCacheExtensions
+    {
+        /// <summary>
+        /// Looks up the cached value by the given key.
+        /// </summary>
+        /// <param name="cache">grain directory cache to look up results from</param>
+        /// <param name="key">key for the lookup</param>
+        /// <param name="result">value if the key is found, undefined otherwise</param>
+        /// <returns>true iff the the given key is in the cache</returns>
+        public static bool LookUp<TValue>(this IGrainDirectoryCache<TValue> cache, GrainId key, out TValue result)
+        {
+            int version;
+            return cache.LookUp(key, out result, out version);
+        }
     }
 }

--- a/src/OrleansRuntime/GrainDirectory/LRUBasedGrainDirectoryCache.cs
+++ b/src/OrleansRuntime/GrainDirectory/LRUBasedGrainDirectoryCache.cs
@@ -53,12 +53,13 @@ namespace Orleans.Runtime.GrainDirectory
             cache.Clear();
         }
 
-        public bool LookUp(GrainId key, out TValue result)
+        public bool LookUp(GrainId key, out TValue result, out int version)
         {
+            version = default(int);
             return cache.TryGetValue(key, out result);
         }
 
-        public List<Tuple<GrainId, TValue, int>> KeyValues
+        public IReadOnlyList<Tuple<GrainId, TValue, int>> KeyValues
         {
             get
             {

--- a/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
@@ -53,7 +53,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         internal SiloAddress MyAddress { get; private set; }
 
-        internal IGrainDirectoryCache<List<Tuple<SiloAddress, ActivationId>>> DirectoryCache { get; private set; }
+        internal IGrainDirectoryCache<IReadOnlyList<Tuple<SiloAddress, ActivationId>>> DirectoryCache { get; private set; }
         internal GrainDirectoryPartition DirectoryPartition { get; private set; }
 
         public RemoteGrainDirectory RemGrainDirectory { get; private set; }
@@ -111,10 +111,10 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 lock (membershipCache)
                 {
-                    DirectoryCache = GrainDirectoryCacheFactory<List<Tuple<SiloAddress, ActivationId>>>.CreateGrainDirectoryCache(silo.GlobalConfig);
+                    DirectoryCache = GrainDirectoryCacheFactory<IReadOnlyList<Tuple<SiloAddress, ActivationId>>>.CreateGrainDirectoryCache(silo.GlobalConfig);
                 }
             });
-            maintainer = GrainDirectoryCacheFactory<List<Tuple<SiloAddress, ActivationId>>>.CreateGrainDirectoryCacheMaintainer(this, DirectoryCache);
+            maintainer = GrainDirectoryCacheFactory<IReadOnlyList<Tuple<SiloAddress, ActivationId>>>.CreateGrainDirectoryCacheMaintainer(this, DirectoryCache);
 
             if (silo.GlobalConfig.SeedNodes.Count > 0)
             {
@@ -330,25 +330,16 @@ namespace Orleans.Runtime.GrainDirectory
         protected void AdjustLocalCache(SiloAddress removedSilo)
         {
             // remove all records of activations located on the removed silo
-            foreach (Tuple<GrainId, List<Tuple<SiloAddress, ActivationId>>, int> tuple in DirectoryCache.KeyValues)
+            foreach (Tuple<GrainId, IReadOnlyList<Tuple<SiloAddress, ActivationId>>, int> tuple in DirectoryCache.KeyValues)
             {
-                // 2) remove entries owned by me (they should be retrieved from my directory partition)
+                // 2) remove entries now owned by me (they should be retrieved from my directory partition)
                 if (MyAddress.Equals(CalculateTargetSilo(tuple.Item1)))
                 {
                     DirectoryCache.Remove(tuple.Item1);
                 }
 
                 // 1) remove entries that point to activations located on the removed silo
-                if (tuple.Item2.RemoveAll(tuple2 => tuple2.Item1.Equals(removedSilo)) <= 0) continue;
-
-                if (tuple.Item2.Count > 0)
-                {
-                    DirectoryCache.AddOrUpdate(tuple.Item1, tuple.Item2, tuple.Item3);
-                }
-                else
-                {
-                    DirectoryCache.Remove(tuple.Item1);
-                }
+                RemoveActivations(DirectoryCache, tuple.Item1, tuple.Item2, tuple.Item3, t => t.Item1.Equals(removedSilo));
             }
         }
 
@@ -545,7 +536,7 @@ namespace Orleans.Runtime.GrainDirectory
 
                 if (!address.Equals(returnedAddress.Item1) || !IsValidSilo(address.Silo)) return returnedAddress.Item1;
 
-                var cached = new List<Tuple<SiloAddress, ActivationId>>( new [] { Tuple.Create(address.Silo, address.Activation) });
+                var cached = new List<Tuple<SiloAddress, ActivationId>>(1) { Tuple.Create(address.Silo, address.Activation) };
                 // update the cache so next local lookup will find this ActivationAddress in the cache and we will save full lookup.
                 DirectoryCache.AddOrUpdate(address.Grain, cached, returnedAddress.Item2);
                 return returnedAddress.Item1;
@@ -577,12 +568,21 @@ namespace Orleans.Runtime.GrainDirectory
                     // Caching optimization:
                     // cache the result of a successfull RegisterActivation call, only if it is not a duplicate activation.
                     // this way next local lookup will find this ActivationAddress in the cache and we will save a full lookup!
-                    List<Tuple<SiloAddress, ActivationId>> cached;
+                    IReadOnlyList<Tuple<SiloAddress, ActivationId>> cached;
                     if (!DirectoryCache.LookUp(address.Grain, out cached))
                     {
-                        cached = new List<Tuple<SiloAddress, ActivationId>>(1);
+                        cached = new List<Tuple<SiloAddress, ActivationId>>(1)
+                        {
+                            Tuple.Create(address.Silo, address.Activation)
+                        };
                     }
-                    cached.Add(Tuple.Create(address.Silo, address.Activation));
+                    else
+                    {
+                        var newcached = new List<Tuple<SiloAddress, ActivationId>>(cached.Count + 1);
+                        newcached.AddRange(cached);
+                        newcached.Add(Tuple.Create(address.Silo, address.Activation));
+                        cached = newcached;
+                    }
                     // update the cache so next local lookup will find this ActivationAddress in the cache and we will save full lookup.
                     DirectoryCache.AddOrUpdate(address.Grain, cached, eTag);
                 }
@@ -710,7 +710,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public List<ActivationAddress> GetLocalCacheData(GrainId grain)
         {
-            List<Tuple<SiloAddress, ActivationId>> cached;
+            IReadOnlyList<Tuple<SiloAddress, ActivationId>> cached;
             return DirectoryCache.LookUp(grain, out cached) ? 
                 cached.Select(elem => ActivationAddress.GetAddress(elem.Item1, grain, elem.Item2)).Where(addr => IsValidSilo(addr.Silo)).ToList() : 
                 null;
@@ -791,16 +791,16 @@ namespace Orleans.Runtime.GrainDirectory
 
         public void InvalidateCacheEntry(ActivationAddress activationAddress)
         {
+            int version;
+            IReadOnlyList<Tuple<SiloAddress, ActivationId>> list;
             var grainId = activationAddress.Grain;
             var activationId = activationAddress.Activation;
-            List<Tuple<SiloAddress, ActivationId>> list;
-            if (!DirectoryCache.LookUp(grainId, out list)) return;
 
-            list.RemoveAll(tuple => tuple.Item2.Equals(activationId));
-
-            // if list empty, need to remove from cache
-            if (list.Count == 0)
-                DirectoryCache.Remove(grainId);
+            // look up grain activations
+            if (DirectoryCache.LookUp(grainId, out list, out version))
+            {
+                RemoveActivations(DirectoryCache, grainId, list, version, t => t.Item2.Equals(activationId));
+            }
         }
 
         /// <summary>
@@ -954,6 +954,26 @@ namespace Orleans.Runtime.GrainDirectory
         internal IRemoteGrainDirectory GetDirectoryReference(SiloAddress silo)
         {
             return InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, silo);
+        }
+
+        private static void RemoveActivations(IGrainDirectoryCache<IReadOnlyList<Tuple<SiloAddress, ActivationId>>> directoryCache, GrainId key, IReadOnlyList<Tuple<SiloAddress, ActivationId>> activations, int version, Func<Tuple<SiloAddress, ActivationId>, bool> doRemove)
+        {
+            int removeCount = activations.Count(doRemove);
+            if (removeCount == 0)
+            {
+                return; // nothing to remove, done here
+            }
+
+            if (activations.Count > removeCount) // still some left, update activation list.  Note: Most of the time there should be only one activation
+            {
+                var newList = new List<Tuple<SiloAddress, ActivationId>>(activations.Count - removeCount);
+                newList.AddRange(activations.Where(t => !doRemove(t)));
+                directoryCache.AddOrUpdate(key, newList, version);
+            }
+            else // no activations left, remove from cache
+            {
+                directoryCache.Remove(key);
+            }
         }
     }
 }


### PR DESCRIPTION
List of grain activations in local cache are now read only.  This forces immutable treatment of these lists, preventing enumeration and modification of the list from occurring at the same time.

The reported manifestation of the problem was that the call `GetLocalCacheData` was throwing an exception because it was iterating over the list of activations while that list was being modified in another thread.  This was fairly rare.

The `GetLocalCacheData` call is made in a grains turn while making a grain call.  This means it may be commonly called by many threads and needs to be thread safe.  It was not thread safe because the calls `AdjustLocalCache`, `RegisterAsync`, and `InvalidateCacheEntry` all modified the inner list with no thread synchronization.

Rather than adding thread synchronization, the list was marked read-only, so it could not be modified.  All code modifying the list was updated to respect the read-only constraint on the data.  When removing items from the list, instead of removing entries from the list in-place, we build a new list with the remaining items.  When adding items to the list, instead of adding them to the existing list, we make a new list containing the items from the original list, along with those we are adding.  Since the list can no longer be modified all readers are thread safe, because writers must replace the list, rather than modifying it.

There may still exist race conditions around the updating of the activation list, since changes are not protected, but this would only cause data consistency issues that the system will self correct.

It should also be noted that multiple activations of the same grain reference is supported by the grain directory but not currently supported by any Orleans grain types.  This means that while the activation lists support multiple activations, there really should only be a single activation in the list.  The code is written with some simple optimizations around this, which reduce the cost of maintaining readonly lists that must be duplicated.