### PR TITLE
Removed detailed message tracing.

### DIFF
--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -83,7 +83,6 @@ namespace Orleans.Runtime.Configuration
 
         public Severity DefaultTraceLevel { get; set; }
         public IList<Tuple<string, Severity>> TraceLevelOverrides { get; private set; }
-        public bool WriteMessagingTraces { get; set; }
         public bool TraceToConsole { get; set; }
         public int LargeMessageWarningThreshold { get; set; }
         public bool PropagateActivityId { get; set; }
@@ -184,7 +183,6 @@ namespace Orleans.Runtime.Configuration
             TraceLevelOverrides = new List<Tuple<string, Severity>>();
             TraceToConsole = true;
             TraceFilePattern = "{0}-{1}.log";
-            WriteMessagingTraces = false;
             LargeMessageWarningThreshold = Constants.LARGE_OBJECT_HEAP_THRESHOLD;
             PropagateActivityId = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
             BulkMessageLimit = Constants.DEFAULT_LOGGER_BULK_MESSAGE_LIMIT;

--- a/src/Orleans/Configuration/ConfigUtilities.cs
+++ b/src/Orleans/Configuration/ConfigUtilities.cs
@@ -85,11 +85,6 @@ namespace Orleans.Runtime.Configuration
             {
                 config.TraceFilePattern = root.GetAttribute("TraceToFile");
             }
-            if (root.HasAttribute("WriteMessagingTraces"))
-            {
-                config.WriteMessagingTraces = ParseBool(root.GetAttribute("WriteMessagingTraces"),
-                    "Invalid boolean value for WriteMessagingTraces attribute on Tracing element for " + nodeName);
-            }
             if (root.HasAttribute("LargeMessageWarningThreshold"))
             {
                 config.LargeMessageWarningThreshold = ParseInt(root.GetAttribute("LargeMessageWarningThreshold"),
@@ -468,7 +463,6 @@ namespace Orleans.Runtime.Configuration
             }
             sb.Append("     Trace to Console: ").Append(config.TraceToConsole).AppendLine();
             sb.Append("     Trace File Name: ").Append(string.IsNullOrWhiteSpace(config.TraceFileName) ? "" : Path.GetFullPath(config.TraceFileName)).AppendLine();
-            sb.Append("     Write Messaging Traces: ").Append(config.WriteMessagingTraces).AppendLine();
             sb.Append("     LargeMessageWarningThreshold: ").Append(config.LargeMessageWarningThreshold).AppendLine();
             sb.Append("     PropagateActivityId: ").Append(config.PropagateActivityId).AppendLine();
             sb.Append("     BulkMessageLimit: ").Append(config.BulkMessageLimit).AppendLine();

--- a/src/Orleans/Configuration/ITraceConfiguration.cs
+++ b/src/Orleans/Configuration/ITraceConfiguration.cs
@@ -37,11 +37,6 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         bool TraceToConsole { get; set; }
         /// <summary>
-        /// The WriteMessagingTraces attribute specifies whether to write details message traces.
-        /// This should be used only in development mode and never in production.
-        /// </summary>
-        bool WriteMessagingTraces { get; set; }
-        /// <summary>
         /// The LargeMessageWarningThreshold attribute specifies when to generate a warning trace message for large messages.
         /// </summary>
         int LargeMessageWarningThreshold { get; set; }

--- a/src/Orleans/Configuration/NodeConfiguration.cs
+++ b/src/Orleans/Configuration/NodeConfiguration.cs
@@ -142,9 +142,6 @@ namespace Orleans.Runtime.Configuration
         public IList<Tuple<string, Severity>> TraceLevelOverrides { get; private set; }
         /// <summary>
         /// </summary>
-        public bool WriteMessagingTraces { get; set; }
-        /// <summary>
-        /// </summary>
         public bool TraceToConsole { get; set; }
         /// <summary>
         /// </summary>
@@ -261,7 +258,6 @@ namespace Orleans.Runtime.Configuration
             TraceLevelOverrides = new List<Tuple<string, Severity>>();
             TraceToConsole = true;
             TraceFilePattern = "{0}-{1}.log";
-            WriteMessagingTraces = false;
             LargeMessageWarningThreshold = Constants.LARGE_OBJECT_HEAP_THRESHOLD;
             PropagateActivityId = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
             BulkMessageLimit = Constants.DEFAULT_LOGGER_BULK_MESSAGE_LIMIT;
@@ -308,7 +304,6 @@ namespace Orleans.Runtime.Configuration
             TraceToConsole = other.TraceToConsole;
             TraceFilePattern = other.TraceFilePattern;
             TraceFileName = other.TraceFileName;
-            WriteMessagingTraces = other.WriteMessagingTraces;
             LargeMessageWarningThreshold = other.LargeMessageWarningThreshold;
             PropagateActivityId = other.PropagateActivityId;
             BulkMessageLimit = other.BulkMessageLimit;

--- a/src/Orleans/Configuration/OrleansConfiguration.xsd
+++ b/src/Orleans/Configuration/OrleansConfiguration.xsd
@@ -595,16 +595,6 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="WriteMessagingTraces" type="xs:boolean" use="optional">
-      <xs:annotation>
-        <xs:documentation>
-          The WriteMessagingTraces attribute specifies whether or not message traces will be collected and reported.
-          Message traces are written when the message is completed (that is, when the response promise is resolved).
-          Traces are written at Verbose level.
-          The default is to not collect and write message traces, as trace collection is moderately expensive.
-        </xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="LargeMessageWarningThreshold" type="xs:int" use="optional">
       <xs:annotation>
         <xs:documentation>

--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -207,7 +207,6 @@ namespace Orleans.Runtime
                 runtimeTraceLevel = config.DefaultTraceLevel;
                 appTraceLevel = config.DefaultTraceLevel;
                 SetTraceLevelOverrides(config.TraceLevelOverrides);
-                Message.WriteMessagingTraces = config.WriteMessagingTraces;
                 Message.LargeMessageSizeThreshold = config.LargeMessageWarningThreshold;
                 SerializationManager.LARGE_OBJECT_LIMIT = config.LargeMessageWarningThreshold;
                 RequestContext.PropagateActivityId = config.PropagateActivityId;

--- a/src/Orleans/Runtime/CallbackData.cs
+++ b/src/Orleans/Runtime/CallbackData.cs
@@ -144,8 +144,6 @@ namespace Orleans.Runtime
                     unregister();
                 }     
             }
