### PR TITLE
Repro: F# option deserialization error

### DIFF
--- a/src/TestFSharpInterfaces/IFSharpParameters.fs
+++ b/src/TestFSharpInterfaces/IFSharpParameters.fs
@@ -1,0 +1,11 @@
+﻿namespace UnitTests.FSharpInterfaces
+
+open System.Threading.Tasks
+
+type public DiscriminatedUnion<'T> =
+    | Nothing
+    | Something of 'T
+
+type public IFSharpParameters<'T> =
+    abstract OptionRoundtrip: 'T option -> Task<'T option>
+

--- a/src/TestFSharpInterfaces/TestFSharpInterfaces.fsproj
+++ b/src/TestFSharpInterfaces/TestFSharpInterfaces.fsproj
@@ -62,6 +62,7 @@
     </Compile>
     <Content Include="packages.config" />
     <Compile Include="IFSharpBaseInterface.fs" />
+    <Compile Include="IFSharpParameters.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core">

--- a/src/TestGrainInterfaces/IFSharpParametersGrain.cs
+++ b/src/TestGrainInterfaces/IFSharpParametersGrain.cs
@@ -1,0 +1,14 @@
+﻿using Orleans;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnitTests.FSharpInterfaces;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IFSharpParametersGrain<T,U> : IGrainWithGuidKey, IFSharpParameters<T>
+    {
+    }
+}

--- a/src/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/src/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -40,6 +40,10 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>    
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
@@ -61,6 +65,7 @@
     <Compile Include="IExtensionTestGrain.cs" />
     <Compile Include="IExternalTypeGrain.cs" />
     <Compile Include="IFaultableConsumerGrain.cs" />
+    <Compile Include="IFSharpParametersGrain.cs" />
     <Compile Include="IGeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs" />
     <Compile Include="IGeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs" />
     <Compile Include="IGeneratorTestDerivedDerivedGrain.cs" />

--- a/src/TestGrainInterfaces/packages.config
+++ b/src/TestGrainInterfaces/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net451" /> 
 </packages>

--- a/test/Tester/FSharpGrainTests.cs
+++ b/test/Tester/FSharpGrainTests.cs
@@ -80,7 +80,7 @@ namespace UnitTests.General
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics"), TestCategory("FSharp"), TestCategory("Serialization")]
         public async Task FSharpGrains_Ping_IntOption_Some()
         {
-            var input = FSharpOption<int>.Some(0);
+            var input = FSharpOption<int>.Some(10);
             await PingTest<FSharpOption<int>>(input);
         }
 

--- a/test/Tester/SerializationTests/SerializationTests.FSharpTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.FSharpTypes.cs
@@ -26,7 +26,7 @@ namespace UnitTests.Serialization
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
         public void SerializationTests_FSharp_IntOption_Some()
         {
-            RoundtripSerializationTest(FSharpOption<int>.Some(0));
+            RoundtripSerializationTest(FSharpOption<int>.Some(10));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]


### PR DESCRIPTION
Repro for #1346 

Test result (currently skipped for CI):
```
Test Name:	UnitTests.Serialization.SerializationTestsFsharpTypes.SerializationTests_FSharp_IntOption_Some
Test FullName:	UnitTests.Serialization.SerializationTestsFsharpTypes.SerializationTests_FSharp_IntOption_Some
Test Source:	C:\code\ca-ta\orleans\test\Tester\SerializationTests\SerializationTests.FSharpTypes.cs : line 28
Test Outcome:	Failed
Test Duration:	0:00:03.61

Result StackTrace:	
at valueSet(FSharpOption`1 , Int32 )
   at UnitTests.GrainInterfaces.OrleansCodeGenMicrosoft_FSharp_Core_FSharpOptionSerializer`1.Deserializer(Type expected, BinaryTokenStreamReader stream) in C:\code\ca-ta\orleans\src\TestGrainInterfaces\Properties\orleans.codegen.cs:line 7760
   at Orleans.Serialization.SerializationManager.DeserializeInner(Type expected, BinaryTokenStreamReader stream) in C:\code\ca-ta\orleans\src\Orleans\Serialization\SerializationManager.cs:line 1525
   at Orleans.Serialization.SerializationManager.DeserializeInner[T](BinaryTokenStreamReader stream) in C:\code\ca-ta\orleans\src\Orleans\Serialization\SerializationManager.cs:line 1435
   at Orleans.Serialization.SerializationManager.DeserializeFromByteArray[T](Byte[] data) in C:\code\ca-ta\orleans\src\Orleans\Serialization\SerializationManager.cs:line 1709
   at Orleans.Serialization.SerializationManager.RoundTripSerializationForTesting[T](T source) in C:\code\ca-ta\orleans\src\Orleans\Serialization\SerializationManager.cs:line 2203
   at UnitTests.Serialization.SerializationTestsFsharpTypes.RoundtripSerializationTest[T](T input) in C:\code\ca-ta\orleans\test\Tester\SerializationTests\SerializationTests.FSharpTypes.cs:line 22
   at UnitTests.Serialization.SerializationTestsFsharpTypes.SerializationTests_FSharp_IntOption_Some() in C:\code\ca-ta\orleans\test\Tester\SerializationTests\SerializationTests.FSharpTypes.cs:line 29
Result Message:	System.Security.VerificationException : Operation could destabilize the runtime.

```