### PR TITLE
CodeGen: Allow [KnownType] & [KnownAssembly] hints, fix AssemblyProcessor scanning

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyProcessor.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyProcessor.cs
@@ -113,8 +113,8 @@ namespace Orleans.Runtime
         /// <param name="assembly">The assembly to process.</param>
         private static void ProcessAssembly(Assembly assembly)
         {
-            // If the assembly is loaded for reflection only or it does not reference Orleans, avoid processing it.
-            if (assembly.ReflectionOnly || !TypeUtils.IsOrleansOrReferencesOrleans(assembly))
+            // If the assembly is loaded for reflection only avoid processing it.
+            if (assembly.ReflectionOnly)
             {
                 return;
             }
@@ -128,12 +128,16 @@ namespace Orleans.Runtime
                 }
             }
 
-            // Code generation occurs in a self-contained assembly, so invoke it separately.
-            CodeGeneratorManager.GenerateAndCacheCodeForAssembly(assembly);
+            // If the assembly does not reference Orleans, avoid generating code for it.
+            if (TypeUtils.IsOrleansOrReferencesOrleans(assembly))
+            {
+                // Code generation occurs in a self-contained assembly, so invoke it separately.
+                CodeGeneratorManager.GenerateAndCacheCodeForAssembly(assembly);
+            }
 
             // Process each type in the assembly.
             var shouldProcessSerialization = SerializationManager.ShouldFindSerializationInfo(assembly);
-            Type[] assemblyTypes;
+            TypeInfo[] assemblyTypes;
             try
             {
                 assemblyTypes = assembly.DefinedTypes.ToArray();
@@ -147,10 +151,7 @@ namespace Orleans.Runtime
                             "AssemblyLoader encountered an exception loading types from assembly '{0}': {1}",
                             assembly.FullName,
                             exception);
-                    Logger.Warn(
-                        ErrorCode.Loader_TypeLoadError_5,
-                        message,
-                        exception);
+                    Logger.Warn(ErrorCode.Loader_TypeLoadError_5, message, exception);
                 }
 
                 return;

--- a/src/Orleans/CodeGeneration/KnownAssemblyAttribute.cs
+++ b/src/Orleans/CodeGeneration/KnownAssemblyAttribute.cs
@@ -1,0 +1,50 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace Orleans.CodeGeneration
+{
+    using System;
+    using System.Reflection;
+
+    /// <summary>
+    /// The attribute which informs the code generator that code should be generated an assembly.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public class KnownAssemblyAttribute : Attribute
+    {
+        public KnownAssemblyAttribute(Type type)
+        {
+            this.Assembly = type.Assembly;
+        }
+
+        public KnownAssemblyAttribute(string assemblyName)
+        {
+            this.Assembly = Assembly.Load(assemblyName);
+        }
+
+        /// <summary>
+        /// Gets or sets the assembly to include in code generation.
+        /// </summary>
+        public Assembly Assembly { get; set; }
+    }
+}

--- a/src/Orleans/CodeGeneration/KnownTypeAttribute.cs
+++ b/src/Orleans/CodeGeneration/KnownTypeAttribute.cs
@@ -1,0 +1,41 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace Orleans.CodeGeneration
+{
+    using System;
+
+    /// <summary>
+    /// The attribute which informs the code generator that code should be generated a type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public class KnownTypeAttribute : Attribute
+    {
+        public KnownTypeAttribute(Type type)
+        {
+            this.Type = type;
+        }
+
+        public Type Type { get; set; }
+    }
+}

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -98,8 +98,10 @@
     <Compile Include="CodeGeneration\IGrainMethodInvoker.cs" />
     <Compile Include="CodeGeneration\IRuntimeCodeGenerator.cs" />
     <Compile Include="CodeGeneration\ISourceCodeGenerator.cs" />
+    <Compile Include="CodeGeneration\KnownAssemblyAttribute.cs" />
     <Compile Include="CodeGeneration\Language.cs" />
     <Compile Include="CodeGeneration\OrleansCodeGenerationTargetAttribute.cs" />
+    <Compile Include="CodeGeneration\KnownTypeAttribute.cs" />
     <Compile Include="CodeGeneration\SkipCodeGenerationAttribute.cs" />
     <Compile Include="Providers\DefaultServiceProvider.cs" />
     <Compile Include="Serialization\IExternalSerializer.cs" />

