### PR TITLE
More AggregateException propagation tests

### DIFF
--- a/src/TestGrainInterfaces/IExceptionGrain.cs
+++ b/src/TestGrainInterfaces/IExceptionGrain.cs
@@ -22,5 +22,9 @@ namespace UnitTests.GrainInterfaces
         Task GrainCallToThrowsAggregateExceptionWrappingInvalidOperationException(long otherGrainId);
 
         Task ThrowsSynchronousInvalidOperationException();
+
+        Task ThrowsMultipleExceptionsAggregatedInFaultedTask();
+
+        Task ThrowsSynchronousAggregateExceptionWithMultipleInnerExceptions();
     }
 }

--- a/src/TestGrains/ExceptionGrain.cs
+++ b/src/TestGrains/ExceptionGrain.cs
@@ -52,5 +52,25 @@ namespace UnitTests.Grains
         {
             throw new InvalidOperationException("Test exception");
         }
+
+        public Task ThrowsMultipleExceptionsAggregatedInFaultedTask()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            tcs.SetException(new[]
+            {
+                new InvalidOperationException("Test exception 1"),
+                new InvalidOperationException("Test exception 2"),
+            });
+
+            return tcs.Task;
+        }
+
+        public Task ThrowsSynchronousAggregateExceptionWithMultipleInnerExceptions()
+        {
+            throw new AggregateException(
+                "Test AggregateException message",
+                new InvalidOperationException("Test exception 1"),
+                new InvalidOperationException("Test exception 2"));
+        }
     }
 }

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using FluentAssertions.Collections;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
 using Xunit;
@@ -86,6 +87,44 @@ namespace UnitTests.General
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => grainCallTask);
 
             Assert.Equal("Test exception", exception.Message);
+        }
+
+        [Fact(Skip = "Implementation of issue #1378 is still pending"), TestCategory("BVT"), TestCategory("Functional")]
+        public void ExceptionPropagationForwardsEntireAggregateException()
+        {
+            IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
+            var grainCall = grain.ThrowsMultipleExceptionsAggregatedInFaultedTask();
+
+            // use Wait() so that we get the entire AggregateException ('await' would just catch the first inner exception)
+            var exception = Assert.Throws<AggregateException>(
+                () => grainCall.Wait());
+
+            // make sure that all exceptions in the task are present, and not just the first one.
+            Assert.Equal(2, exception.InnerExceptions.Count);
+            var firstEx = Assert.IsAssignableFrom<InvalidOperationException>(exception.InnerExceptions[0]);
+            Assert.Equal("Test exception 1", firstEx.Message);
+            var secondEx = Assert.IsAssignableFrom<InvalidOperationException>(exception.InnerExceptions[1]);
+            Assert.Equal("Test exception 2", secondEx.Message);
+        }
+
+        [Fact(Skip = "Implementation of issue #1378 is still pending"), TestCategory("BVT"), TestCategory("Functional")]
+        public async Task SynchronousAggregateExceptionThrownShouldResultInFaultedTaskWithOriginalAggregateExceptionUnmodifiedAsInnerException()
+        {
+            IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
+
+            // start the grain call but don't await it nor wrap in try/catch, to make sure it doesn't throw synchronously
+            var grainCallTask = grain.ThrowsSynchronousAggregateExceptionWithMultipleInnerExceptions();
+
+            // assert that the faulted task has an inner exception of type AggregateException, which should be our original exception
+            var exception = await Assert.ThrowsAsync<AggregateException>(() => grainCallTask);
+
+            Assert.Equal("Test AggregateException message", exception.Message);
+            // make sure that all exceptions in the task are present, and not just the first one.
+            Assert.Equal(2, exception.InnerExceptions.Count);
+            var firstEx = Assert.IsAssignableFrom<InvalidOperationException>(exception.InnerExceptions[0]);
+            Assert.Equal("Test exception 1", firstEx.Message);
+            var secondEx = Assert.IsAssignableFrom<InvalidOperationException>(exception.InnerExceptions[1]);
+            Assert.Equal("Test exception 2", secondEx.Message);
         }
     }
 }


### PR DESCRIPTION
Since AggregateExceptions are a little bit special, some more tests to cover scenarios like AggregateExceptions with multiple inner exceptions, as well as synchronous throws of these.
This is to fulfill user facing expectations in #1378