### PR TITLE
Fix functional tests

### DIFF
--- a/src/TesterInternal/ClientInitTests.cs
+++ b/src/TesterInternal/ClientInitTests.cs
@@ -10,7 +10,7 @@ using UnitTests.Tester;
 namespace UnitTests
 {
     [TestClass]
-    public class ClientInitTests : HostedTestClusterEnsureDefaultStarted
+    public class ClientInitTests : HostedTestClusterPerFixture
     {
         [TestMethod, TestCategory("Functional"), TestCategory("Client")]
         public void ClientInit_IsInitialized()

--- a/src/TesterInternal/General/RequestContextTest.cs
+++ b/src/TesterInternal/General/RequestContextTest.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using Orleans.CodeGeneration;
 using Orleans.Runtime;
+using Orleans.Serialization;
 using Orleans.TestingHost;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
@@ -73,6 +74,7 @@ namespace UnitTests.General
         [TestMethod, TestCategory("Functional"), TestCategory("RequestContext")]
         public void RequestContext_ActivityId_ExportToMessage()
         {
+            SerializationManager.InitializeForTesting();
             Guid activityId = Guid.NewGuid();
             Guid activityId2 = Guid.NewGuid();
             Guid nullActivityId = Guid.Empty;
@@ -128,6 +130,7 @@ namespace UnitTests.General
         [TestMethod, TestCategory("Functional"), TestCategory("RequestContext")]
         public void RequestContext_ActivityId_ExportImport()
         {
+            SerializationManager.InitializeForTesting();
             Guid activityId = Guid.NewGuid();
             Guid activityId2 = Guid.NewGuid();
             Guid nullActivityId = Guid.Empty;

--- a/src/TesterInternal/MockStats_ServerConfiguration.xml
+++ b/src/TesterInternal/MockStats_ServerConfiguration.xml
@@ -16,11 +16,4 @@
     </Tracing>
     <Statistics MetricsTableWriteInterval="1s" LogWriteInterval="1s" WriteLogStatisticsToTable="true" />
   </Defaults>
-  <Override Node="Primary">
-    <Networking Port="22222" />
-    <ProxyingGateway Address="localhost" Port="40000"/>
-  </Override>
-  <Override Node="Secondary_1">
-    <Networking Port="22223" />
-  </Override>
 </OrleansConfiguration>

--- a/src/TesterInternal/StreamingTests/AQStreamingTests.cs
+++ b/src/TesterInternal/StreamingTests/AQStreamingTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Streaming
     [DeploymentItem("ClientConfig_AzureStreamProviders.xml")]
     [DeploymentItem("OrleansProviders.dll")]
     [TestClass]
-    public class AQStreamingTests : HostedTestClusterPerFixture
+    public class AQStreamingTests : HostedTestClusterPerTest
     {
         internal static readonly FileInfo SiloConfigFile = new FileInfo("Config_AzureStreamProviders.xml");
         internal static readonly FileInfo ClientConfigFile = new FileInfo("ClientConfig_AzureStreamProviders.xml");

--- a/src/TesterInternal/StreamingTests/StreamLimitTests.cs
+++ b/src/TesterInternal/StreamingTests/StreamLimitTests.cs
@@ -21,7 +21,7 @@ namespace UnitTests.StreamingTests
     [DeploymentItem("Config_StreamProviders.xml")]
     [DeploymentItem("ClientConfig_StreamProviders.xml")]
     [DeploymentItem("OrleansProviders.dll")]
-    public class StreamLimitTests : HostedTestClusterPerFixture
+    public class StreamLimitTests : HostedTestClusterPerTest
     {
         public TestContext TestContext { get; set; }
 

--- a/src/TesterInternal/StreamingTests/StreamReliabilityTests.cs
+++ b/src/TesterInternal/StreamingTests/StreamReliabilityTests.cs
@@ -27,7 +27,7 @@ namespace UnitTests.Streaming.Reliability
     [DeploymentItem("Config_AzureStreamProviders.xml")]
     [DeploymentItem("ClientConfig_AzureStreamProviders.xml")]
     [DeploymentItem("OrleansProviders.dll")]
-    public class StreamReliabilityTests : HostedTestClusterPerFixture
+    public class StreamReliabilityTests : HostedTestClusterPerTest
     {
         public TestContext TestContext { get; set; }
         public const string SMS_STREAM_PROVIDER_NAME = "SMSProvider";
@@ -43,6 +43,7 @@ namespace UnitTests.Streaming.Reliability
         {
             SiloConfigFile = new FileInfo("Config_AzureStreamProviders.xml"),
             LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable,
+            DataConnectionString = StorageTestConstants.DataConnectionString,
         };
 
         private static readonly TestingClientOptions clientRunOptions = new TestingClientOptions

--- a/src/TesterInternal/TimerTests/ReminderTests_AzureTable.cs
+++ b/src/TesterInternal/TimerTests/ReminderTests_AzureTable.cs
@@ -26,7 +26,10 @@ namespace UnitTests.TimerTests
             ReminderServiceType = GlobalConfiguration.ReminderServiceProviderType.AzureTable,
             DataConnectionString = StorageTestConstants.DataConnectionString,
             LivenessType = GlobalConfiguration.LivenessProviderType.MembershipTableGrain, // Seperate testing of Reminders storage from membership storage
-            SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
+            AdjustConfig = config =>
+            {
+                config.Globals.ServiceId = Guid.NewGuid();
+            },
         };
 
         public static TestingSiloHost CreateSiloHost()
@@ -42,8 +45,6 @@ namespace UnitTests.TimerTests
             // so we must proxy the call through a grain.
             //var controlProxy = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(-1);
             //controlProxy.EraseReminderTable().WaitWithThrow(VSOTestConstants.InitTimeout);
-
-            Assert.AreEqual(GlobalConfiguration.LivenessProviderType.MembershipTableGrain, this.HostedCluster.Primary.Silo.GlobalConfig.LivenessType, "LivenesType");
         }
 
         [TestCleanup]


### PR DESCRIPTION
This fixes some functional tests that are failing in VSO. Sometimes by restarting the silos for each tests, or sometimes by making sure tests are correctly set up.