### PR TITLE
Stream Recovery Tests

### DIFF
--- a/src/TestGrains/GeneratedEventCollectorGrain.cs
+++ b/src/TestGrains/GeneratedEventCollectorGrain.cs
@@ -4,15 +4,14 @@ using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams;
 using TestGrainInterfaces;
+using UnitTests.Grains;
 
 namespace TestGrains
 {
     [ImplicitStreamSubscription(StreamNamespace)]
     public class GeneratedEventCollectorGrain : Grain, IGeneratedEventCollectorGrain
     {
-        public static Guid ReporterId = new Guid("f83247af-c14d-422c-8141-74d7a79717dc");
         public const string StreamNamespace = "Generated";
-        public const string StreamProviderName = "GeneratedStreamProvider";
 
         private Logger logger;
         private IAsyncStream<GeneratedEvent> stream;
@@ -23,7 +22,7 @@ namespace TestGrains
             logger = base.GetLogger("GeneratedEvenCollectorGrain " + base.IdentityString);
             logger.Info("OnActivateAsync");
 
-            var streamProvider = GetStreamProvider(StreamProviderName);
+            var streamProvider = GetStreamProvider(GeneratedStreamTestConstants.StreamProviderName);
             stream = streamProvider.GetStream<GeneratedEvent>(this.GetPrimaryKey(), StreamNamespace);
 
             await stream.SubscribeAsync(
@@ -35,8 +34,8 @@ namespace TestGrains
                     {
                         return TaskDone.Done;
                     }
-                    var reporter = this.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(ReporterId);
-                    return reporter.ReportResult(this.GetPrimaryKey(), StreamProviderName, StreamNamespace, counter);
+                    var reporter = this.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
+                    return reporter.ReportResult(this.GetPrimaryKey(), GeneratedStreamTestConstants.StreamProviderName, StreamNamespace, counter);
                 });
         }
     }

--- a/src/TestGrains/GeneratedEventReporterGrain.cs
+++ b/src/TestGrains/GeneratedEventReporterGrain.cs
@@ -29,7 +29,7 @@ namespace TestGrains
             if (!reports.TryGetValue(key, out counts))
             {
                 counts = new Dictionary<Guid, int>();
-                reports.Add(key, counts);
+                reports[key] = counts;
             }
             logger.Info("ReportResult. StreamProvider: {0}, StreamNamespace: {1}, StreamGuid: {2}, Count: {3}", streamProvider, streamNamespace, streamGuid, count);
             counts[streamGuid] = count;

--- a/src/TestGrains/GeneratedStreamTestConstants.cs
+++ b/src/TestGrains/GeneratedStreamTestConstants.cs
@@ -1,0 +1,11 @@
+﻿
+using System;
+
+namespace UnitTests.Grains
+{
+    public class GeneratedStreamTestConstants
+    {
+        public static Guid ReporterId = new Guid("f83247af-c14d-422c-8141-74d7a79717dc");
+        public const string StreamProviderName = "GeneratedStreamProvider";
+    }
+}

