### PR TITLE
Cleanup NodeConfig management in ClusterConfiguration.

### DIFF
--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -205,19 +205,38 @@ namespace Orleans.Runtime.Configuration
         }
 
         /// <summary>
-        /// Returns the configuration for a given silo.
+        /// Obtains the configuration for a given silo.
         /// </summary>
-        /// <param name="name">Silo name.</param>
-        /// <returns>NodeConfiguration associated with the specified silo.</returns>
-        public NodeConfiguration GetOrAddConfigurationForNode(string name)
+        /// <param name="siloName">Silo name.</param>
+        /// <param name="siloNode">NodeConfiguration associated with the specified silo.</param>
+        /// <returns>true if node was found</returns>
+        public bool TryGetNodeConfigurationForSilo(string siloName, out NodeConfiguration siloNode)
         {
-            NodeConfiguration n;
-            if (Overrides.TryGetValue(name, out n)) return n;
+            return Overrides.TryGetValue(siloName, out siloNode);
+        }
 
-            n = new NodeConfiguration(Defaults) {SiloName = name};
-            InitNodeSettingsFromGlobals(n);
-            Overrides[name] = n;
-            return n;
+        /// <summary>
+        /// Creates a configuration node for a given silo.
+        /// </summary>
+        /// <param name="siloName">Silo name.</param>
+        /// <returns>NodeConfiguration associated with the specified silo.</returns>
+        public NodeConfiguration CreateNodeConfigurationForSilo(string siloName)
+        {
+            var siloNode = new NodeConfiguration(Defaults) { SiloName = siloName };
+            InitNodeSettingsFromGlobals(siloNode);
+            Overrides[siloName] = siloNode;
+            return siloNode;
+        }
+
+        /// <summary>
+        /// Creates a node config for the specified silo if one does not exist.  Returns existing node if one already exists
+        /// </summary>
+        /// <param name="siloName">Silo name.</param>
+        /// <returns>NodeConfiguration associated with the specified silo.</returns>
+        public NodeConfiguration GetOrCreateNodeConfigurationForSilo(string siloName)
+        {
+            NodeConfiguration siloNode;
+            return !TryGetNodeConfigurationForSilo(siloName, out siloNode) ? CreateNodeConfigurationForSilo(siloName) : siloNode;
         }
 
         private void SetPrimaryNode(IPEndPoint primary)
@@ -386,8 +405,11 @@ namespace Orleans.Runtime.Configuration
             sb.Append("Primary node: ").AppendLine(PrimaryNode == null ? "null" : PrimaryNode.ToString());
             sb.AppendLine("Platform version info:").Append(ConfigUtilities.RuntimeVersionInfo());
             sb.AppendLine("Global configuration:").Append(Globals.ToString());
-            NodeConfiguration nc = GetOrAddConfigurationForNode(siloName);
-            sb.AppendLine("Silo configuration:").Append(nc.ToString());
+            NodeConfiguration nc;
+            if (TryGetNodeConfigurationForSilo(siloName, out nc))
+            {
+                sb.AppendLine("Silo configuration:").Append(nc);
+            }
             sb.AppendLine();
             return sb.ToString();
         }

--- a/src/OrleansAzureUtils/Hosting/AzureSilo.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureSilo.cs
@@ -118,7 +118,7 @@ namespace Orleans.Runtime.Host
                 Port = myEndpoint.Port.ToString(CultureInfo.InvariantCulture),
                 Generation = generation.ToString(CultureInfo.InvariantCulture),
 
-                HostName = host.Config.GetOrAddConfigurationForNode(host.Name).DNSHostName,
+                HostName = host.Config.GetOrCreateNodeConfigurationForSilo(host.Name).DNSHostName,
                 ProxyPort = (proxyEndpoint != null ? proxyEndpoint.Port : 0).ToString(CultureInfo.InvariantCulture),
 
                 RoleName = serviceRuntimeWrapper.RoleName, 

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -155,7 +155,7 @@ namespace Orleans.Runtime
 
             OrleansConfig = config;
             globalConfig = config.Globals;
