### PR TITLE
AzureStorage 6.1 compatibility

### DIFF
--- a/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
+++ b/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
@@ -92,7 +92,8 @@ namespace Orleans.AzureUtils
             if (exc is StorageException)
             {
                 StorageException ste = exc as StorageException;
-                return ste.RequestInformation.ExtendedErrorInformation.ErrorCode;
+                if(ste.RequestInformation.ExtendedErrorInformation != null)
+                    return ste.RequestInformation.ExtendedErrorInformation.ErrorCode;
             }
             return null;
         }

--- a/src/TesterInternal/App.config
+++ b/src/TesterInternal/App.config
@@ -7,5 +7,11 @@
     <ThrowUnobservedTaskExceptions enabled="false"/>
     <gcServer enabled="true"/>
     <gcConcurrent enabled="false"/>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Updated azure storage call patterns to be compatible with azure storage 6.1

The issue stemmed from the fact that the call signature for TableOperation.Retrieve<T> changed between azure storage 5.x and 6.x

< 6.x - public static TableOperation Retrieve<TElement>(string partitionKey, string rowkey) where TElement : ITableEntity
\> 6.x - public static TableOperation Retrieve<TElement>(string partitionKey, string rowkey, List<string> selectColumns = null) where TElement : ITableEntity

To address this, the table query call using Retrieve<T> was replaced with a newer azure storage call pattern using TableQuery.

There are a number of different ways to form such a query, but this one was selected because it demonstrated improved performance characteristics over some of the simpler patterns.  This performance testing was done using azure storage 2.1 (months after it was released), and it's findings have not been reexamined since.