--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -225,9 +225,9 @@ namespace Orleans.Serialization
             }
         }
 
-        public static bool IsTypeIsInaccessibleForSerialization(Type t, Module fromModule, Assembly fromAssembly)
+        public static bool IsTypeIsInaccessibleForSerialization(Type type, Module fromModule, Assembly fromAssembly)
         {
-            var typeInfo = t.GetTypeInfo();
+            var typeInfo = type.GetTypeInfo();
 
             if (!typeInfo.IsVisible && typeInfo.IsConstructedGenericType)
             {
@@ -265,7 +265,7 @@ namespace Orleans.Serialization
                 return IsTypeIsInaccessibleForSerialization(typeInfo.GetElementType(), fromModule, fromAssembly);
             }
 
-            var result = typeInfo.IsNestedPrivate || typeInfo.IsNestedFamily;
+            var result = typeInfo.IsNestedPrivate || typeInfo.IsNestedFamily || type.IsPointer;
             
             return result;
         }

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -354,8 +354,10 @@ namespace Orleans.CodeGenerator
         private static MethodDeclarationSyntax GenerateGetMethodNameMethod(Type grainType)
         {
             // Get the method with the correct type.
-            var method = typeof(GrainReference).GetMethods(
-                BindingFlags.NonPublic | BindingFlags.Instance).Where(m=>m.Name == "GetMethodName").FirstOrDefault();
+            var method =
+                typeof(GrainReference)
+                    .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                    .FirstOrDefault(m => m.Name == "GetMethodName");
 
             var methodDeclaration =
                 method.GetDeclarationSyntax()

--- a/src/Tester/CodeGenTests/IRuntimeCodeGenGrain.cs
+++ b/src/Tester/CodeGenTests/IRuntimeCodeGenGrain.cs
@@ -52,6 +52,12 @@ namespace Tester.CodeGenTests
     {
         private static readonly IEqualityComparer<@event> EventComparerInstance = new EventEqualityComparer();
 
+        public enum @enum
+        {
+            @async,
+            @int,
+        }
+
         /// <summary>
         /// A public field.
         /// </summary>
@@ -66,6 +72,11 @@ namespace Tester.CodeGenTests
         /// A property with a reserved keyword type and identifier.
         /// </summary>
         public @event @public { get; set; }
+
+        /// <summary>
+        /// Gets or sets the enum.
+        /// </summary>
+        public @enum Enum { get; set; }
 
         /// <summary>
         /// A property with a reserved keyword generic type and identifier.
@@ -153,7 +164,7 @@ namespace Tester.CodeGenTests
                 }
             }
 
-            return this.privateId.Equals(other.privateId) && this.Id.Equals(other.Id);
+            return this.privateId.Equals(other.privateId) && this.Id.Equals(other.Id) && this.Enum == other.Enum;
         }
 
         private sealed class EventEqualityComparer : IEqualityComparer<@event>

--- a/src/Tester/CodeGenTests/RuntimeCodeGenerationTests.cs
+++ b/src/Tester/CodeGenTests/RuntimeCodeGenerationTests.cs
@@ -61,7 +61,8 @@ namespace Tester.CodeGenTests
                 Id = Guid.NewGuid(),
                 @if = new List<@event> { new @event { Id = Guid.NewGuid() } },
                 PrivateId = Guid.NewGuid(),
-                @public = new @event { Id = Guid.NewGuid() }
+                @public = new @event { Id = Guid.NewGuid() },
+                Enum = @event.@enum.@int
             };
 
             var actual = await grain.SetState(expected);


### PR DESCRIPTION
Fixes #1072 & #1064.

I altered @randa1's tests from #1077 to fix them given this change.

`[assembly: KnownType(typeof(ConcreteType))]` will consider a single type for code generation. 

`[assembly: KnownAssembly(typeof(FSharpOption<int>))]` will consider an entire assembly for code generation.

I opted to allow specifying a `Type` for both attributes. In the case of `[KnownAssembly]`, it will take the assembly which the type is defined in. `[KnownAssembly]` can also take a string, `assemblyName`.

`AssemblyProcessor` was only calling `SerializationManager.FindSerializationInfo` and `GrainFactory.FindSupportClasses` for assemblies which were also candidates for code generation (i.e, is/references Orleans.dll). I've updated that so that any non-`ReflectionOnly` assembly will be scanned.