### PR TITLE
CommandBehavior and CancellationToken added to relational back-end

### DIFF
--- a/src/OrleansSQLUtils/OrleansRelationalDownloadStream.cs
+++ b/src/OrleansSQLUtils/OrleansRelationalDownloadStream.cs
@@ -1,0 +1,314 @@
+﻿using System;
+using System.Data.Common;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.SqlUtils
+{
+    /// <summary>
+    /// This is a chunked read implementation for ADO.NET providers which do
+    /// not otherwise implement <see cref="DbDataReader.GetStream(int)"/> natively.
+    /// </summary>
+    public class OrleansRelationalDownloadStream: Stream
+    {
+        /// <summary>
+        /// A cached task as if there are multiple rounds of reads, it is likely
+        /// the bytes read is the same. This saves one allocation.
+        /// </summary>
+        private Task<int> lastTask;
+
+        /// <summary>
+        /// The reader to use to read from the database.
+        /// </summary>
+        private DbDataReader reader;
+
+        /// <summary>
+        /// The position in the overall stream.
+        /// </summary>
+        private long position;
+
+        /// <summary>
+        /// The column ordinal to read from.
+        /// </summary>
+        private readonly int ordinal;
+
+        /// <summary>
+        /// The total number of bytes in the column.
+        /// </summary>
+        private readonly long totalBytes;
+
+        /// <summary>
+        /// The internal byte array buffer size used in .CopyToAsync.
+        /// This size is just a guess and is likely dependent on the database
+        /// tuning settings (e.g. read_buffer_size in case of MySQL).
+        /// </summary>
+        private const int InternalReadBufferLength = 4092;
+
+
+        /// <summary>
+        /// The default constructor.
+        /// </summary>
+        /// <param name="reader">The reader to use to read from the database.</param>
+        /// <param name="ordinal">The column ordinal to read from.</param>
+        public OrleansRelationalDownloadStream(DbDataReader reader, int ordinal)
+        {            
+            this.reader = reader;
+            this.ordinal = ordinal;
+                        
+            //This return the total length of the column pointed by the ordinal.
+            totalBytes = reader.GetBytes(ordinal, 0, null, 0, 0);
+        }
+
+
+        /// <summary>
+        /// Can the stream be read.
+        /// </summary>
+        public override bool CanRead
+        {
+            get { return ((reader != null) && (!reader.IsClosed)); }
+        }
+
+
+        /// <summary>
+        /// Are seeks supported.
+        /// </summary>
+        /// <remarks>Returns <em>FALSE</em>.</remarks>
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+
+        /// <summary>
+        /// Can the stream timeout.
+        /// </summary>
+        /// <remarks>Returns <em>FALSE</em>.</remarks>
+        public override bool CanTimeout
+        {
+            get { return true; }
+        }
+
+
+        /// <summary>
+        /// Can the stream write.
+        /// </summary>
+        /// <remarks>Returns <em>FALSE</em>.</remarks>
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+
+        /// <summary>
+        /// The length of the stream.
+        /// </summary>        
+        public override long Length
+        {
+            get { return totalBytes; }
+        }
+
+
+        /// <summary>
+        /// The current position in the stream.
+        /// </summary>
+        public override long Position
+        {
+            get { return position; }
+            set { throw new NotSupportedException(); }
+        }
+
+        
+        /// <summary>
+        /// Throws <exception cref="NotSupportedException"/>.
+        /// </summary>        
+        /// <exception cref="NotSupportedException" />.
+        public override void Flush()
+        {
+            throw new NotSupportedException();
+        }
+
+
+        /// <summary>
+        /// Reads the stream.
+        /// </summary>
+        /// <param name="buffer">The buffer to read to.</param>
+        /// <param name="offset">The offset to the buffer to stat reading.</param>
+        /// <param name="count">The count of bytes to read to.</param>
+        /// <returns>The number of actual bytes read from the stream.</returns>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            //This will throw with the same parameter names if the parameters are not valid.
+            ValidateReadParameters(buffer, offset, count);
+
+            try
+            {                                                               
+                int length = Math.Min(count, (int)(totalBytes - position));
+                long bytesRead = 0;
+                if(length > 0)
+                {
+                    bytesRead = reader.GetBytes(ordinal, position, buffer, offset, length);
+                    position += bytesRead;
+                }
+
+                return (int)bytesRead;
+            }
+            catch(DbException dex)
+            {
+                //It's not OK to throw non-IOExceptions from a Stream.
+                throw new IOException(dex.Message, dex);
+            }
+        }
+
+
+        /// <summary>
+        /// Reads the stream.
+        /// </summary>
+        /// <param name="buffer">The buffer to read to.</param>
+        /// <param name="offset">The offset to the buffer to stat reading.</param>
+        /// <param name="count">The count of bytes to read to.</param>        
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The number of actual bytes read from the stream.</returns>
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            //This will throw with the same parameter names if the parameters are not valid.
+            ValidateReadParameters(buffer, offset, count);
+
+            if(cancellationToken.IsCancellationRequested)
+            {
+                var tcs = new TaskCompletionSource<int>();
+                tcs.SetCanceled();
+                return tcs.Task;
+            }
+
+            try
+            {
+                //The last used task is saved in order to avoid one allocation when the number of bytes read
+                //will likely be the same multiple times.
+                int bytesRead = Read(buffer, offset, count);
+                var ret = lastTask != null && bytesRead == lastTask.Result ? lastTask : (lastTask = Task.FromResult(bytesRead));
+
+                return ret;
+            }
+            catch(Exception e)
+            {
+                //Due to call to Read, this is for sure a IOException and can be thrown out.
+                var tcs = new TaskCompletionSource<int>();
+                tcs.SetException(e);
+
+                return tcs.Task;
+            }
+        }
+
+
+        /// <summary>
+        /// A buffer copy operation from database to the destination stream.
+        /// </summary>
+        /// <param name="destination">The destination stream.</param>
+        /// <param name="bufferSize">The buffer size.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <remarks>Reading from the underlying ADO.NET provider is currently synchro</remarks>
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            if(!cancellationToken.IsCancellationRequested)
+            {
+                byte[] buffer = new byte[InternalReadBufferLength];
+                int bytesRead;
+                while((bytesRead = Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    if(cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+       
+        /// <summary>
+        /// Throws <exception cref="NotSupportedException"/>.
+        /// </summary>
+        /// <param name="offset">The offset to the stream.</param>
+        /// <param name="origin">The origin.</param>
+        /// <returns>Throws <exception cref="NotSupportedException"/>.</returns>
+        /// <exception cref="NotSupportedException" />.
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+
+        /// <summary>
+        /// Throws <exception cref="NotSupportedException"/>. 
+        /// </summary>
+        /// <returns>Throws <exception cref="NotSupportedException"/>.</returns>
+        /// <exception cref="NotSupportedException" />.
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+
+        /// <summary>
+        /// Throws <exception cref="NotSupportedException"/>. 
+        /// </summary>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="offset">The offset to the buffer.</param>
+        /// <param name="count">The count of bytes to read.</param>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+
+        /// <summary>
+        /// Dispose.
+        /// </summary>
+        /// <param name="disposing">Whether is disposing or not.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if(disposing)
+            {
+                reader = null;
+            }
+
+            base.Dispose(disposing);
+        }
+
+
+        /// <summary>
+        /// Checks the the parameters passed into a ReadAsync() or Read() are valid.
+        /// </summary>        
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        private static void ValidateReadParameters(byte[] buffer, int offset, int count)
+        {            
+            if(buffer == null)
+            {
+                throw new ArgumentNullException("buffer");                    
+            }
+            if(offset < 0)
+            {
+                throw new ArgumentOutOfRangeException("offset");
+            }
+            if(count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count");
+            }
+            try
+            {
+                if(checked(offset + count) > buffer.Length)
+                {
+                    throw new ArgumentException("Invalid offset length");
+                }
+            }
+            catch(OverflowException)
+            {                
+                throw new ArgumentException("Invalid offset length");
+            }
+        }
+    }
+}

--- a/src/OrleansSQLUtils/OrleansSQLUtils.csproj
+++ b/src/OrleansSQLUtils/OrleansSQLUtils.csproj
@@ -63,6 +63,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Messaging\SqlMembershipTable.cs" />
+    <Compile Include="OrleansRelationalDownloadStream.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReminderService\SqlReminderTable.cs" />
     <Compile Include="Storage\AdoNetInvariants.cs" />

--- a/src/OrleansSQLUtils/Storage/DbConstantsStore.cs
+++ b/src/OrleansSQLUtils/Storage/DbConstantsStore.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Data.Common;
 
 namespace Orleans.SqlUtils
 {
@@ -9,7 +11,7 @@ namespace Orleans.SqlUtils
             {
                 {
                     AdoNetInvariants.InvariantNameSqlServer,
-                    new DbConstants(startEscapeIndicator: '[', 
+                    new DbConstants(startEscapeIndicator: '[',
                                     endEscapeIndicator: ']',
                                     unionAllSelectTemplate: " UNION ALL SELECT ")
                 },
@@ -28,7 +30,81 @@ namespace Orleans.SqlUtils
         {
             return invariantNameToConsts[invariantName];
         }
+
+        /// <summary>
+        /// If the underlying <see cref="DbCommand"/> the storage supports cancellation or not.
+        /// </summary>
+        /// <param name="storage">The storage used.</param>
+        /// <returns><em>TRUE</em> if cancellation is supported. <em>FALSE</em> otherwise.</returns>
+        public static bool SupportsCommandCancellation(this IRelationalStorage storage)
+        {
+            //Currently the assumption is all but MySQL support DbCommand cancellation.
+            //For MySQL, see at https://dev.mysql.com/doc/connector-net/en/connector-net-ref-mysqlclient-mysqlcommandmembers.html.
+            return SupportsCommandCancellation(storage.InvariantName);
+        }
+
+
+        /// <summary>
+        /// If the <see cref="DbCommand"/> that would be used supports cancellation or not.
+        /// </summary>
+        /// <param name="adoNetProvider">The ADO.NET provider invariant string.</param>
+        /// <returns><em>TRUE</em> if cancellation is supported. <em>FALSE</em> otherwise.</returns>
+        public static bool SupportsCommandCancellation(string adoNetProvider)
+        {
+            //Currently the assumption is all but MySQL support DbCommand cancellation.
+            //For MySQL, see at https://dev.mysql.com/doc/connector-net/en/connector-net-ref-mysqlclient-mysqlcommandmembers.html.
+            return !adoNetProvider.Equals(AdoNetInvariants.InvariantNameMySql, StringComparison.OrdinalIgnoreCase);
+        }
+
+
+        /// <summary>
+        /// If the underlying <see cref="DbCommand"/> the storage supports streaming natively.
+        /// </summary>
+        /// <param name="storage">The storage used.</param>
+        /// <returns><em>TRUE</em> if streaming is supported natively. <em>FALSE</em> otherwise.</returns>
+        public static bool SupportsStreamNatively(this IRelationalStorage storage)
+        {
+            //Currently the assumption is all but MySQL support streaming natively.            
+            return SupportsStreamNatively(storage.InvariantName);
+        }
+
+
+        /// <summary>
+        /// If the underlying <see cref="DbCommand"/> the storage supports streaming natively.
+        /// </summary>
+        /// <param name="adoNetProvider">The ADO.NET provider invariant string.</param>
+        /// <returns><em>TRUE</em> if streaming is supported natively. <em>FALSE</em> otherwise.</returns>
+        public static bool SupportsStreamNatively(string adoNetProvider)
+        {
+            //Currently the assumption is all but MySQL support streaming natively.            
+            return !adoNetProvider.Equals(AdoNetInvariants.InvariantNameMySql, StringComparison.OrdinalIgnoreCase);
+        }
+
+
+        /// <summary>
+        /// If the underlying ADO.NET implementation is known to be synchronous.
+        /// </summary>
+        /// <param name="storage">The storage used.</param>
+        /// <returns></returns>
+        public static bool IsSynchronousAdoNetImplementation(this IRelationalStorage storage)
+        {
+            //Currently the assumption is all but MySQL are asynchronous.            
+            return IsSynchronousAdoNetImplementation(storage.InvariantName);
+        }
+
+
+        /// <summary>
+        /// If the <see cref="DbCommand"/> that would be used supports cancellation or not.
+        /// </summary>
+        /// <param name="adoNetProvider">The ADO.NET provider invariant string.</param>
+        /// <returns></returns>
+        public static bool IsSynchronousAdoNetImplementation(string adoNetProvider)
+        {
+            //Currently the assumption is all but MySQL support DbCommand cancellation.            
+            return !adoNetProvider.Equals(AdoNetInvariants.InvariantNameMySql, StringComparison.OrdinalIgnoreCase);
+        }        
     }
+
 
     internal class DbConstants
     {

--- a/src/OrleansSQLUtils/Storage/DbExtensions.cs
+++ b/src/OrleansSQLUtils/Storage/DbExtensions.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace Orleans.SqlUtils
 {
@@ -106,14 +108,45 @@ namespace Orleans.SqlUtils
         /// </summary>
         /// <typeparam name="TValue">The type of the value to request.</typeparam>
         /// <param name="record">The record from which to retrieve the value.</param>
-        /// <param name="ordinal">The ordinal of the fieldname.</param>
+        /// <param name="fieldName">The name of the field to retrieve.</param>
         /// <param name="default">The default value if value in position is <see cref="System.DBNull"/>.</param>
         /// <returns>Either the given value or the default for the requested type.</returns>
         /// <exception cref="IndexOutOfRangeException"/>
-        /// <remarks>This function throws if the given <see paramref="fieldName"/> does not exist.</remarks>        
+        /// <remarks>This function throws if the given <see paramref="fieldName"/> does not exist.</remarks>
+        public static async Task<TValue> GetValueOrDefaultAsync<TValue>(this DbDataReader record, string fieldName, TValue @default = default(TValue))
+        {
+            var ordinal = record.GetOrdinal(fieldName);
+            return (await record.IsDBNullAsync(ordinal).ConfigureAwait(false)) ? @default : (await record.GetFieldValueAsync<TValue>(ordinal).ConfigureAwait(false));
+        }
+
+
+        /// <summary>
+        /// Returns a value if it is not <see cref="System.DBNull"/>, <em>default(TValue)</em> otherwise.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value to request.</typeparam>
+        /// <param name="record">The record from which to retrieve the value.</param>
+        /// <param name="ordinal">The ordinal of the fieldname.</param>
+        /// <param name="default">The default value if value in position is <see cref="System.DBNull"/>.</param>
+        /// <returns>Either the given value or the default for the requested type.</returns>
+        /// <exception cref="IndexOutOfRangeException"/>                
         public static TValue GetValueOrDefault<TValue>(this IDataRecord record, int ordinal, TValue @default = default(TValue))
         {
             return record.IsDBNull(ordinal) ? @default : (TValue)record.GetValue(ordinal);
+        }
+
+
+        /// <summary>
+        /// Returns a value if it is not <see cref="System.DBNull"/>, <em>default(TValue)</em> otherwise.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value to request.</typeparam>
+        /// <param name="record">The record from which to retrieve the value.</param>
+        /// <param name="ordinal">The ordinal of the fieldname.</param>
+        /// <param name="default">The default value if value in position is <see cref="System.DBNull"/>.</param>
+        /// <returns>Either the given value or the default for the requested type.</returns>
+        /// <exception cref="IndexOutOfRangeException"/>                
+        public static async Task<TValue> GetValueOrDefaultAsync<TValue>(this DbDataReader record, int ordinal, TValue @default = default(TValue))
+        {
+            return (await record.IsDBNullAsync(ordinal).ConfigureAwait(false)) ? @default : (await record.GetFieldValueAsync<TValue>(ordinal).ConfigureAwait(false));
         }
 
 
@@ -130,8 +163,24 @@ namespace Orleans.SqlUtils
         {
             var ordinal = record.GetOrdinal(fieldName);
             return (TValue)record.GetValue(ordinal);
-        }        
-        
+        }
+
+
+        /// <summary>
+        /// Returns a value with the given <see paramref="fieldName"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The type of value to retrieve.</typeparam>
+        /// <param name="record">The record from which to retrieve the value.</param>
+        /// <param name="fieldName">The name of the field.</param>
+        /// <returns>Value in the given field indicated by <see paramref="fieldName"/>.</returns>
+        /// <exception cref="IndexOutOfRangeException"/>
+        /// <remarks>This function throws if the given <see paramref="fieldName"/> does not exist.</remarks>        
+        public static async Task<TValue> GetValueAsync<TValue>(this DbDataReader record, string fieldName)
+        {
+            var ordinal = record.GetOrdinal(fieldName);
+            return await record.GetFieldValueAsync<TValue>(ordinal).ConfigureAwait(false);
+        }
+
 
 
         /// <summary>

--- a/src/OrleansSQLUtils/Storage/IRelationalStorage.cs
+++ b/src/OrleansSQLUtils/Storage/IRelationalStorage.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.SqlUtils
@@ -17,6 +18,8 @@ namespace Orleans.SqlUtils
         /// <param name="query">The query to execute.</param>
         /// <param name="parameterProvider">Adds parameters to the query. The parameters must be in the same order with same names as defined in the query.</param>
         /// <param name="selector">This function transforms the raw <see cref="IDataRecord"/> results to type <see paramref="TResult"/> the <see cref="int"/> parameter being the resultset number.</param>
+        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
+        /// <param name="commandBehavior">The command behavior that should be used. Defaults to <see cref="CommandBehavior.Default"/>.</param>
         /// <returns>A list of objects as a result of the <see paramref="query"/>.</returns>
         /// <example>This sample shows how to make a hand-tuned database call.
         /// <code>
@@ -57,13 +60,15 @@ namespace Orleans.SqlUtils
         ///}).ConfigureAwait(continueOnCapturedContext: false);                
         /// </code>        
         /// </example>
-        Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, TResult> selector);
+        Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default);
 
         /// <summary>
         /// Executes a given statement. Especially intended to use with <em>INSERT</em>, <em>UPDATE</em>, <em>DELETE</em> or <em>DDL</em> queries.
         /// </summary>
         /// <param name="query">The query to execute.</param>
         /// <param name="parameterProvider">Adds parameters to the query. Parameter names must match those defined in the query.</param>
+        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
+        /// <param name="commandBehavior">The command behavior that should be used. Defaults to <see cref="CommandBehavior.Default"/>.</param>
         /// <returns>Affected rows count.</returns>
         /// <example>This sample shows how to make a hand-tuned database call.
         /// <code>
@@ -78,7 +83,7 @@ namespace Orleans.SqlUtils
         /// }).ConfigureAwait(continueOnCapturedContext: false);                
         /// </code>
         /// </example>
-        Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider);
+        Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default);
 
         /// <summary>
         /// The well known invariant name of the underlying database.

