### PR TITLE
fix MySql script concurrency issues and add sql publisher tests

### DIFF
--- a/src/OrleansSQLUtils/CreateOrleansTables_MySql.sql
+++ b/src/OrleansSQLUtils/CreateOrleansTables_MySql.sql
@@ -396,31 +396,7 @@ DELIMITER ;
 INSERT INTO OrleansQuery(QueryKey, QueryText)
 VALUES
 (
-	'UpsertReminderRowKey', 'call UpsertReminderRowKey(@serviceId, @grainId, @reminderName, @startTime, @period, 
-    @grainIdConsistentHash);'
-);
-
-DELIMITER $$
-CREATE PROCEDURE UpsertReminderRowKey(
-	in 	_serviceId NVARCHAR(150),
-	in 	_grainId NVARCHAR(150),
-	in 	_reminderName NVARCHAR(150),
-	in 	_startTime DATETIME,
-	in 	_period INT,
-	in 	_grainIdConsistentHash INT
-)
-BEGIN
-		DECLARE _newEtag BIGINT;
-		START TRANSACTION;
-        SET _newEtag = (SELECT ETag + 1 FROM OrleansRemindersTable WHERE
-						ServiceId = _serviceId AND _serviceId IS NOT NULL
-						AND GrainId = _grainId AND _grainId IS NOT NULL
-						AND ReminderName = _reminderName AND _reminderName IS NOT NULL 
-						FOR UPDATE);
-                        
-		IF _newEtag IS NULL
-		THEN
-			SET _newEtag = 0;
+	'UpsertReminderRowKey', '
 			INSERT INTO OrleansRemindersTable
 			(
 				ServiceId,
@@ -432,77 +408,26 @@ BEGIN
 			)
 			VALUES
 			(
-				_serviceId,
-				_grainId,
-				_reminderName,
-				_startTime,
-				_period,
-				_grainIdConsistentHash
-			);
-		ELSE
-			UPDATE OrleansRemindersTable
-			SET				
-				StartTime             = _startTime,
-				Period                = _period,
-				GrainIdConsistentHash = _grainIdConsistentHash,
-				ETag                  = _newEtag
-			WHERE
-				ServiceId = _serviceId AND _serviceId IS NOT NULL
-				AND GrainId = _grainId AND _grainId IS NOT NULL
-				AND ReminderName = _reminderName AND _reminderName IS NOT NULL;
-		END IF;
-		COMMIT;
-		SELECT CONVERT(_newEtag, BINARY) AS ETag;
-END$$
-
-DELIMITER ;
+				@serviceId,
+				@grainId,
+				@reminderName,
+				@startTime,
+				@period,
+				@grainIdConsistentHash
+			)
+		ON DUPLICATE KEY UPDATE 
+				StartTime             = @startTime,
+				Period                = @period,
+				GrainIdConsistentHash = @grainIdConsistentHash,
+				ETag                  = last_insert_id(ETag+1);
+	
+		SELECT CONVERT(last_insert_id(), BINARY) AS ETag;
+');
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
 VALUES
 (
-	'UpsertReportClientMetricsKey','call UpsertReportClientMetricsKey(@deploymentId, @clientId, @timestamp, 
-    @address, @hostName, @cpuUsage, @memoryUsage, @sendQueueLength, @receiveQueueLength, @sentMessagesCount,
-    @receivedMessagesCount, @connectedGatewaysCount);'
-);
-
-DELIMITER $$
-
-CREATE PROCEDURE UpsertReportClientMetricsKey(
-	in	_deploymentId NVARCHAR(150),
-	in	_clientId NVARCHAR(150),
-	in	_timestamp DATETIME,
-	in	_address VARCHAR(45),
-	in	_hostName NVARCHAR(150),
-	in	_cpuUsage FLOAT,
-	in	_memoryUsage BIGINT,
-	in	_sendQueueLength INT,
-	in	_receiveQueueLength INT,
-	in	_sentMessagesCount BIGINT,
-	in	_receivedMessagesCount BIGINT,
-	in	_connectedGatewaysCount BIGINT
-)
-BEGIN
-		START TRANSACTION;     
-		IF EXISTS(SELECT 1 FROM OrleansClientMetricsTable WHERE
-			DeploymentId = _deploymentId AND _deploymentId IS NOT NULL
-			AND ClientId = _clientId AND _clientId IS NOT NULL
-			FOR UPDATE) 
-		THEN
-			UPDATE OrleansClientMetricsTable
-			SET			
-				Address = _address,
-				HostName = _hostName,
-				CPU = _cpuUsage,
-				Memory = _memoryUsage,
-				SendQueue = _sendQueueLength,
-				ReceiveQueue = _receiveQueueLength,
-				SentMessages = _sentMessagesCount,
-				ReceivedMessages = _receivedMessagesCount,
-				ConnectedGatewayCount = _connectedGatewaysCount
-			WHERE
-				(DeploymentId = _deploymentId AND _deploymentId IS NOT NULL)
-				AND (ClientId = _clientId AND _clientId IS NOT NULL);
-		ELSE
+	'UpsertReportClientMetricsKey','
 			INSERT INTO OrleansClientMetricsTable
 			(
 				DeploymentId,
@@ -519,87 +444,34 @@ BEGIN
 			)
 			VALUES
 			(
-				_deploymentId,
-				_clientId,
-				_address,
-				_hostName,
-				_cpuUsage,
-				_memoryUsage,
-				_sendQueueLength,
-				_receiveQueueLength,
-				_sentMessagesCount,
-				_receivedMessagesCount,
-				_connectedGatewaysCount
-			);
-		END IF;
-		COMMIT;
-END$$    
-
-DELIMITER ;
+				@deploymentId,
+				@clientId,
+				@address,
+				@hostName,
+				@cpuUsage,
+				@memoryUsage,
+				@sendQueueLength,
+				@receiveQueueLength,
+				@sentMessagesCount,
+				@receivedMessagesCount,
+				@connectedGatewaysCount
+			)
+		ON DUPLICATE KEY UPDATE 
+				Address 		= @address,
+				HostName 		= @hostName,
+				CPU 			= @cpuUsage,
+				Memory 			= @memoryUsage,
+				SendQueue 		= @sendQueueLength,
+				ReceiveQueue 		= @receiveQueueLength,
+				SentMessages 		= @sentMessagesCount,
+				ReceivedMessages 	= @receivedMessagesCount,
+				ConnectedGatewayCount 	= @connectedGatewaysCount;
+');
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
 VALUES
 (
-	'UpsertSiloMetricsKey','call UpsertSiloMetricsKey(@deploymentId, @siloId, @address, @port, @generation, 
-    @hostName, @gatewayAddress, @gatewayPort, @cpuUsage, @memoryUsage, @activationsCount, @recentlyUsedActivationsCount,
-	@sendQueueLength, @receiveQueueLength, @requestQueueLength, @sentMessagesCount, @receivedMessagesCount,
-	@isOverloaded, @clientCount);'
-);
-
-DELIMITER $$
-
-CREATE PROCEDURE UpsertSiloMetricsKey(
-	in	_deploymentId NVARCHAR(150),
-	in	_siloId NVARCHAR(150),
-    in	_timestamp DATETIME,
-    in	_address VARCHAR(45),
-    in	_port INT,
-    in	_generation INT,
-    in	_hostName NVARCHAR(150),
-    in	_gatewayAddress VARCHAR(45),
-    in	_gatewayPort INT,
-    in	_cpuUsage FLOAT,
-    in	_memoryUsage BIGINT,
-    in	_activationsCount INT,
-    in	_recentlyUsedActivationsCount INT,
-    in	_sendQueueLength INT,
-    in	_receiveQueueLength INT,
-    in	_requestQueueLength BIGINT,
-    in	_sentMessagesCount BIGINT,
-	in	_receivedMessagesCount BIGINT,
-    in	_isOverloaded BIT,
-    in	_clientCount BIGINT
-)
-BEGIN
-		START TRANSACTION;
-		IF EXISTS(SELECT 1 FROM  OrleansSiloMetricsTable WHERE
-			DeploymentId = _deploymentId AND _deploymentId IS NOT NULL
-			AND SiloId = _siloId AND _siloId IS NOT NULL
-			FOR UPDATE)
-		THEN
-			UPDATE OrleansSiloMetricsTable
-			SET
-				Address = _address,
-				Port = _port,
-				Generation = _generation,
-				HostName = _hostName,
-				GatewayAddress = _gatewayAddress,
-				GatewayPort = _gatewayPort,
-				CPU = _cpuUsage,
-				Memory = _memoryUsage,
-				Activations = _activationsCount,
-				RecentlyUsedActivations = _recentlyUsedActivationsCount,
-				SendQueue = _sendQueueLength,
-				ReceiveQueue = _receiveQueueLength,
-				RequestQueue = _requestQueueLength,
-				SentMessages = _sentMessagesCount,
-				ReceivedMessages = _receivedMessagesCount,
-				LoadShedding = _isOverloaded,
-				ClientCount = _clientCount
-			WHERE
-				(DeploymentId = _deploymentId AND _deploymentId IS NOT NULL)
-				AND (SiloId = _siloId AND _siloId IS NOT NULL);
-		ELSE
+	'UpsertSiloMetricsKey','
 			INSERT INTO OrleansSiloMetricsTable
 			(
 				DeploymentId,
@@ -624,31 +496,45 @@ BEGIN
 			)
 			VALUES
 			(
-				_deploymentId,
-				_siloId,
-				_address,
-				_port,
-				_generation,
-				_hostName,
-				_gatewayAddress,
-				_gatewayPort,
-				_cpuUsage,
-				_memoryUsage,
-				_activationsCount,
-				_recentlyUsedActivationsCount,
-				_sendQueueLength,
-				_receiveQueueLength,
-				_requestQueueLength,
-				_sentMessagesCount,
-				_receivedMessagesCount,
-				_isOverloaded,
-				_clientCount
-			);
-		END IF;
-		COMMIT;
-END$$    
-
-DELIMITER ;
+				@deploymentId,
+				@siloId,
+				@address,
+				@port,
+				@generation,
+				@hostName,
+				@gatewayAddress,
+				@gatewayPort,
+				@cpuUsage,
+				@memoryUsage,
+				@activationsCount,
+				@recentlyUsedActivationsCount,
+				@sendQueueLength,
+				@receiveQueueLength,
+				@requestQueueLength,
+				@sentMessagesCount,
+				@receivedMessagesCount,
+				@isOverloaded,
+				@clientCount
+			)
+		ON DUPLICATE KEY UPDATE 
+				Address 		= @address,
+				Port 			= @port,
+				Generation 		= @generation,
+				HostName 		= @hostName,
+				GatewayAddress	 	= @gatewayAddress,
+				GatewayPort		= @gatewayPort,
+				CPU 			= @cpuUsage,
+				Memory 			= @memoryUsage,
+				Activations 		= @activationsCount,
+				RecentlyUsedActivations	= @recentlyUsedActivationsCount,
+				SendQueue 		= @sendQueueLength,
+				ReceiveQueue 		= @receiveQueueLength,
+				RequestQueue 		= @requestQueueLength,
+				SentMessages 		= @sentMessagesCount,
+				ReceivedMessages 	= @receivedMessagesCount,
+				LoadShedding 		= @isOverloaded,
+				ClientCount 		= @clientCount;
+');
 
 INSERT INTO OrleansQuery(QueryKey, QueryText)
 VALUES

