### PR TITLE
Fixed relational tests

### DIFF
--- a/src/Local.testsettings
+++ b/src/Local.testsettings
@@ -4,6 +4,8 @@
   <Deployment>
     <DeploymentItem filename="Tester\bin\Debug\TestInput\" />
     <DeploymentItem filename="TestInput\" />
+    <DeploymentItem filename="CreateOrleansTables_MySql.sql" />
+    <DeploymentItem filename="CreateOrleansTables_SqlServer.sql" />
   </Deployment>
   <NamingScheme baseName="BuildResults" appendTimeStamp="false" />
   <Scripts setupScript=".\SetupTestScript.cmd" />


### PR DESCRIPTION
The relational tests could not be run because of missing
SQL scripts. This is fixed by adding them to Local.testsettings.
