### PR TITLE
CodeGen: replace FieldInfo getters/setters with IL-based getters/setters

### DIFF
--- a/src/Orleans/CodeGeneration/GrainInterfaceData.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceData.cs
@@ -22,7 +22,6 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.CodeDom;
 using System.Reflection;
 using Orleans.CodeGeneration;
 using System.Linq.Expressions;

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -41,6 +41,7 @@ using Orleans.Runtime.Configuration;
 namespace Orleans.Serialization
 {
     using System.Diagnostics.CodeAnalysis;
+    using System.Reflection.Emit;
 
     /// <summary>
     /// SerializationManager to oversee the Orleans syrializer system.
@@ -67,6 +68,15 @@ namespace Orleans.Serialization
         /// <param name="stream">Input stream to be read from.</param>
         /// <returns>Rehydrated object of the specified Type read from the current position in the input stream.</returns>
         public delegate object Deserializer(Type expected, BinaryTokenStreamReader stream);
+
+        /// <summary>
+        /// The delegate used to set fields in value types.
+        /// </summary>
+        /// <typeparam name="TDeclaring">The declaring type of the field.</typeparam>
+        /// <typeparam name="TField">The field type.</typeparam>
+        /// <param name="instance">The instance having its field set.</param>
+        /// <param name="value">The value being set.</param>
+        public delegate void ValueTypeSetter<TDeclaring, in TField>(ref TDeclaring instance, TField value);
 
         private static readonly string[] safeFailSerializers = { "Orleans.FSharp" };
 
@@ -2048,6 +2058,107 @@ namespace Orleans.Serialization
         }
 
         #endregion
+
+        public static Delegate GetGetter(FieldInfo field)
+        {
+            return GetGetDelegate(
+                field,
+                typeof(Func<,>).MakeGenericType(field.DeclaringType, field.FieldType),
+                new[] { field.DeclaringType });
+        }
+
+        /// <summary>
+        /// Returns a delegate to get the value of a specified field.
+        /// </summary>
+        /// <param name="field">
+        /// The field.
+        /// </param>
+        /// <param name="delegateType">The delegate type.</param>
+        /// <param name="parameterTypes">The parameter types.</param>
+        /// <returns>A delegate to get the value of a specified field.</returns>
+        private static Delegate GetGetDelegate(FieldInfo field, Type delegateType, Type[] parameterTypes)
+        {
+            var declaringType = field.DeclaringType;
+            if (declaringType == null)
+            {
+                throw new InvalidOperationException("Field " + field.Name + " does not have a declaring type.");
+            }
+
+            // Create a method to hold the generated IL.
+            var method = new DynamicMethod(
+                field.Name + "Get",
+                field.FieldType,
+                parameterTypes,
+                declaringType.Module,
+                true);
+
+            // Emit IL to return the value of the Transaction property.
+            var emitter = method.GetILGenerator();
+            emitter.Emit(OpCodes.Ldarg_0);
+            emitter.Emit(OpCodes.Ldfld, field);
+            emitter.Emit(OpCodes.Ret);
+
+            return method.CreateDelegate(delegateType);
+        }
+
+        /// <summary>
+        /// Returns a delegate to set the value of this field for an instance.
+        /// </summary>
+        /// <returns>A delegate to set the value of this field for an instance.</returns>
+        public static Delegate GetReferenceSetter(FieldInfo field)
+        {
+            var delegateType = typeof(Action<,>).MakeGenericType(field.DeclaringType, field.FieldType);
+            return GetSetDelegate(field, delegateType, new[] { field.DeclaringType, field.FieldType });
+        }
+
+        /// <summary>
+        /// Returns a delegate to set the value of this field for an instance.
+        /// </summary>
+        /// <returns>A delegate to set the value of this field for an instance.</returns>
+        public static Delegate GetValueSetter(FieldInfo field)
+        {
+            var declaringType = field.DeclaringType;
+            if (declaringType == null)
+            {
+                throw new InvalidOperationException("Field " + field.Name + " does not have a declaring type.");
+            }
+
+            // Value types need to be passed by-ref.
+            var parameterTypes = new[] { declaringType.MakeByRefType(), field.FieldType };
+            var delegateType = typeof(ValueTypeSetter<,>).MakeGenericType(field.DeclaringType, field.FieldType);
+
+            return GetSetDelegate(field, delegateType, parameterTypes);
+        }
+
+        /// <summary>
+        /// Returns a delegate to set the value of a specified field.
+        /// </summary>
+        /// <param name="field">
+        /// The field.
+        /// </param>
+        /// <param name="delegateType">The delegate type.</param>
+        /// <param name="parameterTypes">The parameter types.</param>
+        /// <returns>A delegate to set the value of a specified field.</returns>
+        private static Delegate GetSetDelegate(FieldInfo field, Type delegateType, Type[] parameterTypes)
+        {
+            var declaringType = field.DeclaringType;
+            if (declaringType == null)
+            {
+                throw new InvalidOperationException("Field " + field.Name + " does not have a declaring type.");
+            }
+
+            // Create a method to hold the generated IL.
+            var method = new DynamicMethod(field.Name + "Set", null, parameterTypes, declaringType.Module, true);
+
+            // Emit IL to return the value of the Transaction property.
+            var emitter = method.GetILGenerator();
+            emitter.Emit(OpCodes.Ldarg_0);
+            emitter.Emit(OpCodes.Ldarg_1);
+            emitter.Emit(OpCodes.Stfld, field);
+            emitter.Emit(OpCodes.Ret);
+
+            return method.CreateDelegate(delegateType);
+        }
 
         /// <summary>
         /// Internal test method to do a round-trip Serialize+Deserialize loop

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -24,7 +24,6 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 namespace Orleans.CodeGenerator
 {
     using System;
-    using System.CodeDom.Compiler;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
@@ -58,26 +57,11 @@ namespace Orleans.CodeGenerator
         /// The suffix appended to the name of the generic serializer registration class.
         /// </summary>
         private const string RegistererClassSuffix = "Registerer";
-        
-        /// <summary>
-        /// Returns true if the provided type is a seed type for serialization generation.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>true if the provided type is a seed type for serialization generation.</returns>
-        internal static bool IsSerializationSeedType(Type type)
-        {
-            // Skip compiler-generated types (whose names begin with a '<' character).
-            return !type.Name.StartsWith("<") && type.GetCustomAttribute<GeneratedCodeAttribute>() == null
-                   && type.GetCustomAttribute<NonSerializableAttribute>() == null
-                   && !TypeUtils.IsInNamespace(type, SerializerGenerationManager.IgnoredNamespaces);
-        }
 
         /// <summary>
         /// Generates the class for the provided grain types.
         /// </summary>
-        /// <param name="type">
-        ///     The grain interface type.
-        /// </param>
+        /// <param name="type">The grain interface type.</param>
         /// <param name="onEncounteredType">
         /// The callback invoked when a type is encountered.
         /// </param>
@@ -112,7 +96,7 @@ namespace Orleans.CodeGenerator
                 onEncounteredType(fieldType);
             }
 
