### PR TITLE
Json serializer settings improvements.

### DIFF
--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -4,11 +4,10 @@ using System.Runtime.Serialization.Formatters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Orleans.Runtime;
-using Orleans.Providers;
 
 namespace Orleans.Serialization
 {
-    public class OrleansJsonSerializer : IExternalSerializer
+    internal class OrleansJsonSerializer : IExternalSerializer
     {
         private static JsonSerializerSettings defaultSettings;
         private TraceLogger logger;
@@ -17,7 +16,7 @@ namespace Orleans.Serialization
         /// Returns a configured <see cref="JsonSerializerSettings"/> 
         /// </summary>
         /// <returns></returns>
-        public static JsonSerializerSettings GetDefaultSerializerSettings()
+        internal static JsonSerializerSettings GetDefaultSerializerSettings()
         {
             var settings = new JsonSerializerSettings
             {
@@ -39,41 +38,6 @@ namespace Orleans.Serialization
             settings.Converters.Add(new UniqueKeyConverter());
 
             return settings;
-        }
-
-        /// <summary>
-        /// Customises the given serializer settings
-        /// using provider configuration.
-        /// Can be used by any provider, allowing the users to use a standard set of configuration attributes.
-        /// </summary>
-        /// <param name="set"></param>
-        /// <param name="config"></param>
-        /// <returns><see cref="JsonSerializerSettings" /></returns>
-        public static JsonSerializerSettings UpdateSerializerSettings(JsonSerializerSettings set, IProviderConfiguration config)
-        {
-            if (config.Properties.ContainsKey("UseFullAssemblyNames"))
-            {
-                bool useFullAssemblyNames = false;
-                var UseFullAssemblyNamesValue = config.Properties["UseFullAssemblyNames"];
-                bool.TryParse(UseFullAssemblyNamesValue, out useFullAssemblyNames);
-                if (useFullAssemblyNames)
-                {
-                    set.TypeNameAssemblyFormat = FormatterAssemblyStyle.Full;
-                }
-            }
-
-            if (config.Properties.ContainsKey("IndentJSON"))
-            {
-                bool indentJSON = false;
-                var indentJSONValue = config.Properties["IndentJSON"];
-                bool.TryParse(indentJSONValue, out indentJSON);
-                if (indentJSON)
-                {
-                    set.Formatting = Formatting.Indented;
-                }
-            }
-
-            return set;
         }
 
         static OrleansJsonSerializer()
@@ -161,7 +125,7 @@ namespace Orleans.Serialization
 
     #region JsonConverters
 
-    class IPAddressConverter : JsonConverter
+    internal class IPAddressConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -181,7 +145,7 @@ namespace Orleans.Serialization
         }
     }
 
-    class GrainIdConverter : JsonConverter
+    internal class GrainIdConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -205,7 +169,7 @@ namespace Orleans.Serialization
         }
     }
 
-    class SiloAddressConverter : JsonConverter
+    internal class SiloAddressConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -229,7 +193,7 @@ namespace Orleans.Serialization
         }
     }
 
-    class UniqueKeyConverter : JsonConverter
+    internal class UniqueKeyConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -252,8 +216,8 @@ namespace Orleans.Serialization
             return addr;
         }
     }
- 
-    class IPEndPointConverter : JsonConverter
+
+    internal class IPEndPointConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -15,6 +15,9 @@ using Orleans.Runtime;
 using Orleans.Concurrency;
 using Orleans.CodeGeneration;
 using Orleans.Runtime.Configuration;
+using Newtonsoft.Json;
+using Orleans.Providers;
+using System.Runtime.Serialization.Formatters;
 
 namespace Orleans.Serialization
 {
@@ -2299,6 +2302,41 @@ namespace Orleans.Serialization
             if (UseStandardSerializer) return false;
             
             return true;
+        }
+
+        public static JsonSerializerSettings GetDefaultJsonSerializerSettings()
+        {
+            return OrleansJsonSerializer.GetDefaultSerializerSettings();
+        }
+
+        /// <summary>
+        /// Customises the given serializer settings
+        /// using provider configuration.
+        /// Can be used by any provider, allowing the users to use a standard set of configuration attributes.
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <param name="config"></param>
+        /// <returns><see cref="JsonSerializerSettings" /></returns>
+        public static JsonSerializerSettings UpdateSerializerSettings(JsonSerializerSettings settings, IProviderConfiguration config)
+        {
+            if (config.Properties.ContainsKey("UseFullAssemblyNames"))
+            {
+                bool useFullAssemblyNames = false;
+                if (bool.TryParse(config.Properties["UseFullAssemblyNames"], out useFullAssemblyNames) && useFullAssemblyNames)
+                {
+                    settings.TypeNameAssemblyFormat = FormatterAssemblyStyle.Full;
+                }
+            }
+
+            if (config.Properties.ContainsKey("IndentJSON"))
+            {
+                bool indentJSON = false;
+                if (bool.TryParse(config.Properties["IndentJSON"], out indentJSON) && indentJSON)
+                {
+                    settings.Formatting = Formatting.Indented;
+                }
+            }
+            return settings;
         }
     }
 }

