### PR TITLE
CodeGen: Add support for F# interfaces

### DIFF
--- a/src/Build/GlobalAssemblyInfo.fs
+++ b/src/Build/GlobalAssemblyInfo.fs
@@ -1,7 +1,6 @@
 ﻿namespace Orleans.AssemblyInfo
 
 open System.Reflection
-open Orleans.CodeGeneration
 
 [<assembly: AssemblyCompany("Microsoft Corporation")>]
 [<assembly: AssemblyProduct("Orleans")>]
@@ -10,7 +9,5 @@ open Orleans.CodeGeneration
 [<assembly: AssemblyFileVersion("1.1.0.0")>]
 [<assembly: AssemblyInformationalVersion("1.1.0.0")>]
 
-// generate Orleans serializers for types in FSharp.core.dll
-[<assembly: KnownAssembly(typedefof<unit option>)>]
-
-do ()
+do
+    ()

--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -183,6 +183,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tester", "..\test\Tester\Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestExtensions", "..\test\TestExtensions\TestExtensions.csproj", "{8FD242B4-EDA9-42CD-BA39-E410B98ADD26}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestInterfaces", "TestInterfaces\TestInterfaces.csproj", "{AEFF3B6C-7986-4BF9-85F5-2571DECF8959}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TestFSharpInterfaces", "TestFSharpInterfaces\TestFSharpInterfaces.fsproj", "{2375D7D5-9B30-493F-9C2E-A6B2811A3C5A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -301,6 +305,14 @@ Global
 		{8FD242B4-EDA9-42CD-BA39-E410B98ADD26}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8FD242B4-EDA9-42CD-BA39-E410B98ADD26}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8FD242B4-EDA9-42CD-BA39-E410B98ADD26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEFF3B6C-7986-4BF9-85F5-2571DECF8959}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEFF3B6C-7986-4BF9-85F5-2571DECF8959}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEFF3B6C-7986-4BF9-85F5-2571DECF8959}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEFF3B6C-7986-4BF9-85F5-2571DECF8959}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2375D7D5-9B30-493F-9C2E-A6B2811A3C5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2375D7D5-9B30-493F-9C2E-A6B2811A3C5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2375D7D5-9B30-493F-9C2E-A6B2811A3C5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2375D7D5-9B30-493F-9C2E-A6B2811A3C5A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -255,9 +255,9 @@ namespace Orleans.CodeGenerator
             return SF.Argument(SF.NameColon("options"), SF.Token(SyntaxKind.None), allOptions);
         }
 
-        private static ExpressionSyntax GetParameterForInvocation(ParameterInfo arg)
+         private static ExpressionSyntax GetParameterForInvocation(ParameterInfo arg, int argIndex)
         {
-            var argIdentifier = arg.Name.ToIdentifierName();
+            var argIdentifier = arg.GetOrCreateName(argIndex).ToIdentifierName();
 
             // Addressable arguments must be converted to references before passing.
             if (typeof(IAddressable).IsAssignableFrom(arg.ParameterType)

--- a/src/OrleansCodeGenerator/Utilities/SyntaxFactoryExtensions.cs
+++ b/src/OrleansCodeGenerator/Utilities/SyntaxFactoryExtensions.cs
@@ -11,7 +11,8 @@ namespace Orleans.CodeGenerator.Utilities
     using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     using Orleans.Runtime;
-
+    using System.Globalization;
+	
     /// <summary>
     /// The syntax factory extensions.
     /// </summary>
@@ -249,6 +250,30 @@ namespace Orleans.CodeGenerator.Utilities
         }
 
         /// <summary>
+        /// Returns the name of the provided parameter.
+        /// If the parameter has no name (possible in F#),
+        /// it returns a name computed by suffixing "arg" with the parameter's index
+        /// </summary>
+        /// <param name="arg">
+        /// The parameter.
+        /// </param>
+        /// <param name="argIndex">
+        /// The parameter index in the list of parameters.
+        /// </param>
+        /// <returns>
+        /// The parameter name.
+        /// </returns>
+        public static string GetOrCreateName(this ParameterInfo parameter, int parameterIndex)
+        {
+            var argName = parameter.Name;
+            if (String.IsNullOrWhiteSpace(argName))
+            {
+                argName = String.Format(CultureInfo.InvariantCulture, "arg{0:G}", parameterIndex);
+            }
+            return argName;
+        }
+
+        /// <summary>
         /// Returns the parameter list syntax for the provided method.
         /// </summary>
         /// <param name="method">
@@ -262,8 +287,8 @@ namespace Orleans.CodeGenerator.Utilities
             return
                 method.GetParameters()
                     .Select(
-                        parameter =>
-                        SyntaxFactory.Parameter(parameter.Name.ToIdentifier())
+                        (parameter, parameterIndex) =>
+                        SyntaxFactory.Parameter(parameter.GetOrCreateName(parameterIndex).ToIdentifier())
                             .WithType(parameter.ParameterType.GetTypeSyntax()))
                     .ToArray();
         }