--- a/src/OrleansSQLUtils/Storage/RelationalStorage.cs
+++ b/src/OrleansSQLUtils/Storage/RelationalStorage.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.SqlUtils
@@ -23,6 +24,20 @@ namespace Orleans.SqlUtils
         /// The invariant name of the connector for this database.
         /// </summary>
         private readonly string invariantName;
+
+        /// <summary>
+        /// If the ADO.NET provider of this storage supports cancellation or not. This
+        /// capability is queried and the the result is cached here.
+        /// </summary>
+        private readonly bool supportsCommandCancellation;
+
+        /// <summary>
+        /// If the underlying ADO.NET implementation is natively asynchronous
+        /// (the ADO.NET Db*.XXXAsync classes are overriden) or not.
+        /// </summary>
+        private readonly bool isSynchronousAdoNetImplementation;
+
+
         /// <summary>
         /// The invariant name of the connector for this database.
         /// </summary>
@@ -76,6 +91,8 @@ namespace Orleans.SqlUtils
         /// <param name="query">Executes a given statement. Especially intended to use with <em>SELECT</em> statement.</param>        
         /// <param name="parameterProvider">Adds parameters to the query. Parameter names must match those defined in the query.</param>
         /// <param name="selector">This function transforms the raw <see cref="IDataRecord"/> results to type <see paramref="TResult"/> the <see cref="int"/> parameter being the resultset number.</param>
