### PR TITLE
xUnit runner to use AppDomains.

### DIFF
--- a/test/Tester/Tester.xunit.runner.json
+++ b/test/Tester/Tester.xunit.runner.json
@@ -1,5 +1,5 @@
 ﻿{
-  "appDomain": "denied",
+  "appDomain": "ifAvailable",
   "diagnosticMessages": true,
   "parallelizeAssembly": false,
   "parallelizeTestCollections": false,


### PR DESCRIPTION
This is so that the test assembly's binding redirects work as expected.

I believe there is some support for [config files in dotnet core also](https://github.com/dotnet/cli/issues/807), but we can deal with that later.