--- a/src/TestFSharp/AssemblyInfo.fs
+++ b/src/TestFSharp/AssemblyInfo.fs
@@ -1,0 +1,22 @@
+﻿namespace TestFSharp.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.InteropServices
+
+open Orleans.CodeGeneration
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("TestFSharp")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// generate Orleans serializers for types in FSharp.core.dll
+[<assembly: KnownAssembly(typedefof<unit option>)>]
+
+do
+    ()

--- a/src/TestFSharpInterfaces/AssemblyInfo.fs
+++ b/src/TestFSharpInterfaces/AssemblyInfo.fs
@@ -1,0 +1,17 @@
+﻿namespace TestFSharpInterfaces.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("TestFSharpInterfaces")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+do
+    ()

--- a/src/TestFSharpInterfaces/IFSharpBaseInterface.fs
+++ b/src/TestFSharpInterfaces/IFSharpBaseInterface.fs
@@ -1,0 +1,8 @@
+﻿namespace UnitTests.FSharpInterfaces
+
+open System.Threading.Tasks
+
+type public IFSharpBaseInterface =
+    abstract Echo: int -> Task<int>
+
+

--- a/src/TestFSharpInterfaces/TestFSharpInterfaces.fsproj
+++ b/src/TestFSharpInterfaces/TestFSharpInterfaces.fsproj
@@ -4,14 +4,14 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>ca8dab68-17e9-48bf-afa3-9ccfd4b0a3cd</ProjectGuid>
+    <ProjectGuid>2375d7d5-9b30-493f-9c2e-a6b2811a3c5a</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>TestFSharp</RootNamespace>
-    <AssemblyName>TestFSharp</AssemblyName>
+    <RootNamespace>TestFSharpInterfaces</RootNamespace>
+    <AssemblyName>TestFSharpInterfaces</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Name>TestFSharp</Name>
+    <Name>TestFSharpInterfaces</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,7 +21,7 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\TestFSharp.XML</DocumentationFile>
+    <DocumentationFile>bin\Debug\TestFSharpInterfaces.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,7 +30,7 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\TestFSharp.XML</DocumentationFile>
+    <DocumentationFile>bin\Release\TestFSharpInterfaces.XML</DocumentationFile>
   </PropertyGroup>
   <!--BEGIN: Workaround allowing the use of the FSharp.Compiler.Tools package from within Visual Studio-->
   <Choose>
@@ -60,9 +60,8 @@
     <Compile Include="..\Build\GlobalAssemblyInfo.fs">
       <Link>GlobalAssemblyInfo.fs</Link>
     </Compile>
-    <Compile Include="Types.fs" />
-    <Compile Include="Grains.fs" />
     <Content Include="packages.config" />