+        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
+        /// <param name="commandBehavior">The command behavior that should be used. Defaults to <see cref="CommandBehavior.Default"/>.</param>
         /// <returns>A list of objects as a result of the <see paramref="query"/>.</returns>
         /// <example>This sample shows how to make a hand-tuned database call.
         /// <code>
@@ -116,7 +133,7 @@ namespace Orleans.SqlUtils
         ///}).ConfigureAwait(continueOnCapturedContext: false);                
         /// </code>
         /// </example>
-        public async Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, TResult> selector)
+        public Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default)
         {
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
@@ -129,7 +146,11 @@ namespace Orleans.SqlUtils
                 throw new ArgumentNullException("selector");
             }
 
-            return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, selector).ConfigureAwait(continueOnCapturedContext: false)).Item1;
+            //It is certain the result is already ready here and can be collected straight away. Having a truly asynchronous result collection
+            //IAsyncEnumerable<TResult> or equivalent method ought to be used. Taking the result here without async-await saves for generating
+            //the async state machine.
+            var ret = ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, selector, cancellationToken, commandBehavior).GetAwaiter().GetResult().Item1;
+            return Task.FromResult(ret);
         }
 
 
@@ -138,6 +159,8 @@ namespace Orleans.SqlUtils
         /// </summary>
         /// <param name="query">The query to execute.</param>
         /// <param name="parameterProvider">Adds parameters to the query. Parameter names must match those defined in the query.</param>
