### PR TITLE
Fixed dependencies in OrleansAzureUtils.nuspec

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -22,8 +22,7 @@
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansProviders" version="$version$" />
 
-      <dependency id="WindowsAzure.Storage" version="4.2.0.0" />
-      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" />
+      <dependency id="WindowsAzure.Storage" version="5.0.2" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -60,7 +60,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
-      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.2\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/src/OrleansAzureUtils/packages.config
+++ b/src/OrleansAzureUtils/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net451" />
 </packages>

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -100,7 +100,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
-      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.2\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/src/Tester/packages.config
+++ b/src/Tester/packages.config
@@ -12,5 +12,5 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0-rc1-final" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net451" />
 </packages>

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -62,7 +62,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
-      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.2\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/src/TesterInternal/packages.config
+++ b/src/TesterInternal/packages.config
@@ -7,5 +7,5 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
OrleansAzureUtils.nuspec dependency changes:
 - WindowsAzure.Storage is 5.0.2
 - Removed dependency on Microsoft.WindowsAzure.ConfigurationManager
Updated WindowsAzure.Storage from 5.0.0 to 5.0.2 (as 5.0.0 is unlisted in nuget.org due to a bug).