### PR TITLE
missing argument to trace format in TraceLogger.Initialize

### DIFF
--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -268,7 +268,7 @@ namespace Orleans.Runtime
                     catch (Exception exc)
                     {
                         Trace.Listeners.Add(new DefaultTraceListener());
-                        Trace.TraceError("Error opening trace file {0} -- Using DefaultTraceListener instead -- Exception={1}", exc);
+                        Trace.TraceError("Error opening trace file {0} -- Using DefaultTraceListener instead -- Exception={1}", config.TraceFileName, exc);
                     }
                 }
 


### PR DESCRIPTION
I noticed that all our cloud deployments are failing and traced it back to this line.