### PR TITLE
No-op Test.cmd script for gh-pages branch.

### DIFF
--- a/Test.cmd
+++ b/Test.cmd
@@ -1,0 +1,4 @@
+@echo OFF
+@setlocal
+
+@Echo Test.cmd - No-op build file to stop the CI server from breaking


### PR DESCRIPTION
- Add back a no-op Test.cmd script for gh-pages branch, removed in error by PR #1191.