### PR TITLE
GrainDirectory Refactoring and Multi-Cluster Registration

### DIFF
--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Net;
 using System.Xml;
+using Orleans.GrainDirectory;
 using Orleans.Providers;
 using Orleans.Streams;
 using Orleans.Storage;
@@ -329,6 +330,8 @@ namespace Orleans.Runtime.Configuration
 
         public string DefaultPlacementStrategy { get; set; }
 
+        public string DefaultMultiClusterRegistrationStrategy { get; set; }
+
         public TimeSpan DeploymentLoadPublisherRefreshTime { get; set; }
 
         public int ActivationCountBasedPlacementChooseOutOf { get; set; }
@@ -399,6 +402,7 @@ namespace Orleans.Runtime.Configuration
         private static readonly TimeSpan DEFAULT_CLIENT_REGISTRATION_REFRESH = TimeSpan.FromMinutes(5);
         public const bool DEFAULT_PERFORM_DEADLOCK_DETECTION = false;
         public static readonly string DEFAULT_PLACEMENT_STRATEGY = typeof(RandomPlacement).Name;
+        public static readonly string DEFAULT_MULTICLUSTER_REGISTRATION_STRATEGY = typeof(ClusterLocalRegistration).Name;
         private static readonly TimeSpan DEFAULT_DEPLOYMENT_LOAD_PUBLISHER_REFRESH_TIME = TimeSpan.FromSeconds(1);
         private const int DEFAULT_ACTIVATION_COUNT_BASED_PLACEMENT_CHOOSE_OUT_OF = 2;
 
@@ -446,6 +450,7 @@ namespace Orleans.Runtime.Configuration
             PerformDeadlockDetection = DEFAULT_PERFORM_DEADLOCK_DETECTION;
             reminderServiceType = ReminderServiceProviderType.NotSpecified;
             DefaultPlacementStrategy = DEFAULT_PLACEMENT_STRATEGY;
+            DefaultMultiClusterRegistrationStrategy = DEFAULT_MULTICLUSTER_REGISTRATION_STRATEGY;
             DeploymentLoadPublisherRefreshTime = DEFAULT_DEPLOYMENT_LOAD_PUBLISHER_REFRESH_TIME;
             ActivationCountBasedPlacementChooseOutOf = DEFAULT_ACTIVATION_COUNT_BASED_PLACEMENT_CHOOSE_OUT_OF;
             UseVirtualBucketsConsistentRing = DEFAULT_USE_VIRTUAL_RING_BUCKETS;

--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -1,4 +1,5 @@
 using System;
+using Orleans.GrainDirectory;
 
 namespace Orleans
 {
@@ -83,6 +84,36 @@ namespace Orleans
         [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class)]
         public sealed class ImmutableAttribute : Attribute
         {
+        }
+    }
+
+    namespace MultiCluster
+    {
+        /// <summary>
+        /// base class for multi cluster registration strategies.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Class)]
+        public abstract class RegistrationAttribute : Attribute
+        {
+            internal MultiClusterRegistrationStrategy RegistrationStrategy { get; private set; }
+
+            internal RegistrationAttribute(MultiClusterRegistrationStrategy strategy)
+            {
+                RegistrationStrategy = strategy ?? MultiClusterRegistrationStrategy.GetDefault();
+            }
+        }
+
+        /// <summary>
+        /// This attribute indicates that instances of the marked grain class
+        /// will have an independent instance for each cluster with 
+        /// no coordination. 
+        /// </summary>
+        public class OneInstancePerClusterAttribute : RegistrationAttribute
+        {
+            public OneInstancePerClusterAttribute()
+                : base(ClusterLocalRegistration.Singleton)
+            {
+            }
         }
     }
 

--- a/src/Orleans/GrainDirectory/ClusterLocalRegistration.cs
+++ b/src/Orleans/GrainDirectory/ClusterLocalRegistration.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace Orleans.GrainDirectory
+{
+    /// <summary>
+    /// A multi-cluster registration strategy where each cluster has 
+    /// its own independent directory. This is the default.
+    /// </summary>
+    [Serializable]
+    internal class ClusterLocalRegistration : MultiClusterRegistrationStrategy
+    {
+        private static readonly Lazy<ClusterLocalRegistration> singleton = new Lazy<ClusterLocalRegistration>(() => new ClusterLocalRegistration());
+
+        internal static ClusterLocalRegistration Singleton
+        {
+            get { return singleton.Value; }
+        }
+
+        internal static void Initialize()
+        {
+            var instance = Singleton;
+        }
+
+        private ClusterLocalRegistration()
+        { }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ClusterLocalRegistration;
+        }
+
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode();
+        }
+
+        internal override bool IsSingleInstance()
+        {
+            return true;
+        }
+    }
+}

--- a/src/Orleans/GrainDirectory/IGrainDirectory.cs
+++ b/src/Orleans/GrainDirectory/IGrainDirectory.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace Orleans.GrainDirectory
+{
+
+    /// <summary>
+    /// Recursive distributed operations on grain directories.
+    /// Each operation may forward the request to a remote owner, increasing the hopCount.
+    /// 
+    /// The methods here can be called remotely (where extended by IRemoteGrainDirectory) or
+    /// locally (where extended by ILocalGrainDirectory)
+    /// </summary>
+    interface IGrainDirectory
+    {
+        /// <summary>
+        /// Record a new grain activation by adding it to the directory.
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="address">The address of the new activation.</param>
+        /// <param name="singleActivation">If true, use single-activation mode: 
+        /// If there is already an activation registered for this grain, then the new activation will
+        /// not be registered and the address of the existing activation will be returned.
+        /// Otherwise, the passed-in address will be returned.</param>
+        /// <param name="hopCount">Counts recursion depth across silos</param>
+        /// <returns>The registered address and the version associated with this directory mapping.</returns>
+        Task<AddressAndTag> RegisterAsync(ActivationAddress address, bool singleActivation, int hopCount = 0);
+
+        /// <summary>
+        /// Removes the record for an existing activation from the directory service.
+        /// This is used when an activation is being deleted.
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="address">The address of the activation to remove.</param>
+        /// <param name="hopCount">Counts recursion depth across silos</param>
+        /// <returns>An acknowledgement that the unregistration has completed.</returns>
+        Task UnregisterAsync(ActivationAddress address, bool force = true, int hopCount = 0);
+
+        /// <summary>
+        /// Unregister a batch of addresses at once
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="addresses"></param>
+        /// <param name="hopCount">Counts recursion depth across silos</param>
+        /// <returns>An acknowledgement that the unregistration has completed.</returns>
+        Task UnregisterManyAsync(List<ActivationAddress> addresses, int hopCount = 0);
+
+        /// <summary>
+        /// Removes all directory information about a grain.
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="grainId">The ID of the grain.</param>
+        /// <param name="hopCount">Counts recursion depth across silos</param>
+        /// <returns>An acknowledgement that the deletion has completed.
+        /// It is safe to ignore this result.</returns>
+        Task DeleteGrainAsync(GrainId grainId, int hopCount = 0);
+
+        /// <summary>
+        /// Fetches complete directory information for a grain.
+        /// If there is no local information, then this method will query the appropriate remote directory node.
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="grain">The ID of the grain to look up.</param>
+        /// <param name="hopCount">Counts recursion depth across silos</param>
+        /// <returns>A list of all known activations of the grain, and the e-tag.</returns>
+        Task<AddressesAndTag> LookupAsync(GrainId grainId, int hopCount = 0);
+    }
+
+
+    [Serializable]
+    internal struct AddressAndTag
+    {
+        public ActivationAddress Address;
+        public int VersionTag;
+    }
+    
+
+    [Serializable]
+    internal struct AddressesAndTag 
+    {
+        public List<ActivationAddress> Addresses;
+        public int VersionTag;
+    }
+}

--- a/src/Orleans/GrainDirectory/IGrainRegistrar.cs
+++ b/src/Orleans/GrainDirectory/IGrainRegistrar.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace Orleans.GrainDirectory
+{
+    /// <summary>
+    /// A grain registrar takes responsibility of coordinating the registration of a grains,
+    /// possibly involving multiple clusters. 
+    /// The grain registrar is called only on the silo that is the owner for that grain.
+    /// </summary>
+    interface IGrainRegistrar
+    {
+
+        /// <summary>
+        /// Indicates whether this registrar can be called synchronously
+        /// </summary>
+        /// <returns>true if synchronous methods should be used, false if asynchronous methods should be used</returns>
+        bool IsSynchronous { get; }
+
+        /// <summary>
+        /// Registers a new activation with the directory service.
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="address">The address of the activation to register.</param>
+        /// <param name="singleActivation">If true, use single-activation registration</param>
+        /// <returns>The address registered for the grain's single activation.</returns>
+        AddressAndTag Register(ActivationAddress address, bool singleActivation);
+
+        /// <summary>
+        /// Registers a new activation with the directory service.
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="address">The address of the activation to register.</param>
+        /// <param name="singleActivation">If true, use single-activation registration</param>
+        /// <returns>The address registered for the grain's single activation.</returns>
+        Task<AddressAndTag> RegisterAsync(ActivationAddress address, bool singleActivation);
+
+        /// <summary>
+        /// Removes the given activation for the grain.
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="address"></param>
+        /// <param name="force"></param>
+        /// <returns></returns>
+        void Unregister(ActivationAddress address, bool force);
+
+        /// <summary>
+        /// Removes the given activation for the grain.
+        /// <para>This method must be called from a scheduler thread.</para>
+        /// </summary>
+        /// <param name="address"></param>
+        /// <param name="force"></param>
+        /// <returns></returns>
+        Task UnregisterAsync(ActivationAddress address, bool force);
+
+        /// <summary>
+        /// Deletes the grain activation.
+        /// </summary>
+        /// <returns></returns>
+        void Delete(GrainId gid);
+
+        /// <summary>
+        /// Deletes the grain activation.
+        /// </summary>
+        /// <returns></returns>
+        Task DeleteAsync(GrainId gid);
+    }
+}