-            config.OnConfigChange("Defaults", () => nodeConfig = config.GetOrAddConfigurationForNode(name));
+            config.OnConfigChange("Defaults", () => nodeConfig = config.GetOrCreateNodeConfigurationForSilo(name));
 
             if (!TraceLogger.IsInitialized)
                 TraceLogger.Initialize(nodeConfig);

--- a/src/OrleansRuntime/Silo/SiloHost.cs
+++ b/src/OrleansRuntime/Silo/SiloHost.cs
@@ -453,18 +453,18 @@ namespace Orleans.Runtime.Host
             if (string.IsNullOrWhiteSpace(Name))
                 throw new ArgumentException("SiloName not defined - cannot initialize config");
 
-            NodeConfig = Config.GetOrAddConfigurationForNode(Name);
+            NodeConfig = Config.GetOrCreateNodeConfigurationForSilo(Name);
             Type = NodeConfig.IsPrimaryNode ? Silo.SiloType.Primary : Silo.SiloType.Secondary;
 
             if (TraceFilePath != null)
             {
-                var traceFileName = Config.GetOrAddConfigurationForNode(Name).TraceFileName;
+                var traceFileName = NodeConfig.TraceFileName;
                 if (traceFileName != null && !Path.IsPathRooted(traceFileName))
-                    Config.GetOrAddConfigurationForNode(Name).TraceFileName = TraceFilePath + "\\" + traceFileName;
+                    NodeConfig.TraceFileName = TraceFilePath + "\\" + traceFileName;
             }
 
             ConfigLoaded = true;
-            InitializeLogger(config.GetOrAddConfigurationForNode(Name));
+            InitializeLogger(NodeConfig);
         }
 
         private void InitializeLogger(NodeConfiguration nodeCfg)

--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -684,7 +684,7 @@ namespace Orleans.TestingHost
                     break;
             }
 
-            NodeConfiguration nodeConfig = config.GetOrAddConfigurationForNode(siloName);
+            NodeConfiguration nodeConfig = config.GetOrCreateNodeConfigurationForSilo(siloName);
             nodeConfig.HostNameOrIPAddress = "loopback";
             nodeConfig.Port = basePort + instanceCount;
             nodeConfig.DefaultTraceLevel = config.Defaults.DefaultTraceLevel;

--- a/src/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
+++ b/src/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Placement;
 using Orleans.Runtime;
 using Orleans.Streams;
 using TestGrainInterfaces;
@@ -11,6 +12,7 @@ using UnitTests.Grains;
 namespace TestGrains
 {
     [ImplicitStreamSubscription(StreamNamespace)]
+    [PreferLocalPlacement]
     public class ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain : Grain<StreamCheckpoint<int>>, IGeneratedEventCollectorGrain
     {
         public const string StreamNamespace = "NonTransientError_RecoverableStream";

--- a/src/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
+++ b/src/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Placement;
 using Orleans.Runtime;
 using Orleans.Streams;
 using TestGrainInterfaces;
@@ -11,6 +12,7 @@ using UnitTests.Grains;
 namespace TestGrains
 {
     [ImplicitStreamSubscription(StreamNamespace)]
+    [PreferLocalPlacement]
     public class ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain : Grain<StreamCheckpoint<int>>, IGeneratedEventCollectorGrain
     {
         public const string StreamNamespace = "TransientError_RecoverableStream";

--- a/src/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/src/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -56,9 +56,10 @@ namespace UnitTests.StreamingTests
                         // register stream provider
                         config.Globals.RegisterStreamProvider<GeneratorStreamProvider>(StreamProviderName, settings);
 
-                        // make sure all node configs exist, for dynamic cluster queue balancer
-                        config.GetOrAddConfigurationForNode("Primary");
-                        config.GetOrAddConfigurationForNode("Secondary_1");
+                        // Make sure a node config exist for each silo in the cluster.
+                        // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
+                        config.GetOrCreateNodeConfigurationForSilo("Primary");
+                        config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
                     }
                 });
         }

--- a/src/Tester/StreamingTests/ControllableStreamProviderTests.cs
+++ b/src/Tester/StreamingTests/ControllableStreamProviderTests.cs
@@ -36,8 +36,10 @@ namespace UnitTests.StreamingTests
                                 {PersistentStreamProviderConfig.STREAM_PUBSUB_TYPE, StreamPubSubType.ImplicitOnly.ToString()}
                             };
                         config.Globals.RegisterStreamProvider<ControllableTestStreamProvider>(StreamProviderName, settings);
