### PR TITLE
EventHubStreamProvider extensibility.

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Streams\Internal\StreamHandshakeToken.cs" />
     <Compile Include="Serialization\NonSerializableAttribute.cs" />
     <Compile Include="Streams\PersistentStreams\IDeploymentConfiguration.cs" />
+    <Compile Include="Streams\PersistentStreams\IStreamQueueCheckpointer.cs" />
     <Compile Include="Streams\PersistentStreams\NoOpStreamFailureHandler.cs" />
     <Compile Include="Streams\PersistentStreams\IStreamFailureHandler.cs" />
     <Compile Include="Streams\PersistentStreams\StreamEventDeliveryFailureException.cs" />

--- a/src/Orleans/Streams/PersistentStreams/IStreamQueueCheckpointer.cs
+++ b/src/Orleans/Streams/PersistentStreams/IStreamQueueCheckpointer.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Orleans.Streams
+{
+    public interface IStreamQueueCheckpointer<TCheckpoint>
+    {
+        bool CheckpointExists { get; }
+        Task<TCheckpoint> Load();
+        void Update(TCheckpoint offset, DateTime utcNow);
+    }
+}

--- a/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
@@ -27,11 +27,10 @@ namespace Orleans.Streams
         /// Acquire a stream message cursor.  This can be used to retreave messages from the
         ///   cache starting at the location indicated by the provided token.
         /// </summary>
-        /// <param name="streamGuid"></param>
-        /// <param name="streamNamespace"></param>
+        /// <param name="streamIdentity"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        IQueueCacheCursor GetCacheCursor(Guid streamGuid, string streamNamespace, StreamSequenceToken token);
+        IQueueCacheCursor GetCacheCursor(IStreamIdentity streamIdentity, StreamSequenceToken token);
 
         /// <summary>
         /// Returns true if this cache is under pressure.

--- a/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using Orleans.Runtime;
 using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.Common
@@ -12,7 +13,6 @@ namespace Orleans.Providers.Streams.Common
     /// </summary>
     /// <typeparam name="TQueueMessage"></typeparam>
     /// <typeparam name="TCachedMessage"></typeparam>
-    ///   most recent message purged from the cache.</typeparam>
     public interface ICacheDataAdapter<in TQueueMessage, TCachedMessage>
         where TQueueMessage : class
         where TCachedMessage : struct
@@ -20,9 +20,26 @@ namespace Orleans.Providers.Streams.Common
         void QueueMessageToCachedMessage(ref TCachedMessage cachedMessage, TQueueMessage queueMessage);
         IBatchContainer GetBatchContainer(ref TCachedMessage cachedMessage);
         StreamSequenceToken GetSequenceToken(ref TCachedMessage cachedMessage);
-        int CompareCachedMessageToSequenceToken(ref TCachedMessage cachedMessage, StreamSequenceToken token);
-        bool IsInStream(ref TCachedMessage cachedMessage, Guid streamGuid, string streamNamespace);
         bool ShouldPurge(ref TCachedMessage cachedMessage, IDisposable purgeRequest);
         Action<IDisposable> PurgeAction { set; }
+    }
+
+    public interface ICacheDataComparer<in TCachedMessage>
+    {
+        int Compare(TCachedMessage cachedMessage, StreamSequenceToken streamToken);
+        int Compare(TCachedMessage cachedMessage, IStreamIdentity streamIdentity);
+    }
+
+    public static class CacheDataComparerExtensions
+    {
+        public static int Compare<TCachedMessage>(this ICacheDataComparer<TCachedMessage> comparer, StreamSequenceToken streamToken, TCachedMessage cachedMessage)
+        {
+            return 0 - comparer.Compare(cachedMessage, streamToken);
+        }
+
+        public static int Compare<TCachedMessage>(this ICacheDataComparer<TCachedMessage> comparer, IStreamIdentity streamIdentity, TCachedMessage cachedMessage)
+        {
+            return 0 - comparer.Compare(cachedMessage, streamIdentity);
+        }
     }
 }

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
@@ -131,7 +131,7 @@ namespace Orleans.Providers.Streams.Common
             }
         }
 
