### PR TITLE
Reduce number of allocations during grain method call

### DIFF
--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -351,7 +351,7 @@ namespace Orleans.Runtime
         {
             if (debugContext == null && USE_DEBUG_CONTEXT)
             {
-                debugContext = GetDebugContext(this.InterfaceName, GetMethodName(this.InterfaceId, request.MethodId), request.Arguments);
+                debugContext = string.Intern(GetDebugContext(this.InterfaceName, GetMethodName(this.InterfaceId, request.MethodId), request.Arguments));
             }
 
             // Call any registered client pre-call interceptor function.


### PR DESCRIPTION
Currently on each grain method call string with debug context is being [allocated](https://github.com/dotnet/orleans/blob/master/src/Orleans/Runtime/GrainReference.cs#L354). 
Sample run of 28k grain methods calls.
Before fix:
![image](https://cloud.githubusercontent.com/assets/5787619/11433524/bc931ac6-94c6-11e5-80f0-341f63afede5.png)
After:
![2015-11-27_05-04-50](https://cloud.githubusercontent.com/assets/5787619/11433430/a6f027fa-94c5-11e5-8c8e-71490b67408f.png)