### PR TITLE
Updated ReadMe with links to the new Contributing page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,18 @@ Orleans - Distributed Actor Model
 [![Help Wanted Issues](https://badge.waffle.io/dotnet/orleans.svg?label=help%20wanted&title=Help Wanted Issues)](http://waffle.io/dotnet/orleans)
 
 Orleans is a framework that provides a straight-forward approach to building distributed high-scale computing applications, without the need to learn and apply complex concurrency or other scaling patterns. 
-It was created by [Microsoft Research][MSR-ProjectOrleans] and designed for use in the cloud. 
-Orleans has been used extensively running in Microsoft Azure by several Microsoft product groups, most notably by 343 Industries as a platform for all of Halo 4 and Halo 5 cloud services, as well as by [a number of other projects and companies](http://dotnet.github.io/orleans/Who-Is-Using-Orleans).
+
+It was created by [Microsoft Research](http://research.microsoft.com/projects/orleans/) 
+implementing the [Virtual Actor Model](http://research.microsoft.com/apps/pubs/default.aspx?id=210931) 
+and designed for use in the cloud. 
+
+Orleans has been used extensively running in Microsoft Azure by several Microsoft product groups, most notably by [343 Industries](https://www.halowaypoint.com/) as a platform for all of Halo 4 and Halo 5 cloud services, as well as by [a number of other projects and companies](http://dotnet.github.io/orleans/Who-Is-Using-Orleans).
 
 Installation
-=======
+============
 
-Installation is performed via NuGet. There are several packages, one for each different project type (interfaces, grains, silo, and client).
+Installation is performed via [NuGet](https://www.nuget.org/packages?q=orleans). 
+There are several packages, one for each different project type (interfaces, grains, silo, and client).
 
 In the grain interfaces project:
 ```
@@ -40,21 +45,25 @@ PM> Install-Package Microsoft.Orleans.Client
 ```
 
 ### Official Builds
+
 The stable production-quality release is located [here](https://github.com/dotnet/orleans/releases/latest).
 
 The latest clean development branch build from CI is located: [here](http://dotnet-ci.cloudapp.net/job/dotnet_orleans/job/innerloop/lastStableBuild/artifact/)
 
 ### Building From Source
-Clone the sources and run the `Build.cmd` script to build the binaries locally.
 
-Then reference the required assemblies from `Binaries\Release\*` or the NuGet packages from `Binaries\NuGet.Packages\*`.
+Clone the sources from the GitHub [repo](https://github.com/dotnet/orleans) 
 
-[Documentation][Orleans Documentation]
-=======
-Documentation is located [here][Orleans Documentation]
+Run run the `Build.cmd` script to build the binaries locally,
+then reference the required NuGet packages from `Binaries\NuGet.Packages\*`.
 
-Example
-=======
+Documentation
+=============
+
+Documentation is located [here](http://dotnet.github.io/orleans/)
+
+Code Examples
+=============
 
 Create an interface for your grain:
 ```c#
@@ -84,30 +93,26 @@ var friend = GrainClient.GrainFactory.GetGrain<IHello>(0);
 Console.WriteLine(await friend.SayHello("Good morning, my friend!"));
 ```
 
-Contributing To This Project
-=======
+Community
+=========
 
-* List of [Ideas for Contributions]
+* Follow the [@ProjectOrleans](https://twitter.com/ProjectOrleans) Twitter account for Orleans project news announcements.
 
-* [Contributing Guide]
+* [OrleansContrib - Repository of community add-ons to Orleans](https://github.com/OrleansContrib/) Various community projects, including Orleans Monitoring, Design Patterns, Storage Provider, etc.
 
-* [CLA - Contribution License Agreement][CLA]
+* Guidelines for developers wanting to [contribute code changes to Project Orleans](http://dotnet.github.io/orleans/Contributing).
 
-* The coding standards / style guide used for Orleans code is the [.NET Framework Design Guidelines][DotNet Framework Design Guidelines]
-
-* [Orleans Community - Repository of community add-ons to Orleans](https://github.com/OrleansContrib/) Various community projects, including Orleans Monitoring, Design Patterns, Storage Provider, etc.
-
-You are also encouraged to start a discussion by filing an issue.
+* You are also encouraged to report bugs or start a technical discussion by starting a new [thread](https://github.com/dotnet/orleans/issues) on GitHub.
 
 License
 =======
 This project is licensed under the [MIT license](https://github.com/dotnet/orleans/blob/master/LICENSE).
 
+Quick Links
+===========
 
-[MSR-ProjectOrleans]: http://research.microsoft.com/projects/orleans/
-[Orleans Documentation]: http://dotnet.github.io/orleans/
-[Ideas for Contributions]: http://dotnet.github.io/orleans/Ideas-for-Contributions
-[Contributing Guide]: https://github.com/dotnet/corefx/wiki/Contributing
-[CLA]: https://github.com/dotnet/corefx/wiki/Contribution-License-Agreement-%28CLA%29
-[DotNet Framework Design Guidelines]: https://github.com/dotnet/corefx/wiki/Framework-Design-Guidelines-Digest
-[Download Link]: http://orleans.codeplex.com/releases/view/144111
+* [MSR-ProjectOrleans](http://research.microsoft.com/projects/orleans/)
+* Orleans Tech Report - [Distributed Virtual Actors for Programmability and Scalability](http://research.microsoft.com/apps/pubs/default.aspx?id=210931)
+* [Orleans-GitHub](https://github.com/dotnet/orleans)
+* [Orleans Documentation](http://dotnet.github.io/orleans/)
+* [Contributing](http://dotnet.github.io/orleans/Contributing)


### PR DESCRIPTION
- This is a follow-on change from PR #1131

- Updated the main ReadMe with link to the new Contributing page on website http://dotnet.github.io/orleans/Contributing

- Fixed some broken content / layout, and cleaned up some crufty wording.