### PR TITLE
EventHubStreamProvider checkpointing

### DIFF
--- a/src/Orleans/Providers/IOrleansProvider.cs
+++ b/src/Orleans/Providers/IOrleansProvider.cs
@@ -1,9 +1,8 @@
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-
 
 namespace Orleans.Providers
 {
@@ -139,6 +138,26 @@ namespace Orleans.Providers
             }
             string s;
             return config.Properties.TryGetValue(key, out s) ? Type.GetType(s) : settingDefault;
+        }
+
+        public static bool GetBoolProperty(this IProviderConfiguration config, string key, bool settingDefault)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException("config");
+            }
+            string s;
+            return config.Properties.TryGetValue(key, out s) ? bool.Parse(s) : settingDefault;
+        }
+
+        public static TimeSpan GetTimeSpanProperty(this IProviderConfiguration config, string key, TimeSpan settingDefault)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException("config");
+            }
+            string s;
+            return config.Properties.TryGetValue(key, out s) ? TimeSpan.Parse(s) : settingDefault;
         }
     }
 }

--- a/src/OrleansProviders/Streams/Common/PooledCache/CachedMessagePool.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/CachedMessagePool.cs
@@ -21,7 +21,8 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="cacheDataAdapter"></param>
         public CachedMessagePool(ICacheDataAdapter<TQueueMessage, TCachedMessage> cacheDataAdapter)
         {
-            cachedMessagePool = new ObjectPool<CachedMessageBlock<TQueueMessage, TCachedMessage>>(pool => new CachedMessageBlock<TQueueMessage, TCachedMessage>(pool, cacheDataAdapter));
+            cachedMessagePool = new ObjectPool<CachedMessageBlock<TQueueMessage, TCachedMessage>>(
+                pool => new CachedMessageBlock<TQueueMessage, TCachedMessage>(pool, cacheDataAdapter));
         }
 
         /// <summary>

--- a/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
@@ -12,6 +12,7 @@ namespace Orleans.Providers.Streams.Common
     /// </summary>
     /// <typeparam name="TQueueMessage"></typeparam>
     /// <typeparam name="TCachedMessage"></typeparam>
+    ///   most recent message purged from the cache.</typeparam>
     public interface ICacheDataAdapter<in TQueueMessage, TCachedMessage>
         where TQueueMessage : class
         where TCachedMessage : struct
@@ -21,6 +22,7 @@ namespace Orleans.Providers.Streams.Common
         StreamSequenceToken GetSequenceToken(ref TCachedMessage cachedMessage);
         int CompareCachedMessageToSequenceToken(ref TCachedMessage cachedMessage, StreamSequenceToken token);
         bool IsInStream(ref TCachedMessage cachedMessage, Guid streamGuid, string streamNamespace);
-        bool ShouldPurge(TCachedMessage cachedMessage, IDisposable purgeRequest);
+        bool ShouldPurge(ref TCachedMessage cachedMessage, IDisposable purgeRequest);
+        Action<IDisposable> PurgeAction { set; }
     }
 }

--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{8BFF0092-15D2-4425-80C0-29E381702F2B}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>OrleansServiceBusUtils</RootNamespace>
-    <AssemblyName>OrleansServiceBusUtils</AssemblyName>
+    <RootNamespace>OrleansServiceBus</RootNamespace>
+    <AssemblyName>OrleansServiceBus</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -30,16 +30,35 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Azure.KeyVault.Core">
+      <HintPath>$(SolutionDir)packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm">
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData">
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client">
+      <HintPath>$(SolutionDir)packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.ServiceBus">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.3.0.8\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.ServiceBus.3.0.8\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(SolutionDir)packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage">
+      <HintPath>$(SolutionDir)packages\WindowsAzure.Storage.5.0.2\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -47,6 +66,10 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -63,14 +86,22 @@
     <Compile Include="Providers\Streams\EventHub\EventHubAdapterReceiver.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubBatchContainer.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubDataAdapter.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubPartitionCheckpoint.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubPartitionCheckpointEntity.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubQueueMapper.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSequenceToken.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProvider.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProviderConfig.cs" />
+    <Compile Include="Providers\Streams\EventHub\ICheckpointSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubSettings.cs" />
+    <Compile Include="Providers\Streams\EventHub\SegmentBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\OrleansAzureUtils\OrleansAzureUtils.csproj">
+      <Project>{792818ef-b3f8-4ce2-9886-4808713b15c4}</Project>
+      <Name>OrleansAzureUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj">
       <Project>{0054DB14-2A92-4CC0-959E-A2C51F5E65D4}</Project>
       <Name>OrleansProviders</Name>

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
@@ -1,7 +1,7 @@
 ﻿
 using Microsoft.ServiceBus.Messaging;
 