+    <Compile Include="IFSharpBaseInterface.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core">
@@ -73,16 +72,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <ProjectReference Include="..\Orleans\Orleans.csproj">
-      <Name>Orleans</Name>
-      <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj">
-      <Name>TestGrainInterfaces</Name>
-      <Project>{3972213f-189b-41d4-90fe-38d513c1106d}</Project>
-      <Private>True</Private>
-    </ProjectReference>
   </ItemGroup>
   <!--END: Workaround allowing the use of the FSharp.Compiler.Tools package from within Visual Studio-->
 </Project>

--- a/src/TestFSharpInterfaces/packages.config
+++ b/src/TestFSharpInterfaces/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FSharp.Compiler.Tools" version="4.0.0.1" targetFramework="net451" />
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net451" />
+</packages>

--- a/src/TestGrainInterfaces/IGeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs
+++ b/src/TestGrainInterfaces/IGeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Orleans;
+using UnitTests.Interfaces;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IGeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain : IGrainWithGuidKey, ICSharpBaseInterface
+    {
+    }
+}

--- a/src/TestGrainInterfaces/IGeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs
+++ b/src/TestGrainInterfaces/IGeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading.Tasks;
+using Orleans;
+using UnitTests.FSharpInterfaces;
+
+namespace UnitTests.GrainInterfaces
+{
+    // uncomment the following interface definition to reproduce #1349
+
+    public interface IGeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain : IGrainWithGuidKey, IFSharpBaseInterface
+    {
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -58,6 +58,8 @@
     <Compile Include="IExtensionTestGrain.cs" />
     <Compile Include="IExternalTypeGrain.cs" />
     <Compile Include="IFaultableConsumerGrain.cs" />
+    <Compile Include="IGeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs" />
+    <Compile Include="IGeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs" />
     <Compile Include="IGeneratorTestDerivedDerivedGrain.cs" />
     <Compile Include="IGeneratorTestDerivedGrain1.cs" />
     <Compile Include="IGeneratorTestDerivedGrain2.cs" />
@@ -124,6 +126,14 @@
     <ProjectReference Include="..\Orleans\Orleans.csproj">
       <Project>{BC1BD60C-E7D8-4452-A21C-290AEC8E2E74}</Project>
       <Name>Orleans</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestFSharpInterfaces\TestFSharpInterfaces.fsproj">
+      <Project>{2375d7d5-9b30-493f-9c2e-a6b2811a3c5a}</Project>
+      <Name>TestFSharpInterfaces</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestInterfaces\TestInterfaces.csproj">
+      <Project>{aeff3b6c-7986-4bf9-85f5-2571decf8959}</Project>
+      <Name>TestInterfaces</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/TestGrains/GeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs
+++ b/src/TestGrains/GeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading.Tasks;
+using UnitTests.GrainInterfaces;
+using Orleans;
+
+namespace UnitTests.Grains
+{
+    public class GeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain : Grain, IGeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain
+    {
+        public Task<int> Echo(int x)
+        {
+            return Task.FromResult(x);
+        }
+    }
+}

--- a/src/TestGrains/GeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs
+++ b/src/TestGrains/GeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+using UnitTests.GrainInterfaces;
+using Orleans;
+
+namespace UnitTests.Grains
+{
+
+    // uncomment the following class to verify correct code generation for #1349
+    // (do so once code generation succeeds)
+    // NOTE: also uncomment the corresponding test in Tester/GeneratorGrainTests.cs
+
+    public class GeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain : Grain, IGeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain
+    {
+        public Task<int> Echo(int x)
+        {
+            return Task.FromResult(x);
+        }
+    }
+}

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -66,6 +66,8 @@
     <Compile Include="GeneratedEventCollectorGrain.cs" />
     <Compile Include="GeneratedEvent.cs" />
     <Compile Include="GeneratedStreamTestConstants.cs" />
+    <Compile Include="GeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs" />
+    <Compile Include="GeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs" />
     <Compile Include="ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs" />
     <Compile Include="ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs" />
     <Compile Include="GeneratedEventReporterGrain.cs" />
@@ -129,9 +131,17 @@
       <Project>{BC1BD60C-E7D8-4452-A21C-290AEC8E2E74}</Project>
       <Name>Orleans</Name>
     </ProjectReference>
+    <ProjectReference Include="..\TestFSharpInterfaces\TestFSharpInterfaces.fsproj">
+      <Project>{2375d7d5-9b30-493f-9c2e-a6b2811a3c5a}</Project>
+      <Name>TestFSharpInterfaces</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj">
       <Project>{3972213f-189b-41d4-90fe-38d513c1106d}</Project>
       <Name>TestGrainInterfaces</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestInterfaces\TestInterfaces.csproj">
+      <Project>{aeff3b6c-7986-4bf9-85f5-2571decf8959}</Project>
+      <Name>TestInterfaces</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />

--- a/src/TestInterfaces/ICSharpBaseInterface.cs
+++ b/src/TestInterfaces/ICSharpBaseInterface.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests.Interfaces
+{
+    public interface ICSharpBaseInterface
+    {
+        Task<int> Echo(int x);
+    }
+}

--- a/src/TestInterfaces/Properties/AssemblyInfo.cs
+++ b/src/TestInterfaces/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestInterfaces")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestInterfaces")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("aeff3b6c-7986-4bf9-85f5-2571decf8959")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TestInterfaces/TestInterfaces.csproj
+++ b/src/TestInterfaces/TestInterfaces.csproj
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AEFF3B6C-7986-4BF9-85F5-2571DECF8959}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>UnitTests.Interfaces</RootNamespace>
+    <AssemblyName>TestInterfaces</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ICSharpBaseInterface.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/test/Tester/CodeGenTests/GeneratorGrainTest.cs
+++ b/test/Tester/CodeGenTests/GeneratorGrainTest.cs
@@ -242,5 +242,23 @@ namespace Tester.CodeGenTests
             Assert.AreEqual("StringBegin", members.stringVar);
             Assert.AreEqual(ReturnCode.Fail, members.code);
         }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
