### PR TITLE
Fixed a flipped boolean condition in the code generator when testing …

### DIFF
--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -266,12 +266,7 @@ namespace Orleans.Serialization
             // Check InternalsVisibleTo attributes on the from-assembly, pointing to the to-assembly.
             var serializationAssemblyName = toAssembly.GetName().FullName;
             var internalsVisibleTo = fromAssembly.GetCustomAttributes<InternalsVisibleToAttribute>();
-            if (internalsVisibleTo.All(_ => _.AssemblyName != serializationAssemblyName))
-            {
-                return true;
-            }
-
-            return false;
+            return internalsVisibleTo.Any(_ => _.AssemblyName == serializationAssemblyName);
         }
     }
 }


### PR DESCRIPTION
…if the InternalsVisibleTo attribute allows internal access to the assembly containing the type.

Used by IsTypeIsInaccessibleForSerialization.