### PR TITLE
Event hub stream provider recovery

### DIFF
--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Providers\Streams\EventHub\EventHubAdapterFactory.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubAdapterReceiver.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubBatchContainer.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubDataAdapter.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubQueueMapper.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSequenceToken.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSettings.cs" />

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -39,15 +39,7 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
             public Dictionary<string, object> RequestContext { get; set; }
         }
 
-        public EventHubBatchContainer(Guid streamGuid, string streamNamespace, byte[] data)
-        {
-            StreamGuid = streamGuid;
-            StreamNamespace = streamNamespace;
-            payloadBytes = data;
-        }
-
         public EventHubBatchContainer(Guid streamGuid, string streamNamespace, string offset, long sequenceNumber, byte[] data)
-            : this(streamGuid, streamNamespace, data)
         {
             StreamGuid = streamGuid;
             StreamNamespace = streamNamespace;
@@ -89,14 +81,6 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
                 eventData.SetStreamNamespaceProperty(streamNamespace);
             }
             return eventData;
-        }
-
-        internal static IBatchContainer FromEventData(EventData eventData)
-        {
-            Guid streamGuid = Guid.Parse(eventData.PartitionKey);
-            string streamNamespace = eventData.GetStreamNamespaceProperty();
-            byte[] bytes = eventData.GetBytes();
-            return new EventHubBatchContainer(streamGuid, streamNamespace, eventData.Offset, eventData.SequenceNumber, bytes);
         }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -1,0 +1,255 @@
