### PR TITLE
Output messages only once in ConsoleTelemetryConsumer.

### DIFF
--- a/src/Orleans/Telemetry/Consumers/ConsoleTelemetryConsumer.cs
+++ b/src/Orleans/Telemetry/Consumers/ConsoleTelemetryConsumer.cs
@@ -40,9 +40,10 @@ namespace Orleans.Runtime
                     break;
                 case Severity.Off:
                     return;
+                default:
+                    TrackTrace(message);
+                    break;
             }
-
-            TrackTrace(message);
         }
 
         public void TrackTrace(string message, Severity severityLevel, IDictionary<string, string> properties = null)


### PR DESCRIPTION
Currently console output is duplicated: first with a color message, and then with a non-color message.
Example:
![image](https://cloud.githubusercontent.com/assets/203839/11945405/b2276240-a8a3-11e5-837b-9cfaa48aca79.png)
This change removes the non-color message in all but the default case (just in case we add new severity levels).