### PR TITLE
Tighten up queue adapter interfaces

### DIFF
--- a/src/Orleans/Streams/QueueAdapters/IQueueAdapterCache.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueAdapterCache.cs
@@ -21,10 +21,6 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using Orleans.Streams;
-
 namespace Orleans.Streams
 {
     public interface IQueueAdapterCache
@@ -34,10 +30,5 @@ namespace Orleans.Streams
         /// </summary>
         /// <param name="messages"></param>
         IQueueCache CreateQueueCache(QueueId queueId);
-
-        /// <summary>
-        /// Current total size of this cache.
-        /// </summary>
-        int Size { get; }
     }
 }

--- a/src/Orleans/Streams/QueueAdapters/IQueueAdapterReceiver.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueAdapterReceiver.cs
@@ -32,8 +32,6 @@ namespace Orleans.Streams
     /// </summary>
     public interface IQueueAdapterReceiver
     {
-        QueueId Id { get; }
-
         /// <summary>
         /// Initialize this receiver.
         /// </summary>

--- a/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
@@ -29,16 +29,6 @@ namespace Orleans.Streams
     public interface IQueueCache
     {
         /// <summary>
-        /// The id of the queue for which this cache is caching data.
-        /// </summary>
-        QueueId Id { get; }
-
-        /// <summary>
-        /// Current cache size.
-        /// </summary>
-        int Size { get; }
-
-        /// <summary>
         /// The limit of the maximum number of items that can be added to the cache in a single AddToCache operation.
         /// </summary>
         int MaxAddCount { get; }

--- a/src/OrleansProviders/Streams/Common/SimpleQueueAdapterCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleQueueAdapterCache.cs
@@ -49,12 +49,7 @@ namespace Orleans.Providers.Streams.Common
 
         public IQueueCache CreateQueueCache(QueueId queueId)
         {
-            return caches.AddOrUpdate(queueId, (id) => new SimpleQueueCache(id, cacheSize, logger), (id, queueCache) => queueCache);
-        }
-
-        public int Size
-        {
-            get { return caches.Select(pair => pair.Value.Size).Sum(); }
+            return caches.AddOrUpdate(queueId, (id) => new SimpleQueueCache(cacheSize, logger), (id, queueCache) => queueCache);
         }
 
         public static int ParseSize(IProviderConfiguration config, int defaultSize)

--- a/src/OrleansProviders/Streams/Common/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleQueueCache.cs
@@ -66,8 +66,6 @@ namespace Orleans.Providers.Streams.Common
         private const int NUM_CACHE_HISTOGRAM_BUCKETS = 10;
         private readonly int CACHE_HISTOGRAM_MAX_BUCKET_SIZE;
 
-        public QueueId Id { get; private set; }
-
         public int Size 
         {
             get { return cachedMessages.Count; }
@@ -78,9 +76,8 @@ namespace Orleans.Providers.Streams.Common
             get { return CACHE_HISTOGRAM_MAX_BUCKET_SIZE; }
         }
 
-        public SimpleQueueCache(QueueId queueId, int cacheSize, Logger logger)
+        public SimpleQueueCache(int cacheSize, Logger logger)
         {
-            Id = queueId;
             cachedMessages = new LinkedList<SimpleQueueCacheItem>();
             maxCacheSize = cacheSize;
             

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -89,7 +89,8 @@ namespace Orleans.Streams
             numReadMessagesCounter = CounterStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_NUM_READ_MESSAGES, statUniquePostfix));
             numSentMessagesCounter = CounterStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_NUM_SENT_MESSAGES, statUniquePostfix));
             IntValueStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_PUBSUB_CACHE_SIZE, statUniquePostfix), () => pubSubCache.Count);
-            IntValueStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_QUEUE_CACHE_SIZE, statUniquePostfix), () => queueCache !=null ? queueCache.Size : 0);
+            // TODO: move queue cache size statistics tracking into queue cache implementation once Telemetry APIs and LogStatistics have been reconciled.
+            //IntValueStatistic.FindOrCreate(new StatisticName(StatisticNames.STREAMS_PERSISTENT_STREAM_QUEUE_CACHE_SIZE, statUniquePostfix), () => queueCache != null ? queueCache.Size : 0);
         }
 
         /// <summary>


### PR DESCRIPTION
In preparation for the introduction of a rewindable persistent stream provider using EventHub as it's backend queue, I'm making a cleanup pass of the queue adapter interfaces.

This change reduces queue interfaces’ surface area by limiting them to core functionality.
