### PR TITLE
Relational Storage: reminders range queries: cast to int before range check

### DIFF
--- a/src/OrleansSQLUtils/Storage/RelationalOrleansQueries.cs
+++ b/src/OrleansSQLUtils/Storage/RelationalOrleansQueries.cs
@@ -325,7 +325,7 @@ namespace Orleans.SqlUtils
         /// <returns>Reminder table data.</returns>
         internal async Task<ReminderTableData> ReadReminderRowsAsync(string serviceId, uint beginHash, uint endHash)
         {
-            var query = beginHash < endHash ? orleansQueries.ReadRangeRows1Key : orleansQueries.ReadRangeRows2Key;
+            var query = (int)beginHash < (int)endHash ? orleansQueries.ReadRangeRows1Key : orleansQueries.ReadRangeRows2Key;
             var ret = await storage.ReadAsync(query, command =>
             {                
                 var serviceIdParameter = CreateServiceIdParameter(command, serviceId);

--- a/src/TesterInternal/RemindersTest/MySqlRemindersTableTests.cs
+++ b/src/TesterInternal/RemindersTest/MySqlRemindersTableTests.cs
@@ -97,10 +97,10 @@ namespace UnitTests.RemindersTest
 
 
         [TestMethod, TestCategory("Reminders"), TestCategory("MySql")]
-        public async Task RemindersTable_MySql_UpsertReminderParallel()
+        public async Task RemindersTable_MySql_RemindersTest()
         {
             await Initialize();
-            await ReminderTablePluginTests.ReminderTableUpsertParallel(reminder);
+            await ReminderTablePluginTests.ReminderTableTest(reminder);
         }
     }
 }

--- a/src/TesterInternal/RemindersTest/ReminderTablePluginTests.cs
+++ b/src/TesterInternal/RemindersTest/ReminderTablePluginTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -9,32 +10,84 @@ namespace UnitTests.RemindersTest
 {
     internal class ReminderTablePluginTests
     {
-        internal static async Task ReminderTableUpsertParallel(IReminderTable reminder)
-        {
-            var grainRef = MakeTestGrainReference();
-            var period = TimeSpan.FromMinutes(1);
-            var reminderName = "testReminderName";
-            var startAt = DateTime.UtcNow.Add(TimeSpan.FromMinutes(1));
-            var results = await Task.WhenAll(Enumerable.Range(0, 10).Select(x => UpsertReminder(reminder, grainRef, reminderName, startAt, period)));
-
-            Assert.IsTrue(results.Distinct().Count() == results.Length);
-        }
-
-        private static async Task<string> UpsertReminder(IReminderTable reminder, GrainReference grainRef, string reminderName, DateTime startAt, TimeSpan period)
-        {
-            var reminderRow = new ReminderEntry
-                              {
-                                  GrainRef = grainRef,
-                                  Period = period,
-                                  StartAt = startAt,
-                                  ReminderName = reminderName
-                              };
-            return await reminder.UpsertRow(reminderRow);
-        }
-
-        private static GrainReference MakeTestGrainReference()
+        internal static async Task ReminderTableTest(IReminderTable reminderTable)
         {
             Guid guid = Guid.NewGuid();
+            var results = await Task.WhenAll(Enumerable.Range(0, 10).
+                Select(x => reminderTable.UpsertRow(CreateReminder(MakeTestGrainReference(guid), "0"))));
+
+            Assert.AreEqual(results.Distinct().Count(), results.Length);
+
+            await Task.WhenAll(Enumerable.Range(1, 999).Select(async i =>
+            {
+                GrainReference grainRef = MakeTestGrainReference(Guid.NewGuid());
+                await reminderTable.UpsertRow(CreateReminder(grainRef, i.ToString()));
+            }));
+
+            var rows = await reminderTable.ReadRows(0, uint.MaxValue);
+
+            Assert.AreEqual(rows.Reminders.Count, 1000);
+
+            rows = await reminderTable.ReadRows(0, 0);
+
+            Assert.AreEqual(rows.Reminders.Count, 1000);
+
+            var remindersHashes = rows.Reminders.Select(r => r.GrainRef.GetUniformHashCode()).ToArray();
+            
+            SafeRandom random = new SafeRandom();
+
+            await Task.WhenAll(Enumerable.Repeat(
+                        TestRemindersHashInterval(reminderTable, (uint) random.Next(), (uint) random.Next(),
+                            remindersHashes), 1000));
+
+            var reminder = rows.Reminders.First();
+
+            var shouldExist = await reminderTable.ReadRow(reminder.GrainRef, reminder.ReminderName);
+
+            Assert.IsNotNull(shouldExist);
+
+            string etagTemp = reminder.ETag;
+
+            reminder.ETag = await reminderTable.UpsertRow(reminder);
+
+            var removeRowRes = await reminderTable.RemoveRow(reminder.GrainRef, reminder.ReminderName, etagTemp);
+            Assert.IsFalse(removeRowRes, "should have failed. Etag is wrong");
+            removeRowRes = await reminderTable.RemoveRow(reminder.GrainRef, "bla", reminder.ETag);
+            Assert.IsFalse(removeRowRes, "should have failed. reminder name is wrong");
+            removeRowRes = await reminderTable.RemoveRow(reminder.GrainRef, reminder.ReminderName, reminder.ETag);
+            Assert.IsTrue(removeRowRes, "should have succeeded. Etag is right");
+            removeRowRes = await reminderTable.RemoveRow(reminder.GrainRef, reminder.ReminderName, reminder.ETag);
+            Assert.IsFalse(removeRowRes, "should have failed. reminder shouldn't exist");
+        }
+
+        private static async Task TestRemindersHashInterval(IReminderTable reminderTable, uint beginHash, uint endHash,
+            uint[] remindersHashes)
+        {
+            var rowsTask = reminderTable.ReadRows(beginHash, endHash);
+            var expectedHashes = beginHash < endHash
+                ? remindersHashes.Where(r => r > beginHash && r <= endHash)
+                : remindersHashes.Where(r => r > beginHash || r <= endHash);
+
+            HashSet<uint> expectedSet = new HashSet<uint>(expectedHashes);
+            var returnedHashes = (await rowsTask).Reminders.Select(r => r.GrainRef.GetUniformHashCode());
+            var returnedSet = new HashSet<uint>(returnedHashes);
+
+            Assert.IsTrue(returnedSet.SetEquals(expectedSet));
+        }
+
+        private static ReminderEntry CreateReminder(GrainReference grainRef, string reminderName)
+        {
+            return new ReminderEntry
+            {
+                GrainRef = grainRef,
+                Period = TimeSpan.FromMinutes(1),
+                StartAt = DateTime.UtcNow.Add(TimeSpan.FromMinutes(1)),
+                ReminderName = reminderName
+            };
+        }
+
+        private static GrainReference MakeTestGrainReference(Guid guid)
+        {
             GrainId regularGrainId = GrainId.GetGrainIdForTesting(guid);
             GrainReference grainRef = GrainReference.FromGrainId(regularGrainId);
             return grainRef;

--- a/src/TesterInternal/RemindersTest/SqlServerRemindersTableTests.cs
+++ b/src/TesterInternal/RemindersTest/SqlServerRemindersTableTests.cs
@@ -94,10 +94,10 @@ namespace UnitTests.RemindersTest
 
 
         [TestMethod, TestCategory("Reminders"), TestCategory("SqlServer")]
-        public async Task RemindersTable_SqlServer_UpsertReminderInParallel()
+        public async Task RemindersTable_SqlServer_RemindersTest()
         {
             await Initialize();
-            await ReminderTablePluginTests.ReminderTableUpsertParallel(reminder);
+            await ReminderTablePluginTests.ReminderTableTest(reminder);
         }
 
         #region sampleSpecificMembershipAndRemidersTableConfiguration


### PR DESCRIPTION
a solution for #1365.
At first this was a bit more complicated fix since I wanted to support both `uint` and `int`. IMHO, there's no need for that.
