### PR TITLE
Add support for generic type constraints in codegen

### DIFF
--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -268,7 +268,7 @@ namespace Orleans.Runtime
                     catch (Exception exc)
                     {
                         Trace.Listeners.Add(new DefaultTraceListener());
-                        Trace.TraceError("Error opening trace file {0} -- Using DefaultTraceListener instead -- Exception={1}", exc);
+                        Trace.TraceError("Error opening trace file {0} -- Using DefaultTraceListener instead -- Exception={1}", config.TraceFileName, exc);
                     }
                 }
 

--- a/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
@@ -31,6 +31,7 @@ namespace Orleans.CodeGenerator
     using System.Reflection;
     using System.Threading.Tasks;
 
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -105,6 +106,7 @@ namespace Orleans.CodeGenerator
                     CodeGeneratorCommon.ClassPrefix + TypeUtils.GetSuitableClassName(grainType) + ClassSuffix)
                     .AddModifiers(SF.Token(SyntaxKind.InternalKeyword))
                     .AddBaseListTypes(baseTypes.ToArray())
+                    .AddConstraintClauses(grainType.GetTypeConstraintSyntax())
                     .AddMembers(members.ToArray())
                     .AddAttributeLists(SF.AttributeList().AddAttributes(attributes.ToArray()));
             if (genericTypes.Length > 0)

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -98,6 +98,7 @@ namespace Orleans.CodeGenerator
                     .AddBaseListTypes(
                         SF.SimpleBaseType(typeof(GrainReference).GetTypeSyntax()),
                         SF.SimpleBaseType(grainType.GetTypeSyntax()))
+                    .AddConstraintClauses(grainType.GetTypeConstraintSyntax())
                     .AddMembers(GenerateConstructors(className))
                     .AddMembers(
                         GenerateInterfaceIdProperty(grainType),

--- a/src/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/src/TestGrainInterfaces/IGenericInterfaces.cs
@@ -210,4 +210,11 @@ namespace UnitTests.GrainInterfaces
         Task<T> LongRunningTask(T t, TimeSpan delay);
         Task<T> CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, T t, TimeSpan delay);
     }
+
+    public interface IGenericGrainWithConstraints<A, B> : IGrainWithStringKey where A : ICollection<B>, new()
+    {
+        Task<int> GetCount();
+
+        Task Add(B item);
+    }
 }

--- a/src/TestGrains/GenericGrains.cs
+++ b/src/TestGrains/GenericGrains.cs
@@ -609,4 +609,23 @@ namespace UnitTests.Grains
             return Task.FromResult(RuntimeIdentity);
         }
     }
+
+    public class GenericGrainWithContraints<A, B>: Grain, IGenericGrainWithConstraints<A, B> where A : ICollection<B>, new()
+    {
+        private A collection;
+
+        public override Task OnActivateAsync()
+        {
+            collection = new A();
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetCount() { return Task.FromResult(collection.Count); }
+
+        public Task Add(B item)
+        {
+            collection.Add(item);
+            return TaskDone.Done;
+        }
+    }
 }

--- a/src/Tester/GenericGrainTests.cs
+++ b/src/Tester/GenericGrainTests.cs
@@ -676,5 +676,17 @@ namespace UnitTests.General
             var grain = GrainFactory.GetGrain<ICircularStateTestGrain>(primaryKey: grainId, keyExtension: grainId.ToString("N"));
             var c1 = await grain.GetState();
         }
+
+        [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        public async Task Generic_GrainWithTypeConstraints()
+        {
+            var grainId = Guid.NewGuid().ToString();
+            var grain = GrainFactory.GetGrain<IGenericGrainWithConstraints<List<int>, int>>(grainId);
+            var result = await grain.GetCount();
+            Assert.AreEqual(0, result);
+            await grain.Add(42);
+            result = await grain.GetCount();
+            Assert.AreEqual(1, result);
+        }
     }
 }


### PR DESCRIPTION
for scenarios where a generic grain type also has type constraints, the codegen file has compilation errors because it doesn't preserve the constraints. The case where we hit the issue:

```csharp
public interface IPageWorkerGrain<TCollection, TData> : IGrainWithStringKey where TCollection : ICollection<TData>

public class PageWorkerGrain<TCollection, TData> : Grain, IPageWorkerGrain<TCollection, TData> where TCollection: ICollection<TData>, new()
```