### PR TITLE
Use OrleansJsonSerializer.JsonSerializerSettings in Azure storage provider

### DIFF
--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -13,8 +13,10 @@ namespace Orleans.Serialization
 {
     internal class OrleansJsonSerializer : IExternalSerializer
     {
-        public static JsonSerializerSettings settings;
+        private static JsonSerializerSettings settings;
         private TraceLogger logger;
+
+        internal static JsonSerializerSettings SerializerSettings { get { return settings; } }
 
         static OrleansJsonSerializer()
         {

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -103,8 +103,7 @@ namespace Orleans.Storage
             
             if (useJsonFormat)
             {
-                jsonSettings = new Newtonsoft.Json.JsonSerializerSettings();
-                jsonSettings.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.All;
+                jsonSettings = jsonSettings = OrleansJsonSerializer.SerializerSettings;
             }
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 


### PR DESCRIPTION
This is a smaller version of PR #1204.
Use the same JsonSerializerSettings  in the fallback Orleans serializer and in the Json serializer used in the storage provider.
The OrleansJsonSerializer.JsonSerializerSettings are still internal and not changeable by application code.