--- a/src/Orleans/GrainDirectory/MultiClusterRegistrationStrategy.cs
+++ b/src/Orleans/GrainDirectory/MultiClusterRegistrationStrategy.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.GrainDirectory
+{
+    /// <summary>
+    /// A superclass for all multi-cluster registration strategies.
+    /// Strategy objects are used as keys to select the proper registrar.
+    /// </summary>
+    [Serializable]
+    internal abstract class MultiClusterRegistrationStrategy
+    {
+        private static MultiClusterRegistrationStrategy defaultStrategy;
+
+        internal static void Initialize(GlobalConfiguration config = null)
+        {
+            InitializeStrategies();
+            var strategy = config == null
+                ? GlobalConfiguration.DEFAULT_MULTICLUSTER_REGISTRATION_STRATEGY
+                : config.DefaultMultiClusterRegistrationStrategy;
+            defaultStrategy = GetStrategy(strategy);
+        }
+        
+        private static MultiClusterRegistrationStrategy GetStrategy(string strategy)
+        {
+            if (strategy.Equals(typeof (ClusterLocalRegistration).Name))
+            {
+                return ClusterLocalRegistration.Singleton;
+            }
+            return null;
+        }
+
+        private static void InitializeStrategies()
+        {
+            ClusterLocalRegistration.Initialize();
+        }
+
+        internal static MultiClusterRegistrationStrategy GetDefault()
+        {
+            return defaultStrategy;
+        }
+
+        internal abstract bool IsSingleInstance();
+    }
+}

--- a/src/Orleans/GrainDirectory/MultiClusterStatus.cs
+++ b/src/Orleans/GrainDirectory/MultiClusterStatus.cs
@@ -1,0 +1,33 @@
+﻿namespace Orleans.GrainDirectory
+{
+    /// <summary>
+    /// Status of a directory entry with respect to multi-cluster registration
+    /// </summary>
+    internal enum MultiClusterStatus : byte
+    {
+        /// <summary>
+        /// Registration is owned by this cluster.
+        /// </summary>
+        Owned,
+
+        /// <summary>
+        /// Failed to contact one or more clusters while registering, so may be a duplicate.
+        /// </summary>
+        Doubtful,
+
+        /// <summary>
+        /// Cached reference to a registration owned by a remote cluster.
+        /// </summary>
+        Cached,
+
+        /// <summary>
+        /// The cluster is in the process of checking remote clusters for existing registrations.
+        /// </summary>
+        RequestedOwnership,
+
+        /// <summary>
+        /// The cluster lost a race condition.
+        /// </summary>
+        RaceLoser,
+    }
+}

--- a/src/Orleans/IDs/ActivationAddress.cs
+++ b/src/Orleans/IDs/ActivationAddress.cs
@@ -1,5 +1,6 @@
 using System;
 using Newtonsoft.Json;
+using Orleans.GrainDirectory;
 
 namespace Orleans.Runtime
 {
@@ -9,6 +10,7 @@ namespace Orleans.Runtime
         public GrainId Grain { get; private set; }
         public ActivationId Activation { get; private set; }
         public SiloAddress Silo { get; private set; }
+        public MultiClusterStatus Status { get; private set; }
 
         public bool IsComplete
         {
@@ -16,11 +18,12 @@ namespace Orleans.Runtime
         }
 
         [JsonConstructor]
-        private ActivationAddress(SiloAddress silo, GrainId grain, ActivationId activation)
+        private ActivationAddress(SiloAddress silo, GrainId grain, ActivationId activation, MultiClusterStatus status)
         {
             Silo = silo;
             Grain = grain;
             Activation = activation;
+            Status = status;
         }
 
         public static ActivationAddress NewActivationAddress(SiloAddress silo, GrainId grain)
@@ -29,12 +32,12 @@ namespace Orleans.Runtime
             return GetAddress(silo, grain, activation);
         }
 
-        public static ActivationAddress GetAddress(SiloAddress silo, GrainId grain, ActivationId activation)
+        public static ActivationAddress GetAddress(SiloAddress silo, GrainId grain, ActivationId activation, MultiClusterStatus status = MultiClusterStatus.Owned)
         {
             // Silo part is not mandatory
             if (grain == null) throw new ArgumentNullException("grain");
 
-            return new ActivationAddress(silo, grain, activation);
+            return new ActivationAddress(silo, grain, activation, status);
         }
 
         public override bool Equals(object obj)

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -93,6 +93,7 @@
     <Compile Include="CodeGeneration\TypeFormattingOptions.cs" />
     <Compile Include="Core\IStatefulGrain.cs" />
     <Compile Include="Providers\DefaultServiceProvider.cs" />
+    <Compile Include="GrainDirectory\MultiClusterStatus.cs" />
     <Compile Include="Serialization\IExternalSerializer.cs" />
     <Compile Include="Configuration\LimitNames.cs" />
     <Compile Include="Configuration\LimitValue.cs" />
@@ -101,6 +102,10 @@
     <Compile Include="Core\IGrainIdentity.cs" />
     <Compile Include="Core\IStorage.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="GrainDirectory\MultiClusterRegistrationStrategy.cs" />
+    <Compile Include="GrainDirectory\IGrainDirectory.cs" />
+    <Compile Include="GrainDirectory\IGrainRegistrar.cs" />
+    <Compile Include="GrainDirectory\ClusterLocalRegistration.cs" />
     <Compile Include="IDs\GuidId.cs" />
     <Compile Include="Messaging\GatewayManager.cs" />
     <Compile Include="Messaging\IncomingMessageBuffer.cs" />

--- a/src/Orleans/Serialization/BinaryTokenStreamReader.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamReader.cs
@@ -10,6 +10,7 @@ using System.Text;
 
 using Orleans.Runtime;
 using Orleans.CodeGeneration;
+using Orleans.GrainDirectory;
 
 namespace Orleans.Serialization
 {
@@ -422,6 +423,12 @@ namespace Orleans.Serialization
             return new Guid(bytes);
         }
 
+        internal MultiClusterStatus ReadMultiClusterStatus()
+        {
+            byte val = ReadByte();
+            return (MultiClusterStatus) val;
+        }
+
         /// <summary> Read an <c>ActivationAddress</c> value from the stream. </summary>
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         internal ActivationAddress ReadActivationAddress()
@@ -429,6 +436,7 @@ namespace Orleans.Serialization
             var silo = ReadSiloAddress();
             var grain = ReadGrainId();
             var act = ReadActivationId();
+            var mcstatus = ReadMultiClusterStatus();
 
             if (silo.Equals(SiloAddress.Zero))
                 silo = null;
@@ -436,7 +444,7 @@ namespace Orleans.Serialization
             if (act.Equals(ActivationId.Zero))
                 act = null;
 
-            return ActivationAddress.GetAddress(silo, grain, act);
+            return ActivationAddress.GetAddress(silo, grain, act, mcstatus);
         }
 
         /// <summary>

--- a/src/Orleans/Serialization/BinaryTokenStreamWriter.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamWriter.cs
@@ -452,6 +452,7 @@ namespace Orleans.Serialization
             // GrainId must not be null
             Write(addr.Grain);
             Write(addr.Activation ?? ActivationId.Zero);
+            Write((byte) addr.Status);
         }
 
         /// <summary> Write a <c>SiloAddress</c> value to the stream. </summary>

--- a/src/Orleans/SystemTargetInterfaces/IRemoteGrainDirectory.cs
+++ b/src/Orleans/SystemTargetInterfaces/IRemoteGrainDirectory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Orleans.GrainDirectory;
 
 
 namespace Orleans.Runtime
@@ -9,6 +10,7 @@ namespace Orleans.Runtime
     {
         SiloAddress SiloAddress { get; }
         DateTime TimeCreated { get; }
+        MultiClusterStatus RegistrationStatus { get; set; }
     }
 
     internal interface IGrainInfo
@@ -17,84 +19,27 @@ namespace Orleans.Runtime
         int VersionTag { get; }
         bool SingleInstance { get; }
         bool AddActivation(ActivationId act, SiloAddress silo);
-        ActivationAddress AddSingleActivation(GrainId grain, ActivationId act, SiloAddress silo);
+        ActivationAddress AddSingleActivation(GrainId grain, ActivationId act, SiloAddress silo, MultiClusterStatus registrationStatus = MultiClusterStatus.Owned);
         bool RemoveActivation(ActivationAddress addr);
         bool RemoveActivation(ActivationId act, bool force);
         bool Merge(GrainId grain, IGrainInfo other);
+        void CacheOrUpdateRemoteClusterRegistration(GrainId grain, ActivationId oldActivation, ActivationId activation, SiloAddress silo);
+        bool UpdateClusterRegistrationStatus(ActivationId activationId, MultiClusterStatus registrationStatus, MultiClusterStatus? compareWith = null);
     }
 
     /// <summary>
     /// Per-silo system interface for managing the distributed, partitioned grain-silo-activation directory.
     /// </summary>
