### PR TITLE
Fixed build warning

### DIFF
--- a/src/Tester/JsonFallbackSerializationTests.cs
+++ b/src/Tester/JsonFallbackSerializationTests.cs
@@ -30,7 +30,7 @@ namespace UnitTests.General
     /// Tests for the serialization system.
     /// </summary>
     [TestClass]
-    public class FallbackSerializationTests : SerializationTests
+    public class JsonFallbackSerializationTests : SerializationTests
     {
         /// <summary>
         /// Initializes the system for testing.

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -121,6 +121,7 @@
     <Compile Include="ConcreteStateClassTests.cs" />
     <Compile Include="ConfigurationTests\SerializationProviderTests.cs" />
     <Compile Include="DeactivationTests.cs" />
+    <Compile Include="JsonFallbackSerializationTests.cs" />
     <Compile Include="GenericGrainTests.cs" />
     <Compile Include="GrainInterfaceHierarchyTests.cs" />
     <Compile Include="MembershipTests\LivenessTests.cs" />

--- a/src/TesterInternal/General/InternalSerializationTests.cs
+++ b/src/TesterInternal/General/InternalSerializationTests.cs
@@ -40,7 +40,7 @@ namespace UnitTests.General
     /// Tests for the serialization system.
     /// </summary>
     [TestClass]
-    public class SerializationTests
+    public class InternalSerializationTests
     {
         /// <summary>
         /// Initializes the system for testing.

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -90,7 +90,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="General\BuiltInSerializerTests.cs" />
-    <Compile Include="General\FallbackSerializationTests.cs" />
     <Compile Include="General\Identifiertests.cs" />
     <Compile Include="General\InterfaceRules.cs" />
     <Compile Include="General\FallbackBuiltInSerializationTests.cs" />
@@ -106,7 +105,7 @@
     <Compile Include="RemindersTest\MySqlRemindersTableTests.cs" />
     <Compile Include="RemindersTest\ReminderTablePluginTests.cs" />
     <Compile Include="RemindersTest\SqlServerRemindersTableTests.cs" />
-    <Compile Include="General\SerializationTests.cs" />
+    <Compile Include="General\InternalSerializationTests.cs" />
     <Compile Include="StorageTests\AzureTableDataManagerStressTests.cs" />
     <Compile Include="StorageTests\AzureTableErrorCodeTests.cs" />
     <Compile Include="MembershipTests\AzureMembershipTableTests.cs" />


### PR DESCRIPTION
Fixed ```Warning CS0436 The type 'SerializationTests' in TesterInternal\General\SerializationTests.cs' conflicts with the imported type 'SerializationTests' in 'Tester, Version=1.0.0.0,'``` that was caused by duplicate names of test classes SerializationTests.cs