### PR TITLE
IStorageProvider methods parameter grainType from string to Type

### DIFF
--- a/src/Orleans/Providers/IStorageProvider.cs
+++ b/src/Orleans/Providers/IStorageProvider.cs
@@ -42,25 +42,25 @@ namespace Orleans.Storage
         Logger Log { get; }
 
         /// <summary>Read data function for this storage provider instance.</summary>
-        /// <param name="grainType">Type of this grain [fully qualified class name]</param>
+        /// <param name="grainType">Type of this grain</param>
         /// <param name="grainReference">Grain reference object for this grain.</param>
         /// <param name="grainState">State data object to be populated for this grain.</param>
         /// <returns>Completion promise for the Read operation on the specified grain.</returns>
-        Task ReadStateAsync(string grainType, GrainReference grainReference, GrainState grainState);
+        Task ReadStateAsync(Type grainType, GrainReference grainReference, GrainState grainState);
 
         /// <summary>Write data function for this storage provider instance.</summary>
-        /// <param name="grainType">Type of this grain [fully qualified class name]</param>
+        /// <param name="grainType">Type of this grain</param>
         /// <param name="grainReference">Grain reference object for this grain.</param>
         /// <param name="grainState">State data object to be written for this grain.</param>
         /// <returns>Completion promise for the Write operation on the specified grain.</returns>
-        Task WriteStateAsync(string grainType, GrainReference grainReference, GrainState grainState);
+        Task WriteStateAsync(Type grainType, GrainReference grainReference, GrainState grainState);
 
         /// <summary>Delete / Clear data function for this storage provider instance.</summary>
-        /// <param name="grainType">Type of this grain [fully qualified class name]</param>
+        /// <param name="grainType">Type of this grain</param>
         /// <param name="grainReference">Grain reference object for this grain.</param>
         /// <param name="grainState">Copy of last-known state data object for this grain.</param>
         /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
-        Task ClearStateAsync(string grainType, GrainReference grainReference, GrainState grainState);
+        Task ClearStateAsync(Type grainType, GrainReference grainReference, GrainState grainState);
     }
 
     /// <summary>

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -153,14 +153,14 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IStorageProvider.ReadStateAsync"/>
-        public async Task ReadStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public async Task ReadStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainReference);
             if (Log.IsVerbose3) Log.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_ReadingData, "Reading: GrainType={0} Pk={1} Grainid={2} from Table={3}", grainType, pk, grainReference, tableName);
             string partitionKey = pk;
-            string rowKey = grainType;
+            string rowKey = grainType.FullName;
             GrainStateRecord record = await tableDataManager.Read(partitionKey, rowKey);
             if (record != null)
             {
@@ -176,7 +176,7 @@ namespace Orleans.Storage
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IStorageProvider.WriteStateAsync"/>
-        public async Task WriteStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public async Task WriteStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
@@ -184,7 +184,7 @@ namespace Orleans.Storage
             if (Log.IsVerbose3)
                 Log.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Writing: GrainType={0} Pk={1} Grainid={2} ETag={3} to Table={4}", grainType, pk, grainReference, grainState.Etag, tableName);
 
-            var entity = new GrainStateEntity { PartitionKey = pk, RowKey = grainType };
+            var entity = new GrainStateEntity { PartitionKey = pk, RowKey = grainType.FullName };
             ConvertToStorageFormat(grainState, entity);
             var record = new GrainStateRecord { Entity = entity, ETag = grainState.Etag };
             try
@@ -207,13 +207,13 @@ namespace Orleans.Storage
         /// cleared by overwriting with default / null values.
         /// </remarks>
         /// <see cref="IStorageProvider.ClearStateAsync"/>
-        public async Task ClearStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public async Task ClearStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainReference);
             if (Log.IsVerbose3) Log.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Clearing: GrainType={0} Pk={1} Grainid={2} ETag={3} DeleteStateOnClear={4} from Table={5}", grainType, pk, grainReference, grainState.Etag, isDeleteStateOnClear, tableName);
-            var entity = new GrainStateEntity { PartitionKey = pk, RowKey = grainType };
+            var entity = new GrainStateEntity { PartitionKey = pk, RowKey = grainType.FullName };
             var record = new GrainStateRecord { Entity = entity, ETag = grainState.Etag };
             string operation = "Clearing";
             try

--- a/src/OrleansProviders/Storage/MemoryStorage.cs
+++ b/src/OrleansProviders/Storage/MemoryStorage.cs
@@ -125,9 +125,9 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IStorageProvider#ReadStateAsync"/>
-        public virtual async Task ReadStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public virtual async Task ReadStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
-            var keys = MakeKeys(grainType, grainReference);
+            var keys = MakeKeys(grainType.FullName, grainReference);
 
             if (Log.IsVerbose2) Log.Verbose2("Read Keys={0}", StorageProviderUtils.PrintKeys(keys));
             
@@ -142,9 +142,9 @@ namespace Orleans.Storage
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IStorageProvider#WriteStateAsync"/>
-        public virtual async Task WriteStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public virtual async Task WriteStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
-            var keys = MakeKeys(grainType, grainReference);
+            var keys = MakeKeys(grainType.FullName, grainReference);
             var data = grainState.AsDictionary();
             string receivedEtag = grainState.Etag;
 
@@ -162,9 +162,9 @@ namespace Orleans.Storage
 
         /// <summary> Delete / Clear state data function for this storage provider. </summary>
         /// <see cref="IStorageProvider#ClearStateAsync"/>
