### PR TITLE
Made OrleansJsonSerializer.JsonSerializerSettings public and settable so can be used and changed in providers.

### DIFF
--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -103,8 +103,7 @@ namespace Orleans.Storage
             
             if (useJsonFormat)
             {
-                jsonSettings = new Newtonsoft.Json.JsonSerializerSettings();
-                jsonSettings.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.All;
+                jsonSettings = OrleansJsonSerializer.SerializerSettings;
             }
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/orleans/issues/1187#issuecomment-166768611.

1) Made OrleansJsonSerializer.JsonSerializerSettings public and settable
2) Use this JsonSerializerSettings  in Azure Storage provider.
3) JsonSerializerSettings can now be configured (set or changed) differently, for example in Bootstrap provider.