--- a/src/TesterInternal/RemindersTest/MySqlRemindersTableTests.cs
+++ b/src/TesterInternal/RemindersTest/MySqlRemindersTableTests.cs
@@ -25,7 +25,6 @@ namespace UnitTests.RemindersTest
         public TestContext TestContext { get; set; }
 
         private string deploymentId;
-        private SiloAddress siloAddress;
         private static string connectionString;
         private const string testDatabaseName = "OrleansTest";
         private static readonly TimeSpan timeout = TimeSpan.FromMinutes(1);
@@ -33,7 +32,6 @@ namespace UnitTests.RemindersTest
         private readonly TraceLogger logger = TraceLogger.GetLogger("MySqlRemindersTableTests",
             TraceLogger.LoggerType.Application);
 
-        private Guid serviceId;
         private SqlReminderTable reminder;
 
         // Use ClassInitialize to run code before running the first test in the class
@@ -51,10 +49,8 @@ namespace UnitTests.RemindersTest
 
         private async Task Initialize()
         {
-            serviceId = Guid.NewGuid();
             deploymentId = "test-" + Guid.NewGuid();
             int generation = SiloAddress.AllocateNewGeneration();
-            siloAddress = SiloAddress.NewLocalAddress(generation);
 
             logger.Info("DeploymentId={0} Generation={1}", deploymentId, generation);
 
@@ -101,10 +97,10 @@ namespace UnitTests.RemindersTest
 
 
         [TestMethod, TestCategory("Reminders"), TestCategory("MySql")]
-        public async Task RemindersTable_MySql_UpsertReminderTwice()
+        public async Task RemindersTable_MySql_UpsertReminderParallel()
         {
             await Initialize();
-            await ReminderTablePluginTests.ReminderTableUpsertTwice(reminder);
+            await ReminderTablePluginTests.ReminderTableUpsertParallel(reminder);
         }
     }
 }