+﻿
+using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.ServiceBus.Messaging;
+using Orleans.Providers.Streams.Common;
+using Orleans.ServiceBus.Providers.Streams.EventHub;
+using Orleans.Streams;
+
+namespace OrleansServiceBusUtils.Providers.Streams.EventHub
+{
+    /// <summary>
+    /// This is a tightly packed cached structure containing an event hub message.  
+    /// It should only contain value types.
+    /// </summary>
+    public struct CachedEventHubMessage
+    {
+        public Guid StreamGuid;
+        public long SequenceNumber;
+        public ArraySegment<byte> Segment;
+    }
+
+    class EventHubDataAdapter : ICacheDataAdapter<EventData, CachedEventHubMessage>
+    {
+        private readonly IObjectPool<FixedSizeBuffer> bufferPool;
+        private readonly Action<IDisposable> purgeAction;
+        private FixedSizeBuffer currentBuffer;
+
+        public EventHubDataAdapter(IObjectPool<FixedSizeBuffer> bufferPool, Action<IDisposable> purgeAction)
+        {
+            if (bufferPool == null)
+            {
+                throw new ArgumentNullException("bufferPool");
+            }
+            if (purgeAction == null)
+            {
+                throw new ArgumentNullException("purgeAction");
+            }
+            this.bufferPool = bufferPool;
+            this.purgeAction = purgeAction;
+        }
+
+        public void QueueMessageToCachedMessage(ref CachedEventHubMessage cachedMessage, EventData queueMessage)
+        {
+            cachedMessage.StreamGuid = Guid.Parse(queueMessage.PartitionKey);
+            cachedMessage.SequenceNumber = queueMessage.SequenceNumber;
+            cachedMessage.Segment = SerializeMessageIntoPooledSegment(queueMessage);
+        }
+
+        // Placed object message payload into a segment from a buffer pool.  When this get's too big, older blocks will be purged
+        private ArraySegment<byte> SerializeMessageIntoPooledSegment(EventData queueMessage)
+        {
+            byte[] payloadBytes = queueMessage.GetBytes();
+            string streamNamespace = queueMessage.GetStreamNamespaceProperty();
+            int size = CalculateAppendSize(streamNamespace) + CalculateAppendSize(queueMessage.Offset) + CalculateAppendSize(payloadBytes);
+
+            // get segment from current block
+            ArraySegment<byte> segment;
+            if (currentBuffer == null || !currentBuffer.TryGetSegment(size, out segment))
+            {
+                // no block or block full, get new block and try again
+                currentBuffer = bufferPool.Allocate();
+                currentBuffer.SetPurgeAction(purgeAction);
+                // if this fails with clean block, then requested size is too big
+                if (!currentBuffer.TryGetSegment(size, out segment))
+                {
+                    string errmsg = String.Format(CultureInfo.InvariantCulture,
+                        "Message size is to big. MessageSize: {0}", size);
+                    throw new ArgumentOutOfRangeException("queueMessage", errmsg);
+                }
+            }
+            // encode namespace, offset, and payload into segment
+            int writeOffset = 0;
+            Append(segment, ref writeOffset, streamNamespace);
+            Append(segment, ref writeOffset, queueMessage.Offset);
+            Append(segment, ref writeOffset, payloadBytes);
+
+            return segment;
+        }
+
+        public IBatchContainer GetBatchContainer(ref CachedEventHubMessage cachedMessage)
+        {
+            int readOffset = 0;
+            string streamNamespace = ReadNextString(cachedMessage.Segment, ref readOffset);
+            string offset = ReadNextString(cachedMessage.Segment, ref readOffset);
+            ArraySegment<byte> payload = ReadNextBytes(cachedMessage.Segment, ref readOffset);
+
+            return new EventHubBatchContainer(cachedMessage.StreamGuid, streamNamespace, offset, cachedMessage.SequenceNumber, payload.ToArray());
+        }
+
+        public StreamSequenceToken GetSequenceToken(ref CachedEventHubMessage cachedMessage)
+        {
+            return new EventSequenceToken(cachedMessage.SequenceNumber, 0);
+        }
+
+        public int CompareCachedMessageToSequenceToken(ref CachedEventHubMessage cachedMessage, StreamSequenceToken token)
+        {
+            var realToken = (EventSequenceToken) token;
+            return cachedMessage.SequenceNumber != realToken.SequenceNumber
+                ? (int) (cachedMessage.SequenceNumber - realToken.SequenceNumber)
+                : 0 - realToken.EventIndex;
+        }
+
+        public bool IsInStream(ref CachedEventHubMessage cachedMessage, Guid streamGuid, string streamNamespace)
+        {
+            // fail out early if guids does not match.  Don't incur cost of decoding namespace unless necessary.
+            if (cachedMessage.StreamGuid != streamGuid)
+            {
+                return false;
+            }
+            int readOffset = 0;
+            string decodedStreamNamespace = ReadNextString(cachedMessage.Segment, ref readOffset);
+            return decodedStreamNamespace == streamNamespace;
+        }
+
+        public bool ShouldPurge(CachedEventHubMessage cachedMessage, IDisposable purgeRequest)
+        {
+            var purgedResource = (FixedSizeBuffer) purgeRequest;
+            // if we're purging our current buffer, don't use it any more
+            if (currentBuffer != null && currentBuffer.Id == purgedResource.Id)
+            {
+                currentBuffer = null;
+            }
+            return cachedMessage.Segment.Array == purgedResource.Id;
+        }
+
+        /// <summary>
+        /// Calculates how much space will be needed to append the provided bytes into the segment.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        private static int CalculateAppendSize(byte[] bytes)
+        {
+            return (bytes == null || bytes.Length == 0)
+                ? sizeof(int)
+                : bytes.Length + sizeof(int);
+        }
+
+        /// <summary>
+        /// Calculates how much space will be needed to append the provided string into the segment.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        private static int CalculateAppendSize(string str)
+        {
+            return (string.IsNullOrEmpty(str))
+                ? sizeof(int)
+                : str.Length * sizeof(char) + sizeof(int);
+        }
+
+        /// <summary>
+        /// Appends an array of bytes to the end of the segment
+        /// </summary>
+        /// <param name="writerOffset"></param>
+        /// <param name="bytes"></param>
+        /// <param name="segment"></param>
+        private static void Append(ArraySegment<byte> segment, ref int writerOffset, byte[] bytes)
+        {
+            if (segment.Array == null)
+            {
+                throw new ArgumentNullException("segment");
+            }
+            if (bytes == null)
+            {
+                throw new ArgumentNullException("bytes");
+            }
+
+            if (bytes.Length == 0)
+            {
+                Buffer.BlockCopy(BitConverter.GetBytes(0), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+                writerOffset += sizeof(int);
+            }
+            else
+            {
+                Buffer.BlockCopy(BitConverter.GetBytes(bytes.Length), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+                writerOffset += sizeof(int);
+                Buffer.BlockCopy(bytes, 0, segment.Array, segment.Offset + writerOffset, bytes.Length);
+                writerOffset += bytes.Length;
+            }
+        }
+
+        /// <summary>
+        /// Appends a string to the end of the segment
+        /// </summary>
+        /// <param name="writerOffset"></param>
+        /// <param name="str"></param>
+        /// <param name="segment"></param>
+        private static void Append(ArraySegment<byte> segment, ref int writerOffset, string str)
+        {
+            if (segment.Array == null)
+            {
+                throw new ArgumentNullException("segment");
+            }
+            if (str == null)
+            {
+                Buffer.BlockCopy(BitConverter.GetBytes(-1), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+                writerOffset += sizeof(int);
+            }
+            else if (string.IsNullOrEmpty(str))
+            {
+                Buffer.BlockCopy(BitConverter.GetBytes(0), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+                writerOffset += sizeof(int);
+            }
+            else
+            {
+                var bytes = new byte[str.Length * sizeof(char)];
+                Buffer.BlockCopy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
+                Append(segment, ref writerOffset, bytes);
+            }
+        }
+
+        /// <summary>
+        /// Reads the next item in the segment as a byte array.  For performance, this is returned as a sub-segment of the original segment.
+        /// </summary>
+        /// <returns></returns>
+        private static ArraySegment<byte> ReadNextBytes(ArraySegment<byte> segment, ref int readerOffset)
+        {
+            if (segment.Array == null)
+            {
+                throw new ArgumentNullException("segment");
+            }
+            int size = BitConverter.ToInt32(segment.Array, segment.Offset + readerOffset);
+            readerOffset += sizeof(int);
+            var seg = new ArraySegment<byte>(segment.Array, segment.Offset + readerOffset, size);
+            readerOffset += size;
+            return seg;
+        }
+
+        /// <summary>
+        /// Reads the next item in the segment as a string.
+        /// </summary>
+        /// <returns></returns>
+        private static string ReadNextString(ArraySegment<byte> segment, ref int readerOffset)
+        {
+            if (segment.Array == null)
+            {
+                throw new ArgumentNullException("segment");
+            }
+            int size = BitConverter.ToInt32(segment.Array, segment.Offset + readerOffset);
+            readerOffset += sizeof(int);
+            if (size < 0)
+            {
+                return null;
+            }
+            if (size == 0)
+            {
+                return string.Empty;
+            }
+            var chars = new char[size / sizeof(char)];
+            Buffer.BlockCopy(segment.Array, segment.Offset + readerOffset, chars, 0, size);
+            readerOffset += size;
+            return new string(chars);
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -22,12 +22,12 @@ namespace Orleans.ServiceBus.Providers.Streams.EventHub
         public EventHubSequenceToken(string eventHubOffset, long sequenceNumber, int eventIndex)
             : base(sequenceNumber, eventIndex)
         {
-            this.EventHubOffset = eventHubOffset;
+            EventHubOffset = eventHubOffset;
         }
 
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, "EventHubSequenceToken(EventHubOffset: {0}, SequenceNumber: {1}, EventIndex: {2})", this.EventHubOffset, this.SequenceNumber, this.EventIndex);
+            return string.Format(CultureInfo.InvariantCulture, "EventHubSequenceToken(EventHubOffset: {0}, SequenceNumber: {1}, EventIndex: {2})", EventHubOffset, SequenceNumber, EventIndex);
         }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Orleans.Providers;
 
 namespace Orleans.ServiceBus.Providers
@@ -12,17 +13,21 @@ namespace Orleans.ServiceBus.Providers
 
         public string StreamProviderName { get; private set; }
 
-        public int CacheSize { get { return 1024; } }
+        public const string CacheSizeMbName = "CacheSizeMb";
+        private const int DefaultCacheSizeMb = 100; // default to 100mb cache.
+        public int CacheSizeMb { get; private set; }
 
         public EventHubStreamProviderConfig(string streamProviderName)
         {
             StreamProviderName = streamProviderName;
+            CacheSizeMb = DefaultCacheSizeMb;
         }
 
         public void WriteProperties(Dictionary<string, string> properties)
         {
             if (EventHubSettingsType!=null)
                 properties.Add(EventHubConfigTypeName, EventHubSettingsType.AssemblyQualifiedName);
+            properties.Add(CacheSizeMbName, CacheSizeMb.ToString(CultureInfo.InvariantCulture));
         }
 
         public virtual void PopulateFromProviderConfig(IProviderConfiguration providerConfiguration)
@@ -32,6 +37,7 @@ namespace Orleans.ServiceBus.Providers
             {
                 throw new ArgumentOutOfRangeException("providerConfiguration", "StreamProviderName not set.");
             }
+            CacheSizeMb = providerConfiguration.GetIntProperty(CacheSizeMbName, DefaultCacheSizeMb);
         }
     }
 }

--- a/src/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/src/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -1,0 +1,125 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.ServiceBus.Providers;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using OrleansServiceBusUtils.Providers.Streams.EventHub;
+using Tester.StreamingTests;
+using TestGrains;
+using UnitTests.Grains;
+using UnitTests.Tester;
+
+namespace UnitTests.StreamingTests
+{
+    [DeploymentItem("OrleansConfigurationForTesting.xml")]
+    [DeploymentItem("OrleansProviders.dll")]
+    [TestClass]
+    public class EHImplicitSubscriptionStreamRecoveryTests : HostedTestClusterPerFixture
+    {
+        private const string StreamProviderName = GeneratedStreamTestConstants.StreamProviderName;
+        private const string EHPath = "ehorleanstest";
+        private const string EHConsumerGroup = "orleansnightly";
+
+        private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
+            EHConsumerGroup, EHPath);
+
+        private static readonly EventHubStreamProviderConfig ProviderConfig =
+            new EventHubStreamProviderConfig(StreamProviderName);
+
+        private ImplicitSubscritionRecoverableStreamTestRunner runner;
+
+        public static TestingSiloHost CreateSiloHost()
+        {
+            return new TestingSiloHost(
+                new TestingSiloOptions
+                {
+                    StartFreshOrleans = true,
+                    SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
+                    AdjustConfig = config =>
+                    {
+                        // register stream provider
+                        config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
+
+                        // Make sure a node config exist for each silo in the cluster.
+                        // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
+                        config.GetOrAddConfigurationForNode("Primary");
+                        config.GetOrAddConfigurationForNode("Secondary_1");
+                    }
+                }, new TestingClientOptions()
+                {
+                    AdjustConfig = config =>
+                    {
+                        config.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
+                        config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 40001));
+                    },
+                });
+        }
+
+        private static Dictionary<string, string> BuildProviderSettings()
+        {
+            var settings = new Dictionary<string, string>();
+
+            // get initial settings from configs
+            ProviderConfig.WriteProperties(settings);
+            EventHubConfig.WriteProperties(settings);
+
+            // add queue balancer setting
+            settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());
+
+            // add pub/sub settting
+            settings.Add(PersistentStreamProviderConfig.STREAM_PUBSUB_TYPE, StreamPubSubType.ImplicitOnly.ToString());
+            return settings;
+        }
+
+        [TestInitialize] 
+        public void InitializeOrleans()
+        {
+            runner = new ImplicitSubscritionRecoverableStreamTestRunner(GrainClient.GrainFactory, StreamProviderName);
+        }
+
+
+        [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task Recoverable100EventStreamsWithTransientErrorsTest()
+        {
+            logger.Info("************************ EHRecoverable100EventStreamsWithTransientErrorsTest *********************************");
+            await runner.Recoverable100EventStreamsWithTransientErrors(GenerateEvents, ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.StreamNamespace, 4, 100);
+        }
+
+        [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task Recoverable100EventStreamsWith1NonTransientErrorTest()
+        {
+            logger.Info("************************ EHRecoverable100EventStreamsWith1NonTransientErrorTest *********************************");
+            await runner.Recoverable100EventStreamsWith1NonTransientError(GenerateEvents, ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.StreamNamespace, 4, 100);
+        }
+
+        private async Task GenerateEvents(string streamNamespace, int streamCount, int eventsInStream)
+        {
+            IStreamProvider streamProvider = GrainClient.GetStreamProvider(StreamProviderName);
+            IAsyncStream<GeneratedEvent>[] producers =
+                Enumerable.Range(0, streamCount)
+                    .Select(i => streamProvider.GetStream<GeneratedEvent>(Guid.NewGuid(), streamNamespace))
+                    .ToArray();
+
+            for (int i = 0; i < eventsInStream - 1; i++)
+            {
+                // send event on each stream
+                for (int j = 0; j < streamCount; j++)
+                {
+                    await producers[j].OnNextAsync(new GeneratedEvent {EventType = GeneratedEvent.GeneratedEventType.Fill});
+                }
+            }
+            // send end events
+            for (int j = 0; j < streamCount; j++)
+            {
+                await producers[j].OnNextAsync(new GeneratedEvent { EventType = GeneratedEvent.GeneratedEventType.End });
+            }
+        }
+    }
+}