-    internal interface IRemoteGrainDirectory : ISystemTarget
-    {
-        /// <summary>
-        /// Record a new grain activation by adding it to the directory.
-        /// </summary>
-        /// <param name="address">The address of the new activation.</param>
-        /// <param name="retries">Number of retries to execute the method in case the virtual ring (servers) changes.</param>
-        /// <returns>The version associated with this directory mapping.</returns>
-        Task<int> Register(ActivationAddress address, int retries = 0);
-
+    internal interface IRemoteGrainDirectory : ISystemTarget, IGrainDirectory
+    {        
         /// <summary>
         /// Records a bunch of new grain activations.
+        /// This method should be called only remotely during handoff.
         /// </summary>
-        /// <param name="silo"></param>
-        /// <param name="addresses"></param>
-        /// <param name="retries">Number of retries to execute the method in case the virtual ring (servers) changes.</param>
+        /// <param name="addresses">The addresses of the grains to register</param>
+        /// <param name="singleActivation">If true, use single-activation registration</param>
         /// <returns></returns>
-        Task RegisterMany(List<ActivationAddress> addresses, int retries = 0);
-
-        /// <summary>
-        /// Registers a new activation, in single activation mode, with the directory service.
-        /// If there is already an activation registered for this grain, then the new activation will
-        /// not be registered and the address of the existing activation will be returned.
-        /// Otherwise, the passed-in address will be returned.
-        /// <para>This method must be called from a scheduler thread.</para>
-        /// </summary>
-        /// <param name="silo"></param>
-        /// <param name="address">The address of the potential new activation.</param>
-        /// <param name="retries">Number of retries to execute the method in case the virtual ring (servers) changes.</param>
-        /// <returns>The address registered for the grain's single activation and the version associated with it.</returns>
-        Task<Tuple<ActivationAddress, int>> RegisterSingleActivation(ActivationAddress address, int retries = 0);
-
-        /// <summary>
-        /// Registers multiple new activations, in single activation mode, with the directory service.
-        /// If there is already an activation registered for any of the grains, then the corresponding new activation will
-        /// not be registered.
-        /// <para>This method must be called from a scheduler thread.</para>
-        /// </summary>
-        /// <param name="silo"></param>
-        /// <param name="addresses"></param>
-        /// <param name="retries">Number of retries to execute the method in case the virtual ring (servers) changes.</param>
-        /// <returns></returns>
-        Task RegisterManySingleActivation(List<ActivationAddress> addresses, int retries = 0);
-
-        /// <summary>
-        /// Remove an activation from the directory.
-        /// </summary>
-        /// <param name="address">The address of the activation to unregister.</param>
-        /// <param name="force">If true, then the entry is removed; if false, then the entry is removed only if it is
-        /// sufficiently old.</param>
-        /// <param name="retries">Number of retries to execute the method in case the virtual ring (servers) changes.</param>
-        /// <returns>Success</returns>
-        Task Unregister(ActivationAddress address, bool force, int retries = 0);
-
-        /// <summary>
-        /// Removes all directory information about a grain.
-        /// </summary>
-        /// <param name="grain">The ID of the grain to look up.</param>
-        /// <param name="retries">Number of retries to execute the method in case the virtual ring (servers) changes.</param>
-        /// <returns></returns>
-        Task DeleteGrain(GrainId grain, int retries = 0);
-
-        /// <summary>
-        /// Fetch the list of the current activations for a grain along with the version number of the list.
-        /// </summary>
-        /// <param name="grain">The ID of the grain.</param>
-        /// <param name="retries">Number of retries to execute the method in case the virtual ring (servers) changes.</param>
-        /// <returns></returns>
-        Task<Tuple<List<Tuple<SiloAddress, ActivationId>>, int>> LookUp(GrainId grain, int retries = 0);
+        Task RegisterMany(List<ActivationAddress> addresses, bool singleActivation);
 
         /// <summary>
         /// Fetch the updated information on the given list of grains.
@@ -106,7 +51,7 @@ namespace Orleans.Runtime
         /// <returns>list of tuples holding a grain, generation number of the list of activations, and the list of activations. 
         /// If the generation number of the invoker matches the number of the destination, the list is null. If the destination does not
         /// hold the information on the grain, generation counter -1 is returned (and the list of activations is null)</returns>
-        Task<List<Tuple<GrainId, int, List<Tuple<SiloAddress, ActivationId>>>>> LookUpMany(List<Tuple<GrainId, int>> grainAndETagList, int retries = 0);
+        Task<List<Tuple<GrainId, int, List<ActivationAddress>>>> LookUpMany(List<Tuple<GrainId, int>> grainAndETagList);
 
         /// <summary>
         /// Handoffs the the directory partition from source silo to the destination silo.
@@ -124,13 +69,5 @@ namespace Orleans.Runtime
         /// <param name="source">The address of the owner of the partition.</param>
         /// <returns></returns>
         Task RemoveHandoffPartition(SiloAddress source);
-
-        /// <summary>
-        /// Unregister a block of addresses at once
-        /// </summary>
-        /// <param name="activationAddresses"></param>
-        /// <param name="retries"></param>
-        /// <returns></returns>
-        Task UnregisterMany(List<ActivationAddress> activationAddresses, int retries);
     }
 }

--- a/src/OrleansManager/Program.cs
+++ b/src/OrleansManager/Program.cs
@@ -10,7 +10,6 @@ namespace OrleansManager
     class Program
     {
         private static IManagementGrain systemManagement;
-        const int RETRIES = 3;
 
         static void Main(string[] args)
         {
@@ -167,8 +166,8 @@ namespace OrleansManager
 
             var directory = GrainClient.InternalGrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, silo);
 
-            WriteStatus(string.Format("**Calling DeleteGrain({0}, {1}, {2})", silo, grainId, RETRIES));
-            directory.DeleteGrain(grainId, RETRIES).Wait();
+            WriteStatus(string.Format("**Calling DeleteGrain({0}, {1}, {2})", silo, grainId));
+            directory.DeleteGrainAsync(grainId).Wait();
             WriteStatus(string.Format("**DeleteGrain finished OK."));
         }
 
@@ -181,11 +180,12 @@ namespace OrleansManager
 
             var directory = GrainClient.InternalGrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, silo);
   
-            WriteStatus(string.Format("**Calling LookupGrain({0}, {1}, {2})", silo, grainId, RETRIES));
-            Tuple<List<Tuple<SiloAddress, ActivationId>>, int> lookupResult = await directory.LookUp(grainId, RETRIES);
+            WriteStatus(string.Format("**Calling LookupGrain({0}, {1}, {2})", silo, grainId));
+            //Tuple<List<Tuple<SiloAddress, ActivationId>>, int> lookupResult = await directory.FullLookUp(grainId, true);
+            var lookupResult = await directory.LookupAsync(grainId);
 
             WriteStatus(string.Format("**LookupGrain finished OK. Lookup result is:"));
-            List<Tuple<SiloAddress, ActivationId>> list = lookupResult.Item1;
+            var list = lookupResult.Addresses;
             if (list == null)
             {
                 WriteStatus(string.Format("**The returned activation list is null."));
@@ -197,9 +197,9 @@ namespace OrleansManager
                 return;
             }
             Console.WriteLine("**There {0} {1} activations registered in the directory for this grain. The activations are:", (list.Count > 1) ? "are" : "is", list.Count);
-            foreach (Tuple<SiloAddress, ActivationId> tuple in list)
+            foreach (var tuple in list)
             {
-                WriteStatus(string.Format("**Activation {0} on silo {1}", tuple.Item2, tuple.Item1));
+                WriteStatus(string.Format("**Activation {0} on silo {1}", tuple.Activation, tuple.Silo));
             }
         }
 

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Orleans.Runtime.Configuration;
 using Orleans.Storage;
 using Orleans.CodeGeneration;
+using Orleans.GrainDirectory;
 
 namespace Orleans.Runtime
 {
@@ -143,7 +144,7 @@ namespace Orleans.Runtime
             nodeConfiguration = nodeConfig;
         }
 
