### PR TITLE
Coreclr compatibility: Delegate.Method -> Delegate.GetMethodInfo()

### DIFF
--- a/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
+++ b/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
@@ -82,7 +82,7 @@ namespace Orleans.Streams
 #if DEBUG
             CheckFilterPredicateFunc(pred); // Assert expected pre-conditions are always true.
 #endif
-            MethodInfo method = pred.Method;
+            MethodInfo method = pred.GetMethodInfo();
             className = method.DeclaringType.FullName;
             methodName = method.Name;
         }
@@ -99,7 +99,7 @@ namespace Orleans.Streams
                 throw new ArgumentNullException("predicate", "Stream Filter predicate function must not be null.");
             }
 
-            MethodInfo method = predicate.Method;
+            MethodInfo method = predicate.GetMethodInfo();
 
             if (!method.IsStatic || method.IsAbstract)
             {

--- a/src/OrleansRuntime/Core/GrainTimer.cs
+++ b/src/OrleansRuntime/Core/GrainTimer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -143,10 +144,24 @@ namespace Orleans.Runtime
 
         private string GetFullName()
         {
-            return String.Format("GrainTimer.{0} TimerCallbackHandler:{1}->{2}",
-               Name == null ? "" : Name + ".",
-               (asyncCallback != null && asyncCallback.Target != null) ? asyncCallback.Target.ToString() : "",
-               (asyncCallback != null && asyncCallback.Method != null) ? asyncCallback.Method.ToString() : "");
+            var callbackTarget = string.Empty;
+            var callbackMethodInfo = string.Empty;
+            if (asyncCallback != null)
+            {
+                if (asyncCallback.Target != null)
+                {
+                    callbackTarget = asyncCallback.Target.ToString();
+                }
+
+                var methodInfo = asyncCallback.GetMethodInfo();
+                if (methodInfo != null)
+                {
+                    callbackMethodInfo = methodInfo.ToString();
+                }
+            }
+
+            return string.Format("GrainTimer.{0} TimerCallbackHandler:{1}->{2}",
+                Name == null ? "" : Name + ".", callbackTarget, callbackMethodInfo);
         }
 
         internal int GetNumTicks()

--- a/src/OrleansRuntime/Scheduler/ClosureWorkItem.cs
+++ b/src/OrleansRuntime/Scheduler/ClosureWorkItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace Orleans.Runtime.Scheduler
 {
@@ -51,12 +52,17 @@ namespace Orleans.Runtime.Scheduler
 
         public override string ToString()
         {
-            var detailedName = nameGetter != null ? "" :  // if NameGetter != null, base.ToString() will print its name.
-                String.Format(": {0}->{1}", 
-                    (continuation.Target == null) ? "" : continuation.Target.ToString(),
-                    (continuation.Method == null) ? "" : continuation.Method.ToString());
+            var detailedName = string.Empty; 
+            if (nameGetter == null) // if NameGetter != null, base.ToString() will print its name.
+            {
+                var continuationMethodInfo = continuation.GetMethodInfo();
+                detailedName = string.Format(": {0}->{1}",
+                   (continuation.Target == null) ? "" : continuation.Target.ToString(),
+                   (continuationMethodInfo == null) ? "" : continuationMethodInfo.ToString());
+            }
+               
 
-            return String.Format("{0}{1}", base.ToString(), detailedName);
+            return string.Format("{0}{1}", base.ToString(), detailedName);
         }
     }
 }


### PR DESCRIPTION
#368; 
Even though `GetMethodInfo` is located in `System.Reflection` namespace, in .Net 4.5.* it's only a accessor of  del's `Method` property: 
![devenv_2016-01-30_11-56-53](https://cloud.githubusercontent.com/assets/5787619/12695015/b92fa962-c748-11e5-81f1-3fae6f593d7c.png)