### PR TITLE
Move away from dating terminology

### DIFF
--- a/src/OrleansRuntime/Catalog/ActivationCollector.cs
+++ b/src/OrleansRuntime/Catalog/ActivationCollector.cs
@@ -332,9 +332,9 @@ namespace Orleans.Runtime
                 condemned.Add(activation);
             }
 
-            if (Silo.CurrentSilo.TestHookup.Debug_OnDecideToCollectActivation != null)
+            if (Silo.CurrentSilo.TestHook.Debug_OnDecideToCollectActivation != null)
             {
-                Silo.CurrentSilo.TestHookup.Debug_OnDecideToCollectActivation(activation.Grain);
+                Silo.CurrentSilo.TestHook.Debug_OnDecideToCollectActivation(activation.Grain);
             }
         }
 

--- a/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.Messaging
                 }
 
                 // check for simulation of lost messages
-                if(Silo.CurrentSilo.TestHookup.ShouldDrop(msg))
+                if(Silo.CurrentSilo.TestHook.ShouldDrop(msg))
                 {
                     logger.Info(ErrorCode.Messaging_SimulatedMessageLoss, "Message blocked by test");
                     messageCenter.SendRejection(msg, Message.RejectionTypes.Unrecoverable, "Message blocked by test");

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -116,9 +116,9 @@ namespace Orleans.Runtime
         public WaitHandle SiloTerminatedEvent { get { return siloTerminatedEvent; } } // one event for all types of termination (shutdown, stop and fast kill).
 
         /// <summary>
-        /// Test hookup connection for white-box testing of silo.
+        /// Test hook connection for white-box testing of silo.
         /// </summary>
-        public TestHookups TestHookup;
+        public TestHooks TestHook;
         
         /// <summary>
         /// Creates and initializes the silo from the specified config data.
@@ -309,7 +309,7 @@ namespace Orleans.Runtime
             StringValueStatistic.FindOrCreate(StatisticNames.SILO_START_TIME,
                 () => TraceLogger.PrintDate(startTime)); // this will help troubleshoot production deployment when looking at MDS logs.
 
-            TestHookup = new TestHookups(this);
+            TestHook = new TestHooks(this);
 
             logger.Info(ErrorCode.SiloInitializingFinished, "-------------- Started silo {0}, ConsistentHashCode {1:X} --------------", SiloAddress.ToLongString(), SiloAddress.GetConsistentHashCode());
         }
@@ -806,7 +806,7 @@ namespace Orleans.Runtime
                     SystemStatus.Current = SystemStatus.Stopping;
                 }
 
-                if (!TestHookup.ExecuteFastKillInProcessExit) return;
+                if (!TestHook.ExecuteFastKillInProcessExit) return;
 
                 logger.Info(ErrorCode.SiloStopping, "Silo.HandleProcessExit() - starting to FastKill()");
                 FastKill();
@@ -818,9 +818,9 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
-        /// Test hookup functions for white box testing.
+        /// Test hook functions for white box testing.
         /// </summary>
