### PR TITLE
Mark F# test cases currently expected to fail.

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Brutal.Dev.StrongNameSigner" version="1.5.1" />
+  <package id="FSharp.Compiler.Tools" version="4.0.0.1" />
 </packages>

--- a/src/Tester/FSharpGrainTests.cs
+++ b/src/Tester/FSharpGrainTests.cs
@@ -22,19 +22,14 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
-using System.Globalization;
 using System.Threading.Tasks;
+using Microsoft.FSharp.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Orleans;
-using Orleans.Runtime;
 using Orleans.TestingHost;
+
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
-using System.Collections.Generic;
-using TestGrainInterfaces;
 using UnitTests.FSharpTypes;
-using Microsoft.FSharp.Core;
-using Microsoft.FSharp.Collections;
 
 namespace UnitTests.General
 {
@@ -76,7 +71,7 @@ namespace UnitTests.General
         }
 
         /// F# record without Serializable and Immutable attributes applied - yields a more meaningful error message
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofIntOption_Some_WithNoAttributes()
         {
             await PingTest<RecordOfIntOptionWithNoAttributes>(RecordOfIntOptionWithNoAttributes.ofInt(1));
@@ -84,7 +79,7 @@ namespace UnitTests.General
 
         /// F# record with Serializable and Immutable attributes applied - grain call times out,
         /// Debugging the test reveals the same root cause as for FSharpGrains_Record_ofIntOption_WithNoAttributes
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofIntOption_Some()
         {
             await PingTest<RecordOfIntOption>(RecordOfIntOption.ofInt(1));
@@ -103,7 +98,7 @@ namespace UnitTests.General
             await PingTest<GenericRecord<int>>(input);
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_GenericRecord_ofIntOption_Some()
         {
             var input = GenericRecord<FSharpOption<int>>.ofT(FSharpOption<int>.Some(0));
@@ -117,14 +112,14 @@ namespace UnitTests.General
             await PingTest<GenericRecord<FSharpOption<int>>>(input);
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_IntOption_Some()
         {
             var input = FSharpOption<int>.Some(0);
             await PingTest<FSharpOption<int>>(input);
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_IntOption_None()
         {
             var input = FSharpOption<int>.None;

--- a/src/Tester/SerializationTests.FSharpTypes.cs
+++ b/src/Tester/SerializationTests.FSharpTypes.cs
@@ -22,21 +22,11 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 
-using System;
-using System.Globalization;
+using Microsoft.FSharp.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Orleans.CodeGeneration;
 using Orleans.Serialization;
-using UnitTests.GrainInterfaces;
-using System.Collections.Generic;
-using Orleans.TestingHost;
-using System.Runtime.Serialization;
 
 using UnitTests.FSharpTypes;
-using Microsoft.FSharp.Core;
-using Microsoft.FSharp.Collections;
 
 namespace UnitTests.General
 {
@@ -52,7 +42,7 @@ namespace UnitTests.General
             SerializationManager.InitializeForTesting();
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_IntOption_Some()
         {
             var input = FSharpOption<int>.Some(0);
@@ -60,7 +50,7 @@ namespace UnitTests.General
             Assert.IsTrue(output.Equals(input));
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_IntOption_None()
         {
             var input = FSharpOption<int>.None;
@@ -76,7 +66,7 @@ namespace UnitTests.General
             Assert.IsTrue(output.Equals(input));
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Record_ofIntOption_Some()
         {
             var input = RecordOfIntOption.ofInt(1);


### PR DESCRIPTION
- Remove from the Functional suite the F# test cases currently expected to fail.

- Cleanup of unused imports.

- VS2013 auto-added the FSharp.Compiler.Tools package to the .sln level nuget packages.config list.