### PR TITLE
Ifdeffing non-coreclr RAM perf counter

### DIFF
--- a/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
+++ b/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
@@ -182,13 +182,11 @@ namespace Orleans.Runtime
             FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PROMOTEDMEMORYFROMGEN0KB, () => promotedFinalizationMemoryFromGen0.NextValue() / 1024f);
             FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_NUMBEROFINDUCEDGCS, () => numberOfInducedGCs.NextValue());
 
-#if DNXCORE50
             IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_MEMORY_TOTALPHYSICALMEMORYMB, () => (TotalPhysicalMemory / 1024) / 1024);
             if (availableMemoryCounter != null)
             {
                 IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_MEMORY_AVAILABLEMEMORYMB, () => (AvailableMemory/ 1024) / 1024); // Round up
             }
-#endif
 #endif
             IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_DOT_NET_THREADPOOL_INUSE_WORKERTHREADS, () =>
             {

--- a/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
+++ b/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
@@ -64,7 +64,6 @@ namespace Orleans.Runtime
         /// 
         public long AvailableMemory { get { return availableMemoryCounter != null ? Convert.ToInt64(availableMemoryCounter.NextValue()) : 0; } }
 
-
         public float CpuUsage { get; private set; }
 
         private static string GCGenCollectionCount
@@ -121,8 +120,9 @@ namespace Orleans.Runtime
                 largeObjectHeapSize = new PerformanceCounter(".NET CLR Memory", "Large Object Heap size", thisProcess, true);
                 promotedFinalizationMemoryFromGen0 = new PerformanceCounter(".NET CLR Memory", "Promoted Finalization-Memory from Gen 0", thisProcess, true);
 #endif
-
-                // For Mono one could use PerformanceCounter("Mono Memory", "Total Physical Memory");
+                
+#if !(DNXCORE50 || __MonoCS__)
+                //.NET on Windows without mono
                 const string Query = "SELECT Capacity FROM Win32_PhysicalMemory";
                 var searcher = new ManagementObjectSearcher(Query);
                 long Capacity = 0;
@@ -133,6 +133,13 @@ namespace Orleans.Runtime
                     throw new Exception("No physical ram installed on machine?");
 
                 TotalPhysicalMemory = Capacity;
+#elif __MonoCS__
+                //Cross platform mono
+                var totalPhysicalMemory = new PerformanceCounter("Mono Memory", "Total Physical Memory");
+                TotalPhysicalMemory = Convert.ToInt64(totalPhysicalMemory.NextValue());
+#elif DNXCORE50
+                //Cross platform CoreCLR
+#endif
                 countersAvailable = true;
             }
             catch (Exception)
@@ -174,11 +181,14 @@ namespace Orleans.Runtime
             FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_LARGEOBJECTHEAPSIZEKB, () => largeObjectHeapSize.NextValue() / 11024f);
             FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PROMOTEDMEMORYFROMGEN0KB, () => promotedFinalizationMemoryFromGen0.NextValue() / 1024f);
             FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_NUMBEROFINDUCEDGCS, () => numberOfInducedGCs.NextValue());
+
+#if DNXCORE50
             IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_MEMORY_TOTALPHYSICALMEMORYMB, () => (TotalPhysicalMemory / 1024) / 1024);
             if (availableMemoryCounter != null)
             {
                 IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_MEMORY_AVAILABLEMEMORYMB, () => (AvailableMemory/ 1024) / 1024); // Round up
             }
+#endif
 #endif
             IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_DOT_NET_THREADPOOL_INUSE_WORKERTHREADS, () =>
             {


### PR DESCRIPTION
For #1040 and related to #368 

Currently I've just ifdeffed my way around the incompatible `ManagementObject` code for getting total physical memory.

This means on Core CLR the value for `RuntimeStatisticsGroup.TotalPhysicalMemory` will always be 0. I thought this should be fine because the `RuntimeStatisticsGroup.AvailableMemory` can also be 0.