### PR TITLE
Cleanup/fix usage of IsNested vs. IsNestedXXX & serialize nested types.

### DIFF
--- a/src/Orleans/CodeGeneration/TypeFormattingOptions.cs
+++ b/src/Orleans/CodeGeneration/TypeFormattingOptions.cs
@@ -1,0 +1,135 @@
+namespace Orleans.Runtime
+{
+    using System;
+
+    /// <summary>
+    /// Options for formatting type names.
+    /// </summary>
+    public class TypeFormattingOptions : IEquatable<TypeFormattingOptions>
+    {
+        public TypeFormattingOptions(
+            string nameSuffix = null,
+            bool includeNamespace = true,
+            bool includeGenericParameters = true,
+            bool includeTypeParameters = true,
+            char nestedClassSeparator = '.',
+            bool includeGlobal = true)
+        {
+
+            this.NameSuffix = nameSuffix;
+            this.IncludeNamespace = includeNamespace;
+            this.IncludeGenericTypeParameters = includeGenericParameters;
+            this.IncludeTypeParameters = includeTypeParameters;
+            this.NestedTypeSeparator = nestedClassSeparator;
+            this.IncludeGlobal = includeGlobal;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to include the fully-qualified namespace of the class in the result.
+        /// </summary>
+        public bool IncludeNamespace { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to include concrete type parameters in the result.
+        /// </summary>
+        public bool IncludeTypeParameters { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to include generic type parameters in the result.
+        /// </summary>
+        public bool IncludeGenericTypeParameters { get; private set; }
+
+        /// <summary>
+        /// Gets the separator used between declaring types and their declared types.
+        /// </summary>
+        public char NestedTypeSeparator { get; private set; }
+
+        /// <summary>
+        /// Gets the name to append to the formatted name, before any type parameters.
+        /// </summary>
+        public string NameSuffix { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to include the global namespace qualifier.
+        /// </summary>
+        public bool IncludeGlobal { get; private set; }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <see langword="true"/> if the specified object  is equal to the current object; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool Equals(TypeFormattingOptions other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            return this.IncludeNamespace == other.IncludeNamespace
+                   && this.IncludeTypeParameters == other.IncludeTypeParameters
+                   && this.IncludeGenericTypeParameters == other.IncludeGenericTypeParameters
+                   && this.NestedTypeSeparator == other.NestedTypeSeparator
+                   && string.Equals(this.NameSuffix, other.NameSuffix) && this.IncludeGlobal == other.IncludeGlobal;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>
+        /// <see langword="true"/> if the specified object  is equal to the current object; otherwise, <see langword="false"/>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+            return Equals((TypeFormattingOptions)obj);
+        }
+
+        /// <summary>
+        /// Serves as a hash function for a particular type. 
+        /// </summary>
+        /// <returns>
+        /// A hash code for the current object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = this.IncludeNamespace.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.IncludeTypeParameters.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.IncludeGenericTypeParameters.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.NestedTypeSeparator.GetHashCode();
+                hashCode = (hashCode * 397) ^ (this.NameSuffix != null ? this.NameSuffix.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ this.IncludeGlobal.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public static bool operator ==(TypeFormattingOptions left, TypeFormattingOptions right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(TypeFormattingOptions left, TypeFormattingOptions right)
+        {
+            return !Equals(left, right);
+        }
+    }
+}

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -19,7 +19,7 @@ namespace Orleans.Runtime
         /// </summary>
         private static readonly string OrleansCoreAssembly = typeof(IGrain).Assembly.GetName().FullName;
 
-        private static readonly ConcurrentDictionary<Tuple<Type, string, bool, bool>, string> ParseableNameCache = new ConcurrentDictionary<Tuple<Type, string, bool, bool>, string>();
+        private static readonly ConcurrentDictionary<Tuple<Type, TypeFormattingOptions>, string> ParseableNameCache = new ConcurrentDictionary<Tuple<Type, TypeFormattingOptions>, string>();
 
         private static readonly ConcurrentDictionary<Tuple<Type, bool>, List<Type>> ReferencedTypes = new ConcurrentDictionary<Tuple<Type, bool>, List<Type>>();
 
@@ -37,8 +37,15 @@ namespace Orleans.Runtime
             if (typeInfo.IsNestedPublic || typeInfo.IsNestedPrivate)
             {
                 if (typeInfo.DeclaringType.IsGenericType)
-                    return GetTemplatedName(GetUntemplatedTypeName(typeInfo.DeclaringType.Name), typeInfo.DeclaringType, typeInfo.GetGenericArguments(), _ => true, language) + "." + GetUntemplatedTypeName(typeInfo.Name);
-                
+                {
+                    return GetTemplatedName(
+                        GetUntemplatedTypeName(typeInfo.DeclaringType.Name),
+                        typeInfo.DeclaringType,
+                        typeInfo.GetGenericArguments(),
+                        _ => true,
+                        language) + "." + GetUntemplatedTypeName(typeInfo.Name);
+                }
+
                 return GetTemplatedName(typeInfo.DeclaringType, language: language) + "." + GetUntemplatedTypeName(typeInfo.Name);
             }
 
@@ -585,25 +592,25 @@ namespace Orleans.Runtime
         /// <returns>
         /// A string representation of the <paramref name="type"/>.
         /// </returns>
-        public static string GetParseableName(this Type type, string nameSuffix = null, bool includeNamespace = true, bool includeGenericParameters = true)
+        public static string GetParseableName(this Type type, TypeFormattingOptions options = null)
         {
-            return
-                ParseableNameCache.GetOrAdd(
-                    Tuple.Create(type, nameSuffix, includeNamespace, includeGenericParameters),
-                    _ =>
-                    {
-                        var builder = new StringBuilder();
-                        var typeInfo = type.GetTypeInfo();
-                        GetParseableName(
-                            type,
-                            nameSuffix ?? string.Empty,
-                            builder,
-                            new Queue<Type>(
-                                typeInfo.IsGenericTypeDefinition ? typeInfo.GetGenericArguments() : typeInfo.GenericTypeArguments),
-                            includeNamespace,
-                            includeGenericParameters);
-                        return builder.ToString();
-                    });
+            options = options ?? new TypeFormattingOptions();
+            return ParseableNameCache.GetOrAdd(
+                Tuple.Create(type, options),
+                _ =>
+                {
+                    var builder = new StringBuilder();
+                    var typeInfo = type.GetTypeInfo();
+                    GetParseableName(
+                        type,
+                        builder,
+                        new Queue<Type>(
+                            typeInfo.IsGenericTypeDefinition
+                                ? typeInfo.GetGenericArguments()
+                                : typeInfo.GenericTypeArguments),
+                        options);
+                    return builder.ToString();
+                });
         }
 
         /// <summary>
@@ -618,33 +625,28 @@ namespace Orleans.Runtime
         /// <param name="typeArguments">
         /// The type arguments of <paramref name="type"/>.
         /// </param>
-        /// <param name="includeNamespace">
-        /// A value indicating whether or not to include the namespace name.
+        /// <param name="options">
+        /// The type formatting options.
         /// </param>
         private static void GetParseableName(
             Type type,
-            string nameSuffix,
             StringBuilder builder,
             Queue<Type> typeArguments,
-            bool includeNamespace = true,
-            bool includeGenericParameters = true)
+            TypeFormattingOptions options)
         {
             var typeInfo = type.GetTypeInfo();
             if (typeInfo.IsArray)
             {
                 builder.AppendFormat(
                     "{0}[{1}]",
-                    typeInfo.GetElementType()
-                        .GetParseableName(
-                            includeNamespace: includeNamespace,
-                            includeGenericParameters: includeGenericParameters),
+                    typeInfo.GetElementType().GetParseableName(options),
                     string.Concat(Enumerable.Range(0, type.GetArrayRank() - 1).Select(_ => ',')));
                 return;
             }
 
             if (typeInfo.IsGenericParameter)
             {
-                if (includeGenericParameters)
+                if (options.IncludeGenericTypeParameters)
                 {
                     builder.Append(typeInfo.GetUnadornedTypeName());
                 }
@@ -655,57 +657,63 @@ namespace Orleans.Runtime
             if (typeInfo.DeclaringType != null)
             {
                 // This is not the root type.
-                GetParseableName(typeInfo.DeclaringType, string.Empty, builder, typeArguments, includeNamespace, includeGenericParameters);
-                builder.Append('.');
+                GetParseableName(typeInfo.DeclaringType, builder, typeArguments, options);
+                builder.Append(options.NestedTypeSeparator);
             }
-            else if (!string.IsNullOrWhiteSpace(type.Namespace) && includeNamespace)
+            else if (!string.IsNullOrWhiteSpace(type.Namespace) && options.IncludeNamespace)
             {
-                // This is the root type.
-                builder.AppendFormat("global::{0}.", type.Namespace);
+                // This is the root type, so include the namespace.
+                var namespaceName = type.Namespace;
+                if (options.NestedTypeSeparator != '.')
+                {
+                    namespaceName = namespaceName.Replace('.', options.NestedTypeSeparator);
+                }
+
+                if (options.IncludeGlobal)
+                {
+                    builder.AppendFormat("global::");
+                }
+
+                builder.AppendFormat("{0}{1}", namespaceName, options.NestedTypeSeparator);
             }
 
             if (typeInfo.IsConstructedGenericType)
             {
                 // Get the unadorned name, the generic parameters, and add them together.
-                var unadornedTypeName = typeInfo.GetUnadornedTypeName() + nameSuffix;
+                var unadornedTypeName = typeInfo.GetUnadornedTypeName() + options.NameSuffix;
                 builder.Append(EscapeIdentifier(unadornedTypeName));
                 var generics =
                     Enumerable.Range(0, Math.Min(typeInfo.GetGenericArguments().Count(), typeArguments.Count))
                         .Select(_ => typeArguments.Dequeue())
                         .ToList();
-                if (generics.Count > 0)
+                if (generics.Count > 0 && options.IncludeTypeParameters)
                 {
                     var genericParameters = string.Join(
                         ",",
-                        generics.Select(
-                            generic =>
-                            GetParseableName(
-                                generic,
-                                includeNamespace: includeNamespace,
-                                includeGenericParameters: includeGenericParameters)));
+                        generics.Select(generic => GetParseableName(generic, options)));
                     builder.AppendFormat("<{0}>", genericParameters);
                 }
             }
             else if (typeInfo.IsGenericTypeDefinition)
             {
                 // Get the unadorned name, the generic parameters, and add them together.
-                var unadornedTypeName = type.GetUnadornedTypeName() + nameSuffix;
+                var unadornedTypeName = type.GetUnadornedTypeName() + options.NameSuffix;
                 builder.Append(EscapeIdentifier(unadornedTypeName));
                 var generics =
                     Enumerable.Range(0, Math.Min(type.GetGenericArguments().Count(), typeArguments.Count))
                         .Select(_ => typeArguments.Dequeue())
                         .ToList();
-                if (generics.Count > 0)
+                if (generics.Count > 0 && options.IncludeTypeParameters)
                 {
                     var genericParameters = string.Join(
                         ",",
-                        generics.Select(_ => includeGenericParameters ? _.ToString() : string.Empty));
+                        generics.Select(_ => options.IncludeGenericTypeParameters ? _.ToString() : string.Empty));
                     builder.AppendFormat("<{0}>", genericParameters);
                 }
             }
             else
             {
-                builder.Append(EscapeIdentifier(type.GetUnadornedTypeName() + nameSuffix));
+                builder.Append(EscapeIdentifier(type.GetUnadornedTypeName() + options.NameSuffix));
             }
         }
 

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -90,6 +90,7 @@
     <Compile Include="CodeGeneration\KnownTypeAttribute.cs" />
     <Compile Include="CodeGeneration\SkipCodeGenerationAttribute.cs" />
     <Compile Include="CodeGeneration\IGrainState.cs" />
+    <Compile Include="CodeGeneration\TypeFormattingOptions.cs" />
     <Compile Include="Core\IStatefulGrain.cs" />
     <Compile Include="Providers\DefaultServiceProvider.cs" />
     <Compile Include="Serialization\IExternalSerializer.cs" />

--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -242,9 +242,7 @@ namespace Orleans.Serialization
                 return IsTypeIsInaccessibleForSerialization(typeInfo.GetElementType(), fromModule, fromAssembly);
             }
 
-            var result = typeInfo.IsNestedPrivate || typeInfo.IsNestedFamily || type.IsPointer;
-            
-            return result;
+            return typeInfo.IsNestedPrivate || typeInfo.IsNestedFamily || type.IsPointer;
         }
 
         /// <summary>

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -445,8 +445,6 @@ namespace Orleans.CodeGenerator
 
         private static void RecordType(Type type, Module module, Assembly targetAssembly, ISet<Type> includedTypes)
         {
-            if (type.IsNested) return;
-
             if (SerializerGenerationManager.RecordTypeToGenerate(type, module, targetAssembly))
                 includedTypes.Add(type);
         }

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -60,7 +60,7 @@ namespace Orleans.CodeGenerator
                 return false;
             }
 
-            if (typeInfo.IsNestedPublic || typeInfo.IsNestedFamily || typeInfo.IsNestedPrivate)
+            if (typeInfo.IsNestedFamily || typeInfo.IsNestedPrivate)
             {
                 Log.Warn(
                     ErrorCode.CodeGenIgnoringTypes,

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -9,7 +9,6 @@ namespace Orleans.CodeGenerator
     using System.Runtime.Serialization;
     using System.Text.RegularExpressions;
 
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -26,6 +25,13 @@ namespace Orleans.CodeGenerator
     /// </summary>
     public static class SerializerGenerator
     {
+        private static readonly TypeFormattingOptions GeneratedTypeNameOptions = new TypeFormattingOptions(
+            ClassSuffix,
+            includeGenericParameters: false,
+            includeTypeParameters: false,
+            nestedClassSeparator: '_',
+            includeGlobal: false);
+
         /// <summary>
         /// The suffix appended to the name of generated classes.
         /// </summary>
@@ -62,9 +68,7 @@ namespace Orleans.CodeGenerator
                         SF.AttributeArgument(SF.TypeOfExpression(type.GetTypeSyntax(includeGenericParameters: false))))
             };
 
-            var className = CodeGeneratorCommon.ClassPrefix
-                            + TypeUtils.GetSimpleTypeName(type, _ => !_.IsGenericParameter).Replace('.', '_')
-                            + ClassSuffix;
+            var className = CodeGeneratorCommon.ClassPrefix + type.GetParseableName(GeneratedTypeNameOptions);
             var fields = GetFields(type);
 
             // Mark each field type for generation

--- a/src/OrleansCodeGenerator/Utilities/SyntaxFactoryExtensions.cs
+++ b/src/OrleansCodeGenerator/Utilities/SyntaxFactoryExtensions.cs
@@ -45,8 +45,9 @@ namespace Orleans.CodeGenerator.Utilities
             return
                 SyntaxFactory.ParseTypeName(
                     type.GetParseableName(
-                        includeNamespace: includeNamespace,
-                        includeGenericParameters: includeGenericParameters));
+                        new TypeFormattingOptions(
+                            includeNamespace: includeNamespace,
+                            includeGenericParameters: includeGenericParameters)));
         }
         
         /// <summary>