-namespace Orleans.ServiceBus.Providers.Streams.EventHub
+namespace Orleans.ServiceBus.Providers
 {
     internal static class EventDataExtensions
     {

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -8,13 +8,14 @@ using Microsoft.ServiceBus.Messaging;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
-using OrleansServiceBusUtils.Providers.Streams.EventHub;
 
-namespace Orleans.ServiceBus.Providers.Streams.EventHub
+namespace Orleans.ServiceBus.Providers
 {
     internal class EventHubPartitionConfig
     {
         public IEventHubSettings Hub { get; set; }
+        public ICheckpointSettings CheckpointSettings { get; set; }
+        public string StreamProviderName { get; set; }
         public string Partition { get; set; }
     }
 
@@ -22,11 +23,141 @@ namespace Orleans.ServiceBus.Providers.Streams.EventHub
     {
         private static readonly TimeSpan ReceiveTimeout = TimeSpan.FromSeconds(5);
 
-        private readonly ICacheDataAdapter<EventData, CachedEventHubMessage> dataAdapter;
         private readonly EventHubPartitionConfig config;
+        private readonly IObjectPool<FixedSizeBuffer> bufferPool;
 
         private PooledQueueCache<EventData, CachedEventHubMessage> cache;
         private EventHubReceiver receiver;
+        private EventHubPartitionCheckpoint checkpoint;
+
+        public int MaxAddCount { get { return 1000; } }
+
+        public EventHubAdapterReceiver(EventHubPartitionConfig partitionConfig, IObjectPool<FixedSizeBuffer> bufferPool, Logger log)
+        {
+            config = partitionConfig;
+            this.bufferPool = bufferPool;
+        }
+
+        public async Task Initialize(TimeSpan timeout)
+        {
+            var dataAdapter = new EventHubDataAdapter(bufferPool);
+            cache = new PooledQueueCache<EventData, CachedEventHubMessage>(dataAdapter) { OnPurged = OnPurged };
+            dataAdapter.PurgeAction = cache.Purge;
+            checkpoint = await EventHubPartitionCheckpoint.Create(config.CheckpointSettings, config.StreamProviderName, config.Partition);
+            string offset = await checkpoint.Load();
+            receiver = await CreateReceiver(config, offset);
+        }
+
+        public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
+        {
+            var localReciever = receiver;
+            if (localReciever == null)
+            {
+                return new List<IBatchContainer>();
+            }
+            List<EventData> messages = (await localReciever.ReceiveAsync(maxCount, ReceiveTimeout)).ToList();
+
+            var batches = new List<IBatchContainer>();
+            if (messages.Count == 0)
+            {
+                return batches;
+            }
+            foreach (EventData message in messages)
+            {
+                cache.Add(message);
+                batches.Add(new StreamActivityNotificationBatch(Guid.Parse(message.PartitionKey),
+                    message.GetStreamNamespaceProperty(), new EventSequenceToken(message.SequenceNumber, 0)));
+
+            }
+
+            if (!checkpoint.Exists)
+            {
+                checkpoint.Update(messages[0].Offset, DateTime.UtcNow);
+            }
+            return batches;
+        }
+
+        public void AddToCache(IList<IBatchContainer> messages)
+        {
+            // do nothing, we add data directly into cache.  No need for agent involvement
+        }
+
+        public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+        {
+            purgedItems = null;
+            return false;
+        }
+
+        public IQueueCacheCursor GetCacheCursor(Guid streamGuid, string streamNamespace, StreamSequenceToken token)
+        {
+            return new Cursor(cache, streamGuid, streamNamespace, token);
+        }
+
+        public bool IsUnderPressure()
+        {
+            return false;
+        }
+
+        public Task MessagesDeliveredAsync(IList<IBatchContainer> messages)
+        {
+            return TaskDone.Done;
+        }
+
+        public async Task Shutdown(TimeSpan timeout)
+        {
+            if (cache != null)
+            {
+                cache.OnPurged = null;
+            }
+            EventHubReceiver localReceiver = Interlocked.Exchange(ref receiver, null);
+            if (localReceiver != null)
+            {
+                await localReceiver.CloseAsync();
+            }
+        }
+
+        private static Task<EventHubReceiver> CreateReceiver(EventHubPartitionConfig partitionConfig, string offset)
+        {
+            EventHubClient client = EventHubClient.CreateFromConnectionString(partitionConfig.Hub.ConnectionString, partitionConfig.Hub.Path);
+            EventHubConsumerGroup consumerGroup = client.GetConsumerGroup(partitionConfig.Hub.ConsumerGroup);
+            if (partitionConfig.Hub.PrefetchCount.HasValue)
+            {
+                consumerGroup.PrefetchCount = partitionConfig.Hub.PrefetchCount.Value;
+            }
+            // if we have a starting offset or if we're not configured to start reading from utc now, read from offset
+            if (!partitionConfig.Hub.StartFromNow || offset != EventHubConsumerGroup.StartOfStream)
+            {
+                return consumerGroup.CreateReceiverAsync(partitionConfig.Partition, offset, true);
+            }
+            return consumerGroup.CreateReceiverAsync(partitionConfig.Partition, DateTime.UtcNow);
+        }
+
+        private void OnPurged(CachedEventHubMessage lastItemPurged)
+        {
+            int readOffset = 0;
+            SegmentBuilder.ReadNextString(lastItemPurged.Segment, ref readOffset); // read namespace, not needed so throw away.
+            string offset = SegmentBuilder.ReadNextString(lastItemPurged.Segment, ref readOffset); // read offset
+            checkpoint.Update(offset, DateTime.UtcNow);
+        }
+
+        private class StreamActivityNotificationBatch : IBatchContainer
+        {
+            public Guid StreamGuid { get; private set; }
+            public string StreamNamespace { get; private set; }
+            public StreamSequenceToken SequenceToken { get; private set; }
+
+            public StreamActivityNotificationBatch(Guid streamGuid, string streamNamespace,
+                StreamSequenceToken sequenceToken)
+            {
+                StreamGuid = streamGuid;
+                StreamNamespace = streamNamespace;
+                SequenceToken = sequenceToken;
+            }
+
+            public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>() { throw new NotSupportedException(); }
+            public bool ImportRequestContext() { throw new NotSupportedException(); }
+            public bool ShouldDeliver(IStreamIdentity stream, object filterData, StreamFilterPredicate shouldReceiveFunc) { throw new NotSupportedException(); }
+        }
 
         private class Cursor : IQueueCacheCursor
         {
@@ -65,113 +196,6 @@ namespace Orleans.ServiceBus.Providers.Streams.EventHub
             public void Refresh()
             {
             }
-        }
-
-        public int MaxAddCount { get { return 1000; } }
-
-        public EventHubAdapterReceiver(EventHubPartitionConfig partitionConfig, IObjectPool<FixedSizeBuffer> bufferPool, Logger log)
-        {
-            dataAdapter = new EventHubDataAdapter(bufferPool, Purge);
-            config = partitionConfig;
-        }
-
-        public void AddToCache(IList<IBatchContainer> messages)
-        {
-            // do nothing, we add data directly into cache.  No need for agent involvment
-        }
-
-        public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
-        {
-            purgedItems = null;
-            return false;
-        }
-
-        public IQueueCacheCursor GetCacheCursor(Guid streamGuid, string streamNamespace, StreamSequenceToken token)
-        {
-            return new Cursor(cache, streamGuid, streamNamespace, token);
-        }
-
-        public bool IsUnderPressure()
-        {
-            return false;
-        }
-
-        private static Task<EventHubReceiver> CreateReceiver(EventHubPartitionConfig partitionConfig)
-        {
-            EventHubClient client = EventHubClient.CreateFromConnectionString(partitionConfig.Hub.ConnectionString, partitionConfig.Hub.Path);
-            EventHubConsumerGroup consumerGroup = client.GetConsumerGroup(partitionConfig.Hub.ConsumerGroup);
-            if (partitionConfig.Hub.PrefetchCount.HasValue)
-            {
-                consumerGroup.PrefetchCount = partitionConfig.Hub.PrefetchCount.Value;
-            }
-            return consumerGroup.CreateReceiverAsync(partitionConfig.Partition, DateTime.UtcNow);
-        }
-
-        public async Task Initialize(TimeSpan timeout)
-        {
-            cache = new PooledQueueCache<EventData, CachedEventHubMessage>(dataAdapter);
-            receiver = await CreateReceiver(config);
-        }
-
-        public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
-        {
-            IEnumerable<EventData> messages = await receiver.ReceiveAsync(maxCount, ReceiveTimeout);
-            return BuildBatchList(messages);
-        }
-
-        public Task MessagesDeliveredAsync(IList<IBatchContainer> messages)
-        {
-            return TaskDone.Done;
-        }
-
-        public async Task Shutdown(TimeSpan timeout)
-        {
-            EventHubReceiver localReceiver = Interlocked.Exchange(ref receiver, null);
-            if (localReceiver != null)
-            {
-                await localReceiver.CloseAsync();
-            }
-        }
-
-        private IList<IBatchContainer> BuildBatchList(IEnumerable<EventData> messages)
-        {
-            var batches = new List<IBatchContainer>();
-            foreach (EventData message in messages)
-            {
-                cache.Add(message);
-                batches.Add(new StreamActivityNotificationBatch(Guid.Parse(message.PartitionKey),
-                    message.GetStreamNamespaceProperty(), new EventSequenceToken(message.SequenceNumber, 0)));
-                
-            }
-            return batches;
-        }
-
-        private void Purge(IDisposable purgedResource)
-        {
-            cache.Purge(purgedResource);
-        }
-
-        /// <summary>
-        /// This batch is primarily used to notify the adapter of stream activity.  It is never delivered
-        ///   to consumers, so does not need to be serializable.
-        /// </summary>
-        private class StreamActivityNotificationBatch : IBatchContainer
-        {
-            public Guid StreamGuid { get; private set; }
-            public string StreamNamespace { get; private set; }
-            public StreamSequenceToken SequenceToken { get; private set; }
-
-            public StreamActivityNotificationBatch(Guid streamGuid, string streamNamespace,
-                StreamSequenceToken sequenceToken)
-            {
-                StreamGuid = streamGuid;
-                StreamNamespace = streamNamespace;
-                SequenceToken = sequenceToken;
-            }
-
-            public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>() { throw new NotSupportedException(); }
-            public bool ImportRequestContext() { throw new NotSupportedException(); }
-            public bool ShouldDeliver(IStreamIdentity stream, object filterData, StreamFilterPredicate shouldReceiveFunc) { throw new NotSupportedException(); }
         }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -6,10 +6,9 @@ using Microsoft.ServiceBus.Messaging;
 using Newtonsoft.Json;
 using Orleans.Runtime;
 using Orleans.Serialization;
-using Orleans.ServiceBus.Providers.Streams.EventHub;
 using Orleans.Streams;
 
-namespace OrleansServiceBusUtils.Providers.Streams.EventHub
+namespace Orleans.ServiceBus.Providers
 {
     [Serializable]
     internal class EventHubBatchContainer : IBatchContainer

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -4,40 +4,35 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.ServiceBus.Messaging;
 using Orleans.Providers.Streams.Common;
-using Orleans.ServiceBus.Providers.Streams.EventHub;
 using Orleans.Streams;
 
-namespace OrleansServiceBusUtils.Providers.Streams.EventHub
+namespace Orleans.ServiceBus.Providers
 {
     /// <summary>
     /// This is a tightly packed cached structure containing an event hub message.  
     /// It should only contain value types.
     /// </summary>
-    public struct CachedEventHubMessage
+    internal struct CachedEventHubMessage
     {
         public Guid StreamGuid;
         public long SequenceNumber;
         public ArraySegment<byte> Segment;
     }
 
-    class EventHubDataAdapter : ICacheDataAdapter<EventData, CachedEventHubMessage>
+    internal class EventHubDataAdapter : ICacheDataAdapter<EventData, CachedEventHubMessage>
     {
         private readonly IObjectPool<FixedSizeBuffer> bufferPool;
-        private readonly Action<IDisposable> purgeAction;
         private FixedSizeBuffer currentBuffer;
 
-        public EventHubDataAdapter(IObjectPool<FixedSizeBuffer> bufferPool, Action<IDisposable> purgeAction)
+        public Action<IDisposable> PurgeAction { private get; set; }
+
+        public EventHubDataAdapter(IObjectPool<FixedSizeBuffer> bufferPool)
         {
             if (bufferPool == null)
             {
                 throw new ArgumentNullException("bufferPool");
             }
-            if (purgeAction == null)
-            {
-                throw new ArgumentNullException("purgeAction");
-            }
             this.bufferPool = bufferPool;
-            this.purgeAction = purgeAction;
         }
 
         public void QueueMessageToCachedMessage(ref CachedEventHubMessage cachedMessage, EventData queueMessage)
@@ -52,7 +47,9 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
         {
             byte[] payloadBytes = queueMessage.GetBytes();
             string streamNamespace = queueMessage.GetStreamNamespaceProperty();
-            int size = CalculateAppendSize(streamNamespace) + CalculateAppendSize(queueMessage.Offset) + CalculateAppendSize(payloadBytes);
+            int size = SegmentBuilder.CalculateAppendSize(streamNamespace) +
+                       SegmentBuilder.CalculateAppendSize(queueMessage.Offset) +
+                       SegmentBuilder.CalculateAppendSize(payloadBytes);
 
             // get segment from current block
             ArraySegment<byte> segment;
@@ -60,7 +57,7 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
             {
                 // no block or block full, get new block and try again
                 currentBuffer = bufferPool.Allocate();
-                currentBuffer.SetPurgeAction(purgeAction);
+                currentBuffer.SetPurgeAction(PurgeAction);
                 // if this fails with clean block, then requested size is too big
                 if (!currentBuffer.TryGetSegment(size, out segment))
                 {
@@ -71,9 +68,9 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
             }
             // encode namespace, offset, and payload into segment
             int writeOffset = 0;
-            Append(segment, ref writeOffset, streamNamespace);
-            Append(segment, ref writeOffset, queueMessage.Offset);
-            Append(segment, ref writeOffset, payloadBytes);
+            SegmentBuilder.Append(segment, ref writeOffset, streamNamespace);
+            SegmentBuilder.Append(segment, ref writeOffset, queueMessage.Offset);
+            SegmentBuilder.Append(segment, ref writeOffset, payloadBytes);
 
             return segment;
         }
@@ -81,9 +78,9 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
         public IBatchContainer GetBatchContainer(ref CachedEventHubMessage cachedMessage)
         {
             int readOffset = 0;
-            string streamNamespace = ReadNextString(cachedMessage.Segment, ref readOffset);
-            string offset = ReadNextString(cachedMessage.Segment, ref readOffset);
-            ArraySegment<byte> payload = ReadNextBytes(cachedMessage.Segment, ref readOffset);
+            string streamNamespace = SegmentBuilder.ReadNextString(cachedMessage.Segment, ref readOffset);
+            string offset = SegmentBuilder.ReadNextString(cachedMessage.Segment, ref readOffset);
+            ArraySegment<byte> payload = SegmentBuilder.ReadNextBytes(cachedMessage.Segment, ref readOffset);
 
             return new EventHubBatchContainer(cachedMessage.StreamGuid, streamNamespace, offset, cachedMessage.SequenceNumber, payload.ToArray());
         }
@@ -109,11 +106,11 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
                 return false;
             }
             int readOffset = 0;
-            string decodedStreamNamespace = ReadNextString(cachedMessage.Segment, ref readOffset);
+            string decodedStreamNamespace = SegmentBuilder.ReadNextString(cachedMessage.Segment, ref readOffset);
             return decodedStreamNamespace == streamNamespace;
         }
 
-        public bool ShouldPurge(CachedEventHubMessage cachedMessage, IDisposable purgeRequest)
+        public bool ShouldPurge(ref CachedEventHubMessage cachedMessage, IDisposable purgeRequest)
         {
             var purgedResource = (FixedSizeBuffer) purgeRequest;
             // if we're purging our current buffer, don't use it any more
@@ -122,134 +119,6 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
                 currentBuffer = null;
             }
             return cachedMessage.Segment.Array == purgedResource.Id;
-        }
-
-        /// <summary>
-        /// Calculates how much space will be needed to append the provided bytes into the segment.
-        /// </summary>
-        /// <param name="bytes"></param>
-        /// <returns></returns>
-        private static int CalculateAppendSize(byte[] bytes)
-        {
-            return (bytes == null || bytes.Length == 0)
-                ? sizeof(int)
-                : bytes.Length + sizeof(int);
-        }
-
-        /// <summary>
-        /// Calculates how much space will be needed to append the provided string into the segment.
-        /// </summary>
-        /// <param name="str"></param>
-        /// <returns></returns>
-        private static int CalculateAppendSize(string str)
-        {
-            return (string.IsNullOrEmpty(str))
-                ? sizeof(int)
-                : str.Length * sizeof(char) + sizeof(int);
-        }
-
-        /// <summary>
-        /// Appends an array of bytes to the end of the segment
-        /// </summary>
-        /// <param name="writerOffset"></param>
-        /// <param name="bytes"></param>
-        /// <param name="segment"></param>
-        private static void Append(ArraySegment<byte> segment, ref int writerOffset, byte[] bytes)
-        {
-            if (segment.Array == null)
-            {
-                throw new ArgumentNullException("segment");
-            }
-            if (bytes == null)
-            {
-                throw new ArgumentNullException("bytes");
-            }
-
-            if (bytes.Length == 0)
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(0), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
-                writerOffset += sizeof(int);
-            }
-            else
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(bytes.Length), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
-                writerOffset += sizeof(int);
-                Buffer.BlockCopy(bytes, 0, segment.Array, segment.Offset + writerOffset, bytes.Length);
-                writerOffset += bytes.Length;
-            }
-        }
-
-        /// <summary>
-        /// Appends a string to the end of the segment
-        /// </summary>
-        /// <param name="writerOffset"></param>
-        /// <param name="str"></param>
-        /// <param name="segment"></param>
-        private static void Append(ArraySegment<byte> segment, ref int writerOffset, string str)
-        {
-            if (segment.Array == null)
-            {
-                throw new ArgumentNullException("segment");
-            }
-            if (str == null)
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(-1), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
-                writerOffset += sizeof(int);
-            }
-            else if (string.IsNullOrEmpty(str))
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(0), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
-                writerOffset += sizeof(int);
-            }
-            else
-            {
-                var bytes = new byte[str.Length * sizeof(char)];
-                Buffer.BlockCopy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
-                Append(segment, ref writerOffset, bytes);
-            }
-        }
-
-        /// <summary>
-        /// Reads the next item in the segment as a byte array.  For performance, this is returned as a sub-segment of the original segment.
-        /// </summary>
-        /// <returns></returns>
-        private static ArraySegment<byte> ReadNextBytes(ArraySegment<byte> segment, ref int readerOffset)
-        {
-            if (segment.Array == null)
-            {
-                throw new ArgumentNullException("segment");
-            }
-            int size = BitConverter.ToInt32(segment.Array, segment.Offset + readerOffset);
-            readerOffset += sizeof(int);
-            var seg = new ArraySegment<byte>(segment.Array, segment.Offset + readerOffset, size);
-            readerOffset += size;
-            return seg;
-        }
-
-        /// <summary>
-        /// Reads the next item in the segment as a string.
-        /// </summary>
-        /// <returns></returns>
-        private static string ReadNextString(ArraySegment<byte> segment, ref int readerOffset)
-        {
-            if (segment.Array == null)
-            {
-                throw new ArgumentNullException("segment");
-            }
-            int size = BitConverter.ToInt32(segment.Array, segment.Offset + readerOffset);
-            readerOffset += sizeof(int);
-            if (size < 0)
-            {
-                return null;
-            }
-            if (size == 0)
-            {
-                return string.Empty;
-            }
-            var chars = new char[size / sizeof(char)];
-            Buffer.BlockCopy(segment.Array, segment.Offset + readerOffset, chars, 0, size);
-            readerOffset += size;
-            return new string(chars);
         }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpoint.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpoint.cs
@@ -1,0 +1,89 @@
+﻿
+using System;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using Orleans.AzureUtils;
+
+namespace Orleans.ServiceBus.Providers
+{
+    /// <summary>
+    /// This class stores EventHub partition checkpoint information (a partition offset) in azure table storage.
+    /// TODO: Use dependency injection to fill this behavior.
+    /// This class stores data into table storage, which will not be ideal for all users.  Further, it introduces
+    ///   a dependency on azure storage to this assembly.  Ideally this should be an injectable behavior, rather
+    ///   than a concrete class.
+    /// </summary>
+    internal class EventHubPartitionCheckpoint
+    {
+        private readonly AzureTableDataManager<EventHubPartitionCheckpointEntity> dataManager;
+        private readonly TimeSpan persistInterval;
+
+        private EventHubPartitionCheckpointEntity entity;
+        private Task inProgressSave;
+        private DateTime? throttleSavesUntilUtc;
+
+        public bool Exists { get { return entity != null && entity.Offset != EventHubConsumerGroup.StartOfStream; } }
+
+        public static async Task<EventHubPartitionCheckpoint> Create(ICheckpointSettings settings, string streamProviderName, string partition)
+        {
+            var checkpoint = new EventHubPartitionCheckpoint(settings, streamProviderName, partition);
+            await checkpoint.Initialize();
+            return checkpoint;
+        }
+
+        private EventHubPartitionCheckpoint(ICheckpointSettings settings, string streamProviderName, string partition)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            if (string.IsNullOrWhiteSpace(streamProviderName))
+            {
+                throw new ArgumentNullException("streamProviderName");
+            }
+            if (string.IsNullOrWhiteSpace(partition))
+            {
+                throw new ArgumentNullException("partition");
+            }
+            persistInterval = settings.PersistInterval;
+            dataManager = new AzureTableDataManager<EventHubPartitionCheckpointEntity>(settings.TableName, settings.DataConnectionString);
+            entity = EventHubPartitionCheckpointEntity.Create(streamProviderName, settings.CheckpointNamespace, partition);
+        }
+
+        private Task Initialize()
+        {
+            return dataManager.InitTableAsync();
+        }
+
+        public async Task<string> Load()
+        {
+            Tuple<EventHubPartitionCheckpointEntity, string> results =
+                await dataManager.ReadSingleTableEntryAsync(entity.PartitionKey, entity.RowKey);
+            if (results != null)
+            {
+                entity = results.Item1;
+            }
+            return entity.Offset;
+        }
+
+        public void Update(string offset, DateTime utcNow)
+        {
+            // if offset has not changed, do nothing
+            if (string.Compare(entity.Offset, offset, StringComparison.InvariantCulture)==0)
+            {
+                return;
+            }
+
+            // if we've saved before but it's not time for another save or the last save operation has not completed, do nothing
+            if (throttleSavesUntilUtc.HasValue && (throttleSavesUntilUtc.Value > utcNow || !inProgressSave.IsCompleted))
+            {
+                return;
+            }
+
+            entity.Offset = offset;
+            throttleSavesUntilUtc = utcNow + persistInterval;
+            inProgressSave = dataManager.UpsertTableEntryAsync(entity);
+            inProgressSave.Ignore();
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
@@ -1,0 +1,39 @@
+﻿
+using System;
+using Microsoft.ServiceBus.Messaging;
+using Microsoft.WindowsAzure.Storage.Table;
+using Orleans.AzureUtils;
+
+namespace Orleans.ServiceBus.Providers
+{
+    internal class EventHubPartitionCheckpointEntity : TableEntity
+    {
+        public string Offset { get; set; }
+
+        public EventHubPartitionCheckpointEntity()
+        {
+            Offset = EventHubConsumerGroup.StartOfStream;
+        }
+
+        public static EventHubPartitionCheckpointEntity Create(string streamProviderName, string checkpointNamespace, string partition)
+        {
+            return new EventHubPartitionCheckpointEntity
+            {
+                PartitionKey = MakePartitionKey(streamProviderName, checkpointNamespace),
+                RowKey = MakeRowKey(partition)
+            };
+        }
+
+        public static string MakePartitionKey(string streamProviderName, string checkpointNamespace)
+        {
+            string key = String.Format("EHCheckpoints_{0}_{1}", streamProviderName, checkpointNamespace);
+            return AzureStorageUtils.SanitizeTableProperty(key);
+        }
+
+        public static string MakeRowKey(string partition)
+        {
+            string key = String.Format("partition_{0}", partition);
+            return AzureStorageUtils.SanitizeTableProperty(key);
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueMapper.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueMapper.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 using System.Linq;
 using Orleans.Streams;
 
-namespace Orleans.ServiceBus.Providers.Streams.EventHub
+namespace Orleans.ServiceBus.Providers
 {
     internal class EventHubQueueMapper : HashRingBasedStreamQueueMapper
     {

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -3,7 +3,7 @@ using System;
 using System.Globalization;
 using Orleans.Providers.Streams.Common;
 
-namespace Orleans.ServiceBus.Providers.Streams.EventHub
+namespace Orleans.ServiceBus.Providers
 {
     /// <summary>
     /// Event Hub messages consist of a batch of application layer events, so EventHub tokens contain three pieces of information.

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSettings.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Orleans.Providers;
 
-namespace OrleansServiceBusUtils.Providers.Streams.EventHub
+namespace Orleans.ServiceBus.Providers
 {
     [Serializable]
     public class EventHubSettings : IEventHubSettings
@@ -14,10 +14,12 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
         private const string PathName = "EventHubPath";
         private const string PrefetchCountName = "EventHubPrefetchCount";
         private const int InvalidPrefetchCount = -1;
+        private const string StartFromNowName = "StartFromNow";
+        private const bool StartFromNowDefault = true;
 
-        public EventHubSettings() { }
+        public EventHubSettings(){}
 
-        public EventHubSettings(string connectionString, string consumerGroup, string path, int? prefetchCount = null)
+        public EventHubSettings(string connectionString, string consumerGroup, string path, bool startFromNow = StartFromNowDefault, int? prefetchCount = null)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -35,11 +37,14 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
             ConsumerGroup = consumerGroup;
             Path = path;
             PrefetchCount = prefetchCount;
+            StartFromNow = startFromNow;
         }
+
         public string ConnectionString { get; private set; }
         public string ConsumerGroup { get; private set; }
         public string Path { get; private set; }
         public int? PrefetchCount { get; private set; }
+        public bool StartFromNow { get; private set; }
 
         /// <summary>
         /// Utility function to convert config to property bag for use in stream provider configuration
@@ -54,6 +59,7 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
             {
                 properties.Add(PrefetchCountName, PrefetchCount.Value.ToString(CultureInfo.InvariantCulture));
             }
+            properties.Add(StartFromNowName, StartFromNow.ToString());
         }
 
         /// <summary>
@@ -82,6 +88,7 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
             {
                 PrefetchCount = null;
             }
+            StartFromNow = providerConfiguration.GetBoolProperty(StartFromNowName, StartFromNowDefault);
         }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProvider.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProvider.cs
@@ -5,7 +5,6 @@ namespace Orleans.ServiceBus.Providers
 {
     /// <summary>
     /// Persistent stream provider that uses EventHub for persistence
-    /// TODO: This stream provider is still under development.  DO NOT USE IN PRODUCTION - jbragg
     ///  </summary>
     public class EventHubStreamProvider : PersistentStreamProvider<EventHubAdapterFactory>
     {

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
@@ -11,33 +11,87 @@ namespace Orleans.ServiceBus.Providers
         public const string EventHubConfigTypeName = "EventHubSettingsType";
         public Type EventHubSettingsType { get; set; }
 
+        public const string CheckpointSettingsTypeName = "CheckpointSettingsType";
+        public Type CheckpointSettingsType { get; set; }
+
         public string StreamProviderName { get; private set; }
 
         public const string CacheSizeMbName = "CacheSizeMb";
-        private const int DefaultCacheSizeMb = 100; // default to 100mb cache.
+        private const int DefaultCacheSizeMb = 128; // default to 128mb cache.
         public int CacheSizeMb { get; private set; }
 
-        public EventHubStreamProviderConfig(string streamProviderName)
+        public EventHubStreamProviderConfig(string streamProviderName, int cacheSizeMb = DefaultCacheSizeMb)
         {
             StreamProviderName = streamProviderName;
-            CacheSizeMb = DefaultCacheSizeMb;
+            CacheSizeMb = cacheSizeMb;
         }
 
         public void WriteProperties(Dictionary<string, string> properties)
         {
-            if (EventHubSettingsType!=null)
+            if (EventHubSettingsType != null)
                 properties.Add(EventHubConfigTypeName, EventHubSettingsType.AssemblyQualifiedName);
+            if (CheckpointSettingsType != null)
+                properties.Add(CheckpointSettingsTypeName, CheckpointSettingsType.AssemblyQualifiedName);
             properties.Add(CacheSizeMbName, CacheSizeMb.ToString(CultureInfo.InvariantCulture));
         }
 
-        public virtual void PopulateFromProviderConfig(IProviderConfiguration providerConfiguration)
+        public void PopulateFromProviderConfig(IProviderConfiguration providerConfiguration)
         {
             EventHubSettingsType = providerConfiguration.GetTypeProperty(EventHubConfigTypeName, null);
+            CheckpointSettingsType = providerConfiguration.GetTypeProperty(CheckpointSettingsTypeName, null);
             if (string.IsNullOrWhiteSpace(StreamProviderName))
             {
                 throw new ArgumentOutOfRangeException("providerConfiguration", "StreamProviderName not set.");
             }
             CacheSizeMb = providerConfiguration.GetIntProperty(CacheSizeMbName, DefaultCacheSizeMb);
+        }
+
+        public IEventHubSettings GetEventHubSettings(IProviderConfiguration providerConfig, IServiceProvider serviceProvider)
+        {
+            // if no event hub settings type is provided, use EventHubSettings and get populate settings from providerConfig
+            if (EventHubSettingsType == null)
+            {
+                EventHubSettingsType = typeof(EventHubSettings);
+            }
+
+            var hubSettings = serviceProvider.GetService(EventHubSettingsType) as IEventHubSettings;
+            if (hubSettings == null)
+            {
+                throw new ArgumentOutOfRangeException("providerConfig", "EventHubSettingsType not valid.");
+            }
+
+            // if settings is an EventHubSettings class, populate settings from providerConfig
+            var settings = hubSettings as EventHubSettings;
+            if (settings != null)
+            {
+                settings.PopulateFromProviderConfig(providerConfig);
+            }
+
+            return hubSettings;
+        }
+
+        public ICheckpointSettings GetCheckpointSettings(IProviderConfiguration providerConfig, IServiceProvider serviceProvider)
+        {
+            // if no checkpoint settings type is provided, use EventHubCheckpointSettings and get populate settings from providerConfig
+            if (CheckpointSettingsType == null)
+            {
+                CheckpointSettingsType = typeof(EventHubCheckpointSettings);
+            }
+
+            var checkpointConfig = serviceProvider.GetService(CheckpointSettingsType) as ICheckpointSettings;
+            if (checkpointConfig == null)
+            {
+                throw new ArgumentOutOfRangeException("providerConfig", "CheckpointSettingsType not valid.");
+            }
+
+            // if settings is an EventHubCheckpointSettings class, populate settings from providerConfig
+            var settings = checkpointConfig as EventHubCheckpointSettings;
+            if (settings != null)
+            {
+                settings.PopulateFromProviderConfig(providerConfig);
+            }
+
+            return checkpointConfig;
         }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/ICheckpointSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/ICheckpointSettings.cs
@@ -1,0 +1,102 @@
+﻿
+using System;
+using System.Collections.Generic;
+using Orleans.Providers;
+
+namespace Orleans.ServiceBus.Providers
+{
+    public interface ICheckpointSettings
+    {
+        /// <summary>
+        /// Azure table storage data connections string
+        /// </summary>
+        string DataConnectionString { get; }
+
+        /// <summary>
+        /// Azure storage table name where the checkpoints will be stored
+        /// </summary>
+        string TableName { get; }
+
+        /// <summary>
+        /// How often to persist the checkpoints, if they've changed.
+        /// </summary>
+        TimeSpan PersistInterval { get; }
+
+        /// <summary>
+        /// This name partitions a services checkpoint information from other services.
+        /// </summary>
+        string CheckpointNamespace { get; }
+    }
+
+    public class EventHubCheckpointSettings : ICheckpointSettings
+    {
+        private const string DataConnectionStringName = "CheckpointDataConnectionString";
+        private const string TableNameName = "CheckpointTableName";
+        private const string PersistIntervalName = "CheckpointPersistInterval";
+        private const string CheckpointNamespaceName = "CheckpointNamespace";
+        private static readonly TimeSpan DefaultPersistInterval = TimeSpan.FromMinutes(1);
+
+        public EventHubCheckpointSettings(){}
+
+        public EventHubCheckpointSettings(string dataConnectionString, string table, string checkpointNamespace, TimeSpan? persistInterval = null)
+        {
+            if (string.IsNullOrWhiteSpace(dataConnectionString))
+            {
+                throw new ArgumentNullException("dataConnectionString");
+            }
+            if (string.IsNullOrWhiteSpace(table))
+            {
+                throw new ArgumentNullException("table");
+            }
+            if (string.IsNullOrWhiteSpace(checkpointNamespace))
+            {
+                throw new ArgumentNullException("checkpointNamespace");
+            }
+            DataConnectionString = dataConnectionString;
+            TableName = table;
+            CheckpointNamespace = checkpointNamespace;
+            PersistInterval = persistInterval.HasValue ? persistInterval.Value : DefaultPersistInterval;
+        }
+
+        public string DataConnectionString { get; private set; }
+        public string TableName { get; private set; }
+        public TimeSpan PersistInterval { get; private set; }
+        public string CheckpointNamespace { get; private set; }
+
+        /// <summary>
+        /// Utility function to convert config to property bag for use in stream provider configuration
+        /// </summary>
+        /// <returns></returns>
+        public void WriteProperties(Dictionary<string, string> properties)
+        {
+            properties.Add(DataConnectionStringName, DataConnectionString);
+            properties.Add(TableNameName, TableName);
+            properties.Add(PersistIntervalName, PersistInterval.ToString());
+            properties.Add(CheckpointNamespaceName, CheckpointNamespace);
+        }
+
+        /// <summary>
+        /// Utility function to populate config from provider config
+        /// </summary>
+        /// <param name="providerConfiguration"></param>
+        public virtual void PopulateFromProviderConfig(IProviderConfiguration providerConfiguration)
+        {
+            DataConnectionString = providerConfiguration.GetProperty(DataConnectionStringName, null);
+            if (string.IsNullOrWhiteSpace(DataConnectionString))
+            {
+                throw new ArgumentOutOfRangeException("providerConfiguration", DataConnectionStringName + " not set.");
+            }
+            TableName = providerConfiguration.GetProperty(TableNameName, null);
+            if (string.IsNullOrWhiteSpace(TableName))
+            {
+                throw new ArgumentOutOfRangeException("providerConfiguration", TableNameName + " not set.");
+            }
+            PersistInterval = providerConfiguration.GetTimeSpanProperty(PersistIntervalName, DefaultPersistInterval);
+            CheckpointNamespace = providerConfiguration.GetProperty(CheckpointNamespaceName, null);
+            if (string.IsNullOrWhiteSpace(CheckpointNamespace))
+            {
+                throw new ArgumentOutOfRangeException("providerConfiguration", CheckpointNamespaceName + " not set.");
+            }
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubSettings.cs
@@ -1,5 +1,6 @@
 ﻿
-namespace OrleansServiceBusUtils.Providers.Streams.EventHub
+
+namespace Orleans.ServiceBus.Providers
 {
     public interface IEventHubSettings
     {
@@ -7,5 +8,6 @@ namespace OrleansServiceBusUtils.Providers.Streams.EventHub
         string ConsumerGroup { get; }
         string Path { get; }
         int? PrefetchCount { get; }
+        bool StartFromNow { get; }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/SegmentBuilder.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/SegmentBuilder.cs
@@ -1,0 +1,130 @@
+﻿using System;
+
+namespace Orleans.ServiceBus.Providers
+{
+    internal static class SegmentBuilder
+    {
+        /// <summary>
+        /// Calculates how much space will be needed to append the provided bytes into the segment.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public static int CalculateAppendSize(byte[] bytes)
+        {
+            return (bytes == null || bytes.Length == 0)
+                ? sizeof(int)
+                : bytes.Length + sizeof(int);
+        }
+
+        /// <summary>
+        /// Calculates how much space will be needed to append the provided string into the segment.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public static int CalculateAppendSize(string str)
+        {
+            return (string.IsNullOrEmpty(str))
+                ? sizeof(int)
+                : str.Length * sizeof(char) + sizeof(int);
+        }
+
+        /// <summary>
+        /// Appends an array of bytes to the end of the segment
+        /// </summary>
+        /// <param name="writerOffset"></param>
+        /// <param name="bytes"></param>
+        /// <param name="segment"></param>
+        public static void Append(ArraySegment<byte> segment, ref int writerOffset, byte[] bytes)
+        {
+            if (segment.Array == null)
+            {
+                throw new ArgumentNullException("segment");
+            }
+            if (bytes == null)
+            {
+                throw new ArgumentNullException("bytes");
+            }
+
+            Buffer.BlockCopy(BitConverter.GetBytes(bytes.Length), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+            writerOffset += sizeof(int);
+            if (bytes.Length != 0)
+            {
+                Buffer.BlockCopy(bytes, 0, segment.Array, segment.Offset + writerOffset, bytes.Length);
+                writerOffset += bytes.Length;
+            }
+        }
+
+        /// <summary>
+        /// Appends a string to the end of the segment
+        /// </summary>
+        /// <param name="writerOffset"></param>
+        /// <param name="str"></param>
+        /// <param name="segment"></param>
+        public static void Append(ArraySegment<byte> segment, ref int writerOffset, string str)
+        {
+            if (segment.Array == null)
+            {
+                throw new ArgumentNullException("segment");
+            }
+            if (str == null)
+            {
+                Buffer.BlockCopy(BitConverter.GetBytes(-1), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+                writerOffset += sizeof(int);
+            }
+            else if (string.IsNullOrEmpty(str))
+            {
+                Buffer.BlockCopy(BitConverter.GetBytes(0), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+                writerOffset += sizeof(int);
+            }
+            else
+            {
+                var bytes = new byte[str.Length * sizeof(char)];
+                Buffer.BlockCopy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
+                Append(segment, ref writerOffset, bytes);
+            }
+        }
+
+        /// <summary>
+        /// Reads the next item in the segment as a byte array.  For performance, this is returned as a sub-segment of the original segment.
+        /// </summary>
+        /// <returns></returns>
+        public static ArraySegment<byte> ReadNextBytes(ArraySegment<byte> segment, ref int readerOffset)
+        {
+            if (segment.Array == null)
+            {
+                throw new ArgumentNullException("segment");
+            }
+            int size = BitConverter.ToInt32(segment.Array, segment.Offset + readerOffset);
+            readerOffset += sizeof(int);
+            var seg = new ArraySegment<byte>(segment.Array, segment.Offset + readerOffset, size);
+            readerOffset += size;
+            return seg;
+        }
+
+        /// <summary>
+        /// Reads the next item in the segment as a string.
+        /// </summary>
+        /// <returns></returns>
+        public static string ReadNextString(ArraySegment<byte> segment, ref int readerOffset)
+        {
+            if (segment.Array == null)
+            {
+                throw new ArgumentNullException("segment");
+            }
+            int size = BitConverter.ToInt32(segment.Array, segment.Offset + readerOffset);
+            readerOffset += sizeof(int);
+            if (size < 0)
+            {
+                return null;
+            }
+            if (size == 0)
+            {
+                return string.Empty;
+            }
+            var chars = new char[size / sizeof(char)];
+            Buffer.BlockCopy(segment.Array, segment.Offset + readerOffset, chars, 0, size);
+            readerOffset += size;
+            return new string(chars);
+        }
+    }
+}

--- a/src/OrleansServiceBus/packages.config
+++ b/src/OrleansServiceBus/packages.config
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
   <package id="WindowsAzure.ServiceBus" version="3.0.8" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net451" />
 </packages>

--- a/src/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
+++ b/src/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Runtime;
 
 namespace TestGrainInterfaces
 {
@@ -12,5 +13,7 @@ namespace TestGrainInterfaces
         Task<IDictionary<Guid,int>> GetReport(string streamProvider, string streamNamespace);
 
         Task Reset();
+
+        Task<bool> IsLocatedOnSilo(SiloAddress siloAddress);
     }
 }

--- a/src/TestGrains/GeneratedEvent.cs
+++ b/src/TestGrains/GeneratedEvent.cs
@@ -8,9 +8,10 @@ namespace TestGrains
         public enum GeneratedEventType
         {
             Fill,
-            End,
+            Report,
         }
 
         public GeneratedEventType EventType { get; set; }
+        public int[] Payload { get; set; }
     }
 }

--- a/src/TestGrains/GeneratedEventReporterGrain.cs
+++ b/src/TestGrains/GeneratedEventReporterGrain.cs
@@ -52,5 +52,10 @@ namespace TestGrains
             reports = new Dictionary<Tuple<string, string>, Dictionary<Guid, int>>();
             return TaskDone.Done;
         }
+
+        public Task<bool> IsLocatedOnSilo(SiloAddress siloAddress)
+        {
+            return Task.FromResult(RuntimeIdentity == siloAddress.ToLongString());
+        }
     }
 }

--- a/src/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
+++ b/src/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
@@ -116,7 +116,7 @@ namespace TestGrains
 
             State.Accumulator++;
             State.LastProcessedToken = sequenceToken;
-            if (evt.EventType != GeneratedEvent.GeneratedEventType.End)
+            if (evt.EventType != GeneratedEvent.GeneratedEventType.Report)
             {
                 Faults.onFirstMessageProcessedFault.TryFire(InjectFault);
                 Faults.on33rdMessageFault.TryFire(InjectFault);

--- a/src/TestGrains/TestGrains.csproj
+++ b/src/TestGrains/TestGrains.csproj
@@ -72,6 +72,7 @@
     <Compile Include="GeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs" />
     <Compile Include="GeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs" />
     <Compile Include="ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs" />
+    <Compile Include="ImplicitSubscription_RecoverableStream_CollectorGrain.cs" />
     <Compile Include="ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs" />
     <Compile Include="GeneratedEventReporterGrain.cs" />
     <Compile Include="GeneratorTestDerivedDerivedGrain.cs" />

--- a/src/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
+++ b/src/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
@@ -51,6 +51,8 @@ namespace UnitTests.OrleansRuntime.Streams
 
         private class TestCacheDataAdapter : ICacheDataAdapter<TestQueueMessage, TestCachedMessage>
         {
+            public Action<IDisposable> PurgeAction { private get; set; }
+
             public void QueueMessageToCachedMessage(ref TestCachedMessage cachedMessage, TestQueueMessage queueMessage)
             {
                 cachedMessage.StreamGuid = queueMessage.StreamGuid;
@@ -82,7 +84,7 @@ namespace UnitTests.OrleansRuntime.Streams
                 return cachedMessage.StreamGuid == streamGuid && streamNamespace == null;
             }
 
-            public bool ShouldPurge(TestCachedMessage cachedMessage, IDisposable purgeRequest)
+            public bool ShouldPurge(ref TestCachedMessage cachedMessage, IDisposable purgeRequest)
             {
                 throw new NotImplementedException();
             }

--- a/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -5,11 +5,12 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Table;
 using Orleans;
+using Orleans.AzureUtils;
 using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
 using Orleans.TestingHost;
-using OrleansServiceBusUtils.Providers.Streams.EventHub;
 using Tester;
 using Tester.StreamingTests;
 using TestGrains;
@@ -19,65 +20,82 @@ using Xunit;
 
 namespace UnitTests.StreamingTests
 {
-    public class EHImplicitSubscriptionStreamRecoveryTestsFixture : BaseClusterFixture
+    public class EHImplicitSubscriptionStreamRecoveryTests :  OrleansTestingBase, IClassFixture<EHImplicitSubscriptionStreamRecoveryTests.Fixture>
     {
-        public const string StreamProviderName = GeneratedStreamTestConstants.StreamProviderName;
+        private const string StreamProviderName = GeneratedStreamTestConstants.StreamProviderName;
         private const string EHPath = "ehorleanstest";
         private const string EHConsumerGroup = "orleansnightly";
+        private const string EHCheckpointTable = "ehcheckpoint";
+        private static readonly string CheckpointNamespace = Guid.NewGuid().ToString();
 
-        private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString, EHConsumerGroup, EHPath);
+        private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
+                EHConsumerGroup, EHPath);
 
-        private static readonly EventHubStreamProviderConfig ProviderConfig = new EventHubStreamProviderConfig(StreamProviderName);
+        private static readonly EventHubStreamProviderConfig ProviderConfig =
+            new EventHubStreamProviderConfig(StreamProviderName);
 
-        public EHImplicitSubscriptionStreamRecoveryTestsFixture()
-            : base(new TestingSiloHost(
-                new TestingSiloOptions
-                {
-                    StartFreshOrleans = true,
-                    SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
-                    AdjustConfig = config =>
-                    {
-                        // register stream provider
-                        config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
-
-                        // Make sure a node config exist for each silo in the cluster.
-                        // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
-                        config.GetOrCreateNodeConfigurationForSilo("Primary");
-                        config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
-                    }
-                }, new TestingClientOptions()
-                {
-                    AdjustConfig = config =>
-                    {
-                        config.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
-                        config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 40001));
-                    },
-                }))
-        {
-        }
-
-        private static Dictionary<string, string> BuildProviderSettings()
-        {
-            var settings = new Dictionary<string, string>();
-
-            // get initial settings from configs
-            ProviderConfig.WriteProperties(settings);
-            EventHubConfig.WriteProperties(settings);
-
-            // add queue balancer setting
-            settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());
-
-            // add pub/sub settting
-            settings.Add(PersistentStreamProviderConfig.STREAM_PUBSUB_TYPE, StreamPubSubType.ImplicitOnly.ToString());
-            return settings;
-        }
-    }
-
-    public class EHImplicitSubscriptionStreamRecoveryTests :  OrleansTestingBase, IClassFixture<EHImplicitSubscriptionStreamRecoveryTestsFixture>
-    {
-        private static readonly string StreamProviderName = EHImplicitSubscriptionStreamRecoveryTestsFixture.StreamProviderName;
+        private static readonly EventHubCheckpointSettings CheckpointSettings =
+            new EventHubCheckpointSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
+                TimeSpan.FromSeconds(1));
 
         private readonly ImplicitSubscritionRecoverableStreamTestRunner runner;
+
+        private class Fixture : BaseClusterFixture
+        {
+            public Fixture()
+                : base(new TestingSiloHost(
+                    new TestingSiloOptions
+                    {
+                        StartFreshOrleans = true,
+                        SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
+                        AdjustConfig = config =>
+                        {
+                            // register stream provider
+                            config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName,
+                                BuildProviderSettings());
+
+                            // Make sure a node config exist for each silo in the cluster.
+                            // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
+                            config.GetOrCreateNodeConfigurationForSilo("Primary");
+                            config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
+                        }
+                    }, new TestingClientOptions
+                    {
+                        AdjustConfig = config =>
+                        {
+                            config.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName,
+                                BuildProviderSettings());
+                            config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 40001));
+                        },
+                    }))
+            {
+            }
+
+            public override void Dispose()
+            {
+                var dataManager = new AzureTableDataManager<TableEntity>(CheckpointSettings.TableName, CheckpointSettings.DataConnectionString);
+                dataManager.InitTableAsync().Wait();
+                dataManager.DeleteTableAsync().Wait();
+                base.Dispose();
+            }
+
+            private static Dictionary<string, string> BuildProviderSettings()
+            {
+                var settings = new Dictionary<string, string>();
+
+                // get initial settings from configs
+                ProviderConfig.WriteProperties(settings);
+                EventHubConfig.WriteProperties(settings);
+                CheckpointSettings.WriteProperties(settings);
+
+                // add queue balancer setting
+                settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());
+
+                // add pub/sub settting
+                settings.Add(PersistentStreamProviderConfig.STREAM_PUBSUB_TYPE, StreamPubSubType.ImplicitOnly.ToString());
+                return settings;
+            }
+        }
 
         public EHImplicitSubscriptionStreamRecoveryTests()
         {
@@ -117,7 +135,7 @@ namespace UnitTests.StreamingTests
             // send end events
             for (int j = 0; j < streamCount; j++)
             {
-                await producers[j].OnNextAsync(new GeneratedEvent { EventType = GeneratedEvent.GeneratedEventType.End });
+                await producers[j].OnNextAsync(new GeneratedEvent { EventType = GeneratedEvent.GeneratedEventType.Report });
             }
         }
     }

--- a/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
+++ b/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
@@ -1,0 +1,214 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Table;
+using Orleans;
+using Orleans.AzureUtils;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.ServiceBus.Providers;
+using Orleans.Storage;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using TestGrainInterfaces;
+using TestGrains;
+using UnitTests.Grains;
+using UnitTests.Tester;
+using Xunit;
+
+namespace UnitTests.StreamingTests
+{
+    public class EHStreamProviderCheckpointTests : HostedTestClusterPerTest
+    {
+        private static readonly string StreamProviderTypeName = typeof(EventHubStreamProvider).FullName;
+        private const string StreamProviderName = GeneratedStreamTestConstants.StreamProviderName;
+        private const string EHPath = "ehorleanstest";
+        private const string EHConsumerGroup = "orleansnightly";
+        private const string EHCheckpointTable = "ehcheckpoint";
+        private static readonly string CheckpointNamespace = Guid.NewGuid().ToString();
+
+        private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
+            EHConsumerGroup, EHPath);
+
+        private static readonly EventHubStreamProviderConfig ProviderConfig =
+            new EventHubStreamProviderConfig(StreamProviderName, 3);
+
+        private static readonly EventHubCheckpointSettings CheckpointSettings =
+            new EventHubCheckpointSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
+                TimeSpan.FromSeconds(1));
+
+        public override TestingSiloHost CreateSiloHost()
+        {
+            return new TestingSiloHost(new TestingSiloOptions
+                {
+                    StartFreshOrleans = true,
+                    SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
+                    AdjustConfig = AdjustConfig
+                }, new TestingClientOptions
+                {
+                    AdjustConfig = AdjustConfig
+                });
+        }
+        
+        [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task ReloadFromCheckpointTest()
+        {
+            logger.Info("************************ EHReloadFromCheckpointTest *********************************");
+            await ReloadFromCheckpointTest(ImplicitSubscription_RecoverableStream_CollectorGrain.StreamNamespace, 1, 256);
+        }
+
+        [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task RestartSiloAfterCheckpointTest()
+        {
+            logger.Info("************************ EHRestartSiloAfterCheckpointTest *********************************");
+            await RestartSiloAfterCheckpointTest(ImplicitSubscription_RecoverableStream_CollectorGrain.StreamNamespace, 8, 32);
+        }
+
+        public override void Dispose()
+        {
+            var dataManager = new AzureTableDataManager<TableEntity>(CheckpointSettings.TableName, CheckpointSettings.DataConnectionString);
+            dataManager.InitTableAsync().Wait();
+            dataManager.DeleteTableAsync().Wait();
+            base.Dispose();
+        }
+
+        private async Task ReloadFromCheckpointTest(string streamNamespace, int streamCount, int eventsInStream)
+        {
+            List<Guid> streamGuids = Enumerable.Range(0, streamCount).Select(_=>Guid.NewGuid()).ToList();
+            try
+            {
+                await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
+                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream, assertIsTrue), TimeSpan.FromSeconds(30));
+
+                await RestartAgents();
+
+                await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
+                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream*2, assertIsTrue), TimeSpan.FromSeconds(30));
+            }
+            finally
+            {
+                var reporter = GrainClient.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
+                reporter.Reset().Ignore();
+            }
+        }
+
+        private async Task RestartSiloAfterCheckpointTest(string streamNamespace, int streamCount, int eventsInStream)
+        {
+            List<Guid> streamGuids = Enumerable.Range(0, streamCount).Select(_ => Guid.NewGuid()).ToList();
+            try
+            {
+                await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 0);
+                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream, assertIsTrue), TimeSpan.FromSeconds(30));
+
+                HostedCluster.RestartSilo(HostedCluster.Secondary);
+                await HostedCluster.WaitForLivenessToStabilizeAsync();
+
+                await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 0);
+                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, assertIsTrue), TimeSpan.FromSeconds(90));
+            }
+            finally
+            {
+                var reporter = GrainClient.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
+                reporter.Reset().Ignore();
+            }
+        }
+
+        private async Task<bool> CheckCounters(string streamNamespace, int streamCount, int eventsInStream, bool assertIsTrue)
+        {
+            var reporter = GrainClient.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
+
+            var report = await reporter.GetReport(StreamProviderName, streamNamespace);
+            if (assertIsTrue)
+            {
+                // one stream per queue
+                Assert.Equal(streamCount, report.Count);
+                foreach (int eventsPerStream in report.Values)
+                {
+                    Assert.Equal(eventsInStream, eventsPerStream);
+                }
+            }
+            else if (streamCount != report.Count ||
+                     report.Values.Any(count => count != eventsInStream))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        private async Task RestartAgents()
+        {
+            var mgmt = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
+
+            await mgmt.SendControlCommandToProvider(StreamProviderTypeName, StreamProviderName, (int)PersistentStreamProviderCommand.StopAgents);
+            await mgmt.SendControlCommandToProvider(StreamProviderTypeName, StreamProviderName, (int)PersistentStreamProviderCommand.StartAgents);
+        }
+
+        private async Task GenerateEvents(string streamNamespace, List<Guid> streamGuids, int eventsInStream, int payloadSize)
+        {
+            IStreamProvider streamProvider = GrainClient.GetStreamProvider(StreamProviderName);
+            IAsyncStream<GeneratedEvent>[] producers = streamGuids
+                    .Select(streamGuid => streamProvider.GetStream<GeneratedEvent>(streamGuid, streamNamespace))
+                    .ToArray();
+
+            for (int i = 0; i < eventsInStream - 1; i++)
+            {
+                // send event on each stream
+                for (int j = 0; j < streamGuids.Count; j++)
+                {
+                    await producers[j].OnNextAsync(new GeneratedEvent { EventType = GeneratedEvent.GeneratedEventType.Fill, Payload = new int[payloadSize] });
+                }
+            }
+            // send end events
+            for (int j = 0; j < streamGuids.Count; j++)
+            {
+                await producers[j].OnNextAsync(new GeneratedEvent { EventType = GeneratedEvent.GeneratedEventType.Report, Payload = new int[payloadSize] });
+            }
+        }
+
+        private static void AdjustConfig(ClusterConfiguration config)
+        {
+            // register stream provider
+            config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
+            config.Globals.RegisterStorageProvider<AzureTableStorage>(
+                ImplicitSubscription_RecoverableStream_CollectorGrain.StorageProviderName,
+                new Dictionary<string, string>
+                {
+                    {"DataConnectionString", StorageTestConstants.DataConnectionString}
+                });
+
+            // Make sure a node config exist for each silo in the cluster.
+            // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
+            // GetConfigurationForNode will materialize a node in the configuration for each silo, if one does not already exist.
+            config.GetOrCreateNodeConfigurationForSilo("Primary");
+            config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
+
+        }
+        private static void AdjustConfig(ClientConfiguration config)
+        {
+            config.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
+            config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 40001));
+        }
+
+        private static Dictionary<string, string> BuildProviderSettings()
+        {
+            var settings = new Dictionary<string, string>();
+
+            // get initial settings from configs
+            ProviderConfig.WriteProperties(settings);
+            EventHubConfig.WriteProperties(settings);
+            CheckpointSettings.WriteProperties(settings);
+
+            // add queue balancer setting
+            settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());
+
+            // add pub/sub settting
+            settings.Add(PersistentStreamProviderConfig.STREAM_PUBSUB_TYPE, StreamPubSubType.ImplicitOnly.ToString());
+            return settings;
+        }
+    }
+}