-        public ActivationData(ActivationAddress addr, string genericArguments, PlacementStrategy placedUsing, IActivationCollector collector, TimeSpan ageLimit)
+        public ActivationData(ActivationAddress addr, string genericArguments, PlacementStrategy placedUsing, MultiClusterRegistrationStrategy registrationStrategy, IActivationCollector collector, TimeSpan ageLimit)
         {
             if (null == addr) throw new ArgumentNullException("addr");
             if (null == placedUsing) throw new ArgumentNullException("placedUsing");
@@ -154,7 +155,7 @@ namespace Orleans.Runtime
             Address = addr;
             State = ActivationState.Create;
             PlacedUsing = placedUsing;
-
+            RegistrationStrategy = registrationStrategy;
             if (!Grain.IsSystemTarget && !Constants.IsSystemGrain(Grain))
             {
                 this.collector = collector;
@@ -371,6 +372,8 @@ namespace Orleans.Runtime
         #region Dispatcher
 
         public PlacementStrategy PlacedUsing { get; private set; }
+
+        public MultiClusterRegistrationStrategy RegistrationStrategy { get; private set; }
 
         // currently, the only supported multi-activation grain is one using the StatelessWorkerPlacement strategy.
         internal bool IsStatelessWorker { get { return PlacedUsing is StatelessWorkerPlacement; } }

--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
 using Orleans.Runtime.MembershipService;
+using Orleans.MultiCluster;
 
 
 namespace Orleans.Runtime.Management
@@ -12,6 +13,7 @@ namespace Orleans.Runtime.Management
     /// <summary>
     /// Implementation class for the Orleans management grain.
     /// </summary>
+    [OneInstancePerCluster]
     internal class ManagementGrain : Grain, IManagementGrain
     {
         private Logger logger;

--- a/src/OrleansRuntime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
+++ b/src/OrleansRuntime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 
 using Orleans.Runtime.Scheduler;
@@ -142,8 +143,8 @@ namespace Orleans.Runtime.GrainDirectory
         }
 
         private void ProcessCacheRefreshResponse(
-            SiloAddress silo, 
-            IReadOnlyCollection<Tuple<GrainId, int, List<Tuple<SiloAddress, ActivationId>>>> refreshResponse)
+            SiloAddress silo,
+            IReadOnlyCollection<Tuple<GrainId, int, List<ActivationAddress>>> refreshResponse)
         {
             if (Log.IsVerbose2) Log.Verbose2("Silo {0} received ProcessCacheRefreshResponse. #Response entries {1}.", router.MyAddress, refreshResponse.Count);
 
@@ -153,12 +154,13 @@ namespace Orleans.Runtime.GrainDirectory
             var cacheRef = cache as AdaptiveGrainDirectoryCache<List<Tuple<SiloAddress, ActivationId>>>; 
 
             // pass through returned results and update the cache if needed
-            foreach (Tuple<GrainId, int, List<Tuple<SiloAddress, ActivationId>>> tuple in refreshResponse)
+            foreach (Tuple<GrainId, int, List<ActivationAddress>> tuple in refreshResponse)
             {
                 if (tuple.Item3 != null)
                 {
                     // the server returned an updated entry
-                    cacheRef.AddOrUpdate(tuple.Item1, tuple.Item3, tuple.Item2);
+                    var list = tuple.Item3.Select(a => Tuple.Create(a.Silo, a.Activation)).ToList();
+                    cacheRef.AddOrUpdate(tuple.Item1, list, tuple.Item2);
                     cnt1++;
                 }
                 else if (tuple.Item2 == -1)

--- a/src/OrleansRuntime/GrainDirectory/ClientObserverRegistrar.cs
+++ b/src/OrleansRuntime/GrainDirectory/ClientObserverRegistrar.cs
@@ -61,7 +61,7 @@ namespace Orleans.Runtime
             // That way, when we refresh it in the directiry, it's the same one.
             var addr = GetClientActivationAddress(clientId);
             scheduler.QueueTask(
-                () => ExecuteWithRetries(() => grainDirectory.RegisterAsync(addr), ErrorCode.ClientRegistrarFailedToRegister, String.Format("Directory.RegisterAsync {0} failed.", addr)),
+                () => ExecuteWithRetries(() => grainDirectory.RegisterAsync(addr, singleActivation:false), ErrorCode.ClientRegistrarFailedToRegister, String.Format("Directory.RegisterAsync {0} failed.", addr)),
                 this.SchedulingContext)
                         .Ignore();
         }
@@ -70,7 +70,7 @@ namespace Orleans.Runtime
         {
             var addr = GetClientActivationAddress(clientId);
             scheduler.QueueTask(
-                () => ExecuteWithRetries(() => grainDirectory.UnregisterAsync(addr), ErrorCode.ClientRegistrarFailedToUnregister, String.Format("Directory.UnRegisterAsync {0} failed.", addr)),
+                () => ExecuteWithRetries(() => grainDirectory.UnregisterAsync(addr, force:true), ErrorCode.ClientRegistrarFailedToUnregister, String.Format("Directory.UnRegisterAsync {0} failed.", addr)), 
                 this.SchedulingContext)
                         .Ignore();
         }
@@ -109,7 +109,7 @@ namespace Orleans.Runtime
                 foreach (GrainId clientId in clients)
                 {
                     var addr = GetClientActivationAddress(clientId);
-                    Task task = grainDirectory.RegisterAsync(addr).
+                    Task task = grainDirectory.RegisterAsync(addr, singleActivation:false).
                         LogException(logger, ErrorCode.ClientRegistrarFailedToRegister_2, String.Format("Directory.RegisterAsync {0} failed.", addr));
                     tasks.Add(task);
                 }

--- a/src/OrleansRuntime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/OrleansRuntime/GrainDirectory/GrainDirectoryPartition.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 using System.Text;
 using System;
+using Orleans.GrainDirectory;
 
 
 namespace Orleans.Runtime.GrainDirectory
@@ -12,17 +13,20 @@ namespace Orleans.Runtime.GrainDirectory
     {
         public SiloAddress SiloAddress { get; private set; }
         public DateTime TimeCreated { get; private set; }
+        public MultiClusterStatus RegistrationStatus { get; set; }
 
-        public ActivationInfo(SiloAddress siloAddress)
+        public ActivationInfo(SiloAddress siloAddress, MultiClusterStatus registrationStatus)
         {
             SiloAddress = siloAddress;
             TimeCreated = DateTime.UtcNow;
+            RegistrationStatus = registrationStatus;
         }
 
         public ActivationInfo(IActivationInfo iActivationInfo)
         {
             SiloAddress = iActivationInfo.SiloAddress;
             TimeCreated = iActivationInfo.TimeCreated;
+            RegistrationStatus = iActivationInfo.RegistrationStatus;
         }
 
         public override string ToString()
@@ -69,12 +73,12 @@ namespace Orleans.Runtime.GrainDirectory
                     return false;
                 }
             }
-            Instances[act] = new ActivationInfo(silo);
+            Instances[act] = new ActivationInfo(silo, MultiClusterStatus.Owned);
             VersionTag = rand.Next();
             return true;
         }
 
-        public ActivationAddress AddSingleActivation(GrainId grain, ActivationId act, SiloAddress silo)
+        public ActivationAddress AddSingleActivation(GrainId grain, ActivationId act, SiloAddress silo, MultiClusterStatus registrationStatus = MultiClusterStatus.Owned)
         {
             SingleInstance = true;
             if (Instances.Count > 0)
@@ -84,9 +88,9 @@ namespace Orleans.Runtime.GrainDirectory
             }
             else
             {
-                Instances.Add(act, new ActivationInfo(silo));
+                Instances.Add(act, new ActivationInfo(silo, registrationStatus));
                 VersionTag = rand.Next();
-                return ActivationAddress.GetAddress(silo, grain, act);
+                return ActivationAddress.GetAddress(silo, grain, act, registrationStatus);
             }
         }
 
@@ -127,7 +131,7 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 if (Instances.ContainsKey(pair.Key)) continue;
 
-                Instances[pair.Key] = new ActivationInfo(pair.Value.SiloAddress);
+                Instances[pair.Key] = new ActivationInfo(pair.Value.SiloAddress, pair.Value.RegistrationStatus);
                 modified = true;
             }
 
@@ -157,6 +161,28 @@ namespace Orleans.Runtime.GrainDirectory
                 return true;
             }
             return false;
+        }
+
+        public void CacheOrUpdateRemoteClusterRegistration(GrainId grain, ActivationId oldActivation, ActivationId activation, SiloAddress silo)
+        {
+            SingleInstance = true;
+
+            if (Instances.Count > 0)
+            {
+                Instances.Remove(oldActivation);
+            }
+            Instances.Add(activation, new ActivationInfo(silo, MultiClusterStatus.Cached));
+        }
+
+        public bool UpdateClusterRegistrationStatus(ActivationId activationId, MultiClusterStatus status, MultiClusterStatus? compareWith = null)
+        {
+            IActivationInfo activationInfo;
+            if (!Instances.TryGetValue(activationId, out activationInfo))
+                return false;
+            if (compareWith.HasValue && compareWith.Value != activationInfo.RegistrationStatus)
+                return false;
+            activationInfo.RegistrationStatus = status;
+            return true;
         }
     }
 
@@ -243,24 +269,28 @@ namespace Orleans.Runtime.GrainDirectory
         /// <param name="grain"></param>
         /// <param name="activation"></param>
         /// <param name="silo"></param>
+        /// <param name="registrationStatus"></param>
         /// <returns>The registered ActivationAddress and version associated with this directory mapping</returns>
-        internal virtual Tuple<ActivationAddress, int> AddSingleActivation(GrainId grain, ActivationId activation, SiloAddress silo)
+        internal virtual AddressAndTag AddSingleActivation(GrainId grain, ActivationId activation, SiloAddress silo, MultiClusterStatus registrationStatus = MultiClusterStatus.Owned)
         {
             if (log.IsVerbose3) log.Verbose3("Adding single activation for grain {0}{1}{2}", silo, grain, activation);
 
+            AddressAndTag result = new AddressAndTag();
+
             if (!IsValidSilo(silo))
-                return null;
+                return result;
             
-            ActivationAddress result;
             lock (lockable)
             {
                 if (!partitionData.ContainsKey(grain))
                 {
                     partitionData[grain] = new GrainInfo();
                 }
-                result = partitionData[grain].AddSingleActivation(grain, activation, silo);
+                var grainInfo = partitionData[grain];
+                result.Address = grainInfo.AddSingleActivation(grain, activation, silo, registrationStatus);
+                result.VersionTag = grainInfo.VersionTag;
             }
-            return Tuple.Create(result, partitionData[grain].VersionTag);
+            return result;
         }
 
         /// <summary>
@@ -300,24 +330,23 @@ namespace Orleans.Runtime.GrainDirectory
         /// </summary>
         /// <param name="grain"></param>
         /// <returns></returns>
-        internal Tuple<List<Tuple<SiloAddress, ActivationId>>, int> LookUpGrain(GrainId grain)
+        internal AddressesAndTag LookUpGrain(GrainId grain)
         {
+            var result = new AddressesAndTag();
             lock (lockable)
             {
-                if (!partitionData.ContainsKey(grain)) return null;
-
-                var result = new Tuple<List<Tuple<SiloAddress, ActivationId>>, int>(
-                    new List<Tuple<SiloAddress, ActivationId>>(), partitionData[grain].VersionTag);
-
-                foreach (var route in partitionData[grain].Instances)
+                if (partitionData.ContainsKey(grain))
                 {
-                    if (IsValidSilo(route.Value.SiloAddress))
+                    result.Addresses = new List<ActivationAddress>();
+                    result.VersionTag = partitionData[grain].VersionTag;
+
+                    foreach (var route in partitionData[grain].Instances.Where(route => IsValidSilo(route.Value.SiloAddress)))
                     {
-                        result.Item1.Add(new Tuple<SiloAddress, ActivationId>(route.Value.SiloAddress, route.Key));
+                        result.Addresses.Add(ActivationAddress.GetAddress(route.Value.SiloAddress, grain, route.Key, route.Value.RegistrationStatus));
                     }
                 }
-                return result;
             }
+            return result;
         }
 
         /// <summary>
@@ -481,5 +510,37 @@ namespace Orleans.Runtime.GrainDirectory
 
             return sb.ToString();
         }