-        public virtual IQueueCacheCursor GetCacheCursor(Guid streamGuid, string streamNamespace, StreamSequenceToken token)
+        public virtual IQueueCacheCursor GetCacheCursor(IStreamIdentity streamIdentity, StreamSequenceToken token)
         {
             if (token != null && !(token is EventSequenceToken))
             {
@@ -139,7 +139,7 @@ namespace Orleans.Providers.Streams.Common
                 throw new ArgumentOutOfRangeException("token", "token must be of type EventSequenceToken");
             }
 
-            var cursor = new SimpleQueueCacheCursor(this, streamGuid, streamNamespace, logger);
+            var cursor = new SimpleQueueCacheCursor(this, streamIdentity, logger);
             InitializeCursor(cursor, token, true);
             return cursor;
         }

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCacheCursor.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCacheCursor.cs
@@ -7,8 +7,7 @@ namespace Orleans.Providers.Streams.Common
 {
     public class SimpleQueueCacheCursor : IQueueCacheCursor
     {
-        private readonly Guid streamGuid;
-        private readonly string streamNamespace;
+        private readonly IStreamIdentity streamIdentity;
         private readonly SimpleQueueCache cache;
         private readonly Logger logger;
         private IBatchContainer current; // this is a pointer to the current element in the cache. It is what will be returned by GetCurrent().
@@ -37,18 +36,17 @@ namespace Orleans.Providers.Streams.Common
             SequenceToken = item.Value.SequenceToken;
         }
 
-        public SimpleQueueCacheCursor(SimpleQueueCache cache, Guid streamGuid, string streamNamespace, Logger logger)
+        public SimpleQueueCacheCursor(SimpleQueueCache cache, IStreamIdentity streamIdentity, Logger logger)
         {
             if (cache == null)
             {
                 throw new ArgumentNullException("cache");
             }
             this.cache = cache;
-            this.streamGuid = streamGuid;
-            this.streamNamespace = streamNamespace;
+            this.streamIdentity = streamIdentity;
             this.logger = logger;
             current = null;
-            SimpleQueueCache.Log(logger, "SimpleQueueCacheCursor New Cursor for {0}, {1}", streamGuid, streamNamespace);
+            SimpleQueueCache.Log(logger, "SimpleQueueCacheCursor New Cursor for {0}, {1}", streamIdentity.Guid, streamIdentity.Namespace);
         }
 
         public virtual IBatchContainer GetCurrent(out Exception exception)
@@ -93,8 +91,8 @@ namespace Orleans.Providers.Streams.Common
         private bool IsInStream(IBatchContainer batchContainer)
         {
             return batchContainer != null &&
-                    batchContainer.StreamGuid.Equals(streamGuid) &&
-                    String.Equals(batchContainer.StreamNamespace, streamNamespace);
+                    batchContainer.StreamGuid.Equals(streamIdentity.Guid) &&
+                    String.Equals(batchContainer.StreamNamespace, streamIdentity.Namespace);
         }
 
         #region IDisposable Members

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -249,12 +249,12 @@ namespace Orleans.Streams
                     if (requestedHandshakeToken != null)
                     {
                         consumerData.SafeDisposeCursor(logger);
-                        consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId.Guid, consumerData.StreamId.Namespace, requestedHandshakeToken.Token);
+                        consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, requestedHandshakeToken.Token);
                     }
                     else
                     {
                         if (consumerData.Cursor == null) // if the consumer did not ask for a specific token and we already have a cursor, jsut keep using it.
-                            consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId.Guid, consumerData.StreamId.Namespace, cacheToken);
+                            consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, cacheToken);
                     }
                 }
                 catch (Exception exception)
@@ -273,11 +273,11 @@ namespace Orleans.Streams
             {
                 try
                 {
-                    consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId.Guid, consumerData.StreamId.Namespace, cacheToken);
+                    consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, cacheToken);
                 }
                 catch (Exception)
                 {
-                    consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId.Guid, consumerData.StreamId.Namespace, null); // just in case last GetCacheCursor failed.
+                    consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, null); // just in case last GetCacheCursor failed.
                 }
             }
             return true;
