### PR TITLE
Improve robustness of serializer codegen for obsolete properties & fields

### DIFF
--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -34,7 +34,7 @@ namespace Orleans.Runtime
         public static string GetSimpleTypeName(Type t, Func<Type, bool> fullName=null, Language language = Language.CSharp)
         {
             var typeInfo = t.GetTypeInfo();
-            if (typeInfo.IsNestedPublic || typeInfo.IsNestedPrivate)
+            if (typeInfo.IsNested)
             {
                 if (typeInfo.DeclaringType.IsGenericType)
                     return GetTemplatedName(GetUntemplatedTypeName(typeInfo.DeclaringType.Name), typeInfo.DeclaringType, typeInfo.GetGenericArguments(), _ => true, language) + "." + GetUntemplatedTypeName(typeInfo.Name);

--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -242,9 +242,7 @@ namespace Orleans.Serialization
                 return IsTypeIsInaccessibleForSerialization(typeInfo.GetElementType(), fromModule, fromAssembly);
             }
 
-            var result = typeInfo.IsNestedPrivate || typeInfo.IsNestedFamily || type.IsPointer;
-            
-            return result;
+            return typeInfo.IsNestedPrivate || typeInfo.IsNestedFamily || type.IsPointer;
         }
 
         /// <summary>

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -445,8 +445,6 @@ namespace Orleans.CodeGenerator
 
         private static void RecordType(Type type, Module module, Assembly targetAssembly, ISet<Type> includedTypes)
         {
-            if (type.IsNested) return;
-
             if (SerializerGenerationManager.RecordTypeToGenerate(type, module, targetAssembly))
                 includedTypes.Add(type);
         }

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -52,7 +52,8 @@ namespace Orleans.CodeGenerator
             var typeInfo = t.GetTypeInfo();
 
             if (typeInfo.IsGenericParameter || ProcessedTypes.Contains(t) || TypesToProcess.Contains(t)
-                || typeof(Exception).GetTypeInfo().IsAssignableFrom(t)) return false;
+                || typeof(Exception).GetTypeInfo().IsAssignableFrom(t)
+                || typeof(Delegate).GetTypeInfo().IsAssignableFrom(t)) return false;
 
             if (typeInfo.IsArray)
             {

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -60,7 +60,7 @@ namespace Orleans.CodeGenerator
                 return false;
             }
 
