### PR TITLE
Adding checks to the bond serializer install/uninstall

### DIFF
--- a/src/NuGet/BondSerializerInstall.ps1
+++ b/src/NuGet/BondSerializerInstall.ps1
@@ -23,22 +23,70 @@ function AddOrGetElement(
 }
 
 function RegisterSerializer(
+    [OutputType([void])]
     [Parameter(Mandatory=$true)]
-    [string]$filePath,
+    [string]$fileKey,
+    [Parameter(Mandatory=$true)]
+    [System.__ComObject]$project,
     [Parameter(Mandatory=$true)]
     [string]$type)
 {
-	$fileXml = [xml](Get-Content $filePath)
-	if ($fileXml -eq $null) {Q
-		return
-	}
+    Try
+    {
+    $project.Save([string]::Empty)
+    }
+    Catch 
+    {
+    }
+
+    Try
+    {
+        $projectItem = $project.ProjectItems.Item($fileKey)
+        Write-Host "Found $fileKey in project"
+    }
+    Catch
+    {
+        return
+    }
+
+    if ($projectItem -eq $null) {
+        Write-Error "The fileKey $fileKey had a null entry"
+        return
+    }
+    
+    Try
+    {
+    $projectItem.Save([string]::Empty)
+    }
+    Catch
+    {
+    }
+    
+    $documentEntry = $projectItem.Document
+    if ($documentEntry -eq $null) {
+        Write-Error "The fileKey $fileKey had no associated document"
+        return
+    }
+    
+    $fullFilePath = $documentEntry.FullName
+    
+    if (-not [System.IO.File]::Exists($fullFilePath)) {
+        Write-Error "The file $fullFilePath was not found"
+        return
+    }
+
+    $fileXml = [xml](Get-Content $fullFilePath)
+    if ($fileXml -eq $null) {
+        Write-Error "Unable to load file xml $filePath"
+        return
+    }
 
     $nameTable = $fileXml.NameTable
     $namespaceManager = New-Object -TypeName System.Xml.XmlNamespaceManager -ArgumentList $nameTable
     $namespaceManager.AddNamespace([string]::Empty, "urn:orleans");
     $namespaceManager.AddNamespace("o", "urn:orleans");
     $rootNode = $fileXml.DocumentElement;
-	$isServerConfig = $fileXml.SelectSingleNode("/o:OrleansConfiguration", $namespaceManager) -ne $null
+    $isServerConfig = $fileXml.SelectSingleNode("/o:OrleansConfiguration", $namespaceManager) -ne $null
     if ($isServerConfig) {
         $globalsNode = AddOrGetElement -xml $rootNode -name "Globals" -namespaceManager $namespaceManager
         $parentNode = $globalsNode
@@ -53,22 +101,17 @@ function RegisterSerializer(
 
     if ($bondTypeProvider -eq $null)
     {
+        Write-Host Adding provider to provider list
         $provider = AddOrGetElement -xml $providersNode -name "Provider" -namespaceManager $namespaceManager
         $typeAttribute = $fileXml.CreateAttribute("type");
         $typeAttribute.Value = $type
         $provider.Attributes.Append($typeAttribute) | Out-Null
-        $fileXml.Save($filePath);
+        Write-Host Saving updated $fileKey
+        $fileXml.Save($fullFilePath)
     }
 
-	Out-Null
+    Out-Null
 }
 
-$configXml = $project.ProjectItems.Item("OrleansConfiguration.xml")
-if ($configXml -ne $null -and $configXml.Document -ne $null) {
-	RegisterSerializer -filePath $configXml.Document.FullName -type $bondSerializerTypeName
-}
-
-$configXml = $project.ProjectItems.Item("ClientConfiguration.xml")
-if ($configXml -ne $null -and $configXml.Document -ne $null) {
-	RegisterSerializer -filePath $configXml.Document.FullName -type $bondSerializerTypeName
-}
+RegisterSerializer -fileKey "OrleansConfiguration.xml" -project $project -type $bondSerializerTypeName
+RegisterSerializer -fileKey "ClientConfiguration.xml" -project $project -type $bondSerializerTypeName

--- a/src/NuGet/BondSerializerUninstall.ps1
+++ b/src/NuGet/BondSerializerUninstall.ps1
@@ -3,13 +3,54 @@ param($installPath, $toolsPath, $package, $project)
 $bondSerializerTypeName = 'Orleans.Serialization.BondSerializer, OrleansBondUtils'
 
 function UnregisterSerializer(
+    [OutputType([void])]
     [Parameter(Mandatory=$true)]
-    [string]$filePath,
+    [string]$fileKey,
+    [Parameter(Mandatory=$true)]
+    [System.__ComObject]$project,
     [Parameter(Mandatory=$true)]
     [string]$type
     )
 {
+    Try
+    {
+        $project.Save([string]::Empty)
+    }
+    Catch
+    {
+    }
+    
+    Try
+    {
+        $projectItem = $project.ProjectItems.Item($fileKey)
+        Write-Host "Removing Bond Serializer from $fileKey"
+    }
+    Catch
+    {
+        return
+    }
+    
+    if ($projectItem -eq $null) {
+        Write-Error "The project item for $fileKey was null"
+        return
+    }
+
+    Try
+    {
+        $projectItem.Save([string]::Empty)
+    }
+    Catch
+    {
+    }
+    
+    $projectDocument = $projectItem.Document
+    if ($projectDocument -eq $null) {
+        Write-Error "The project document for $fileKey was null"
+    }
+
+    $filePath = $projectDocument.FullName
     if ([System.IO.File]::Exists($filePath) -eq $false) {
+        Write-Error "The file $filePath was not found"
         return
     }
 
@@ -28,20 +69,10 @@ function UnregisterSerializer(
 
     if ($providerNode -ne $null)
     {
-        $providerNode.ParentNode.RemoveChild($providerNode);
-        $fileXml.Save($filePath);
+        $providerNode.ParentNode.RemoveChild($providerNode) | Out-Null
+        $fileXml.Save($filePath)
     }
-
-    Out-Null
 }
 
-
-$configXml = $project.ProjectItems.Item("OrleansConfiguration.xml")
-if ($configXml -ne $null -and $configXml.Document -ne $null) {
-	UnregisterSerializer -filePath $configXml.Document.FullName -type $bondSerializerTypeName
-}
-
-$configXml = $project.ProjectItems.Item("ClientConfiguration.xml")
-if ($configXml -ne $null -and $configXml.Document -ne $null) {
-	UnregisterSerializer -filePath $configXml.Document.FullName -type $bondSerializerTypeName
-}
+UnregisterSerializer -fileKey "OrleansConfiguration.xml" -project $project -type $bondSerializerTypeName
+UnregisterSerializer -fileKey "ClientConfiguration.xml" -project $project -type $bondSerializerTypeName


### PR DESCRIPTION
made the bond serializer installer/uninstaller a bit more robust
* saves pending project changes, otherwise the operation will fail
* saves pending file changes to the configuration file being changed, otherwise the operation will fail
* writes a bit more info to the console
* doesn't write an error to the console if one of the config files doesn't exist
* made the ps1 files a bit more reusable by other serializer installers by moving checks in to the Register/Unregister functions