@@ -408,7 +408,7 @@ namespace Orleans.Streams
             // That way we will not purge the event from the cache, until we talk to pub sub.
             // This will help ensure the "casual consistency" between pre-existing subscripton (of a potentially new already subscribed consumer) 
             // and later production.
-            var pinCursor = queueCache.GetCacheCursor(streamId.Guid, streamId.Namespace, firstToken);
+            var pinCursor = queueCache.GetCacheCursor(streamId, firstToken);
 
             try
             {
@@ -465,7 +465,7 @@ namespace Orleans.Streams
                     {
                         exceptionOccured = exc;
                         consumerData.SafeDisposeCursor(logger);
-                        consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId.Guid, consumerData.StreamId.Namespace, null);
+                        consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, null);
                     }
 
                     // Apply filtering to this batch, if applicable
@@ -500,8 +500,7 @@ namespace Orleans.Streams
                             if (newToken != null)
                             {
                                 consumerData.LastToken = newToken;
-                                IQueueCacheCursor newCursor = queueCache.GetCacheCursor(consumerData.StreamId.Guid,
-                                    consumerData.StreamId.Namespace, newToken.Token);
+                                IQueueCacheCursor newCursor = queueCache.GetCacheCursor(consumerData.StreamId, newToken.Token);
                                 consumerData.SafeDisposeCursor(logger);
                                 consumerData.Cursor = newCursor;
                             }

--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -86,15 +86,17 @@
     <Compile Include="Providers\Streams\EventHub\EventHubAdapterReceiver.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubBatchContainer.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubDataAdapter.cs" />
-    <Compile Include="Providers\Streams\EventHub\EventHubPartitionCheckpoint.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubCheckpointer.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubPartitionCheckpointEntity.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubQueueCache.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubQueueMapper.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSequenceToken.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProvider.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProviderConfig.cs" />
-    <Compile Include="Providers\Streams\EventHub\ICheckpointSettings.cs" />
+    <Compile Include="Providers\Streams\EventHub\ICheckpointerSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubSettings.cs" />
+    <Compile Include="Providers\Streams\EventHub\IEventHubQueueCache.cs" />
     <Compile Include="Providers\Streams\EventHub\SegmentBuilder.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -9,6 +9,7 @@ using Orleans.Providers;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
+using OrleansServiceBus.Providers.Streams.EventHub;
 
 namespace Orleans.ServiceBus.Providers
 {
@@ -18,18 +19,20 @@ namespace Orleans.ServiceBus.Providers
         private IServiceProvider serviceProvider;
         private EventHubStreamProviderConfig adapterConfig;
         private IEventHubSettings hubSettings;
-        private ICheckpointSettings checkpointSettings;
+        private ICheckpointerSettings checkpointerSettings;
         private EventHubQueueMapper streamQueueMapper;
-        private IStreamFailureHandler streamFailureHandler;
         private string[] partitionIds;
         private ConcurrentDictionary<QueueId, EventHubAdapterReceiver> receivers;
         private EventHubClient client;
-        private IObjectPool<FixedSizeBuffer> bufferPool;
 
         public string Name { get { return adapterConfig.StreamProviderName; } }
         public bool IsRewindable { get { return true; } }
         public StreamProviderDirection Direction { get { return StreamProviderDirection.ReadWrite; } }
 
+        protected Func<IStreamQueueCheckpointer<string>, IEventHubQueueCache> CacheFactory { get; set; }
+        protected Func<string, Task<IStreamQueueCheckpointer<string>>> CheckpointerFactory { get; set; }
+        protected Func<string, Task<IStreamFailureHandler>> StreamFailureHandlerFactory { get; set; }
+        
         /// <summary>
         /// Factory initialization.
         /// Provider config must contain the event hub settings type or the settings themselves.
@@ -48,15 +51,30 @@ namespace Orleans.ServiceBus.Providers
 
             logger = log;
             serviceProvider = svcProvider;
+            receivers = new ConcurrentDictionary<QueueId, EventHubAdapterReceiver>();
+
             adapterConfig = new EventHubStreamProviderConfig(providerName);
             adapterConfig.PopulateFromProviderConfig(providerConfig);
-
             hubSettings = adapterConfig.GetEventHubSettings(providerConfig, serviceProvider);
-            checkpointSettings = adapterConfig.GetCheckpointSettings(providerConfig, serviceProvider);
-
-            receivers = new ConcurrentDictionary<QueueId, EventHubAdapterReceiver>();
             client = EventHubClient.CreateFromConnectionString(hubSettings.ConnectionString, hubSettings.Path);
-            bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, pool => new FixedSizeBuffer(1 << 20, pool));
+
+            if (CheckpointerFactory == null)
+            {
+                checkpointerSettings = adapterConfig.GetCheckpointerSettings(providerConfig, serviceProvider);
+                CheckpointerFactory = partition => EventHubCheckpointer.Create(checkpointerSettings, adapterConfig.StreamProviderName, partition);
+            }
+            
+            if (CacheFactory == null)
+            {
+                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, pool => new FixedSizeBuffer(1 << 20, pool));
+                CacheFactory = checkpointer => new DefaultEventHubQueueCache(checkpointer, bufferPool);
+            }
+
+            if (StreamFailureHandlerFactory == null)
+            {
+                //TODO: Add a queue specific default failure handler with reasonable error reporting.
+                StreamFailureHandlerFactory = partition => Task.FromResult<IStreamFailureHandler>(new NoOpStreamDeliveryFailureHandler());
+            }
         }
 
         public async Task<IQueueAdapter> CreateAdapter()