+        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
+        /// <param name="commandBehavior">The command behavior that should be used. Defaults to <see cref="CommandBehavior.Default"/>.</param>
         /// <returns>Affected rows count.</returns>
         /// <example>This sample shows how to make a hand-tuned database call.
         /// <code>
@@ -152,7 +175,7 @@ namespace Orleans.SqlUtils
         /// }).ConfigureAwait(continueOnCapturedContext: false);                
         /// </code>
         /// </example>
-        public async Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider)
+        public Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default)
         {
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
@@ -160,7 +183,11 @@ namespace Orleans.SqlUtils
                 throw new ArgumentNullException("query");
             }
 
-            return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, (unit, id) => unit).ConfigureAwait(continueOnCapturedContext: false)).Item2;
+            //It is certain the result is already ready here and can be collected straight away. Having a truly asynchronous result collection
+            //IAsyncEnumerable<TResult> or equivalent method ought to be used. Taking the result here without async-await saves for generating
+            //the async state machine.
+            var ret = ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, (unit, id, c) => Task.FromResult(unit), cancellationToken, commandBehavior).GetAwaiter().GetResult().Item2;
+            return Task.FromResult(ret);
         }
 
         /// <summary>
@@ -170,24 +197,47 @@ namespace Orleans.SqlUtils
         /// <param name="connectionString">The connection string this database should use for database operations.</param>
         private RelationalStorage(string invariantName, string connectionString)
         {
+            //These are private, read-only variables (with a property accessor).
             this.connectionString = connectionString;
             this.invariantName = invariantName;
+            supportsCommandCancellation = DbConstantsStore.SupportsCommandCancellation(InvariantName);
+            isSynchronousAdoNetImplementation = DbConstantsStore.IsSynchronousAdoNetImplementation(InvariantName);
         }
 
 
