### PR TITLE
Add ToStringKeyWithoutType to GrainReference

### DIFF
--- a/src/Orleans/IDs/GrainId.cs
+++ b/src/Orleans/IDs/GrainId.cs
@@ -213,6 +213,11 @@ namespace Orleans.Runtime
             return Key.GetUniformHashCode();
         }
 
+        internal string ToKeyStringWithoutType()
+        {
+            return Key.ToKeyStringWithoutType();
+        }
+
         public override string ToString()
         {
             return ToStringImpl(false);

--- a/src/Orleans/IDs/UniqueKey.cs
+++ b/src/Orleans/IDs/UniqueKey.cs
@@ -304,6 +304,23 @@ namespace Orleans.Runtime
             // ReSharper restore NonReadonlyFieldInGetHashCode
         }
 
+        internal string ToKeyStringWithoutType()
+        {
+            string key = string.Empty;
+
+            if (IsLongKey)
+            {
+                key = PrimaryKeyToLong().ToString();
+            }
+            else if (N1 != 0)
+            {
+                key = PrimaryKeyToGuid().ToString();
+            }
+
+            if (!HasKeyExt) return key;
+            return key == string.Empty ? KeyExt : key + "+" + KeyExt;
+        }
+
         private Guid ConvertToGuid()
         {
             return new Guid((UInt32)(N0 & 0xffffffff), (UInt16)(N0 >> 32), (UInt16)(N0 >> 48), (byte)N1, (byte)(N1 >> 8), (byte)(N1 >> 16), (byte)(N1 >> 24), (byte)(N1 >> 32), (byte)(N1 >> 40), (byte)(N1 >> 48), (byte)(N1 >> 56));

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -621,6 +621,10 @@ namespace Orleans.Runtime
                    !HasGenericArgument ? String.Empty : String.Format("<{0}>", genericArguments)); 
         }
 
+        public string ToKeyStringWithoutType()
+        {
+            return GrainId.ToKeyStringWithoutType();
+        }
 
         /// <summary> Get the key value for this grain, as a string. </summary>
         public string ToKeyString()


### PR DESCRIPTION
I'm currently trying to implement an `IStorageProvider`.
The problem I'm facing is the lack of a method to get the original key provided by the user.
AFAIK, Orleans flattens the key to `UniqueKey` which I don't see any way to convert back.
I've implemented a method that attempts to do that, but it assumes too much. 
the problem is that a `GUID` that its first half is zeros is saved the same as a `long`.
the `UniqueKey.IsLongKey` always returns true if the first half is zeroes.
[this](https://github.com/dotnet/orleans/blob/master/src/Orleans/IDs/UniqueKey.cs#L136) is a bug, but fixing it will mean you can't use a long key equals to zero or a guid with all zeroes.
I thought about adding another enum value to `UniqueKey.Category` but that will break any current reminders kept without it.