--- a/src/TesterInternal/RemindersTest/SqlServerRemindersTableTests.cs
+++ b/src/TesterInternal/RemindersTest/SqlServerRemindersTableTests.cs
@@ -22,7 +22,6 @@ namespace UnitTests.RemindersTest
         public TestContext TestContext { get; set; }
 
         private string deploymentId;
-        private SiloAddress siloAddress;
         private static string connectionString;
         private const string testDatabaseName = "OrleansTest";
         private static readonly TimeSpan timeout = TimeSpan.FromMinutes(1);
@@ -30,7 +29,6 @@ namespace UnitTests.RemindersTest
         private readonly TraceLogger logger = TraceLogger.GetLogger("SqlServerRemindersTableTests",
             TraceLogger.LoggerType.Application);
 
-        private Guid serviceId;
         private SqlReminderTable reminder;
 
         // Use ClassInitialize to run code before running the first test in the class
@@ -48,10 +46,8 @@ namespace UnitTests.RemindersTest
 
         private async Task Initialize()
         {
-            serviceId = Guid.NewGuid();
             deploymentId = "test-" + Guid.NewGuid();
             int generation = SiloAddress.AllocateNewGeneration();
-            siloAddress = SiloAddress.NewLocalAddress(generation);
 
             logger.Info("DeploymentId={0} Generation={1}", deploymentId, generation);
 
@@ -98,10 +94,10 @@ namespace UnitTests.RemindersTest
 
 
         [TestMethod, TestCategory("Reminders"), TestCategory("SqlServer")]
-        public async Task RemindersTable_SqlServer_UpsertReminderTwice()
+        public async Task RemindersTable_SqlServer_UpsertReminderInParallel()
         {
             await Initialize();
-            await ReminderTablePluginTests.ReminderTableUpsertTwice(reminder);
+            await ReminderTablePluginTests.ReminderTableUpsertParallel(reminder);
         }
 
         #region sampleSpecificMembershipAndRemidersTableConfiguration

--- a/src/TesterInternal/SqlStatisticsPublisherTests/DummyCounter.cs
+++ b/src/TesterInternal/SqlStatisticsPublisherTests/DummyCounter.cs
@@ -1,0 +1,41 @@
+﻿using Orleans.Runtime;
+
+namespace UnitTests.SqlStatisticsPublisherTests
+{
+    internal class DummyCounter : ICounter
+    {
+        public string Name
+        {
+            get { return "DummyCounter"; }
+        }
+
+        public bool IsValueDelta
+        {
+            get { return true; }
+        }
+
+        public string GetValueString()
+        {
+            return "GetValueString";
+        }
+
+        public string GetDeltaString()
+        {
+            return "GetDeltaString";
+        }
+
+        public void ResetCurrent()
+        {
+        }
+
+        public string GetDisplayString()
+        {
+            return "GetDisplayString";
+        }
+
+        public CounterStorage Storage
+        {
+            get { return CounterStorage.LogAndTable; }
+        }
+    }
+}

--- a/src/TesterInternal/SqlStatisticsPublisherTests/DummyPerformanceMetrics.cs
+++ b/src/TesterInternal/SqlStatisticsPublisherTests/DummyPerformanceMetrics.cs
@@ -1,0 +1,38 @@
+﻿using Orleans.Runtime;
+
+namespace UnitTests.SqlStatisticsPublisherTests
+{
+    internal class DummyPerformanceMetrics : IClientPerformanceMetrics, ISiloPerformanceMetrics
+    {
+        public float CpuUsage {get { return 1; } }
+        public long AvailablePhysicalMemory { get { return 2; } }
+        public long MemoryUsage { get { return 3; } }
+        public long TotalPhysicalMemory { get { return 4; } }
+        public int SendQueueLength { get { return 5; } }
+        public int ReceiveQueueLength { get { return 6; } }
+        public long SentMessages { get { return 7; } }
+        public long ReceivedMessages { get { return 8; } }
+        public long ConnectedGatewayCount { get { return 9; } }
+        public long RequestQueueLength { get { return 10; } }
+        public int ActivationCount { get { return 11; } }
+        public int RecentlyUsedActivationCount { get { return 12; } }
+        public long ClientCount { get { return 13; } }
+        public bool IsOverloaded { get { return false; } }
+
+        public void LatchIsOverload(bool overloaded)
+        {
+        }
+
+        public void UnlatchIsOverloaded()
+        {
+        }
+
+        public void LatchCpuUsage(float value)
+        {
+        }
+
+        public void UnlatchCpuUsage()
+        {
+        }
+    }
+}

--- a/src/TesterInternal/SqlStatisticsPublisherTests/MySqlStatisticsPublisherTests.cs
+++ b/src/TesterInternal/SqlStatisticsPublisherTests/MySqlStatisticsPublisherTests.cs
@@ -1,0 +1,110 @@
+using System;
+using Orleans.Providers.SqlServer;
+using UnitTests.General;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.Runtime.MembershipService;
+using Orleans.SqlUtils;
+using UnitTests.SqlStatisticsPublisherTests;
+
+namespace UnitTests.SqlStatisticsTest
+{
+    /// <summary>
+    /// Tests for operation of Orleans Statistics Publisher using MySQL
+    /// </summary>
+    [TestClass]
+    public class MySqlStatisticsPublisherTests
+    {
+        public TestContext TestContext { get; set; }
+        private static readonly TimeSpan timeout = TimeSpan.FromMinutes(1);
+        private static string connectionString;
+        private const string testDatabaseName = "OrleansTest";
+        private const string adoInvariant = AdoNetInvariants.InvariantNameMySql;
+        private const string dbName = "MySql";
+
+        private static readonly TraceLogger logger = TraceLogger.GetLogger("MySqlStatisticsPublisherTests",
+            TraceLogger.LoggerType.Application);
+
+        private SqlStatisticsPublisher statisticsPublisher;
+
+        // Use ClassInitialize to run code before running the first test in the class
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            TraceLogger.Initialize(new NodeConfiguration());
+            TraceLogger.AddTraceLevelOverride("MySqlStatisticsPublisherTests", Severity.Verbose3);
+
+            connectionString =
+                RelationalStorageForTesting.SetupInstance(adoInvariant, testDatabaseName)
+                    .Result.CurrentConnectionString;
+        }
+
+
+        private async Task Initialize()
+        {
+            statisticsPublisher = new SqlStatisticsPublisher();
+            await statisticsPublisher.Init("Test", new StatisticsPublisherProviderRuntime(logger),
+                new StatisticsPublisherProviderConfig(adoInvariant, connectionString));
+        }
+
+        // Use TestCleanup to run code after each test has run
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            logger.Info("Test {0} completed - Outcome = {1}", TestContext.TestName, TestContext.CurrentTestOutcome);
+        }
+
+
+        [TestMethod, TestCategory("Statistics"), TestCategory(dbName)]
+        public async Task SqlStatisticsPublisher_MySql_Init()
+        {
+            await Initialize();
+            Assert.IsNotNull(statisticsPublisher, "Statistics publisher created");
+        }
+
+
+        [TestMethod, TestCategory("Statistics"), TestCategory(dbName)]
+        public async Task SqlStatisticsPublisher_MySql_ReportMetrics_Client()
+        {
+            await Initialize();
+            statisticsPublisher.AddConfiguration("statisticsDeployment", "statisticsHostName", "statisticsClient", IPAddress.Loopback);
+            await RunParallel(10, () => statisticsPublisher.ReportMetrics((IClientPerformanceMetrics) new DummyPerformanceMetrics()));
+        }
+
+        [TestMethod, TestCategory("Statistics"), TestCategory(dbName)]
+        public async Task SqlStatisticsPublisher_MySql_ReportStats()
+        {
+            await Initialize();
+            statisticsPublisher.AddConfiguration("statisticsDeployment", "statisticsHostName", "statisticsClient", IPAddress.Loopback);
+            await RunParallel(10, () => statisticsPublisher.ReportStats(new List<ICounter> { new DummyCounter() }));
+        }
+
+        [TestMethod, TestCategory("Statistics"), TestCategory(dbName)]
+        public async Task SqlStatisticsPublisher_MySql_ReportMetrics_Silo()
+        {
+            GlobalConfiguration config = new GlobalConfiguration
+            {
+                DeploymentId = "statisticsDeployment",
+                AdoInvariant = adoInvariant,
+                DataConnectionString = connectionString
+            };
+
+            IMembershipTable mbr = new SqlMembershipTable();
+            await mbr.InitializeMembershipTable(config, true, logger).WithTimeout(timeout);
+            await Initialize();
+            statisticsPublisher.AddConfiguration("statisticsDeployment", true, "statisticsSiloId", SiloAddress.NewLocalAddress(0), new IPEndPoint(IPAddress.Loopback, 12345), "statisticsHostName");
+            await RunParallel(10, () => statisticsPublisher.ReportMetrics((ISiloPerformanceMetrics)new DummyPerformanceMetrics()));
+        }
+
+        private Task RunParallel(int count, Func<Task> taskFactory)
+        {
+            return Task.WhenAll(Enumerable.Range(0, count).Select(x => taskFactory()));
+        }
+    }
+}

