### PR TITLE
Fixed fire and forget delivery default in SimpleMessageStreamProvider

### DIFF
--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -36,7 +36,6 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         private IStreamProviderRuntime      providerRuntime;
         private bool                        fireAndForgetDelivery;
         internal const string               FIRE_AND_FORGET_DELIVERY = "FireAndForgetDelivery";
-        internal const bool                 DEFAULT_FIRE_AND_FORGET_DELIVERY_VALUE = false;
         internal const StreamPubSubType     DEFAULT_STREAM_PUBSUB_TYPE = StreamPubSubType.ExplicitGrainBasedAndImplicit;
 
         public bool IsRewindable { get { return false; } }
@@ -46,7 +45,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             this.Name = name;
             providerRuntime = (IStreamProviderRuntime) providerUtilitiesManager;
             string fireAndForgetDeliveryStr;
-            fireAndForgetDelivery = config.Properties.TryGetValue(FIRE_AND_FORGET_DELIVERY, out fireAndForgetDeliveryStr) ? Boolean.Parse(fireAndForgetDeliveryStr) : false;
+            fireAndForgetDelivery = config.Properties.TryGetValue(FIRE_AND_FORGET_DELIVERY, out fireAndForgetDeliveryStr) && Boolean.Parse(fireAndForgetDeliveryStr);
 
             logger = providerRuntime.GetLogger(this.GetType().Name);
             logger.Info("Initialized SimpleMessageStreamProvider with name {0} and with property FireAndForgetDelivery: {1}.", Name, fireAndForgetDelivery);

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -46,7 +46,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             this.Name = name;
             providerRuntime = (IStreamProviderRuntime) providerUtilitiesManager;
             string fireAndForgetDeliveryStr;
-            fireAndForgetDelivery = !config.Properties.TryGetValue(FIRE_AND_FORGET_DELIVERY, out fireAndForgetDeliveryStr) || Boolean.Parse(fireAndForgetDeliveryStr);
+            fireAndForgetDelivery = config.Properties.TryGetValue(FIRE_AND_FORGET_DELIVERY, out fireAndForgetDeliveryStr) ? Boolean.Parse(fireAndForgetDeliveryStr) : false;
 
             logger = providerRuntime.GetLogger(this.GetType().Name);
             logger.Info("Initialized SimpleMessageStreamProvider with name {0} and with property FireAndForgetDelivery: {1}.", Name, fireAndForgetDelivery);


### PR DESCRIPTION
Fire and forget delivery was defaulting to true in SimpleMessageStreamProvider when unspecified in the FireAndForgetDelivery attribute.