### PR TITLE
Make Namespace access modifier public in ImplicitStreamSubscriptionAttribute. Add Provider property.

### DIFF
--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -280,25 +280,11 @@ namespace Orleans
     public sealed class ImplicitStreamSubscriptionAttribute : Attribute
     {
         public string Namespace { get; private set; }
-
-        public string Provider { get; private set; }
-
+        
         // We have not yet come to an agreement whether the provider should be specified as well.
         public ImplicitStreamSubscriptionAttribute(string streamNamespace)
         {
             Namespace = streamNamespace;
-        }
-
-
-        /// <summary>
-        /// Constructor which allows you to specify both namespace and provider names
-        /// </summary>
-        /// <param name="streamNamespace"></param>
-        /// <param name="streamProvider"></param>
-        public ImplicitStreamSubscriptionAttribute(string streamNamespace, string streamProvider)
-        {
-            Namespace = streamNamespace;
-            Provider = streamProvider;
         }
     }
 }

--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -279,12 +279,26 @@ namespace Orleans
     [AttributeUsage(AttributeTargets.Class, AllowMultiple=true)]
     public sealed class ImplicitStreamSubscriptionAttribute : Attribute
     {
-        internal string Namespace { get; private set; }
+        public string Namespace { get; private set; }
+
+        public string Provider { get; private set; }
 
         // We have not yet come to an agreement whether the provider should be specified as well.
         public ImplicitStreamSubscriptionAttribute(string streamNamespace)
         {
             Namespace = streamNamespace;
+        }
+
+
+        /// <summary>
+        /// Constructor which allows you to specify both namespace and provider names
+        /// </summary>
+        /// <param name="streamNamespace"></param>
+        /// <param name="streamProvider"></param>
+        public ImplicitStreamSubscriptionAttribute(string streamNamespace, string streamProvider)
+        {
+            Namespace = streamNamespace;
+            Provider = streamProvider;
         }
     }
 }


### PR DESCRIPTION
Issue #1266 : update Namespace access modifier to public. Add Provider property and create constructor which takes it as a second parameter.