### PR TITLE
Fixed a bug of not properly handling DeactivateOnIdle inside OnActivateAsync.

### DIFF
--- a/src/TestGrainInterfaces/IActivateDeactivateTestGrain.cs
+++ b/src/TestGrainInterfaces/IActivateDeactivateTestGrain.cs
@@ -46,4 +46,10 @@ namespace UnitTests.GrainInterfaces
 
         Task ForwardCall(IBadActivateDeactivateTestGrain otherGrain);
     }
+
+    public interface IDeactivatingWhileActivatingTestGrain : IGrainWithIntegerKey
+    {
+        Task<string> DoSomething();
+    }
+    
 }

--- a/src/TestInternalGrains/ActivateDeactivateTestGrain.cs
+++ b/src/TestInternalGrains/ActivateDeactivateTestGrain.cs
@@ -360,6 +360,31 @@ namespace UnitTests.Grains
         }
     }
 
+    internal class DeactivatingWhileActivatingTestGrain : Grain, IDeactivatingWhileActivatingTestGrain
+    {
+        private Logger logger;
+
+        public override Task OnActivateAsync()
+        {
+            logger = GetLogger();
+            logger.Info("OnActivateAsync");
+            this.DeactivateOnIdle();
+            return TaskDone.Done;
+        }
+
+        public override Task OnDeactivateAsync()
+        {
+            logger.Info("OnDeactivateAsync");
+            return TaskDone.Done;
+        }
+
+        public Task<string> DoSomething()
+        {
+            logger.Info("DoSomething");
+            throw new NotImplementedException("DoSomething should not have been called");
+        }
+    }
+
     internal class CreateGrainReferenceTestGrain : Grain, ICreateGrainReferenceTestGrain
     {
         private Logger logger;

--- a/src/Tester/GrainActivateDeactivateTests.cs
+++ b/src/Tester/GrainActivateDeactivateTests.cs
@@ -288,6 +288,26 @@ namespace UnitTests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(1, 1, activation.ToString());
         }
 
+        [TestMethod, TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        public async Task DeactivateOnIdleWhileActivate()
+        {
+            int id = random.Next();
+            IDeactivatingWhileActivatingTestGrain grain = GrainClient.GrainFactory.GetGrain<IDeactivatingWhileActivatingTestGrain>(id);
+
+            try
+            {
+                string activation = await grain.DoSomething();
+                Assert.Fail("Should have thrown.");
+            }
+            catch(Exception exc)
+            {
+                logger.Info("Thrown as expected:", exc);
+                Exception e = exc.GetBaseException();
+                Assert.IsTrue(e.Message.Contains("Forwarding failed"),
+                        "Did not get expected exception message returned: " + e.Message);
+            }  
+        }
+
         private async Task CheckNumActivateDeactivateCalls(
             int expectedActivateCalls,
             int expectedDeactivateCalls,


### PR DESCRIPTION
Discovered by @richorama while working of ["Raft on Orleans"](https://github.com/richorama/OrleansRaft/issues/1).

We used to just ignore the `DeactivateOnIdle` call made inside `OnActivateAsync` (there was just never a scenario for a grain to refuse to activate cleanly).
This fixes the bug.

Notice that refusing to activate via `DeactivateOnIdle` differs from throwing exception from within  `OnActivateAsync` in that in the former case `OnDeactivateAsync` will be called (since `OnActivateAsync` succeeded, thus we have to call `OnDeactivateAsync` before deactivating this activation). In the exception case  `OnDeactivateAsync` will not be called.