--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -65,7 +65,7 @@ namespace Orleans.Storage
             try
             {
                 this.Name = name;
-                this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
+                this.jsonSettings = SerializationManager.UpdateSerializerSettings(SerializationManager.GetDefaultJsonSerializerSettings(), config);
 
                 if (!config.Properties.ContainsKey("DataConnectionString")) throw new BadProviderConfigException("The DataConnectionString setting has not been configured in the cloud role. Please add a DataConnectionString setting with a valid Azure Storage connection string.");
 

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -101,7 +101,7 @@ namespace Orleans.Storage
             
             if (useJsonFormat)
             {
-                this.jsonSettings = AzureStorageUtils.ConfigureJsonSerializerSettings(config);
+                this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
             }
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -101,7 +101,7 @@ namespace Orleans.Storage
             
             if (useJsonFormat)
             {
-                this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
+                this.jsonSettings = SerializationManager.UpdateSerializerSettings(SerializationManager.GetDefaultJsonSerializerSettings(), config);
             }
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 

--- a/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
+++ b/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
@@ -6,10 +6,6 @@ using Microsoft.WindowsAzure.Storage.Queue;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Microsoft.WindowsAzure.Storage.Shared.Protocol;
 using Orleans.Runtime;
-using Newtonsoft.Json;
-using Orleans.Providers;
-using System.Runtime.Serialization.Formatters;
-using Orleans.Serialization;
 
 namespace Orleans.AzureUtils
 {
@@ -388,46 +384,6 @@ namespace Orleans.AzureUtils
                         extendedError.ErrorMessage,
                         (extendedError.AdditionalDetails != null && extendedError.AdditionalDetails.Count > 0) ?
                             String.Format(", ExtendedErrorInformation.AdditionalDetails = {0}", Utils.DictionaryToString(extendedError.AdditionalDetails)) : String.Empty);
-        }
-
-        /// <summary>
-        /// Customises the serializer settings returned by <see cref="OrleansJsonSerializer"/>
-        /// using provider configuration.
-        /// Can be used by any provider, allowing the users to use a standard set of configuration attributes.
-        /// </summary>
-        /// <param name="config"></param>
-        /// <returns><see cref="JsonSerializerSettings" /></returns>
-        public static JsonSerializerSettings ConfigureJsonSerializerSettings(IProviderConfiguration config)
-        {
-            // By default, use the standard Orleans serializer settings
-            var settings = OrleansJsonSerializer.GetSerializerSettings();
-
-            settings.TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple;
-            settings.Formatting = Formatting.None;
-
-            if (config.Properties.ContainsKey("UseFullAssemblyNames"))
-            {
-                bool useFullAssemblyNames = false;
-                var UseFullAssemblyNamesValue = config.Properties["UseFullAssemblyNames"];
-                bool.TryParse(UseFullAssemblyNamesValue, out useFullAssemblyNames);
-                if (useFullAssemblyNames)
-                {
-                    settings.TypeNameAssemblyFormat = FormatterAssemblyStyle.Full;
-                }
-            }
-
-            if (config.Properties.ContainsKey("IndentJSON"))
-            {
-                bool indentJSON = false;
-                var indentJSONValue = config.Properties["IndentJSON"];
-                bool.TryParse(indentJSONValue, out indentJSON);
-                if (indentJSON)
-                {
-                    settings.Formatting = Formatting.Indented;
-                }
-            }
-
-            return settings;
         }
     }
 }


### PR DESCRIPTION
The main change in this PR is making OrleansJsonSerializer public.
This is a first step in https://github.com/dotnet/orleans/issues/1495 3): "Expose publicly settings of the JSON serializer used for A & C that app will have full control of."
That way any application code, and not only privileged Azure providers (that have internal control to the runtime assemblies) can use use Json settings.

In addition, small API improvements to the utility class, decoupling mutating the settings from where the default settings are stored.