### PR TITLE
.Net 4.5.1 and Microsoft DI RC1 Update

### DIFF
--- a/src/ClientGenerator/ClientGenerator.csproj
+++ b/src/ClientGenerator/ClientGenerator.csproj
@@ -14,23 +14,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.CodeGeneration</RootNamespace>
     <AssemblyName>ClientGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>

--- a/src/NuGet/Microsoft.Orleans.Core.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Core.nuspec
@@ -22,9 +22,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Orleans.dll" target="lib\net45" />
-    <file src="Orleans.pdb" target="lib\net45" />
-	  <file src="Orleans.xml" target="lib\net45" />
+    <file src="Orleans.dll" target="lib\net451" />
+    <file src="Orleans.pdb" target="lib\net451" />
+	  <file src="Orleans.xml" target="lib\net451" />
     <file src="$SRC_DIR$Orleans\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
+++ b/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
@@ -24,9 +24,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansCounterControl.exe" target="lib\net45" />
-    <file src="OrleansCounterControl.pdb" target="lib\net45" />
-    <file src="OrleansCounterControl.exe.config" target="lib\net45" />
+    <file src="OrleansCounterControl.exe" target="lib\net451" />
+    <file src="OrleansCounterControl.pdb" target="lib\net451" />
+    <file src="OrleansCounterControl.exe.config" target="lib\net451" />
     <file src="$SRC_DIR$OrleansCounterControl\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.EventSourcing.nuspec
+++ b/src/NuGet/Microsoft.Orleans.EventSourcing.nuspec
@@ -22,9 +22,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansEventSourcing.dll" target="lib\net45" />
-    <file src="OrleansEventSourcing.pdb" target="lib\net45" />
-    <file src="OrleansEventSourcing.xml" target="lib\net45" />
+    <file src="OrleansEventSourcing.dll" target="lib\net451" />
+    <file src="OrleansEventSourcing.pdb" target="lib\net451" />
+    <file src="OrleansEventSourcing.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansEventSourcing\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -27,9 +27,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansAzureUtils.dll" target="lib\net45" />
-    <file src="OrleansAzureUtils.pdb" target="lib\net45" />
-    <file src="OrleansAzureUtils.xml" target="lib\net45" />
+    <file src="OrleansAzureUtils.dll" target="lib\net451" />
+    <file src="OrleansAzureUtils.pdb" target="lib\net451" />
+    <file src="OrleansAzureUtils.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansAzureUtils\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
@@ -23,7 +23,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansCodeGenerator.dll" target="lib\net45" />
+    <file src="OrleansCodeGenerator.dll" target="lib\net451" />
     <file src="$SRC_DIR$OrleansCodeGenerator\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
@@ -23,9 +23,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansHost.exe" target="lib\net45" />
-    <file src="OrleansHost.pdb" target="lib\net45" />
-    <file src="OrleansHost.exe.config" target="lib\net45" />
+    <file src="OrleansHost.exe" target="lib\net451" />
+    <file src="OrleansHost.pdb" target="lib\net451" />
+    <file src="OrleansHost.exe.config" target="lib\net451" />
     <file src="$SRC_DIR$OrleansHost\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
@@ -22,10 +22,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansManager.exe" target="lib\net45" />
-    <file src="OrleansManager.pdb" target="lib\net45" />
-    <file src="OrleansManager.exe.config" target="lib\net45" />
-    <file src="ClientConfiguration.xml" target="lib\net45" />
+    <file src="OrleansManager.exe" target="lib\net451" />
+    <file src="OrleansManager.pdb" target="lib\net451" />
+    <file src="OrleansManager.exe.config" target="lib\net451" />
+    <file src="ClientConfiguration.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansManager\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
@@ -22,8 +22,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansProviders.dll" target="lib\net45" />
-    <file src="OrleansProviders.pdb" target="lib\net45" />    
+    <file src="OrleansProviders.dll" target="lib\net451" />
+    <file src="OrleansProviders.pdb" target="lib\net451" />    
     <file src="$SRC_DIR$OrleansProviders\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
