### PR TITLE
Cleanup some menu items on Orleans website.

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -43,12 +43,12 @@
 <h2 id="community-and-contributions">Community and Contributions</h2>
 
 <ul class="list-unstyled">
-	<li><a href="https://github.com/OrleansContrib">Community add-ons to Orleans</a></li>
-	<li><a href="https://github.com/OrleansContrib/meetups">Virtual Meetups</a></li>
-	<li><a href="https://gitter.im/dotnet/orleans">Gitter Chat Forum</a></li>
-	<li><a href="https://twitter.com/projectorleans">Twitter</a></li>
-	<li><a href="https://orleans.codeplex.com">Orleans on Codeplex</a></li> 
-	<li><a href="https://orleans.codeplex.com/discussions">Discussion forum</a></li>
+	<li><a href="https://github.com/OrleansContrib">OrleansContrib - Community add-ons to Orleans</a></li>
+	<li><a href="https://github.com/OrleansContrib/meetups">Orleans Community Virtual Meetups</a></li>
+	<li><a href="https://gitter.im/dotnet/orleans">Orleans Gitter Chat Forum</a></li>
+	<li><a href="https://twitter.com/projectorleans">Twitter - @ProjectOrleans</a></li>
+	<li><a href="https://orleans.codeplex.com">Orleans on Codeplex (DEPRECATED)</a></li> 
+	<li><a href="https://orleans.codeplex.com/discussions">CodePlex Discussion Forum (DEPRECATED)</a></li>
 	<li><a href="http://stackoverflow.com/questions/tagged/orleans">Orleans on StackOverflow</a></li>
 	<li><a href="/orleans/Who-Is-Using-Orleans">Who Is Using Orleans?</a></li>
 </ul>
@@ -57,7 +57,7 @@
 
 <ul class="list-unstyled">
 	<li><a href="/orleans/Contributing">Contribution Guide</a></li>
-	<li><a href="https://github.com/dotnet/orleans/issues">GitHub Issues</a></li>
+	<li><a href="https://github.com/dotnet/orleans/issues">GitHub Issues List</a></li>
 </ul>
 
 <h2 id="other-documentation-resources">Other Documentation Resources</h2>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -47,8 +47,7 @@
 	<li><a href="https://github.com/OrleansContrib/meetups">Orleans Community Virtual Meetups</a></li>
 	<li><a href="https://gitter.im/dotnet/orleans">Orleans Gitter Chat Forum</a></li>
 	<li><a href="https://twitter.com/projectorleans">Twitter - @ProjectOrleans</a></li>
-	<li><a href="https://orleans.codeplex.com">Orleans on Codeplex (DEPRECATED)</a></li> 
-	<li><a href="https://orleans.codeplex.com/discussions">CodePlex Discussion Forum (DEPRECATED)</a></li>
+	<li><a href="https://orleans.codeplex.com">Orleans on Codeplex (Historical)</a></li> 
 	<li><a href="http://stackoverflow.com/questions/tagged/orleans">Orleans on StackOverflow</a></li>
 	<li><a href="/orleans/Who-Is-Using-Orleans">Who Is Using Orleans?</a></li>
 </ul>


### PR DESCRIPTION
- Add OrleansContrib name to the link to community add-ons.
- ~~Mark CodePlex links as "deprecated" - or can these be removed now?~~
- Removed link to old CodePlex discussion forum, and mark the old CodePlex Orleans home page link as "historical"
- List the @ProjectOrleans name in the Twitter link.
- Minor tweaks to link descriptions, for clarity.

CC: @richorama 