### PR TITLE
Added Delete method to all ICounters.

### DIFF
--- a/src/Orleans/Statistics/AverageTimeSpanStatistic.cs
+++ b/src/Orleans/Statistics/AverageTimeSpanStatistic.cs
@@ -82,6 +82,18 @@ namespace Orleans.Runtime
             }
         }
 
+        static public void Delete(StatisticName name)
+        {
+            lock (classLock)
+            {
+                AverageTimeSpanStatistic stat;
+                if (registeredStatistics.TryGetValue(name.Name, out stat))
+                {
+                    registeredStatistics.Remove(name.Name);
+                }
+            }
+        }
+
         public static void AddCounters(List<ICounter> list, Func<ICounter, bool> predicate)
         {
             lock (classLock)

--- a/src/Orleans/Statistics/AverageValueStatistic.cs
+++ b/src/Orleans/Statistics/AverageValueStatistic.cs
@@ -40,6 +40,11 @@ namespace Orleans.Runtime
             return stat;
         }
 
+        static public void Delete(StatisticName name)
+        {
+            FloatValueStatistic.Delete(name);
+        }
+
         protected AverageValueStatistic(StatisticName name)
         {
             Name = name.Name;

--- a/src/Orleans/Statistics/IntValueStatistic.cs
+++ b/src/Orleans/Statistics/IntValueStatistic.cs
@@ -13,7 +13,7 @@ namespace Orleans.Runtime
         public string Name { get; private set; }
         public CounterStorage Storage { get; private set; }
 
-        private readonly Func<long> fetcher;
+        private Func<long> fetcher;
 
         static IntValueStatistic()
         {
@@ -49,6 +49,20 @@ namespace Orleans.Runtime
                 registeredStatistics[name.Name] = ctr;
                 return ctr;
             }
+        }
+
+        static public void Delete(StatisticName name)
+        {
+            lock (lockable)
+            {
+                IntValueStatistic stat;
+                if (registeredStatistics.TryGetValue(name.Name, out stat))
+                {
+                    registeredStatistics.Remove(name.Name);
+                    // Null the fetcher delegate to prevent memory leaks via undesirable reference capture by the fetcher lambda.
+                    stat.fetcher = null;
+                }
+            }   
         }
 
         /// <summary>


### PR DESCRIPTION
Added Delete method to all ICounters, to allow deleting the counter statistics in order to prevent any potential memory leaks.
The need for that was raised by #1160.