-            var members = new List<MemberDeclarationSyntax>(GetFieldInfoFields(fields))
+            var members = new List<MemberDeclarationSyntax>(GetStaticFields(fields))
             {
                 GenerateDeepCopierMethod(type, fields),
                 GenerateSerializerMethod(type, fields),
@@ -168,6 +152,12 @@ namespace Orleans.CodeGenerator
             return classes;
         }
 
+        /// <summary>
+        /// Returns syntax for the deserializer method.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="fields">The fields.</param>
+        /// <returns>Syntax for the deserializer method.</returns>
         private static MemberDeclarationSyntax GenerateDeserializerMethod(Type type, List<FieldInfoMember> fields)
         {
             Expression<Action> deserializeInner =
@@ -181,20 +171,9 @@ namespace Orleans.CodeGenerator
                             SF.VariableDeclarator("result")
                                 .WithInitializer(SF.EqualsValueClause(GetObjectCreationExpressionSyntax(type)))));
             var resultVariable = SF.IdentifierName("result");
-            var boxedResultVariable = resultVariable;
 
             var body = new List<StatementSyntax> { resultDeclaration };
-
-            if (type.GetTypeInfo().IsValueType)
-            {
-                // For value types, we need to box the result for reflection-based setters to work.
-                body.Add(SF.LocalDeclarationStatement(
-                    SF.VariableDeclaration(typeof(object).GetTypeSyntax())
-                        .AddVariables(
-                            SF.VariableDeclarator("boxedResult").WithInitializer(SF.EqualsValueClause(resultVariable)))));
-                boxedResultVariable = SF.IdentifierName("boxedResult");
-            }
-            
+          
             // Record the result for cyclic deserialization.
             Expression<Action> recordObject =
                 () => DeserializationContext.Current.RecordObject(default(object));
@@ -209,7 +188,7 @@ namespace Orleans.CodeGenerator
                 SF.ExpressionStatement(
                     recordObject.Invoke(currentSerializationContext)
                         .AddArgumentListArguments(
-                            SF.Argument(boxedResultVariable))));
+                            SF.Argument(resultVariable))));
 
             // Deserialize all fields.
             foreach (var field in fields)
@@ -223,11 +202,10 @@ namespace Orleans.CodeGenerator
                     SF.ExpressionStatement(
                         field.GetSetter(
                             resultVariable,
-                            SF.CastExpression(field.Type, deserialized),
-                            boxedResultVariable)));
+                            SF.CastExpression(field.Type, deserialized))));
             }
 
-            body.Add(SF.ReturnStatement(SF.CastExpression(type.GetTypeSyntax(), boxedResultVariable)));
+            body.Add(SF.ReturnStatement(SF.CastExpression(type.GetTypeSyntax(), resultVariable)));
             return
                 SF.MethodDeclaration(typeof(object).GetTypeSyntax(), "Deserializer")
                     .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.StaticKeyword))
