### PR TITLE
GeneratorStreamProvider - stream generation on command

### DIFF
--- a/src/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
+++ b/src/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
@@ -33,5 +33,7 @@ namespace TestGrainInterfaces
         Task ReportResult(Guid streamGuid, string streamProvider, string streamNamespace, int count);
 
         Task<IDictionary<Guid,int>> GetReport(string streamProvider, string streamNamespace);
+
+        Task Reset();
     }
 }

--- a/src/TestGrains/GeneratedEventReporterGrain.cs
+++ b/src/TestGrains/GeneratedEventReporterGrain.cs
@@ -69,5 +69,11 @@ namespace TestGrains
             }
             return Task.FromResult<IDictionary<Guid, int>>(counts);
         }
+
+        public Task Reset()
+        {
+            reports = new Dictionary<Tuple<string, string>, Dictionary<Guid, int>>();
+            return TaskDone.Done;
+        }
     }
 }

--- a/src/Tester/TestStreamProviders/Generator/GeneratorAdapterConfig.cs
+++ b/src/Tester/TestStreamProviders/Generator/GeneratorAdapterConfig.cs
@@ -57,7 +57,10 @@ namespace Tester.TestStreamProviders.Generator
         /// <returns></returns>
         public void WriteProperties(Dictionary<string, string> properties)
         {
-            properties.Add(GeneratorConfigTypeName, GeneratorConfigType.AssemblyQualifiedName);
+            if (GeneratorConfigType != null)
+            {
+                properties.Add(GeneratorConfigTypeName, GeneratorConfigType.AssemblyQualifiedName);
+            }
             properties.Add(TotalQueueCountName, TotalQueueCount.ToString(CultureInfo.InvariantCulture));
         }
 