@@ -22,11 +22,11 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansRuntime.dll" target="lib\net45" />
-    <file src="OrleansRuntime.pdb" target="lib\net45" />
+    <file src="OrleansRuntime.dll" target="lib\net451" />
+    <file src="OrleansRuntime.pdb" target="lib\net451" />
     <file src="$SRC_DIR$OrleansRuntime\**\*.cs" target="src" />
-    <file src="OrleansDependencyInjection.dll" target="lib\net45" />
-    <file src="OrleansDependencyInjection.pdb" target="lib\net45" />
+    <file src="OrleansDependencyInjection.dll" target="lib\net451" />
+    <file src="OrleansDependencyInjection.pdb" target="lib\net451" />
     <file src="$SRC_DIR$OrleansDependencyInjection\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansSqlUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansSqlUtils.nuspec
@@ -25,10 +25,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansSqlUtils.dll" target="lib\net45" />
-    <file src="OrleansSqlUtils.pdb" target="lib\net45" />
-    <file src="OrleansSqlUtils.xml" target="lib\net45" />
-    <file src="CreateOrleansTables_SqlServer.sql" target="lib\net45\SQLServer" />
-    <file src="CreateOrleansTables_MySql.sql" target="lib\net45\MySql" />
+    <file src="OrleansSqlUtils.dll" target="lib\net451" />
+    <file src="OrleansSqlUtils.pdb" target="lib\net451" />
+    <file src="OrleansSqlUtils.xml" target="lib\net451" />
+    <file src="CreateOrleansTables_SqlServer.sql" target="lib\net451\SQLServer" />
+    <file src="CreateOrleansTables_MySql.sql" target="lib\net451\MySql" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -24,8 +24,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansZooKeeperUtils.dll" target="lib\net45" />
-    <file src="OrleansZooKeeperUtils.pdb" target="lib\net45" />
+    <file src="OrleansZooKeeperUtils.dll" target="lib\net451" />
+    <file src="OrleansZooKeeperUtils.pdb" target="lib\net451" />
     <file src="$SRC_DIR$OrleansZooKeeperUtils\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.Serialization.Bond.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Serialization.Bond.nuspec
@@ -24,9 +24,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansBondUtils.dll" target="lib\net45" />
-    <file src="OrleansBondUtils.pdb" target="lib\net45" />
-    <file src="OrleansBondUtils.xml" target="lib\net45" />
+    <file src="OrleansBondUtils.dll" target="lib\net451" />
+    <file src="OrleansBondUtils.pdb" target="lib\net451" />
+    <file src="OrleansBondUtils.xml" target="lib\net451" />
     <file src="BondSerializerInstall.ps1" target="tools\Install.ps1" />
     <file src="BondSerializerUninstall.ps1" target="tools\Uninstall.ps1" />
     <file src="$SRC_DIR$OrleansBondUtils\**\*.cs" target="src" />

--- a/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
@@ -23,8 +23,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansTestingHost.dll" target="lib\net45" />
-    <file src="OrleansTestingHost.pdb" target="lib\net45" />
+    <file src="OrleansTestingHost.dll" target="lib\net451" />
+    <file src="OrleansTestingHost.pdb" target="lib\net451" />
     
     <file src="ClientConfigurationForTesting.xml" target="content" />
     <file src="OrleansConfigurationForTesting.xml" target="content" />

--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{013DFD29-E1DB-4968-A67B-C2342E6F5B6E}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -13,24 +13,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans</RootNamespace>
     <AssemblyName>Orleans</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>false</SignAssembly>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
@@ -76,6 +61,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(SolutionDir)packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Management" />
@@ -389,7 +375,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="GenerateVersionNumber" BeforeTargets="VersionInit" Condition="'$(BuildingInsideVisualStudio)' != 'true'" Outputs="$(SolutionDir)Build\Version.txt">
     <PropertyGroup Condition="'$(BuildNumber)' == ''">

--- a/src/Orleans/packages.config
+++ b/src/Orleans/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
 </packages>

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -10,23 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.Runtime.Host</RootNamespace>
     <AssemblyName>OrleansAzureUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
   </PropertyGroup>
@@ -56,42 +41,37 @@
     <Prefer32Bit>false</Prefer32Bit>
     <WarningsAsErrors>4014</WarningsAsErrors>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.KeyVault.Core">
