### PR TITLE
Update Concurrency.md to fix #1320

### DIFF
--- a/Step-by-step-Tutorials/Concurrency.md
+++ b/Step-by-step-Tutorials/Concurrency.md
@@ -119,15 +119,7 @@ Orleans offers us a way to deal with this, by marking the grain `[Reentrant]`, w
 [Reentrant]
 public class Employee : Orleans.Grain, Interfaces.IEmployee
 {
-    public async Task Greeting(GreetingData data)
-    {
-        Console.WriteLine("{0} said: {1}", 
-                      data.From.GetPrimaryKey().ToString(), 
-                      data.Message);
-        await data.From.Greeting(
-            new GreetingData { 
-                From = this.AsReference<IEmployee>(), 
-                Message = "Hi yourself!" });
+    ...
 }  
 ```
 


### PR DESCRIPTION
Goal of this code snippet is to show where Reentrant attribute should go
on the class, so it is not needed to include Greeting method, which was
listed higher on the page.

Also repeated Greeting method could not be compiled as it was listed.