### PR TITLE
Discussion: Exception propagation doesn't look right

### DIFF
--- a/src/TestGrainInterfaces/IExceptionGrain.cs
+++ b/src/TestGrainInterfaces/IExceptionGrain.cs
@@ -9,10 +9,16 @@ namespace UnitTests.GrainInterfaces
     /// </summary>
     public interface IExceptionGrain : IGrainWithIntegerKey
     {
-        /// <summary>
-        /// Returns a canceled <see cref="Task"/>.
-        /// </summary>
-        /// <returns>A canceled <see cref="Task"/>.</returns>
-        Task Cancelled();
+        Task Canceled();
+
+        Task ThrowsInvalidOperationException();
+
+        Task ThrowsAggregateExceptionWrappingInvalidOperationException();
+
+        Task ThrowsNestedAggregateExceptionsWrappingInvalidOperationException();
+
+        Task GrainCallToThrowsInvalidOperationException(long otherGrainId);
+
+        Task GrainCallToThrowsAggregateExceptionWrappingInvalidOperationException(long otherGrainId);
     }
 }

--- a/src/TestGrains/ExceptionGrain.cs
+++ b/src/TestGrains/ExceptionGrain.cs
@@ -1,22 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using Orleans;
+using UnitTests.GrainInterfaces;
+
 namespace UnitTests.Grains
 {
-    using System.Threading.Tasks;
-
-    using Orleans;
-
-    using UnitTests.GrainInterfaces;
-
     public class ExceptionGrain : Grain, IExceptionGrain
     {
         /// <summary>
         /// Returns a canceled <see cref="Task"/>.
         /// </summary>
         /// <returns>A canceled <see cref="Task"/>.</returns>
-        public Task Cancelled()
+        public Task Canceled()
         {
             var tcs = new TaskCompletionSource<int>();
             tcs.TrySetCanceled();
             return tcs.Task;
+        }
+
+        public async Task ThrowsInvalidOperationException()
+        {
+            await Task.Delay(0);
+            throw new InvalidOperationException("Test exception");
+        }
+
+        public async Task ThrowsAggregateExceptionWrappingInvalidOperationException()
+        {
+            await Task.Delay(0);
+            ThrowsInvalidOperationException().Wait();
+        }
+
+        public async Task ThrowsNestedAggregateExceptionsWrappingInvalidOperationException()
+        {
+            await Task.Delay(0);
+            ThrowsAggregateExceptionWrappingInvalidOperationException().Wait();
+        }
+
+        public Task GrainCallToThrowsInvalidOperationException(long otherGrainId)
+        {
+            var otherGrain = GrainFactory.GetGrain<IExceptionGrain>(otherGrainId);
+            return otherGrain.ThrowsInvalidOperationException();
+        }
+
+        public Task GrainCallToThrowsAggregateExceptionWrappingInvalidOperationException(long otherGrainId)
+        {
+            var otherGrain = GrainFactory.GetGrain<IExceptionGrain>(otherGrainId);
+            return otherGrain.ThrowsAggregateExceptionWrappingInvalidOperationException();
         }
     }
 }

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -11,7 +11,7 @@ namespace UnitTests.General
     /// </summary>
     public class ExceptionPropagationTests : HostedTestClusterEnsureDefaultStarted
     {
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact(Skip = "Implementation of issue #1378 is still pending"), TestCategory("BVT"), TestCategory("Functional")]
         public async Task BasicExceptionPropagation()
         {
             IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -32,7 +32,7 @@ namespace UnitTests.General
             Assert.Equal("Test exception", nestedEx.Message);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact(Skip = "Implementation of issue #1378 is still pending"), TestCategory("BVT"), TestCategory("Functional")]
         public async Task ExceptionPropagationDoesNoFlattenAggregateExceptions()
         {
             IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -44,7 +44,7 @@ namespace UnitTests.General
             Assert.Equal("Test exception", doubleNestedEx.Message);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact(Skip = "Implementation of issue #1378 is still pending"), TestCategory("BVT"), TestCategory("Functional")]
         public async Task TaskCancelationPropagation()
         {
             IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
@@ -52,7 +52,7 @@ namespace UnitTests.General
                 () => grain.Canceled());
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact(Skip = "Implementation of issue #1378 is still pending"), TestCategory("BVT"), TestCategory("Functional")]
         public async Task GrainForwardingExceptionPropagation()
         {
             IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());


### PR DESCRIPTION
Hi, this PR is mainly for discussion first, as fixing it would require a breaking change that might not be easy to catch for our users (no pun intended).
I did not fix the implementation in this PR, just created a bunch of tests on what would be my expectations about exception propagation (most test are failing, and some are passing but for the wrong reasons).

In a nutshell, when a grain throws an exception, the client will always get an `AggregateException` back instead of the original exception. Also, if the grain would return an aggregate exception (or many nested ones), Orleans would flatten all of those as if it was its reponsibility to do so, and then return the flattened exception inside this extra `AggregateException`.

```
BasicExceptionPropagation: Failed
	Test method UnitTests.General.ExceptionPropagationTests.BasicExceptionPropagation threw exception: 
	System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException: Test exception

ExceptionPropagationDoesNoFlattenAggregateExceptions: Failed
	Assert.IsInstanceOfType failed.  Expected type:<System.AggregateException>. Actual type:<System.InvalidOperationException>.

GrainForwardingExceptionPropagation: Failed
	Test method UnitTests.General.ExceptionPropagationTests.GrainForwardingExceptionPropagation threw exception: 
	System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException: Test exception

TaskCancelationPropagation: Failed
	Test method UnitTests.General.ExceptionPropagationTests.TaskCancelationPropagation threw exception: 
	System.AggregateException: One or more errors occurred. ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
```

Both `ExceptionPropagationDoesNotUnwrapAggregateExceptions` and `GrainForwardingExceptionPropagationDoesNotUnwrapAggregateExceptions` are currently passing, but because in [ConvertTaskViaTcs](https://github.com/dotnet/orleans/blob/a64fa8953e764ac391ebd549d395ac66374b545f/src/Orleans/Async/TaskExtensions.cs#L306) we Flatten the aggregate exceptions once, which is wrong behavior too.

What do you guys think? These tests are what I would expect from Orleans as a user. Nevertheless, if the user has code relying solely on catching `AggregateException`, then we might brake them in a sneaky way if we decide to fix it.