-      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm">
-      <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.OData">
-      <HintPath>..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client">
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Spatial">
-      <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />

--- a/src/OrleansAzureUtils/packages.config
+++ b/src/OrleansAzureUtils/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net451" />
 </packages>

--- a/src/OrleansBondUtils/OrleansBondUtils.csproj
+++ b/src/OrleansBondUtils/OrleansBondUtils.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.Serialization</RootNamespace>
     <AssemblyName>OrleansBondUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -42,20 +42,24 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bond">
+    <Reference Include="Bond, Version">
       <HintPath>$(SolutionDir)packages\Bond.Runtime.CSharp.3.0.7\lib\net45\Bond.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Bond.Attributes">
       <HintPath>$(SolutionDir)packages\Bond.Runtime.CSharp.3.0.7\lib\net45\Bond.Attributes.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Bond.IO">
       <HintPath>$(SolutionDir)packages\Bond.Runtime.CSharp.3.0.7\lib\net45\Bond.IO.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Bond.JSON">
       <HintPath>$(SolutionDir)packages\Bond.Runtime.CSharp.3.0.7\lib\net45\Bond.JSON.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -74,9 +78,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj">
       <Project>{6ff2004c-cdf8-479c-bf27-c6bfe8ef93e0}</Project>
       <Name>OrleansRuntime</Name>
@@ -85,6 +86,9 @@
       <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
       <Name>Orleans</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/OrleansBondUtils/packages.config
+++ b/src/OrleansBondUtils/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bond.Runtime.CSharp" version="3.0.7" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Bond.Runtime.CSharp" version="3.0.7" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
 </packages>

--- a/src/OrleansCodeGenerator/OrleansCodeGenerator.csproj
+++ b/src/OrleansCodeGenerator/OrleansCodeGenerator.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.CodeGenerator</RootNamespace>
     <AssemblyName>OrleansCodeGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
@@ -36,27 +36,24 @@
     <IntermediateOutputPath>$(BootstrapOutputPath)Intermediate\</IntermediateOutputPath>
     <DefineConstants>$(DefineConstants);EXCLUDE_CODEGEN</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>$(SolutionDir)packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
       <HintPath>$(SolutionDir)packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable">
-      <Private>True</Private>
       <HintPath>$(SolutionDir)packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>$(SolutionDir)packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -78,13 +75,13 @@
     <Compile Include="Utilities\SyntaxFactoryExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Orleans\Orleans.csproj">
       <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
       <Name>Orleans</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/OrleansCodeGenerator/packages.config
+++ b/src/OrleansCodeGenerator/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net451" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net451" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net451" />
 </packages>

--- a/src/OrleansCounterControl/OrleansCounterControl.csproj
+++ b/src/OrleansCounterControl/OrleansCounterControl.csproj
@@ -10,23 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.Counter.Control</RootNamespace>
     <AssemblyName>OrleansCounterControl</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -52,10 +37,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/OrleansDependencyInjection/ConfigureServicesBuilder.cs
