### PR TITLE
Allow to configure PubSub for SMS.

### DIFF
--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
@@ -28,12 +28,13 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         internal bool IsRewindable { get; private set; }
 
-        internal SimpleMessageStreamProducer(StreamImpl<T> stream, string streamProviderName, IStreamProviderRuntime providerUtilities, bool fireAndForgetDelivery, bool isRewindable)
+        internal SimpleMessageStreamProducer(StreamImpl<T> stream, string streamProviderName,
+            IStreamProviderRuntime providerUtilities, bool fireAndForgetDelivery, IStreamPubSub pubSub, bool isRewindable)
         {
             this.stream = stream;
             this.streamProviderName = streamProviderName;
             providerRuntime = providerUtilities;
-            pubSub = providerRuntime.PubSub(SimpleMessageStreamProvider.DEFAULT_STREAM_PUBSUB_TYPE);
+            this.pubSub = pubSub;
             connectedToRendezvous = false;
             this.fireAndForgetDelivery = fireAndForgetDelivery;
             IsRewindable = isRewindable;

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -12,8 +12,11 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         private Logger                      logger;
         private IStreamProviderRuntime      providerRuntime;
         private bool                        fireAndForgetDelivery;
-        internal const string               FIRE_AND_FORGET_DELIVERY = "FireAndForgetDelivery";
-        internal const StreamPubSubType     DEFAULT_STREAM_PUBSUB_TYPE = StreamPubSubType.ExplicitGrainBasedAndImplicit;
+        private StreamPubSubType            pubSubType;
+
+        private const string                STREAM_PUBSUB_TYPE = "PubSubType";
+        internal const string                FIRE_AND_FORGET_DELIVERY = "FireAndForgetDelivery";
+        private const StreamPubSubType      DEFAULT_STREAM_PUBSUB_TYPE = StreamPubSubType.ExplicitGrainBasedAndImplicit;
 
         public bool IsRewindable { get { return false; } }
 
@@ -24,8 +27,14 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             string fireAndForgetDeliveryStr;
             fireAndForgetDelivery = config.Properties.TryGetValue(FIRE_AND_FORGET_DELIVERY, out fireAndForgetDeliveryStr) && Boolean.Parse(fireAndForgetDeliveryStr);
 
+            string pubSubTypeString;
+            pubSubType = !config.Properties.TryGetValue(STREAM_PUBSUB_TYPE, out pubSubTypeString)
+                ? DEFAULT_STREAM_PUBSUB_TYPE
+                : (StreamPubSubType)Enum.Parse(typeof(StreamPubSubType), pubSubTypeString);
+
             logger = providerRuntime.GetLogger(this.GetType().Name);
-            logger.Info("Initialized SimpleMessageStreamProvider with name {0} and with property FireAndForgetDelivery: {1}.", Name, fireAndForgetDelivery);
+            logger.Info("Initialized SimpleMessageStreamProvider with name {0} and with property FireAndForgetDelivery: {1} " +
+                "and PubSubType: {2}", Name, fireAndForgetDelivery, pubSubType);
             return TaskDone.Done;
         }
 
@@ -49,7 +58,8 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         IInternalAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> stream)
         {
-            return new SimpleMessageStreamProducer<T>((StreamImpl<T>)stream, Name, providerRuntime, fireAndForgetDelivery, IsRewindable);
+            return new SimpleMessageStreamProducer<T>((StreamImpl<T>)stream, Name, providerRuntime,
+                fireAndForgetDelivery, providerRuntime.PubSub(pubSubType), IsRewindable);
         }
 
         IInternalAsyncObservable<T> IInternalStreamProvider.GetConsumerInterface<T>(IAsyncStream<T> streamId)
@@ -59,7 +69,8 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         private IInternalAsyncObservable<T> GetConsumerInterfaceImpl<T>(IAsyncStream<T> stream)
         {
-            return new StreamConsumer<T>((StreamImpl<T>)stream, Name, providerRuntime, providerRuntime.PubSub(DEFAULT_STREAM_PUBSUB_TYPE), IsRewindable);
+            return new StreamConsumer<T>((StreamImpl<T>)stream, Name, providerRuntime,
+                providerRuntime.PubSub(pubSubType), IsRewindable);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/orleans/issues/1272#issuecomment-171465129 where @centur pointed out that `SimpleMessageStreamProvider` does not currently allow to configure pub sub type.