### PR TITLE
Fix broken link in `Where Next?`

### DIFF
--- a/index.md
+++ b/index.md
@@ -65,7 +65,7 @@ await grain.SayHello("World");
 
 ## Where Next?
 
-To learn more about the concepts in Orleans, read the getting [started guide](Getting-Started-With-Orleans/Core-Concepts).
+To learn more about the concepts in Orleans, read the [introduction](Introduction).
 
 There are a number of [step-by-step tutorials](Step-by-step-Tutorials).
 


### PR DESCRIPTION
0b2705da94841e5152 merged the `Core Concepts` section of the Getting Started Guide with the Introduction.