+
+        public void CacheOrUpdateRemoteClusterRegistration(GrainId grain, ActivationId oldActivation, ActivationAddress otherClusterAddress)
+        {
+            lock (lockable)
+            {
+                if (partitionData.ContainsKey(grain))
+                {
+                    partitionData[grain].CacheOrUpdateRemoteClusterRegistration(grain, oldActivation,
+                        otherClusterAddress.Activation, otherClusterAddress.Silo);
+
+                }
+                else
+                {
+                    AddSingleActivation(grain, otherClusterAddress.Activation, otherClusterAddress.Silo,
+                        MultiClusterStatus.Cached);
+                }
+            }
+        }
+
+        public bool UpdateClusterRegistrationStatus(GrainId grain, ActivationId activationId, MultiClusterStatus registrationStatus, MultiClusterStatus? compareWith = null)
+        {
+            lock (lockable)
+            {
+                if (partitionData.ContainsKey(grain))
+                {
+                    return partitionData[grain].UpdateClusterRegistrationStatus(activationId, registrationStatus, compareWith);
+                }
+                return false;
+            }
+        }
+
+     
     }
 }

--- a/src/OrleansRuntime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/ILocalGrainDirectory.cs
@@ -1,9 +1,10 @@
+using Orleans.GrainDirectory;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Orleans.Runtime.GrainDirectory
 {
-    interface ILocalGrainDirectory
+    interface ILocalGrainDirectory : IGrainDirectory
     {
         /// <summary>
         /// Starts the local portion of the directory service.
@@ -21,28 +22,6 @@ namespace Orleans.Runtime.GrainDirectory
         Task StopPreparationCompletion { get; }  // Will be resolved when this directory is prepared to stop
 
         /// <summary>
-        /// Registers a new activation with the directory service.
-        /// <para>This method must be called from a scheduler thread.</para>
-        /// </summary>
-        /// <param name="address">The address of the activation to register.</param>
-        Task RegisterAsync(ActivationAddress address);
-
-        /// <summary>
-        /// Removes the record for an existing activation from the directory service.
-        /// This is used when an activation is being deleted.
-        /// <para>This method must be called from a scheduler thread.</para>
-        /// </summary>
-        /// <param name="address">The address of the activation to remove.</param>
-        Task UnregisterAsync(ActivationAddress address);
-
-        /// <summary>
-        /// Unregister a batch of addresses at once
-        /// </summary>
-        /// <param name="addresses"></param>
-        /// <returns></returns>
-        Task UnregisterManyAsync(List<ActivationAddress> addresses);
-
-        /// <summary>
         /// Removes the record for an existing activation from the directory service,
         /// if it was created before the passed-in timestamp.
         /// This is used when a request is received for an activation that cannot be found, 
@@ -58,17 +37,6 @@ namespace Orleans.Runtime.GrainDirectory
         Task UnregisterConditionallyAsync(ActivationAddress address);
 
         /// <summary>
-        /// Registers a new activation, in single activation mode, with the directory service.
-        /// If there is already an activation registered for this grain, then the new activation will
-        /// not be registered and the address of the existing activation will be returned.
-        /// Otherwise, the passed-in address will be returned.
-        /// <para>This method must be called from a scheduler thread.</para>
-        /// </summary>
-        /// <param name="address">The address of the potential new activation.</param>
-        /// <returns>The address registered for the grain's single activation.</returns>
-        Task<ActivationAddress> RegisterSingleActivationAsync(ActivationAddress address);
-
-        /// <summary>
         /// Fetches locally known directory information for a grain.
         /// If there is no local information, either in the cache or in this node's directory partition,
         /// then this method will return false and leave the list empty.
@@ -76,25 +44,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// <param name="grain">The ID of the grain to look up.</param>
         /// <param name="addresses">An output parameter that receives the list of locally-known activations of the grain.</param>
         /// <returns>True if remote addresses are complete within freshness constraint</returns>
-        bool LocalLookup(GrainId grain, out List<ActivationAddress> addresses);
-
-        /// <summary>
-        /// Fetches complete directory information for a grain.
-        /// If there is no local information, then this method will query the appropriate remote directory node.
-        /// <para>This method must be called from a scheduler thread.</para>
-        /// </summary>
-        /// <param name="grain">The ID of the grain to look up.</param>
-        /// <returns>A list of all known activations of the grain.</returns>
-        Task<List<ActivationAddress>> FullLookup(GrainId grain);
-
-        /// <summary>
-        /// Removes all directory information about a grain.
-        /// <para>This method must be called from a scheduler thread.</para>
-        /// </summary>
-        /// <param name="grain">The ID of the grain to look up.</param>
-        /// <returns>An acknowledgement that the deletion has completed.
-        /// It is safe to ignore this result.</returns>
-        Task DeleteGrain(GrainId grain);
+        bool LocalLookup(GrainId grain, out AddressesAndTag addresses);
 
         /// <summary>
         /// Invalidates cache entry for the given activation address.
@@ -139,7 +89,7 @@ namespace Orleans.Runtime.GrainDirectory
         /// </summary>
         /// <param name="grain"></param>
         /// <returns></returns>
-        List<ActivationAddress> GetLocalDirectoryData(GrainId grain);
+        AddressesAndTag GetLocalDirectoryData(GrainId grain);
 
         /// <summary>
         /// For testing and troubleshhoting purposes only.

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/ClusterLocalRegistrar.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/ClusterLocalRegistrar.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.GrainDirectory;
+
+namespace Orleans.Runtime.GrainDirectory
+{
+    /// <summary>
+    /// The registrar for the Cluster-Local Registration Strategy.
+    /// </summary>
+    internal class ClusterLocalRegistrar : IGrainRegistrar
+    {
+        private GrainDirectoryPartition DirectoryPartition;
+
+        public ClusterLocalRegistrar(GrainDirectoryPartition partition)
+        {
+            DirectoryPartition = partition;
+        }
+
+        public bool IsSynchronous { get { return true; } }
+
+        public virtual AddressAndTag Register(ActivationAddress address, bool singleActivation)
+        {
+            if (singleActivation)
+            {
+                var result = DirectoryPartition.AddSingleActivation(address.Grain, address.Activation, address.Silo);
+                return result;
+            }
+            else
+            {
+                var tag = DirectoryPartition.AddActivation(address.Grain, address.Activation, address.Silo);
+                return new AddressAndTag() { Address = address, VersionTag = tag };
+            }
+        }
+  
+        public virtual void Unregister(ActivationAddress address, bool force)
+        {
+            DirectoryPartition.RemoveActivation(address.Grain, address.Activation, force);
+        }
+
+        public virtual void Delete(GrainId gid)
+        {
+            DirectoryPartition.RemoveGrain(gid);
+        }
+
+
+        public virtual Task<AddressAndTag> RegisterAsync(ActivationAddress address, bool singleActivation)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public virtual Task UnregisterAsync(ActivationAddress address, bool force)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public virtual Task DeleteAsync(GrainId gid)
+        {
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/RegistrarManager.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/RegistrarManager.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using Orleans.GrainDirectory;
+
+namespace Orleans.Runtime.GrainDirectory
+{
+    /// <summary>
+    /// Maps multi-cluster registration strategies to the corresponding registrar
+    /// </summary>
+    internal class RegistrarManager
+    {
+        private readonly Dictionary<Type, IGrainRegistrar> registrars = new Dictionary<Type, IGrainRegistrar>();
+
+        public static RegistrarManager Instance { get; private set; }
+
+
+        private RegistrarManager()
+        {
+        }
+
+        public static void InitializeGrainDirectoryManager(LocalGrainDirectory router)
+        {
+            Instance = new RegistrarManager();
+            Instance.Register<ClusterLocalRegistration>(new ClusterLocalRegistrar(router.DirectoryPartition));
+        }
+
+        private void Register<TStrategy>(IGrainRegistrar directory)
+            where TStrategy : MultiClusterRegistrationStrategy
+        {
+            this.registrars.Add(typeof(TStrategy), directory);
+        }
+
+        public IGrainRegistrar GetRegistrarForGrain(GrainId grainId)
+        {
+            MultiClusterRegistrationStrategy strategy;
+
+            var typeCode = grainId.GetTypeCode();
+
+            if (typeCode != 0)
+            {
+                string unusedGrainClass;
+                PlacementStrategy unusedPlacement;
+                GrainTypeManager.Instance.GetTypeInfo(grainId.GetTypeCode(), out unusedGrainClass, out unusedPlacement, out strategy);
+            }
+            else
+            {
+                // special case for Membership grain or client grain.
+                strategy = ClusterLocalRegistration.Singleton; // default
+            }
+
+            return this.registrars[strategy.GetType()];
+        }
+    }
+}

--- a/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
+using Orleans.GrainDirectory;
 
 namespace Orleans.Runtime.GrainDirectory
 {
@@ -12,8 +12,6 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly GrainDirectoryPartition partition;
         private readonly TraceLogger logger;
 
-        private static readonly TimeSpan RETRY_DELAY = TimeSpan.FromSeconds(5); // Pause 5 seconds between forwards to let the membership directory settle down
-
         internal RemoteGrainDirectory(LocalGrainDirectory r, GrainId id)
             : base(id, r.MyAddress)
         {
@@ -22,313 +20,53 @@ namespace Orleans.Runtime.GrainDirectory
             logger = TraceLogger.GetLogger("Orleans.GrainDirectory.CacheValidator", TraceLogger.LoggerType.Runtime);
         }
 
-        public async Task<int> Register(ActivationAddress address, int retries)
+        public async Task<AddressAndTag> RegisterAsync(ActivationAddress address, bool singleActivation, int hopCount)
         {
-            router.RegistrationsRemoteReceived.Increment();
-            // validate that this grain should be stored in our partition
-            SiloAddress owner = router.CalculateTargetSilo(address.Grain);
-            if (owner == null)
-            {
-                // We don't know about any other silos, and we're stopping, so throw
-                throw new InvalidOperationException("Grain directory is stopping");
-            }
+            (singleActivation ? router.RegistrationsSingleActRemoteReceived : router.RegistrationsRemoteReceived).Increment();
             
-            if (router.MyAddress.Equals(owner))
-            {
-                router.RegistrationsLocal.Increment();
-                return partition.AddActivation(address.Grain, address.Activation, address.Silo);
-            }
-
-            if (retries > 0)
-            {
-                if (logger.IsVerbose2) logger.Verbose2("Retry " + retries + " RemoteGrainDirectory.Register for address=" + address + " at Owner=" + owner);
-                PrepareForRetry(retries);
-
-                await Task.Delay(RETRY_DELAY);
-                
-                SiloAddress o = router.CalculateTargetSilo(address.Grain);
-                if (o == null)
-                {
-                    // We don't know about any other silos, and we're stopping, so throw
-                    throw new InvalidOperationException("Grain directory is stopping");
-                }
-                if (router.MyAddress.Equals(o))
-                {
-                    router.RegistrationsLocal.Increment();
-                    return partition.AddActivation(address.Grain, address.Activation, address.Silo);
-                }
-                router.RegistrationsRemoteSent.Increment();
-                return await GetDirectoryReference(o).Register(address, retries - 1);
-            }
-            
-            throw new OrleansException("Silo " + router.MyAddress + " is not the owner of the grain " + address.Grain + " Owner=" + owner);
+            return await router.RegisterAsync(address, singleActivation, hopCount);
         }
 
-        public Task RegisterMany(List<ActivationAddress> addresses, int retries)
+        public Task RegisterMany(List<ActivationAddress> addresses, bool singleActivation)
         {
-            return Task.WhenAll(addresses.Select(addr => Register(addr, retries)));
-        }
+            if (addresses == null || addresses.Count == 0)
+                throw new ArgumentException("addresses cannot be an empty list or null");
 
-        /// <summary>
-        /// Registers a new activation, in single activation mode, with the directory service.
-        /// If there is already an activation registered for this grain, then the new activation will
-        /// not be registered and the address of the existing activation will be returned.
-        /// Otherwise, the passed-in address will be returned.
-        /// <para>This method must be called from a scheduler thread.</para>
-        /// </summary>
-        /// <param name="address">The address of the potential new activation.</param>
-        /// <param name="retries"></param>
-        /// <returns>The address registered for the grain's single activation.</returns>
-        public async Task<Tuple<ActivationAddress, int>> RegisterSingleActivation(ActivationAddress address, int retries)
-        {
-            router.RegistrationsSingleActRemoteReceived.Increment();
-            if (logger.IsVerbose2) logger.Verbose2("Trying to register activation for grain. GrainId: {0}. ActivationId: {1}.", address.Grain, address.Activation);
-
-            // validate that this grain should be stored in our partition
-            SiloAddress owner = router.CalculateTargetSilo(address.Grain);
-            if (owner == null)
-            {
-                // We don't know about any other silos, and we're stopping, so throw
-                throw new InvalidOperationException("Grain directory is stopping");
-            }
-
-            if (router.MyAddress.Equals(owner))
-            {
-                router.RegistrationsSingleActLocal.Increment();
-                return partition.AddSingleActivation(address.Grain, address.Activation, address.Silo);
-            }
-
-            if (retries <= 0)
-                throw new OrleansException("Silo " + router.MyAddress + " is not the owner of the grain " +
-                                                address.Grain + " Owner=" + owner);
-
-            if (logger.IsVerbose2) logger.Verbose2("Retry {0} RemoteGrainDirectory.RegisterSingleActivation for address={1} at Owner={2}", retries, address, owner);
-            PrepareForRetry(retries);
-
-            await Task.Delay(RETRY_DELAY);
-
-            SiloAddress o = router.CalculateTargetSilo(address.Grain);
-            if (o == null)
-            {
-                // We don't know about any other silos, and we're stopping, so throw
-                throw new InvalidOperationException("Grain directory is stopping");
-            }
-            if (o.Equals(router.MyAddress))
-            {
-                router.RegistrationsSingleActLocal.Increment();
-                return partition.AddSingleActivation(address.Grain, address.Activation, address.Silo);
-            }
-            router.RegistrationsSingleActRemoteSent.Increment();
-            return await GetDirectoryReference(o).RegisterSingleActivation(address, retries - 1);
-        }
-
-        /// <summary>
-        /// Registers multiple new activations, in single activation mode, with the directory service.
-        /// If there is already an activation registered for any of the grains, then the corresponding new activation will
-        /// not be registered and the address of the existing activation will be returned.
-        /// Otherwise, the passed-in address will be returned.
-        /// <para>This method must be called from a scheduler thread.</para>
-        /// </summary>
-        /// <param name="addresses"></param>
-        /// <param name="retries">Number of retries to execute the method in case the virtual ring (servers) changes.</param>
-        /// <returns></returns>
-        public Task RegisterManySingleActivation(List<ActivationAddress> addresses, int retries)
-        {
             // validate that this request arrived correctly
             //logger.Assert(ErrorCode.Runtime_Error_100140, silo.Matches(router.MyAddress), "destination address != my address");
-            //var result = new List<ActivationAddress>();
-            if (logger.IsVerbose2) logger.Verbose2("RegisterManySingleActivation Count={0}", addresses.Count);
 
-            if (addresses.Count == 0)
-                return TaskDone.Done;
-            
-            var done = addresses.Select(addr => RegisterSingleActivation(addr, retries));
-            return Task.WhenAll(done);
+            if (logger.IsVerbose2) logger.Verbose2("RegisterMany Count={0}", addresses.Count);
+
+
+            return Task.WhenAll(addresses.Select(addr => router.RegisterAsync(addr, singleActivation, 1)));
         }
 
-        public async Task Unregister(ActivationAddress address, bool force, int retries)
+        public Task UnregisterAsync(ActivationAddress address, bool force, int hopCount)
         {
-            router.UnregistrationsRemoteReceived.Increment();
-            // validate that this grain should be stored in our partition
-            SiloAddress owner = router.CalculateTargetSilo(address.Grain);
-            if (owner == null)
-            {
-                // We don't know about any other silos, and we're stopping, so throw
-                throw new InvalidOperationException("Grain directory is stopping");
-            }
-
-            if (owner.Equals(router.MyAddress))
-            {
-                router.UnregistrationsLocal.Increment();
-                partition.RemoveActivation(address.Grain, address.Activation, force);
-                return;
-            }
-            
-            if (retries > 0)
-            {
-                if (logger.IsVerbose2) logger.Verbose2("Retry {0} RemoteGrainDirectory.Unregister for address={1} at Owner={2}", retries, address, owner);
-                PrepareForRetry(retries);
-
-                await Task.Delay(RETRY_DELAY);
-
-                SiloAddress o = router.CalculateTargetSilo(address.Grain);
-                if (o == null)
-                {
-                    // We don't know about any other silos, and we're stopping, so throw
-                    throw new InvalidOperationException("Grain directory is stopping");
-                }
-                if (o.Equals(router.MyAddress))
-                {
-                    router.UnregistrationsLocal.Increment();
-                    partition.RemoveActivation(address.Grain, address.Activation, force);
-                    return;
-                }
-                router.UnregistrationsRemoteSent.Increment();
-                await GetDirectoryReference(o).Unregister(address, force, retries - 1);
-            }
-            else
-            {
-                throw new OrleansException("Silo " + router.MyAddress + " is not the owner of the grain " + address.Grain + " Owner=" + owner);
-            }
+            return router.UnregisterAsync(address, force, hopCount);
         }
 
-        public async Task UnregisterMany(List<ActivationAddress> addresses, int retries)
+        public Task UnregisterManyAsync(List<ActivationAddress> addresses, int hopCount)
         {
-            router.UnregistrationsManyRemoteReceived.Increment();
-            var retry = new Dictionary<SiloAddress, List<ActivationAddress>>();
-            foreach (var address in addresses)
-            {
-                SiloAddress owner = router.CalculateTargetSilo(address.Grain);
-                if (owner == null)
-                {
-                    // We don't know about any other silos, and we're stopping, so throw
-                    throw new InvalidOperationException("Grain directory is stopping");
-                }
-
-                if (owner.Equals(router.MyAddress))
-                {
-                    router.UnregistrationsLocal.Increment();
-                    partition.RemoveActivation(address.Grain, address.Activation, true);
-                }
-                else
-                {
-                    List<ActivationAddress> list;
-                    if (retry.TryGetValue(owner, out list))
-                        list.Add(address);
-                    else
-                        retry[owner] = new List<ActivationAddress> {address};
-                }
-            }
-
-            if (retry.Count == 0) return;
-            if (retries <= 0)
-                throw new OrleansException("Silo " + router.MyAddress + " is not the owner of grains" + 
-                            Utils.DictionaryToString(retry, null, " "));
-            
-            PrepareForRetry(retries);
-            await Task.Delay(RETRY_DELAY);
-            await Task.WhenAll( retry.Select(p =>
-                    {
-                        router.UnregistrationsManyRemoteSent.Increment();
-                        return GetDirectoryReference(p.Key).UnregisterMany(p.Value, retries - 1);
-                    }));
+            return router.UnregisterManyAsync(addresses, hopCount);
         }
 
-        public async Task DeleteGrain(GrainId grain, int retries)
+        public  Task DeleteGrainAsync(GrainId grainId, int hopCount)
         {
-            // validate that this grain should be stored in our partition
-            SiloAddress owner = router.CalculateTargetSilo(grain);
-            if (owner == null)
-            {
-                // We don't know about any other silos, and we're stopping, so throw
-                throw new InvalidOperationException("Grain directory is stopping");
-            }
-            
-            if (owner.Equals(router.MyAddress))
-            {
-                partition.RemoveGrain(grain);
-                return;
-            }
-            
-            if (retries > 0)
-            {
-                if (logger.IsVerbose2) logger.Verbose2("Retry {0} RemoteGrainDirectory.DeleteGrain for Grain={1} at Owner={2}", retries, grain, owner);
-                PrepareForRetry(retries);
-
-                await Task.Delay(RETRY_DELAY);
-
-                SiloAddress o = router.CalculateTargetSilo(grain);
-                    if (o == null)
-                    {
-                        // We don't know about any other silos, and we're stopping, so throw
-                        throw new InvalidOperationException("Grain directory is stopping");
-                    }
-                    if (o.Equals(router.MyAddress))
-                    {
-                        partition.RemoveGrain(grain);
-                        return;
-                    }
-                    await GetDirectoryReference(o).DeleteGrain(grain, retries - 1);
-            }
-            else
-            {
-                throw new OrleansException("Silo " + router.MyAddress + " is not the owner of the grain " + grain + " Owner=" + owner);
-            }
+            return router.DeleteGrainAsync(grainId, hopCount);
         }
 
-        public async Task<Tuple<List<Tuple<SiloAddress, ActivationId>>, int>> LookUp(GrainId grain, int retries)
+        public Task<AddressesAndTag> LookupAsync(GrainId grainId, int hopCount)
         {
-            router.RemoteLookupsReceived.Increment();
-
-            // validate that this grain should be stored in our partition
-            SiloAddress owner = router.CalculateTargetSilo(grain, false);
-            if (router.MyAddress.Equals(owner))
-            {
-                router.LocalDirectoryLookups.Increment();
-                // It can happen that we cannot find the grain in our partition if there were 
-                // some recent changes in the membership. Return empty list in such case (and not null) to avoid
-                // NullReference exceptions in the code of invokers
-                Tuple<List<Tuple<SiloAddress, ActivationId>>, int> res = partition.LookUpGrain(grain);
-                if (res != null)
-                {
-                    router.LocalDirectorySuccesses.Increment();
-                    return res;
-                }
-
-                return new Tuple<List<Tuple<SiloAddress, ActivationId>>, int>(new List<Tuple<SiloAddress, ActivationId>>(), GrainInfo.NO_ETAG);
-            }
-
-            if (retries <= 0)
-                throw new OrleansException("Silo " + router.MyAddress + " is not the owner of the grain " + 
-                    grain + " Owner=" + owner);
-
-            if (logger.IsVerbose2) logger.Verbose2("Retry " + retries + " RemoteGrainDirectory.LookUp for Grain=" + grain + " at Owner=" + owner);
-            
-            PrepareForRetry(retries);
-            await Task.Delay(RETRY_DELAY);
-
-            SiloAddress o = router.CalculateTargetSilo(grain, false);
-            if (router.MyAddress.Equals(o))
-            {
-                router.LocalDirectoryLookups.Increment();
-                var res = partition.LookUpGrain(grain);
-                if (res == null)
-                    return new Tuple<List<Tuple<SiloAddress, ActivationId>>, int>(
-                        new List<Tuple<SiloAddress, ActivationId>>(), GrainInfo.NO_ETAG);
-
-                router.LocalDirectorySuccesses.Increment();
-                return res;
-            }
-            router.RemoteLookupsSent.Increment();
-            return await GetDirectoryReference(o).LookUp(grain, retries - 1);
+            return router.LookupAsync(grainId, hopCount);
         }
 
-        public Task<List<Tuple<GrainId, int, List<Tuple<SiloAddress, ActivationId>>>>> LookUpMany(List<Tuple<GrainId, int>> grainAndETagList, int retries)
+        public Task<List<Tuple<GrainId, int, List<ActivationAddress>>>> LookUpMany(List<Tuple<GrainId, int>> grainAndETagList)
         {
             router.CacheValidationsReceived.Increment();
             if (logger.IsVerbose2) logger.Verbose2("LookUpMany for {0} entries", grainAndETagList.Count);
 
-            var result = new List<Tuple<GrainId, int, List<Tuple<SiloAddress, ActivationId>>>>();
+            var result = new List<Tuple<GrainId, int, List<ActivationAddress>>>();
 
             foreach (Tuple<GrainId, int> tuple in grainAndETagList)
             {
@@ -336,20 +74,20 @@ namespace Orleans.Runtime.GrainDirectory
                 if (curGen == tuple.Item2 || curGen == GrainInfo.NO_ETAG)
                 {
                     // the grain entry either does not exist in the local partition (curGen = -1) or has not been updated
-                    result.Add(new Tuple<GrainId, int, List<Tuple<SiloAddress, ActivationId>>>(tuple.Item1, curGen, null));
+                    result.Add(new Tuple<GrainId, int, List<ActivationAddress>>(tuple.Item1, curGen, null));
                 }
                 else
                 {
                     // the grain entry has been updated -- fetch and return its current version
-                    Tuple<List<Tuple<SiloAddress, ActivationId>>, int> lookupResult = partition.LookUpGrain(tuple.Item1);
+                    var lookupResult = partition.LookUpGrain(tuple.Item1);
                     // validate that the entry is still in the directory (i.e., it was not removed concurrently)
-                    if (lookupResult != null)
+                    if (lookupResult.Addresses != null)
                     {
-                        result.Add(new Tuple<GrainId, int, List<Tuple<SiloAddress, ActivationId>>>(tuple.Item1, lookupResult.Item2, lookupResult.Item1));
+                        result.Add(new Tuple<GrainId, int, List<ActivationAddress>>(tuple.Item1, lookupResult.VersionTag, lookupResult.Addresses));
                     }
                     else
                     {
-                        result.Add(new Tuple<GrainId, int, List<Tuple<SiloAddress, ActivationId>>>(tuple.Item1, GrainInfo.NO_ETAG, null));
+                        result.Add(new Tuple<GrainId, int, List<ActivationAddress>>(tuple.Item1, GrainInfo.NO_ETAG, null));
                     }
                 }
             }

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Orleans.Concurrency;
+using Orleans.GrainDirectory;
 using Orleans.Placement;
 
 
@@ -105,6 +106,25 @@ namespace Orleans.Runtime
             }
 
             return PlacementStrategy.GetDefault();
+        }
+
+        internal static MultiClusterRegistrationStrategy GetMultiClusterRegistrationStrategy(Type grainClass)
+        {
+            var attribs = grainClass.GetCustomAttributes(typeof(Orleans.MultiCluster.RegistrationAttribute), inherit: true);
+
+            switch (attribs.Length)
+            {
+                case 0:
+                    return ClusterLocalRegistration.Singleton;
+                case 1:
+                    return ((Orleans.MultiCluster.RegistrationAttribute)attribs[0]).RegistrationStrategy;
+                default:
+                    throw new InvalidOperationException(
+                        string.Format(
+                            "More than one {0} cannot be specified for grain interface {1}",
+                            typeof(MultiClusterRegistrationStrategy).Name,
+                            grainClass.Name));
+            }
         }
     }
 }

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Orleans.CodeGeneration;
+using Orleans.GrainDirectory;
 using Orleans.Runtime.Providers;
 using Orleans.Serialization;
 using System.Reflection;
@@ -120,9 +121,9 @@ namespace Orleans.Runtime
             }
         }
 
-        internal void GetTypeInfo(int typeCode, out string grainClass, out PlacementStrategy placement, string genericArguments = null)
+        internal void GetTypeInfo(int typeCode, out string grainClass, out PlacementStrategy placement, out MultiClusterRegistrationStrategy activationStrategy, string genericArguments = null)
         {
-            if (!grainInterfaceMap.TryGetTypeInfo(typeCode, out grainClass, out placement, genericArguments))
+            if (!grainInterfaceMap.TryGetTypeInfo(typeCode, out grainClass, out placement, out activationStrategy, genericArguments))
                 throw new OrleansException(String.Format("Unexpected: Cannot find an implementation class for grain interface {0}", typeCode));
         }
 
@@ -154,6 +155,7 @@ namespace Orleans.Runtime
             var isGenericGrainClass = grainClass.ContainsGenericParameters;
             var grainClassTypeCode = CodeGeneration.GrainInterfaceData.GetGrainClassTypeCode(grainClass);
             var placement = GrainTypeData.GetPlacementStrategy(grainClass);
+            var registrationStrategy = GrainTypeData.GetMultiClusterRegistrationStrategy(grainClass);
 
             foreach (var iface in grainInterfaces)
             {
@@ -162,7 +164,7 @@ namespace Orleans.Runtime
                 var isPrimaryImplementor = IsPrimaryImplementor(grainClass, iface);
                 var ifaceId = CodeGeneration.GrainInterfaceData.GetGrainInterfaceId(iface);
                 grainInterfaceMap.AddEntry(ifaceId, iface, grainClassTypeCode, ifaceName, grainClassCompleteName, 
-                    grainClass.Assembly.CodeBase, isGenericGrainClass, placement, isPrimaryImplementor);
+                    grainClass.Assembly.CodeBase, isGenericGrainClass, placement, registrationStrategy, isPrimaryImplementor);
             }
 
             if (isUnordered)

