### PR TITLE
Add the CWD to the DLL search path

### DIFF
--- a/src/OrleansHost/Program.cs
+++ b/src/OrleansHost/Program.cs
@@ -43,7 +43,7 @@ namespace Orleans.Runtime.Host
 
         private static void DumpCommandLineArgs(string[] args)
         {
-            ConsoleText.WriteUsage(string.Format("Environement.CommandLine=[{0}]", Environment.CommandLine));
+            ConsoleText.WriteUsage(string.Format("Environment.CommandLine=[{0}]", Environment.CommandLine));
 
             if (args == null || args.Length == 0)
             {
@@ -56,9 +56,9 @@ namespace Orleans.Runtime.Host
                     ConsoleText.WriteUsage(string.Format("args[{0}]='{1}'", i, args[i]));
                 
                 string[] cmdArgs = Environment.GetCommandLineArgs();
-                ConsoleText.WriteUsage(string.Format("Called with Environement.CommandLineArgs.Length={0}", cmdArgs.Length));
+                ConsoleText.WriteUsage(string.Format("Called with Environment.CommandLineArgs.Length={0}", cmdArgs.Length));
                 for (int i = 0; i < cmdArgs.Length; i++)
-                    ConsoleText.WriteUsage(string.Format("Environement.CommandLineArgs[{0}]='{1}'", i, cmdArgs[i]));
+                    ConsoleText.WriteUsage(string.Format("Environment.CommandLineArgs[{0}]='{1}'", i, cmdArgs[i]));
             }
         }
     }

--- a/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
+++ b/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
@@ -27,11 +27,17 @@ namespace Orleans.Runtime
         {
             var exeRoot = Path.GetDirectoryName(typeof(SiloAssemblyLoader).GetTypeInfo().Assembly.Location);
             var appRoot = Path.Combine(exeRoot, "Applications");
+            var cwd = Directory.GetCurrentDirectory();
             var directories = new Dictionary<string, SearchOption>
                     {
                         { exeRoot, SearchOption.TopDirectoryOnly },
                         { appRoot, SearchOption.AllDirectories }
                     };
+
+            if (!directories.ContainsKey(cwd))
+            {
+                directories.Add(cwd, SearchOption.TopDirectoryOnly);
+            }
 
             AssemblyLoaderPathNameCriterion[] excludeCriteria =
                 {


### PR DESCRIPTION
(I also fixed a couple of typos)

This change would allow Orleans to be installed as a command line tool (via chocolatey or similar). 

This enables the developer to have a quick dev environment up and running by executing SiloHost.exe with their `bin\debug` folder as the CWD. 