-            if (Message.WriteMessagingTraces) response.AddTimestamp(Message.LifecycleTag.InvokeIncoming);
-            if (logger.IsVerbose2) logger.Verbose2("Message {0} timestamps: {1}", response, response.GetTimestampString());
             if (StatisticsCollector.CollectApplicationRequestsStats)
             {
                 ApplicationRequestsStatisticsGroup.OnAppRequestsEnd(timeSinceIssued.Elapsed);

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -301,7 +301,6 @@ namespace Orleans.Serialization
             // Enum names we need to recognize
             Register(typeof(Message.Categories));
             Register(typeof(Message.Directions));
-            Register(typeof(Message.LifecycleTag));
             Register(typeof(Message.RejectionTypes));
             Register(typeof(Message.ResponseTypes));
         }

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -362,8 +362,6 @@ namespace Orleans.Runtime
                 // Now we can actually scheduler processing of this request
                 targetActivation.RecordRunning(message);
                 var context = new SchedulingContext(targetActivation);
-                if (Message.WriteMessagingTraces) 
-                    message.AddTimestamp(Message.LifecycleTag.EnqueueWorkItem);
 
                 MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedOk(message);
                 Scheduler.QueueWorkItem(new InvokeWorkItem(targetActivation, message, context), context);
@@ -384,8 +382,6 @@ namespace Orleans.Runtime
                 RejectMessage(message, Message.RejectionTypes.Overloaded, overloadException, "Target activation is overloaded " + targetActivation);
                 return;
             }
-            if (Message.WriteMessagingTraces) 
-                message.AddTimestamp(Message.LifecycleTag.EnqueueWaiting);
             
             bool enqueuedOk = targetActivation.EnqueueMessage(message);
             if (!enqueuedOk)