-        private static async Task<Tuple<IEnumerable<TResult>, int>> SelectAsync<TResult>(DbDataReader reader, Func<IDataReader, int, TResult> selector)
+        /// <summary>
+        /// A cached value if the underlying ADO.NET provider supports cancellation or not.        
+        /// </summary>
+        private bool SupportsCommandCancellation
+        {
+            get { return supportsCommandCancellation; }
+        }
+
+
+        /// <summary>
+        /// If the underlying ADO.NET implementation is natively asynchronous
+        /// (the ADO.NET Db*.XXXAsync classes are overriden) or not.
+        /// </summary>
+        private bool IsSynchronousAdoNetImplementation
+        {
+            get { return isSynchronousAdoNetImplementation; }
+        }
+
+
+
+        private static async Task<Tuple<IEnumerable<TResult>, int>> SelectAsync<TResult>(DbDataReader reader, Func<IDataReader, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken)
         {
             var results = new List<TResult>();
             int resultSetCount = 0;
             while(reader.HasRows)
             {
-                while(await reader.ReadAsync().ConfigureAwait(continueOnCapturedContext: false))
+                while(await reader.ReadAsync(cancellationToken).ConfigureAwait(continueOnCapturedContext: false))
                 {
-                    var obj = selector(reader, resultSetCount);
+                    var obj = await selector(reader, resultSetCount, cancellationToken).ConfigureAwait(false);
                     results.Add(obj);
                 }
 
-                await reader.NextResultAsync();
+                await reader.NextResultAsync(cancellationToken);
                 ++resultSetCount;
             }
 
@@ -195,34 +245,72 @@ namespace Orleans.SqlUtils
         }
 
 
