### PR TITLE
Added a missing call to SerializationManager.InitializeForTesting()

### DIFF
--- a/src/TesterInternal/General/Identifiertests.cs
+++ b/src/TesterInternal/General/Identifiertests.cs
@@ -49,6 +49,7 @@ namespace UnitTests.General
         [TestInitialize]
         public void InitializeForTesting()
         {
+            SerializationManager.InitializeForTesting();
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
         }
 


### PR DESCRIPTION
Added a missing call to SerializationManager.InitializeForTesting(), absense of which was causing tests failures. For example, it caused a test failure in https://github.com/dotnet/orleans/pull/1082.