### PR TITLE
Avoid resizing of Message headers dictionary

### DIFF
--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -446,7 +446,10 @@ namespace Orleans.Runtime
 
         public Message()
         {
-            headers = new Dictionary<Header, object>();
+            // average headers items count is 14 items, and while the Header enum contains 18 entries
+            // the closest prime number is 17; assuming that possibility of all 18 headers being at the same time is low enough to
+            // choose 17 in order to avoid allocations of two additional items on each call, and allocate 37 instead of 19 in rare cases
+            headers = new Dictionary<Header, object>(17);
             metadata = new Dictionary<string, object>();
             bodyObject = null;
             bodyBytes = null;


### PR DESCRIPTION
Currently resizing of the `Message` headers dictionary are being conducted multiple times for a single grain call, and this leads to high memory traffic:
  1:
![2015-11-30_23-04-17](https://cloud.githubusercontent.com/assets/5787619/13478203/a1299cf2-e0d8-11e5-94d1-0f56aa098de3.png)
  2:
![2015-11-30_23-01-55](https://cloud.githubusercontent.com/assets/5787619/13478548/302d3642-e0da-11e5-939b-0c476d9630c7.png)

and CPU consumption:
![sharex_2016-02-03_20-31-26](https://cloud.githubusercontent.com/assets/5787619/13478227/bc0e53dc-e0d8-11e5-9dd9-38540a102571.png)

Setting initial size of `headers` to 17 will reduce CPU consumption by ~ 200 ms (46%) per 1 million calls. ([used benchmark](https://gist.github.com/dVakulen/4c06da7a07121840098b)) for most common case of 14 items:

             Method |      Median |    StdDev | InitialDictionarySize | ItemsCount |
------------------- |------------ |---------- |---------------- |------ |
 DictionaryCreation |  51.6067 ms | 0.5801 ms |               0 |     1 |
 DictionaryCreation | 444.2622 ms | 5.5458 ms |               0 |    14 |
 DictionaryCreation | 198.1903 ms | 1.7021 ms |               0 |     5 |
 DictionaryCreation |  79.7746 ms | 0.6836 ms |              17 |     1 |
 DictionaryCreation | 251.0595 ms | 3.5210 ms |              17 |    14 |
 DictionaryCreation | 128.9653 ms | 0.3659 ms |              17 |     5 |