--- a/src/TesterInternal/SqlStatisticsPublisherTests/SqlServerStatisticsPublisherTests.cs
+++ b/src/TesterInternal/SqlStatisticsPublisherTests/SqlServerStatisticsPublisherTests.cs
@@ -1,0 +1,110 @@
+using System;
+using Orleans.Providers.SqlServer;
+using UnitTests.General;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.Runtime.MembershipService;
+using Orleans.SqlUtils;
+using UnitTests.SqlStatisticsPublisherTests;
+
+namespace UnitTests.SqlStatisticsTest
+{
+    /// <summary>
+    /// Tests for operation of Orleans Statistics Publisher using SQL Server
+    /// </summary>
+    [TestClass]
+    public class SqlServerStatisticsPublisherTests
+    {
+        public TestContext TestContext { get; set; }
+        private static readonly TimeSpan timeout = TimeSpan.FromMinutes(1);
+        private static string connectionString;
+        private const string testDatabaseName = "OrleansTest";
+        private const string adoInvariant = AdoNetInvariants.InvariantNameSqlServer;
+        private const string dbName = "SqlServer";
+
+        private static readonly TraceLogger logger = TraceLogger.GetLogger("MySqlStatisticsPublisherTests",
+            TraceLogger.LoggerType.Application);
+
+        private SqlStatisticsPublisher statisticsPublisher;
+
+        // Use ClassInitialize to run code before running the first test in the class
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            TraceLogger.Initialize(new NodeConfiguration());
+            TraceLogger.AddTraceLevelOverride("MySqlStatisticsPublisherTests", Severity.Verbose3);
+
+            connectionString =
+                RelationalStorageForTesting.SetupInstance(adoInvariant, testDatabaseName)
+                    .Result.CurrentConnectionString;
+        }
+
+
+        private async Task Initialize()
+        {
+            statisticsPublisher = new SqlStatisticsPublisher();
+            await statisticsPublisher.Init("Test", new StatisticsPublisherProviderRuntime(logger),
+                new StatisticsPublisherProviderConfig(adoInvariant, connectionString));
+        }
+
+        // Use TestCleanup to run code after each test has run
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            logger.Info("Test {0} completed - Outcome = {1}", TestContext.TestName, TestContext.CurrentTestOutcome);
+        }
+
+
+        [TestMethod, TestCategory("Statistics"), TestCategory(dbName)]
+        public async Task SqlStatisticsPublisher_SqlServer_Init()
+        {
+            await Initialize();
+            Assert.IsNotNull(statisticsPublisher, "Statistics publisher created");
+        }
+
+
+        [TestMethod, TestCategory("Statistics"), TestCategory(dbName)]
+        public async Task SqlStatisticsPublisher_SqlServer_ReportMetrics_Client()
+        {
+            await Initialize();
+            statisticsPublisher.AddConfiguration("statisticsDeployment", "statisticsHostName", "statisticsClient", IPAddress.Loopback);
+            await RunParallel(10, () => statisticsPublisher.ReportMetrics((IClientPerformanceMetrics)new DummyPerformanceMetrics()));
+        }
+
+        [TestMethod, TestCategory("Statistics"), TestCategory(dbName)]
+        public async Task SqlStatisticsPublisher_SqlServer_ReportStats()
+        {
+            await Initialize();
+            statisticsPublisher.AddConfiguration("statisticsDeployment", "statisticsHostName", "statisticsClient", IPAddress.Loopback);
+            await RunParallel(10, () => statisticsPublisher.ReportStats(new List<ICounter> { new DummyCounter() }));
+        }
+
+        [TestMethod, TestCategory("Statistics"), TestCategory(dbName)]
+        public async Task SqlStatisticsPublisher_SqlServer_ReportMetrics_Silo()
+        {
+            GlobalConfiguration config = new GlobalConfiguration
+            {
+                DeploymentId = "statisticsDeployment",
+                AdoInvariant = adoInvariant,
+                DataConnectionString = connectionString
+            };
+
+            IMembershipTable mbr = new SqlMembershipTable();
+            await mbr.InitializeMembershipTable(config, true, logger).WithTimeout(timeout);
+            await Initialize();
+            statisticsPublisher.AddConfiguration("statisticsDeployment", true, "statisticsSiloId", SiloAddress.NewLocalAddress(0), new IPEndPoint(IPAddress.Loopback, 12345), "statisticsHostName");
+            await RunParallel(10, () => statisticsPublisher.ReportMetrics((ISiloPerformanceMetrics)new DummyPerformanceMetrics()));
+        }
+
+        private Task RunParallel(int count, Func<Task> taskFactory)
+        {
+            return Task.WhenAll(Enumerable.Range(0, count).Select(x => taskFactory()));
+        }
+    }
+}

