### PR TITLE
Fix OrleansHost's app.config to reflect the upgrade of Newtonsoft.Json from 6 to 7

### DIFF
--- a/src/OrleansHost/app.config
+++ b/src/OrleansHost/app.config
@@ -27,7 +27,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
We missed updating this file, so OrleansHost.exe.config is incorrect as the result.