--- a/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
@@ -3,114 +3,129 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Xunit;
+using Microsoft.WindowsAzure.Storage.Table;
 using Orleans;
+using Orleans.AzureUtils;
 using Orleans.Runtime.Configuration;
 using Orleans.ServiceBus.Providers;
 using Orleans.Storage;
 using Orleans.Streams;
 using Orleans.TestingHost;
-using OrleansServiceBusUtils.Providers.Streams.EventHub;
 using Tester;
-using Orleans.Runtime;
 using UnitTests.Tester;
+using Xunit;
 
 namespace UnitTests.StreamingTests
 {
-    public class EHSubscriptionMultiplicityTestsFixture : BaseClusterFixture
+    public class EHSubscriptionMultiplicityTests : OrleansTestingBase, IClassFixture<EHSubscriptionMultiplicityTests.Fixture>
     {
-        public const string StreamProviderName = "EventHubStreamProvider";
-        public const string StreamNamespace = "EHSubscriptionMultiplicityTestsNamespace";
-        public const string EHPath = "ehorleanstest";
-        public const string EHConsumerGroup = "orleansnightly";
+        private const string StreamProviderName = "EventHubStreamProvider";
+        private const string StreamNamespace = "EHSubscriptionMultiplicityTestsNamespace";
+        private const string EHPath = "ehorleanstest";
+        private const string EHConsumerGroup = "orleansnightly";
+        private const string EHCheckpointTable = "ehcheckpoint";
+        private static readonly string CheckpointNamespace = Guid.NewGuid().ToString();
 
         public static readonly EventHubStreamProviderConfig ProviderConfig =
             new EventHubStreamProviderConfig(StreamProviderName);
 
-        public static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
+        private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
             EHConsumerGroup, EHPath);
 
-        public EHSubscriptionMultiplicityTestsFixture()
-            : base(new TestingSiloHost(
-                new TestingSiloOptions
-                {
-                    StartFreshOrleans = true,
-                    SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
-                    AdjustConfig = AdjustClusterConfiguration
-                }))
-        {
-        }
+        private static readonly EventHubCheckpointSettings CheckpointSettings =
+            new EventHubCheckpointSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
+                TimeSpan.FromSeconds(1));
 
