### PR TITLE
Switch C# project template in VSIX to use use new CodeGen nuget

### DIFF
--- a/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
+++ b/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
@@ -255,6 +255,10 @@
       <Link>Packages\Microsoft.Orleans.Templates.Interfaces.1.2.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="..\..\..\Binaries\NuGet.Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg">
+      <Link>Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="OrleansVSTools.snk" />
     <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">

--- a/src/OrleansVSTools/OrleansVSTools/source.extension.vsixmanifest
+++ b/src/OrleansVSTools/OrleansVSTools/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
   <Metadata>
     <Identity Id="462db41f-31a4-48f0-834c-1bdcc0578511" Version="1.2.0" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Microsoft Orleans Tools for Visual Studio</DisplayName>
-    <Description xml:space="preserve">Microsoft Orleans Tools for Visual Studio 2012, 2013, 2015
+    <Description xml:space="preserve">Microsoft Orleans Tools for Visual Studio 2013, 2015
 C#, VB, F#  Project templates and item templates
     </Description>
     <MoreInfo>htts://github.com/dotnet/orleans/</MoreInfo>
@@ -13,9 +13,9 @@ C#, VB, F#  Project templates and item templates
     <Tags>Orleans,Cloud-Computing,Actor-Model,Actors,Distributed-Systems,C#,VB,F#</Tags>
   </Metadata>
   <Installation AllUsers="false">
-    <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Ultimate" />
+    <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Premium" />
+    <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Ultimate" />
     <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Enterprise" />
     <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Community" />
   </Installation>

--- a/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
+++ b/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
@@ -70,8 +70,6 @@
       <Asset Type="Microsoft.Orleans.OrleansProviders.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansProviders.1.2.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.Orleans.OrleansRuntime.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansRuntime.1.2.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.Orleans.Server.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Server.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.Templates.Grains.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Grains.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.Templates.Interfaces.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Interfaces.1.2.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Newtonsoft.Json.7.0.1.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.7.0.1.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementation/ProjectTemplate.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementation/ProjectTemplate.csproj
@@ -34,9 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    $if$ ($targetframeworkversion$ >= 4.0)
     <Reference Include="Microsoft.CSharp"/>
-    $endif$
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementation/ProjectTemplate.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementation/ProjectTemplate.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)packages\Microsoft.Orleans.Templates.Grains.1.2.0\build\Microsoft.Orleans.Templates.Grains.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Orleans.Templates.Grains.1.2.0\build\Microsoft.Orleans.Templates.Grains.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform>AnyCPU</Platform>
@@ -47,7 +46,7 @@
     <Compile Include="Properties\orleans.codegen.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)packages\Microsoft.Orleans.Templates.Grains.1.2.0\build\Microsoft.Orleans.Templates.Grains.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Orleans.Templates.Grains.1.2.0\build\Microsoft.Orleans.Templates.Grains.targets')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.vstemplate
@@ -32,8 +32,7 @@
       <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" />
       <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" />
       <package id="Microsoft.Orleans.Core" version="1.2.0" />
-      <package id="Microsoft.Orleans.Templates.Grains" version="1.2.0" />
-      <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.2.0" />
+      <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.2.0" />
       <package id="Newtonsoft.Json" version="7.0.1" />
       <package id="System.Collections.Immutable" version="1.1.36" />
       <package id="System.Reflection.Metadata" version="1.0.21" />
@@ -50,8 +49,7 @@
       <Asset Type="Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.Orleans.Core.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.Templates.Grains.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Grains.1.2.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Newtonsoft.Json.7.0.1.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.7.0.1.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterface/ProjectTemplate.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterface/ProjectTemplate.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)packages\Microsoft.Orleans.Templates.Interfaces.1.2.0\build\Microsoft.Orleans.Templates.Interfaces.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Orleans.Templates.Interfaces.1.2.0\build\Microsoft.Orleans.Templates.Interfaces.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform>AnyCPU</Platform>
@@ -47,7 +46,7 @@
     <Compile Include="Properties\orleans.codegen.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)packages\Microsoft.Orleans.Templates.Interfaces.1.2.0\build\Microsoft.Orleans.Templates.Interfaces.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Orleans.Templates.Interfaces.1.2.0\build\Microsoft.Orleans.Templates.Interfaces.targets')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterface/ProjectTemplate.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterface/ProjectTemplate.csproj
@@ -34,9 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    $if$ ($targetframeworkversion$ >= 4.0)
     <Reference Include="Microsoft.CSharp"/>
-    $endif$
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.vstemplate
@@ -32,8 +32,7 @@
       <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" />
       <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" />
       <package id="Microsoft.Orleans.Core" version="1.2.0" />
-      <package id="Microsoft.Orleans.Templates.Interfaces" version="1.2.0" />
-      <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.2.0" />
+      <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.2.0" />
       <package id="Newtonsoft.Json" version="7.0.1" />
       <package id="System.Collections.Immutable" version="1.1.36" />
       <package id="System.Reflection.Metadata" version="1.0.21" />
@@ -47,8 +46,7 @@
       <Asset Type="Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.Orleans.Core.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.Templates.Interfaces.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Templates.Interfaces.1.2.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Newtonsoft.Json.7.0.1.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.7.0.1.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />

--- a/src/SDK/UninstallOrleansVSTools.cmd
+++ b/src/SDK/UninstallOrleansVSTools.cmd
@@ -2,12 +2,17 @@
 @prompt $G$S
 @set CMDHOME=%~dp0.
 
-@if NOT "%VS120COMNTOOLS%"=="" (
-  @set VSTOOLSDIR="%VS120COMNTOOLS%"
-  @set VSVER=Visual Studio 2013
+@if NOT "%VS140COMNTOOLS%"=="" (
+  @set VSTOOLSDIR="%VS140COMNTOOLS%"
+  @set VSVER=Visual Studio 2015
 ) else (
-  @set VSTOOLSDIR="%VS110COMNTOOLS%"
-  @set VSVER=Visual Studio 2012
+  @if NOT "%VS120COMNTOOLS%"=="" (
+    @set VSTOOLSDIR="%VS120COMNTOOLS%"
+    @set VSVER=Visual Studio 2013
+  ) else (
+    @set VSTOOLSDIR="%VS110COMNTOOLS%"
+    @set VSVER=Visual Studio 2012
+  )
 )
 
 @set PKG=Orleans Tools for %VSVER%


### PR DESCRIPTION
Switch C# project template in VSIX to use new CodeGen nuget.
Also, removed support for VS 2012 from the VSIX.