### PR TITLE
Structured test overrides file

### DIFF
--- a/src/OrleansTestingHost/OrleansTestSecrets.cs
+++ b/src/OrleansTestingHost/OrleansTestSecrets.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Orleans.TestingHost
+{
+    public static class OrleansTestSecrets
+    {
+        // In order to specify your own test secrets you should:
+        // 1) Create a file named OrleansTestSecrets.json with the below Contract data in it.
+        //    "{\"DataConnectionString\": \"DefaultEndpointsProtocol=https;AccountName=XXX;AccountKey=YYY\"}"
+        // 2) Define an environment variable ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH and point it to the folder where this file is located.
+        // 
+        // MSBuild unit test framework runs a script "SetupTestScript.cmd" (that is specified in Local.testsettings), which
+        // copies ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH\OrleansTestSecrets.json into where the unit tests are run.
+        // At runtime OrleansTestSecrets class will read this file and use your storage account key.
+        public const string ORLEANS_TEST_SECRETS_FILE_NAME = "OrleansTestSecrets.json";
+
+        [Serializable]
+        private class Contract
+        {
+            public string DataConnectionString { get; set; }
+        }
+
+        public static bool TryLoad()
+        {
+            try
+            {
+                if (!File.Exists(ORLEANS_TEST_SECRETS_FILE_NAME))
+                {
+                    string fileNotFoundMsg = string.Format("Did not find the {0} file or it was empty. Using Default Storage Data Connection String instead.", ORLEANS_TEST_SECRETS_FILE_NAME);
+                    Console.Out.WriteLine(fileNotFoundMsg);
+                    Trace.WriteLine(fileNotFoundMsg);
+                    return false;
+                }
+
+                using (TextReader input = File.OpenText(ORLEANS_TEST_SECRETS_FILE_NAME))
+                {
+                    var contract = JsonConvert.DeserializeObject<Contract>(input.ReadToEnd());
+                    StorageTestConstants.DataConnectionString = contract.DataConnectionString;
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                string fileFoundMsg = string.Format("Error loading {0}.  Exception: {1}", ORLEANS_TEST_SECRETS_FILE_NAME, ex);
+                Console.Out.WriteLine(fileFoundMsg);
+            }
+            return false;
+        }
+    }
+}

--- a/src/OrleansTestingHost/OrleansTestStorageKey.cs
+++ b/src/OrleansTestingHost/OrleansTestStorageKey.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Orleans.TestingHost
+{
+    public static class OrleansTestStorageKey
+    {
+        //
+        // This is depricated. Please use OrleansTestSecrets
+        //
+        // In order to specify your own Azure Storage DataConnectionString you should:
+        // 1) Create a file named OrleansTestStorageKey.txt and put one line with your storage key there, without "", like this:
+        // DefaultEndpointsProtocol=https;AccountName=XXX;AccountKey=YYY
+        // 2) Define an environment variable ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH and point it to the folder where this file is located.
+        // 
+        // MSBuild unit test framework runs a script "SetupTestScript.cmd" (that is specified in Local.testsettings), which
+        // copies ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH\OrleansTestStorageKey.txt into where the unit tests are run.
+        // At runtime StorageTestConstants class will read this file and use your storage account key.
+        // 
+        // Alternativerly, instead of using a file, you can just:
+        // Set DefaultStorageDataConnectionString to your actual Azure Storage DataConnectionString
+        // private const string DefaultStorageDataConnectionString ="DefaultEndpointsProtocol=https;AccountName=XXX;AccountKey=YYY"
+        public const string ORLEANS_TEST_STORAGE_KEY_FILE_NAME = "OrleansTestStorageKey.txt";
+
+        public static bool TryLoad()
+        {
+            try
+            {
+                if (!File.Exists(ORLEANS_TEST_STORAGE_KEY_FILE_NAME))
+                {
+                    string fileNotFoundMsg = string.Format("Did not find the {0} file or it was empty. Using Default Storage Data Connection String instead.", ORLEANS_TEST_STORAGE_KEY_FILE_NAME);
+                    Console.Out.WriteLine(fileNotFoundMsg);
+                    Trace.WriteLine(fileNotFoundMsg);
+                    return false;
+                }
+
+                using (TextReader input = File.OpenText(ORLEANS_TEST_STORAGE_KEY_FILE_NAME))
+                {
+                    string line = input.ReadToEnd();
+                    line = line.Trim();
+                    if (!String.IsNullOrEmpty(line))
+                    {
+                        string fileFoundMsg = string.Format("Found the {0} file and using the Storage Key from there.", ORLEANS_TEST_STORAGE_KEY_FILE_NAME);
+                        Console.Out.WriteLine(fileFoundMsg);
+                        Trace.WriteLine(fileFoundMsg);
+                        StorageTestConstants.DataConnectionString = line;
+                    }
+                }
+
+                return !string.IsNullOrWhiteSpace(StorageTestConstants.DataConnectionString);
+            }
+            catch (Exception ex)
+            {
+                string fileFoundMsg = string.Format("Error loading {0}.  Exception: {1}", ORLEANS_TEST_STORAGE_KEY_FILE_NAME, ex);
+                Console.Out.WriteLine(fileFoundMsg);
+            }
+            return false;
+        }
+    }
+}

--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -33,6 +33,10 @@
     <WarningsAsErrors>4014</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -47,6 +51,8 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Extensions\TestConfigurationExtensions.cs" />
+    <Compile Include="OrleansTestSecrets.cs" />
+    <Compile Include="OrleansTestStorageKey.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AsyncResultHandle.cs" />
     <Compile Include="StorageEmulator.cs" />
@@ -77,6 +83,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="TestingHost.Install.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/OrleansTestingHost/StorageTestConstants.cs
+++ b/src/OrleansTestingHost/StorageTestConstants.cs
@@ -7,52 +7,22 @@ namespace Orleans.TestingHost
 {
     public static class StorageTestConstants
     {
-        // In order to specify your own Azure Storage DataConnectionString you should:
-        // 1) Create a file named OrleansTestStorageKey.txt and put one line with your storage key there, without "", like this:
-        // DefaultEndpointsProtocol=https;AccountName=XXX;AccountKey=YYY
-        // 2) Define an environment variable ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH and point it to the folder where this file is located.
-        // 
-        // MSBuild unit test framework runs a script "SetupTestScript.cmd" (that is specified in Local.testsettings), which
-        // copies ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH\OrleansTestStorageKey.txt into where the unit tests are run.
-        // At runtime StorageTestConstants class will read this file and use your storage account key.
-        // 
-        // Alternativerly, instead of using a file, you can just:
-        // Set DefaultStorageDataConnectionString to your actual Azure Storage DataConnectionString
+        // Set DefaultStorageDataConnectionString to your actual Azure Storage DataConnectionString, or load if from OrleansTestSecrets
         // private const string DefaultStorageDataConnectionString ="DefaultEndpointsProtocol=https;AccountName=XXX;AccountKey=YYY"
-        public static string DataConnectionString { get; private set; }
-        public const string ORLEANS_TEST_STORAGE_KEY_FILE_NAME = "OrleansTestStorageKey.txt";
-
+        public static string DataConnectionString { get; set; }
         private const string DEFAULT_STORAGE_DATA_CONNECTION_STRING = "UseDevelopmentStorage=true";
 
         static StorageTestConstants()
         {
             if (DataConnectionString != null)
             {
-                return; // already initialized
+                return;
             }
-            if (File.Exists(ORLEANS_TEST_STORAGE_KEY_FILE_NAME))
+
+            if (!OrleansTestSecrets.TryLoad() && !OrleansTestStorageKey.TryLoad())
             {
-                using (TextReader input = File.OpenText(ORLEANS_TEST_STORAGE_KEY_FILE_NAME))
-                {
-                    string line = input.ReadToEnd();
-                    line = line.Trim();
-                    if (!String.IsNullOrEmpty(line))
-                    {
-                        string fileFoundMsg = string.Format("Found the {0} file and using the Storage Key from there.", ORLEANS_TEST_STORAGE_KEY_FILE_NAME);
-                        Console.Out.WriteLine(fileFoundMsg);
-                        Trace.WriteLine(fileFoundMsg);
-                        DataConnectionString = line;
-                    }
-                }
+                DataConnectionString = DEFAULT_STORAGE_DATA_CONNECTION_STRING;
             }
-
-            if (DataConnectionString != null) return;
-
-            // If did not find the file, just use the DevelopmentStorage
-            string fileNotFoundMsg = string.Format("Did not find the {0} file or it was empty. Using Default Storage Data Connection String instead.", ORLEANS_TEST_STORAGE_KEY_FILE_NAME);
-            Console.Out.WriteLine(fileNotFoundMsg);
-            Trace.WriteLine(fileNotFoundMsg);
-            DataConnectionString = DEFAULT_STORAGE_DATA_CONNECTION_STRING;
         }
 
         public static bool UsingAzureLocalStorageEmulator

--- a/src/OrleansTestingHost/packages.config
+++ b/src/OrleansTestingHost/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+</packages>

--- a/src/SetupTestScript.cmd
+++ b/src/SetupTestScript.cmd
@@ -9,15 +9,27 @@ if exist "%CMDHOME%\..\..\..\Test" (
   SET DEFAULT_FILE="%CMDHOME%\..\..\src\Test\OrleansTestStorageKey.txt"
 )
 
+if exist "%CMDHOME%\..\..\..\Test" (
+  SET DEFAULT_SECRETS_FILE="%CMDHOME%\..\..\..\Test\OrleansTestSecrets.json"
+) else (
+  SET DEFAULT_SECRETS_FILE="%CMDHOME%\..\..\src\Test\OrleansTestSecrets.json"
+)
 
 echo ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH is %ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH% >> SetupTestScriptOutput.txt 
 echo CMDHOME is %CMDHOME% >> SetupTestScriptOutput.txt
 echo DEFAULT_FILE is %DEFAULT_FILE% >> SetupTestScriptOutput.txt
+echo DEFAULT_SECRETS_FILE is %DEFAULT_SECRETS_FILE% >> SetupTestScriptOutput.txt
 
 if not exist %DEFAULT_FILE% (
 echo DEFAULT_FILE %DEFAULT_FILE% does not exist!! >> SetupTestScriptOutput.txt 
 ) else (
 echo DEFAULT_FILE %DEFAULT_FILE% does exist!! >> SetupTestScriptOutput.txt 
+)
+
+if not exist %DEFAULT_SECRETS_FILE% (
+echo DEFAULT_SECRETS_FILE %DEFAULT_SECRETS_FILE% does not exist!! >> SetupTestScriptOutput.txt 
+) else (
+echo DEFAULT_SECRETS_FILE %DEFAULT_SECRETS_FILE% does exist!! >> SetupTestScriptOutput.txt 
 )
 
 echo "-----------------------------------------------" >> SetupTestScriptOutput.txt 
@@ -29,18 +41,33 @@ if "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%" == "" (
 echo ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH env var is not set. Taking %DEFAULT_FILE%. >> SetupTestScriptOutput.txt
 copy /y %DEFAULT_FILE% . >> SetupTestScriptOutput.txt 
 
-) else if not exist "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestStorageKey.txt" (
-
-echo ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH env var is set but %ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestStorageKey.txt does not exist. Taking %DEFAULT_FILE%. >> SetupTestScriptOutput.txt
-copy /y %DEFAULT_FILE% . >> SetupTestScriptOutput.txt 
-
 ) else (
 
-echo ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH env var is set and found "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestStorageKey.txt". Taking it. >> SetupTestScriptOutput.txt 
-copy /y "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestStorageKey.txt"  . >> SetupTestScriptOutput.txt 
+  if not exist "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestStorageKey.txt" (
+
+    echo ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH env var is set but %ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestStorageKey.txt does not exist. Taking %DEFAULT_FILE%. >> SetupTestScriptOutput.txt
+    copy /y %DEFAULT_FILE% . >> SetupTestScriptOutput.txt 
+
+	) else (
+
+	echo ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH env var is set and found "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestStorageKey.txt". Taking it. >> SetupTestScriptOutput.txt 
+	copy /y "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestStorageKey.txt"  . >> SetupTestScriptOutput.txt 
+
+	)
+
+  if not exist "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestSecrets.json" (
+
+    echo ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH env var is set but %ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestSecrets.json does not exist. Taking %DEFAULT_FILE%. >> SetupTestScriptOutput.txt
+    copy /y %DEFAULT_SECRETS_FILE% . >> SetupTestScriptOutput.txt 
+
+	) else (
+
+	echo ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH env var is set and found "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestSecrets.json". Taking it. >> SetupTestScriptOutput.txt 
+	copy /y "%ORLEANS_TEST_STORAGE_KEY_FOLDER_PATH%\OrleansTestSecrets.json"  . >> SetupTestScriptOutput.txt 
+
+	)
 
 )
-
 
 echo "-----------------------------------------------" >> SetupTestScriptOutput.txt 
 echo "-----------------------------------------------" >> SetupTestScriptOutput.txt 


### PR DESCRIPTION
Added structured test settings overrides file OrleansTestSecrets to support more test settings overrides.

We will need local overrides for EventHub test settings and the existing OrleansTestStorageKeys.txt is not well structured.  Replacing it with structured file OrleansTestSecrets.json.  Leaving in OrleanTestStorageKeys.txt support for now to not break those using it, but it should be deprecated soon.