+++ b/src/OrleansDependencyInjection/ConfigureServicesBuilder.cs
@@ -24,7 +24,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Framework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Orleans.Runtime.Startup
 {

--- a/src/OrleansDependencyInjection/ConfigureStartupBuilder.cs
+++ b/src/OrleansDependencyInjection/ConfigureStartupBuilder.cs
@@ -24,7 +24,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Framework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Providers;
 using Orleans.Runtime.Management;
 using Orleans.Runtime.MembershipService;

--- a/src/OrleansDependencyInjection/OrleansDependencyInjection.csproj
+++ b/src/OrleansDependencyInjection/OrleansDependencyInjection.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OrleansDependencyInjection</RootNamespace>
     <AssemblyName>OrleansDependencyInjection</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -30,12 +30,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Framework.DependencyInjection">
-      <HintPath>..\packages\Microsoft.Framework.DependencyInjection.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection">
+      <HintPath>$(SolutionDir)packages\Microsoft.Extensions.DependencyInjection.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Framework.DependencyInjection.Abstractions">
-      <HintPath>..\packages\Microsoft.Framework.DependencyInjection.Abstractions.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
+      <HintPath>$(SolutionDir)packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -55,9 +55,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj">
       <Project>{6ff2004c-cdf8-479c-bf27-c6bfe8ef93e0}</Project>
       <Name>OrleansRuntime</Name>
@@ -66,6 +63,9 @@
       <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
       <Name>Orleans</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/OrleansDependencyInjection/packages.config
+++ b/src/OrleansDependencyInjection/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Framework.DependencyInjection" version="1.0.0-beta8" targetFramework="net45" />
-  <package id="Microsoft.Framework.DependencyInjection.Abstractions" version="1.0.0-beta8" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0-rc1-final" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0-rc1-final" targetFramework="net451" />
 </packages>

--- a/src/OrleansEventSourcing/OrleansEventSourcing.csproj
+++ b/src/OrleansEventSourcing/OrleansEventSourcing.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.EventSourcing</RootNamespace>
     <AssemblyName>OrleansEventSourcing</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -32,10 +32,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\OrleansEventSourcing.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/OrleansHost/OrleansHost.csproj
+++ b/src/OrleansHost/OrleansHost.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.Runtime.Host</RootNamespace>
     <AssemblyName>OrleansHost</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -47,10 +47,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>Orleans.Runtime.Host.Program</StartupObject>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/OrleansManager/OrleansManager.csproj
+++ b/src/OrleansManager/OrleansManager.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OrleansManager</RootNamespace>
     <AssemblyName>OrleansManager</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -39,10 +39,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
     <WarningsAsErrors>4014</WarningsAsErrors>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -10,10 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.Providers</RootNamespace>
     <AssemblyName>OrleansProviders</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -10,25 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.Runtime</RootNamespace>
     <AssemblyName>OrleansRuntime</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>

--- a/src/OrleansSQLUtils/OrleansSQLUtils.csproj
+++ b/src/OrleansSQLUtils/OrleansSQLUtils.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OrleansSQLUtils</RootNamespace>
     <AssemblyName>OrleansSQLUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -40,11 +40,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.SqlDatabase.ElasticScale.Client">
-      <HintPath>..\packages\Microsoft.Azure.SqlDatabase.ElasticScale.Client.1.1.0\lib\net45\Microsoft.Azure.SqlDatabase.ElasticScale.Client.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Azure.SqlDatabase.ElasticScale.Client.1.1.0\lib\net45\Microsoft.Azure.SqlDatabase.ElasticScale.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling">
-      <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -53,7 +53,7 @@
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Data" />
     <Reference Include="System.Threading.Tasks.Dataflow">
-      <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/src/OrleansSQLUtils/packages.config
+++ b/src/OrleansSQLUtils/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.SqlDatabase.ElasticScale.Client" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net45" />
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net451" />
+  <package id="Microsoft.Azure.SqlDatabase.ElasticScale.Client" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net451" />
 </packages>

--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.TestingHost</RootNamespace>
     <AssemblyName>OrleansTestingHost</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -31,12 +31,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <WarningsAsErrors>4014</WarningsAsErrors>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
+++ b/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
@@ -18,7 +18,7 @@
     <AssemblyName>OrleansVSTools</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Orleans.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/OrleansVSTools/VSItemTemplateGrainImplementation/VSItemTemplateGrainImplementation.csproj
+++ b/src/OrleansVSTools/VSItemTemplateGrainImplementation/VSItemTemplateGrainImplementation.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VSItemTemplateGrainImplementation</RootNamespace>
     <AssemblyName>VSItemTemplateGrainImplementation</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/OrleansVSTools/VSItemTemplateGrainImplementationFSharp/VSItemTemplateGrainImplementationFSharp.fsproj
+++ b/src/OrleansVSTools/VSItemTemplateGrainImplementationFSharp/VSItemTemplateGrainImplementationFSharp.fsproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>VSProjectTemplateGrainImplementationFSharp</RootNamespace>
     <AssemblyName>VSProjectTemplateGrainImplementationFSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <Name>VSProjectTemplateGrainImplementationFSharp</Name>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>

--- a/src/OrleansVSTools/VSItemTemplateGrainImplementationVB/VSItemTemplateGrainImplementationVB.vbproj
+++ b/src/OrleansVSTools/VSItemTemplateGrainImplementationVB/VSItemTemplateGrainImplementationVB.vbproj
@@ -16,7 +16,7 @@
     <RootNamespace>VSItemTemplateGrainImplementationVB</RootNamespace>
     <AssemblyName>VSItemTemplateGrainImplementationVB</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <OptionExplicit>On</OptionExplicit>
     <OptionCompare>Binary</OptionCompare>
     <OptionStrict>Off</OptionStrict>

--- a/src/OrleansVSTools/VSItemTemplateGrainInterface/VSItemTemplateGrainInterface.csproj
+++ b/src/OrleansVSTools/VSItemTemplateGrainInterface/VSItemTemplateGrainInterface.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VSItemTemplateGrainInterface</RootNamespace>
     <AssemblyName>VSItemTemplateGrainInterface</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/OrleansVSTools/VSItemTemplateGrainInterfaceVB/VSItemTemplateGrainInterfaceVB.vbproj
+++ b/src/OrleansVSTools/VSItemTemplateGrainInterfaceVB/VSItemTemplateGrainInterfaceVB.vbproj
@@ -16,7 +16,7 @@
     <RootNamespace>VSItemTemplateGrainImplementationVB</RootNamespace>
     <AssemblyName>VSItemTemplateGrainImplementationVB</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <OptionExplicit>On</OptionExplicit>
     <OptionCompare>Binary</OptionCompare>
     <OptionStrict>Off</OptionStrict>

--- a/src/OrleansVSTools/VSItemTemplatePersistedGrain/VSItemTemplatePersistedGrain.csproj
+++ b/src/OrleansVSTools/VSItemTemplatePersistedGrain/VSItemTemplatePersistedGrain.csproj
@@ -16,7 +16,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VSItemTemplatePersistedGrain</RootNamespace>
     <AssemblyName>VSItemTemplatePersistedGrain</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/OrleansVSTools/VSItemTemplatePersistedGrainVB/VSItemTemplatePersistedGrainVB.vbproj
+++ b/src/OrleansVSTools/VSItemTemplatePersistedGrainVB/VSItemTemplatePersistedGrainVB.vbproj
@@ -16,7 +16,7 @@
     <RootNamespace>VSItemTemplatePersistedGrainVB</RootNamespace>
     <AssemblyName>VSItemTemplatePersistedGrainVB</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <OptionExplicit>On</OptionExplicit>
     <OptionCompare>Binary</OptionCompare>
     <OptionStrict>Off</OptionStrict>

--- a/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.csproj
+++ b/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.csproj
@@ -19,7 +19,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VSProjectSiloHost</RootNamespace>
     <AssemblyName>VSProjectSiloHost</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementation/ProjectTemplate.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementation/ProjectTemplate.csproj
@@ -11,7 +11,7 @@
 		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>$safeprojectname$</RootNamespace>
 		<AssemblyName>$safeprojectname$</AssemblyName>
-		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
 	</PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VSProjectTemplateGrainImplementation</RootNamespace>
     <AssemblyName>VSProjectTemplateGrainImplementation</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementationFSharp/ProjectTemplate.fsproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementationFSharp/ProjectTemplate.fsproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <AssemblyName>$safeprojectname$</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <Name>$safeprojectname$</Name>
   </PropertyGroup>

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementationFSharp/VSProjectTemplateGrainImplementationFSharp.fsproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementationFSharp/VSProjectTemplateGrainImplementationFSharp.fsproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>VSProjectTemplateGrainImplementationFSharp</RootNamespace>
     <AssemblyName>VSProjectTemplateGrainImplementationFSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <Name>VSProjectTemplateGrainImplementationFSharp</Name>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementationVB/VSProjectTemplateGrainImplementationVB.vbproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementationVB/VSProjectTemplateGrainImplementationVB.vbproj
@@ -16,7 +16,7 @@
     <RootNamespace>VSProjectTemplateGrainImplementationVB</RootNamespace>
     <AssemblyName>VSProjectTemplateGrainImplementationVB</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <OptionExplicit>On</OptionExplicit>
     <OptionCompare>Binary</OptionCompare>
     <OptionStrict>Off</OptionStrict>

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterface/ProjectTemplate.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterface/ProjectTemplate.csproj
@@ -11,7 +11,7 @@
 		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>$safeprojectname$</RootNamespace>
 		<AssemblyName>$safeprojectname$</AssemblyName>
-		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VSProjectTemplateGrainInterface</RootNamespace>
     <AssemblyName>VSProjectTemplateGrainInterface</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterfaceVB/VSProjectTemplateGrainInterfaceVB.vbproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterfaceVB/VSProjectTemplateGrainInterfaceVB.vbproj
@@ -15,7 +15,7 @@
     <RootNamespace>VSProjectTemplateGrainInterfaceVB</RootNamespace>
     <AssemblyName>VSProjectTemplateGrainInterfaceVB</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <OptionExplicit>On</OptionExplicit>
     <OptionCompare>Binary</OptionCompare>
     <OptionStrict>Off</OptionStrict>

--- a/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
+++ b/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.Runtime.Host</RootNamespace>
     <AssemblyName>OrleansZooKeeperUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
@@ -31,12 +31,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
@@ -46,20 +40,17 @@
     <Compile Include="ZooKeeperBasedMembershipTable.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="ZooKeeperNetEx">
-      <HintPath>$(SolutionDir)packages\ZooKeeperNetEx.3.4.6.1006\lib\net45\ZooKeeperNetEx.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\ZooKeeperNetEx.3.4.6.1008\lib\net45\ZooKeeperNetEx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -67,6 +58,9 @@
       <Project>{BC1BD60C-E7D8-4452-A21C-290AEC8E2E74}</Project>
       <Name>Orleans</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/OrleansZooKeeperUtils/packages.config
+++ b/src/OrleansZooKeeperUtils/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="ZooKeeperNetEx" version="3.4.6.1006" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="ZooKeeperNetEx" version="3.4.6.1008" targetFramework="net451" />
 </packages>

--- a/src/TestFSharp/TestFSharp.fsproj
+++ b/src/TestFSharp/TestFSharp.fsproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TestFSharp</RootNamespace>
     <AssemblyName>TestFSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>TestFSharp</Name>
@@ -32,6 +32,29 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\TestFSharp.XML</DocumentationFile>
   </PropertyGroup>
+  <!--BEGIN: Workaround allowing the use of the FSharp.Compiler.Tools package from within Visual Studio-->
+  <Choose>
+    <When Condition="Exists('..\packages\FSharp.Compiler.Tools.4.0.0.1\tools\Microsoft.FSharp.Targets')">
+      <PropertyGroup>
+        <FSharpTargets>..\packages\FSharp.Compiler.Tools.4.0.0.1\tools\Microsoft.FSharp.Targets</FSharpTargets>
+        <PackagesRestored>true</PackagesRestored>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargets>$(MSBuildBinPath)\Microsoft.Common.targets</FSharpTargets>
+        <PackagesRestored>false</PackagesRestored>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Target Name="CreateManifestResourceNames" Condition="'@(EmbeddedResource)' != '' And '$(PackagesRestored)' == 'false'">
+  </Target>
+  <Target Name="CoreCompile" Condition="'$(PackagesRestored)' == 'false'" Inputs="$(MSBuildAllProjects);&#xD;&#xA;            @(CompileBefore);&#xD;&#xA;            @(Compile);                               &#xD;&#xA;            @(CompileAfter);&#xD;&#xA;            @(_CoreCompileResourceInputs);&#xD;&#xA;            @(ManifestNonResxWithNoCultureOnDisk);&#xD;&#xA;            $(ApplicationIcon);&#xD;&#xA;            $(AssemblyOriginatorKeyFile);&#xD;&#xA;            @(ReferencePath);&#xD;&#xA;            @(CompiledLicenseFile);&#xD;&#xA;            @(EmbeddedDocumentation); &#xD;&#xA;            $(Win32Resource);&#xD;&#xA;            $(Win32Manifest);&#xD;&#xA;            @(CustomAdditionalCompileInputs);&#xD;&#xA;            $(VersionFile);&#xD;&#xA;            $(KeyOriginatorFile)" Outputs="@(DocFileItem);&#xD;&#xA;              @(IntermediateAssembly);&#xD;&#xA;              @(_DebugSymbolsIntermediatePath);                 &#xD;&#xA;              $(NonExistentFile);&#xD;&#xA;              @(CustomAdditionalCompileOutputs)">
+    <!--Recursively invoking the build allows for the discovery of restored packages-->
+    <!--Note that we are only attempting this once, in order to avoid an infinite loop-->
+    <MSBuild Condition="'$(HasBuilt)' == ''" Projects="$(ProjectPath)" Properties="HasBuilt=true;Platform=$(Platform);Configuration=$(Configuration)" ContinueOnError="false" />
+  </Target>
+  <Import Project="$(FSharpTargets)" />
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.fs">
       <Link>GlobalAssemblyInfo.fs</Link>
@@ -60,57 +83,5 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-
-  <!--BEGIN: Workaround allowing the use of the FSharp.Compiler.Tools package from within Visual Studio-->
-  <Choose>
-    <When Condition="Exists('..\packages\FSharp.Compiler.Tools.4.0.0.1\tools\Microsoft.FSharp.Targets')">
-      <PropertyGroup>
-        <FSharpTargets>..\packages\FSharp.Compiler.Tools.4.0.0.1\tools\Microsoft.FSharp.Targets</FSharpTargets>
-        <PackagesRestored>true</PackagesRestored>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargets>$(MSBuildBinPath)\Microsoft.Common.targets</FSharpTargets>
-        <PackagesRestored>false</PackagesRestored>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
-  <Target
-      Name="CreateManifestResourceNames"
-      Condition="'@(EmbeddedResource)' != '' And '$(PackagesRestored)' == 'false'" >
-  </Target>
-  
-  <Target 
-    Name="CoreCompile" 
-    Condition ="'$(PackagesRestored)' == 'false'"
-    Inputs="$(MSBuildAllProjects);
-            @(CompileBefore);
-            @(Compile);                               
-            @(CompileAfter);
-            @(_CoreCompileResourceInputs);
-            @(ManifestNonResxWithNoCultureOnDisk);
-            $(ApplicationIcon);
-            $(AssemblyOriginatorKeyFile);
-            @(ReferencePath);
-            @(CompiledLicenseFile);
-            @(EmbeddedDocumentation); 
-            $(Win32Resource);
-            $(Win32Manifest);
-            @(CustomAdditionalCompileInputs);
-            $(VersionFile);
-            $(KeyOriginatorFile)"
-    Outputs="@(DocFileItem);
-              @(IntermediateAssembly);
-              @(_DebugSymbolsIntermediatePath);                 
-              $(NonExistentFile);
-              @(CustomAdditionalCompileOutputs)"
-  >
-    <!--Recursively invoking the build allows for the discovery of restored packages-->
-    <!--Note that we are only attempting this once, in order to avoid an infinite loop-->
-    <MSBuild Condition="'$(HasBuilt)' == ''" Projects="$(ProjectPath)" Properties="HasBuilt=true;Platform=$(Platform);Configuration=$(Configuration)" ContinueOnError="false" />
-  </Target>
-  <Import Project="$(FSharpTargets)"/>
   <!--END: Workaround allowing the use of the FSharp.Compiler.Tools package from within Visual Studio-->
 </Project>

--- a/src/TestFSharp/packages.config
+++ b/src/TestFSharp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Compiler.Tools" version="4.0.0.1" targetFramework="net45" />
-  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />
+  <package id="FSharp.Compiler.Tools" version="4.0.0.1" targetFramework="net451" />
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net451" />
 </packages>

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
     <AssemblyName>TestGrainInterfaces</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -35,10 +35,6 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <WarningsAsErrors>4014</WarningsAsErrors>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -10,10 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTests.Grains</RootNamespace>
     <AssemblyName>TestGrains</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>

--- a/src/TestInternalGrainInterfaces/TestInternalGrainInterfaces.csproj
+++ b/src/TestInternalGrainInterfaces/TestInternalGrainInterfaces.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestInternalGrainInterfaces</RootNamespace>
     <AssemblyName>TestInternalGrainInterfaces</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/TestInternalGrains/TestInternalGrains.csproj
+++ b/src/TestInternalGrains/TestInternalGrains.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestInternalGrains</RootNamespace>
     <AssemblyName>TestInternalGrains</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Tester/DependencyInjectionGrainTests.cs
+++ b/src/Tester/DependencyInjectionGrainTests.cs
@@ -24,7 +24,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Framework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans.TestingHost;
 using UnitTests.GrainInterfaces;

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Tester</RootNamespace>
     <AssemblyName>Tester</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -38,68 +38,69 @@
     <Prefer32Bit>false</Prefer32Bit>
     <WarningsAsErrors>4014</WarningsAsErrors>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Bond">
       <HintPath>$(SolutionDir)packages\Bond.Runtime.CSharp.3.0.7\lib\net45\Bond.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Bond.Attributes">
       <HintPath>$(SolutionDir)packages\Bond.Runtime.CSharp.3.0.7\lib\net45\Bond.Attributes.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Bond.IO">
       <HintPath>$(SolutionDir)packages\Bond.Runtime.CSharp.3.0.7\lib\net45\Bond.IO.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Bond.JSON">
       <HintPath>$(SolutionDir)packages\Bond.Runtime.CSharp.3.0.7\lib\net45\Bond.JSON.dll</HintPath>
-    </Reference>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.dll</HintPath>
-    </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.KeyVault.Core">
-      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
+    <Reference Include="FluentAssertions">
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core">
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>$(SolutionDir)packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core">
+      <HintPath>$(SolutionDir)packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm">
-      <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.OData">
-      <HintPath>..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Framework.DependencyInjection">
-      <HintPath>..\packages\Microsoft.Framework.DependencyInjection.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection">
+      <HintPath>$(SolutionDir)packages\Microsoft.Extensions.DependencyInjection.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Framework.DependencyInjection.Abstractions">
-      <HintPath>..\packages\Microsoft.Framework.DependencyInjection.Abstractions.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
+      <HintPath>$(SolutionDir)packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
-      <HintPath>..\packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -108,7 +109,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Spatial">
-      <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
@@ -315,9 +316,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
     <None Include="ReadMe.md" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/Tester/packages.config
+++ b/src/Tester/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bond.Runtime.CSharp" version="3.0.7" targetFramework="net45" />
-  <package id="FluentAssertions" version="4.0.0" targetFramework="net45" />
-  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Framework.DependencyInjection" version="1.0.0-beta8" targetFramework="net45" />
-  <package id="Microsoft.Framework.DependencyInjection.Abstractions" version="1.0.0-beta8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net45" />
+  <package id="Bond.Runtime.CSharp" version="3.0.7" targetFramework="net451" />
+  <package id="FluentAssertions" version="4.0.0" targetFramework="net451" />
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net451" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0-rc1-final" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0-rc1-final" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net451" />
 </packages>

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTests</RootNamespace>
     <AssemblyName>TesterInternal</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -36,43 +36,37 @@
     <Prefer32Bit>false</Prefer32Bit>
     <WarningsAsErrors>4014</WarningsAsErrors>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Orleans.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.KeyVault.Core">
-      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.SqlDatabase.ElasticScale.Client">
-      <HintPath>..\packages\Microsoft.Azure.SqlDatabase.ElasticScale.Client.1.1.0\lib\net45\Microsoft.Azure.SqlDatabase.ElasticScale.Client.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Azure.SqlDatabase.ElasticScale.Client.1.1.0\lib\net45\Microsoft.Azure.SqlDatabase.ElasticScale.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.OData">
-      <HintPath>..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
-      <HintPath>..\packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -82,7 +76,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Services" />
     <Reference Include="System.Spatial">
-      <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Transactions" />

--- a/src/TesterInternal/packages.config
+++ b/src/TesterInternal/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.SqlDatabase.ElasticScale.Client" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Azure.SqlDatabase.ElasticScale.Client" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Updated Orleans to .Net 4.5.1
Updated Microsoft DI to RC1

Steps involved:
- Updated target framework in proj files to 4.5.1
- Ran Update-Package -Reinstall command
- Removed old DI packages (package and namespace change from Beta 8 to RC1)
- Added new DI packages.