-                        config.GetOrAddConfigurationForNode("Primary");
-                        config.GetOrAddConfigurationForNode("Secondary_1");
+                        // Make sure a node config exist for each silo in the cluster.
+                        // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
+                        config.GetOrCreateNodeConfigurationForSilo("Primary");
+                        config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
                     }
                 });
         }

--- a/src/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/src/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -49,8 +49,8 @@ namespace UnitTests.StreamingTests
 
                         // Make sure a node config exist for each silo in the cluster.
                         // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
-                        config.GetOrAddConfigurationForNode("Primary");
-                        config.GetOrAddConfigurationForNode("Secondary_1");
+                        config.GetOrCreateNodeConfigurationForSilo("Primary");
+                        config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
                     }
                 }, new TestingClientOptions()
                 {

--- a/src/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
+++ b/src/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
@@ -64,9 +64,10 @@ namespace UnitTests.StreamingTests
             config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, settings);
             config.Globals.RegisterStorageProvider<MemoryStorage>("PubSubStore");
 
-            // make sure all node configs exist, for dynamic cluster queue balancer
-            config.GetOrAddConfigurationForNode("Primary");
-            config.GetOrAddConfigurationForNode("Secondary_1");
+            // Make sure a node config exist for each silo in the cluster.
+            // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
+            config.GetOrCreateNodeConfigurationForSilo("Primary");
+            config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
         }
 
         [TestMethod, TestCategory("EventHub"), TestCategory("Streaming")]

--- a/src/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/src/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -56,9 +56,8 @@ namespace UnitTests.StreamingTests
 
                         // Make sure a node config exist for each silo in the cluster.
                         // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
-                        // GetOrAddConfigurationForNode will materialize a node in the configuration for each silo, if one does not already exist.
-                        config.GetOrAddConfigurationForNode("Primary");
-                        config.GetOrAddConfigurationForNode("Secondary_1");
+                        config.GetOrCreateNodeConfigurationForSilo("Primary");
+                        config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
                     }
                 });
         }

--- a/src/Tester/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/src/Tester/StreamingTests/StreamGeneratorProviderTests.cs
@@ -60,8 +60,8 @@ namespace UnitTests.StreamingTests
                         config.Globals.RegisterStreamProvider<GeneratorStreamProvider>(StreamProviderName, settings);
 
                         // make sure all node configs exist, for dynamic cluster queue balancer
-                        config.GetOrAddConfigurationForNode("Primary");
-                        config.GetOrAddConfigurationForNode("Secondary_1");
+                        config.GetOrCreateNodeConfigurationForSilo("Primary");
+                        config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
                     }
                 });
         }

--- a/src/TesterInternal/ConfigTests.cs
+++ b/src/TesterInternal/ConfigTests.cs
@@ -94,19 +94,23 @@ namespace UnitTests
 
             Assert.AreEqual<int>(12345, config.Defaults.Port, "Default port is set incorrectly");
 
-            NodeConfiguration nc = config.GetOrAddConfigurationForNode("Node1");
+            NodeConfiguration nc;
+            bool hasNodeConfig = config.TryGetNodeConfigurationForSilo("Node1", out nc);
+            Assert.IsTrue(hasNodeConfig, "Node Node1 has config");
             Assert.AreEqual<int>(11111, nc.Port, "Port is set incorrectly for node Node1");
             Assert.IsTrue(nc.IsPrimaryNode, "Node1 should be primary node");
             Assert.IsTrue(nc.IsSeedNode, "Node1 should be seed node");
             Assert.IsFalse(nc.IsGatewayNode, "Node1 should not be gateway node");
 
-            nc = config.GetOrAddConfigurationForNode("Node2");
+            hasNodeConfig = config.TryGetNodeConfigurationForSilo("Node2", out nc);
+            Assert.IsTrue(hasNodeConfig, "Node Node2 has config");
             Assert.AreEqual<int>(22222, nc.Port, "Port is set incorrectly for node Node2");
             Assert.IsFalse(nc.IsPrimaryNode, "Node2 should not be primary node");
             Assert.IsTrue(nc.IsSeedNode, "Node2 should be seed node");
             Assert.IsTrue(nc.IsGatewayNode, "Node2 should be gateway node");
 
