### PR TITLE
Avoid using Console.WriteLine from grain code

### DIFF
--- a/src/TestGrains/ChainedGrain.cs
+++ b/src/TestGrains/ChainedGrain.cs
@@ -23,9 +23,15 @@ namespace UnitTests.Grains
     [StorageProvider(ProviderName = "MemoryStore")]
     public class ChainedGrain : Grain<ChainedGrainState>, IChainedGrain
     {
+        private Logger logger;
+
+        public override Task OnActivateAsync()
+        {
+            logger = GetLogger("ChainedGrain-" + IdentityString);
+            return base.OnActivateAsync();
+        }
+
         #region IChainedGrain Members
-
-
 
         Task<IChainedGrain> IChainedGrain.GetNext() { return Task.FromResult(State.Next); } 
 
@@ -60,16 +66,12 @@ namespace UnitTests.Grains
         {
             if ((nextIsSet && State.Next != null) || (!nextIsSet && State.Next == null))
             {
-                //Console.ForegroundColor = ConsoleColor.Green;
-                //Console.WriteLine(String.Format("Id={0} validated successfully: Next={1}", Id, Next));
-                //Console.ResetColor();
+                // logger.Verbose("Id={0} validated successfully: Next={1}", State.Id, State.Next);
                 return TaskDone.Done;
             }
 
             string msg = String.Format("ChainGrain Id={0} is in an invalid state. Next={1}", State.Id, State.Next);
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine(msg);
-            Console.ResetColor();
+            logger.Warn(0, msg);
             throw new OrleansException(msg);
         }
 

--- a/src/TestInternalGrains/PersistenceTestGrains.cs
+++ b/src/TestInternalGrains/PersistenceTestGrains.cs
@@ -896,6 +896,14 @@ namespace UnitTests.Grains
 
         private readonly int _instanceFilterValue2 = _staticFilterValue2;
 
+        private Logger logger;
+
+        public override Task OnActivateAsync()
+        {
+            logger = GetLogger("SerializationTestGrain-" + IdentityString);
+            return base.OnActivateAsync();
+        }
+
         public Task Test_Serialize_Func()
         {
             Func<int, bool> staticFilterFunc = i => i == _staticFilterValue3;
@@ -963,7 +971,7 @@ namespace UnitTests.Grains
             foreach (
                 var val in new[] {_staticFilterValue1, _staticFilterValue2, _staticFilterValue3, _staticFilterValue4})
             {
-                Console.WriteLine("{0} -- Compare value={1}", what, val);
+                logger.Verbose("{0} -- Compare value={1}", what, val);
                 Assert.AreEqual(func1(val), func2(val), "{0} -- Wrong function after round-trip of {1} with value={2}",
                     what, func1, val);
             }
@@ -977,7 +985,7 @@ namespace UnitTests.Grains
             foreach (
                 var val in new[] {_staticFilterValue1, _staticFilterValue2, _staticFilterValue3, _staticFilterValue4})
             {
-                Console.WriteLine("{0} -- Compare value={1}", what, val);
+                logger.Verbose("{0} -- Compare value={1}", what, val);
                 Assert.AreEqual(pred1(val), pred2(val), "{0} -- Wrong predicate after round-trip of {1} with value={2}",
                     what, pred1, val);
             }

--- a/src/TesterInternal/Tester/OrleansTestingBase.cs
+++ b/src/TesterInternal/Tester/OrleansTestingBase.cs
@@ -44,7 +44,7 @@ namespace UnitTests.Tester
             Dictionary<SiloAddress, SiloStatus> statuses = mgmtGrain.GetHosts(onlyActive: true).Result;
             foreach (var pair in statuses)
             {
-                Console.WriteLine("       ######## Silo {0}, status: {1}", pair.Key, pair.Value);
+                logger.Info("       ######## Silo {0}, status: {1}", pair.Key, pair.Value);
                 Assert.AreEqual(
                     SiloStatus.Active,
                     pair.Value,

--- a/test/Tester/OrleansTestingBase.cs
+++ b/test/Tester/OrleansTestingBase.cs
@@ -44,7 +44,7 @@ namespace UnitTests.Tester
             Dictionary<SiloAddress, SiloStatus> statuses = mgmtGrain.GetHosts(onlyActive: true).Result;
             foreach (var pair in statuses)
             {
-                Console.WriteLine("       ######## Silo {0}, status: {1}", pair.Key, pair.Value);
+                logger.Info("       ######## Silo {0}, status: {1}", pair.Key, pair.Value);
                 Assert.AreEqual(
                     SiloStatus.Active,
                     pair.Value,


### PR DESCRIPTION
In preparation for the migration to xUnit of TesterInternal