### PR TITLE
Fix for bug #1471

### DIFF
--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -977,6 +977,15 @@ namespace Orleans.Runtime
                     }
                     catch (Exception) { }
                 }
+
+                foreach (var consumer in TelemetryConsumers)
+                {
+                    try
+                    {
+                        consumer.Flush();
+                    }
+                    catch (Exception) { }
+                }
             }
             catch (Exception) { }
         }
@@ -988,6 +997,15 @@ namespace Orleans.Runtime
             try
             {
                 foreach (ICloseableLogConsumer consumer in LogConsumers.OfType<ICloseableLogConsumer>())
+                {
+                    try
+                    {
+                        consumer.Close();
+                    }
+                    catch (Exception) { }
+                }
+
+                foreach (var consumer in TelemetryConsumers)
                 {
                     try
                     {

--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -113,6 +113,9 @@ namespace Orleans.Runtime
         private Dictionary<int, int> recentLogMessageCounts = new Dictionary<int, int>();
         private DateTime lastBulkLogMessageFlush = DateTime.MinValue;
 
+        private TimeSpan flushInterval = Debugger.IsAttached ? TimeSpan.FromMilliseconds(10) : TimeSpan.FromSeconds(1);
+        private DateTime lastFlush = DateTime.UtcNow;
+
         /// <summary>List of log codes that won't have bulk message compaction policy applied to them</summary>
         private static readonly int[] excludedBulkLogCodes = {
             0,
@@ -802,6 +805,12 @@ namespace Orleans.Runtime
                     (int)ErrorCode.Logger_LogMessageTruncated);
 
                 TrackTrace(formatedTraceMessage);
+            }
+
+            if ((DateTime.UtcNow - lastFlush) > flushInterval)
+            {
+                lastFlush = DateTime.UtcNow;
+                Flush();
             }
         }
 

--- a/src/Orleans/Telemetry/Consumers/ConsoleTelemetryConsumer.cs
+++ b/src/Orleans/Telemetry/Consumers/ConsoleTelemetryConsumer.cs
@@ -49,6 +49,9 @@ namespace Orleans.Runtime
         public void TrackTrace(string message, Severity severityLevel, IDictionary<string, string> properties = null)
         {
             TrackTrace(TraceParserUtils.PrintProperties(message, properties));
-        }                
+        }
+
+        public void Flush() { }
+        public void Close() { }
     }
 }

--- a/src/Orleans/Telemetry/Consumers/TraceTelemetryConsumer.cs
+++ b/src/Orleans/Telemetry/Consumers/TraceTelemetryConsumer.cs
@@ -8,7 +8,6 @@ namespace Orleans.Runtime
         public void TrackTrace(string message)
         {
             Trace.TraceInformation(message);
-            Trace.Flush();
         }
 
         public void TrackTrace(string message, IDictionary<string, string> properties)
@@ -43,6 +42,16 @@ namespace Orleans.Runtime
         public void TrackTrace(string message, Severity severity, IDictionary<string, string> properties)
         {
             TrackTrace(TraceParserUtils.PrintProperties(message, properties), severity);
+        }
+
+        public void Flush()
+        {
+            Trace.Flush();
+        }
+
+        public void Close()
+        {
+            Trace.Close();
         }
     }
 }

--- a/src/Orleans/Telemetry/ITelemetryConsumer.cs
+++ b/src/Orleans/Telemetry/ITelemetryConsumer.cs
@@ -5,5 +5,7 @@
     /// </summary>
     public interface ITelemetryConsumer
     {
+        void Flush();
+        void Close();
     }
 }

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -748,8 +748,8 @@ namespace Orleans.Runtime
             finally
             {
                 // 10, 11, 12: Write Dead in the table, Drain scheduler, Stop msg center, ...
-                FastKill();
                 logger.Info(ErrorCode.SiloStopped, "Silo is Stopped()");
+                FastKill();                
             }
         }
 
@@ -781,14 +781,14 @@ namespace Orleans.Runtime
             SafeExecute(activationDirectory.PrintActivationDirectory);
             SafeExecute(messageCenter.Stop);
             SafeExecute(siloStatistics.Stop);
-            SafeExecute(TraceLogger.Close);
-
             SafeExecute(GrainTypeManager.Stop);
 
             UnobservedExceptionsHandlerClass.ResetUnobservedExceptionHandler();
 
             SystemStatus.Current = SystemStatus.Terminated;
             siloTerminatedEvent.Set();
+
+            SafeExecute(TraceLogger.Close);
         }
 
         private void SafeExecute(Action action)

--- a/src/OrleansTelemetryConsumers.AI/AITelemetryConsumer.cs
+++ b/src/OrleansTelemetryConsumers.AI/AITelemetryConsumer.cs
@@ -125,5 +125,8 @@ namespace Orleans.TelemetryConsumers.AI
                 _client.TrackTrace(message, sev, properties);
             }
         }
+
+        public void Flush() { }
+        public void Close() { }
     }
 }

--- a/src/OrleansTelemetryConsumers.NewRelic/NRTelemetryConsumer.cs
+++ b/src/OrleansTelemetryConsumers.NewRelic/NRTelemetryConsumer.cs
@@ -91,5 +91,8 @@ namespace Orleans.TelemetryConsumers.NewRelic
                 }); 
             }
         }
+
+        public void Flush() { }
+        public void Close() { }
     }
 }


### PR DESCRIPTION
Fix for bug #1471

- Added `Close()` and `Flush()` to `ITelemetryConsumer`.
- TraceLogger now properly closes the telemetry consumers.