### PR TITLE
Fixed F# tests to allow for null values. Ignore failing tests, pending #1080.

### DIFF
--- a/src/Tester/FSharpGrainTests.cs
+++ b/src/Tester/FSharpGrainTests.cs
@@ -55,7 +55,7 @@ namespace UnitTests.General
             var id = Guid.NewGuid();
             var grain = GrainFactory.GetGrain<IGeneric1Argument<T>>(id, "UnitTests.Grains.Generic1ArgumentGrain");
             var output = await grain.Ping(input);
-            Assert.IsTrue(output.Equals(input));
+            Assert.AreEqual(input, output);
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp")]
@@ -71,7 +71,7 @@ namespace UnitTests.General
         }
 
         /// F# record without Serializable and Immutable attributes applied - yields a more meaningful error message
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofIntOption_Some_WithNoAttributes()
         {
             await PingTest<RecordOfIntOptionWithNoAttributes>(RecordOfIntOptionWithNoAttributes.ofInt(1));
@@ -79,7 +79,7 @@ namespace UnitTests.General
 
         /// F# record with Serializable and Immutable attributes applied - grain call times out,
         /// Debugging the test reveals the same root cause as for FSharpGrains_Record_ofIntOption_WithNoAttributes
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofIntOption_Some()
         {
             await PingTest<RecordOfIntOption>(RecordOfIntOption.ofInt(1));
@@ -98,7 +98,7 @@ namespace UnitTests.General
             await PingTest<GenericRecord<int>>(input);
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_GenericRecord_ofIntOption_Some()
         {
             var input = GenericRecord<FSharpOption<int>>.ofT(FSharpOption<int>.Some(0));
@@ -112,14 +112,14 @@ namespace UnitTests.General
             await PingTest<GenericRecord<FSharpOption<int>>>(input);
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_IntOption_Some()
         {
             var input = FSharpOption<int>.Some(0);
             await PingTest<FSharpOption<int>>(input);
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_IntOption_None()
         {
             var input = FSharpOption<int>.None;

--- a/src/Tester/SerializationTests.FSharpTypes.cs
+++ b/src/Tester/SerializationTests.FSharpTypes.cs
@@ -42,20 +42,20 @@ namespace UnitTests.General
             SerializationManager.InitializeForTesting();
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_IntOption_Some()
         {
             var input = FSharpOption<int>.Some(0);
             var output = SerializationManager.RoundTripSerializationForTesting(input);
-            Assert.IsTrue(output.Equals(input));
+            Assert.AreEqual(input, output);
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_IntOption_None()
         {
             var input = FSharpOption<int>.None;
             var output = SerializationManager.RoundTripSerializationForTesting(input);
-            Assert.IsTrue(output.Equals(input));
+            Assert.AreEqual(input, output);
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
@@ -63,15 +63,15 @@ namespace UnitTests.General
         {
             var input = Record.ofInt(1);
             var output = SerializationManager.RoundTripSerializationForTesting(input);
-            Assert.IsTrue(output.Equals(input));
+            Assert.AreEqual(input, output);
         }
 
-        [TestMethod, /*TestCategory("BVT"),*/ TestCategory("Failures"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Record_ofIntOption_Some()
         {
             var input = RecordOfIntOption.ofInt(1);
             var output = SerializationManager.RoundTripSerializationForTesting(input);
-            Assert.IsTrue(output.Equals(input));
+            Assert.AreEqual(input, output);
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
@@ -79,7 +79,7 @@ namespace UnitTests.General
         {
             var input = RecordOfIntOption.Empty;
             var output = SerializationManager.RoundTripSerializationForTesting(input);
-            Assert.IsTrue(output.Equals(input));
+            Assert.AreEqual(input, output);
         }
     }
 }


### PR DESCRIPTION
Some of the F# tests were failing due to incorrect checks. 
The remaining failing tests now have the ```Ignore``` attribute, pending the fix in #1080 (also included in  #1077)