### PR TITLE
Exposed ServiceProvider to Grains and Providers.

### DIFF
--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -65,6 +65,8 @@ namespace Orleans
 
         protected IGrainFactory GrainFactory { get; private set; }
 
+        protected IServiceProvider ServiceProvider { get; private set; }
+
         internal IGrainIdentity Identity;
 
         /// <summary>
@@ -87,6 +89,7 @@ namespace Orleans
             Identity = identity;
             Runtime = runtime;
             GrainFactory = runtime.GrainFactory;
+            ServiceProvider = runtime.ServiceProvider;
         }
 
         

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -98,6 +98,7 @@
     <Compile Include="CodeGeneration\Language.cs" />
     <Compile Include="CodeGeneration\OrleansCodeGenerationTargetAttribute.cs" />
     <Compile Include="CodeGeneration\SkipCodeGenerationAttribute.cs" />
+    <Compile Include="Providers\DefaultServiceProvider.cs" />
     <Compile Include="Serialization\IExternalSerializer.cs" />
     <Compile Include="Configuration\LimitNames.cs" />
     <Compile Include="Configuration\LimitValue.cs" />

--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -39,14 +39,16 @@ namespace Orleans.Providers
         private readonly Dictionary<Type, Tuple<IGrainExtension, IAddressable>> caoTable;
         private readonly AsyncLock lockable;
 
-        public ClientProviderRuntime(IGrainFactory grainFactory) 
+        public ClientProviderRuntime(IGrainFactory grainFactory, IServiceProvider serviceProvider) 
         {
             caoTable = new Dictionary<Type, Tuple<IGrainExtension, IAddressable>>();
             lockable = new AsyncLock();
             GrainFactory = grainFactory;
+            ServiceProvider = serviceProvider;
         }
 
         public IGrainFactory GrainFactory { get; private set; }
+        public IServiceProvider ServiceProvider { get; private set; }
 
         public void StreamingInitialize(ImplicitStreamSubscriberTable implicitStreamSubscriberTable) 
         {

--- a/src/Orleans/Providers/DefaultServiceProvider.cs
+++ b/src/Orleans/Providers/DefaultServiceProvider.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Project Orleans Cloud Service SDK ver. 1.0
  
 Copyright (c) Microsoft Corporation
@@ -22,25 +22,18 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
-using System.Threading.Tasks;
-using Orleans.Providers;
-using Orleans.Runtime;
 
-namespace Orleans.Streams
+namespace Orleans.Providers
 {
     /// <summary>
-    /// Adapter factory.  This should create an adapter from the stream provider configuration
+    /// Default service provider.
+    /// This should be replaced with a minimal Dependency Injection system, once a stable version is available.
     /// </summary>
-    public interface IQueueAdapterFactory
+    public class DefaultServiceProvider : IServiceProvider
     {
-        void Init(IProviderConfiguration config, string providerName, Logger logger, IServiceProvider serviceProvider);
-
-        Task<IQueueAdapter> CreateAdapter();
-
-        IQueueAdapterCache GetQueueAdapterCache();
-
-        IStreamQueueMapper GetStreamQueueMapper();
-
-        Task<IStreamFailureHandler> GetDeliveryFailureHandler(QueueId queueId);
+        public object GetService(Type serviceType)
+        {
+            return Activator.CreateInstance(serviceType);
+        }
     }
 }

--- a/src/Orleans/Providers/IProviderRuntime.cs
+++ b/src/Orleans/Providers/IProviderRuntime.cs
@@ -64,6 +64,11 @@ namespace Orleans.Providers
         /// Factory for getting references to grains.
         /// </summary>
         IGrainFactory GrainFactory { get; }
+
+        /// <summary>
+        /// Service provider for dependency injection
+        /// </summary>
+        IServiceProvider ServiceProvider { get; }
     }
 
     /// <summary>

--- a/src/Orleans/Providers/StatisticsProviderManager.cs
+++ b/src/Orleans/Providers/StatisticsProviderManager.cs
@@ -44,7 +44,8 @@ namespace Orleans.Providers
         }
 
         public IGrainFactory GrainFactory { get { return runtime.GrainFactory; }}