-        public class TestHookups : MarshalByRefObject
+        public class TestHooks : MarshalByRefObject
         {
             private readonly Silo silo;
             internal bool ExecuteFastKillInProcessExit;
@@ -857,7 +857,7 @@ namespace Orleans.Runtime
 
             internal Action<GrainId> Debug_OnDecideToCollectActivation { get; set; }
 
-            internal TestHookups(Silo s)
+            internal TestHooks(Silo s)
             {
                 silo = s;
                 ExecuteFastKillInProcessExit = true;
@@ -924,7 +924,7 @@ namespace Orleans.Runtime
                 if (SimulatedMessageLoss != null)
                 {
                     double blockedpercentage = 0.0;
-                    Silo.CurrentSilo.TestHookup.SimulatedMessageLoss.TryGetValue(msg.TargetSilo.Endpoint, out blockedpercentage);
+                    Silo.CurrentSilo.TestHook.SimulatedMessageLoss.TryGetValue(msg.TargetSilo.Endpoint, out blockedpercentage);
                     return (random.NextDouble() * 100 < blockedpercentage);
                 }
                 else

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -121,7 +121,6 @@ namespace Orleans.Runtime.Providers
             where TExtension : IGrainExtension
             where TExtensionInterface : IGrainExtension
         {
-            // Hookup Extension.
             TExtension extension;
             if (!TryGetExtensionHandler(out extension))
             {

--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -394,10 +394,10 @@ namespace Orleans.TestingHost
         private static void ImportGeneratedAssemblies(SiloHandle siloHandle)
         {
             var silo = siloHandle.Silo;
-            if (silo != null && silo.TestHookup != null)
+            if (silo != null && silo.TestHook != null)
             {
-                var generatedAssemblies = new Silo.TestHookups.GeneratedAssemblies();
-                silo.TestHookup.UpdateGeneratedAssemblies(generatedAssemblies);
+                var generatedAssemblies = new Silo.TestHooks.GeneratedAssemblies();
+                silo.TestHook.UpdateGeneratedAssemblies(generatedAssemblies);
                 foreach (var assembly in generatedAssemblies.Assemblies)
                 {
                     // If we have never seen generated code for this assembly before, or generated code might be
@@ -686,16 +686,16 @@ namespace Orleans.TestingHost
             appDomain = AppDomain.CreateDomain(siloName, null, setup);
 
             // Load each of the additional assemblies.
-            Silo.TestHookups.CodeGeneratorOptimizer optimizer = null;
+            Silo.TestHooks.CodeGeneratorOptimizer optimizer = null;
             foreach (var assembly in additionalAssemblies)
             {
                 if (optimizer == null)
                 {
                     optimizer =
-                        (Silo.TestHookups.CodeGeneratorOptimizer)
+                        (Silo.TestHooks.CodeGeneratorOptimizer)
                         appDomain.CreateInstanceFromAndUnwrap(
                             "OrleansRuntime.dll",
-                            typeof(Silo.TestHookups.CodeGeneratorOptimizer).FullName,
+                            typeof(Silo.TestHooks.CodeGeneratorOptimizer).FullName,
                             false,
                             BindingFlags.Default,
                             null,

--- a/src/TesterInternal/BootstrapProviderTests.cs
+++ b/src/TesterInternal/BootstrapProviderTests.cs
@@ -82,7 +82,7 @@ namespace UnitTests.General
             List<SiloHandle> silos = GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                MockBootstrapProvider provider = (MockBootstrapProvider)siloHandle.Silo.TestHookup.GetBootstrapProvider(providerName);
+                MockBootstrapProvider provider = (MockBootstrapProvider)siloHandle.Silo.TestHook.GetBootstrapProvider(providerName);
                 Assert.IsNotNull(provider, "No storage provider found: Name={0} Silo={1}", providerName, siloHandle.Silo.SiloAddress);
                 providerInUse = provider;
             }

--- a/src/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
+++ b/src/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
@@ -40,7 +40,7 @@ namespace UnitTests.General
         public void TestInitialize()
         {
             Console.WriteLine("ConsistentRingProviderTests - TestInitialize");
-            string config = Primary.Silo.TestHookup.PrintSiloConfig();
+            string config = Primary.Silo.TestHook.PrintSiloConfig();
             Console.WriteLine("Running with Silo Config = " + config);
         }
 
@@ -219,12 +219,12 @@ namespace UnitTests.General
             {
                 double next = random.NextDouble();
                 uint randomKey = (uint)((double)RangeFactory.RING_SIZE * next);
-                SiloAddress s = Primary.Silo.TestHookup.ConsistentRingProvider.GetPrimaryTargetSilo(randomKey);
+                SiloAddress s = Primary.Silo.TestHook.ConsistentRingProvider.GetPrimaryTargetSilo(randomKey);
                 if (responsibleSilo.Equals(s))
                     return randomKey;
             }
             throw new Exception(String.Format("Could not pick a key that silo {0} will be responsible for. Primary.Ring = \n{1}",
-                responsibleSilo, Primary.Silo.TestHookup.ConsistentRingProvider));
+                responsibleSilo, Primary.Silo.TestHook.ConsistentRingProvider));
         }
 
         private void VerificationScenario(uint testKey)
@@ -257,7 +257,7 @@ namespace UnitTests.General
 
         private void VerifyKey(uint key, List<SiloAddress> silos)
         {
-            SiloAddress truth = Primary.Silo.TestHookup.ConsistentRingProvider.GetPrimaryTargetSilo(key); //expected;
+            SiloAddress truth = Primary.Silo.TestHook.ConsistentRingProvider.GetPrimaryTargetSilo(key); //expected;
             //if (truth == null) // if the truth isn't passed, we compute it here
             //{
             //    truth = silos.Find(siloAddr => (key <= siloAddr.GetConsistentHashCode()));
@@ -270,7 +270,7 @@ namespace UnitTests.General
             // lookup for 'key' should return 'truth' on all silos
             foreach (var siloHandle in GetActiveSilos()) // do this for each silo
             {
-                SiloAddress s = siloHandle.Silo.TestHookup.ConsistentRingProvider.GetPrimaryTargetSilo((uint)key);
+                SiloAddress s = siloHandle.Silo.TestHook.ConsistentRingProvider.GetPrimaryTargetSilo((uint)key);
                 Assert.AreEqual(truth, s, string.Format("Lookup wrong for key: {0} on silo: {1}", key, siloHandle.Silo.SiloAddress));
             }
         }

--- a/src/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/src/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -231,13 +231,13 @@ namespace Tests.GeoClusterTests
         {
             foreach (var silo in Clusters[from].Silos)
                 foreach (var dest in Clusters[to].Silos)
-                    silo.Silo.TestHookup.BlockSiloCommunication(dest.Endpoint, 100);
+                    silo.Silo.TestHook.BlockSiloCommunication(dest.Endpoint, 100);
         }
 
         public void UnblockAllClusterCommunication(string from)
         {
             foreach (var silo in Clusters[from].Silos)
-                    silo.Silo.TestHookup.UnblockSiloCommunication();
+                    silo.Silo.TestHook.UnblockSiloCommunication();
         }
 
   

--- a/src/TesterInternal/MockStatsCollectors.cs
+++ b/src/TesterInternal/MockStatsCollectors.cs
@@ -21,7 +21,7 @@ namespace UnitTests.Stats
     }
 
     /// <summary>
-    /// Indirection for hookup to client stats / metrics collector singleton instances
+    /// Indirection for a test hook to client stats / metrics collector singleton instances
     /// </summary>
     internal static class MockStatsCollectorClient
     {

--- a/src/TesterInternal/StatsTests.cs
+++ b/src/TesterInternal/StatsTests.cs
@@ -60,11 +60,11 @@ namespace UnitTests.Stats
             Assert.AreEqual("MockStats", config.StatisticsProviderName, "Client.StatisticsProviderName");
 
             Silo silo = Primary.Silo;
-            Assert.IsTrue(silo.TestHookup.HasStatisticsProvider, "Silo StatisticsProviderManager is setup");
+            Assert.IsTrue(silo.TestHook.HasStatisticsProvider, "Silo StatisticsProviderManager is setup");
             Assert.AreEqual("MockStats", silo.LocalConfig.StatisticsProviderName, "Silo.StatisticsProviderName");
 
             // Check we got some stats & metrics callbacks on both client and server.
-            var siloStatsCollector = Primary.Silo.TestHookup.StatisticsProvider as MockStatsSiloCollector;
+            var siloStatsCollector = Primary.Silo.TestHook.StatisticsProvider as MockStatsSiloCollector;
             var clientStatsCollector = MockStatsCollectorClient.StatsPublisherInstance;
             var clientMetricsCollector = MockStatsCollectorClient.MetricsPublisherInstance;
 
@@ -195,7 +195,7 @@ namespace UnitTests.Stats
             Assert.AreEqual("SQL", config.StatisticsProviderName, "Client.StatisticsProviderName");
 
             Silo silo = Primary.Silo;
-            Assert.IsTrue(silo.TestHookup.HasStatisticsProvider, "Silo StatisticsProviderManager is setup");
+            Assert.IsTrue(silo.TestHook.HasStatisticsProvider, "Silo StatisticsProviderManager is setup");
             Assert.AreEqual("SQL", silo.LocalConfig.StatisticsProviderName, "Silo.StatisticsProviderName");
         }
     }

--- a/src/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/src/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -86,11 +86,11 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = GetActiveSilos().ToList();
             foreach (var silo in silos)
             {
-                List<string> providers = silo.Silo.TestHookup.GetStorageProviderNames().ToList();
+                List<string> providers = silo.Silo.TestHook.GetStorageProviderNames().ToList();
                 Assert.IsNotNull(providers, "Null provider manager");
                 Assert.IsTrue(providers.Count > 0, "Some providers loaded");
                 const string providerName = "test1";
-                IStorageProvider store = silo.Silo.TestHookup.GetStorageProvider(providerName);
+                IStorageProvider store = silo.Silo.TestHook.GetStorageProvider(providerName);
                 Assert.IsNotNull(store, "No storage provider found: {0}", providerName);
             }
         }
@@ -102,7 +102,7 @@ namespace UnitTests.StorageTests
             foreach (var silo in silos)
             {
                 const string providerName = "LowerCase";
-                IStorageProvider store = silo.Silo.TestHookup.GetStorageProvider(providerName);
+                IStorageProvider store = silo.Silo.TestHook.GetStorageProvider(providerName);
                 Assert.IsNotNull(store, "No storage provider found: {0}", providerName);
             }
         }
@@ -114,7 +114,7 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = GetActiveSilos().ToList();
             var silo = silos.First();
             const string providerName = "NotPresent";
-            IStorageProvider store = silo.Silo.TestHookup.GetStorageProvider(providerName);
+            IStorageProvider store = silo.Silo.TestHook.GetStorageProvider(providerName);
         }
 
         [TestMethod, TestCategory("Functional"), TestCategory("Persistence")]
@@ -1215,7 +1215,7 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                MockStorageProvider provider = (MockStorageProvider)siloHandle.Silo.TestHookup.GetStorageProvider(providerName);
+                MockStorageProvider provider = (MockStorageProvider)siloHandle.Silo.TestHook.GetStorageProvider(providerName);
                 provider.SetValue<TState>(grainType, (GrainReference)grain, "Field1", newValue);
             }
         }