--- a/src/OrleansRuntime/MembershipService/GrainBasedMembershipTable.cs
+++ b/src/OrleansRuntime/MembershipService/GrainBasedMembershipTable.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
+using Orleans.MultiCluster;
 using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.MembershipService
 {
     [Reentrant]
+    [OneInstancePerCluster]
     internal class GrainBasedMembershipTable : Grain, IMembershipTableGrain
     {
         private InMemoryMembershipTable table;

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -56,6 +56,8 @@
   <ItemGroup>
     <Compile Include="Catalog\ActivationState.cs" />
     <Compile Include="Counters\PerfCounterConfigData.cs" />
+    <Compile Include="GrainDirectory\MultiClusterRegistration\RegistrarManager.cs" />
+    <Compile Include="GrainDirectory\MultiClusterRegistration\ClusterLocalRegistrar.cs" />
     <Compile Include="GrainTypeManager\GenericGrainTypeData.cs" />
     <Compile Include="MembershipService\ISiloStatusListener.cs" />
     <Compile Include="MembershipService\ISiloStatusOracle.cs" />

--- a/src/OrleansRuntime/Placement/IPlacementContext.cs
+++ b/src/OrleansRuntime/Placement/IPlacementContext.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Orleans.GrainDirectory;
 
 namespace Orleans.Runtime.Placement
 {
@@ -13,9 +15,9 @@ namespace Orleans.Runtime.Placement
         /// <param name="grain"></param>
         /// <param name="addresses">Local addresses will always be complete, remote may be partial</param>
         /// <returns>True if remote addresses are complete within freshness constraint</returns>
-        bool FastLookup(GrainId grain, out List<ActivationAddress> addresses);
+        bool FastLookup(GrainId grain, out AddressesAndTag addresses);
 
-        Task<List<ActivationAddress>> FullLookup(GrainId grain);
+        Task<AddressesAndTag> FullLookup(GrainId grain);
 
         bool LocalLookup(GrainId grain, out List<ActivationData> addresses);
 
@@ -31,22 +33,23 @@ namespace Orleans.Runtime.Placement
         /// <returns></returns>
         bool TryGetActivationData(ActivationId id, out ActivationData activationData);
 
-        void GetGrainTypeInfo(int typeCode, out string grainClass, out PlacementStrategy placement, string genericArguments = null);
+        void GetGrainTypeInfo(int typeCode, out string grainClass, out PlacementStrategy placement, out MultiClusterRegistrationStrategy strategy, string genericArguments = null);
     }
 
     internal static class PlacementContextExtensions
     {
-        public static Task<List<ActivationAddress>> Lookup(this IPlacementContext @this, GrainId grainId)
+        public static Task<AddressesAndTag> Lookup(this IPlacementContext @this, GrainId grainId)
         {
-            List<ActivationAddress> l;
-            return @this.FastLookup(grainId, out l) ? Task.FromResult(l) : @this.FullLookup(grainId);
+            AddressesAndTag l;
+            return @this.FastLookup(grainId, out l) ? Task.FromResult(l) : @this.FullLookup(grainId); 
         }
 
         public static PlacementStrategy GetGrainPlacementStrategy(this IPlacementContext @this, int typeCode, string genericArguments = null)
         {
             string unused;
             PlacementStrategy placement;
-            @this.GetGrainTypeInfo(typeCode, out unused, out placement, genericArguments);
+            MultiClusterRegistrationStrategy unusedActivationStrategy;
+            @this.GetGrainTypeInfo(typeCode, out unused, out placement, out unusedActivationStrategy, genericArguments);
             return placement;
         }
 
@@ -59,7 +62,8 @@ namespace Orleans.Runtime.Placement
         {
             string grainClass;
             PlacementStrategy unused;
-            @this.GetGrainTypeInfo(typeCode, out grainClass, out unused, genericArguments);
+            MultiClusterRegistrationStrategy unusedActivationStrategy;
+            @this.GetGrainTypeInfo(typeCode, out grainClass, out unused, out unusedActivationStrategy, genericArguments);
             return grainClass;
         }
 
@@ -68,9 +72,9 @@ namespace Orleans.Runtime.Placement
             return @this.GetGrainTypeName(grainId.GetTypeCode(), genericArguments);
         }
 
-        public static void GetGrainTypeInfo(this IPlacementContext @this, GrainId grainId, out string grainClass, out PlacementStrategy placement, string genericArguments = null)
+        public static void GetGrainTypeInfo(this IPlacementContext @this, GrainId grainId, out string grainClass, out PlacementStrategy placement, out MultiClusterRegistrationStrategy activationStrategy, string genericArguments = null)
         {
-            @this.GetGrainTypeInfo(grainId.GetTypeCode(), out grainClass, out placement, genericArguments);
+            @this.GetGrainTypeInfo(grainId.GetTypeCode(), out grainClass, out placement, out activationStrategy, genericArguments);
         }
     }
 }