@@ -284,12 +262,17 @@ namespace Orleans.CodeGenerator
                             .AddAttributes(SF.Attribute(typeof(SerializerMethodAttribute).GetNameSyntax())));
         }
 
+        /// <summary>
+        /// Returns syntax for the deep copier method.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="fields">The fields.</param>
+        /// <returns>Syntax for the deep copier method.</returns>
         private static MemberDeclarationSyntax GenerateDeepCopierMethod(Type type, List<FieldInfoMember> fields)
         {
             var originalVariable = SF.IdentifierName("original");
             var inputVariable = SF.IdentifierName("input");
             var resultVariable = SF.IdentifierName("result");
-            var boxedResultVariable = resultVariable;
 
             var body = new List<StatementSyntax>();
             if (type.GetCustomAttribute<ImmutableAttribute>() != null)
@@ -315,14 +298,10 @@ namespace Orleans.CodeGenerator
                                 SF.VariableDeclarator("result")
                                     .WithInitializer(SF.EqualsValueClause(GetObjectCreationExpressionSyntax(type))))));
 
-                if (type.GetTypeInfo().IsValueType)
+                // Copy all members from the input to the result.
+                foreach (var field in fields)
                 {
-                    // For value types, we need to box the result for reflection-based setters to work.
-                    body.Add(SF.LocalDeclarationStatement(
-                        SF.VariableDeclaration(typeof(object).GetTypeSyntax())
-                            .AddVariables(
-                                SF.VariableDeclarator("boxedResult").WithInitializer(SF.EqualsValueClause(resultVariable)))));
-                    boxedResultVariable = SF.IdentifierName("boxedResult");
+                    body.Add(SF.ExpressionStatement(field.GetSetter(resultVariable, field.GetGetter(inputVariable))));
                 }
 
                 // Record this serialization.
@@ -338,15 +317,9 @@ namespace Orleans.CodeGenerator
                 body.Add(
                     SF.ExpressionStatement(
                         recordObject.Invoke(currentSerializationContext)
-                            .AddArgumentListArguments(SF.Argument(originalVariable), SF.Argument(boxedResultVariable))));
+                            .AddArgumentListArguments(SF.Argument(originalVariable), SF.Argument(resultVariable))));
 
-                // Copy all members from the input to the result.
-                foreach (var field in fields)
-                {
-                    body.Add(SF.ExpressionStatement(field.GetSetter(boxedResultVariable, field.GetGetter(inputVariable))));
-                }
-
-                body.Add(SF.ReturnStatement(boxedResultVariable));
+                body.Add(SF.ReturnStatement(resultVariable));
             }
 
             return
@@ -359,12 +332,20 @@ namespace Orleans.CodeGenerator
                         SF.AttributeList().AddAttributes(SF.Attribute(typeof(CopierMethodAttribute).GetNameSyntax())));
         }
 
-        private static MemberDeclarationSyntax[] GetFieldInfoFields(List<FieldInfoMember> fields)
+        /// <summary>
+        /// Returns syntax for the static fields of the serializer class.
+        /// </summary>
+        /// <param name="fields">The fields.</param>
+        /// <returns>Syntax for the static fields of the serializer class.</returns>
+        private static MemberDeclarationSyntax[] GetStaticFields(List<FieldInfoMember> fields)
         {
             var result = new List<MemberDeclarationSyntax>();
 
             // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
             Expression<Action<Type>> getField = _ => _.GetField(string.Empty, BindingFlags.Default);
+            Expression<Action> getGetter = () => SerializationManager.GetGetter(default(FieldInfo));
+            Expression<Action> getReferenceSetter = () => SerializationManager.GetReferenceSetter(default(FieldInfo));
+            Expression<Action> getValueSetter = () => SerializationManager.GetValueSetter(default(FieldInfo));
 
             // Expressions for specifying binding flags.
             var flags = SF.IdentifierName("System").Member("Reflection").Member("BindingFlags");
@@ -388,18 +369,97 @@ namespace Orleans.CodeGenerator
                             SF.Argument(bindingFlags));
                 var fieldInfoVariable =
                     SF.VariableDeclarator(field.InfoFieldName).WithInitializer(SF.EqualsValueClause(fieldInfo));
