### PR TITLE
Add special handling of FIleNotFoundException while trying to load DI startup builder

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -406,8 +406,9 @@ namespace Orleans
         SiloShutdownEventCreated        = SiloBase + 42,
         SiloShutdownEventOpened         = SiloBase + 43,
         SiloShutdownEventReceived       = SiloBase + 44,
-        SiloLoadeDI                     = SiloBase + 45,
+        SiloLoadedDI                    = SiloBase + 45,
         SiloFailedToLoadDI              = SiloBase + 46,
+        SiloFileNotFoundLoadingDI       = SiloBase + 47,
 
         CatalogBase                     = Runtime + 500,
         CatalogNonExistingActivation1   = CatalogBase + 1,

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -24,6 +24,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime;
@@ -222,8 +223,15 @@ namespace Orleans.Runtime
             var startupBuilder = AssemblyLoader.TryLoadAndCreateInstance<IStartupBuilder>("OrleansDependencyInjection", logger);
             if (startupBuilder != null)
             {
-                logger.Info(ErrorCode.SiloLoadeDI, "Successfully loaded {0} from OrleansDependencyInjection.dll", startupBuilder.GetType().FullName);
-                services = startupBuilder.ConfigureStartup(nodeConfig.StartupTypeName);
+                logger.Info(ErrorCode.SiloLoadedDI, "Successfully loaded {0} from OrleansDependencyInjection.dll", startupBuilder.GetType().FullName);
+                try
+                {
+                    services = startupBuilder.ConfigureStartup(nodeConfig.StartupTypeName);
+                }
+                catch (FileNotFoundException exc)
+                {
+                    logger.Warn(ErrorCode.SiloFileNotFoundLoadingDI, "Caught a FileNotFoundException calling ConfigureStartup(). Ignoring it. {0}", exc);
+                }
             }
             else
             {


### PR DESCRIPTION
This should enhance the original fix of https://github.com/dotnet/orleans/pull/1007 to also handle the case when OrleansDependencyInjection.dll is present but its dependencies (ASP.NET DI assemblies) are missing.

I didn't want to eat all exceptions, only FIleNotFoundExceptions. Any other exception will still fail silo startup. I'm not sure if there is a better option here.