--- a/src/TesterInternal/SqlStatisticsPublisherTests/StatisticsPublisherProviderConfig.cs
+++ b/src/TesterInternal/SqlStatisticsPublisherTests/StatisticsPublisherProviderConfig.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Orleans.Providers;
+
+namespace UnitTests.SqlStatisticsPublisherTests
+{
+    internal class StatisticsPublisherProviderConfig : IProviderConfiguration
+    {
+        private readonly ReadOnlyDictionary<string, string> props;
+
+        public StatisticsPublisherProviderConfig(string adoInvariant, string connectionString)
+        {
+            props = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>
+            {
+                {"AdoInvariant", adoInvariant},
+                {"ConnectionString", connectionString}
+            });
+        }
+
+        public string Type
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public string Name
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ReadOnlyDictionary<string, string> Properties
+        {
+            get { return props; }
+        }
+
+        public IList<IProvider> Children
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public void SetProperty(string key, string val)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool RemoveProperty(string key)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/TesterInternal/SqlStatisticsPublisherTests/StatisticsPublisherProviderRuntime.cs
+++ b/src/TesterInternal/SqlStatisticsPublisherTests/StatisticsPublisherProviderRuntime.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Orleans;
+using Orleans.Providers;
+using Orleans.Runtime;
+
+namespace UnitTests.SqlStatisticsPublisherTests
+{
+    internal class StatisticsPublisherProviderRuntime : IProviderRuntime
+    {
+        private readonly Logger logger;
+
+        public StatisticsPublisherProviderRuntime(Logger logger)
+        {
+            this.logger = logger;
+        }
+
+        public Logger GetLogger(string loggerName)
+        {
+            return logger;
+        }
+
+        public Guid ServiceId
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public string SiloIdentity
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IGrainFactory GrainFactory
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IServiceProvider ServiceProvider
+        {
+            get { throw new NotImplementedException(); }
+        }
+    }
+}

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -100,6 +100,8 @@
     <Compile Include="ErrorInjectionStorageProvider.cs" />
     <Compile Include="General\CounterStatisticTests.cs" />
     <Compile Include="ManagementGrainTests.cs" />
+    <Compile Include="SqlStatisticsPublisherTests\SqlServerStatisticsPublisherTests.cs" />
+    <Compile Include="SqlStatisticsPublisherTests\MySqlStatisticsPublisherTests.cs" />
     <Compile Include="Serialization\BuiltInSerializerTests.cs" />
     <Compile Include="General\Identifiertests.cs" />
     <Compile Include="General\InterfaceRules.cs" />
@@ -113,6 +115,10 @@
     <Compile Include="LocalErrorGrain.cs" />
     <Compile Include="ManagementAgentTests.cs" />
     <Compile Include="MockStatsCollectors.cs" />
+    <Compile Include="SqlStatisticsPublisherTests\DummyCounter.cs" />
+    <Compile Include="SqlStatisticsPublisherTests\DummyPerformanceMetrics.cs" />
+    <Compile Include="SqlStatisticsPublisherTests\StatisticsPublisherProviderConfig.cs" />
+    <Compile Include="SqlStatisticsPublisherTests\StatisticsPublisherProviderRuntime.cs" />
     <Compile Include="StorageTests\LocalStoreTests.cs" />
     <Compile Include="StorageTests\MockStorageProvider.cs" />
     <Compile Include="MultifacetGrainTest.cs" />


### PR DESCRIPTION
This is a fix for #1169.
Important changes:
* [SELECT ... FOR UPDATE] (http://www.techonthenet.com/oracle/cursors/for_update.php) was changed to [INSERT ... ON DUPLICATE KEY UPDATE](http://dev.mysql.com/doc/refman/5.7/en/insert-on-duplicate.html)
* Removed column `ETag` from `OrleansMembershipVersionTable` because it's the same as `Version`(same can be done to the `MSSQL` script and then remove any references to it from relational code.)
* Added tests for `SqlStatisticsPublisher` for both `MSSQL` and `MySQL`
* Changed reminders upsert test to test in parallel