--- a/src/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
@@ -22,10 +22,10 @@ namespace UnitTests.StreamingTests
     {
         private const string StreamProviderName = "EventHubStreamProvider";
         private const string StreamNamespace = "EHSubscriptionMultiplicityTestsNamespace";
-        private const string EHPath = "orleans_test";
-        private const string EHConsumerGroup = "orleanstestconsumer";
+        private const string EHPath = "ehorleanstest";
+        private const string EHConsumerGroup = "orleansnightly";
 
-        private readonly SubscriptionMultiplicityTestRunner runner;
+        private  SubscriptionMultiplicityTestRunner runner;
 
         private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
             EHConsumerGroup, EHPath);
@@ -33,7 +33,8 @@ namespace UnitTests.StreamingTests
         private static readonly EventHubStreamProviderConfig ProviderConfig =
             new EventHubStreamProviderConfig(StreamProviderName);
 
-        public EHSubscriptionMultiplicityTests()
+        [TestInitialize]
+        public void InitializeOrleans()
         {
             runner = new SubscriptionMultiplicityTestRunner(StreamProviderName, GrainClient.Logger);
         }

--- a/src/Tester/Tester.csproj
+++ b/src/Tester/Tester.csproj
@@ -126,6 +126,7 @@
   <ItemGroup>
     <Compile Include="OrleansTestingBase.cs" />
     <Compile Include="SerializationTests\DeepCopyTests.cs" />
+    <Compile Include="StreamingTests\EHImplicitSubscriptionStreamRecoveryTests.cs" />
     <Compile Include="TestAssemblyCleanup.cs" />
     <Compile Include="BasicActivationTests.cs" />
     <Compile Include="CodeGenTests\GeneratorGrainTest.cs" />


### PR DESCRIPTION
Added rewind/recoverability to EventHubStreamProvider

This work is related to "Recoverable Event Hub Persistent Stream Provider #1096"
It is the first part of stage 4.

Update EventHubStreamProvider to be recoverable.
- Update EventHubQueueAdapter to use PooledQueueCache.
- Add recoverable stream tests comparable to those built against GeneratorStreamProvider.

Does not include:
- EventHubQueueAdapter to persist state that tracks offset into EventHub partition.
