### PR TITLE
update ZooKeeperNetEx to 3.4.6.1009

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -20,7 +20,7 @@
     <dependencies>
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
-	  <dependency id="ZooKeeperNetEx" version="3.4.6.1006" />
+	  <dependency id="ZooKeeperNetEx" version="3.4.6.1009" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
+++ b/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
@@ -49,7 +49,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="ZooKeeperNetEx">
-      <HintPath>$(SolutionDir)packages\ZooKeeperNetEx.3.4.6.1008\lib\net45\ZooKeeperNetEx.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\ZooKeeperNetEx.3.4.6.1009\lib\net45\ZooKeeperNetEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/OrleansZooKeeperUtils/packages.config
+++ b/src/OrleansZooKeeperUtils/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
-  <package id="ZooKeeperNetEx" version="3.4.6.1008" targetFramework="net451" />
+  <package id="ZooKeeperNetEx" version="3.4.6.1009" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Main changes :
* New log system 
 * Configuration is read from `ZooKeeperNetEx.config` when it's next to `ZooKeeperNetEx.dll`
 * Added static method to redirect logs to 3rd party loggers
 * Simplified and *better* tested
* Support the latest `dotnet5.4` framework moniker
 * Tests converted from `nUnit` to `xUnit` and fully parallelized
 * New build system - using `Sake` & `KoreBulid`