-                result.Add(
-                    SF.FieldDeclaration(
-                        SF.VariableDeclaration(typeof(FieldInfo).GetTypeSyntax()).AddVariables(fieldInfoVariable))
-                        .AddModifiers(
-                            SF.Token(SyntaxKind.PrivateKeyword),
-                            SF.Token(SyntaxKind.StaticKeyword),
-                            SF.Token(SyntaxKind.ReadOnlyKeyword)));
+                var fieldInfoField = SF.IdentifierName(field.InfoFieldName);
+
+                if (!field.IsGettableProperty || !field.IsSettableProperty)
+                {
+                    result.Add(
+                        SF.FieldDeclaration(
+                            SF.VariableDeclaration(typeof(FieldInfo).GetTypeSyntax()).AddVariables(fieldInfoVariable))
+                            .AddModifiers(
+                                SF.Token(SyntaxKind.PrivateKeyword),
+                                SF.Token(SyntaxKind.StaticKeyword),
+                                SF.Token(SyntaxKind.ReadOnlyKeyword)));
+                }
+
+                // Declare the getter for this field.
+                if (!field.IsGettableProperty)
+                {
+                    var getterType =
+                        typeof(Func<,>).MakeGenericType(field.FieldInfo.DeclaringType, field.FieldInfo.FieldType)
+                            .GetTypeSyntax();
+                    var fieldGetterVariable =
+                        SF.VariableDeclarator(field.GetterFieldName)
+                            .WithInitializer(
+                                SF.EqualsValueClause(
+                                    SF.CastExpression(
+                                        getterType,
+                                        getGetter.Invoke().AddArgumentListArguments(SF.Argument(fieldInfoField)))));
+                    result.Add(
+                        SF.FieldDeclaration(SF.VariableDeclaration(getterType).AddVariables(fieldGetterVariable))
+                            .AddModifiers(
+                                SF.Token(SyntaxKind.PrivateKeyword),
+                                SF.Token(SyntaxKind.StaticKeyword),
+                                SF.Token(SyntaxKind.ReadOnlyKeyword)));
+                }
+
+                if (!field.IsSettableProperty)
+                {
+                    if (field.FieldInfo.DeclaringType != null && field.FieldInfo.DeclaringType.IsValueType)
+                    {
+                        var setterType =
+                            typeof(SerializationManager.ValueTypeSetter<,>).MakeGenericType(
+                                field.FieldInfo.DeclaringType,
+                                field.FieldInfo.FieldType).GetTypeSyntax();
+
+                        var fieldSetterVariable =
+                            SF.VariableDeclarator(field.SetterFieldName)
+                                .WithInitializer(
+                                    SF.EqualsValueClause(
+                                        SF.CastExpression(
+                                            setterType,
+                                            getValueSetter.Invoke()
+                                                .AddArgumentListArguments(SF.Argument(fieldInfoField)))));
+                        result.Add(
+                            SF.FieldDeclaration(SF.VariableDeclaration(setterType).AddVariables(fieldSetterVariable))
+                                .AddModifiers(
+                                    SF.Token(SyntaxKind.PrivateKeyword),
+                                    SF.Token(SyntaxKind.StaticKeyword),
+                                    SF.Token(SyntaxKind.ReadOnlyKeyword)));
+                    }
+                    else
+                    {
+                        var setterType =
+                            typeof(Action<,>).MakeGenericType(field.FieldInfo.DeclaringType, field.FieldInfo.FieldType)
+                                .GetTypeSyntax();
+
+                        var fieldSetterVariable =
+                            SF.VariableDeclarator(field.SetterFieldName)
+                                .WithInitializer(
+                                    SF.EqualsValueClause(
+                                        SF.CastExpression(
+                                            setterType,
+                                            getReferenceSetter.Invoke()
+                                                .AddArgumentListArguments(SF.Argument(fieldInfoField)))));
+
+                        result.Add(
+                            SF.FieldDeclaration(SF.VariableDeclaration(setterType).AddVariables(fieldSetterVariable))
+                                .AddModifiers(
+                                    SF.Token(SyntaxKind.PrivateKeyword),
+                                    SF.Token(SyntaxKind.StaticKeyword),
+                                    SF.Token(SyntaxKind.ReadOnlyKeyword)));
+                    }
+                }
             }
 
             return result.ToArray();
         }
 
+        /// <summary>
+        /// Returns syntax for initializing a new instance of the provided type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>Syntax for initializing a new instance of the provided type.</returns>
         private static ExpressionSyntax GetObjectCreationExpressionSyntax(Type type)
         {
             ExpressionSyntax result;
@@ -430,7 +490,11 @@ namespace Orleans.CodeGenerator
             return result;
         }
 
-
+        /// <summary>
+        /// Returns syntax for the serializer registration method.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>Syntax for the serializer registration method.</returns>
         private static MemberDeclarationSyntax GenerateRegisterMethod(Type type)
         {
             Expression<Action> register =
@@ -454,6 +518,11 @@ namespace Orleans.CodeGenerator
                                     SF.Argument(SF.IdentifierName("Deserializer")))));
         }
 
+        /// <summary>
+        /// Returns syntax for the constructor.
+        /// </summary>
+        /// <param name="className">The name of the class.</param>
+        /// <returns>Syntax for the constructor.</returns>
         private static ConstructorDeclarationSyntax GenerateConstructor(string className)
         {
             return
@@ -465,6 +534,12 @@ namespace Orleans.CodeGenerator
                             SF.InvocationExpression(SF.IdentifierName("Register")).AddArgumentListArguments()));
         }
 