@@ -82,9 +100,7 @@ namespace Orleans.ServiceBus.Providers
 
         public Task<IStreamFailureHandler> GetDeliveryFailureHandler(QueueId queueId)
         {
-            //TODO: Add a queue specific default failure handler with reasonable error reporting.
-            //TODO: Try to get failure handler from service provider so users can inject their own.
-            return Task.FromResult(streamFailureHandler ?? (streamFailureHandler = new NoOpStreamDeliveryFailureHandler()));
+            return StreamFailureHandlerFactory(streamQueueMapper.QueueToPartition(queueId));
         }
 
         public Task QueueMessageBatchAsync<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, StreamSequenceToken token,
@@ -118,11 +134,9 @@ namespace Orleans.ServiceBus.Providers
             var config = new EventHubPartitionConfig
             {
                 Hub = hubSettings,
-                CheckpointSettings = checkpointSettings,
-                StreamProviderName = adapterConfig.StreamProviderName,
                 Partition = streamQueueMapper.QueueToPartition(queueId),
             };
-            return new EventHubAdapterReceiver(config, bufferPool, logger);
+            return new EventHubAdapterReceiver(config, CacheFactory, CheckpointerFactory, logger);
         }
 
         public async Task<string[]> GetPartitionIdsAsync()

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
@@ -26,7 +26,7 @@ namespace Orleans.ServiceBus.Providers
 
         public static string MakePartitionKey(string streamProviderName, string checkpointNamespace)
         {
-            string key = String.Format("EHCheckpoints_{0}_{1}", streamProviderName, checkpointNamespace);
+            string key = String.Format("EventHubCheckpoints_{0}_{1}", streamProviderName, checkpointNamespace);
             return AzureStorageUtils.SanitizeTableProperty(key);
         }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -1,0 +1,53 @@