-        private static async Task<Tuple<IEnumerable<TResult>, int>> ExecuteReaderAsync<TResult>(DbCommand command, Func<IDataRecord, int, TResult> selector)
+        private async Task<Tuple<IEnumerable<TResult>, int>> ExecuteReaderAsync<TResult>(DbCommand command, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken, CommandBehavior commandBehavior)
         {
-            using(var reader = await command.ExecuteReaderAsync().ConfigureAwait(continueOnCapturedContext: false))
+            using(var reader = await command.ExecuteReaderAsync(commandBehavior, cancellationToken).ConfigureAwait(continueOnCapturedContext: false))
             {
-                return await SelectAsync(reader, selector).ConfigureAwait(false);
+                CancellationTokenRegistration cancellationRegistration = default(CancellationTokenRegistration);
+                try
+                {
+                    if(cancellationToken.CanBeCanceled && SupportsCommandCancellation)
+                    {
+                        cancellationRegistration = cancellationToken.Register(CommandCancellation, Tuple.Create(reader, command), useSynchronizationContext: false);
+                    }
+                    return await SelectAsync(reader, selector, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    cancellationRegistration.Dispose();
+                }
             }
         }
-
+           
 
         private async Task<Tuple<IEnumerable<TResult>, int>> ExecuteAsync<TResult>(
             string query,
             Action<DbCommand> parameterProvider,
-            Func<DbCommand, Func<IDataRecord, int, TResult>, Task<Tuple<IEnumerable<TResult>, int>>> executor,
-            Func<IDataRecord, int, TResult> selector)
+            Func<DbCommand, Func<IDataRecord, int, CancellationToken, Task<TResult>>, CancellationToken, CommandBehavior, Task<Tuple<IEnumerable<TResult>, int>>> executor,
+            Func<IDataRecord, int, CancellationToken, Task<TResult>> selector,
+            CancellationToken cancellationToken,
+            CommandBehavior commandBehavior)
         {
             using (var connection = DbConnectionFactory.CreateConnection(invariantName, connectionString))
             {
-                await connection.OpenAsync().ConfigureAwait(continueOnCapturedContext: false);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
                 using(var command = connection.CreateCommand())
-                {
+                {                    
                     if(parameterProvider != null)
                     {
                         parameterProvider(command);
                     }
-
                     command.CommandText = query;
-                    return await executor(command, selector).ConfigureAwait(continueOnCapturedContext: false);
+
+                    Task<Tuple<IEnumerable<TResult>, int>> ret;
+                    if(IsSynchronousAdoNetImplementation)
+                    {
+                        ret = Task.Run(() => executor(command, selector, cancellationToken, commandBehavior), cancellationToken);
+                    }
+                    else
+                    {
+                        ret = executor(command, selector, cancellationToken, commandBehavior);
+                    }
+
+                    return await ret.ConfigureAwait(continueOnCapturedContext: false);
                 }
+            }
+        }
+
+
+        private static void CommandCancellation(object state)
+        {
+            //The MSDN documentation tells that DbCommand.Cancel() should not be called for SqlCommand if the reader has been closed
+            //in order to avoid a race condition that would cause the SQL Server to stream the result set
+            //despite the connection already closed. Source: https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlcommand.cancel(v=vs.110).aspx.
+            //Enforcing this behavior across all providers does not seem to hurt.
+            var stateTuple = (Tuple<DbDataReader, DbCommand>)state;
+            if(!stateTuple.Item1.IsClosed)
+            {
+                stateTuple.Item2.Cancel();
             }
         }
     }