@@ -1225,7 +1225,7 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider)siloHandle.Silo.TestHookup.GetStorageProvider(providerName);
+                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider)siloHandle.Silo.TestHook.GetStorageProvider(providerName);
                 provider.SetErrorInjection(errorInjectionPoint);
             }
         }
@@ -1279,7 +1279,7 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                MockStorageProvider provider = (MockStorageProvider)siloHandle.Silo.TestHookup.GetStorageProvider(providerName);
+                MockStorageProvider provider = (MockStorageProvider)siloHandle.Silo.TestHook.GetStorageProvider(providerName);
                 Assert.IsNotNull(provider, "No storage provider found: Name={0} Silo={1}", providerName, siloHandle.Silo.SiloAddress);
                 if (provider.ReadCount > 0)
                 {

--- a/src/TesterInternal/StorageTests/PersistenceGrainTests_AzureStore.cs
+++ b/src/TesterInternal/StorageTests/PersistenceGrainTests_AzureStore.cs
@@ -398,7 +398,7 @@ namespace UnitTests.StorageTests
             foreach (var silo in silos)
             {
                 string provider = typeof(AzureTableStorage).FullName;
-                List<string> providers = silo.Silo.TestHookup.GetStorageProviderNames().ToList();
+                List<string> providers = silo.Silo.TestHook.GetStorageProviderNames().ToList();
                 Assert.IsTrue(providers.Contains(provider), "No storage provider found: {0}", provider);
             }
         }

