### PR TITLE
Remove 2 redundant duplicate headers.

### DIFF
--- a/src/Orleans/Core/Exceptions.cs
+++ b/src/Orleans/Core/Exceptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 
 namespace Orleans.Runtime
@@ -96,7 +97,7 @@ namespace Orleans.Runtime
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
     public class DeadlockException : OrleansException
     {
-        internal IEnumerable<Tuple<GrainId, int, int>> CallChain { get; private set; }
+        internal IEnumerable<Tuple<GrainId, string>> CallChain { get; private set; }
 
         public DeadlockException() : base("Deadlock between grain calls") {}
 
@@ -104,11 +105,11 @@ namespace Orleans.Runtime
 
         public DeadlockException(string message, Exception innerException) : base(message, innerException) { }
 
-        internal DeadlockException(IEnumerable<Tuple<GrainId, int, int>> callChain)
-            : base(String.Format("Deadlock Exception for grain call chain {0}.", Utils.EnumerableToString(callChain, 
-                            elem => String.Format("{0}.{1}.{2}", elem.Item1, elem.Item2, elem.Item3)))) 
+        internal DeadlockException(List<RequestInvocationHistory> callChain)
+            : base(String.Format("Deadlock Exception for grain call chain {0}.", Utils.EnumerableToString(callChain,
+                        elem => String.Format("{0}.{1}", elem.GrainId, elem.DebugContext))))
         {
-            CallChain = callChain;
+            CallChain = callChain.Select(req => new Tuple<GrainId, string>(req.GrainId, req.DebugContext)).ToList();
         }
 
         protected DeadlockException(SerializationInfo info, StreamingContext context)
@@ -116,7 +117,7 @@ namespace Orleans.Runtime
         {
             if (info != null)
             {
-                CallChain = (IEnumerable<Tuple<GrainId, int, int>>)info.GetValue("CallChain", typeof(IEnumerable<Tuple<GrainId, int, int>>));
+                CallChain = (IEnumerable<Tuple<GrainId, string>>)info.GetValue("CallChain", typeof(IEnumerable<Tuple<GrainId, string>>));
             }
         }
 
@@ -124,7 +125,7 @@ namespace Orleans.Runtime
         {
             if (info != null)
             {
-                info.AddValue("CallChain", this.CallChain, typeof(IEnumerable<Tuple<GrainId, int, int>>));
+                info.AddValue("CallChain", this.CallChain, typeof(IEnumerable<Tuple<GrainId, string>>));
             }
 
             base.GetObjectData(info, context);

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -23,8 +23,8 @@ namespace Orleans.Runtime
             DIRECTION,
             EXPIRATION,
             FORWARD_COUNT,
-            INTERFACE_ID,
-            METHOD_ID,
+            INTERFACE_ID,  // DEPRECATED - leave that enum value to maintain next enum numerical values
+            METHOD_ID,  // DEPRECATED - leave that enum value to maintain next enum numerical values
             NEW_GRAIN_TYPE,
             GENERIC_GRAIN_TYPE,
             RESULT,
@@ -341,18 +341,6 @@ namespace Orleans.Runtime
             return ForwardCount < config.MaxForwardCount;
         }
 
-        public int MethodId
-        {
-            get { return GetScalarHeader<int>(Header.METHOD_ID); }
-            set { SetHeader(Header.METHOD_ID, value); }
-        }
-
-        public int InterfaceId
-        {
-            get { return GetScalarHeader<int>(Header.INTERFACE_ID); }
-            set { SetHeader(Header.INTERFACE_ID, value); }
-        }
-
         /// <summary>
         /// Set by sender's placement logic when NewPlacementRequested is true
         /// so that receiver knows desired grain type
@@ -466,8 +454,6 @@ namespace Orleans.Runtime
                 (options & InvokeMethodOptions.OneWay) != 0 ? Directions.OneWay : Directions.Request)
             {
                 Id = CorrelationId.GetNext(),
-                InterfaceId = request.InterfaceId,
-                MethodId = request.MethodId,
                 IsReadOnly = (options & InvokeMethodOptions.ReadOnly) != 0,
                 IsUnordered = (options & InvokeMethodOptions.Unordered) != 0,
                 BodyObject = request

--- a/src/Orleans/Messaging/RequestInvocationHistory.cs
+++ b/src/Orleans/Messaging/RequestInvocationHistory.cs
@@ -8,20 +8,18 @@ namespace Orleans.Runtime
     {
         public GrainId GrainId { get; private set; }
         public ActivationId ActivationId { get; private set; }
-        public int InterfaceId { get; private set; }
-        public int MethodId { get; private set; }
+        public string DebugContext { get; private set; }
 
         internal RequestInvocationHistory(Message message)
         {
             GrainId = message.TargetGrain;
             ActivationId = message.TargetActivation;
-            InterfaceId = message.InterfaceId;
-            MethodId = message.MethodId;
+            DebugContext = message.DebugContext;
         }
 
         public override string ToString()
         {
-            return String.Format("RequestInvocationHistory {0}:{1}:{2}:{3}", GrainId, ActivationId, InterfaceId, MethodId);
+            return String.Format("RequestInvocationHistory {0}:{1}:{2}", GrainId, ActivationId, DebugContext);
         }
     }
 }

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -339,8 +339,7 @@ namespace Orleans.Runtime
                 newChain.AddRange(prevChain.Cast<RequestInvocationHistory>());
                 newChain.Add(new RequestInvocationHistory(message));
                 
-                throw new DeadlockException(newChain.Select(req =>
-                    new Tuple<GrainId, int, int>(req.GrainId, req.InterfaceId, req.MethodId)).ToList());
+                throw new DeadlockException(newChain);
             }
         }
 

--- a/src/OrleansRuntime/Core/InsideGrainClient.cs
+++ b/src/OrleansRuntime/Core/InsideGrainClient.cs
@@ -330,12 +330,12 @@ namespace Orleans.Runtime
                     // in RuntimeClient.CreateMessage -> RequestContext.ExportToMessage(message);
                 }
 
-                var invoker = invokable.GetInvoker(message.InterfaceId, message.GenericGrainType);
-
                 object resultObject;
                 try
                 {
                     var request = (InvokeMethodRequest) message.BodyObject;
+
+                    var invoker = invokable.GetInvoker(request.InterfaceId, message.GenericGrainType);
 
                     if (invoker is IGrainExtensionMethodInvoker
                         && !(target is IGrainExtension))


### PR DESCRIPTION
We had 2 headers (MethodId and InterfaceId) that duplicated information that is passed already via `InvokeMethodRequest`. They were only used for deadlock detection algorithm for diagnostics only. Changed the deadlock detection to use Debug Context instead.

This allows to save 2 headers on every msg. Was noticed as a result of @dVakulen 's comment https://github.com/dotnet/orleans/pull/1519#issuecomment-191907943.

Alternatively, we could remove those from `InvokeMethodRequest`, but that would require a much bigger change, this MethodId and InterfaceId in `InvokeMethodRequest` are used everywhere, including the generated code in the invokers.