--- a/src/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
+++ b/src/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
@@ -1,0 +1,104 @@
+﻿
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using TestGrainInterfaces;
+using UnitTests.Grains;
+
+namespace TestGrains
+{
+    [ImplicitStreamSubscription(StreamNamespace)]
+    public class ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain : Grain<StreamCheckpoint<int>>, IGeneratedEventCollectorGrain
+    {
+        public const string StreamNamespace = "NonTransientError_RecoverableStream";
+     
+        // grain instance state
+        private Logger logger;
+        private IAsyncStream<GeneratedEvent> stream;
+
+        private class FaultsState
+        {
+            public bool FaultCleared { get; set; }
+        }
+        private static readonly ConcurrentDictionary<Guid, FaultsState> FaultInjectionTracker = new ConcurrentDictionary<Guid, FaultsState>();
+        private FaultsState myFaults;
+        private FaultsState Faults { get { return myFaults ?? (myFaults = FaultInjectionTracker.GetOrAdd(this.GetPrimaryKey(), key => new FaultsState())); } }
+
+        public override async Task OnActivateAsync()
+        {
+            logger = base.GetLogger("RecoverableStreamCollectorGrain " + base.IdentityString);
+            logger.Info("OnActivateAsync");
+
+            await ReadStateAsync();
+
+            Guid streamGuid = this.GetPrimaryKey();
+            if (State.StreamGuid != streamGuid)
+            {
+                State.StreamGuid = streamGuid;
+                State.StreamNamespace = StreamNamespace;
+                await WriteStateAsync();
+            }
+
+            var streamProvider = GetStreamProvider(GeneratedStreamTestConstants.StreamProviderName);
+            stream = streamProvider.GetStream<GeneratedEvent>(State.StreamGuid, State.StreamNamespace);
+
+            await stream.SubscribeAsync(OnNextAsync, OnErrorAsync, State.RecoveryToken);
+        }
+
+        private async Task OnNextAsync(GeneratedEvent evt, StreamSequenceToken sequenceToken)
+        {
+            // Ignore duplicates
+            if (State.IsDuplicate(sequenceToken))
+            {
+                logger.Info("Received duplicate event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+                return;
+            }
+
+            logger.Info("Received event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+
+            // We will only update the start token if this is the first event we're processed
+            // In that case, we'll want to save the start token in case something goes wrong.
+            if (State.TryUpdateStartToken(sequenceToken))
+            {
+                await WriteStateAsync();
+            }
+
+            // fault on 33rd event until fault is cleared
+            if (State.Accumulator == 32 && !Faults.FaultCleared)
+            {
+                InjectFault();
+            }
+
+            State.Accumulator++;
+            State.LastProcessedToken = sequenceToken;
+            if (evt.EventType != GeneratedEvent.GeneratedEventType.End)
+            {
+                // every 10 events, checkpoint our grain state
+                if (State.Accumulator%10 != 0) return;
+                logger.Info("Checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+                await WriteStateAsync();
+                return;
+            }
+            logger.Info("Final checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+            await WriteStateAsync();
+            var reporter = GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
+            await reporter.ReportResult(this.GetPrimaryKey(), GeneratedStreamTestConstants.StreamProviderName, StreamNamespace, State.Accumulator);
+        }
+
+        private Task OnErrorAsync(Exception ex)
+        {
+            logger.Info("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
+            Faults.FaultCleared = true;
+            return TaskDone.Done;
+        }
+
+        private void InjectFault()
+        {
+            logger.Info("InjectingFault: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, State.RecoveryToken, State.Accumulator);
+            throw new ApplicationException("Injecting Fault");
+        }
+    }
+}

--- a/src/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
+++ b/src/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
@@ -1,0 +1,147 @@
+﻿
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using TestGrainInterfaces;
+using UnitTests.Grains;
+
+namespace TestGrains
+{
+    [ImplicitStreamSubscription(StreamNamespace)]
+    public class ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain : Grain<StreamCheckpoint<int>>, IGeneratedEventCollectorGrain
+    {
+        public const string StreamNamespace = "TransientError_RecoverableStream";
+
+        // Fault injection
+        // Simulate simple transient failures.
+        // Each failure occures once.
+        // We place failures at key points to test recoverabilty.
+        // - On first grain activation.
+        // - after activation, but before storing start token.
+        // - after start token has been stored, but befor it's message has been processed.
+        // - mid stream processing (33rd message in this test, but realy depends on stream)
+        // - last message in stream.
+        private class FireOnNthTry
+        {
+            private readonly int attemptToFireOn;
+            private int tries;
+
+            public FireOnNthTry(int attemptToFireOn)
+            {
+                this.attemptToFireOn = attemptToFireOn;
+            }
+
+            public bool TryFire(Action fireAction)
+            {
+                tries++;
+                if (tries != attemptToFireOn) return false;
+                fireAction();
+                return true;
+            }
+        }
+
+        private class FaultsState
+        {
+            public readonly FireOnNthTry onActivateFault;
+            public readonly FireOnNthTry onFirstMessageFault;
+            public readonly FireOnNthTry onFirstMessageProcessedFault;
+            public readonly FireOnNthTry on33rdMessageFault;
+            public readonly FireOnNthTry onLastMessageFault;
+
+            public FaultsState()
+            {
+                onActivateFault = new FireOnNthTry(1);
+                onFirstMessageFault = new FireOnNthTry(1);
+                onFirstMessageProcessedFault = new FireOnNthTry(1);
+                on33rdMessageFault = new FireOnNthTry(33);
+                onLastMessageFault = new FireOnNthTry(1);
+            }
+        }
+
+        private static readonly ConcurrentDictionary<Guid, FaultsState> FaultInjectionTracker = new ConcurrentDictionary<Guid, FaultsState>();
+
+        private FaultsState myFaults;
+        private FaultsState Faults { get { return myFaults ?? (myFaults = FaultInjectionTracker.GetOrAdd(this.GetPrimaryKey(), key => new FaultsState())); } }
+     
+        // grain instance state
+        private Logger logger;
+        private IAsyncStream<GeneratedEvent> stream;
+
+        public override async Task OnActivateAsync()
+        {
+            logger = base.GetLogger("RecoverableStreamCollectorGrain " + base.IdentityString);
+            logger.Info("OnActivateAsync");
+
+            Faults.onActivateFault.TryFire(InjectFault);
+            await ReadStateAsync();
+
+            Guid streamGuid = this.GetPrimaryKey();
+            if (State.StreamGuid != streamGuid)
+            {
+                State.StreamGuid = streamGuid;
+                State.StreamNamespace = StreamNamespace;
+                await WriteStateAsync();
+            }
+
+            var streamProvider = GetStreamProvider(GeneratedStreamTestConstants.StreamProviderName);
+            stream = streamProvider.GetStream<GeneratedEvent>(State.StreamGuid, State.StreamNamespace);
+
+            await stream.SubscribeAsync(OnNextAsync, OnErrorAsync, State.RecoveryToken);
+        }
+
+        private async Task OnNextAsync(GeneratedEvent evt, StreamSequenceToken sequenceToken)
+        {
+
+            // ignore duplicates
+            if (State.IsDuplicate(sequenceToken))
+            {
+                logger.Info("Received duplicate event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+                return;
+            }
+
+            logger.Info("Received event.  StreamGuid: {0}, SequenceToken: {1}", State.StreamGuid, sequenceToken);
+
+            // We will only update the start token if this is the first event we're processed
+            // In that case, we'll want to save the start token in case something goes wrong.
+            if (State.TryUpdateStartToken(sequenceToken))
+            {
+                Faults.onFirstMessageFault.TryFire(InjectFault);
+                await WriteStateAsync();
+            }
+
+            State.Accumulator++;
+            State.LastProcessedToken = sequenceToken;
+            if (evt.EventType != GeneratedEvent.GeneratedEventType.End)
+            {
+                Faults.onFirstMessageProcessedFault.TryFire(InjectFault);
+                Faults.on33rdMessageFault.TryFire(InjectFault);
+                // every 10 events, checkpoint our grain state
+                if (State.Accumulator%10 != 0) return;
+                logger.Info("Checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+                await WriteStateAsync();
+                return;
+            }
+            Faults.onLastMessageFault.TryFire(InjectFault);
+            logger.Info("Final checkpointing: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, sequenceToken, State.Accumulator);
+            await WriteStateAsync();
+            var reporter = GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
+            await reporter.ReportResult(this.GetPrimaryKey(), GeneratedStreamTestConstants.StreamProviderName, StreamNamespace, State.Accumulator);
+        }
+
+        private Task OnErrorAsync(Exception ex)
+        {
+            logger.Info("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
+            return TaskDone.Done;
+        }
+
+        private void InjectFault()
+        {
+            logger.Info("InjectingFault: StreamGuid: {0}, StreamNamespace: {1}, SequenceToken: {2}, Accumulator: {3}.", State.StreamGuid, State.StreamNamespace, State.RecoveryToken, State.Accumulator);
+            DeactivateOnIdle(); // kill grain and reaload from checkpoint
+            throw new ApplicationException("Injecting Fault");
+        }
+    }
+}

--- a/src/TestGrains/StreamCheckpoint.cs
+++ b/src/TestGrains/StreamCheckpoint.cs
@@ -1,0 +1,45 @@
+﻿
+using System;
+using Orleans.Streams;
+
+namespace TestGrains
+{
+    [Serializable]
+    public class StreamCheckpoint<TState>
+    {
+        public Guid StreamGuid { get; set; }
+        public string StreamNamespace { get; set; }
+        public StreamSequenceToken StartToken { get; set; }
+        public StreamSequenceToken LastProcessedToken { get; set; }
+        public TState Accumulator { get; set; }
+
+        public StreamSequenceToken RecoveryToken { get { return LastProcessedToken ?? StartToken; } }
+
+        public bool IsDuplicate(StreamSequenceToken sequenceToken)
+        {
+            // This is the first event, so it can't be a duplicate
+            if (StartToken == null)
+                return false;
+
+            // if we have processed events, compare with the sequence token of last event we processed.
+            if (LastProcessedToken != null)
+            {
+                // if Last processed is not older than this sequence token, then this token is a duplicate
+                return !LastProcessedToken.Older(sequenceToken);
+            }
+
+            // If all we have is the start token, then we've not processed the first event, so we should process any event at or after the start token.
+            return StartToken.Newer(sequenceToken);
+        }
+
+        public bool TryUpdateStartToken(StreamSequenceToken sequenceToken)
+        {
+            if (StartToken == null)
+            {
+                StartToken = sequenceToken;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -65,6 +65,9 @@
     <Compile Include="EventSourcing\PersonState.cs" />
     <Compile Include="GeneratedEventCollectorGrain.cs" />
     <Compile Include="GeneratedEvent.cs" />
+    <Compile Include="GeneratedStreamTestConstants.cs" />
+    <Compile Include="ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs" />
+    <Compile Include="ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs" />
     <Compile Include="GeneratedEventReporterGrain.cs" />
     <Compile Include="GeneratorTestDerivedDerivedGrain.cs" />
     <Compile Include="GeneratorTestDerivedGrain1.cs" />
@@ -109,6 +112,7 @@
     <Compile Include="GrainInterfaceHierarchyGrains.cs" />
     <Compile Include="LivenessTestGrain.cs" />
     <Compile Include="SpecializedSimpleGenericGrain.cs" />
+    <Compile Include="StreamCheckpoint.cs" />
     <Compile Include="ValueTypeTestGrain.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/src/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -1,3 +1,4 @@
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -12,6 +13,7 @@ using Tester.TestStreamProviders.Generator;
 using Tester.TestStreamProviders.Generator.Generators;
 using TestGrainInterfaces;
 using TestGrains;
+using UnitTests.Grains;
 using UnitTests.Tester;
 
 namespace UnitTests.StreamingTests
@@ -23,7 +25,7 @@ namespace UnitTests.StreamingTests
     {
         private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
-        private const string StreamProviderName = GeneratedEventCollectorGrain.StreamProviderName;
+        private const string StreamProviderName = GeneratedStreamTestConstants.StreamProviderName;
         private static readonly string StreamProviderTypeName = typeof(GeneratorStreamProvider).FullName;
         private const string StreamNamespace = GeneratedEventCollectorGrain.StreamNamespace;
 
@@ -99,16 +101,16 @@ namespace UnitTests.StreamingTests
             }
             finally
             {
-                var reporter = GrainClient.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedEventCollectorGrain.ReporterId);
+                var reporter = GrainClient.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
                 reporter.Reset().Ignore();
             }
         }
 
         private async Task<bool> CheckCounters(SimpleGeneratorConfig generatorConfig, bool assertIsTrue)
         {
-            var reporter = GrainClient.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedEventCollectorGrain.ReporterId);
+            var reporter = GrainClient.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
 
-            var report = await reporter.GetReport(GeneratedEventCollectorGrain.StreamProviderName, GeneratedEventCollectorGrain.StreamNamespace);
+            var report = await reporter.GetReport(GeneratedStreamTestConstants.StreamProviderName, GeneratedEventCollectorGrain.StreamNamespace);
             if (assertIsTrue)
             {
                 // one stream per queue

--- a/src/Tester/StreamingTests/ControllableStreamProviderTests.cs
+++ b/src/Tester/StreamingTests/ControllableStreamProviderTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using Tester.TestStreamProviders.Controllable;

--- a/src/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/src/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -51,7 +51,8 @@ namespace UnitTests.StreamingTests
                         // register stream provider
                         config.Globals.RegisterStreamProvider<GeneratorStreamProvider>(StreamProviderName, settings);
 
-                        // make sure all node configs exist, for dynamic cluster queue balancer
+                        // make sure all node configs exist, for deployment based queue balancer
+                        // GetConfigurationForNode will add a note to the configuration if one does not already exist.
                         config.GetConfigurationForNode("Primary");
                         config.GetConfigurationForNode("Secondary_1");
                     }

--- a/src/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/src/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -51,8 +51,9 @@ namespace UnitTests.StreamingTests
                         // register stream provider
                         config.Globals.RegisterStreamProvider<GeneratorStreamProvider>(StreamProviderName, settings);
 
-                        // make sure all node configs exist, for deployment based queue balancer
-                        // GetConfigurationForNode will add a note to the configuration if one does not already exist.
+                        // Make sure a node config exist for each silo in the cluster.
+                        // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
+                        // GetConfigurationForNode will materialize a node in the configuration for each silo, if one does not already exist.
                         config.GetConfigurationForNode("Primary");
                         config.GetConfigurationForNode("Secondary_1");
                     }

--- a/src/Tester/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
+++ b/src/Tester/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
@@ -1,0 +1,110 @@
+﻿
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using Tester.TestStreamProviders.Generator;
+using Tester.TestStreamProviders.Generator.Generators;
+using TestGrainInterfaces;
+using UnitTests.Grains;
+
+namespace Tester.StreamingTests
+{
+    public class ImplicitSubscritionRecoverableStreamTestRunner
+    {
+        private readonly IGrainFactory grainFactory;
+        private readonly string streamProviderTypeName;
+        private readonly string streamProviderName;
+        private readonly GeneratorAdapterConfig adapterConfig;
+
+        public ImplicitSubscritionRecoverableStreamTestRunner(IGrainFactory grainFactory, string streamProviderTypeName, string streamProviderName, GeneratorAdapterConfig adapterConfig)
+        {
+            this.grainFactory = grainFactory;
+            this.streamProviderTypeName = streamProviderTypeName;
+            this.streamProviderName = streamProviderName;
+            this.adapterConfig = adapterConfig;
+        }
+
+        public async Task Recoverable100EventStreamsWithTransientErrors(string streamNamespace)
+        {
+            try
+            {
+                var generatorConfig = new SimpleGeneratorConfig
+                {
+                    StreamNamespace = streamNamespace,
+                    EventsInStream = 100
+                };
+
+                var mgmt = grainFactory.GetGrain<IManagementGrain>(0);
+                object[] results = await mgmt.SendControlCommandToProvider(streamProviderTypeName, streamProviderName, (int)StreamGeneratorCommand.Configure, generatorConfig);
+                Assert.AreEqual(2, results.Length, "expected responses");
+                bool[] bResults = results.Cast<bool>().ToArray();
+                foreach (var result in bResults)
+                {
+                    Assert.AreEqual(true, result, "Control command result");
+                }
+
+                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(generatorConfig, generatorConfig.EventsInStream, assertIsTrue), TimeSpan.FromSeconds(30));
+            }
+            finally
+            {
+                var reporter = GrainClient.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
+                reporter.Reset().Ignore();
+            }
+        }
+
+        public async Task Recoverable100EventStreamsWith1NonTransientError(string streamNamespace)
+        {
+            try
+            {
+                var generatorConfig = new SimpleGeneratorConfig
+                {
+                    StreamNamespace = streamNamespace,
+                    EventsInStream = 100
+                };
+
+                var mgmt = grainFactory.GetGrain<IManagementGrain>(0);
+                object[] results = await mgmt.SendControlCommandToProvider(streamProviderTypeName, streamProviderName, (int)StreamGeneratorCommand.Configure, generatorConfig);
+                Assert.AreEqual(2, results.Length, "expected responses");
+                bool[] bResults = results.Cast<bool>().ToArray();
+                foreach (var result in bResults)
+                {
+                    Assert.AreEqual(true, result, "Control command result");
+                }
+
+                // should eventually skip the faulted event, so event count should be one (faulted event) less that number of events in stream.
+                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(generatorConfig, generatorConfig.EventsInStream - 1, assertIsTrue), TimeSpan.FromSeconds(90));
+            }
+            finally
+            {
+                var reporter = GrainClient.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
+                reporter.Reset().Ignore();
+            }
+        }
+
+        private async Task<bool> CheckCounters(SimpleGeneratorConfig generatorConfig, int eventsInStream, bool assertIsTrue)
+        {
+            var reporter = grainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
+
+            var report = await reporter.GetReport(streamProviderName, generatorConfig.StreamNamespace);
+            if (assertIsTrue)
+            {
+                // one stream per queue
+                Assert.AreEqual(adapterConfig.TotalQueueCount, report.Count, "Stream count");
+                foreach (int eventsPerStream in report.Values)
+                {
+                    Assert.AreEqual(eventsInStream, eventsPerStream, "Events per stream");
+                }
+            }
+            else if (adapterConfig.TotalQueueCount != report.Count ||
+                     report.Values.Any(count => count != eventsInStream))
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -174,8 +174,10 @@
     <Compile Include="StreamingTests\DeactivationTestRunner.cs" />
     <Compile Include="MembershipTests\SilosStopTests.cs" />
     <Compile Include="StreamingTests\EHSubscriptionMultiplicityTests.cs" />
+    <Compile Include="StreamingTests\GeneratedStreamRecoveryTests.cs" />
     <Compile Include="StreamingTests\PullingAgentManagementTests.cs" />
     <Compile Include="StreamingTests\DelayedQueueRebalancingTests.cs" />
+    <Compile Include="StreamingTests\ImplicitSubscritionRecoverableStreamTestRunner.cs" />
     <Compile Include="StreamingTests\StreamFilteringTests.cs" />
     <Compile Include="StreamingTests\ControllableStreamGeneratorProviderTests.cs" />
     <Compile Include="StreamingTests\SampleStreamingTests.cs" />


### PR DESCRIPTION
Added testing for some basic stream recovery tests.
Tests use test generated streams
Tests are limited to implicit subscriptions
Tests transient stream processing errors, exercising delivery retry and stream rewind logic.
Tests non-transient stream processing errors, exercising exhaustion of delivery retries and error notification.