### PR TITLE
Log AppDomain unloading events in the client.

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -649,6 +649,7 @@ namespace Orleans
         ProxyClient_ClientInvokeCallback_Error      = ProxyClientBase + 28,
         ProxyClient_StartDone                       = ProxyClientBase + 29,
         ProxyClient_OGC_TargetNotFound_2            = ProxyClientBase + 30,
+        ProxyClient_AppDomain_Unload                = ProxyClientBase + 31,
 
         MessagingBase                           = Runtime + 1000,
         Messaging_IMA_DroppingConnection        = MessagingBase + 1,


### PR DESCRIPTION
Add logging of AppDomain unloading events in the client, for easier troubleshooting/diagnostics.
Follow up from Gitter thread: 
https://gitter.im/dotnet/orleans?at=5683367a66a282570f904a4d

