### PR TITLE
Move embedded NuGet packages from the top level down to individual project templates

### DIFF
--- a/src/OrleansVSTools/OrleansVSTools/source.extension.vsixmanifest
+++ b/src/OrleansVSTools/OrleansVSTools/source.extension.vsixmanifest
@@ -31,30 +31,7 @@ C#, VB, F#  Project templates and item templates
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterface" d:TargetPath="|VSProjectTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterface" d:TargetPath="|VSItemTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainImplementation" d:TargetPath="|VSItemTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainImplementationVB" d:TargetPath="|VSItemTemplateGrainImplementationVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementationVB" d:TargetPath="|VSProjectTemplateGrainImplementationVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplatePersistedGrain" d:TargetPath="|VSItemTemplatePersistedGrain;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplatePersistedGrainVB" d:TargetPath="|VSItemTemplatePersistedGrainVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectSiloHost" d:TargetPath="|VSProjectSiloHost;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterfaceVB" d:TargetPath="|VSProjectTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterfaceVB" d:TargetPath="|VSItemTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementationFSharp" d:TargetPath="|VSProjectTemplateGrainImplementationFSharp;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-    <Asset Type="Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Extensions.DependencyInjection.1.0.0-rc1-final.nupkg" d:Source="File" Path="Packages\Microsoft.Extensions.DependencyInjection.1.0.0-rc1-final.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc1-final" d:Source="File" Path="Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc1-final" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Orleans.Core.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Orleans.CounterControl.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.CounterControl.1.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.1.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Orleans.OrleansHost.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansHost.1.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Orleans.OrleansProviders.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansProviders.1.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Orleans.OrleansRuntime.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansRuntime.1.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Orleans.Server.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Server.1.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Orleans.Templates.Grains.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Grains.1.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Microsoft.Orleans.Templates.Interfaces.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Interfaces.1.1.0.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="Newtonsoft.Json.6.0.8.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.6.0.8.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
-    <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />
   </Assets>
 </PackageManifest>

--- a/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
+++ b/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
+<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <TemplateData>
     <Name>Orleans Dev/Test Host</Name>
     <Description>A project for creating a console application hosting an Orleans silo, intended for use during development and test</Description>
@@ -45,5 +45,37 @@
       <package id="System.Collections.Immutable" version="1.1.36" />
       <package id="System.Reflection.Metadata" version="1.0.21" />
     </packages>
+    <Assets>
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementation" d:TargetPath="|VSProjectTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterface" d:TargetPath="|VSProjectTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterface" d:TargetPath="|VSItemTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainImplementation" d:TargetPath="|VSItemTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainImplementationVB" d:TargetPath="|VSItemTemplateGrainImplementationVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementationVB" d:TargetPath="|VSProjectTemplateGrainImplementationVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplatePersistedGrain" d:TargetPath="|VSItemTemplatePersistedGrain;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplatePersistedGrainVB" d:TargetPath="|VSItemTemplatePersistedGrainVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectSiloHost" d:TargetPath="|VSProjectSiloHost;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterfaceVB" d:TargetPath="|VSProjectTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterfaceVB" d:TargetPath="|VSItemTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementationFSharp" d:TargetPath="|VSProjectTemplateGrainImplementationFSharp;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Extensions.DependencyInjection.1.0.0-rc1-final.nupkg" d:Source="File" Path="Packages\Microsoft.Extensions.DependencyInjection.1.0.0-rc1-final.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc1-final" d:Source="File" Path="Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc1-final" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Core.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.CounterControl.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.CounterControl.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansHost.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansHost.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansProviders.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansProviders.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansRuntime.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansRuntime.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Server.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Server.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Templates.Grains.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Grains.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Templates.Interfaces.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Interfaces.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Newtonsoft.Json.6.0.8.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.6.0.8.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />
+    </Assets>
   </WizardData>
+  
 </VSTemplate>

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.vstemplate
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
+<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <TemplateData>
     <Name>Orleans Grain Class Collection</Name>
     <Description>A project for defining a collection of grain classes to be distributed as a unit</Description>
@@ -38,5 +38,23 @@
       <package id="System.Collections.Immutable" version="1.1.36" />
       <package id="System.Reflection.Metadata" version="1.0.21" />
     </packages>
+    <Assets>
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementation" d:TargetPath="|VSProjectTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainImplementation" d:TargetPath="|VSItemTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainImplementationVB" d:TargetPath="|VSItemTemplateGrainImplementationVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementationVB" d:TargetPath="|VSProjectTemplateGrainImplementationVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplatePersistedGrain" d:TargetPath="|VSItemTemplatePersistedGrain;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplatePersistedGrainVB" d:TargetPath="|VSItemTemplatePersistedGrainVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementationFSharp" d:TargetPath="|VSProjectTemplateGrainImplementationFSharp;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Core.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Templates.Grains.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Grains.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Newtonsoft.Json.6.0.8.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.6.0.8.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />
+    </Assets>
   </WizardData>
 </VSTemplate>

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.vstemplate
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
+<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <TemplateData>
     <Name>Orleans Grain Interface Collection</Name>
     <Description>A project for defining a collection of grain communication interfaces and their payloads</Description>
@@ -38,5 +38,20 @@
       <package id="System.Collections.Immutable" version="1.1.36" />
       <package id="System.Reflection.Metadata" version="1.0.21" />
     </packages>
+    <Assets>
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterface" d:TargetPath="|VSProjectTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterface" d:TargetPath="|VSItemTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterfaceVB" d:TargetPath="|VSProjectTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterfaceVB" d:TargetPath="|VSItemTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
+      <Asset Type="Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Core.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Templates.Interfaces.1.1.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Interfaces.1.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Newtonsoft.Json.6.0.8.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.6.0.8.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />
+    </Assets>
   </WizardData>
 </VSTemplate>


### PR DESCRIPTION
Move embedded NuGet packages from the top level down to individual project templates
Remove VB and F# templates.

These were necessary changes to get the VSIX published to the VS Gallery. Fixes https://github.com/dotnet/orleans/issues/1162.

I already published the VSIX, so this needs to be merged as is.