### PR TITLE
Repro for #1484; Json deserialization of POCO with object generic argument

### DIFF
--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -31,7 +31,6 @@ namespace Orleans.Serialization
             settings.Converters.Add(new GrainIdConverter());
             settings.Converters.Add(new SiloAddressConverter());
             settings.Converters.Add(new UniqueKeyConverter());
-            settings.Converters.Add(new GuidJsonConverter());
         }
         
         /// <summary>
@@ -232,94 +231,5 @@ namespace Orleans.Serialization
             return new IPEndPoint(address, port);
         }
     }
-
-    /// <summary>
-    ///     JSON converter for <see cref="Guid"/>.
-    /// </summary>
-    class GuidJsonConverter : JsonConverter
-    {
-        /// <summary>
-        ///     Gets a value indicating whether this <see cref="T:Newtonsoft.Json.JsonConverter"/> can read JSON.
-        /// </summary>
-        /// <value><see langword="true"/> if this <see cref="T:Newtonsoft.Json.JsonConverter"/> can read JSON; otherwise, <see langword="false"/>.
-        /// </value>
-        public override bool CanRead { get { return true; } }
-
-        /// <summary>
-        ///     Gets a value indicating whether this <see cref="T:Newtonsoft.Json.JsonConverter"/> can write JSON.
-        /// </summary>
-        /// <value><see langword="true"/> if this <see cref="T:Newtonsoft.Json.JsonConverter"/> can write JSON; otherwise, <see langword="false"/>.
-        /// </value>
-        public override bool CanWrite { get { return true; } }
-
-        /// <summary>
-        /// Determines whether this instance can convert the specified object type.
-        /// </summary>
-        /// <param name="objectType">
-        /// Kind of the object.
-        /// </param>
-        /// <returns>
-        /// <see langword="true"/> if this instance can convert the specified object type; otherwise,
-        /// .
-        /// </returns>
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType.IsAssignableFrom(typeof(Guid)) || objectType.IsAssignableFrom(typeof(Guid?));
-        }
-
-        /// <summary>
-        /// Writes the JSON representation of the object.
-        /// </summary>
-        /// <param name="writer">
-        /// The <see cref="T:Newtonsoft.Json.JsonWriter"/> to write to.
-        /// </param>
-        /// <param name="value">
-        /// The value.
-        /// </param>
-        /// <param name="serializer">
-        /// The calling serializer.
-        /// </param>
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            if (value == null)
-            {
-                writer.WriteValue(default(string));
-            }
-            else if (value is Guid)
-            {
-                var guid = (Guid)value;
-                writer.WriteValue(guid.ToString("N"));
-            }
-        }
-
-        /// <summary>
-        /// Reads the JSON representation of the object.
-        /// </summary>
-        /// <param name="reader">
-        /// The <see cref="T:Newtonsoft.Json.JsonReader"/> to read from.
-        /// </param>
-        /// <param name="objectType">
-        /// Kind of the object.
-        /// </param>
-        /// <param name="existingValue">
-        /// The existing value of object being read.
-        /// </param>
-        /// <param name="serializer">
-        /// The calling serializer.
-        /// </param>
-        /// <returns>
-        /// The object value.
-        /// </returns>
-        public override object ReadJson(
-            JsonReader reader,
-            Type objectType,
-            object existingValue,
-            JsonSerializer serializer)
-        {
-            var str = reader.Value as string;
-            return str != null ? Guid.Parse(str) : default(Guid);
-        }
-    }
-
     #endregion
 }

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using Orleans.CodeGeneration;
 using Orleans.Serialization;
 using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
 
 namespace UnitTests.Serialization
 {
@@ -52,6 +53,17 @@ namespace UnitTests.Serialization
             var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
             settings.Converters.Add(new GuidJsonTestConverter());
             Do_Json_Guid_Test(settings);
+        }
+
+        [Fact(Skip = "Fix of issue #1484 is still pending"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
+        public void SerializationTests_Json_POCO_WithGuidConverter()
+        {
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+            settings.Converters.Add(new GuidJsonTestConverter());
+            var obj = new SimplePersistentGrain_State();
+            string objSerialized = JsonConvert.SerializeObject(obj, settings);
+            var objDeserialized = JsonConvert.DeserializeObject<object>(objSerialized, settings);
+            Assert.AreEqual(typeof(SimplePersistentGrain_State), objDeserialized.GetType());
         }
 
         private void Do_Json_Guid_Test(JsonSerializerSettings settings)

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using Xunit;
 using Newtonsoft.Json;
@@ -7,7 +6,6 @@ using Newtonsoft.Json.Linq;
 using Orleans.CodeGeneration;
 using Orleans.Serialization;
 using UnitTests.GrainInterfaces;
-using UnitTests.Grains;
 
 namespace UnitTests.Serialization
 {
@@ -18,7 +16,7 @@ namespace UnitTests.Serialization
     {
         public SerializationTestsJsonTypes()
         {
-            SerializationManager.InitializeForTesting();
+            SerializationManager.InitializeForTesting(useJsonFallbackSerializer: true);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
@@ -35,82 +33,6 @@ namespace UnitTests.Serialization
             JObject input = JObject.Parse(json);
             JObject output = SerializationManager.RoundTripSerializationForTesting(input);
             Assert.AreEqual(input.ToString(), output.ToString());
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
-        public void SerializationTests_Json_Guid_WithoutConverter()
-        {
-            Xunit.Assert.Throws(typeof(Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException), () =>
-            {
-                var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
-                Do_Json_Guid_Test(settings);
-            });
-        }
-
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
-        public void SerializationTests_Json_Guid_WithConverter()
-        {
-            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
-            settings.Converters.Add(new GuidJsonTestConverter());
-            Do_Json_Guid_Test(settings);
-        }
-
-        [Fact(Skip = "Fix of issue #1484 is still pending"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
-        public void SerializationTests_Json_POCO_WithGuidConverter()
-        {
-            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
-            settings.Converters.Add(new GuidJsonTestConverter());
-            var obj = new SimplePersistentGrain_State();
-            string objSerialized = JsonConvert.SerializeObject(obj, settings);
-            var objDeserialized = JsonConvert.DeserializeObject<object>(objSerialized, settings);
-            Assert.AreEqual(typeof(SimplePersistentGrain_State), objDeserialized.GetType());
-        }
-
-        private void Do_Json_Guid_Test(JsonSerializerSettings settings)
-        {
-            var dict = new Dictionary<string, object>
-                {
-                    {"key", Guid.NewGuid()},
-                };
-
-            string dictSerialized = JsonConvert.SerializeObject(dict, settings);
-            var dictDeserialized = JsonConvert.DeserializeObject<Dictionary<string, object>>(dictSerialized, settings);
-            var originalGuid = dict["key"];
-            var deserGuid = dictDeserialized["key"];
-
-            Assert.AreEqual(typeof(Guid), originalGuid.GetType());
-            Assert.AreEqual(typeof(Guid), deserGuid.GetType());
-            Assert.AreEqual(originalGuid, deserGuid);
-        }
-
-        private class GuidJsonTestConverter : JsonConverter
-        { 
-            public override bool CanRead { get { return true; } }
-            public override bool CanWrite { get { return true; } }
-
-            public override bool CanConvert(Type objectType)
-            {
-                return objectType.IsAssignableFrom(typeof(Guid)) || objectType.IsAssignableFrom(typeof(Guid?));
-            }
-
-            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-            {
-                if (value == null)
-                {
-                    writer.WriteValue(default(string));
-                }
-                else if (value is Guid)
-                {
-                    var guid = (Guid)value;
-                    writer.WriteValue(guid.ToString("N"));
-                }
-            }
-
-            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-            {
-                var str = reader.Value as string;
-                return str != null ? Guid.Parse(str) : default(Guid);
-            }
         }
 
         [RegisterSerializerAttribute]
@@ -191,6 +113,21 @@ namespace UnitTests.Serialization
             Assert.AreEqual(typeof(JObject), orleansJsonDeser.MyDictionary["obj1"].GetType());
             // The below assert fails, but only since JObject does not correctly implement Equals.
             //Assert.AreEqual(jsonDeser, orleansJsonDeser);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
+        public void SerializationTests_Json_POCO()
+        {
+            var obj = new SimplePOCO();
+            var deepCopied = SerializationManager.RoundTripSerializationForTesting(obj);
+            Assert.AreEqual(typeof(SimplePOCO), deepCopied.GetType());
+        }
+
+        [Serializable]
+        public class SimplePOCO
+        {
+            public int A { get; set; }
+            public int B { get; set; }
         }
 
         /// <summary>


### PR DESCRIPTION
Repro for the #1484; 
Also the [```GuidJsonTestConverter```](https://github.com/dotnet/orleans/blob/master/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs#L74) is duplicate of the [```GuidJsonConverter```](https://github.com/dotnet/orleans/blob/master/src/Orleans/Serialization/OrleansJsonSerializer.cs#L239), and probably should be removed. 