### PR TITLE
Correctly serialize [Obsolete] fields and properties.

### DIFF
--- a/src/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/src/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -115,11 +115,33 @@ namespace UnitTests.GrainInterfaces
     [Serializable]
     public abstract class SomeAbstractClass : ISomeInterface
     {
+        [NonSerialized]
+        private int nonSerializedIntField;
+
         public abstract int Int { get; set; }
 
         public List<ISomeInterface> Interfaces { get; set; }
 
         public List<SomeAbstractClass> Classes { get; set; }
+
+        [Obsolete("This field should not be serialized", true)]
+        public int ObsoleteIntWithError { get; set; }
+
+        [Obsolete("This field should be serialized")]
+        public int ObsoleteInt { get; set; }
+
+        public int NonSerializedInt
+        {
+            get
+            {
+                return this.nonSerializedIntField;
+            }
+
+            set
+            {
+                this.nonSerializedIntField = value;
+            }
+        }
 
         [Serializable]
         public enum SomeEnum


### PR DESCRIPTION
Fixes #1215: in generated code, all [Obsolete] properties/fields are accessed using the IL method instead of directly in order to avoid compiler warnings/errors.