-        public static void AdjustClusterConfiguration(ClusterConfiguration config)
-        {
-            var settings = new Dictionary<string, string>();
-            // get initial settings from configs
-            ProviderConfig.WriteProperties(settings);
-            EventHubConfig.WriteProperties(settings);
-
-            // add queue balancer setting
-            settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());
-
-            // register stream provider
-            config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, settings);
-            config.Globals.RegisterStorageProvider<MemoryStorage>("PubSubStore");
-
-            // Make sure a node config exist for each silo in the cluster.
-            // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
-            config.GetOrCreateNodeConfigurationForSilo("Primary");
-            config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
-        }
-    }
-
-    public class EHSubscriptionMultiplicityTests : OrleansTestingBase, IClassFixture<EHSubscriptionMultiplicityTestsFixture>
-    {
         private readonly SubscriptionMultiplicityTestRunner runner;
+
+        private class Fixture : BaseClusterFixture
+        {
+            public Fixture()
+                : base(new TestingSiloHost(
+                    new TestingSiloOptions
+                    {
+                        StartFreshOrleans = true,
+                        SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
+                        AdjustConfig = AdjustClusterConfiguration
+                    }))
+            {
+            }
+
+            public override void Dispose()
+            {
+                var dataManager = new AzureTableDataManager<TableEntity>(CheckpointSettings.TableName, CheckpointSettings.DataConnectionString);
+                dataManager.InitTableAsync().Wait();
+                dataManager.DeleteTableAsync().Wait();
+                base.Dispose();
+            }
+
+            private static void AdjustClusterConfiguration(ClusterConfiguration config)
+            {
+                var settings = new Dictionary<string, string>();
+                // get initial settings from configs
+                ProviderConfig.WriteProperties(settings);
+                EventHubConfig.WriteProperties(settings);
+                CheckpointSettings.WriteProperties(settings);
+
+                // add queue balancer setting
+                settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());
+
+                // register stream provider
+                config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, settings);
+                config.Globals.RegisterStorageProvider<MemoryStorage>("PubSubStore");
+
+                // Make sure a node config exist for each silo in the cluster.
+                // This is required for the DynamicClusterConfigDeploymentBalancer to properly balance queues.
+                config.GetOrCreateNodeConfigurationForSilo("Primary");
+                config.GetOrCreateNodeConfigurationForSilo("Secondary_1");
+            }
+        }
 
         public EHSubscriptionMultiplicityTests()
         {
-            runner = new SubscriptionMultiplicityTestRunner(EHSubscriptionMultiplicityTestsFixture.StreamProviderName, GrainClient.Logger);            
+            runner = new SubscriptionMultiplicityTestRunner(StreamProviderName, GrainClient.Logger);            
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHMultipleParallelSubscriptionTest()
         {
             logger.Info("************************ EHMultipleParallelSubscriptionTest *********************************");
-            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), EHSubscriptionMultiplicityTestsFixture.StreamNamespace);
+            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHMultipleLinearSubscriptionTest()
         {
             logger.Info("************************ EHMultipleLinearSubscriptionTest *********************************");
-            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), EHSubscriptionMultiplicityTestsFixture.StreamNamespace);
+            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHMultipleSubscriptionTest_AddRemove()
         {
             logger.Info("************************ EHMultipleSubscriptionTest_AddRemove *********************************");
-            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), EHSubscriptionMultiplicityTestsFixture.StreamNamespace);
+            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHResubscriptionTest()
         {
             logger.Info("************************ EHResubscriptionTest *********************************");
-            await runner.ResubscriptionTest(Guid.NewGuid(), EHSubscriptionMultiplicityTestsFixture.StreamNamespace);
+            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHResubscriptionAfterDeactivationTest()
         {
             logger.Info("************************ EHResubscriptionAfterDeactivationTest *********************************");
-            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), EHSubscriptionMultiplicityTestsFixture.StreamNamespace);
+            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHActiveSubscriptionTest()
         {
             logger.Info("************************ EHActiveSubscriptionTest *********************************");
-            await runner.ActiveSubscriptionTest(Guid.NewGuid(), EHSubscriptionMultiplicityTestsFixture.StreamNamespace);
+            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]

