### PR TITLE
Added helper methods for programmatic test configurations.

### DIFF
--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -499,5 +499,18 @@ namespace Orleans.Runtime.Configuration
                     break;
             }
         }
+
+        /// <summary>
+        /// Retuurns a ClientConfiguration object for connecting to a local silo (for testing).
+        /// </summary>
+        /// <param name="gatewayPort">Client gateway TCP port</param>
+        /// <returns>ClientConfiguration object that can be passed to GrainClient class for initialization</returns>
+        public static ClientConfiguration LocalhostSilo(int gatewayPort = 40000)
+        {
+            var config = new ClientConfiguration {GatewayProvider = GatewayProviderType.Config};
+            config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, gatewayPort));
+
+            return config;
+        }
     }
 }

--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -562,5 +562,28 @@ namespace Orleans.Runtime.Configuration
             doc.Load(xmlReader);
             return doc.DocumentElement;
         }
+
+        /// <summary>
+        /// Returns a prepopulated ClusterConfiguration object for a primary local silo (for testing)
+        /// </summary>
+        /// <param name="siloPort">TCP port for silo to silo communication</param>
+        /// <param name="gatewayPort">Client gateway TCP port</param>
+        /// <returns>ClusterConfiguration object that can be passed to Silo or SiloHost classes for initialization</returns>
+        public static ClusterConfiguration LocalhostPrimarySilo(int siloPort = 22222, int gatewayPort = 40000)
+        {
+            var config = new ClusterConfiguration();
+            var siloAddress = new IPEndPoint(IPAddress.Loopback, siloPort);
+            config.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.MembershipTableGrain;
+            config.Globals.SeedNodes.Add(siloAddress);
+            config.Globals.ReminderServiceType = GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain;
+
+            config.Defaults.HostNameOrIPAddress = "localhost";
+            config.Defaults.Port = siloPort;
+            config.Defaults.ProxyGatewayEndpoint = new IPEndPoint(IPAddress.Loopback, gatewayPort);
+            
+            config.PrimaryNode = siloAddress;
+
+            return config;
+        }
     }
 }


### PR DESCRIPTION
We want to change samples and the Dev/Test Host template to use programmatic config instead of the config files. This adds a couple of static helper methods that simplify otherwise tedious task of programmatic configuration.

An usage example is in https://github.com/sergeybykov/orleans/blob/sample/Samples/HelloWorld/HelloWorld/OrleansHostWrapper.cs#L135 and https://github.com/sergeybykov/orleans/blob/sample/Samples/HelloWorld/HelloWorld/Program.cs#L29.

Note that we can't update samples until we publish NuGets with this feature and an updated VSIX.