### PR TITLE
Add json.net as a dependency for Orleans.Core

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Brutal.Dev.StrongNameSigner" version="1.5.1" />
   <package id="FSharp.Compiler.Tools" version="4.0.0.1" />
 </packages>

--- a/src/NuGet/Microsoft.Orleans.Core.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Core.nuspec
@@ -17,6 +17,9 @@
     </description>
     <copyright>Copyright Microsoft 2015</copyright>
     <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
+    <dependencies>
+      <dependency id="Newtonsoft.Json" version="6.0.5" />
+    </dependencies>
   </metadata>
   <files>
     <file src="Orleans.dll" target="lib\net45" />

--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -20,7 +20,6 @@
     <dependencies>
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
-      <dependency id="Newtonsoft.Json" version="5.0.8" />
 	  <dependency id="ZooKeeperNetEx" version="3.4.6.1006" />
     </dependencies>
   </metadata>

--- a/src/NuGet/Microsoft.Orleans.Serialization.Bond.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Serialization.Bond.nuspec
@@ -21,7 +21,6 @@
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
       <dependency id="Bond.Runtime.CSharp" version="3.0.7" />
-      <dependency id="Newtonsoft.Json" version="6.0.5" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Orleans.dll depends on Newtonsoft.Json.dll now, so this is needed.
Removed dependencies on Newtonsoft.Json from other nuspecs.
Also, removed the unneeded reference to Brutal.Dev.StrongNameSigner.

This also needs to go to the 1.1.0 branch.