### PR TITLE
Web Page: Contributing.md

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,0 +1,4 @@
+@echo OFF
+@setlocal
+
+@Echo Build.cmd - Nothing to see here, move along people.

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,114 @@
+---
+layout: page
+title: Contributing to Project Orleans
+---
+{% include JB/setup %}
+
+Some notes and guidelines for developers wanting to contribute to Project Orleans.
+
+# Contributing To This Project
+
+Here are some pointers for anyone looking for mini-features and work items that would make a positive contribution to Project Orleans. 
+
+These are just a few ideas, so if you think of something else that would be useful, then spin up a [discussion thread](https://github.com/dotnet/orleans/issues) on GitHub to discuss the proposal, and go for it!
+
+* **[Orleans GitHub Repository](https://github.com/dotnet/orleans)** 
+Pull requests are always welcome!
+
+* **[Ideas for Contributions](Ideas-for-Contributions)**
+
+* **[Intern and Student Projects](Student-Projects)** 
+Some suggestions for possible intern / student projects.
+
+* **[Documentation Guidelines](Documentation-Guidelines)** A style guide for writing documentation for this site.
+
+
+## Code Contributions:
+
+This project uses the same contribution process as the other **[DotNet projects](http://dotnet.github.io/)** on GitHub.
+
+* **[DotNet Project Contribution Guidelines](https://github.com/dotnet/corefx/wiki/Contributing)**
+Guidelines and workflow for contributing to DotNet projects on GitHub.
+
+* **[DotNet CLA](https://github.com/dotnet/corefx/wiki/Contribution-License-Agreement-%28CLA%29)**
+Contribution License Agreement for DotNet projects on GitHub.
+
+* **[.NET Framework Design Guidelines](https://github.com/dotnet/corefx/wiki/Framework-Design-Guidelines-Digest)** 
+Some basic API design rules, coding standards, and style guide for .NET Framework APIs.
+
+
+# Coding Standards and Conventions
+
+We try not to be too OCD about coding style wars, but in case of disputes we do fall back to the core principles in the two ".NET Coding Standards" books used by the other DotNet OSS projects on GitHub:
+
+
+- [C# Coding Style Guide](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md) 
+- [.NET Framework Design Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/framework-design-guidelines-digest.md) 
+
+There are lots of other useful documents on the [.NET CoreCLR](https://github.com/dotnet/coreclr/tree/master/Documentation) and [.NET Core Framework](https://github.com/dotnet/corefx/tree/master/Documentation) documentation sites which are worth reading, although most experienced C# developers will probably have picked up many of those best-practices by osmosis, particularly around performance and memory management. 
+
+## Source Code Organization
+
+Project Orleans has not religiously followed a "One Class Per File" rule, but instead we have tried to use pragmatic judgment to maximize the change of "code understand-ability" for developers on the team. 
+If lots of small-ish classes share a "common theme" and/or are always dealt with together, then it is OK to place those into one source code file in most cases. 
+See for example the various "log consumer" classes were originally placed in single source file, as they represented a single unit of code comprehension.
+
+As a corollary, it is much easier to find the source code for a class if it is in a file with the same name as the class [similar to Java file naming rules], so there is a tension and value judgment here between code find-ability and minimizing / constraining the number of projects in a solution and files within a project [which both have direct impact on the Visual Studio "Opening" and "Building" times for large projects]. 
+
+Code search tools in VS and ReSharper definitely help here.    
+
+
+## Dependencies and Inter-Project References
+
+One topic that we are very strict about is around dependency references between components and sub-systems.
+
+### Component / Project References
+
+References between projects in a solution must always use "**Project References**" rather than "_DLL References_" to ensure that component build relationships are known to the build tools. 
+
+**Right**:
+
+    <ProjectReference Include="..\Orleans\Orleans.csproj">
+      <Project>{BC1BD60C-E7D8-4452-A21C-290AEC8E2E74}</Project>
+      <Name>Orleans</Name>
+    </ProjectReference>
+
+_Wrong_:
+
+    <Reference Include="Orleans" >
+       <HintPath>..\Orleans\bin\Debug\Orleans.dll</HintPath>
+    </Reference>
+
+In order to help ensure we keep inter-project references clean, then on the build servers [and local `Build.cmd` script] we deliberately use side-by-side input `.\src` and output `.\Binaries` directories rather than the more normal in-place build directory structure (eg. `[PROJ]\bin\Release`) used by VS on local dev machines.
+
+### External Assembly References
+
+We use "**soft**" assembly references (semantic versions) when referencing external assemblies, rather than the "_hard_" (4-digit) fully qualified assembly names that many tools try to sprinkle into our lives at every opportunity.
+
+What this means in practice is that the `Include="Name"` part of a  `Reference` block in any `.csproj` file in the Orleans code base should **just** use the **short assembly names** (eg. `Newtonsoft.Json`) rather than long fully-qualifies assembly names (eg. `Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL`)
+
+**Right**:
+
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+
+_Wrong_:
+
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+
+### Unified Component Versions
+
+We use the same unified versions of external component throughout the Orleans code base, and so should never need to add `bindingRedirect` entries in `App.config` files.
+
+Also, in general it should almost never be necessary to have `Private=True` elements in Orleans project files, except to override a conflict with a Windows / VS "system" component.
+Some package management tools can occasionally get confused when making version changes, and sometimes think that we are using multiple versions of the same assembly within a solution, which of course we never do.
+ 
+We long for the day when package management tools for .NET can make version changes transactionally! 
+Until then, it is occasionally necessary to "fix" the misguided actions of some .NET package management tools by hand-editing the .csproj files (they are just XML text files) back to sanity and/or using the "Discard Edited Line" functions that most good Git tools such as [Atlassian SourceTree](https://www.sourcetreeapp.com/) provide.
+
+Using "sort" references and unified component versions avoids creating brittle links between Orleans run-time and/or external components, and has proved highly effective in the last several years at reducing stress levels for the Orleans Team during important deployment milestones. :)
+    

--- a/Test.cmd
+++ b/Test.cmd
@@ -1,0 +1,4 @@
+@echo OFF
+@setlocal
+
+@Echo Test.cmd - Nothing to see here, move along people.

--- a/index.md
+++ b/index.md
@@ -88,30 +88,9 @@ A partial list of companies, projects and applications which are using Orleans.
 
 ### Contributing To This Project
 
-* **[Orleans GitHub Repository](https://github.com/dotnet/orleans)** 
-Pull requests are always welcome!
+* Notes and guidelines for people wanting to [contribute code changes to Project Orleans](Contributing).
 
-* **[Ideas for Contributions](Ideas-for-Contributions)**
-
-* **[Intern and Student Projects](Student-Projects)** 
-Some suggestions for possible intern / student projects.
-
-* **[Documentation Guidelines](Documentation-Guidelines)** A style guide for writing documentation for this site.
-
-#### Code Contributions:
-
-This project uses the same contribution process as the other **[DotNet projects](http://dotnet.github.io/)** on GitHub.
-
-* **[DotNet Project Contribution Guidelines](https://github.com/dotnet/corefx/wiki/Contributing)**
-Guidelines and workflow for contributing to DotNet projects on GitHub.
-
-* **[DotNet CLA](https://github.com/dotnet/corefx/wiki/Contribution-License-Agreement-%28CLA%29)**
-Contribution License Agreement for DotNet projects on GitHub.
-
-* **[.NET Framework Design Guidelines](https://github.com/dotnet/corefx/wiki/Framework-Design-Guidelines-Digest)** 
-Some basic API design rules, coding standards, and style guide for .NET Framework APIs.
-
-You are also encouraged to start a technical discussion by filing an new [issue](https://github.com/dotnet/orleans/issues) on GitHub.
+* You are also encouraged to report bugs or start a technical discussion by filing an new [thread](https://github.com/dotnet/orleans/issues) on GitHub.
 
 ## Other Documentation Resources
 


### PR DESCRIPTION
Web Page : Contributing.md

- Some more detailed contribution guidelines for Project Orleans.

- Moving some existing developer contribution info
from the main project home page into separate Contributing.md web page,
and fleshing out that info with current working practices used by the dev team.

This is to address the follow-up action item we talked about previously during PR #1115 and PR #910 (among others) to document and fill in some of the more "hidden" / unexplained parts of the development process we have been and continue to follow on this project.

I think we might have osmosed so much of our current Orleans Team working practices into sub-conscious level over the years that I probably forgot something here! 

Feel free to remind me -- especially external non-MSFT observers that might be better placed to notice any "funny" stuff that we do here. :)

I tried to make this less "wall-of-text" and more separate guidance sections with worked examples, but always much more that could be written on this subject, and lots of formatting options. 
Comments and suggestions are most welcome.

/cc: @sergeybykov @gabikliot @jason-bragg @attilah @ReubenBond 