+﻿
+using System;
+using Microsoft.ServiceBus.Messaging;
+using Orleans.Providers.Streams.Common;
+using Orleans.ServiceBus.Providers;
+using Orleans.Streams;
+
+namespace OrleansServiceBus.Providers.Streams.EventHub
+{
+    public abstract class EventHubQueueCache<TCachedMessage> : PooledQueueCache<EventData, TCachedMessage>, IEventHubQueueCache
+        where TCachedMessage : struct
+    {
+        protected IStreamQueueCheckpointer<string> Checkpointer { private set; get; }
+
+        protected EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, TCachedMessage> cacheDataAdapter, ICacheDataComparer<TCachedMessage> comparer)
+            : base(cacheDataAdapter, comparer)
+        {
+            cacheDataAdapter.PurgeAction = Purge;
+            Checkpointer = checkpointer;
+            OnPurged = CheckpointOnPurged;
+        }
+
+        public void Dispose()
+        {
+            OnPurged = null;
+        }
+
+        protected abstract string GetOffset(TCachedMessage lastItemPurged);
+
+        private void CheckpointOnPurged(TCachedMessage lastItemPurged)
+        {
+            Checkpointer.Update(GetOffset(lastItemPurged), DateTime.UtcNow);
+        }
+    }
+
+    /// <summary>
+    /// Message cache that stores EventData as a CachedEventHubMessage in a pooled message cache
+    /// </summary>
+    internal class DefaultEventHubQueueCache : EventHubQueueCache<CachedEventHubMessage>
+    {
+        public DefaultEventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, IObjectPool<FixedSizeBuffer> bufferPool)
+            : base(checkpointer, new EventHubDataAdapter(bufferPool), EventHubDataComparer.Instance)
+        {
+        }
+
+        protected override string GetOffset(CachedEventHubMessage lastItemPurged)
+        {
+            int readOffset = 0;
+            SegmentBuilder.ReadNextString(lastItemPurged.Segment, ref readOffset); // read namespace, not needed so throw away.
+            return SegmentBuilder.ReadNextString(lastItemPurged.Segment, ref readOffset); // read offset
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
@@ -11,8 +11,8 @@ namespace Orleans.ServiceBus.Providers
         public const string EventHubConfigTypeName = "EventHubSettingsType";
         public Type EventHubSettingsType { get; set; }
 
-        public const string CheckpointSettingsTypeName = "CheckpointSettingsType";
-        public Type CheckpointSettingsType { get; set; }
+        public const string CheckpointerSettingsTypeName = "CheckpointerSettingsType";
+        public Type CheckpointerSettingsType { get; set; }
 
         public string StreamProviderName { get; private set; }
 
@@ -30,15 +30,15 @@ namespace Orleans.ServiceBus.Providers
         {
             if (EventHubSettingsType != null)
                 properties.Add(EventHubConfigTypeName, EventHubSettingsType.AssemblyQualifiedName);
-            if (CheckpointSettingsType != null)
-                properties.Add(CheckpointSettingsTypeName, CheckpointSettingsType.AssemblyQualifiedName);
+            if (CheckpointerSettingsType != null)
+                properties.Add(CheckpointerSettingsTypeName, CheckpointerSettingsType.AssemblyQualifiedName);
             properties.Add(CacheSizeMbName, CacheSizeMb.ToString(CultureInfo.InvariantCulture));
         }
 
         public void PopulateFromProviderConfig(IProviderConfiguration providerConfiguration)
         {
             EventHubSettingsType = providerConfiguration.GetTypeProperty(EventHubConfigTypeName, null);
-            CheckpointSettingsType = providerConfiguration.GetTypeProperty(CheckpointSettingsTypeName, null);
+            CheckpointerSettingsType = providerConfiguration.GetTypeProperty(CheckpointerSettingsTypeName, null);
             if (string.IsNullOrWhiteSpace(StreamProviderName))
             {
                 throw new ArgumentOutOfRangeException("providerConfiguration", "StreamProviderName not set.");
@@ -70,28 +70,28 @@ namespace Orleans.ServiceBus.Providers
             return hubSettings;
         }
 
-        public ICheckpointSettings GetCheckpointSettings(IProviderConfiguration providerConfig, IServiceProvider serviceProvider)
+        public ICheckpointerSettings GetCheckpointerSettings(IProviderConfiguration providerConfig, IServiceProvider serviceProvider)
         {
-            // if no checkpoint settings type is provided, use EventHubCheckpointSettings and get populate settings from providerConfig
-            if (CheckpointSettingsType == null)
+            // if no checkpointer settings type is provided, use EventHubCheckpointerSettings and get populate settings from providerConfig
+            if (CheckpointerSettingsType == null)
             {
-                CheckpointSettingsType = typeof(EventHubCheckpointSettings);
+                CheckpointerSettingsType = typeof(EventHubCheckpointerSettings);
             }
 
-            var checkpointConfig = serviceProvider.GetService(CheckpointSettingsType) as ICheckpointSettings;
-            if (checkpointConfig == null)
+            var checkpointerSettings = serviceProvider.GetService(CheckpointerSettingsType) as ICheckpointerSettings;
+            if (checkpointerSettings == null)
             {
-                throw new ArgumentOutOfRangeException("providerConfig", "CheckpointSettingsType not valid.");
+                throw new ArgumentOutOfRangeException("providerConfig", "CheckpointerSettingsType not valid.");
             }
 
-            // if settings is an EventHubCheckpointSettings class, populate settings from providerConfig
-            var settings = checkpointConfig as EventHubCheckpointSettings;
+            // if settings is an EventHubCheckpointerSettings class, populate settings from providerConfig
+            var settings = checkpointerSettings as EventHubCheckpointerSettings;
             if (settings != null)
             {
                 settings.PopulateFromProviderConfig(providerConfig);
             }
 
-            return checkpointConfig;
+            return checkpointerSettings;
         }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/ICheckpointerSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/ICheckpointerSettings.cs
@@ -5,7 +5,7 @@ using Orleans.Providers;
 
 namespace Orleans.ServiceBus.Providers
 {
-    public interface ICheckpointSettings
+    public interface ICheckpointerSettings
     {
         /// <summary>
         /// Azure table storage data connections string
@@ -23,22 +23,22 @@ namespace Orleans.ServiceBus.Providers
         TimeSpan PersistInterval { get; }
 
         /// <summary>
-        /// This name partitions a services checkpoint information from other services.
+        /// This name partitions a service's checkpoint information from other services.
         /// </summary>
         string CheckpointNamespace { get; }
     }
 
-    public class EventHubCheckpointSettings : ICheckpointSettings
+    public class EventHubCheckpointerSettings : ICheckpointerSettings
     {
-        private const string DataConnectionStringName = "CheckpointDataConnectionString";
+        private const string DataConnectionStringName = "CheckpointerDataConnectionString";
         private const string TableNameName = "CheckpointTableName";
         private const string PersistIntervalName = "CheckpointPersistInterval";
         private const string CheckpointNamespaceName = "CheckpointNamespace";
         private static readonly TimeSpan DefaultPersistInterval = TimeSpan.FromMinutes(1);
 
-        public EventHubCheckpointSettings(){}
+        public EventHubCheckpointerSettings(){}
 
-        public EventHubCheckpointSettings(string dataConnectionString, string table, string checkpointNamespace, TimeSpan? persistInterval = null)
+        public EventHubCheckpointerSettings(string dataConnectionString, string table, string checkpointNamespace, TimeSpan? persistInterval = null)
         {
             if (string.IsNullOrWhiteSpace(dataConnectionString))
             {

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -1,0 +1,14 @@
+﻿
+using System;
+using Microsoft.ServiceBus.Messaging;
+using Orleans.Streams;
+
+namespace Orleans.ServiceBus.Providers
+{
+    public interface IEventHubQueueCache : IDisposable
+    {
+        void Add(EventData message);
+        object GetCursor(IStreamIdentity streamIdentity, StreamSequenceToken sequenceToken);
+        bool TryGetNextMessage(object cursorObj, out IBatchContainer message);
+    }
+}

--- a/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -34,8 +34,8 @@ namespace UnitTests.StreamingTests
         private static readonly EventHubStreamProviderConfig ProviderConfig =
             new EventHubStreamProviderConfig(StreamProviderName);
 
-        private static readonly EventHubCheckpointSettings CheckpointSettings =
-            new EventHubCheckpointSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
+        private static readonly EventHubCheckpointerSettings CheckpointerSettings =
+            new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
                 TimeSpan.FromSeconds(1));
 
         private readonly ImplicitSubscritionRecoverableStreamTestRunner runner;
@@ -73,7 +73,7 @@ namespace UnitTests.StreamingTests
             public override void Dispose()
             {
                 base.Dispose();
-                var dataManager = new AzureTableDataManager<TableEntity>(CheckpointSettings.TableName, CheckpointSettings.DataConnectionString);
+                var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString);
                 dataManager.InitTableAsync().Wait();
                 dataManager.DeleteTableAsync().Wait();
             }
@@ -85,7 +85,7 @@ namespace UnitTests.StreamingTests
                 // get initial settings from configs
                 ProviderConfig.WriteProperties(settings);
                 EventHubConfig.WriteProperties(settings);
-                CheckpointSettings.WriteProperties(settings);
+                CheckpointerSettings.WriteProperties(settings);
 
                 // add queue balancer setting
                 settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());

--- a/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
+++ b/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
@@ -38,8 +38,8 @@ namespace UnitTests.StreamingTests
         private static readonly EventHubStreamProviderConfig ProviderConfig =
             new EventHubStreamProviderConfig(StreamProviderName, 3);
 
-        private static readonly EventHubCheckpointSettings CheckpointSettings =
-            new EventHubCheckpointSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
+        private static readonly EventHubCheckpointerSettings CheckpointerSettings =
+            new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
                 TimeSpan.FromSeconds(1));
 
         public override TestingSiloHost CreateSiloHost()
@@ -71,7 +71,7 @@ namespace UnitTests.StreamingTests
 
         public override void Dispose()
         {
-            var dataManager = new AzureTableDataManager<TableEntity>(CheckpointSettings.TableName, CheckpointSettings.DataConnectionString);
+            var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString);
             dataManager.InitTableAsync().Wait();
             dataManager.DeleteTableAsync().Wait();
             base.Dispose();
@@ -201,7 +201,7 @@ namespace UnitTests.StreamingTests
             // get initial settings from configs
             ProviderConfig.WriteProperties(settings);
             EventHubConfig.WriteProperties(settings);
-            CheckpointSettings.WriteProperties(settings);
+            CheckpointerSettings.WriteProperties(settings);
 
             // add queue balancer setting
             settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());

--- a/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
@@ -32,8 +32,8 @@ namespace UnitTests.StreamingTests
         private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
             EHConsumerGroup, EHPath);
 
