### PR TITLE
check name instead of value

### DIFF
--- a/src/Orleans/Configuration/ConfigUtilities.cs
+++ b/src/Orleans/Configuration/ConfigUtilities.cs
@@ -71,7 +71,7 @@ namespace Orleans.Runtime.Configuration
                         var pluginType = assembly.GetType(className);
                         if (pluginType == null) throw new TypeLoadException("Cannot locate plugin class " + className + " in assembly " + assembly.FullName);
 
-                        var args = grandchild.Attributes.Cast<XmlAttribute>().Where(a => a.Value != "Type" && a.Value != "Assembly").ToArray();
+                        var args = grandchild.Attributes.Cast<XmlAttribute>().Where(a => a.LocalName != "Type" && a.LocalName != "Assembly").ToArray();
 
                         var plugin = Activator.CreateInstance(pluginType, args);
                         


### PR DESCRIPTION
checks the name of the xml attribute instead of the value of the xml attribute