--- a/src/OrleansRuntime/Core/InsideGrainClient.cs
+++ b/src/OrleansRuntime/Core/InsideGrainClient.cs
@@ -170,9 +170,6 @@ namespace Orleans.Runtime
             if (context == null && !oneWay)
                 logger.Warn(ErrorCode.IGC_SendRequest_NullContext, "Null context {0}: {1}", message, new StackTrace());
 
-            if (Message.WriteMessagingTraces)
-                message.AddTimestamp(Message.LifecycleTag.Create);
-
             if (message.IsExpirableMessage(Config.Globals))
                 message.Expiration = DateTime.UtcNow + ResponseTimeout + Constants.MAXIMUM_CLOCK_SKEW;
             
@@ -324,10 +321,6 @@ namespace Orleans.Runtime
                     message.DropExpiredMessage(MessagingStatisticsGroup.Phase.Invoke);
                     return;
                 }
-
-                //MessagingProcessingStatisticsGroup.OnRequestProcessed(message, "Invoked");
-                if (Message.WriteMessagingTraces)
-                    message.AddTimestamp(Message.LifecycleTag.InvokeIncoming);
 
                 RequestContext.Import(message.RequestContextData);
                 if (Config.Globals.PerformDeadlockDetection && !message.TargetGrain.IsSystemTarget)

--- a/src/OrleansRuntime/Messaging/GatewayAcceptor.cs
+++ b/src/OrleansRuntime/Messaging/GatewayAcceptor.cs
@@ -52,9 +52,6 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-            if (Message.WriteMessagingTraces)
-                msg.AddTimestamp(Message.LifecycleTag.ReceiveIncoming);
-
             gatewayTrafficCounter.Increment();
 
             // Are we overloaded?
@@ -83,7 +80,6 @@ namespace Orleans.Runtime.Messaging
                     msg.TargetActivation = ActivationId.GetSystemActivation(msg.TargetGrain, MessageCenter.MyAddress);
                 }
 
-                if (Message.WriteMessagingTraces) msg.AddTimestamp(Message.LifecycleTag.RerouteIncoming);
                 MessagingStatisticsGroup.OnMessageReRoute(msg);
                 MessageCenter.RerouteMessage(msg);
             }