-        private static readonly EventHubCheckpointSettings CheckpointSettings =
-            new EventHubCheckpointSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
+        private static readonly EventHubCheckpointerSettings CheckpointerSettings =
+            new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
                 TimeSpan.FromSeconds(1));
 
         private readonly SubscriptionMultiplicityTestRunner runner;
@@ -53,7 +53,7 @@ namespace UnitTests.StreamingTests
             public override void Dispose()
             {
                 base.Dispose();
-                var dataManager = new AzureTableDataManager<TableEntity>(CheckpointSettings.TableName, CheckpointSettings.DataConnectionString);
+                var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString);
                 dataManager.InitTableAsync().Wait();
                 dataManager.DeleteTableAsync().Wait();
             }
@@ -64,7 +64,7 @@ namespace UnitTests.StreamingTests
                 // get initial settings from configs
                 ProviderConfig.WriteProperties(settings);
                 EventHubConfig.WriteProperties(settings);
-                CheckpointSettings.WriteProperties(settings);
+                CheckpointerSettings.WriteProperties(settings);
 
                 // add queue balancer setting
                 settings.Add(PersistentStreamProviderConfig.QUEUE_BALANCER_TYPE, StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer.ToString());

--- a/test/TesterInternal/StreamingTests/TestStreamIdentity.cs
+++ b/test/TesterInternal/StreamingTests/TestStreamIdentity.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Orleans.Streams;
+
+namespace UnitTests.StreamingTests
+{
+    internal class TestStreamIdentity : IStreamIdentity
+    {
+        public Guid Guid { get; set; }
+        public string Namespace { get; set; }
+    }
+}

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -236,6 +236,7 @@
     <Compile Include="StreamingTests\StreamReliabilityTests.cs" />
     <Compile Include="StreamingTests\StreamTestHelperClasses.cs" />
     <Compile Include="StreamingTests\StreamTestUtils.cs" />
+    <Compile Include="StreamingTests\TestStreamIdentity.cs" />
     <Compile Include="StreamProvidersTests.cs" />
     <Compile Include="TestConstants.cs" />
     <Compile Include="TestInternalHelper.cs" />


### PR DESCRIPTION
This change allows application developers to provide their own stream failure handlers, checkpointing logic, and data adapters.

This should address feature "Modular Message format" in "Recoverable Event Hub Persistent Stream Provider - Part 2" #1454 

>Modular Message format. – For the EventHubStreamProvider to process a wide range of messages from EventHub, the cache data adapter must be a pluggable component that application developers can provide.
