### PR TITLE
EventHubStreamProvider Prototype

### DIFF
--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -173,6 +173,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestInternalGrainInterfaces
 		{E782DD19-51F7-4F66-8217-BACAC33767E4} = {E782DD19-51F7-4F66-8217-BACAC33767E4}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansServiceBus", "OrleansServiceBus\OrleansServiceBus.csproj", "{8BFF0092-15D2-4425-80C0-29E381702F2B}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansTelemetryConsumers.AI", "OrleansTelemetryConsumers.AI\OrleansTelemetryConsumers.AI.csproj", "{99A8E011-3A30-423A-9F67-D1349FD8B1CD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansTelemetryConsumers.NewRelic", "OrleansTelemetryConsumers.NewRelic\OrleansTelemetryConsumers.NewRelic.csproj", "{CCE2639F-5D20-429F-947F-B904CF745E92}"
@@ -273,6 +275,10 @@ Global
 		{2AE67055-F38A-45F0-AEA7-5754F4814EA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2AE67055-F38A-45F0-AEA7-5754F4814EA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2AE67055-F38A-45F0-AEA7-5754F4814EA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BFF0092-15D2-4425-80C0-29E381702F2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BFF0092-15D2-4425-80C0-29E381702F2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BFF0092-15D2-4425-80C0-29E381702F2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BFF0092-15D2-4425-80C0-29E381702F2B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{99A8E011-3A30-423A-9F67-D1349FD8B1CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{99A8E011-3A30-423A-9F67-D1349FD8B1CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{99A8E011-3A30-423A-9F67-D1349FD8B1CD}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
@@ -18,7 +18,7 @@ namespace Orleans.Providers.Streams.Common
             EventIndex = 0;
         }
 
-        internal EventSequenceToken(long seqNumber, int eventInd)
+        public EventSequenceToken(long seqNumber, int eventInd)
         {
             SequenceNumber = seqNumber;
             EventIndex = eventInd;

--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8BFF0092-15D2-4425-80C0-29E381702F2B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>OrleansServiceBusUtils</RootNamespace>
+    <AssemblyName>OrleansServiceBusUtils</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.ServiceBus">
+      <HintPath>..\packages\WindowsAzure.ServiceBus.3.0.8\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventDataExtensions.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubAdapterFactory.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubAdapterReceiver.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubBatchContainer.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubQueueMapper.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubSequenceToken.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubSettings.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubStreamProvider.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubStreamProviderConfig.cs" />
+    <Compile Include="Providers\Streams\EventHub\IEventHubSettings.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj">
+      <Project>{0054DB14-2A92-4CC0-959E-A2C51F5E65D4}</Project>
+      <Name>OrleansProviders</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Orleans\Orleans.csproj">
+      <Project>{BC1BD60C-E7D8-4452-A21C-290AEC8E2E74}</Project>
+      <Name>Orleans</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/OrleansServiceBus/Properties/AssemblyInfo.cs
+++ b/src/OrleansServiceBus/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("OrleansServiceBus")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OrleansServiceBus")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("60c5eab4-80ac-4c12-a231-37a7f10db25a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
@@ -1,0 +1,25 @@
+﻿
+using Microsoft.ServiceBus.Messaging;
+
+namespace Orleans.ServiceBus.Providers.Streams.EventHub
+{
+    internal static class EventDataExtensions
+    {
+        public const string EventDataPropertyStreamNamespaceKey = "StreamNamespace";
+
+        public static void SetStreamNamespaceProperty(this EventData eventData, string streamNamespace)
+        {
+            eventData.Properties[EventDataPropertyStreamNamespaceKey] = streamNamespace;
+        }
+
+        public static string GetStreamNamespaceProperty(this EventData eventData)
+        {
+            object namespaceObj;
+            if (eventData.Properties.TryGetValue(EventDataPropertyStreamNamespaceKey, out namespaceObj))
+            {
+                return (string)namespaceObj;
+            }
+            return null;
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -1,0 +1,148 @@
+﻿
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus;
+using Microsoft.ServiceBus.Messaging;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.ServiceBus.Providers.Streams.EventHub;
+using Orleans.Streams;
+using OrleansServiceBusUtils.Providers.Streams.EventHub;
+
+namespace Orleans.ServiceBus.Providers
+{
+    public class EventHubAdapterFactory : IQueueAdapterFactory, IQueueAdapter, IQueueAdapterCache
+    {
+        private Logger logger;
+        private IServiceProvider serviceProvider;
+        private EventHubStreamProviderConfig adapterConfig;
+        private IEventHubSettings hubSettings;
+        private EventHubQueueMapper streamQueueMapper;
+        private IStreamFailureHandler streamFailureHandler;
+        private string[] partitionIds;
+        private ConcurrentDictionary<QueueId, EventHubAdapterReceiver> receivers;
+        private EventHubClient client;
+
+        public string Name { get { return adapterConfig.StreamProviderName; } }
+        public bool IsRewindable { get { return true; } }
+        public StreamProviderDirection Direction { get { return StreamProviderDirection.ReadWrite; } }
+
+        /// <summary>
+        /// Factory initialization.
+        /// Provider config must contain the event hub settings type or the settings themselves.
+        /// EventHubSettingsType is recommended for consumers that do not want to include secure information in the cluster configuration.
+        /// </summary>
+        /// <param name="providerConfig"></param>
+        /// <param name="providerName"></param>
+        /// <param name="log"></param>
+        /// <param name="svcProvider"></param>
+        public void Init(IProviderConfiguration providerConfig, string providerName, Logger log, IServiceProvider svcProvider)
+        {
+            if (providerConfig == null) throw new ArgumentNullException("providerConfig");
+            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException("providerName");
+            if (log == null) throw new ArgumentNullException("log");
+            if (svcProvider == null) throw new ArgumentNullException("svcProvider");
+
+            logger = log;
+            serviceProvider = svcProvider;
+            adapterConfig = new EventHubStreamProviderConfig(providerName);
+            adapterConfig.PopulateFromProviderConfig(providerConfig);
+
+            // if no event hub settings type is provided, use EventHubSettings and get populate settings from providerConfig
+            if (adapterConfig.EventHubSettingsType == null)
+            {
+                adapterConfig.EventHubSettingsType = typeof (EventHubSettings);
+            }
+
+            hubSettings = serviceProvider.GetService(adapterConfig.EventHubSettingsType) as IEventHubSettings;
+            if (hubSettings == null)
+            {
+                throw new ArgumentOutOfRangeException("providerConfig", "EventHubSettingsType not valid.");
+            }
+
+            // if settings is an EventHubSettings class, populate settings from providerConfig
+            var settings = hubSettings as EventHubSettings;
+            if (settings != null)
+            {
+                settings.PopulateFromProviderConfig(providerConfig);
+            }
+
+            receivers = new ConcurrentDictionary<QueueId, EventHubAdapterReceiver>();
+            client = EventHubClient.CreateFromConnectionString(hubSettings.ConnectionString, hubSettings.Path);
+        }
+
+        public async Task<IQueueAdapter> CreateAdapter()
+        {
+            if (streamQueueMapper == null)
+            {
+                partitionIds = await GetPartitionIdsAsync();
+                streamQueueMapper = new EventHubQueueMapper(partitionIds, adapterConfig.StreamProviderName);
+            }
+            return this;
+        }
+
+        public IQueueAdapterCache GetQueueAdapterCache()
+        {
+            return this;
+        }
+
+        public IStreamQueueMapper GetStreamQueueMapper()
+        {
+            //TODO: CreateAdapter must be called first.  Figure out how to safely enforce this
+            return streamQueueMapper;
+        }
+
+        public Task<IStreamFailureHandler> GetDeliveryFailureHandler(QueueId queueId)
+        {
+            //TODO: Add a queue specific default failure handler with reasonable error reporting.
+            //TODO: Try to get failure handler from service provider so users can inject their own.
+            return Task.FromResult(streamFailureHandler ?? (streamFailureHandler = new NoOpStreamDeliveryFailureHandler()));
+        }
+
+        public Task QueueMessageBatchAsync<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, StreamSequenceToken token,
+            Dictionary<string, object> requestContext)
+        {
+            if (token != null)
+            {
+                throw new NotImplementedException("EventHub stream provider currently does not support non-null StreamSequenceToken.");
+            }
+            EventData eventData = EventHubBatchContainer.ToEventData(streamGuid, streamNamespace, events, requestContext);
+            return client.SendAsync(eventData);
+        }
+
+        public IQueueAdapterReceiver CreateReceiver(QueueId queueId)
+        {
+            return GetOrCreateReceiver(queueId);
+        }
+
+        public IQueueCache CreateQueueCache(QueueId queueId)
+        {
+            return GetOrCreateReceiver(queueId);
+        }
+
+        private EventHubAdapterReceiver GetOrCreateReceiver(QueueId queueId)
+        {
+            return receivers.GetOrAdd(queueId, q => MakeReceiver(queueId));
+        }
+
+        private EventHubAdapterReceiver MakeReceiver(QueueId queueId)
+        {
+            var config = new EventHubPartitionConfig
+            {
+                Hub = hubSettings,
+                Partition = streamQueueMapper.QueueToPartition(queueId),
+                CacheSize = adapterConfig.CacheSize,
+            };
+            return new EventHubAdapterReceiver(config, logger);
+        }
+
+        public async Task<string[]> GetPartitionIdsAsync()
+        {
+            NamespaceManager namespaceManager = NamespaceManager.CreateFromConnectionString(hubSettings.ConnectionString);
+            EventHubDescription hubDescription = await namespaceManager.GetEventHubAsync(hubSettings.Path);
+            return hubDescription.PartitionIds;
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -1,0 +1,102 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Streams;
+using OrleansServiceBusUtils.Providers.Streams.EventHub;
+
+namespace Orleans.ServiceBus.Providers.Streams.EventHub
+{
+    internal class EventHubPartitionConfig
+    {
+        public IEventHubSettings Hub { get; set; }
+        public string Partition { get; set; }
+        public int CacheSize { get; set; }
+    }
+
+    internal class EventHubAdapterReceiver : IQueueAdapterReceiver, IQueueCache
+    {
+        private static readonly TimeSpan ReceiveTimeout = TimeSpan.FromSeconds(5);
+
+        private readonly EventHubPartitionConfig config;
+        private readonly Logger logger;
+
+        private IQueueCache cache;
+        private EventHubReceiver receiver;
+
+        public int MaxAddCount { get { return cache.MaxAddCount; } }
+
+        public EventHubAdapterReceiver(EventHubPartitionConfig partitionConfig, Logger log)
+        {
+            config = partitionConfig;
+            logger = log;
+        }
+
+        public void AddToCache(IList<IBatchContainer> messages)
+        {
+            cache.AddToCache(messages);
+        }
+
+        public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+        {
+            return cache.TryPurgeFromCache(out purgedItems);
+        }
+
+        public IQueueCacheCursor GetCacheCursor(Guid streamGuid, string streamNamespace, StreamSequenceToken token)
+        {
+            return cache.GetCacheCursor(streamGuid, streamNamespace, token);
+        }
+
+        public bool IsUnderPressure()
+        {
+            return cache.IsUnderPressure();
+        }
+
+        private static Task<EventHubReceiver> CreateReceiver(EventHubPartitionConfig partitionConfig)
+        {
+            EventHubClient client = EventHubClient.CreateFromConnectionString(partitionConfig.Hub.ConnectionString, partitionConfig.Hub.Path);
+            EventHubConsumerGroup consumerGroup = client.GetConsumerGroup(partitionConfig.Hub.ConsumerGroup);
+            if (partitionConfig.Hub.PrefetchCount.HasValue)
+            {
+                consumerGroup.PrefetchCount = partitionConfig.Hub.PrefetchCount.Value;
+            }
+            return consumerGroup.CreateReceiverAsync(partitionConfig.Partition, DateTime.UtcNow);
+        }
+
+        public async Task Initialize(TimeSpan timeout)
+        {
+            cache = new SimpleQueueCache(config.CacheSize, logger);
+            receiver = await CreateReceiver(config);
+        }
+
+        public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
+        {
+            IEnumerable<EventData> messages = await receiver.ReceiveAsync(maxCount, ReceiveTimeout);
+            return BuildBatchList(messages);
+        }
+
+        public Task MessagesDeliveredAsync(IList<IBatchContainer> messages)
+        {
+            return TaskDone.Done;
+        }
+
+        public async Task Shutdown(TimeSpan timeout)
+        {
+            EventHubReceiver localReceiver = Interlocked.Exchange(ref receiver, null);
+            if (localReceiver != null)
+            {
+                await localReceiver.CloseAsync();
+            }
+        }
+
+        private IList<IBatchContainer> BuildBatchList(IEnumerable<EventData> messages)
+        {
+            return messages.Select(EventHubBatchContainer.FromEventData).ToList();
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -1,0 +1,102 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ServiceBus.Messaging;
+using Newtonsoft.Json;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.ServiceBus.Providers.Streams.EventHub;
+using Orleans.Streams;
+
+namespace OrleansServiceBusUtils.Providers.Streams.EventHub
+{
+    [Serializable]
+    internal class EventHubBatchContainer : IBatchContainer
+    {
+        [JsonProperty]
+        private readonly EventHubSequenceToken token;
+
+        [JsonProperty]
+        private readonly byte[] payloadBytes;
+
+        public Guid StreamGuid { get; private set; }
+        public string StreamNamespace { get; private set; }
+        public StreamSequenceToken SequenceToken { get { return token; } }
+
+        // Payload is local cache of deserialized payloadBytes.  Should never be serialized as part of batch container.  During batch container serialization raw payloadBytes will always be used.
+        [NonSerialized]
+        private Body payload;
+        private Body Payload
+        {
+            get { return payload ?? (payload = SerializationManager.DeserializeFromByteArray<Body>(payloadBytes)); }
+        }
+        
+        [Serializable]
+        private class Body
+        {
+            public List<object> Events { get; set; }
+            public Dictionary<string, object> RequestContext { get; set; }
+        }
+
+        public EventHubBatchContainer(Guid streamGuid, string streamNamespace, byte[] data)
+        {
+            StreamGuid = streamGuid;
+            StreamNamespace = streamNamespace;
+            payloadBytes = data;
+        }
+
+        public EventHubBatchContainer(Guid streamGuid, string streamNamespace, string offset, long sequenceNumber, byte[] data)
+            : this(streamGuid, streamNamespace, data)
+        {
+            StreamGuid = streamGuid;
+            StreamNamespace = streamNamespace;
+            token = new EventHubSequenceToken(offset, sequenceNumber, 0);
+            payloadBytes = data;
+        }
+
+        public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
+        {
+            return Payload.Events.Cast<T>().Select((e, i) => Tuple.Create<T, StreamSequenceToken>(e, new EventHubSequenceToken(token.EventHubOffset, token.SequenceNumber, i)));
+        }
+
+        public bool ImportRequestContext()
+        {
+            if (Payload.RequestContext != null)
+            {
+                RequestContext.Import(Payload.RequestContext);
+                return true;
+            }
+            return false;
+        }
+
+        public bool ShouldDeliver(IStreamIdentity stream, object filterData, StreamFilterPredicate shouldReceiveFunc)
+        {
+            return true;
+        }
+
+        internal static EventData ToEventData<T>(Guid streamGuid, String streamNamespace, IEnumerable<T> events, Dictionary<string, object> requestContext)
+        {
+            var payload = new Body
+            {
+                Events = events.Cast<object>().ToList(),
+                RequestContext = requestContext
+            };
+            var bytes = SerializationManager.SerializeToByteArray(payload);
+            var eventData = new EventData(bytes) { PartitionKey = streamGuid.ToString() };
+            if (!string.IsNullOrWhiteSpace(streamNamespace))
+            {
+                eventData.SetStreamNamespaceProperty(streamNamespace);
+            }
+            return eventData;
+        }
+
+        internal static IBatchContainer FromEventData(EventData eventData)
+        {
+            Guid streamGuid = Guid.Parse(eventData.PartitionKey);
+            string streamNamespace = eventData.GetStreamNamespaceProperty();
+            byte[] bytes = eventData.GetBytes();
+            return new EventHubBatchContainer(streamGuid, streamNamespace, eventData.Offset, eventData.SequenceNumber, bytes);
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueMapper.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueMapper.cs
@@ -1,0 +1,43 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Orleans.Streams;
+
+namespace Orleans.ServiceBus.Providers.Streams.EventHub
+{
+    internal class EventHubQueueMapper : HashRingBasedStreamQueueMapper
+    {
+        private readonly Dictionary<QueueId, string> partitionDictionary = new Dictionary<QueueId, string>();
+
+        internal EventHubQueueMapper(string[] partitionIds, string queueNamePrefix)
+            : base(partitionIds.Length, queueNamePrefix)
+        {
+            QueueId[] queues = GetAllQueues().ToArray();
+            if (queues.Length != partitionIds.Length)
+            {
+                throw new ArgumentOutOfRangeException("partitionIds", "partitons and Queues do not line up");
+            }
+            for (int i = 0; i < queues.Length; i++)
+            {
+                partitionDictionary.Add(queues[i], partitionIds[i]);
+            }
+        }
+
+        public string QueueToPartition(QueueId queue)
+        {
+            if (queue == null)
+            {
+                throw new ArgumentNullException("queue");
+            }
+
+            string partitionId;
+            if (!partitionDictionary.TryGetValue(queue, out partitionId))
+            {
+                throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "queue {0}", queue.ToStringWithHashCode()));
+            }
+            return partitionId;
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -1,0 +1,33 @@
+﻿
+using System;
+using System.Globalization;
+using Orleans.Providers.Streams.Common;
+
+namespace Orleans.ServiceBus.Providers.Streams.EventHub
+{
+    /// <summary>
+    /// Event Hub messages consist of a batch of application layer events, so EventHub tokens contain three pieces of information.
+    /// EventHubOffset - this is a unique value per partition that is used to start reading from this message in the partition.
+    /// SequenceNumber - EventHub sequence numbers are unique ordered message IDs for messages within a partition.  
+    ///   The SequenceNumber is required for uniqueness and ordering of EventHub messages within a partition.
+    /// event Index - Since each EventHub message may contain more than one application layer event, this value
+    ///   indicates which application layer event this token is for, within an EventHub message.  It is required for uniqueness
+    ///   and ordering of aplication layer events within an EventHub message.
+    /// </summary>
+    [Serializable]
+    internal class EventHubSequenceToken : EventSequenceToken
+    {
+        public string EventHubOffset { get; private set; }
+
+        public EventHubSequenceToken(string eventHubOffset, long sequenceNumber, int eventIndex)
+            : base(sequenceNumber, eventIndex)
+        {
+            this.EventHubOffset = eventHubOffset;
+        }
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "EventHubSequenceToken(EventHubOffset: {0}, SequenceNumber: {1}, EventIndex: {2})", this.EventHubOffset, this.SequenceNumber, this.EventIndex);
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSettings.cs
@@ -1,0 +1,87 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Orleans.Providers;
+
+namespace OrleansServiceBusUtils.Providers.Streams.EventHub
+{
+    [Serializable]
+    public class EventHubSettings : IEventHubSettings
+    {
+        private const string ConnectionStringName = "EventHubConnectionString";
+        private const string ConsumerGroupName = "EventHubConsumerGroup";
+        private const string PathName = "EventHubPath";
+        private const string PrefetchCountName = "EventHubPrefetchCount";
+        private const int InvalidPrefetchCount = -1;
+
+        public EventHubSettings() { }
+
+        public EventHubSettings(string connectionString, string consumerGroup, string path, int? prefetchCount = null)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException("connectionString");
+            }
+            if (string.IsNullOrWhiteSpace(consumerGroup))
+            {
+                throw new ArgumentNullException("consumerGroup");
+            }
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentNullException("path");
+            }
+            ConnectionString = connectionString;
+            ConsumerGroup = consumerGroup;
+            Path = path;
+            PrefetchCount = prefetchCount;
+        }
+        public string ConnectionString { get; private set; }
+        public string ConsumerGroup { get; private set; }
+        public string Path { get; private set; }
+        public int? PrefetchCount { get; private set; }
+
+        /// <summary>
+        /// Utility function to convert config to property bag for use in stream provider configuration
+        /// </summary>
+        /// <returns></returns>
+        public void WriteProperties(Dictionary<string, string> properties)
+        {
+            properties.Add(ConnectionStringName, ConnectionString);
+            properties.Add(ConsumerGroupName, ConsumerGroup);
+            properties.Add(PathName, Path);
+            if (PrefetchCount != null)
+            {
+                properties.Add(PrefetchCountName, PrefetchCount.Value.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        /// <summary>
+        /// Utility function to populate config from provider config
+        /// </summary>
+        /// <param name="providerConfiguration"></param>
+        public virtual void PopulateFromProviderConfig(IProviderConfiguration providerConfiguration)
+        {
+            ConnectionString = providerConfiguration.GetProperty(ConnectionStringName, null);
+            if (string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                throw new ArgumentOutOfRangeException("providerConfiguration", ConnectionStringName + " not set.");
+            }
+            ConsumerGroup = providerConfiguration.GetProperty(ConsumerGroupName, null);
+            if (string.IsNullOrWhiteSpace(ConsumerGroup))
+            {
+                throw new ArgumentOutOfRangeException("providerConfiguration", ConsumerGroupName + " not set.");
+            }
+            Path = providerConfiguration.GetProperty(PathName, null);
+            if (string.IsNullOrWhiteSpace(Path))
+            {
+                throw new ArgumentOutOfRangeException("providerConfiguration", PathName + " not set.");
+            }
+            PrefetchCount = providerConfiguration.GetIntProperty(PrefetchCountName, InvalidPrefetchCount);
+            if (PrefetchCount == InvalidPrefetchCount)
+            {
+                PrefetchCount = null;
+            }
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProvider.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProvider.cs
@@ -1,0 +1,13 @@
+﻿
+using Orleans.Providers.Streams.Common;
+
+namespace Orleans.ServiceBus.Providers
+{
+    /// <summary>
+    /// Persistent stream provider that uses EventHub for persistence
+    /// TODO: This stream provider is still under development.  DO NOT USE IN PRODUCTION - jbragg
+    ///  </summary>
+    public class EventHubStreamProvider : PersistentStreamProvider<EventHubAdapterFactory>
+    {
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
@@ -1,0 +1,37 @@
+﻿
+using System;
+using System.Collections.Generic;
+using Orleans.Providers;
+
+namespace Orleans.ServiceBus.Providers
+{
+    public class EventHubStreamProviderConfig
+    {
+        public const string EventHubConfigTypeName = "EventHubSettingsType";
+        public Type EventHubSettingsType { get; set; }
+
+        public string StreamProviderName { get; private set; }
+
+        public int CacheSize { get { return 1024; } }
+
+        public EventHubStreamProviderConfig(string streamProviderName)
+        {
+            StreamProviderName = streamProviderName;
+        }
+
+        public void WriteProperties(Dictionary<string, string> properties)
+        {
+            if (EventHubSettingsType!=null)
+                properties.Add(EventHubConfigTypeName, EventHubSettingsType.AssemblyQualifiedName);
+        }
+
+        public virtual void PopulateFromProviderConfig(IProviderConfiguration providerConfiguration)
+        {
+            EventHubSettingsType = providerConfiguration.GetTypeProperty(EventHubConfigTypeName, null);
+            if (string.IsNullOrWhiteSpace(StreamProviderName))
+            {
+                throw new ArgumentOutOfRangeException("providerConfiguration", "StreamProviderName not set.");
+            }
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubSettings.cs
@@ -1,0 +1,11 @@
+﻿
+namespace OrleansServiceBusUtils.Providers.Streams.EventHub
+{
+    public interface IEventHubSettings
+    {
+        string ConnectionString { get; }
+        string ConsumerGroup { get; }
+        string Path { get; }
+        int? PrefetchCount { get; }
+    }
+}

--- a/src/OrleansServiceBus/packages.config
+++ b/src/OrleansServiceBus/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="WindowsAzure.ServiceBus" version="3.0.8" targetFramework="net45" />
+</packages>

--- a/src/OrleansTestingHost/OrleansTestSecrets.cs
+++ b/src/OrleansTestingHost/OrleansTestSecrets.cs
@@ -22,6 +22,7 @@ namespace Orleans.TestingHost
         private class Contract
         {
             public string DataConnectionString { get; set; }
+            public string EventHubConnectionString { get; set; }
         }
 
         public static bool TryLoad()
@@ -40,6 +41,7 @@ namespace Orleans.TestingHost
                 {
                     var contract = JsonConvert.DeserializeObject<Contract>(input.ReadToEnd());
                     StorageTestConstants.DataConnectionString = contract.DataConnectionString;
+                    StorageTestConstants.EventHubConnectionString = contract.EventHubConnectionString;
                     return true;
                 }
             }

--- a/src/OrleansTestingHost/StorageTestConstants.cs
+++ b/src/OrleansTestingHost/StorageTestConstants.cs
@@ -1,7 +1,5 @@
+
 using System;
-using System.Diagnostics;
-using System.IO;
-using Orleans.Runtime.Configuration;
 
 namespace Orleans.TestingHost
 {
@@ -11,6 +9,8 @@ namespace Orleans.TestingHost
         // private const string DefaultStorageDataConnectionString ="DefaultEndpointsProtocol=https;AccountName=XXX;AccountKey=YYY"
         public static string DataConnectionString { get; set; }
         private const string DEFAULT_STORAGE_DATA_CONNECTION_STRING = "UseDevelopmentStorage=true";
+
+        public static string EventHubConnectionString { get; set; }
 
         static StorageTestConstants()
         {

--- a/src/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
@@ -1,0 +1,122 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Runtime.Configuration;
+using Orleans.ServiceBus.Providers;
+using Orleans.Storage;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using OrleansServiceBusUtils.Providers.Streams.EventHub;
+using UnitTests.Tester;
+
+namespace UnitTests.StreamingTests
+{
+    [DeploymentItem("OrleansConfigurationForTesting.xml")]
+    [DeploymentItem("OrleansProviders.dll")]
+    [TestClass]
+    public class EHSubscriptionMultiplicityTests : UnitTestSiloHost
+    {
+        private const string StreamProviderName = "EventHubStreamProvider";
+        private const string StreamNamespace = "EHSubscriptionMultiplicityTestsNamespace";
+        private const string EHPath = "orleans_test";
+        private const string EHConsumerGroup = "orleanstestconsumer";
+
+        private readonly SubscriptionMultiplicityTestRunner runner;
+
+        private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
+            EHConsumerGroup, EHPath);
+
+        private static readonly EventHubStreamProviderConfig ProviderConfig =
+            new EventHubStreamProviderConfig(StreamProviderName);
+
+        public EHSubscriptionMultiplicityTests()
+            : base(new TestingSiloOptions
+            {
+                StartFreshOrleans = true,
+                SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
+                AdjustConfig = AdjustClusterConfiguration
+            })
+        {
+            runner = new SubscriptionMultiplicityTestRunner(StreamProviderName, GrainClient.Logger);
+        }
+
+        public static void AdjustClusterConfiguration(ClusterConfiguration config)
+        {
+            var settings = new Dictionary<string, string>();
+            // get initial settings from configs
+            ProviderConfig.WriteProperties(settings);
+            EventHubConfig.WriteProperties(settings);
+
+            // add queue balancer setting
+            settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());
+
+            // register stream provider
+            config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, settings);
+            config.Globals.RegisterStorageProvider<MemoryStorage>("PubSubStore");
+
+            // make sure all node configs exist, for dynamic cluster queue balancer
+            config.GetConfigurationForNode("Primary");
+            config.GetConfigurationForNode("Secondary_1");
+        }
+
+        // Use ClassCleanup to run code after all tests in a class have run
+        [ClassCleanup]
+        public static void MyClassCleanup()
+        {
+            StopAllSilos();
+        }
+
+        [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task EHMultipleParallelSubscriptionTest()
+        {
+            logger.Info("************************ EHMultipleParallelSubscriptionTest *********************************");
+            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+        }
+
+        [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task EHMultipleLinearSubscriptionTest()
+        {
+            logger.Info("************************ EHMultipleLinearSubscriptionTest *********************************");
+            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+        }
+
+        [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task EHMultipleSubscriptionTest_AddRemove()
+        {
+            logger.Info("************************ EHMultipleSubscriptionTest_AddRemove *********************************");
+            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+        }
+
+        [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task EHResubscriptionTest()
+        {
+            logger.Info("************************ EHResubscriptionTest *********************************");
+            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
+        }
+
+        [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task EHResubscriptionAfterDeactivationTest()
+        {
+            logger.Info("************************ EHResubscriptionAfterDeactivationTest *********************************");
+            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
+        }
+
+        [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task EHActiveSubscriptionTest()
+        {
+            logger.Info("************************ EHActiveSubscriptionTest *********************************");
+            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+        }
+
+        [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task EHTwoIntermitentStreamTest()
+        {
+            logger.Info("************************ EHTwoIntermitentStreamTest *********************************");
+            await runner.TwoIntermitentStreamTest(Guid.NewGuid());
+        }
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -168,6 +168,7 @@
     <Compile Include="StreamingTests\ControllableStreamProviderTests.cs" />
     <Compile Include="StreamingTests\DeactivationTestRunner.cs" />
     <Compile Include="MembershipTests\SilosStopTests.cs" />
+    <Compile Include="StreamingTests\EHSubscriptionMultiplicityTests.cs" />
     <Compile Include="StreamingTests\PullingAgentManagementTests.cs" />
     <Compile Include="StreamingTests\DelayedQueueRebalancingTests.cs" />
     <Compile Include="StreamingTests\StreamFilteringTests.cs" />
@@ -295,6 +296,10 @@
     <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj">
       <Project>{6FF2004C-CDF8-479C-BF27-C6BFE8EF93E0}</Project>
       <Name>OrleansRuntime</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OrleansServiceBus\OrleansServiceBus.csproj">
+      <Project>{8BFF0092-15D2-4425-80C0-29E381702F2B}</Project>
+      <Name>OrleansServiceBus</Name>
     </ProjectReference>
     <ProjectReference Include="..\OrleansSQLUtils\OrleansSqlUtils.csproj">
       <Project>{47e9ae37-4eae-48d5-a778-2c80e9a6375f}</Project>


### PR DESCRIPTION
This is the initial prototype of a recoverable EventHubStreamProvider.

See: Recoverable Event Hub Persistent Stream Provider #1096
This is aproxamatly what is described in "1. Minimal non-recoverable EventHub stream provider"

>Minimal non-recoverable EventHub stream provider
◦Introduction of a new ServiceBus specific project. OrleansServiceBus. This will be comparable to the azure specific project OrleansAzureUtils.
◦Development of EventHubQueueAdapter comparable to AzureQueueAdapter, with similar limitations.
a.Non-rewindable
b.Will use simple queue cache.
◦Define an EventHubStreamProvider that is a persistent stream provider that uses the EventHubAdapter.
◦Add test coverage for EventHubStreamProvider comparable to that of AzureQueueStreamProvider.

This provider is not yet production ready.