### PR TITLE
Fixed intermittent failure of test AQSubscribeFromClientTest.

### DIFF
--- a/src/OrleansAzureUtils/Storage/AzureQueueDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/AzureQueueDataManager.cs
@@ -130,12 +130,12 @@ namespace Orleans.AzureUtils
             {
                 // Retrieve a reference to a queue.
                 // Not sure if this is a blocking call or not. Did not find an alternative async API. Should probably use BeginListQueuesSegmented.
-                queue = queueOperationsClient.GetQueueReference(QueueName);
+                var myQueue = queueOperationsClient.GetQueueReference(QueueName);
 
                 // Create the queue if it doesn't already exist.
 
-                bool didCreate = await Task<bool>.Factory.FromAsync(queue.BeginCreateIfNotExists, queue.EndCreateIfNotExists, null);
-
+                bool didCreate = await Task<bool>.Factory.FromAsync(myQueue.BeginCreateIfNotExists, myQueue.EndCreateIfNotExists, null);
+                queue = myQueue;
                 logger.Info(ErrorCode.AzureQueue_01, "{0} Azure storage queue {1}", (didCreate ? "Created" : "Attached to"), QueueName);
             }
             catch (Exception exc)

--- a/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
@@ -24,10 +24,12 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using UnitTests.Tester;
 
@@ -53,9 +55,10 @@ namespace UnitTests.StreamingTests
             runner = new SubscriptionMultiplicityTestRunner(AQStreamProviderName, GrainClient.Logger);
         }
 
-        public override void AdjustForTest(Orleans.Runtime.Configuration.ClientConfiguration config)
+        public override void AdjustForTest(ClientConfiguration config)
         {
             config.RegisterStreamProvider<AzureQueueStreamProvider>(AQStreamProviderName, new Dictionary<string, string>());
+            config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 40001));
             base.AdjustForTest(config);
         }
 


### PR DESCRIPTION
Two issues addressed:
1) AzureQueueDataManager initialization was not thread safe.
2) Until we fix issue #1069, tests accessing PersistentStreamProviders from clients must have gateways configured for all silos in the cluster.