### PR TITLE
Fixed a bug of not properly handling DeactivateOnIdle inside OnActivateAsync by throwing Exception.

### DIFF
--- a/src/Orleans/Core/Exceptions.cs
+++ b/src/Orleans/Core/Exceptions.cs
@@ -175,23 +175,5 @@ namespace Orleans.Runtime
             : base(info, context)
         { }
     }
-
-    /// <summary>
-    /// Exception to indicate that the activation refused to activate by calling DeactivateOnIdle from within OnActivateAsync.
-    /// </summary>
-    [Serializable]
-    internal class GrainRefusedToActivateException : OrleansException
-    {
-        public GrainRefusedToActivateException() : base("Grain Refused To Activate") { }
-
-        public GrainRefusedToActivateException(string message) : base(message) { }
-
-        public GrainRefusedToActivateException(string message, Exception innerException) : base(message, innerException) { }
-
-        protected GrainRefusedToActivateException(SerializationInfo info, StreamingContext context)
-                : base(info, context)
-        {
-        }
-    }
 }
 

--- a/src/Orleans/Core/Exceptions.cs
+++ b/src/Orleans/Core/Exceptions.cs
@@ -175,5 +175,23 @@ namespace Orleans.Runtime
             : base(info, context)
         { }
     }
+
+    /// <summary>
+    /// Exception to indicate that the activation refused to activate by calling DeactivateOnIdle from within OnActivateAsync.
+    /// </summary>
+    [Serializable]
+    internal class GrainRefusedToActivateException : OrleansException
+    {
+        public GrainRefusedToActivateException() : base("Grain Refused To Activate") { }
+
+        public GrainRefusedToActivateException(string message) : base(message) { }
+
+        public GrainRefusedToActivateException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected GrainRefusedToActivateException(SerializationInfo info, StreamingContext context)
+                : base(info, context)
+        {
+        }
+    }
 }
 

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -111,7 +111,7 @@ namespace Orleans.Runtime
             }
         }
 
-        
+
         public GrainTypeManager GrainTypeManager { get; private set; }
         public SiloAddress LocalSilo { get; private set; }
         internal ISiloStatusOracle SiloStatusOracle { get; set; }
@@ -792,6 +792,12 @@ namespace Orleans.Runtime
                     {
                         data.AddOnInactive(() => DestroyActivationVoid(data));
                     }
+                }
+                else if (data.State == ActivationState.Activating)
+                {
+                    throw new GrainRefusedToActivateException(String.Format(
+                        "Activation {0} refused to activate by calling DeactivateOnIdle from within OnActivateAsync",
+                            data.ToString()));
                 }
                 else
                 {

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -793,10 +793,16 @@ namespace Orleans.Runtime
                         data.AddOnInactive(() => DestroyActivationVoid(data));
                     }
                 }
+                else if (data.State == ActivationState.Create)
+                {
+                    throw new InvalidOperationException(String.Format(
+                        "Activation {0} has called DeactivateOnIdle from within a constructor, which is not allowed.",
+                            data.ToString()));
+                }
                 else if (data.State == ActivationState.Activating)
                 {
-                    throw new GrainRefusedToActivateException(String.Format(
-                        "Activation {0} refused to activate by calling DeactivateOnIdle from within OnActivateAsync",
+                    throw new InvalidOperationException(String.Format(
+                        "Activation {0} has called DeactivateOnIdle from within OnActivateAsync, which is not allowed.",
                             data.ToString()));
                 }
                 else

--- a/src/TestGrainInterfaces/IActivateDeactivateTestGrain.cs
+++ b/src/TestGrainInterfaces/IActivateDeactivateTestGrain.cs
@@ -46,4 +46,10 @@ namespace UnitTests.GrainInterfaces
 
         Task ForwardCall(IBadActivateDeactivateTestGrain otherGrain);
     }
+
+    public interface IDeactivatingWhileActivatingTestGrain : IGrainWithIntegerKey
+    {
+        Task<string> DoSomething();
+    }
+    
 }

--- a/src/TestInternalGrains/ActivateDeactivateTestGrain.cs
+++ b/src/TestInternalGrains/ActivateDeactivateTestGrain.cs
@@ -360,6 +360,31 @@ namespace UnitTests.Grains
         }
     }
 
+    internal class DeactivatingWhileActivatingTestGrain : Grain, IDeactivatingWhileActivatingTestGrain
+    {
+        private Logger logger;
+
+        public override Task OnActivateAsync()
+        {
+            logger = GetLogger();
+            logger.Info("OnActivateAsync");
+            this.DeactivateOnIdle();
+            return TaskDone.Done;
+        }
+
+        public override Task OnDeactivateAsync()
+        {
+            logger.Info("OnDeactivateAsync");
+            return TaskDone.Done;
+        }
+
+        public Task<string> DoSomething()
+        {
+            logger.Info("DoSomething");
+            throw new NotImplementedException("DoSomething should not have been called");
+        }
+    }
+
     internal class CreateGrainReferenceTestGrain : Grain, ICreateGrainReferenceTestGrain
     {
         private Logger logger;

--- a/src/Tester/GrainActivateDeactivateTests.cs
+++ b/src/Tester/GrainActivateDeactivateTests.cs
@@ -288,6 +288,26 @@ namespace UnitTests.ActivationsLifeCycleTests
             await CheckNumActivateDeactivateCalls(1, 1, activation.ToString());
         }
 
+        [TestMethod, TestCategory("Functional"), TestCategory("ActivateDeactivate")]
+        public async Task DeactivateOnIdleWhileActivate()
+        {
+            int id = random.Next();
+            IDeactivatingWhileActivatingTestGrain grain = GrainClient.GrainFactory.GetGrain<IDeactivatingWhileActivatingTestGrain>(id);
+
+            try
+            {
+                string activation = await grain.DoSomething();
+                Assert.Fail("Should have thrown.");
+            }
+            catch(Exception exc)
+            {
+                logger.Info("Thrown as expected:", exc);
+                Exception e = exc.GetBaseException();
+                Assert.IsTrue(e.Message.Contains("Forwarding failed"),
+                        "Did not get expected exception message returned: " + e.Message);
+            }  
+        }
+
         private async Task CheckNumActivateDeactivateCalls(
             int expectedActivateCalls,
             int expectedDeactivateCalls,


### PR DESCRIPTION
Take 2 on #1325.

We used to just ignore the `DeactivateOnIdle` call made inside OnActivateAsync.
As proposed by @sergeybykov in #1325, `DeactivateOnIdle`  should throw if called from within `OnActivateAsync`.

I disagree with this semantics (I think the right fix is to cause grain to Deactivate immediately, which will also call `OnDeactivateAsync`), but there appears to be a wider opinion that this is the right behavior and since this fix is better than just completely ignoring, I prefer a sub-optimal fix rather than leaving a hanging bug (I don't like leaving hanging bugs).