### PR TITLE
AzureQueueStreamProvider violates at-least-once delivery bug fix

### DIFF
--- a/src/Orleans/Streams/QueueAdapters/IQueueCacheCursor.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueCacheCursor.cs
@@ -32,5 +32,10 @@ namespace Orleans.Streams
         /// </summary>
         /// <returns></returns>
         void Refresh();
+
+        /// <summary>
+        /// Record that delivery of the current event has failed
+        /// </summary>
+        void RecordDeliveryFailure();
     }
 }

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
@@ -26,9 +26,10 @@ namespace Orleans.Providers.Streams.Common
         }
     }
 
-    internal struct SimpleQueueCacheItem
+    internal class SimpleQueueCacheItem
     {
         internal IBatchContainer Batch;
+        internal bool DeliveryFailure;
         internal StreamSequenceToken SequenceToken;
         internal CacheBucket CacheBucket;
     }
@@ -102,7 +103,10 @@ namespace Orleans.Providers.Streams.Common
                 SimpleQueueCacheItem item = cachedMessages.Last.Value;
                 if (item.CacheBucket.Equals(bucket))
                 {
-                    itemsToRelease.Add(item.Batch);
+                    if (!item.DeliveryFailure)
+                    {
+                        itemsToRelease.Add(item.Batch);
+                    }
                     bucket.UpdateNumItems(-1);
                     cachedMessages.RemoveLast();
                 }

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCacheCursor.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCacheCursor.cs
@@ -82,6 +82,14 @@ namespace Orleans.Providers.Streams.Common
             }
         }
 
+        public void RecordDeliveryFailure()
+        {
+            if (IsSet && current != null)
+            {
+                Element.Value.DeliveryFailure = true;
+            }
+        }
+
         private bool IsInStream(IBatchContainer batchContainer)
         {
             return batchContainer != null &&

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -509,6 +509,10 @@ namespace Orleans.Streams
                     }
                     catch (Exception exc)
                     {
+                        if (consumerData.Cursor != null)
+                        {
+                            consumerData.Cursor.RecordDeliveryFailure();
+                        }
                         var message = string.Format("Exception while trying to deliver msgs to stream {0} in PersistentStreamPullingAgentGrain.RunConsumerCursor", consumerData.StreamId);
                         logger.Error((int)ErrorCode.PersistentStreamPullingAgent_14, message, exc);
                         exceptionOccured = new StreamEventDeliveryFailureException(consumerData.StreamId);

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -196,6 +196,10 @@ namespace Orleans.ServiceBus.Providers
             public void Refresh()
             {
             }
+
+            public void RecordDeliveryFailure()
+            {
+            }
         }
     }
 }

--- a/test/Tester/TestStreamProviders/Generator/GeneratorPooledCache.cs
+++ b/test/Tester/TestStreamProviders/Generator/GeneratorPooledCache.cs
@@ -155,6 +155,10 @@ namespace Tester.TestStreamProviders.Generator
             public void Refresh()
             {
             }
+
+            public void RecordDeliveryFailure()
+            {
+            }
         }
 
         public int MaxAddCount { get { return 100; } }


### PR DESCRIPTION
Addresses AzureQueueStreamProvider violates at-least-once delivery #1416 

Added RecordDeliveryFailure to IQueueCacheCursor.
Stored delivery failure flag in SimpleQueueCache's SimpleQueueCacheItem.
Use delivery failure flag to removed failed to delivered batches from those passed back to the receiver for deletion.