-            nc = config.GetOrAddConfigurationForNode("Store");
+            hasNodeConfig = config.TryGetNodeConfigurationForSilo("Store", out nc);
+            Assert.IsTrue(hasNodeConfig, "Node Store has config");
             Assert.AreEqual<int>(12345, nc.Port, "IP port is set incorrectly for node Store");
             Assert.IsFalse(nc.IsPrimaryNode, "Store should not be primary node");
             Assert.IsFalse(nc.IsSeedNode, "Store should not be seed node");
@@ -131,7 +135,7 @@ namespace UnitTests
         {
             var oc = new ClusterConfiguration();
             oc.StandardLoad();
-            var n = oc.GetOrAddConfigurationForNode("Node1");
+            NodeConfiguration n = oc.CreateNodeConfigurationForSilo("Node1");
             string fname = n.TraceFileName;
             Console.WriteLine("LogFileName = " + fname);
             Assert.IsNotNull(fname);
@@ -157,7 +161,7 @@ namespace UnitTests
 
             var config = new ClusterConfiguration();
             config.LoadFromFile(configFileName);
-            var n = config.GetOrAddConfigurationForNode(siloName);
+            NodeConfiguration n = config.CreateNodeConfigurationForSilo(siloName);
             string fname = n.TraceFileName;
             Console.WriteLine("LogFileName = " + fname);
             
@@ -186,7 +190,7 @@ namespace UnitTests
 
             var config = new ClusterConfiguration();
             config.LoadFromFile(configFileName);
-            var n = config.GetOrAddConfigurationForNode(siloName);
+            NodeConfiguration n = config.CreateNodeConfigurationForSilo(siloName);
             string fname = n.TraceFileName;
             Console.WriteLine("LogFileName = " + fname);
 
@@ -215,7 +219,7 @@ namespace UnitTests
 
             var config = new ClusterConfiguration();
             config.LoadFromFile(configFileName);
-            var n = config.GetOrAddConfigurationForNode(siloName);
+            NodeConfiguration n = config.CreateNodeConfigurationForSilo(siloName);
             string fname = n.TraceFileName;
             Console.WriteLine("LogFileName = " + fname);
 
@@ -255,7 +259,7 @@ namespace UnitTests
 
             var config = new ClusterConfiguration();
             config.LoadFromFile(configFileName);
-            var n = config.GetOrAddConfigurationForNode(siloName);
+            NodeConfiguration n = config.CreateNodeConfigurationForSilo(siloName);
             string fname = n.TraceFileName;
             Console.WriteLine("LogFileName = " + fname);
 
@@ -393,7 +397,7 @@ namespace UnitTests
             cfg.LoadFromFile(filename);
             Assert.AreEqual(filename, cfg.SourceFile);
 
-            TraceLogger.Initialize(cfg.GetOrAddConfigurationForNode("Primary"));
+            TraceLogger.Initialize(cfg.CreateNodeConfigurationForSilo("Primary"));
             Assert.AreEqual(1, TraceLogger.LogConsumers.Count, "Number of log consumers: " + string.Join(",", TraceLogger.LogConsumers));
             Assert.AreEqual("UnitTests.DummyLogConsumer", TraceLogger.LogConsumers.Last().GetType().FullName, "Log consumer type");
 
@@ -436,7 +440,10 @@ namespace UnitTests
             const string filename = "Config_LogConsumers-OrleansConfiguration.xml";
             var orleansConfig = new ClusterConfiguration();
             orleansConfig.LoadFromFile(filename);
-            NodeConfiguration config = orleansConfig.GetOrAddConfigurationForNode("Primary");
+            NodeConfiguration config;
+            bool hasNodeConfig = orleansConfig.TryGetNodeConfigurationForSilo("Primary", out config);
+            Assert.IsTrue(hasNodeConfig, "Node Primary has config");
+
 
             string limitName;
             LimitValue limit;
@@ -478,7 +485,10 @@ namespace UnitTests
             const string filename = "Config_LogConsumers-OrleansConfiguration.xml";
             var orleansConfig = new ClusterConfiguration();
             orleansConfig.LoadFromFile(filename);
-            NodeConfiguration config = orleansConfig.GetOrAddConfigurationForNode("Primary");
+            NodeConfiguration config;
+            bool hasNodeConfig = orleansConfig.TryGetNodeConfigurationForSilo("Primary", out config);
+            Assert.IsTrue(hasNodeConfig, "Node Primary has config");
+
 
             string limitName = "NotPresent";
             LimitValue limit = config.LimitManager.GetLimit(limitName);
@@ -493,7 +503,10 @@ namespace UnitTests
             const string filename = "Config_LogConsumers-OrleansConfiguration.xml";
             var orleansConfig = new ClusterConfiguration();
             orleansConfig.LoadFromFile(filename);
-            NodeConfiguration config = orleansConfig.GetOrAddConfigurationForNode("Primary");
+            NodeConfiguration config;
+            bool hasNodeConfig = orleansConfig.TryGetNodeConfigurationForSilo("Primary", out config);
+            Assert.IsTrue(hasNodeConfig, "Node Primary has config");
+
 
             string limitName;
             LimitValue limit;
@@ -589,7 +602,9 @@ namespace UnitTests
             const string filename = "Config_LogConsumers-OrleansConfiguration.xml";
             var orleansConfig = new ClusterConfiguration();
             orleansConfig.LoadFromFile(filename);
-            NodeConfiguration config = orleansConfig.GetOrAddConfigurationForNode("Primary");
+            NodeConfiguration config;
+            bool hasNodeConfig = orleansConfig.TryGetNodeConfigurationForSilo("Primary", out config);
+            Assert.IsTrue(hasNodeConfig, "Node Primary has config");
 
             string limitName;
             LimitValue limit;

--- a/src/TesterInternal/LivenessTests/MembershipTablePluginTests.cs
+++ b/src/TesterInternal/LivenessTests/MembershipTablePluginTests.cs
@@ -1,10 +1,7 @@
-﻿//#define USE_SQL_SERVER
+﻿
+//#define USE_SQL_SERVER
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
@@ -37,7 +34,7 @@ namespace UnitTests.LivenessTests
 
             ClusterConfiguration cfg = new ClusterConfiguration();
             cfg.LoadFromFile("OrleansConfigurationForTesting.xml");
-            TraceLogger.Initialize(cfg.GetOrAddConfigurationForNode("Primary"));
+            TraceLogger.Initialize(cfg.CreateNodeConfigurationForSilo("Primary"));
 
             TraceLogger.AddTraceLevelOverride("AzureTableDataManager", Severity.Verbose3);
             TraceLogger.AddTraceLevelOverride("OrleansSiloInstanceManager", Severity.Verbose3);

--- a/src/TesterInternal/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/src/TesterInternal/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -781,7 +781,7 @@ namespace UnitTests.SchedulerTests
 
             var orleansConfig = new ClusterConfiguration();
             orleansConfig.StandardLoad();
-            NodeConfiguration config = orleansConfig.GetOrAddConfigurationForNode("Primary");
+            NodeConfiguration config = orleansConfig.CreateNodeConfigurationForSilo("Primary");
             StatisticsCollector.Initialize(config);
             SchedulerStatisticsGroup.Init();
         }


### PR DESCRIPTION
This is another pass at addressing comments in Stream Recovery Tests #1289
First pass was GetOrAddConfigurationForNode #1313 

The issue here is that the silo nodes are optional in the configuration, so code that needs them tends to use a 'get or create' pattern.  This pattern was coded into the original GetConfigurationForNode call.  From the call name it's not clear that one would be creating the node if it does not exist, when all it appears to do is access it.

Since the actual behavior was 'get or create' the first pass at addressing this ( #1313) simply renamed the operation to GetOrAddConfigurationForNode, to make it more clear what the call was actually doing.  This change introduced no new capabilities, just made the existing behavior more clear.  There remained no means of querying the configuration node without creating it.

This PR breaks the functionality up into the following functions, affording users better control over the node management.

        public NodeConfiguration CreateNodeConfigurationForSilo(string siloName);
        public bool TryGetNodeConfigurationForSilo(string siloName, out NodeConfiguration siloNode);
        public NodeConfiguration GetOrCreateNodeConfigurationForSilo(string siloName)
