### PR TITLE
Switch to using NetworkInterface.NetworkInterfaceType

### DIFF
--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -512,7 +512,7 @@ namespace Orleans.Runtime.Configuration
                 if (!string.IsNullOrWhiteSpace(interfaceName) &&
                     !netInterface.Name.StartsWith(interfaceName, StringComparison.Ordinal)) continue;
 
-                bool isLoopbackInterface = (i == NetworkInterface.LoopbackInterfaceIndex);
+                bool isLoopbackInterface = (netInterface.NetworkInterfaceType == NetworkInterfaceType.Loopback);
                 // get list of all unicast IPs from current interface
                 UnicastIPAddressInformationCollection ipAddresses = netInterface.GetIPProperties().UnicastAddresses;
 


### PR DESCRIPTION
Switch to using NetworkInterface.NetworkInterfaceType instead of NetworkInterface.LoopbackInterfaceIndex to detect loopback IP addresses

This is a fix for https://github.com/dotnet/orleans/issues/1243.