--- a/test/Tester/TestStreamProviders/Generator/Generators/SimpleGenerator.cs
+++ b/test/Tester/TestStreamProviders/Generator/Generators/SimpleGenerator.cs
@@ -55,7 +55,7 @@ namespace Tester.TestStreamProviders.Generator.Generators
                 // If this is the last event generated, mark it as such, so test grains know to report results.
                 EventType = (sequenceId != config.EventsInStream)
                         ? GeneratedEvent.GeneratedEventType.Fill
-                        : GeneratedEvent.GeneratedEventType.End,
+                        : GeneratedEvent.GeneratedEventType.Report,
             };
             return new GeneratedBatchContainer(streamGuid, config.StreamNamespace, evt, new EventSequenceToken(sequenceId));
         }

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -136,6 +136,7 @@
     <Compile Include="General\JsonGrainTests.cs" />
     <Compile Include="SerializationTests\DeepCopyTests.cs" />
     <Compile Include="StreamingTests\EHImplicitSubscriptionStreamRecoveryTests.cs" />
+    <Compile Include="StreamingTests\EHStreamProviderCheckpointTests.cs" />
     <Compile Include="BasicActivationTests.cs" />
     <Compile Include="CodeGenTests\GeneratorGrainTest.cs" />
     <Compile Include="CodeGenTests\IRuntimeCodeGenGrain.cs" />


