### PR TITLE
SiloTerminatedEvent.Set should be the last thing in the silo shutdown sequence.

### DIFF
--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -785,10 +785,12 @@ namespace Orleans.Runtime
 
             UnobservedExceptionsHandlerClass.ResetUnobservedExceptionHandler();
 
-            SystemStatus.Current = SystemStatus.Terminated;
-            siloTerminatedEvent.Set();
-
+            SafeExecute(() => SystemStatus.Current = SystemStatus.Terminated);
             SafeExecute(TraceLogger.Close);
+
+            // Setting the event should be the last thing we do.
+            // Do nothijng after that!
+            siloTerminatedEvent.Set();  
         }
 
         private void SafeExecute(Action action)


### PR DESCRIPTION
Follow up on https://github.com/dotnet/orleans/pull/1494.