### PR TITLE
Update documentation to include storage provider configuration

### DIFF
--- a/Documentation-Guidelines.md
+++ b/Documentation-Guidelines.md
@@ -4,37 +4,37 @@ title: Documentation guidelines
 ---
 {% include JB/setup %}
 
-The Orleans documentation is built in [Markdown](https://help.github.com/articles/markdown-basics/). 
+The Orleans documentation is built in [Markdown](https://help.github.com/articles/markdown-basics/).
 We use a few simple conventions to ensure a homogeneous style throughout the full set of documents.
 
 These standards are being introduced.
 If you have issues with these guidelines then raise an issue or a Pull Request.
 If you find documentation that fails to meet the guidelines, then make a fix and submit a pull request. Also if you are using windows 10 you can go to the store and find free MarkDown editors like [this](https://www.microsoft.com/store/apps/9wzdncrdd2p3)
 
-#Structure
+# Structure
 
-##Language
+## Language
 The documentation will follow US-English spelling.
 Desktop tools like http://markdownpad.com have spell checking features.
 
-##Paragraph structure
+## Paragraph structure
 Each sentence should be written on a single line, and only one sentence per line.
 This makes merging changes easier and also helps identify verbose language.
 
 Paragraphs in Markdown are just one or more lines of consecutive text followed by one or more blank lines.
 
-##Headings
+## Headings
 Heading should be used to structure a document.
-Avoid using other emphasis features like ALLCAPS, *Italics* or **bold** to identify a new topic. 
+Avoid using other emphasis features like ALLCAPS, *Italics* or **bold** to identify a new topic.
 Using a header is not only more consistent, but also allows linking to the header.
 
-##Footers
+## Footers
 At the end of a page, it is helpful to link to the next logical page in the documentation.
-If the page is the last in a sub-section then linking back to the index page is useful. 
+If the page is the last in a sub-section then linking back to the index page is useful.
 
-#Styles
+# Styles
 
-##Code formatting
+## Code formatting
 Blocks of example code should be formatted with the triple back tick format followed by the language
 
 	``` csharp
@@ -71,11 +71,11 @@ If showing text that is an output (e.g. text file content or console output) you
 	1 said: Thanks!
 	0 said: Thanks!
 
- 
 
-##File names and paths
-When referencing a filename, directory/folder or URI then use standard italics to format. 
-This can be done by surrounding the string with either with a single asterisk (`*`) or a single underscore (`_`) 
+
+## File names and paths
+When referencing a filename, directory/folder or URI then use standard italics to format.
+This can be done by surrounding the string with either with a single asterisk (`*`) or a single underscore (`_`)
 
 Examples:
 
@@ -84,26 +84,26 @@ Examples:
 * *../src/Grain.cs*
 
 
-##Tables
+## Tables
 
 Markdown supports [tabular data](https://help.github.com/articles/github-flavored-markdown/#tables).
 Tables could be used to structure data so that is is easily consumable for the reader.
 
-Suffix |     Unit 
+Suffix |     Unit
 -------|-------------
-ms     | millisecond(s)  
-s      | second(s)  
-m      | minute(s)    
+ms     | millisecond(s)
+s      | second(s)
+m      | minute(s)
 
 
-##Links 
+## Links
 When referencing another concept, the concept should be linked to.
 Forward and backward references with in a page can be linked to via the header. e.g. link back to [Structure](#structure)
-Links to other documents can either link to the page, or a sub-section/header within the page. 
+Links to other documents can either link to the page, or a sub-section/header within the page.
 External links should be exposed as a the full link e.g. https://github.com/dotnet/roslyn
 
 
 
-#Contribution
+# Contribution
 The Orleans documentation is managed as Markdown files in a Git repository hosted on [GitHub in the gh-pages branch](https://github.com/dotnet/orleans/tree/gh-pages).
 See the [GitHub Pages](https://pages.github.com/) documentation on how to use the `gh-pages` branch convention for "Project site" documents.

--- a/Getting-Started-With-Orleans/Grain-Persistence.md
+++ b/Getting-Started-With-Orleans/Grain-Persistence.md
@@ -9,7 +9,7 @@ title: Grain Persistence
 1. Allow different grain types to use different types of storage providers (e.g., one uses Azure table, and one uses SQL Azure) or the same type of storage provider but with different configurations (e.g., both use Azure table, but one uses storage account #1 and one uses storage account #2)
 2. Allow configuration of a storage provider instance to be swapped (e.g., Dev-Test-Prod) with just config file changes, and no code changes required.
 3. Provide a framework to allow additional storage providers to be written later, either by the Orleans team or others.
-4. Provide a minimal set of production-grade storage providers, both to demonstrate viability of the storage provider framework, and cover common storage types that will be used by a majority of users. Phase 1 will ship with a non-persistent in-memory store for developer testing scenarios, and a persistent unsharded Azure table storage provider.
+4. Provide a minimal set of production-grade storage providers
 5. Storage providers have complete control over how they store grain state data in persistent backing store. Corollary: Orleans is not providing a comprehensive ORM storage solution, but allows custom storage providers to support specific ORM requirements as and when required.
 
 ## Grain Persistence API
@@ -111,9 +111,9 @@ The following attributes can be added to the `<Provider />` element to configure
 
 ```xml
 <Provider Type="Orleans.Storage.ShardedStorageProvider" Name="ShardedStorage">
-    <Provider ... />
-    <Provider ... />
-    <Provider ... />
+    <Provider />
+    <Provider />
+    <Provider />
 </Provider>
 ```
 Simple storage provider for writing grain state data shared across a number of other storage providers.
@@ -137,8 +137,8 @@ The storage provider instance to use for a given grain type is determined by the
 
 Different grain types can use different configured storage providers, even if both are the same type: for example, two different Azure table storage provider instances, connected to different Azure storage accounts (see config file example above).
 
-For the Phase 1 implementation, all configuration details for storage providers will be defined statically in the silo configuration that is read at silo startup.
-There will be _no_ mechanisms provided at this time to dynamically update or change the list of storage providers used by a silo.
+All configuration details for storage providers is defined statically in the silo configuration that is read at silo startup.
+There are _no_ mechanisms provided at this time to dynamically update or change the list of storage providers used by a silo.
 However, this is a prioritization / workload constraint rather than a fundamental design constraint.
 
 ## State Storage APIs

--- a/Step-by-step-Tutorials/Declarative-Persistence.md
+++ b/Step-by-step-Tutorials/Declarative-Persistence.md
@@ -66,7 +66,7 @@ The silo host project includes a configuration file _DevTestServerConfiguration.
                         DataConnectionString="UseDevelopmentStorage=true" />
         -->
         <!--
-        <Provider Type="Orleans.Storage.AzureTableStorage"
+        <Provider Type="Orleans.Storage.AzureBlobStorage"
                         Name="AzureStore"
                         DataConnectionString="[removed for brevity]" />
         -->
@@ -83,7 +83,9 @@ In the case of the latter, you will have to create a Azure storage account and e
 
 With one of those enabled, we're ready to tackle the grain code.
 
-Note: The built-in storage provider classes `Orleans.Storage.MemoryStorage` and `Orleans.Storage.AzureTableStorage` are in the  _OrleansProviders.dll_ and _OrleansAzureUtils.dll_ assemblies respectively, so make sure those assemblies are referenced in your silo worker role project with _CopyLocal='True'_.
+> Note: The built-in storage provider classes `Orleans.Storage.AzureBlobStorage` and `Orleans.Storage.AzureTableStorage`
+are in the  _OrleansAzureUtils.dll_ assembly, make sure this assembly is referenced in your silo worker role project
+with _CopyLocal='True'_.
 
 ## Declaring State
 


### PR DESCRIPTION
The `SqlStorageProvider` is commented out for now, it's unclear to me how this should be configured.

Most of the changes made can be viewed on this page: http://richorama.github.io/orleans/Getting-Started-With-Orleans/Grain-Persistence