### PR TITLE
Fixed wrongly placed TestInitialize attribute on StreamFilteringTests.

### DIFF
--- a/src/Tester/StreamingTests/StreamFilteringTests.cs
+++ b/src/Tester/StreamingTests/StreamFilteringTests.cs
@@ -301,16 +301,6 @@ namespace Tester.StreamingTests
         {
         }
 
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            //Starts the storage emulator if not started already and it exists (i.e. is installed).
-            if (!StorageEmulator.TryStart())
-            {
-                Console.WriteLine("Azure Storage Emulator could not be started.");
-            }
-        }
-
         [ClassCleanup]
         public static void ClassCleanup()
         {
@@ -404,15 +394,6 @@ namespace Tester.StreamingTests
         {
         }
 
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            //Starts the storage emulator if not started already and it exists (i.e. is installed).
-            if (!StorageEmulator.TryStart())
-            {
-                Console.WriteLine("Azure Storage Emulator could not be started.");
-            }
-        }
 
         [ClassCleanup]
         public static void ClassCleanup()

--- a/src/Tester/StreamingTests/StreamFilteringTests.cs
+++ b/src/Tester/StreamingTests/StreamFilteringTests.cs
@@ -41,8 +41,6 @@ namespace Tester.StreamingTests
     [ExcludeFromCodeCoverage]
     public abstract class StreamFilteringTestsBase : UnitTestSiloHost
     {
-        public TestContext TestContext { get; set; }
-
         protected Guid StreamId;
         protected string StreamNamespace;
         protected string streamProviderName;
@@ -54,34 +52,16 @@ namespace Tester.StreamingTests
         {
         }
 
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
+        protected void TestInitialize()
         {
-            //Starts the storage emulator if not started already and it exists (i.e. is installed).
-            if (!StorageEmulator.TryStart())
-            {
-                Console.WriteLine("Azure Storage Emulator could not be started.");
-            }
-        }
-
-        [ClassCleanup]
-        public static void ClassCleanup()
-        {
-            StopAllSilos();
-        }
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            logger.Info("TestInitialize - {0}", TestContext.TestName);
+            logger.Info("TestInitialize.");
             StreamId = Guid.NewGuid();
-            StreamNamespace = TestContext.TestName;
+            StreamNamespace = Guid.NewGuid().ToString();
         }
 
-        [TestCleanup]
-        public void TestCleanup()
+        protected void TestCleanup()
         {
-            logger.Info("TestCleanup - {0} - Test completed: Outcome = {1}", TestContext.TestName, TestContext.CurrentTestOutcome);
+            logger.Info("TestCleanup.");
 
             if (StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME.Equals(streamProviderName))
             {
@@ -321,6 +301,34 @@ namespace Tester.StreamingTests
         {
         }
 
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if (!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestInitialize]
+        public new void TestInitialize()
+        {
+            base.TestInitialize();
+        }
+
+        [TestCleanup]
+        public new void TestCleanup()
+        {
+            base.TestCleanup();
+        }
+
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Filters")]
         public async Task SMS_Filter_Basic()
         {
@@ -394,6 +402,34 @@ namespace Tester.StreamingTests
         public StreamFilteringTests_AQ()
             : base(siloOptions, clientOptions)
         {
+        }
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            //Starts the storage emulator if not started already and it exists (i.e. is installed).
+            if (!StorageEmulator.TryStart())
+            {
+                Console.WriteLine("Azure Storage Emulator could not be started.");
+            }
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestInitialize]
+        public new void TestInitialize()
+        {
+            base.TestInitialize();
+        }
+
+        [TestCleanup]
+        public new void TestCleanup()
+        {
+            base.TestCleanup();
         }
 
         [Ignore]


### PR DESCRIPTION
`TestInitialize` attribute can only be placed on class marked as `[TestClass]`. Therefore, moved `TestInitialize` attribute from the base class to the actual Test class.