### PR TITLE
two new top level sections: Configuration and Programmer's Guide

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -13,31 +13,49 @@
 <ul class="list-unstyled">
 	<li><a href="/orleans/Introduction">Introduction to Orleans</a></li>
 	<li><a href="/orleans/Getting-Started-With-Orleans/Core-Concepts">Core Concepts</a></li>
-	<li><a href="/orleans/Getting-Started-With-Orleans/Asynchrony-and-Tasks">Asynchrony and Tasks</a></li>
 	<li><a href="/orleans/Getting-Started-With-Orleans/Grains">Grains</a></li>
 	<li><a href="/orleans/Getting-Started-With-Orleans/Silos">Silos</a></li>
 	<li><a href="/orleans/Getting-Started-With-Orleans/Clients">Clients</a></li>
-	<li><a href="/orleans/Getting-Started-With-Orleans/Observers">Client Observers</a></li>
+	<li><a href="/orleans/Frequently-Asked-Questions">Frequently Asked Questions</a></li>
+</ul>
+<h2 id="programmers-guide">Programmer's Guide</h2>
+<ul class="list-unstyled">
+	<li><a href="/orleans/Getting-Started-With-Orleans/Asynchrony-and-Tasks">Asynchrony and Tasks</a></li>
 	<li><a href="/orleans/Getting-Started-With-Orleans/Developing-a-Grain">Developing a Grain</a></li>
 	<li><a href="/orleans/Getting-Started-With-Orleans/Developing-a-Client">Developing a Client</a></li>
+	<li><a href="/orleans/Getting-Started-With-Orleans/Observers">Client Observers</a></li>
 	<li><a href="/orleans/Getting-Started-With-Orleans/Running-the-Application">Running the Application</a></li>
+	<li><a href="/orleans/Advanced-Concepts/Application-Bootstrap-within-a-Silo">Application Bootstrap within a Silo</a></li>
+	<li><a href="/orleans/Advanced-Concepts/Timers-and-Reminders">Timers and Reminders</a></li>
+	<li><a href="/orleans/Orleans-Streams">Orleans Streams</a></li>
+
 </ul>
 
 <h2 id="introduction-and-tutorials">Tutorials</h2>
 <ul class="list-unstyled">
 	<li><a href="/orleans/Step-by-step-Tutorials">Step-by-step Tutorials</a></li>
-	<li><a href="/orleans/Deployment-and-Versioning-of-Dependencies">Deployment and Versioning of Dependencies</a></li>
-	<li><a href="/orleans/Orleans-Streams">Orleans Streams</a></li>
-	<li><a href="/orleans/Frequently-Asked-Questions">Frequently Asked Questions</a></li>
 	<li><a href="/orleans/Samples-Overview">Samples Overview</a></li>
+</ul>
+
+<h2 id="configuration">Configuration</h2>
+<ul class="list-unstyled">
+	<li><a href="/orleans/Orleans-Configuration-Guide">Configuration Guide </a></li>
+	<li><a href="/orleans/Deployment-and-Versioning-of-Dependencies">Deployment and Versioning of Dependencies</a></li>
+	<li><a href="/orleans/Advanced-Concepts/Configuring-SQL-Tables">Configuring SQL Tables</a></li>
+	<li><a href="/orleans/Advanced-Concepts/Configuring-.NET-Garbage-Collection">Configuring .NET Garbage Collection</a></li>
+	<li><a href="/orleans/Advanced-Concepts/Activation-Garbage-Collection">Activation Garbage Collection</a></li>
 </ul>
 
 <h2 id="advanced-documentation">Advanced Documentation</h2>
 
 <ul class="list-unstyled">
 	<li><a href="/orleans/Advanced-Concepts">Advanced Concepts</a></li>
-	<li><a href="/orleans/Orleans-Configuration-Guide">Orleans Configuration Guide</a></li>
-	<li><a href="/orleans/Runtime-Implementation-Details">Runtime Implementation Details</a></li>
+	<li><a href="/orleans/Advanced-Concepts/External-Tasks-and-Grains">External Tasks and Grains</a></li>
+	<li><a href="/orleans/Runtime-Implementation-Details/Cluster-Management">Cluster Management</a></li>
+	<li><a href="/orleans/Runtime-Implementation-Details/Messaging-Delivery-Guarantees">Messaging Delivery Guarantees</a></li>
+	<li><a href="/orleans/Runtime-Implementation-Details/Runtime-Tables">Runtime Tables</a></li>
+	<li><a href="/orleans/Runtime-Implementation-Details/Relational-Storage">Relational Storage</a></li>
+	<li><a href="/orleans/Runtime-Implementation-Details/Load-Balancing">Load Balancing</a></li>
 </ul>
 
 <h2 id="community-and-contributions">Community and Contributions</h2>


### PR DESCRIPTION
Part of #1264.
I think that current documentation menu can be improved by this PR. I haven't removed any page (other than the link to Runtime Implementation Details - which only contains links which I've moved one level up).