+        public async Task CodeGenDerivedFromCSharpInterfaceInDifferentAssembly()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<IGeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain>(Guid.NewGuid());
+            var input = 1;
+            var output = await grain.Echo(input);
+            Assert.AreEqual(input, output);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("FSharp")]
+        public async Task CodeGenDerivedFromFSharpInterfaceInDifferentAssembly()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<IGeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain>(Guid.NewGuid());
+            var input = 1;
+            var output = await grain.Echo(input);
+            Assert.AreEqual(input, output);
+        }
     }
 }

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -345,6 +345,10 @@
       <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
       <Name>Orleans</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\TestFSharpInterfaces\TestFSharpInterfaces.fsproj">
+      <Project>{2375d7d5-9b30-493f-9c2e-a6b2811a3c5a}</Project>
+      <Name>TestFSharpInterfaces</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\TestFSharp\TestFSharp.fsproj">
       <Project>{ca8dab68-17e9-48bf-afa3-9ccfd4b0a3cd}</Project>
       <Name>TestFSharp</Name>
@@ -356,6 +360,10 @@
     <ProjectReference Include="..\..\src\TestGrains\TestGrains.csproj">
       <Project>{eace28ae-f301-472a-b633-02b55434871b}</Project>
       <Name>TestGrains</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\TestInterfaces\TestInterfaces.csproj">
+      <Project>{aeff3b6c-7986-4bf9-85f5-2571decf8959}</Project>
+      <Name>TestInterfaces</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\TestInternalGrainInterfaces\TestInternalGrainInterfaces.csproj">
       <Project>{2ae67055-f38a-45f0-aea7-5754f4814ea5}</Project>


### PR DESCRIPTION
Fixes #1349, includes corresponding tests.

### Background
F# interface definitions do not require parameter names. It is idiomatic to omit parameter names for trivial interface methods:

```
type Interface1 =
    abstract member Multiply : int -> int -> int
```
However, Orleans code generation requires parameter names to be present. The PR addresses this by generating such names when not present, by suffixing the string `"arg"` with the parameter's index (`arg0`, `arg1`, etc.). 