### PR TITLE
Define default VisualStudioVersion

### DIFF
--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -6,6 +6,7 @@
 SET CMDHOME=%~dp0.
 if "%FrameworkDir%" == "" set FrameworkDir=%WINDIR%\Microsoft.NET\Framework
 if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
+if "%VisualStudioVersion%" == "" set VisualStudioVersion=14.0
 
 SET MSBUILDEXEDIR=%FrameworkDir%\%FrameworkVersion%
 SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe


### PR DESCRIPTION
This is because if we run the build script from a non-command prompt, generating the VSIX fails