### PR DESCRIPTION
This change introduces checkpointing of the eventhub partitions as messages are processed.

Each agent reads from a single eventhub partition.  The agent will start reading at the beginning of the hub or from the most recent events, depending on configuration.  Once events have been read, a checkpoint will be recorded and any time the service (or agent) is restarted it will start reading from the checkpointed location in the eventhub partition, rather than the start (or current data).

As the agent reads more and more events from the partition, it will update the checkpoint in a configurable interval.  The checkpoint recorded is the offset into the partition of the oldest message in the cache.  When there is a restart, depending on how large the message cache is, there will likely be duplicate events as the message cache is rebuilt to the state it was in when the last checkpoint occurred.

This prevents the streaming infrastructure from losing events while the service is down, but at the cost of allowing some duplicates.

NOTE:  To get the checkpoint data from the cache, a new generic checkpoint types was introduced.  This was necessary because different queues will use different data to denote read locations in a queue.  This mechanism is clumsy but I failed to devise a more elegant solution.  I'm quite open to alternative suggestions.

This is the last planned change for Recoverable Event Hub Persistent Stream Provider #1096.
After this PR, the EventHubStreamProvider should be in a state where it can be used in production systems, though users should be aware that there is another set of changes being planned for the EventHubStreamProvider.  While it's complete enough to be used in products, it's still very much under development.

I'll soon create an issue similar to #1096 which will describe the next set of changes to the EventHubStreamProvider.  I welcome community input on this.