### PR TITLE
Orleans.TestingHost package depends on OrleansProviders.dll

### DIFF
--- a/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
@@ -15,11 +15,12 @@
     <description>
       Microsoft Orleans library for hosting silo in a testing project.
     </description>
-    <copyright>Copyright Microsoft 2015</copyright>
+    <copyright>Copyright Microsoft 2016</copyright>
     <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
     <dependencies>
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />      
+      <dependency id="Microsoft.Orleans.OrleansProviders" version="$version$" />
     </dependencies>
   </metadata>
   <files>
@@ -30,6 +31,7 @@
     <file src="OrleansConfigurationForTesting.xml" target="content" />
 
     <file src="TestingHost.Install.ps1" target="tools\install.ps1" />
+    
     <file src="$SRC_DIR$OrleansTestingHost\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/Tester/UnitTestSiloHost.cs
+++ b/src/Tester/UnitTestSiloHost.cs
@@ -17,6 +17,7 @@ namespace UnitTests.Tester
     [DeploymentItem("TestGrainInterfaces.dll")]
     [DeploymentItem("TestGrains.dll")]
     [DeploymentItem("OrleansCodeGenerator.dll")]
+    [DeploymentItem("OrleansProviders.dll")]
     [DeploymentItem("TestInternalGrainInterfaces.dll")]
     [DeploymentItem("TestInternalGrains.dll")]
     public class UnitTestSiloHost : TestingSiloHost


### PR DESCRIPTION
Problem Description 
[from the perspective of someone trying to use the Orleans TestingSiloHost in their own project]

Adding NuGet package `Orleans.TestingHost` into a project adds `OrleansConfigurationForTesting.xml` file into that project. 

However, that config file contains an implicit runtime dependency on the `Orleans.Storage.MemoryStorage` class, which is in the `OrleansProviders.dll` assembly, but that assembly is not currently automatically added as dependency of `Orleans.TestingHost`. 

Therefore, the test silo will fail to start because it can't find the memory storage provider class to load.

``` xml
<StorageProviders>
  <Provider Type="Orleans.Storage.MemoryStorage" Name="MemoryStore" />
  <Provider Type="Orleans.Storage.MemoryStorage" Name="Default" />
  <!--<Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore" />-->
</StorageProviders>
```

Changes:

1. We need to add `Orleans.OrleansProviders` as a dependency in the `Orleans.TestingHost` package.

2. Also need to add `[DeploymentItem]` attribute to the test class for `OrleansProviders.dll` if using MsTest (which does automatic shadow copying of test assemblies).

Footnote:

Currently `OrleansProviders.dll` gets included automatically in the Orleans BVT `Tester` assemblies deployment set because other test cases in `Tester.dll` use it directly, but other people's test projects will usually just copy what `UnitTestSiloHost.cs` does, so important to add the missing
`[DeploymentItem("OrleansProviders.dll")]`