### PR TITLE
Used [KnownAssembly] to generate F# serializers for testing

### DIFF
--- a/src/Build/GlobalAssemblyInfo.fs
+++ b/src/Build/GlobalAssemblyInfo.fs
@@ -27,11 +27,16 @@
 namespace Orleans.AssemblyInfo
 
 open System.Reflection
+open Orleans.CodeGeneration
+
 [<assembly: AssemblyCompany("Microsoft Corporation")>]
 [<assembly: AssemblyProduct("Orleans")>]
 [<assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation 2015")>]
 [<assembly: AssemblyVersion("1.0.0.0")>]
 [<assembly: AssemblyFileVersion("1.1.0.0")>]
 [<assembly: AssemblyInformationalVersion("1.1.0.0")>]
+
+// generate Orleans serializers for types in FSharp.core.dll
+[<assembly: KnownAssembly(typedefof<unit option>)>]
 
 do ()

--- a/src/Tester/FSharpGrainTests.cs
+++ b/src/Tester/FSharpGrainTests.cs
@@ -71,7 +71,7 @@ namespace UnitTests.General
         }
 
         /// F# record without Serializable and Immutable attributes applied - yields a more meaningful error message
-        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofIntOption_Some_WithNoAttributes()
         {
             await PingTest<RecordOfIntOptionWithNoAttributes>(RecordOfIntOptionWithNoAttributes.ofInt(1));
@@ -79,7 +79,7 @@ namespace UnitTests.General
 
         /// F# record with Serializable and Immutable attributes applied - grain call times out,
         /// Debugging the test reveals the same root cause as for FSharpGrains_Record_ofIntOption_WithNoAttributes
-        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_Record_ofIntOption_Some()
         {
             await PingTest<RecordOfIntOption>(RecordOfIntOption.ofInt(1));
@@ -98,7 +98,7 @@ namespace UnitTests.General
             await PingTest<GenericRecord<int>>(input);
         }
 
-        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_GenericRecord_ofIntOption_Some()
         {
             var input = GenericRecord<FSharpOption<int>>.ofT(FSharpOption<int>.Some(0));
@@ -112,7 +112,7 @@ namespace UnitTests.General
             await PingTest<GenericRecord<FSharpOption<int>>>(input);
         }
 
-        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_IntOption_Some()
         {
             var input = FSharpOption<int>.Some(0);

--- a/src/Tester/SerializationTests.FSharpTypes.cs
+++ b/src/Tester/SerializationTests.FSharpTypes.cs
@@ -42,44 +42,40 @@ namespace UnitTests.General
             SerializationManager.InitializeForTesting();
         }
 
-        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
-        public void SerializationTests_FSharp_IntOption_Some()
+        void RoundtripSerializationTest<T>(T input)
         {
-            var input = FSharpOption<int>.Some(0);
             var output = SerializationManager.RoundTripSerializationForTesting(input);
             Assert.AreEqual(input, output);
+        }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        public void SerializationTests_FSharp_IntOption_Some()
+        {
+            RoundtripSerializationTest(FSharpOption<int>.Some(0));
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_IntOption_None()
         {
-            var input = FSharpOption<int>.None;
-            var output = SerializationManager.RoundTripSerializationForTesting(input);
-            Assert.AreEqual(input, output);
+            RoundtripSerializationTest(FSharpOption<int>.None);
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Record_ofInt()
         {
-            var input = Record.ofInt(1);
-            var output = SerializationManager.RoundTripSerializationForTesting(input);
-            Assert.AreEqual(input, output);
+            RoundtripSerializationTest(Record.ofInt(1));
         }
 
-        [Ignore, TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Record_ofIntOption_Some()
         {
-            var input = RecordOfIntOption.ofInt(1);
-            var output = SerializationManager.RoundTripSerializationForTesting(input);
-            Assert.AreEqual(input, output);
+            RoundtripSerializationTest(RecordOfIntOption.ofInt(1));
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_Record_ofIntOption_None()
         {
-            var input = RecordOfIntOption.Empty;
-            var output = SerializationManager.RoundTripSerializationForTesting(input);
-            Assert.AreEqual(input, output);
+            RoundtripSerializationTest(RecordOfIntOption.Empty);
         }
     }
 }


### PR DESCRIPTION
F# Option serialization now works - we can close #1056 once this is merged. I've also streamlined the F# roundtrip serialization tests.