--- a/src/OrleansRuntime/Placement/RandomPlacementDirector.cs
+++ b/src/OrleansRuntime/Placement/RandomPlacementDirector.cs
@@ -11,7 +11,7 @@ namespace Orleans.Runtime.Placement
         internal override async Task<PlacementResult> OnSelectActivation(
             PlacementStrategy strategy, GrainId target, IPlacementContext context)
         {
-            List<ActivationAddress> places = await context.Lookup(target);
+            List<ActivationAddress> places = (await context.Lookup(target)).Addresses;
             if (places.Count <= 0)
             {
                 // we return null to indicate that we were unable to select a target from places activations.

--- a/src/OrleansRuntime/ReminderService/GrainBasedReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/GrainBasedReminderTable.cs
@@ -2,12 +2,14 @@ using System;
 using System.Threading.Tasks;
 
 using Orleans.Concurrency;
+using Orleans.MultiCluster;
 using Orleans.Runtime.Configuration;
 
 
 namespace Orleans.Runtime.ReminderService
 {
     [Reentrant]
+    [OneInstancePerCluster]
     internal class GrainBasedReminderTable : Grain, IReminderTableGrain
     {
         private InMemoryRemindersTable remTable;

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
+using Orleans.GrainDirectory;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.ConsistentRing;
@@ -160,7 +161,7 @@ namespace Orleans.Runtime
                 TraceLogger.Initialize(nodeConfig);
 
             config.OnConfigChange("Defaults/Tracing", () => TraceLogger.Initialize(nodeConfig, true), false);
-
+            MultiClusterRegistrationStrategy.Initialize();
             ActivationData.Init(config, nodeConfig);
             StatisticsCollector.Initialize(nodeConfig);
             
@@ -261,6 +262,8 @@ namespace Orleans.Runtime
             // Now the router/directory service
             // This has to come after the message center //; note that it then gets injected back into the message center.;
             localGrainDirectory = new LocalGrainDirectory(this); 
+
+            RegistrarManager.InitializeGrainDirectoryManager(localGrainDirectory);
 
             // Now the activation directory.
             // This needs to know which router to use so that it can keep the global directory in synch with the local one.
@@ -508,7 +511,7 @@ namespace Orleans.Runtime
                 if (reminderService != null)
                 {
                     // so, we have the view of the membership in the consistentRingProvider. We can start the reminder service
-                    scheduler.QueueTask(reminderService.Start, ((SystemTarget) reminderService).SchedulingContext)
+                    scheduler.QueueTask(reminderService.Start, ((SystemTarget)reminderService).SchedulingContext)
                         .WaitWithThrow(initTimeout);
                     if (logger.IsVerbose)
                     {

--- a/src/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
+++ b/src/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
+using Orleans.GrainDirectory;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
@@ -266,9 +267,9 @@ namespace UnitTests.General
             IReminderTable tableGrain = GrainClient.GrainFactory.GetGrain<IReminderTableGrain>(Constants.ReminderTableGrainId);
             SiloAddress reminderTableGrainPrimaryDirectoryAddress = this.HostedCluster.Primary.Silo.LocalGrainDirectory.GetPrimaryForGrain(((GrainReference) tableGrain).GrainId);
             SiloHandle reminderTableGrainPrimaryDirectory = this.HostedCluster.GetActiveSilos().Where(sh => sh.Silo.SiloAddress.Equals(reminderTableGrainPrimaryDirectoryAddress)).FirstOrDefault();
-            List<ActivationAddress> addresses = null;
+            AddressesAndTag addresses;
             bool res = reminderTableGrainPrimaryDirectory.Silo.LocalGrainDirectory.LocalLookup(((GrainReference)tableGrain).GrainId, out addresses);
-            ActivationAddress reminderGrainActivation = addresses.FirstOrDefault();
+            ActivationAddress reminderGrainActivation = addresses.Addresses.FirstOrDefault();
 
             SortedList<int, SiloHandle> ids = new SortedList<int, SiloHandle>();
             foreach (var siloHandle in this.HostedCluster.GetActiveSilos())

--- a/src/TesterInternal/Serialization/BuiltInSerializerTests.cs
+++ b/src/TesterInternal/Serialization/BuiltInSerializerTests.cs
@@ -12,6 +12,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
 using Orleans.CodeGeneration;
+using Orleans.GrainDirectory;
 
 // ReSharper disable NotAccessedVariable
 
@@ -36,17 +37,19 @@ namespace UnitTests.Serialization
         {
             SerializationManager.UseStandardSerializer = false;
             var grain = GrainId.NewId();
-            var addr = ActivationAddress.GetAddress(null, grain, null);
+            var addr = ActivationAddress.GetAddress(null, grain, null, MultiClusterStatus.Doubtful);
             var deserialized = OrleansSerializationLoop(addr, false);
             Assert.IsInstanceOfType(deserialized, typeof(ActivationAddress), "ActivationAddress copied as wrong type");
             Assert.IsNull(((ActivationAddress)deserialized).Activation, "Activation no longer null after copy");
             Assert.IsNull(((ActivationAddress)deserialized).Silo, "Silo no longer null after copy");
             Assert.AreEqual(grain, ((ActivationAddress)deserialized).Grain, "Grain different after copy");
+            Assert.AreEqual(MultiClusterStatus.Doubtful, ((ActivationAddress)deserialized).Status, "MultiClusterStatus different after copy");
             deserialized = OrleansSerializationLoop(addr);
             Assert.IsInstanceOfType(deserialized, typeof(ActivationAddress), "ActivationAddress full serialization loop as wrong type");
             Assert.IsNull(((ActivationAddress)deserialized).Activation, "Activation no longer null after full serialization loop");
             Assert.IsNull(((ActivationAddress)deserialized).Silo, "Silo no longer null after full serialization loop");
             Assert.AreEqual(grain, ((ActivationAddress)deserialized).Grain, "Grain different after copy");
+            Assert.AreEqual(MultiClusterStatus.Doubtful, ((ActivationAddress)deserialized).Status, "MultiClusterStatus different after copy");
         }
 
         [TestMethod, TestCategory("Functional"), TestCategory("Serialization")]


### PR DESCRIPTION
This branch contains

- some basic refactoring of the local and remote grain directory. There was a lot of code duplication between the various functions (register, registersingleact, unregister, delete) and between the local and remote grain directory. The proposed refactoring puts shared functionality into LocalGrainDirectory. It adds a hopcount parameter into the signature of the directory operations (replacing the retries parameter), which allows us to tell if something is a remote or local request, and whether we should retry. 

-  hooks for specifying a multi-cluster grain registration strategy. This strategy is defined by the type of the grain (e.g. using attributes). The strategy is used to look up the corresponding registrar for the grain. The actual registration/unregistration/deletion of a grain is done by that registrar.   
