### PR TITLE
Fixed type name for BondSerializer in PowerShell install scripts

### DIFF
--- a/src/NuGet/BondSerializerInstall.ps1
+++ b/src/NuGet/BondSerializerInstall.ps1
@@ -1,6 +1,6 @@
 param($installPath, $toolsPath, $package, $project)
 
-$bondSerializerTypeName = 'Orleans.Serialization.BondSerializer, BondSerializer'
+$bondSerializerTypeName = 'Orleans.Serialization.BondSerializer, OrleansBondUtils'
 
 function AddOrGetElement(
     [OutputType([System.Xml.XmlElement])]
@@ -9,7 +9,7 @@ function AddOrGetElement(
     [Parameter(Mandatory=$true)]
     [string]$name,
     [Parameter(Mandatory=$true)]
-    [System.Xml.XmlNamespaceManager]$namespaceManager    
+    [System.Xml.XmlNamespaceManager]$namespaceManager
     )
 {
     $node = $xml.ChildNodes | where { $_.Name -eq $name }
@@ -51,7 +51,7 @@ function RegisterSerializer(
 
     $bondTypeProvider = $providersnode.Provider | where { $_.type -eq $type }
 
-    if ($bondTypeProvider -eq $null) 
+    if ($bondTypeProvider -eq $null)
     {
         $provider = AddOrGetElement -xml $providersNode -name "Provider" -namespaceManager $namespaceManager
         $typeAttribute = $fileXml.CreateAttribute("type");

--- a/src/NuGet/BondSerializerUninstall.ps1
+++ b/src/NuGet/BondSerializerUninstall.ps1
@@ -1,6 +1,6 @@
 param($installPath, $toolsPath, $package, $project)
 
-$bondSerializerTypeName = 'Orleans.Serialization.BondSerializer, BondSerializer'
+$bondSerializerTypeName = 'Orleans.Serialization.BondSerializer, OrleansBondUtils'
 
 function UnregisterSerializer(
     [Parameter(Mandatory=$true)]


### PR DESCRIPTION
When testing out the Bond serializer support in the `Microsoft.Orleans.Serialization.Bond` 1.1.0 package I noticed that the type name for the serializer added to the configuration files was incorrect. It appears that the assembly name was changed but the `BondSerializerInstall.ps1` and `BondSerializerUninstall.ps1` files were not updated. I have updated the scripts to use the `OrleansBondUtils` assembly in the type name.