### PR TITLE
Injection of grain factory

### DIFF
--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -46,6 +46,12 @@ namespace Orleans
         private readonly ConcurrentDictionary<Type, IGrainMethodInvoker> invokers =
             new ConcurrentDictionary<Type, IGrainMethodInvoker>();
 
+
+        // hacked singleton instance for DI
+        // TODO: Kill when Microsoft.Extensions.DependencyInjection is released
+        private static GrainFactory grainFactoryDIHack;
+        public static GrainFactory GrainFactoryDIHack { get { return grainFactoryDIHack ?? (grainFactoryDIHack = new GrainFactory()); } }
+
         // Make this internal so that client code is forced to access the IGrainFactory using the 
         // GrainClient (to make sure they don't forget to initialize the client).
         internal GrainFactory()

--- a/src/OrleansDependencyInjection/ConfigureStartupBuilder.cs
+++ b/src/OrleansDependencyInjection/ConfigureStartupBuilder.cs
@@ -55,6 +55,8 @@ namespace Orleans.Runtime.Startup
             serviceCollection.AddTransient<GrainBasedReminderTable>();
             serviceCollection.AddTransient<PubSubRendezvousGrain>();
             serviceCollection.AddTransient<MemoryStorageGrain>();
+            serviceCollection.AddSingleton<IGrainFactory>(sp => GrainFactory.GrainFactoryDIHack);
+            serviceCollection.AddSingleton(sp => GrainFactory.GrainFactoryDIHack);
 
             return serviceCollection;
         }

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -228,7 +228,7 @@ namespace Orleans.Runtime
             AppDomain.CurrentDomain.UnhandledException +=
                 (obj, ev) => DomainUnobservedExceptionHandler(obj, (Exception)ev.ExceptionObject);
 
-            grainFactory = new GrainFactory();
+            grainFactory = GrainFactory.GrainFactoryDIHack;
             typeManager = new GrainTypeManager(here.Address.Equals(IPAddress.Loopback), grainFactory);
 
             // Performance metrics


### PR DESCRIPTION
Addresses "Dependency Injection: register IGrainFactory #988"

To inject the grain factory, we need only to add it to the services collection.  However, we can't do this cleanly because the Microsoft.Extensions.DependencyInjection libraries have not been released, so we can't access them directly from within core, and GrainFactory is an internal class that can't be accessed by the DI library.

Given that there was no clean solution, I compromised on the side of simplicity.  As an interim workaround I added a public singleton instance of grain factory as a -HACK- so we could register it in the services collection for DI.  This will be removed when Microsoft.Extensions.DependencyInjection is released and we can get rid of the OrleansDependencyInjection assembly.

Thoughts?