--- a/src/OrleansRuntime/Messaging/InboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/InboundMessageQueue.cs
@@ -57,8 +57,6 @@ namespace Orleans.Runtime.Messaging
 
         public void PostMessage(Message msg)
         {
-            if (Message.WriteMessagingTraces) msg.AddTimestamp(Message.LifecycleTag.EnqueueIncoming);
-
 #if TRACK_DETAILED_STATS
             if (StatisticsCollector.CollectQueueStats)
             {

--- a/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
@@ -381,9 +381,6 @@ namespace Orleans.Runtime.Messaging
 
         protected virtual void HandleMessage(Message msg, Socket receivedOnSocket)
         {
-            if (Message.WriteMessagingTraces)
-                msg.AddTimestamp(Message.LifecycleTag.ReceiveIncoming);
-
             // See it's a Ping message, and if so, short-circuit it
             object pingObj;
             var requestContext = msg.RequestContextData;
@@ -453,7 +450,6 @@ namespace Orleans.Runtime.Messaging
             {
                 // If the message is for some other silo altogether, then we need to forward it.
                 if (Log.IsVerbose2) Log.Verbose2("Forwarding message {0} from {1} to silo {2}", msg.Id, msg.SendingSilo, msg.TargetSilo);
-                if (Message.WriteMessagingTraces) msg.AddTimestamp(Message.LifecycleTag.EnqueueForForwarding);
                 MessageCenter.OutboundQueue.SendMessage(msg);
                 return;
             }

--- a/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
@@ -82,7 +82,6 @@ namespace Orleans.Runtime.Messaging
         private void ReceiveMessage(Message msg)
         {
             MessagingProcessingStatisticsGroup.OnImaMessageReceived(msg);
-            if (Message.WriteMessagingTraces) msg.AddTimestamp(Message.LifecycleTag.DequeueIncoming);
 
             ISchedulingContext context;
             // Find the activation it targets; first check for a system activation, then an app activation
@@ -102,13 +101,11 @@ namespace Orleans.Runtime.Messaging
                 switch (msg.Direction)
                 {
                     case Message.Directions.Request:
-                        if (Message.WriteMessagingTraces) msg.AddTimestamp(Message.LifecycleTag.EnqueueWorkItem);
                         MessagingProcessingStatisticsGroup.OnImaMessageEnqueued(context);
                         scheduler.QueueWorkItem(new RequestWorkItem(target, msg), context);
                         break;
 
                     case Message.Directions.Response:
-                        if (Message.WriteMessagingTraces) msg.AddTimestamp(Message.LifecycleTag.EnqueueWorkItem);
                         MessagingProcessingStatisticsGroup.OnImaMessageEnqueued(context);
                         scheduler.QueueWorkItem(new ResponseWorkItem(target, msg), context);
                         break;

--- a/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
@@ -84,9 +84,6 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-            if (Message.WriteMessagingTraces)
-                msg.AddTimestamp(Message.LifecycleTag.EnqueueOutgoing);
-
             // Shortcut messages to this silo
             if (msg.TargetSilo.Equals(messageCenter.MyAddress))
             {

--- a/src/OrleansRuntime/Messaging/SiloMessageSender.cs
+++ b/src/OrleansRuntime/Messaging/SiloMessageSender.cs
@@ -71,9 +71,6 @@ namespace Orleans.Runtime.Messaging
                 }
             }
 
-            if (Message.WriteMessagingTraces)
-                msg.AddTimestamp(Message.LifecycleTag.SendOutgoing);
-
             return true;
         }
 

--- a/src/OrleansRuntime/Scheduler/RequestWorkItem.cs
+++ b/src/OrleansRuntime/Scheduler/RequestWorkItem.cs
@@ -24,7 +24,6 @@ namespace Orleans.Runtime.Scheduler
 
         public override void Execute()
         {
-            if (Message.WriteMessagingTraces) request.AddTimestamp(Message.LifecycleTag.DequeueWorkItem);
             target.HandleNewRequest(request);
         }
 

--- a/src/OrleansRuntime/Scheduler/ResponseWorkItem.cs
+++ b/src/OrleansRuntime/Scheduler/ResponseWorkItem.cs
@@ -24,7 +24,6 @@ namespace Orleans.Runtime.Scheduler
 
         public override void Execute()
         {
-            if (Message.WriteMessagingTraces) response.AddTimestamp(Message.LifecycleTag.DequeueWorkItem);
             target.HandleResponse(response);
         }
 

--- a/src/OrleansTestingHost/ClientConfigurationForTesting.xml
+++ b/src/OrleansTestingHost/ClientConfigurationForTesting.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
     <TraceLevelOverride LogPrefix="Runtime" TraceLevel="Info" />
     <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
     <TraceLevelOverride LogPrefix="AssemblyLoader" TraceLevel="Warning" />

--- a/src/TesterInternal/ClientConfig_AzureStreamProviders.xml
+++ b/src/TesterInternal/ClientConfig_AzureStreamProviders.xml
@@ -4,7 +4,7 @@
   <Gateway Address="localhost" Port="40001" Proxied="true" />
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
     <TraceLevelOverride LogPrefix="Runtime" TraceLevel="Info" />
     <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
     <TraceLevelOverride LogPrefix="Tetris" TraceLevel="Info" />

--- a/src/TesterInternal/ClientConfig_StreamProviders.xml
+++ b/src/TesterInternal/ClientConfig_StreamProviders.xml
@@ -4,7 +4,7 @@
   <Gateway Address="localhost" Port="40001" Proxied="true" />
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
     <TraceLevelOverride LogPrefix="Runtime" TraceLevel="Info" />
     <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
     <TraceLevelOverride LogPrefix="Tetris" TraceLevel="Info" />

--- a/src/TesterInternal/Config_ActivationCollectorTests.xml
+++ b/src/TesterInternal/Config_ActivationCollectorTests.xml
@@ -18,7 +18,7 @@
   <Defaults>
     <Networking Address="localhost" Port="0"/>
     <Scheduler MaxActiveThreads="0"/>
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false" BulkMessageLimit="1000">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" BulkMessageLimit="1000">
       <!--
       <TraceLevelOverride LogPrefix="Runtime.MembershipOracle" TraceLevel="Verbose" />
       <TraceLevelOverride LogPrefix="Runtime.Dispatcher" TraceLevel="Verbose2" />

--- a/src/TesterInternal/Config_AzureBlobStorage.xml
+++ b/src/TesterInternal/Config_AzureBlobStorage.xml
@@ -26,7 +26,7 @@
   <Defaults>
     <Networking Address="localhost" Port="0" />
     <Scheduler MaxActiveThreads="0" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false">
       <!--
       <TraceLevelOverride LogPrefix="Runtime.MembershipOracle" TraceLevel="Verbose" />
       <TraceLevelOverride LogPrefix="Runtime.Dispatcher" TraceLevel="Verbose2" />

--- a/src/TesterInternal/Config_AzureStreamProviders.xml
+++ b/src/TesterInternal/Config_AzureStreamProviders.xml
@@ -20,7 +20,7 @@
   </Globals>
   <Defaults>
     <Networking Address="localhost" Port="0" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false" BulkMessageLimit="1000">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" BulkMessageLimit="1000">
       <TraceLevelOverride LogPrefix="AssemblyLoader.Silo" TraceLevel="Warning" />
 <!--
       <TraceLevelOverride LogPrefix="InsideGrainClient.InvokeException" TraceLevel="Verbose" />

--- a/src/TesterInternal/Config_AzureTableStorage.xml
+++ b/src/TesterInternal/Config_AzureTableStorage.xml
@@ -26,7 +26,7 @@
   <Defaults>
     <Networking Address="localhost" Port="0" />
     <Scheduler MaxActiveThreads="0" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false">
       <!--
       <TraceLevelOverride LogPrefix="Runtime.MembershipOracle" TraceLevel="Verbose" />
       <TraceLevelOverride LogPrefix="Runtime.Dispatcher" TraceLevel="Verbose2" />

--- a/src/TesterInternal/Config_BootstrapProviders.xml
+++ b/src/TesterInternal/Config_BootstrapProviders.xml
@@ -16,7 +16,7 @@
   <Defaults>
     <Networking Address="localhost" Port="22222"/>
     <ProxyingGateway Address="localhost" Port="40000" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" >
       <TraceLevelOverride LogPrefix="ProviderLoader" TraceLevel="Verbose" />
       <TraceLevelOverride LogPrefix="BootstrapProviderManager" TraceLevel="Verbose" />
       <TraceLevelOverride LogPrefix="ManagementGrain" TraceLevel="Verbose" />

--- a/src/TesterInternal/Config_DevStorage.xml
+++ b/src/TesterInternal/Config_DevStorage.xml
@@ -14,7 +14,7 @@
   <Defaults>
     <Networking Address="localhost" Port="0" />
     <Scheduler MaxActiveThreads="0" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" >
       <!--
       <TraceLevelOverride LogPrefix="Runtime.MembershipOracle" TraceLevel="Verbose" />
       <TraceLevelOverride LogPrefix="Runtime.Dispatcher" TraceLevel="Verbose2" />

--- a/src/TesterInternal/Config_LogConsumers-ClientConfiguration.xml
+++ b/src/TesterInternal/Config_LogConsumers-ClientConfiguration.xml
@@ -9,7 +9,7 @@
   <Gateway Address="localhost" Port="40000" Proxied="true" />
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="" WriteMessagingTraces="false">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="" >
     <LogConsumer>UnitTests.DummyLogConsumer,TesterInternal</LogConsumer>
     <TraceLevelOverride LogPrefix="Runtime" TraceLevel="Info" />
     <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />

--- a/src/TesterInternal/Config_LogConsumers-OrleansConfiguration.xml
+++ b/src/TesterInternal/Config_LogConsumers-OrleansConfiguration.xml
@@ -7,7 +7,7 @@
   <Defaults>
     <Networking Address="localhost" Port="0" />
     <Scheduler MaxActiveThreads="0" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="" WriteMessagingTraces="false">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="" >
       <LogConsumer>UnitTests.DummyLogConsumer,TesterInternal</LogConsumer>
       <!--
       <TraceLevelOverride LogPrefix="Runtime.MembershipOracle" TraceLevel="Verbose" />

--- a/src/TesterInternal/Config_NewAzure.xml
+++ b/src/TesterInternal/Config_NewAzure.xml
@@ -5,7 +5,7 @@
       DataConnectionString="DefaultEndpointsProtocol=https;AccountName=orleansdata1;AccountKey=SOMETHING1"/>
   </Globals>
   <Defaults>
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false" BulkMessageLimit="1000">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" BulkMessageLimit="1000">
     </Tracing>
   </Defaults>
   <Override Node="Primary">

--- a/src/TesterInternal/Config_NonTimestampedLogFileNames.xml
+++ b/src/TesterInternal/Config_NonTimestampedLogFileNames.xml
@@ -5,6 +5,6 @@
   </Globals>
   <Defaults>
     <Networking Address="localhost" Port="0" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}.log" WriteMessagingTraces="false"/>
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}.log" />
   </Defaults>
 </OrleansConfiguration>

--- a/src/TesterInternal/Config_OldAzure.xml
+++ b/src/TesterInternal/Config_OldAzure.xml
@@ -5,7 +5,7 @@
     <Azure DataConnectionString="DefaultEndpointsProtocol=https;AccountName=orleansdata1;AccountKey=SOMETHING1"/>
   </Globals>
   <Defaults>
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false" BulkMessageLimit="1000">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" BulkMessageLimit="1000">
     </Tracing>
   </Defaults>
   <Override Node="Primary">

--- a/src/TesterInternal/Config_StorageErrors.xml
+++ b/src/TesterInternal/Config_StorageErrors.xml
@@ -14,7 +14,7 @@
   <Defaults>
     <Networking Address="localhost" Port="0" />
     <Scheduler MaxActiveThreads="0" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false" BulkMessageLimit="1000">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" BulkMessageLimit="1000">
       <TraceLevelOverride LogPrefix="AssemblyLoader.Silo" TraceLevel="Warning" />
       <!--
       <TraceLevelOverride LogPrefix="InsideGrainClient.InvokeException" TraceLevel="Verbose" />

--- a/src/TesterInternal/Config_StorageProvider_Memory2.xml
+++ b/src/TesterInternal/Config_StorageProvider_Memory2.xml
@@ -8,7 +8,7 @@
     </StorageProviders>
   </Globals>
   <Defaults>
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false" BulkMessageLimit="1000">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" BulkMessageLimit="1000">
       <!--
       <TraceLevelOverride LogPrefix="Storage" TraceLevel="Verbose3" />
       <TraceLevelOverride LogPrefix="Runtime.MembershipOracle" TraceLevel="Verbose" />

--- a/src/TesterInternal/Config_StreamProviders.xml
+++ b/src/TesterInternal/Config_StreamProviders.xml
@@ -23,7 +23,7 @@
   </Globals>
   <Defaults>
     <Networking Address="localhost" Port="0" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" WriteMessagingTraces="false" BulkMessageLimit="1000">
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="true" TraceToFile="{0}-{1}.log" PropagateActivityId="false" BulkMessageLimit="1000">
       <TraceLevelOverride LogPrefix="AssemblyLoader.Silo" TraceLevel="Warning" />
 <!--
       <TraceLevelOverride LogPrefix="InsideGrainClient.InvokeException" TraceLevel="Verbose" />

--- a/test/Tester/ClientConfigurationForStreamTesting.xml
+++ b/test/Tester/ClientConfigurationForStreamTesting.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
     <TraceLevelOverride LogPrefix="Runtime" TraceLevel="Info" />
     <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
     <TraceLevelOverride LogPrefix="AssemblyLoader" TraceLevel="Warning" />

--- a/test/Tester/DeploymentTests/Configuration/TestAbsolutePaths/OrleansConfiguration.xml
+++ b/test/Tester/DeploymentTests/Configuration/TestAbsolutePaths/OrleansConfiguration.xml
@@ -12,7 +12,7 @@
   <Defaults>
     <Networking Address="" Port="0" Subnet="127"/>
     <Scheduler MaxActiveThreads="10" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false"/>
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" />
   </Defaults>
   <Override Node="Primary">
     <Networking Port="10010" />

--- a/test/Tester/DeploymentTests/Configuration/TestCleanEmptyOrleans/OrleansConfiguration.xml
+++ b/test/Tester/DeploymentTests/Configuration/TestCleanEmptyOrleans/OrleansConfiguration.xml
@@ -12,7 +12,7 @@
   <Defaults>
     <Networking Address="" Port="0" Subnet="127"/>
     <Scheduler MaxActiveThreads="10" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false"/>
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" />
   </Defaults>
   <Override Node="Primary">
     <Networking Port="10010" />

--- a/test/Tester/DeploymentTests/Configuration/TestCleanOrleans/OrleansConfiguration.xml
+++ b/test/Tester/DeploymentTests/Configuration/TestCleanOrleans/OrleansConfiguration.xml
@@ -12,7 +12,7 @@
   <Defaults>
     <Networking Address="" Port="0" Subnet="127"/>
     <Scheduler MaxActiveThreads="10" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false"/>
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log"/>
   </Defaults>
   <Override Node="Primary">
     <Networking Port="10010" />

--- a/test/Tester/DeploymentTests/Configuration/TestRelativePaths/OrleansConfiguration.xml
+++ b/test/Tester/DeploymentTests/Configuration/TestRelativePaths/OrleansConfiguration.xml
@@ -12,7 +12,7 @@
   <Defaults>
     <Networking Address="" Port="0" Subnet="127"/>
     <Scheduler MaxActiveThreads="10" />
-    <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false"/>
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" />
   </Defaults>
   <Override Node="Primary">
     <Networking Port="10010" />

--- a/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer.xml
+++ b/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
   </Tracing>
   <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
   <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0">

--- a/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer2.xml
+++ b/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer2.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
   </Tracing>
   <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
   <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0">

--- a/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer3.xml
+++ b/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer3.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
   </Tracing>
   <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
   <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0">

--- a/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer4.xml
+++ b/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer4.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
   </Tracing>
   <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
   <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0">

--- a/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer5.xml
+++ b/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer5.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
   </Tracing>
   <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
   <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0">

--- a/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer6.xml
+++ b/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer6.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
   </Tracing>
   <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
   <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0">

--- a/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer7.xml
+++ b/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer7.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
   </Tracing>
   <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
   <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0">

--- a/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer8.xml
+++ b/test/Tester/SerializationTests/ConfigurationTests/ClientConfigurationForSerializer8.xml
@@ -3,7 +3,7 @@
   <Gateway Address="localhost" Port="40000"/>
   <!-- To turn tracing off, set DefaultTraceLevel="Off" and have no overrides.
     For the trace log file name, {0} is replaced by "Client" and {1} is the current time. -->
-  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" WriteMessagingTraces="false" BulkMessageLimit="1000">
+  <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log" BulkMessageLimit="1000">
   </Tracing>
   <Statistics MetricsTableWriteInterval="300s" PerfCounterWriteInterval="30s" LogWriteInterval="300s" WriteLogStatisticsToTable="true" StatisticsCollectionLevel="Info"/>
   <Messaging ResponseTimeout="30s" ClientSenderBuckets="8192" MaxResendCount="0">


### PR DESCRIPTION
This PR removes the capability of detailed Messaging Traces.
This capability allows theoretically to trace time in different points in the life of a grain call, and output this trace. This sounded like a great capability at the time.
However, we ended up never using it. I don't remember a single case where we would use that to debug any situation. In prod this was always disabled, due to a large collection overhead.

I think if there is ever a need to bring something like that back to life, we are better off with a totally new implementation, where we would trace directly to a special purpose structured RPC tracing system. Something like Google's Dapper http://research.google.com/pubs/pub36356.html.

The benefit of removing this practicality dead code is a smaller code foootprint, easier maintenance, setting us on the path towards https://github.com/dotnet/orleans/issues/1372#issuecomment-183611938.


