### PR TITLE
Display name including class to work well with Jenkins XSLT transform

### DIFF
--- a/test/Tester/Tester.xunit.runner.json
+++ b/test/Tester/Tester.xunit.runner.json
@@ -3,6 +3,6 @@
   "diagnosticMessages": true,
   "parallelizeAssembly": false,
   "parallelizeTestCollections": false,
-  "methodDisplay": "method",
+  "methodDisplay": "classAndMethod",
   "shadowCopy": false
 }


### PR DESCRIPTION
This is so that our CI and PR builds include the entire test name instead of being empty or truncated