### PR TITLE
Improve coverage for type constraint usage in tests

### DIFF
--- a/src/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/src/TestGrainInterfaces/IGenericInterfaces.cs
@@ -188,10 +188,13 @@ namespace UnitTests.GrainInterfaces
         Task<T> CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, T t, TimeSpan delay);
     }
 
-    public interface IGenericGrainWithConstraints<A, B> : IGrainWithStringKey where A : ICollection<B>, new()
+    public interface IGenericGrainWithConstraints<A, B, C> : IGrainWithStringKey
+        where A : ICollection<B>, new() where B : struct where C : class
     {
         Task<int> GetCount();
 
         Task Add(B item);
+
+        Task<C> RoundTrip(C value);
     }
 }

--- a/src/TestGrains/GenericGrains.cs
+++ b/src/TestGrains/GenericGrains.cs
@@ -587,7 +587,10 @@ namespace UnitTests.Grains
         }
     }
 
-    public class GenericGrainWithContraints<A, B>: Grain, IGenericGrainWithConstraints<A, B> where A : ICollection<B>, new()
+    public class GenericGrainWithContraints<A, B, C>: Grain, IGenericGrainWithConstraints<A, B, C>
+        where A : ICollection<B>, new()
+        where B : struct
+        where C : class
     {
         private A collection;
 
@@ -603,6 +606,11 @@ namespace UnitTests.Grains
         {
             collection.Add(item);
             return TaskDone.Done;
+        }
+
+        public Task<C> RoundTrip(C value)
+        {
+            return Task.FromResult(value);
         }
     }
 }

--- a/src/Tester/GenericGrainTests.cs
+++ b/src/Tester/GenericGrainTests.cs
@@ -653,7 +653,7 @@ namespace UnitTests.General
         public async Task Generic_GrainWithTypeConstraints()
         {
             var grainId = Guid.NewGuid().ToString();
-            var grain = GrainFactory.GetGrain<IGenericGrainWithConstraints<List<int>, int>>(grainId);
+            var grain = GrainFactory.GetGrain<IGenericGrainWithConstraints<List<int>, int, string>>(grainId);
             var result = await grain.GetCount();
             Assert.AreEqual(0, result);
             await grain.Add(42);


### PR DESCRIPTION
Expanded `IGenericGrainWithConstraints` interface to include `struct` and `class` constraints to ensure that they are explicitly covered in testing. This is in response to #1192.
