### PR TITLE
Fixed Azure table property being not sanitized.

### DIFF
--- a/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
+++ b/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
@@ -275,10 +275,11 @@ namespace Orleans.AzureUtils
         {
             // Remove any characters that can't be used in Azure PartitionKey or RowKey values
             // http://www.jamestharpe.com/web-development/azure-table-service-character-combinations-disallowed-in-partitionkey-rowkey/
-            key.Replace('/', '_');  // Forward slash
-            key.Replace('\\', '_'); // Backslash
-            key.Replace('#', '_');  // Pound sign
-            key.Replace('?', '_');  // Question mark
+            key = key
+                .Replace('/', '_')        // Forward slash
+                .Replace('\\', '_')       // Backslash
+                .Replace('#', '_')        // Pound sign
+                .Replace('?', '_');       // Question mark
 
             if (key.Length >= 1024)
                 throw new ArgumentException(string.Format("Key length {0} is too long to be an Azure table key. Key={1}", key.Length, key));

--- a/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
+++ b/src/TesterInternal/StorageTests/AzureTableErrorCodeTests.cs
@@ -56,5 +56,12 @@ namespace UnitTests.StorageTests
             string tableName = "abc-123";
             AzureStorageUtils.ValidateTableName(tableName);
         }
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage")]
+        public void AzureStorageUtils_TablePropertyShouldBeSanitized()
+        {
+            var tableProperty = "/A\\C#?";
+            Assert.AreEqual("_A_C__", AzureStorageUtils.SanitizeTableProperty(tableProperty));
+        }
     }
 }


### PR DESCRIPTION
Return values of pure method `string.Replace` weren't used. 