+        /// <summary>
+        /// Returns syntax for the generic serializer registration method for the provided type..
+        /// </summary>
+        /// <param name="type">The type which is supported by this serializer.</param>
+        /// <param name="serializerType">The type of the serializer.</param>
+        /// <returns>Syntax for the generic serializer registration method for the provided type..</returns>
         private static MemberDeclarationSyntax GenerateMasterRegisterMethod(Type type, TypeSyntax serializerType)
         {
             Expression<Action> register = () => SerializationManager.Register(default(Type), default(Type));
@@ -481,25 +556,98 @@ namespace Orleans.CodeGenerator
                                     SF.Argument(SF.TypeOfExpression(serializerType)))));
         }
 
+        /// <summary>
+        /// Returns a sorted list of the fields of the provided type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>A sorted list of the fields of the provided type.</returns>
         private static List<FieldInfoMember> GetFields(Type type)
         {
             var result =
                 type.GetAllFields()
                     .Where(field => field.GetCustomAttribute<NonSerializedAttribute>() == null)
-                    .Select(
-                        (info, i) => new FieldInfoMember { FieldInfo = info, InfoFieldName = string.Format("field{0}", i) })
+                    .Select((info, i) => new FieldInfoMember { FieldInfo = info, FieldNumber = i })
                     .ToList();
             result.Sort(FieldInfoMember.Comparer.Instance);
             return result;
         }
 
+        /// <summary>
+        /// Represents a field.
+        /// </summary>
         private class FieldInfoMember
         {
             private PropertyInfo property;
+
+            /// <summary>
+            /// Gets or sets the underlying <see cref="FieldInfo"/> instance.
+            /// </summary>
             public FieldInfo FieldInfo { get; set; }
 
-            public string InfoFieldName { get; set; }
+            /// <summary>
+            /// Sets the ordinal assigned to this field.
+            /// </summary>
+            public int FieldNumber { private get; set; }
 
+            /// <summary>
+            /// Gets the name of the field info field.
+            /// </summary>
+            public string InfoFieldName
+            {
+                get
+                {
+                    return "field" + this.FieldNumber;
+                }
+            }
+
+            /// <summary>
+            /// Gets the name of the getter field.
+            /// </summary>
+            public string GetterFieldName
+            {
+                get
+                {
+                    return "getField" + this.FieldNumber;
+                }
+            }
+
+            /// <summary>
+            /// Gets the name of the setter field.
+            /// </summary>
+            public string SetterFieldName
+            {
+                get
+                {
+                    return "setField" + this.FieldNumber;
+                }
+            }
+
+
+            /// <summary>
+            /// Gets a value indicating whether or not this field represents a property with an accessible getter. 
+            /// </summary>
+            public bool IsGettableProperty
+            {
+                get
+                {
+                    return this.PropertyInfo != null && this.PropertyInfo.GetGetMethod() != null;
+                }
+            }
+
+            /// <summary>
+            /// Gets a value indicating whether or not this field represents a property with an accessible setter. 
+            /// </summary>
+            public bool IsSettableProperty
+            {
+                get
+                {
+                    return this.PropertyInfo != null && this.PropertyInfo.GetSetMethod() != null;
+                }
+            }
+
+            /// <summary>
+            /// Gets syntax representing the type of this field.
+            /// </summary>
             public TypeSyntax Type
             {
                 get
@@ -508,6 +656,10 @@ namespace Orleans.CodeGenerator
                 }
             }
 
+            /// <summary>
+            /// Gets the <see cref="PropertyInfo"/> which this field is the backing property for, or
+            /// <see langword="null" /> if this is not the backing field of an auto-property.
+            /// </summary>
             private PropertyInfo PropertyInfo
             {
                 get
@@ -528,60 +680,23 @@ namespace Orleans.CodeGenerator
                 }
             }
 
-            private ExpressionSyntax FieldInfoExpression
+            /// <summary>
+            /// Returns syntax for retrieving the value of this field.
+            /// </summary>
+            /// <param name="instance">The instance of the containing type.</param>
+            /// <param name="forceAvoidCopy">Whether or not to ensure that no copy of the field is made.</param>
+            /// <returns>Syntax for retrieving the value of this field.</returns>
+            public ExpressionSyntax GetGetter(ExpressionSyntax instance, bool forceAvoidCopy = false)
             {
-                get
-                {
-                    return SF.IdentifierName(this.InfoFieldName);
-                }
-            }
+                var typeSyntax = this.FieldInfo.FieldType.GetTypeSyntax();
+                var getFieldExpression =
+                    SF.InvocationExpression(SF.IdentifierName(this.GetterFieldName))
+                        .AddArgumentListArguments(SF.Argument(instance));
 