--- a/src/TesterInternal/StorageTests/RelationalStoreTests.cs
+++ b/src/TesterInternal/StorageTests/RelationalStoreTests.cs
@@ -1,0 +1,222 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.SqlUtils;
+using System;
+using System.Data;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UnitTests.General;
+
+namespace UnitTests.StorageTests.SQLAdapter
+{
+    public class StreamingTest
+    {
+        public int Id { get; set; }
+
+        public byte[] StreamData { get; set; }
+    }
+
+
+    [TestClass]
+    public class RelationalStoreTests
+    {
+        private const string testDatabaseName = "OrleansTest";
+        
+        //This timeout limit should be clearly less than that defined in RelationalStorageForTesting.CancellationTestQuery. 
+        private readonly TimeSpan CancellationTestTimeoutLimit = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan StreamCancellationTimeoutLimit = TimeSpan.FromSeconds(5);
+        private const int MiB = 1048576;
+        private const int StreamSizeToBeInsertedInBytes = MiB * 2;
+        private const int NumberOfParallelStreams = 5;
+
+        private readonly TraceLogger Logger = TraceLogger.GetLogger("RelationalGeneralTests", TraceLogger.LoggerType.Application);
+
+        public TestContext TestContext { get; set; }
+
+        public static RelationalStorageForTesting SqlServerStorage { get; set; }
+
+        public static RelationalStorageForTesting MySqlStorage { get; set; }
+
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            TraceLogger.AddTraceLevelOverride("RelationalStreamingTests", Severity.Verbose3);
+            try
+            {
+                SqlServerStorage = RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, testDatabaseName).GetAwaiter().GetResult();
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine("Failed to initialize SQL Server for RelationalGeneralTests: {0}", ex);
+            }
+
+            try
+            {
+                MySqlStorage = RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameMySql, testDatabaseName).GetAwaiter().GetResult();
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine("Failed to initialize MySQL for RelationalGeneralTests: {0}", ex);
+            }
+        }
+
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Logger.Info("Test {0} completed - Outcome = {1}", TestContext.TestName, TestContext.CurrentTestOutcome);
+        }
+
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("SqlServer")]
+        public async Task Streaming_SqlServer_Test()
+        {
+            using(var tokenSource = new CancellationTokenSource(StreamCancellationTimeoutLimit))
+            {                
+                var isMatch = await Task.WhenAll(InsertAndReadStreamsAndCheckMatch(SqlServerStorage, StreamSizeToBeInsertedInBytes, NumberOfParallelStreams, tokenSource.Token));
+                Assert.IsTrue(isMatch.All(i => i), "All inserted streams should be equal to read streams.");
+            }
+        }
+
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MySql")]
+        public async Task Streaming_MySql_Test()
+        {
+            using(var tokenSource = new CancellationTokenSource(StreamCancellationTimeoutLimit))
+            {             
+                tokenSource.CancelAfter(StreamCancellationTimeoutLimit);
+                var isMatch = await Task.WhenAll(InsertAndReadStreamsAndCheckMatch(MySqlStorage, StreamSizeToBeInsertedInBytes, NumberOfParallelStreams, tokenSource.Token));
+                Assert.IsTrue(isMatch.All(i => i), "All inserted streams should be equal to read streams.");
+            }
+        }
+
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("SqlServer")]
+        public async Task CancellationToken_SqlServer_Test()
+        {
+            await CancellationTokenTest(SqlServerStorage, CancellationTestTimeoutLimit);
+        }
+
+
+        [TestMethod, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MySql")]
+        public async Task CancellationToken_MySql_Test()
+        {
+            await CancellationTokenTest(MySqlStorage, CancellationTestTimeoutLimit);
+        }
+
+
+        private static Task<bool>[] InsertAndReadStreamsAndCheckMatch(RelationalStorageForTesting sut, int streamSize, int countOfStreams, CancellationToken cancellationToken)
+        {
+            //Stream in and steam out three binary streams in parallel.
+            var streamChecks = new Task<bool>[countOfStreams];
+            var sr = new SafeRandom();
+            for(int i = 0; i < countOfStreams; ++i)
+            {
+                int streamId = i;
+                streamChecks[i] = Task.Run(async () =>
+                {
+                    var rb = new byte[streamSize];
+                    sr.NextBytes(rb);
+                    await InsertIntoDatabaseUsingStream(sut, streamId, rb, cancellationToken);
+                    var dataStreamFromTheDb = await ReadFromDatabaseUsingAsyncStream(sut, streamId, cancellationToken);
+                    return dataStreamFromTheDb.StreamData.SequenceEqual(rb);
+                });
+            }
+
+            return streamChecks;
+        }
+
+
+        private static async Task InsertIntoDatabaseUsingStream(RelationalStorageForTesting sut, int streamId, byte[] dataToInsert, CancellationToken cancellationToken)
+        {
+            //The dataToInsert could be inserted here directly, but it wouldn't be streamed.
+            using(var ms = new MemoryStream(dataToInsert))
+            {
+                await sut.Storage.ExecuteAsync(sut.StreamTestInsert, command =>
+                {
+                    var p1 = command.CreateParameter();
+                    p1.ParameterName = "Id";
+                    p1.Value = streamId;
+                    command.Parameters.Add(p1);
+
+                    //MySQL does not support streams in and for the time being there
+                    //is not a custom stream defined. For ideas, see http://dev.mysql.com/doc/refman/5.7/en/blob.html
+                    //for string operations for blobs and http://rusanu.com/2010/12/28/download-and-upload-images-from-sql-server-with-asp-net-mvc/
+                    //on how one could go defining one.
+                    var p2 = command.CreateParameter();
+                    p2.ParameterName = "StreamData";
+                    p2.Value = dataToInsert;
+                    p2.DbType = DbType.Binary;
+                    p2.Size = dataToInsert.Length;
+                    command.Parameters.Add(p2);
+
+                }, cancellationToken, CommandBehavior.SequentialAccess).ConfigureAwait(false);
+            }
+        }
+
+
+        private static async Task<StreamingTest> ReadFromDatabaseUsingAsyncStream(RelationalStorageForTesting sut, int streamId, CancellationToken cancellationToken)
+        {
+            return (await sut.Storage.ReadAsync(sut.StreamTestSelect, command =>
+            {
+                var p = command.CreateParameter();
+                p.ParameterName = "streamId";
+                p.Value = streamId;
+                command.Parameters.Add(p);
+            }, async (selector, resultSetCount, canellationToken) =>
+            {
+                var streamSelector = (DbDataReader)selector;
+                var id = await streamSelector.GetValueAsync<int>("Id");
+                using(var ms = new MemoryStream())
+                {                    
+                    using(var downloadStream = streamSelector.GetStream(1, sut.Storage))
+                    {
+                        await downloadStream.CopyToAsync(ms);
+
+                        return new StreamingTest { Id = id, StreamData = ms.ToArray() };
+                    }
+                }                
+            }, cancellationToken, CommandBehavior.SequentialAccess).ConfigureAwait(false)).Single();
+        }
+
+
+        private static Task CancellationTokenTest(RelationalStorageForTesting sut, TimeSpan timeoutLimit)
+        {
+            using(var tokenSource = new CancellationTokenSource(timeoutLimit))
+            {
+                try
+                {
+                    //Here one second is added to the task timeout limit in order to account for the delays.
+                    //The delays are mainly in the underlying ADO.NET libraries and database.
+                    var task = sut.Storage.ReadAsync<int>(sut.CancellationTestQuery, tokenSource.Token);
+                    if(!task.Wait(timeoutLimit.Add(TimeSpan.FromSeconds(1))))
+                    {
+                        Assert.Fail(string.Format("Timeout limit {0} ms exceeded.", timeoutLimit.TotalMilliseconds));
+                    }
+                }
+                catch(Exception ex)
+                {
+                    //There can be a DbException due to the operation being forcefully cancelled...
+                    //... Unless this is a test for a provider which does not support for cancellation.
+                    if(sut.Storage.SupportsCommandCancellation())
+                    {
+                        //If the operation is cancelled already before database calls, a OperationCancelledException
+                        //will be thrown in any case.
+                        Assert.IsTrue(ex is DbException || ex is OperationCanceledException, "Unexcepted exception: {0}", ex);
+                    }
+                    else
+                    {
+                        Assert.IsTrue(ex is OperationCanceledException, "Unexcepted exception: {0}", ex);
+                    }
+                }
+            }
+
+            return TaskDone.Done;
+        }
+    }
+}

