### PR TITLE
Fixed hardcoded test grain class namespace to match the reality

### DIFF
--- a/src/TestInternalGrains/StreamingGrain.cs
+++ b/src/TestInternalGrains/StreamingGrain.cs
@@ -338,7 +338,7 @@ namespace UnitTests.Grains
 
         public Task AddNewConsumerGrain(Guid consumerGrainId)
         {
-            var grain = _grainFactory.GetGrain<IStreaming_ConsumerGrain>(consumerGrainId, "UnitTestGrains.Streaming_ConsumerGrain");
+            var grain = _grainFactory.GetGrain<IStreaming_ConsumerGrain>(consumerGrainId, "UnitTests.Grains.Streaming_ConsumerGrain");
             return grain.BecomeConsumer(_streamId, _providerName, _streamNamespace);
         }
 


### PR DESCRIPTION
This mistake causes some of the remaining VSO tests to fail.