### PR TITLE
Fixed starting Silo bug

### DIFF
--- a/Samples/TicTacToe/OrleansXO.WorkerRole/WorkerRole.cs
+++ b/Samples/TicTacToe/OrleansXO.WorkerRole/WorkerRole.cs
@@ -36,15 +36,28 @@ namespace OrleansXO.WorkerRole
             // Set the maximum number of concurrent connections 
             ServicePointManager.DefaultConnectionLimit = 12;
 
+            // Do other silo initialization – for example: Azure diagnostics, etc
+            
             // For information on handling configuration changes
             // see the MSDN topic at http://go.microsoft.com/fwlink/?LinkId=166357.
-
-            silo = new AzureSilo();
-
-            return silo.Start(); 
+            return base.OnStart();
         }
 
-        public override void OnStop() { silo.Stop(); }
-        public override void Run() { silo.Run(); } 
+        public override void OnStop() { 
+            silo.Stop();
+            base.Stop();
+        }
+        
+        public override void Run() { 
+            var config = new ClusterConfiguration();
+            config.StandardLoad();
+            
+            // It is IMPORTANT to start the silo not in OnStart but in Run. 
+            // Azure may not have the firewalls open yet (on the remote silos) at the OnStart phase.
+            silo = new AzureSilo();
+            bool isSiloStarted = silo.Start(config);
+            
+            silo.Run(); // Call will block until silo is shutdown
+        } 
     }
 }


### PR DESCRIPTION
Fixed starting Silo bug, I moved the logic to instantiate and start the
Silo into the Run() method.
It is IMPORTANT to start the silo not in OnStart but in Run. Azure may
not have the firewalls open yet (on the remote silos) at the OnStart
phase.