### PR TITLE
Correctly specify struct type constraint in generated code

### DIFF
--- a/src/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/src/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -22,6 +22,7 @@ namespace UnitTests.GrainInterfaces
 
     public interface ISerializationGenerationGrain : IGrainWithIntegerKey
     {
+        Task<object> RoundTripObject(object input);
         Task<SomeStruct> RoundTripStruct(SomeStruct input);
         Task<SomeAbstractClass> RoundTripClass(SomeAbstractClass input);
         Task<ISomeInterface> RoundTripInterface(ISomeInterface input);
@@ -175,5 +176,12 @@ namespace UnitTests.GrainInterfaces
         {
             return base.GetHashCode();
         }
+    }
+
+    [Serializable]
+    public class ClassWithStructConstraint<T>
+        where T : struct
+    {
+        public T Value { get; set; }
     }
 }

--- a/src/TestGrains/SerializationGenerationGrain.cs
+++ b/src/TestGrains/SerializationGenerationGrain.cs
@@ -10,6 +10,11 @@ namespace TestGrains
     using UnitTests.GrainInterfaces;
     public class SerializationGenerationGrain : Grain<SerializationGenerationGrain.MyState>, ISerializationGenerationGrain
     {
+        public Task<object> RoundTripObject(object input)
+        {
+            return Task.FromResult(input);
+        }
+
         public Task<SomeStruct> RoundTripStruct(SomeStruct input)
         {
             return Task.FromResult(input);

--- a/src/Tester/CodeGenTests/GeneratorGrainTest.cs
+++ b/src/Tester/CodeGenTests/GeneratorGrainTest.cs
@@ -84,6 +84,12 @@ namespace Tester.CodeGenTests
             const SomeAbstractClass.SomeEnum ExpectedEnum = SomeAbstractClass.SomeEnum.Something;
             var actualEnum = await grain.RoundTripEnum(ExpectedEnum);
             Assert.AreEqual(ExpectedEnum, actualEnum);
+
+            // Test serialization of a generic class which has a value-type constraint.
+            var expectedStructConstraintObject = new ClassWithStructConstraint<int> { Value = 38 };
+            var actualStructConstraintObject =
+                (ClassWithStructConstraint<int>)await grain.RoundTripObject(expectedStructConstraintObject);
+            Assert.AreEqual(expectedStructConstraintObject.Value, actualStructConstraintObject.Value);
         }
 
         [TestMethod, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GetGrain")]


### PR DESCRIPTION
Fix for #1177.

Generic types with a type constraint of `struct` were being incorrectly specified as having type constraints of `new()`, and `System.ValueType`, which are redundant and illegal when `struct` is specified.

This fixes that & adds a test :smile:
Thank you, @bstead for reporting!