-            if (typeInfo.IsNestedPublic || typeInfo.IsNestedFamily || typeInfo.IsNestedPrivate)
+            if (typeInfo.IsNestedFamily || typeInfo.IsNestedPrivate)
             {
                 Log.Warn(
                     ErrorCode.CodeGenIgnoringTypes,

--- a/src/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/src/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -115,11 +115,33 @@ namespace UnitTests.GrainInterfaces
     [Serializable]
     public abstract class SomeAbstractClass : ISomeInterface
     {
+        [NonSerialized]
+        private int nonSerializedIntField;
+
         public abstract int Int { get; set; }
 
         public List<ISomeInterface> Interfaces { get; set; }
 
         public List<SomeAbstractClass> Classes { get; set; }
+
+        [Obsolete("This field should not be serialized", true)]
+        public int ObsoleteIntWithError { get; set; }
+
+        [Obsolete("This field should be serialized")]
+        public int ObsoleteInt { get; set; }
+
+        public int NonSerializedInt
+        {
+            get
+            {
+                return this.nonSerializedIntField;
+            }
+
+            set
+            {
+                this.nonSerializedIntField = value;
+            }
+        }
 
         [Serializable]
         public enum SomeEnum

--- a/src/Tester/CodeGenTests/GeneratorGrainTest.cs
+++ b/src/Tester/CodeGenTests/GeneratorGrainTest.cs
@@ -50,36 +50,55 @@ namespace Tester.CodeGenTests
             Assert.AreEqual(expectedStruct.GetValueWithPrivateGetter(), actualStruct.GetValueWithPrivateGetter());
 
             // Test abstract class serialization.
-            var expectedAbstract = new OuterClass.SomeConcreteClass { Int = 89, String = Guid.NewGuid().ToString() };
-            expectedAbstract.Classes = new List<SomeAbstractClass>
+            var input = new OuterClass.SomeConcreteClass { Int = 89, String = Guid.NewGuid().ToString() };
+            input.Classes = new List<SomeAbstractClass>
             {
-                expectedAbstract,
+                input,
                 new AnotherConcreteClass
                 {
                     AnotherString = "hi",
-                    Interfaces = new List<ISomeInterface> { expectedAbstract }
+                    Interfaces = new List<ISomeInterface> { input }
                 }
             };
-            var actualAbstract = await grain.RoundTripClass(expectedAbstract);
-            Assert.AreEqual(expectedAbstract.Int, actualAbstract.Int);
-            Assert.AreEqual(expectedAbstract.String, ((OuterClass.SomeConcreteClass)actualAbstract).String);
-            Assert.AreEqual(expectedAbstract.Classes.Count, actualAbstract.Classes.Count);
-            Assert.AreEqual(expectedAbstract.String, ((OuterClass.SomeConcreteClass)actualAbstract.Classes[0]).String);
-            Assert.AreEqual(expectedAbstract.Classes[1].Interfaces[0].Int, actualAbstract.Classes[1].Interfaces[0].Int);
+
+            // Set fields which should not be serialized.
+#pragma warning disable 618
+            input.ObsoleteInt = 38;
+#pragma warning restore 618
+
+            input.NonSerializedInt = 39;
+
+            var output = await grain.RoundTripClass(input);
+
+            Assert.AreEqual(input.Int, output.Int);
+            Assert.AreEqual(input.String, ((OuterClass.SomeConcreteClass)output).String);
+            Assert.AreEqual(input.Classes.Count, output.Classes.Count);
+            Assert.AreEqual(input.String, ((OuterClass.SomeConcreteClass)output.Classes[0]).String);
+            Assert.AreEqual(input.Classes[1].Interfaces[0].Int, output.Classes[1].Interfaces[0].Int);
+
+#pragma warning disable 618
+            Assert.AreEqual(input.ObsoleteInt, output.ObsoleteInt);
+#pragma warning restore 618
+            
+            Assert.AreEqual(0, output.NonSerializedInt);
 
             // Test abstract class serialization with state.
-            await grain.SetState(expectedAbstract);
-            actualAbstract = await grain.GetState();
-            Assert.AreEqual(expectedAbstract.Int, actualAbstract.Int);
-            Assert.AreEqual(expectedAbstract.String, ((OuterClass.SomeConcreteClass)actualAbstract).String);
-            Assert.AreEqual(expectedAbstract.Classes.Count, actualAbstract.Classes.Count);
-            Assert.AreEqual(expectedAbstract.String, ((OuterClass.SomeConcreteClass)actualAbstract.Classes[0]).String);
-            Assert.AreEqual(expectedAbstract.Classes[1].Interfaces[0].Int, actualAbstract.Classes[1].Interfaces[0].Int);
+            await grain.SetState(input);
+            output = await grain.GetState();
+            Assert.AreEqual(input.Int, output.Int);
+            Assert.AreEqual(input.String, ((OuterClass.SomeConcreteClass)output).String);
+            Assert.AreEqual(input.Classes.Count, output.Classes.Count);
+            Assert.AreEqual(input.String, ((OuterClass.SomeConcreteClass)output.Classes[0]).String);
+            Assert.AreEqual(input.Classes[1].Interfaces[0].Int, output.Classes[1].Interfaces[0].Int);
+#pragma warning disable 618
+            Assert.AreEqual(input.ObsoleteInt, output.ObsoleteInt);
+#pragma warning restore 618
+            Assert.AreEqual(0, output.NonSerializedInt);
 
             // Test interface serialization.
-            var expectedInterface = expectedAbstract;
+            var expectedInterface = input;
             var actualInterface = await grain.RoundTripInterface(expectedInterface);
-            Assert.AreEqual(expectedAbstract.Int, actualInterface.Int);
+            Assert.AreEqual(input.Int, actualInterface.Int);
             
             // Test enum serialization.
             const SomeAbstractClass.SomeEnum ExpectedEnum = SomeAbstractClass.SomeEnum.Something;


### PR DESCRIPTION
Fixes #1215: in generated code, all `[Obsolete]` properties/fields are accessed using the IL method instead of directly in order to avoid compiler warnings/errors.

Enables code generation for nested classes (why not, right? Let's see if functionals pass :stuck_out_tongue:)

Improves support for Mono by not serializing `Delegate` types: the implementation of `MulticastDelegate` differs between .NET & Mono.