### PR TITLE
Improve F# support, serializer generation accessibility checks, fix KnownAssembly

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -2129,7 +2129,7 @@ namespace Orleans.Serialization
                 field.Name + "Get",
                 field.FieldType,
                 parameterTypes,
-                declaringType.Module,
+                field.FieldType.Module,
                 true);
 
             // Emit IL to return the value of the Transaction property.
@@ -2188,7 +2188,7 @@ namespace Orleans.Serialization
             }
 
             // Create a method to hold the generated IL.
-            var method = new DynamicMethod(field.Name + "Set", null, parameterTypes, declaringType.Module, true);
+            var method = new DynamicMethod(field.Name + "Set", null, parameterTypes, field.FieldType.Module, true);
 
             // Emit IL to return the value of the Transaction property.
             var emitter = method.GetILGenerator();

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -13,7 +13,6 @@ namespace Orleans.CodeGenerator
     using Orleans.Async;
     using Orleans.CodeGeneration;
     using Orleans.Runtime;
-    using Orleans.Serialization;
 
     using GrainInterfaceData = Orleans.CodeGeneration.GrainInterfaceData;
     using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -307,7 +306,7 @@ namespace Orleans.CodeGenerator
                     .ToSet();
             if (knownAssemblies.Count > 0)
             {
-                knownAssemblies.IntersectWith(assemblies);
+                knownAssemblies.UnionWith(assemblies);
                 assemblies = knownAssemblies.ToList();
             }
 
@@ -427,7 +426,7 @@ namespace Orleans.CodeGenerator
             ISet<Type> includedTypes)
         {
             // The module containing the serializer.
-            var module = runtime ? null : type.Module;
+            var module = runtime || type.Assembly != targetAssembly ? null : type.Module;
             var typeInfo = type.GetTypeInfo();
 
             // If a type was encountered which can be accessed and is marked as [Serializable], process it for serialization.

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -117,8 +117,12 @@ namespace Orleans.CodeGenerator
                                         .Select(_ => SF.OmittedTypeArgument())
                                         .Cast<TypeSyntax>()
                                         .ToArray()));
+                var registererClassName = className + "_" +
+                                          string.Join("_",
+                                              type.GetTypeInfo().GenericTypeParameters.Select(_ => _.Name)) + "_" +
+                                          RegistererClassSuffix;
                 classes.Add(
-                    SF.ClassDeclaration(className + RegistererClassSuffix)
+                    SF.ClassDeclaration(registererClassName)
                         .AddModifiers(SF.Token(SyntaxKind.InternalKeyword))
                         .AddAttributeLists(
                             SF.AttributeList()
@@ -128,7 +132,7 @@ namespace Orleans.CodeGenerator
                                     SF.Attribute(typeof(RegisterSerializerAttribute).GetNameSyntax())))
                         .AddMembers(
                             GenerateMasterRegisterMethod(type, serializerType),
-                            GenerateConstructor(className + RegistererClassSuffix)));
+                            GenerateConstructor(registererClassName)));
             }
 
             return classes;

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -78,7 +78,7 @@ namespace Orleans.CodeGenerator
                 onEncounteredType(fieldType);
             }
 
-            var members = new List<MemberDeclarationSyntax>(GetStaticFields(fields))
+            var members = new List<MemberDeclarationSyntax>(GenerateStaticFields(fields))
             {
                 GenerateDeepCopierMethod(type, fields),
                 GenerateSerializerMethod(type, fields),
@@ -325,7 +325,7 @@ namespace Orleans.CodeGenerator
         /// </summary>
         /// <param name="fields">The fields.</param>
         /// <returns>Syntax for the static fields of the serializer class.</returns>
-        private static MemberDeclarationSyntax[] GetStaticFields(List<FieldInfoMember> fields)
+        private static MemberDeclarationSyntax[] GenerateStaticFields(List<FieldInfoMember> fields)
         {
             var result = new List<MemberDeclarationSyntax>();
 


### PR DESCRIPTION
This PR contains a couple of small related fixes for serializer code generation.

Fix: Certain 'special' types cannot be used as generic constraints in C#, eg `Delegate`. This doesn't seem to be the case in F#, where the core library is doing precisely that.

Fix: When `KnownAssemblyAttribute` was in-use, assemblies were incorrectly intersected with referenced assemblies and not unioned with them.

Fix: Serializer accessibility checks for concrete generic types were not considering the fields of their generic type definition. The code has been simplified to recurse into the generic type definition, reducing duplication.

Fix: Multiple classes with the same name and differing numbers of generic arguments would cause serializer generation to break when generating the 'master' serializer registration class.