--- a/src/TesterInternal/TesterInternal.csproj
+++ b/src/TesterInternal/TesterInternal.csproj
@@ -104,6 +104,7 @@
     <Compile Include="RemindersTest\AzureRemindersTableTests.cs" />
     <Compile Include="StorageTests\PersistenceGrainTests_AzureBlobStore.cs" />
     <Compile Include="StorageTests\PersistenceGrainTests_AzureTableStore.cs" />
+    <Compile Include="StorageTests\RelationalStoreTests.cs" />
     <Compile Include="StreamingTests\AQStreamingTests.cs" />
     <Compile Include="AssemblyLoaderTests.cs" />
     <Compile Include="AsynchAgentRestartTest.cs" />

--- a/test/Tester/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Tester/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -18,6 +18,10 @@ namespace UnitTests.General
                          Asynchronous Processing = True; Max Pool Size = 200; MultipleActiveResultSets = True"; }
         }
 
+        public override string CancellationTestQuery { get { return "WAITFOR DELAY '00:00:010'; SELECT 1; "; } }
+
+        public override string CreateStreamTestTable { get { return "CREATE TABLE StreamingTest(Id INT NOT NULL, StreamData VARBINARY(MAX) NOT NULL);"; } }               
+               
         protected override string SetupSqlScriptFileName
         {
             get { return "CreateOrleansTables_SqlServer.sql"; }
@@ -33,7 +37,7 @@ namespace UnitTests.General
                 (
                     NAME = [{0}], 
                     FILENAME =''' + @fileName + ''', 
-                    SIZE = 5MB, 
+                    SIZE = 20MB, 
                     MAXSIZE = 100MB, 
                     FILEGROWTH = 5MB
                 )')";
@@ -56,13 +60,16 @@ namespace UnitTests.General
             }
         }
 
+
         protected override IEnumerable<string> ConvertToExecutableBatches(string setupScript, string dataBaseName)
         {
             var batches = setupScript.Split(new[] {"GO"}, StringSplitOptions.RemoveEmptyEntries).ToList();
-            //putting the database in simple recovery mode.
+            
             //This removes the use of recovery log in case of database crashes, which
             //improves performance to some degree, depending on usage. For non-performance testing only.
             batches.Add(string.Format("ALTER DATABASE [{0}] SET RECOVERY SIMPLE;", dataBaseName));
+            batches.Add(CreateStreamTestTable);
+
             return batches;
         }
     }


### PR DESCRIPTION
Added CommandBehavior and CancellationToken to the relational
back-end implementation with tests. CommandBehavior is added
in anticipation of using streaming in state and streams provider
due to possibly large payload size.