### PR TITLE
Avoid serialization of Delegate fields

### DIFF
--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -52,7 +52,8 @@ namespace Orleans.CodeGenerator
             var typeInfo = t.GetTypeInfo();
 
             if (typeInfo.IsGenericParameter || ProcessedTypes.Contains(t) || TypesToProcess.Contains(t)
-                || typeof(Exception).GetTypeInfo().IsAssignableFrom(t)) return false;
+                || typeof(Exception).GetTypeInfo().IsAssignableFrom(t)
+                || typeof(Delegate).GetTypeInfo().IsAssignableFrom(t)) return false;
 
             if (typeInfo.IsArray)
             {


### PR DESCRIPTION
Improves Mono support, since Mono and .NET currently have different implementations of `MulticastDelegate`.

cc @bsmatt