### PR TITLE
Added tests to subscribe from streams (SMS and AQ) from client.

### DIFF
--- a/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
@@ -22,6 +22,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -50,6 +51,12 @@ namespace UnitTests.StreamingTests
             })
         {
             runner = new SubscriptionMultiplicityTestRunner(AQStreamProviderName, GrainClient.Logger);
+        }
+
+        public override void AdjustForTest(Orleans.Runtime.Configuration.ClientConfiguration config)
+        {
+            config.RegisterStreamProvider<AzureQueueStreamProvider>(AQStreamProviderName, new Dictionary<string, string>());
+            base.AdjustForTest(config);
         }
 
         // Use ClassCleanup to run code after all tests in a class have run
@@ -113,6 +120,12 @@ namespace UnitTests.StreamingTests
             logger.Info("************************ AQTwoIntermitentStreamTest *********************************");
             await runner.TwoIntermitentStreamTest(Guid.NewGuid());
         }
-        
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
+        public async Task AQSubscribeFromClientTest()
+        {
+            logger.Info("************************ AQSubscribeFromClientTest *********************************");
+            await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
+        }
     }
 }

--- a/src/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
@@ -22,10 +22,12 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
+using Orleans.Providers.Streams.SimpleMessageStream;
 using Orleans.TestingHost;
 using UnitTests.Tester;
 
@@ -48,6 +50,12 @@ namespace UnitTests.StreamingTests
             })
         {
             runner = new SubscriptionMultiplicityTestRunner(SMSStreamProviderName, GrainClient.Logger);
+        }
+
+        public override void AdjustForTest(Orleans.Runtime.Configuration.ClientConfiguration config)
+        {
+            config.RegisterStreamProvider<SimpleMessageStreamProvider>(SMSStreamProviderName, new Dictionary<string,string>());
+ 	        base.AdjustForTest(config);
         }
 
         // Use ClassCleanup to run code after all tests in a class have run
@@ -90,6 +98,13 @@ namespace UnitTests.StreamingTests
         {
             logger.Info("************************ SMSActiveSubscriptionTest *********************************");
             await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        public async Task SMSSubscribeFromClientTest()
+        {
+            logger.Info("************************ SMSSubscribeFromClientTest *********************************");
+            await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
         }
     }
 }

--- a/src/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/src/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -327,6 +327,34 @@ namespace UnitTests.StreamingTests
             await consumer2.StopConsuming(handle2);
         }
 
+        public async Task SubscribeFromClientTest(Guid streamGuid, string streamNamespace)
+        {
+            // get producer and consumer
+            var producer = GrainClient.GrainFactory.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
+            int eventCount = 0;
+
+            var provider = GrainClient.GetStreamProvider(streamProviderName);
+            var stream = provider.GetStream<int>(streamGuid, streamNamespace);
+            var handle = await stream.SubscribeAsync((e,t) =>
+            {
+                eventCount++;
+                return TaskDone.Done;
+            });
+
+            // produce some messages
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+
+            await producer.StartPeriodicProducing();
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
+            await producer.StopPeriodicProducing();
+
+            // check
+            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, () => eventCount, lastTry), Timeout);
+
+            // unsubscribe
+            await handle.UnsubscribeAsync();
+        }
+
         private async Task<bool> CheckCounters(ISampleStreaming_ProducerGrain producer, IMultipleSubscriptionConsumerGrain consumer, int consumerCount, bool assertIsTrue)
         {
             var numProduced = await producer.GetNumberProduced();
@@ -368,6 +396,33 @@ namespace UnitTests.StreamingTests
             }
             logger.Info("All counts are equal. numProduced = {0}, numConsumed = {1}", numProduced, 
                 Utils.EnumerableToString(numConsumed, kvp => kvp.Key.HandleId.ToString() + "->" +  kvp.Value.ToString()));
+            return true;
+        }
+
+        private async Task<bool> CheckCounters(ISampleStreaming_ProducerGrain producer, Func<int> eventCount, bool assertIsTrue)
+        {
+            var numProduced = await producer.GetNumberProduced();
+            var numConsumed = eventCount();
+            if (assertIsTrue)
+            {
+                Assert.IsTrue(numProduced > 0, "Events were not produced");
+                Assert.AreEqual(numProduced, numConsumed, "Produced and consumed counts do not match");
+            }
+            else if (numProduced <= 0 || // no events produced?
+                     numProduced != numConsumed)
+            {
+                if (numProduced <= 0)
+                {
+                    logger.Info("numProduced <= 0: Events were not produced");
+                }
+                if (numProduced != numConsumed)
+                {
+                    logger.Info("numProduced != numConsumed: Produced and consumed counts do not match. numProduced = {0}, consumed = {1}",
+                        numProduced, numConsumed);
+                }
+                return false;
+            }
+            logger.Info("All counts are equal. numProduced = {0}, numConsumed = {1}", numProduced, numConsumed);
             return true;
         }
     }


### PR DESCRIPTION
These were added as an attempt to reproduce github issue:

> "Can't get custom PersistentStreamProvider to work with any non-grain observer #1022"