@@ -63,7 +64,9 @@ namespace Orleans.CodeGenerator.Utilities
         /// </returns>
         public static NameSyntax GetNameSyntax(this Type type, bool includeNamespace = true)
         {
-            return SyntaxFactory.ParseName(type.GetParseableName(includeNamespace: includeNamespace));
+            return
+                SyntaxFactory.ParseName(
+                    type.GetParseableName(new TypeFormattingOptions(includeNamespace: includeNamespace)));
         }
 
         /// <summary>
@@ -175,7 +178,9 @@ namespace Orleans.CodeGenerator.Utilities
         public static ArrayTypeSyntax GetArrayTypeSyntax(this Type type, bool includeNamespace = true)
         {
             return
-                SyntaxFactory.ArrayType(SyntaxFactory.ParseTypeName(type.GetParseableName(includeNamespace: includeNamespace)))
+                SyntaxFactory.ArrayType(
+                    SyntaxFactory.ParseTypeName(
+                        type.GetParseableName(new TypeFormattingOptions(includeNamespace: includeNamespace))))
                     .AddRankSpecifiers(
                         SyntaxFactory.ArrayRankSpecifier().AddSizes(SyntaxFactory.OmittedArraySizeExpression()));
         }


### PR DESCRIPTION
This fix enables serializer generation for nested types and cleans up the usage of `IsNested` vs `IsNestedPrivate`, etc.