### PR TITLE
Performance tweak for generic types

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -768,6 +768,21 @@ namespace Orleans.Serialization
             MethodInfo deserializer;
 
             var concreteSerializerType = genericSerializerType.MakeGenericType(concreteType.GetGenericArguments());
+            var typeAlreadyRegistered = false;
+            
+            lock (registeredTypes)
+            {
+                typeAlreadyRegistered = registeredTypes.Contains(concreteSerializerType);
+            }
+            
+            if (typeAlreadyRegistered)
+            {
+                return new SerializerMethods(
+                    GetCopier(concreteSerializerType),
+                    GetSerializer(concreteSerializerType),
+                    GetDeserializer(concreteSerializerType));
+            }
+
             GetSerializationMethods(concreteSerializerType, out copier, out serializer, out deserializer);
             var concreteCopier = (DeepCopier)copier.CreateDelegate(typeof(DeepCopier));
             var concreteSerializer = (Serializer)serializer.CreateDelegate(typeof(Serializer));


### PR DESCRIPTION
in 
```csharp
SerializationManager.Register(Type, Type)
```
the delegates created for copy/serialize/deserialize with generic types all always call RegisterConcreteSerializer()

This is bad because every time RegisterConcreteSerializer is called, it uses reflection discover serializer/deserializer/copy methods, then re-registers the serializer (forced override) even if it hasn't changed.

The fix is to see if the concrete type has already been registered and use the existing serializer/deserializer/copier instead.