-        public virtual async Task ClearStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public virtual async Task ClearStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
-            var keys = MakeKeys(grainType, grainReference);
+            var keys = MakeKeys(grainType.FullName, grainReference);
             string eTag = grainState.Etag; // TOD: Should this be 'null' for always Delete?
 
             if (Log.IsVerbose2) Log.Verbose2("Delete Keys={0} Etag={1}", StorageProviderUtils.PrintKeys(keys), eTag);

--- a/src/OrleansProviders/Storage/MemoryStorageWithLatency.cs
+++ b/src/OrleansProviders/Storage/MemoryStorageWithLatency.cs
@@ -84,17 +84,17 @@ namespace Orleans.Storage
             await MakeFixedLatencyCall(() => base.Close());
         }
 
-        public override async Task ReadStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public override async Task ReadStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
             await MakeFixedLatencyCall(() => base.ReadStateAsync(grainType, grainReference, grainState));
         }
 
-        public override async Task WriteStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public override async Task WriteStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
             await MakeFixedLatencyCall(() => base.WriteStateAsync(grainType, grainReference, grainState));
         }
 
-        public override async Task ClearStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public override async Task ClearStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
             await MakeFixedLatencyCall(() => base.ClearStateAsync(grainType, grainReference, grainState));
         }

--- a/src/OrleansProviders/Storage/ShardedStorageProvider.cs
+++ b/src/OrleansProviders/Storage/ShardedStorageProvider.cs
@@ -137,27 +137,27 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IStorageProvider#ReadStateAsync"/>
-        public Task ReadStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public Task ReadStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
-            int num = FindStorageShard(grainType, grainReference);
+            int num = FindStorageShard(grainType.FullName, grainReference);
             IStorageProvider provider = storageProviders[num];
             return provider.ReadStateAsync(grainType, grainReference, grainState);
         }
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IStorageProvider#WriteStateAsync"/>
-        public Task WriteStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public Task WriteStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
-            int num = FindStorageShard(grainType, grainReference);
+            int num = FindStorageShard(grainType.FullName, grainReference);
             IStorageProvider provider = storageProviders[num];
             return provider.WriteStateAsync(grainType, grainReference, grainState);
         }
 
         /// <summary> Deleet / Clear state data function for this storage provider. </summary>
         /// <see cref="IStorageProvider#ClearStateAsync"/>
-        public Task ClearStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        public Task ClearStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
-            int num = FindStorageShard(grainType, grainReference);
+            int num = FindStorageShard(grainType.FullName, grainReference);
             IStorageProvider provider = storageProviders[num];
             return provider.ClearStateAsync(grainType, grainReference, grainState);
         }

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -674,7 +674,7 @@ namespace Orleans.Runtime
                     SetupStorageProvider(data);
 
                     data.GrainInstance.GrainState = state;
-                    data.GrainInstance.Storage = new GrainStateStorageBridge(data.GrainTypeName, data.GrainInstance, data.StorageProvider);
+                    data.GrainInstance.Storage = new GrainStateStorageBridge(grainType, data.GrainInstance, data.StorageProvider);
                 }
             }
 
@@ -741,7 +741,7 @@ namespace Orleans.Runtime
                     var grainRef = result.GrainReference;
 
                     await scheduler.RunOrQueueTask(() =>
-                        result.StorageProvider.ReadStateAsync(grainType, grainRef, state),
+                        result.StorageProvider.ReadStateAsync(result.GrainInstanceType, grainRef, state),
                         new SchedulingContext(result));
 
                     sw.Stop();

--- a/src/OrleansSQLUtils/Storage/Provider/SqlStorageProvider.cs
+++ b/src/OrleansSQLUtils/Storage/Provider/SqlStorageProvider.cs
@@ -87,9 +87,9 @@ namespace Orleans.SqlUtils.StorageProvider
             return TaskDone.Done;
         }
 
-        async Task IStorageProvider.ReadStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        async Task IStorageProvider.ReadStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
-            var grainIdentity = GrainIdentity.FromGrainReference(grainType, grainReference);
+            var grainIdentity = GrainIdentity.FromGrainReference(grainType.FullName, grainReference);
 
             if (_ignore)
                 return;
@@ -100,12 +100,12 @@ namespace Orleans.SqlUtils.StorageProvider
         }
 
 
-        async Task IStorageProvider.WriteStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        async Task IStorageProvider.WriteStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
             if (_ignore)
                 return;
 
-            var grainIdentity = GrainIdentity.FromGrainReference(grainType, grainReference);
+            var grainIdentity = GrainIdentity.FromGrainReference(grainType.FullName, grainReference);
             await _dataManager.UpsertStateAsync(grainIdentity, grainState.AsDictionary());
         }
 
@@ -117,9 +117,9 @@ namespace Orleans.SqlUtils.StorageProvider
         /// <param name="grainReference"></param>
         /// <param name="grainState"></param>
         /// <returns></returns>
-        Task IStorageProvider.ClearStateAsync(string grainType, GrainReference grainReference, GrainState grainState)
+        Task IStorageProvider.ClearStateAsync(Type grainType, GrainReference grainReference, GrainState grainState)
         {
-            Log.Verbose2("ClearStateAsync {0} {1} {2}", grainType, grainReference.ToKeyString(), grainState.Etag);
+            Log.Verbose2("ClearStateAsync {0} {1} {2}", grainType.FullName, grainReference.ToKeyString(), grainState.Etag);
 
             return TaskDone.Done;
         }


### PR DESCRIPTION
In my `IStorageProvider` implementation, I need to have the grain type in order to have the complete meta data of the given grain. I'm sure others will find this change useful. 
This is part of @shayhatsor's suggestion https://github.com/dotnet/orleans/issues/1035#issuecomment-159113341