-            public Expression GetGetExpression(Expression instance, bool forceAvoidCopy = false)
-            {
                 // If the field is the backing field for an auto-property, try to use the property directly.
                 if (this.PropertyInfo != null && this.PropertyInfo.GetGetMethod() != null)
                 {
-                    return Expression.Property(instance, this.PropertyInfo);
-                }
-
-                if (forceAvoidCopy || this.FieldInfo.FieldType.IsOrleansShallowCopyable())
-                {
-                    // Shallow-copy the field.
-                    return Expression.Field(instance, this.FieldInfo);
-                }
-
-                // Deep-copy the field.
-                Expression<Func<object,object>> deepCopyInner = input => SerializationManager.DeepCopyInner(input);
-                return Expression.Invoke(deepCopyInner, instance);
-            }
-
-            public Expression GetSetExpression(Expression instance, Expression value, Expression boxedInstance = null)
-            {
-                // If the field is the backing field for an auto-property, try to use the property directly.
-                if (this.PropertyInfo != null && this.PropertyInfo.GetSetMethod() != null)
-                {
-                    return Expression.Assign(Expression.Property(instance ?? boxedInstance, this.PropertyInfo), value);
-                }
-
-                return Expression.Assign(Expression.Field(instance ?? boxedInstance, this.FieldInfo), value);
-            }
-
-            public ExpressionSyntax GetGetter(ExpressionSyntax instance, bool forceAvoidCopy = false)
-            {
-                Expression<Action> fieldGetter = () => this.FieldInfo.GetValue(default(object));
-                var getFieldExpression =
-                    fieldGetter.Invoke(this.FieldInfoExpression).AddArgumentListArguments(SF.Argument(instance));
-
-                // If the field is the backing field for an auto-property, try to use the property directly.
-                var propertyName = Regex.Match(this.FieldInfo.Name, "^<([^>]+)>.*$");
-                if (propertyName.Success && this.FieldInfo.DeclaringType != null)
-                {
-                    var name = propertyName.Groups[1].Value;
-                    var property = this.FieldInfo.DeclaringType.GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
-                    if (property != null && property.GetGetMethod() != null)
-                    {
-                        return instance.Member(property.Name);
-                    }
+                    return instance.Member(this.PropertyInfo.Name);
                 }
 
                 if (forceAvoidCopy || this.FieldInfo.FieldType.IsOrleansShallowCopyable())
@@ -593,31 +708,36 @@ namespace Orleans.CodeGenerator
                 // Deep-copy the field.
                 Expression<Action> deepCopyInner = () => SerializationManager.DeepCopyInner(default(object));
                 return SF.CastExpression(
-                    this.FieldInfo.FieldType.GetTypeSyntax(),
+                    typeSyntax,
                     deepCopyInner.Invoke().AddArgumentListArguments(SF.Argument(getFieldExpression)));
             }
 
-            public ExpressionSyntax GetSetter(ExpressionSyntax instance, ExpressionSyntax value, ExpressionSyntax boxedInstance = null)
+            /// <summary>
+            /// Returns syntax for setting the value of this field.
+            /// </summary>
+            /// <param name="instance">The instance of the containing type.</param>
+            /// <param name="value">Syntax for the new value.</param>
+            /// <returns>Syntax for setting the value of this field.</returns>
+            public ExpressionSyntax GetSetter(ExpressionSyntax instance, ExpressionSyntax value)
             {
-                Expression<Action> fieldSetter = () => this.FieldInfo.SetValue(default(object), default(object));
-
                 // If the field is the backing field for an auto-property, try to use the property directly.
-                var propertyName = Regex.Match(this.FieldInfo.Name, "^<([^>]+)>.*$");
-                if (propertyName.Success && this.FieldInfo.DeclaringType != null)
+                if (this.PropertyInfo != null && this.PropertyInfo.GetSetMethod() != null)
                 {
-                    var name = propertyName.Groups[1].Value;
-                    var property = this.FieldInfo.DeclaringType.GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
-                    if (property != null && property.GetSetMethod() != null)
-                    {
-                        return SF.AssignmentExpression(
-                            SyntaxKind.SimpleAssignmentExpression,
-                            instance.Member(property.Name),
-                            value);
-                    }
+                    return SF.AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        instance.Member(this.PropertyInfo.Name),
+                        value);
                 }
 
-                return fieldSetter.Invoke(this.FieldInfoExpression)
-                    .AddArgumentListArguments(SF.Argument(boxedInstance ?? instance), SF.Argument(value));
+                var instanceArg = SF.Argument(instance);
+                if (this.FieldInfo.DeclaringType != null && this.FieldInfo.DeclaringType.IsValueType)
+                {
+                    instanceArg = instanceArg.WithRefOrOutKeyword(SF.Token(SyntaxKind.RefKeyword));
+                }
+
+                return
+                    SF.InvocationExpression(SF.IdentifierName(this.SetterFieldName))
+                        .AddArgumentListArguments(instanceArg, SF.Argument(value));
             }
 
             /// <summary>