-        
+        public IServiceProvider ServiceProvider { get { return runtime.ServiceProvider; } }
+
         public async Task<string> LoadProvider(IDictionary<string, ProviderCategoryConfiguration> configs)
         {
             statisticsProviderLoader = new ProviderLoader<IProvider>();

--- a/src/Orleans/Runtime/GrainRuntime.cs
+++ b/src/Orleans/Runtime/GrainRuntime.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime
 {
     internal class GrainRuntime : IGrainRuntime
     {
-        public GrainRuntime(Guid serviceId, string siloId, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager)
+        public GrainRuntime(Guid serviceId, string siloId, IGrainFactory grainFactory, ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry, IStreamProviderManager streamProviderManager, IServiceProvider serviceProvider)
         {
             ServiceId = serviceId;
             SiloIdentity = siloId;
@@ -15,6 +15,7 @@ namespace Orleans.Runtime
             TimerRegistry = timerRegistry;
             ReminderRegistry = reminderRegistry;
             StreamProviderManager = streamProviderManager;
+            ServiceProvider = serviceProvider;
         }
 
         public Guid ServiceId { get; private set; }
@@ -28,6 +29,7 @@ namespace Orleans.Runtime
         public IReminderRegistry ReminderRegistry { get; private set; }
         
         public IStreamProviderManager StreamProviderManager { get; private set;}
+        public IServiceProvider ServiceProvider { get; private set; }
 
         public Logger GetLogger(string loggerName, TraceLogger.LoggerType logType)
         {

--- a/src/Orleans/Runtime/IGrainRuntime.cs
+++ b/src/Orleans/Runtime/IGrainRuntime.cs
@@ -35,6 +35,8 @@ namespace Orleans.Runtime
 
         IStreamProviderManager StreamProviderManager { get; }
 
+        IServiceProvider ServiceProvider { get; }
+
         Logger GetLogger(string loggerName, TraceLogger.LoggerType logType);
 
         void DeactivateOnIdle(Grain grain);

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -174,7 +174,7 @@ namespace Orleans
                 // Ensure SerializationManager static constructor is called before AssemblyLoad event is invoked
                 SerializationManager.GetDeserializer(typeof(String));
 
-                clientProviderRuntime = new ClientProviderRuntime(grainFactory);
+                clientProviderRuntime = new ClientProviderRuntime(grainFactory, new DefaultServiceProvider());
                 statisticsProviderManager = new StatisticsProviderManager("Statistics", clientProviderRuntime);
                 var statsProviderName = statisticsProviderManager.LoadProvider(config.ProviderConfigurations)
                     .WaitForResultWithThrow(initTimeout);

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -80,7 +80,7 @@ namespace Orleans.Providers.Streams.Common
             providerRuntime = (IStreamProviderRuntime)providerUtilitiesManager;
             logger = providerRuntime.GetLogger(this.GetType().Name);
             adapterFactory = new TAdapterFactory();
-            adapterFactory.Init(config, Name, logger);
+            adapterFactory.Init(config, Name, logger, providerRuntime.ServiceProvider);
             queueAdapter = await adapterFactory.CreateAdapter();
             myConfig = new PersistentStreamProviderConfig(config);
             string startup;

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -53,7 +53,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         public const string DEPLOYMENT_ID = "DeploymentId";
 
         /// <summary> Init the factory.</summary>
-        public virtual void Init(IProviderConfiguration config, string providerName, Logger logger)
+        public virtual void Init(IProviderConfiguration config, string providerName, Logger logger, IServiceProvider serviceProvider)
         {
             if (config == null) throw new ArgumentNullException("config");
             if (!config.Properties.TryGetValue(DATA_CONNECTION_STRING, out dataConnectionString))

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/SimpleAzureQueueAdapterFactory.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/SimpleAzureQueueAdapterFactory.cs
@@ -39,7 +39,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         public const string QUEUE_NAME_STRING = "QueueName";
 
         /// <summary> Init the factory.</summary>
-        public virtual void Init(IProviderConfiguration config, string providerName, Logger logger)
+        public virtual void Init(IProviderConfiguration config, string providerName, Logger logger, IServiceProvider serviceProvider)
         {
             if (config == null) throw new ArgumentNullException("config");
             if (!config.Properties.TryGetValue(AzureQueueAdapterFactory.DATA_CONNECTION_STRING, out dataConnectionString))

--- a/src/OrleansDependencyInjection/ConfigureStartupBuilder.cs
+++ b/src/OrleansDependencyInjection/ConfigureStartupBuilder.cs
@@ -25,6 +25,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.DependencyInjection;
+using Orleans.Providers;
 using Orleans.Runtime.Management;
 using Orleans.Runtime.MembershipService;
 using Orleans.Runtime.ReminderService;
@@ -126,14 +127,6 @@ namespace Orleans.Runtime.Startup
             }
 
             return methodInfo;
-        }
-
-        private class DefaultServiceProvider : IServiceProvider
-        {
-            public object GetService(Type serviceType)
-            {
-                return Activator.CreateInstance(serviceType);
-            }
         }
 
         IServiceProvider IStartupBuilder.ConfigureStartup(string startupTypeName)

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -220,6 +220,7 @@ namespace Orleans.Runtime
                 LocalDataStoreInstance.LocalDataStore = keyStore;
             }
 
+            services = new DefaultServiceProvider();
             var startupBuilder = AssemblyLoader.TryLoadAndCreateInstance<IStartupBuilder>("OrleansDependencyInjection", logger);
             if (startupBuilder != null)
             {
@@ -275,7 +276,8 @@ namespace Orleans.Runtime
                 grainFactory,
                 new TimerRegistry(),
                 new ReminderRegistry(),
-                new StreamProviderManager());
+                new StreamProviderManager(),
+                Services);
 
 
             // Now the router/directory service
@@ -443,7 +445,7 @@ namespace Orleans.Runtime
             // Set up an execution context for this thread so that the target creation steps can use asynch values.
             RuntimeContext.InitializeMainThread();
 
-            SiloProviderRuntime.Initialize(GlobalConfig, SiloIdentity, grainFactory);
+            SiloProviderRuntime.Initialize(GlobalConfig, SiloIdentity, grainFactory, Services);
             InsideRuntimeClient.Current.CurrentStreamProviderRuntime = SiloProviderRuntime.Instance;
             statisticsProviderManager = new StatisticsProviderManager("Statistics", SiloProviderRuntime.Instance);
             string statsProviderName =  statisticsProviderManager.LoadProvider(GlobalConfig.ProviderConfigurations)
@@ -473,7 +475,7 @@ namespace Orleans.Runtime
             if (logger.IsVerbose) {  logger.Verbose("System grains created successfully."); }
 
             // Initialize storage providers once we have a basic silo runtime environment operating
-            storageProviderManager = new StorageProviderManager(grainFactory);
+            storageProviderManager = new StorageProviderManager(grainFactory, Services);
             scheduler.QueueTask(
                 () => storageProviderManager.LoadStorageProviders(GlobalConfig.ProviderConfigurations),
                 providerManagerSystemTarget.SchedulingContext)

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -46,6 +46,7 @@ namespace Orleans.Runtime.Providers
         private ImplicitStreamSubscriberTable implicitStreamSubscriberTable;
 
         public IGrainFactory GrainFactory { get; private set; }
+        public IServiceProvider ServiceProvider { get; private set; }
         public Guid ServiceId { get; private set; }
         public string SiloIdentity { get; private set; }
 
@@ -53,11 +54,12 @@ namespace Orleans.Runtime.Providers
         {
         }
 
-        internal static void Initialize(GlobalConfiguration config, string siloIdentity, IGrainFactory grainFactory)
+        internal static void Initialize(GlobalConfiguration config, string siloIdentity, IGrainFactory grainFactory, IServiceProvider serviceProvider)
         {
             Instance.ServiceId = config.ServiceId;
             Instance.SiloIdentity = siloIdentity;
             Instance.GrainFactory = grainFactory;
+            Instance.ServiceProvider = serviceProvider;
         }
 
         public static SiloProviderRuntime Instance

--- a/src/OrleansRuntime/Storage/StorageProviderManager.cs
+++ b/src/OrleansRuntime/Storage/StorageProviderManager.cs
@@ -37,9 +37,10 @@ namespace Orleans.Runtime.Storage
         private ProviderLoader<IStorageProvider> storageProviderLoader;
         private IProviderRuntime providerRuntime;
 
-        public StorageProviderManager(IGrainFactory grainFactory)
+        public StorageProviderManager(IGrainFactory grainFactory, IServiceProvider serviceProvider)
         {
             GrainFactory = grainFactory;
+            ServiceProvider = serviceProvider;
         }
 
         internal Task LoadStorageProviders(IDictionary<string, ProviderCategoryConfiguration> configs)
@@ -90,6 +91,7 @@ namespace Orleans.Runtime.Storage
         }
 
         public IGrainFactory GrainFactory { get; private set; }
+        public IServiceProvider ServiceProvider { get; private set; }
 
         /// <summary>
         /// Get list of providers loaded in this silo.

--- a/src/Tester/TestStreamProviders/Controllable/ControllableTestStreamProvider.cs
+++ b/src/Tester/TestStreamProviders/Controllable/ControllableTestStreamProvider.cs
@@ -57,7 +57,7 @@ namespace Tester.TestStreamProviders.Controllable
 
             public bool IsRewindable { get; private set; }
             public StreamProviderDirection Direction { get; private set; }
-            public void Init(IProviderConfiguration config, string providerName, Logger logger)
+            public void Init(IProviderConfiguration config, string providerName, Logger logger, IServiceProvider serviceProvider)
             {
                 Name = providerName;
             }

--- a/src/Tester/TestStreamProviders/Generator/GeneratorAdapterFactory.cs
+++ b/src/Tester/TestStreamProviders/Generator/GeneratorAdapterFactory.cs
@@ -40,7 +40,7 @@ namespace Tester.TestStreamProviders.Generator
     public class GeneratorAdapterFactory : IQueueAdapterFactory, IQueueAdapter
     {
         public const string GeneratorConfigTypeName = "StreamGeneratorConfigType";
-        private readonly IServiceProvider serviceProvider;
+        private IServiceProvider serviceProvider;
         private GeneratorAdapterConfig adapterConfig;
         private IStreamGeneratorConfig generatorConfig;
         private IStreamQueueMapper streamQueueMapper;
@@ -50,27 +50,10 @@ namespace Tester.TestStreamProviders.Generator
         public bool IsRewindable { get { return true; } }
         public StreamProviderDirection Direction { get { return StreamProviderDirection.ReadOnly; } }
 
-        //TODO: Killme when Orleans service provider is accessable to the appication layer.
-        private class TempServiceProvider : IServiceProvider{ public object GetService(Type serviceType) { return Activator.CreateInstance(serviceType); } }
-        private static readonly IServiceProvider DefaultServiceProvider = new TempServiceProvider();
-
-        public GeneratorAdapterFactory()
-            : this(DefaultServiceProvider)
-        {
-        }
-
-        public GeneratorAdapterFactory(IServiceProvider serviceProvider)
-        {
-            if (serviceProvider == null)
-            {
-                throw new ArgumentNullException("serviceProvider");
-            }
-            this.serviceProvider = serviceProvider;
-        }
-
-        public void Init(IProviderConfiguration providerConfig, string providerName, Logger log)
+        public void Init(IProviderConfiguration providerConfig, string providerName, Logger log, IServiceProvider svcProvider)
         {
             this.logger = log;
+            this.serviceProvider = svcProvider;
             adapterConfig = new GeneratorAdapterConfig(providerName);
             adapterConfig.PopulateFromProviderConfig(providerConfig);
             generatorConfig = serviceProvider.GetService(adapterConfig.GeneratorConfigType) as IStreamGeneratorConfig;


### PR DESCRIPTION
The plan is to have dependencies injected via property and/or constructor injection by the DI system.  Currently, `Microsoft.Framework.DependencyInjection` is in beta, so we can't rely on it in the framework.  This is preventing us from using any DI capabilities until it is released.

This change exposes the Service Provider to grains and providers so we can start using injected dependencies.  Once `Microsoft.Framework.DependencyInjection` is released, we can removed these framework hooks and let the DI system provide any dependencies, as planned.