@@ -68,10 +71,6 @@ namespace Tester.TestStreamProviders.Generator
         public virtual void PopulateFromProviderConfig(IProviderConfiguration providerConfiguration)
         {
             GeneratorConfigType = providerConfiguration.GetTypeProperty(GeneratorConfigTypeName, null);
-            if (GeneratorConfigType == null)
-            {
-                throw new ArgumentOutOfRangeException("providerConfiguration", "GeneratorConfigType not set.");
-            }
             if (string.IsNullOrWhiteSpace(StreamProviderName))
             {
                 throw new ArgumentOutOfRangeException("providerConfiguration", "StreamProviderName not set.");

--- a/src/Tester/TestStreamProviders/Generator/GeneratorAdapterFactory.cs
+++ b/src/Tester/TestStreamProviders/Generator/GeneratorAdapterFactory.cs
@@ -22,6 +22,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
@@ -32,12 +33,17 @@ using Orleans.Streams;
 
 namespace Tester.TestStreamProviders.Generator
 {
+    public enum StreamGeneratorCommand
+    {
+        Configure = PersistentStreamProviderCommand.AdapterFactoryCommandStartRange
+    }
+
     /// <summary>
     /// Adapter factory for stream generator stream provider.
     /// This factory acts as the adapter and the adapter factory.  It creates receivers that use configurable generator
     ///   to generate event streams, rather than reading them from storage.
     /// </summary>
-    public class GeneratorAdapterFactory : IQueueAdapterFactory, IQueueAdapter
+    public class GeneratorAdapterFactory : IQueueAdapterFactory, IQueueAdapter, IControllable
     {
         public const string GeneratorConfigTypeName = "StreamGeneratorConfigType";
         private IServiceProvider serviceProvider;
@@ -45,6 +51,7 @@ namespace Tester.TestStreamProviders.Generator
         private IStreamGeneratorConfig generatorConfig;
         private IStreamQueueMapper streamQueueMapper;
         private IStreamFailureHandler streamFailureHandler;
+        private ConcurrentDictionary<QueueId, Receiver> receivers;
         private Logger logger;
 
         public bool IsRewindable { get { return true; } }
@@ -52,16 +59,20 @@ namespace Tester.TestStreamProviders.Generator
 
         public void Init(IProviderConfiguration providerConfig, string providerName, Logger log, IServiceProvider svcProvider)
         {
-            this.logger = log;
-            this.serviceProvider = svcProvider;
+            logger = log;
+            serviceProvider = svcProvider;
+            receivers = new ConcurrentDictionary<QueueId, Receiver>();
             adapterConfig = new GeneratorAdapterConfig(providerName);
             adapterConfig.PopulateFromProviderConfig(providerConfig);
-            generatorConfig = serviceProvider.GetService(adapterConfig.GeneratorConfigType) as IStreamGeneratorConfig;
-            if (generatorConfig == null)
+            if (adapterConfig.GeneratorConfigType != null)
             {
-                throw new ArgumentOutOfRangeException("providerConfig", "GeneratorConfigType not valid.");
+                generatorConfig = serviceProvider.GetService(adapterConfig.GeneratorConfigType) as IStreamGeneratorConfig;
+                if (generatorConfig == null)
+                {
+                    throw new ArgumentOutOfRangeException("providerConfig", "GeneratorConfigType not valid.");
+                }
+                generatorConfig.PopulateFromProviderConfig(providerConfig);
             }
-            generatorConfig.PopulateFromProviderConfig(providerConfig);
         }
 
         public Task<IQueueAdapter> CreateAdapter()
@@ -94,32 +105,38 @@ namespace Tester.TestStreamProviders.Generator
 
         public IQueueAdapterReceiver CreateReceiver(QueueId queueId)
         {
-            var generator = serviceProvider.GetService(generatorConfig.StreamGeneratorType) as IStreamGenerator;
-            if (generator == null)
+            Receiver receiver = receivers.GetOrAdd(queueId, qid => new Receiver());
+            SetGeneratorOnReciever(receiver);
+            return receiver;
+        }
+
+        public Task<object> ExecuteCommand(int command, object arg)
+        {
+            if (arg == null)
             {
-                throw new OrleansException(string.Format("StreamGenerator type no supported: {0}", generatorConfig.StreamGeneratorType));
+                throw new ArgumentNullException("arg");
             }
-            generator.Configure(serviceProvider, generatorConfig);
-            return new Receiver(queueId, generator);
+            generatorConfig = arg as IStreamGeneratorConfig;
+            if (generatorConfig == null)
+            {
+                throw new ArgumentOutOfRangeException("arg", "Arg must by of type IStreamGeneratorConfig");
+            }
+
+            // update generator on recievers
+            foreach (Receiver receiver in receivers.Values)
+            {
+                SetGeneratorOnReciever(receiver);
+            }
+
+            return Task.FromResult<object>(true);
         }
 
         private class Receiver : IQueueAdapterReceiver
         {
             const int MaxDelayMs = 20;
-            private readonly IStreamGenerator queue;
             private readonly Random random = new Random((int)DateTime.UtcNow.Ticks % int.MaxValue);
 
-            public Receiver(QueueId queueId, IStreamGenerator queue)
-            {
-                if (queue == null)
-                {
-                    throw new NullReferenceException("queue");
-                }
-                Id = queueId;
-                this.queue = queue;
-            }
-
-            public QueueId Id { get; private set; }
+            public IStreamGenerator QueueGenerator { get; set; }
 
             public Task Initialize(TimeSpan timeout)
             {
@@ -130,7 +147,7 @@ namespace Tester.TestStreamProviders.Generator
             {
                 await Task.Delay(random.Next(1,MaxDelayMs));
                 List<IBatchContainer> batches;
-                if (!queue.TryReadEvents(DateTime.UtcNow, out batches))
+                if (QueueGenerator == null || !QueueGenerator.TryReadEvents(DateTime.UtcNow, out batches))
                 {
                     return new List<IBatchContainer>();
                 }
@@ -146,6 +163,23 @@ namespace Tester.TestStreamProviders.Generator
             {
                 return TaskDone.Done;
             }
+        }
+
+        private void SetGeneratorOnReciever(Receiver receiver)
+        {
+            // if we don't have generator configuration, don't set generator
+            if (generatorConfig == null)
+            {
+                return;
+            }
+
+            var generator = serviceProvider.GetService(generatorConfig.StreamGeneratorType) as IStreamGenerator;
+            if (generator == null)
+            {
+                throw new OrleansException(string.Format("StreamGenerator type not supported: {0}", generatorConfig.StreamGeneratorType));
+            }
+            generator.Configure(serviceProvider, generatorConfig);
+            receiver.QueueGenerator = generator;
         }
     }
 }

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -151,6 +151,7 @@
     <Compile Include="StreamingTests\PullingAgentManagementTests.cs" />
     <Compile Include="StreamingTests\DelayedQueueRebalancingTests.cs" />
     <Compile Include="StreamingTests\StreamFilteringTests.cs" />
+    <Compile Include="StreamingTests\ControllableStreamGeneratorProviderTests.cs" />
     <Compile Include="StreamingTests\StreamTestsConstants.cs" />
     <Compile Include="StreamingTests\SampleStreamingTests.cs" />
     <Compile Include="SimpleGrainTests.cs" />


### PR DESCRIPTION
Updated GeneratorStreamProvider to support updating stream generation on command.

Tests can now create controlled stream generation for specific scenarios that start on command and do not require silo restart.  This will be used in recoverable stream processing tests.