--- a/src/TesterInternal/StreamProvidersTests.cs
+++ b/src/TesterInternal/StreamProvidersTests.cs
@@ -80,7 +80,7 @@ namespace UnitTests.Streaming
             SiloHandle siloHandle = GetActiveSilos().First();
             Guid serviceId = siloHandle.Silo.GlobalConfig.ServiceId;
             Assert.AreEqual(thisRunServiceId, serviceId, "ServiceId in Silo config");
-            serviceId = siloHandle.Silo.TestHookup.ServiceId;
+            serviceId = siloHandle.Silo.TestHook.ServiceId;
             Assert.AreEqual(thisRunServiceId, serviceId, "ServiceId active in silo");
 
             // ServiceId is not currently available in client config
@@ -113,7 +113,7 @@ namespace UnitTests.Streaming
             SiloHandle siloHandle = GetActiveSilos().First();
             Guid serviceId = siloHandle.Silo.GlobalConfig.ServiceId;
             Assert.AreEqual(initialServiceId, serviceId, "ServiceId in Silo config");
-            serviceId = siloHandle.Silo.TestHookup.ServiceId;
+            serviceId = siloHandle.Silo.TestHook.ServiceId;
             Assert.AreEqual(initialServiceId, serviceId, "ServiceId active in silo");
 
             // ServiceId is not currently available in client config

--- a/src/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
+++ b/src/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
@@ -163,7 +163,7 @@ namespace UnitTests.StreamingTests
             List<SiloHandle> silos = GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider) siloHandle.Silo.TestHookup.GetStorageProvider(providerName);
+                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider) siloHandle.Silo.TestHook.GetStorageProvider(providerName);
                 provider.SetErrorInjection(errorInjectionPoint);
             }
         }


### PR DESCRIPTION
Renamed "hookup" to "hook".

Even though the project is for mature audience, I think this is more appropriate naming.