### PR TITLE
Added locking around InvokeData: cachedGenericInvokers insert.

### DIFF
--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -252,26 +252,37 @@ namespace Orleans.Runtime
             private readonly Type baseInvokerType;
             private IGrainMethodInvoker invoker;
             private readonly Dictionary<string, IGrainMethodInvoker> cachedGenericInvokers;
+            private readonly object cachedGenericInvokersLockObj;
 
             public InvokerData(Type invokerType)
             {
                 baseInvokerType = invokerType;
-                if(invokerType.GetTypeInfo().IsGenericType)
+                if (invokerType.GetTypeInfo().IsGenericType)
+                {
                     cachedGenericInvokers = new Dictionary<string, IGrainMethodInvoker>();
+                    cachedGenericInvokersLockObj = new object();;
+                }
             }
 
             public IGrainMethodInvoker GetInvoker(string genericGrainType = null)
             {
                 if (String.IsNullOrEmpty(genericGrainType))
                     return invoker ?? (invoker = (IGrainMethodInvoker) Activator.CreateInstance(baseInvokerType));
-                
-                if (cachedGenericInvokers.ContainsKey(genericGrainType))
-                    return cachedGenericInvokers[genericGrainType];
+                lock (cachedGenericInvokersLockObj)
+                {
+                    if (cachedGenericInvokers.ContainsKey(genericGrainType))
+                        return cachedGenericInvokers[genericGrainType];
+                }
 
                 var typeArgs = TypeUtils.GenericTypeArgs(genericGrainType);
                 var concreteType = baseInvokerType.MakeGenericType(typeArgs);
                 var inv = (IGrainMethodInvoker) Activator.CreateInstance(concreteType);
-                cachedGenericInvokers[genericGrainType] = inv;
+                lock (cachedGenericInvokersLockObj)
+                {
+                    if (!cachedGenericInvokers.ContainsKey(genericGrainType))
+                        cachedGenericInvokers[genericGrainType] = inv;
+                }
+
                 return inv;
             }
         }


### PR DESCRIPTION
On parallel invoking of the method of the reentrant generic grain the following exception is being thrown due to the parallel access to the non-concurrent dictionary ```cachedGenericInvokers ```. ![2015-11-29_18-02-32](https://cloud.githubusercontent.com/assets/5787619/11458224/d2ba4356-96c4-11e5-8407-5e986fdf5099.png)