--- a/src/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/src/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -49,6 +49,9 @@ namespace UnitTests.GrainInterfaces
         Task<SomeAbstractClass> RoundTripClass(SomeAbstractClass input);
         Task<ISomeInterface> RoundTripInterface(ISomeInterface input);
         Task<SomeAbstractClass.SomeEnum> RoundTripEnum(SomeAbstractClass.SomeEnum input);
+
+        Task SetState(SomeAbstractClass input);
+        Task<SomeAbstractClass> GetState();
     }
 }
 
@@ -135,6 +138,10 @@ namespace UnitTests.GrainInterfaces
     public abstract class SomeAbstractClass : ISomeInterface
     {
         public abstract int Int { get; set; }
+
+        public List<ISomeInterface> Interfaces { get; set; }
+
+        public List<SomeAbstractClass> Classes { get; set; }
 
         [Serializable]
         public enum SomeEnum

--- a/src/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/src/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -42,6 +42,14 @@ namespace UnitTests.GrainInterfaces
         [AlwaysInterleave]
         Task AlwaysInterleave();
     }
+
+    public interface ISerializationGenerationGrain : IGrainWithIntegerKey
+    {
+        Task<SomeStruct> RoundTripStruct(SomeStruct input);
+        Task<SomeAbstractClass> RoundTripClass(SomeAbstractClass input);
+        Task<ISomeInterface> RoundTripInterface(ISomeInterface input);
+        Task<SomeAbstractClass.SomeEnum> RoundTripEnum(SomeAbstractClass.SomeEnum input);
+    }
 }
 
 public class Outsider { }
@@ -82,6 +90,80 @@ namespace UnitTests.GrainInterfaces
         {
             return base.GetHashCode();
         }
+    }
+
+    [Serializable]
+    public struct SomeStruct
+    {
+        public Guid Id { get; set; }
+        public int PublicValue { get; set; }
+        public int ValueWithPrivateSetter { get; private set; }
+        public int ValueWithPrivateGetter { private get; set; }
+        private int PrivateValue { get; set; }
+        public readonly int ReadonlyField;
+
+        public SomeStruct(int readonlyField)
+            : this()
+        {
+            this.ReadonlyField = readonlyField;
+        }
+
+        public int GetValueWithPrivateGetter()
+        {
+            return this.ValueWithPrivateGetter;
+        }
+
+        public int GetPrivateValue()
+        {
+            return this.PrivateValue;
+        }
+
+        public void SetPrivateValue(int value)
+        {
+            this.PrivateValue = value;
+        }
+
+        public void SetValueWithPrivateSetter(int value)
+        {
+            this.ValueWithPrivateSetter = value;
+        }
+    }
+
+    public interface ISomeInterface { int Int { get; set; } }
+
+    [Serializable]
+    public abstract class SomeAbstractClass : ISomeInterface
+    {
+        public abstract int Int { get; set; }
+
+        [Serializable]
+        public enum SomeEnum
+        {
+            None,
+
+            Something,
+
+            SomethingElse
+        }
+    }
+
+    public class OuterClass
+    {
+        [Serializable]
+        public class SomeConcreteClass : SomeAbstractClass
+        {
+            public override int Int { get; set; }
+
+            public string String { get; set; }
+        }
+    }
+
+    [Serializable]
+    public class AnotherConcreteClass : SomeAbstractClass
+    {
+        public override int Int { get; set; }
+
+        public string AnotherString { get; set; }
     }
 
     [Serializable]

--- a/src/TestGrains/SerializationGenerationGrain.cs
+++ b/src/TestGrains/SerializationGenerationGrain.cs
@@ -1,0 +1,53 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System.Threading.Tasks;
+
+namespace TestGrains
+{
+    using Orleans;
+
+    using UnitTests.GrainInterfaces;
+    public class SerializationGenerationGrain : Grain, ISerializationGenerationGrain
+    {
+        public Task<SomeStruct> RoundTripStruct(SomeStruct input)
+        {
+            return Task.FromResult(input);
+        }
+
+        public Task<SomeAbstractClass> RoundTripClass(SomeAbstractClass input)
+        {
+            return Task.FromResult(input);
+        }
+
+        public Task<ISomeInterface> RoundTripInterface(ISomeInterface input)
+        {
+            return Task.FromResult(input);
+        }
+
+        public Task<SomeAbstractClass.SomeEnum> RoundTripEnum(SomeAbstractClass.SomeEnum input)
+        {
+            return Task.FromResult(input);
+        }
+    }
+}

