### PR TITLE
Added test for usage of abstract/enum types from external libraries

### DIFF
--- a/src/TestGrainInterfaces/IExternalTypeGrain.cs
+++ b/src/TestGrainInterfaces/IExternalTypeGrain.cs
@@ -1,0 +1,44 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+using System.Collections.Specialized;
+using System;
+
+namespace UnitTests.GrainInterfaces
+{
+    [Serializable]
+    public class EnumClass
+    {
+        public IEnumerable<DateTimeKind> EnumsList { get; set; }
+    }
+
+    public interface IExternalTypeGrain : IGrainWithIntegerKey
+    {
+        Task GetAbstractModel(IEnumerable<NameObjectCollectionBase> list);
+
+        Task<EnumClass> GetEnumModel();
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -49,6 +49,7 @@
     <Compile Include="ICircularStateTestGrain.cs" />
     <Compile Include="IActivateDeactivateWatcherGrain.cs" />
     <Compile Include="IExceptionGrain.cs" />
+    <Compile Include="IExternalTypeGrain.cs" />
     <Compile Include="IFaultableConsumerGrain.cs" />
     <Compile Include="IGeneratorTestDerivedDerivedGrain.cs" />
     <Compile Include="IGeneratorTestDerivedGrain1.cs" />

--- a/src/TestGrains/ExternalTypeGrain.cs
+++ b/src/TestGrains/ExternalTypeGrain.cs
@@ -1,0 +1,53 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+using System.Collections.Specialized;
+
+namespace UnitTests.Grains
+{
+    /// <summary>
+    /// A simple grain that allows to set two arguments and then multiply them.
+    /// </summary>
+    public class ExternalTypeGrain : Grain, IExternalTypeGrain
+    {
+        public async Task GetAbstractModel(IEnumerable<NameObjectCollectionBase> list)
+        {
+            Console.WriteLine("GetAbstractModel: Success");
+        }
+
+        public async Task<EnumClass> GetEnumModel()
+        {
+            return new EnumClass() { EnumsList = new List<DateTimeKind>() { DateTimeKind.Local } };
+        }
+    }
+}

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -54,6 +54,7 @@
     <Compile Include="CircularStateTestGrain.cs" />
     <Compile Include="ActivateDeactivateWatcherGrain.cs" />
     <Compile Include="ExceptionGrain.cs" />
+    <Compile Include="ExternalTypeGrain.cs" />
     <Compile Include="FaultableConsumerGrain.cs" />
     <Compile Include="EventSourcing\PersonState.cs" />
     <Compile Include="GeneratedEventCollectorGrain.cs" />

--- a/src/Tester/ExternalTypesTests.cs
+++ b/src/Tester/ExternalTypesTests.cs
@@ -1,0 +1,71 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using UnitTests.GrainInterfaces;
+using UnitTests.Tester;
+using System.Collections.Generic;
+using Orleans.Serialization;
+using TestGrainInterfaces;
+using System.Collections.Specialized;
+
+namespace UnitTests.General
+{
+    /// <summary>
+    /// Unit tests for grains implementing generic interfaces
+    /// </summary>
+    [TestClass]
+    public class ExternalTypesTests : UnitTestSiloHost
+    {
+        public ExternalTypesTests()
+            : base(new TestingSiloOptions { StartPrimary = true, StartSecondary = false })
+        {
+        }
+
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public async Task ExternalTypesTest_GrainWithAbstractExternalTypeParam()
+        {
+            var grainWitAbstractTypeParam = GrainClient.GrainFactory.GetGrain<IExternalTypeGrain>(0);
+            await grainWitAbstractTypeParam.GetAbstractModel(new List<NameObjectCollectionBase>() { new NameValueCollection() });
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public async Task ExternalTypesTest_GrainWithEnumExternalTypeParam()
+        {
+            var grainWithEnumTypeParam = GrainClient.GrainFactory.GetGrain<IExternalTypeGrain>(0);
+            await grainWithEnumTypeParam.GetEnumModel();
+        }
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -120,6 +120,7 @@
     <Compile Include="CodeGenTests\IRuntimeCodeGenGrain.cs" />
     <Compile Include="CodeGenTests\RuntimeCodeGenerationTests.cs" />
     <Compile Include="ConcreteStateClassTests.cs" />
+    <Compile Include="ExternalTypesTests.cs" />
     <Compile Include="SerializationTests\ConfigurationTests\SerializationProviderTests.cs" />
     <Compile Include="DeactivationTests.cs" />
     <Compile Include="SerializationTests\JsonFallbackSerializationTests.cs" />


### PR DESCRIPTION
Following #1064 and #1072.

It's worth noting that the tests fail only if the types are used in generics - the serialization for DoStuff(AbstractType p1) will work but for DoStuff(IEnumerable<AbstractType> p1) will fail.

Currently the tests have the Ignore attribute as they are failing until there will be a fix from @ReubenBond.