### PR TITLE
Removed "Functional" category from tests that are ifdef'ed

### DIFF
--- a/src/TesterInternal/GatewaySelectionTest.cs
+++ b/src/TesterInternal/GatewaySelectionTest.cs
@@ -78,7 +78,7 @@ namespace UnitTests.MessageCenterTests
         }
 
 #if USE_SQL_SERVER || DEBUG
-        [TestMethod, TestCategory("Functional"), TestCategory("Gateway"), TestCategory("SqlServer")]
+        [TestMethod, TestCategory("Gateway"), TestCategory("SqlServer")]
         public async Task GatewaySelection_SqlServer()
         {
             string testName = TestContext.TestName;

--- a/src/TesterInternal/LivenessTests/MembershipTablePluginTests.cs
+++ b/src/TesterInternal/LivenessTests/MembershipTablePluginTests.cs
@@ -53,7 +53,7 @@ namespace UnitTests.LivenessTests
         // Test methods 
 
 #if DEBUG
-        [TestMethod, TestCategory("Functional"), TestCategory("Liveness"), TestCategory("Azure")]
+        [TestMethod, TestCategory("Liveness"), TestCategory("Azure")]
         public async Task MT_UpdateRow_Azure()
         {
             var membershipType = GlobalConfiguration.LivenessProviderType.AzureTable;
@@ -64,7 +64,7 @@ namespace UnitTests.LivenessTests
 #endif
 
 #if USE_SQL_SERVER || DEBUG
-        [TestMethod, TestCategory("Functional"), TestCategory("Liveness"), TestCategory("SqlServer")]
+        [TestMethod, TestCategory("Liveness"), TestCategory("SqlServer")]
         public async Task MT_UpdateRow_SqlServer()
         {
             var membershipType = GlobalConfiguration.LivenessProviderType.SqlServer;

--- a/src/TesterInternal/StatsTests.cs
+++ b/src/TesterInternal/StatsTests.cs
@@ -178,7 +178,7 @@ namespace UnitTests.Stats
             StopAllSilos();
         }
 
-        [TestMethod, TestCategory("Functional"), TestCategory("Client"), TestCategory("Stats"), TestCategory("SqlServer")]
+        [TestMethod, TestCategory("Client"), TestCategory("Stats"), TestCategory("SqlServer")]
         public void ClientInit_SqlServer_WithStats()
         {
             Assert.IsTrue(GrainClient.IsInitialized);

--- a/src/TesterInternal/TimerTests/ReminderTests_SqlServer.cs
+++ b/src/TesterInternal/TimerTests/ReminderTests_SqlServer.cs
@@ -69,13 +69,13 @@ namespace UnitTests.TimerTests
 
         // Basic tests
 
-        [TestMethod, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("SqlServer")]
+        [TestMethod, TestCategory("ReminderService"), TestCategory("SqlServer")]
         public async Task Rem_Sql_Basic_StopByRef()
         {
             await Test_Reminders_Basic_StopByRef();
         }
 
-        [TestMethod, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("SqlServer")]
+        [TestMethod, TestCategory("ReminderService"), TestCategory("SqlServer")]
         public async Task Rem_Sql_Basic_ListOps()
         {
             await Test_Reminders_Basic_ListOps();
@@ -83,7 +83,7 @@ namespace UnitTests.TimerTests
 
         // Single join tests ... multi grain, multi reminders
 
-        [TestMethod, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("SqlServer")]
+        [TestMethod, TestCategory("ReminderService"), TestCategory("SqlServer")]
         public async Task Rem_Sql_1J_MultiGrainMultiReminders()
         {
             await Test_Reminders_1J_MultiGrainMultiReminders();


### PR DESCRIPTION
 These tests are not currently run by automated builds and are intended for manual execution by developers. Removing "Functional" category will eliminate the discrepancy between the set of functional tests in Test Explorer and the set that actually gets executed by VSO builds.