--- a/src/TestGrains/SerializationGenerationGrain.cs
+++ b/src/TestGrains/SerializationGenerationGrain.cs
@@ -25,10 +25,13 @@ using System.Threading.Tasks;
 
 namespace TestGrains
 {
+    using System.Collections.Generic;
+    using System.Linq;
+
     using Orleans;
 
     using UnitTests.GrainInterfaces;
-    public class SerializationGenerationGrain : Grain, ISerializationGenerationGrain
+    public class SerializationGenerationGrain : Grain<SerializationGenerationGrain.MyState>, ISerializationGenerationGrain
     {
         public Task<SomeStruct> RoundTripStruct(SomeStruct input)
         {
@@ -48,6 +51,23 @@ namespace TestGrains
         public Task<SomeAbstractClass.SomeEnum> RoundTripEnum(SomeAbstractClass.SomeEnum input)
         {
             return Task.FromResult(input);
+        }
+
+        public async Task SetState(SomeAbstractClass input)
+        {
+            this.State.Classes = new List<SomeAbstractClass> { input };
+            this.DeactivateOnIdle();
+            await this.WriteStateAsync();
+        }
+
+        public Task<SomeAbstractClass> GetState()
+        {
+            return Task.FromResult(this.State.Classes.FirstOrDefault());
+        }
+
+        public class MyState : GrainState
+        {
+            public IList<SomeAbstractClass> Classes { get; set; }
         }
     }
 }

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -73,6 +73,7 @@
     <Compile Include="EventSourcing\JournaledPersonGrain.cs" />
     <Compile Include="EventSourcing\JournaledPerson_Events.cs" />
     <Compile Include="MyObserverSubscriptionManager.cs" />
+    <Compile Include="SerializationGenerationGrain.cs" />
     <Compile Include="SimpleGenericGrain.cs" />
     <Compile Include="MultipleSubscriptionConsumerGrain.cs" />
     <Compile Include="ConcreteGrainsWithGenericInterfaces.cs" />

--- a/src/Tester/CodeGenTests/GeneratorGrainTest.cs
+++ b/src/Tester/CodeGenTests/GeneratorGrainTest.cs
@@ -8,6 +8,10 @@ using UnitTests.Tester;
 
 namespace Tester.CodeGenTests
 {
+    using System;
+
+    using UnitTests.GrainInterfaces;
+
     /// <summary>
     /// Summary description for GrainClientTest
     /// </summary>
@@ -29,6 +33,40 @@ namespace Tester.CodeGenTests
         private static int GetRandomGrainId()
         {
             return random.Next();
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        public async Task CodeGenRoundTripSerialization()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ISerializationGenerationGrain>(GetRandomGrainId());
+
+            // Test struct serialization.
+            var expectedStruct = new SomeStruct(10) { Id = Guid.NewGuid(), PublicValue = 6, ValueWithPrivateGetter = 7 };
+            expectedStruct.SetValueWithPrivateSetter(8);
+            expectedStruct.SetPrivateValue(9);
+            var actualStruct = await grain.RoundTripStruct(expectedStruct);
+            Assert.AreEqual(expectedStruct.Id, actualStruct.Id);
+            Assert.AreEqual(expectedStruct.ReadonlyField, actualStruct.ReadonlyField);
+            Assert.AreEqual(expectedStruct.PublicValue, actualStruct.PublicValue);
+            Assert.AreEqual(expectedStruct.ValueWithPrivateSetter, actualStruct.ValueWithPrivateSetter);
+            Assert.AreEqual(expectedStruct.GetPrivateValue(), actualStruct.GetPrivateValue());
+            Assert.AreEqual(expectedStruct.GetValueWithPrivateGetter(), actualStruct.GetValueWithPrivateGetter());
+
+            // Test abstract class serialization.
+            var expectedAbstract = new OuterClass.SomeConcreteClass { Int = 89, String = Guid.NewGuid().ToString() };
+            var actualAbstract = await grain.RoundTripClass(expectedAbstract);
+            Assert.AreEqual(expectedAbstract.Int, actualAbstract.Int);
+            Assert.AreEqual(expectedAbstract.String, ((OuterClass.SomeConcreteClass)actualAbstract).String);
+
+            // Test interface serialization.
+            var expectedInterface = expectedAbstract;
+            var actualInterface = await grain.RoundTripInterface(expectedInterface);
+            Assert.AreEqual(expectedAbstract.Int, actualInterface.Int);
+            
+            // Test enum serialization.
+            const SomeAbstractClass.SomeEnum ExpectedEnum = SomeAbstractClass.SomeEnum.Something;
+            var actualEnum = await grain.RoundTripEnum(ExpectedEnum);
+            Assert.AreEqual(ExpectedEnum, actualEnum);
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GetGrain")]


### PR DESCRIPTION
Currently the serializers use `FieldInfo.GetValue`/`FieldInfo.SetValue` to access/mutate inaccessible fields.

This PR introduces an IL-based method for getting/setting fields which allows us to avoid most boxing and access restrictions.

![CodeGen](http://i.imgur.com/O1ONMDd.png)

In the second commit, I remove the call to `RecordObject` in generated Deserializer methods becausei it is not applicable when deserializing a value type. Please correct me if I am wrong.