### PR TITLE
Safe load of types from failing assemblies in TypeUtils.GetTypes

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -89,7 +89,7 @@ namespace Orleans.Runtime
                         assembly,
                         type =>
                         typeof(T).GetTypeInfo().IsAssignableFrom(type) && !type.GetTypeInfo().IsInterface
-                        && type.GetTypeInfo().GetConstructor(Type.EmptyTypes) != null).FirstOrDefault();
+                        && type.GetTypeInfo().GetConstructor(Type.EmptyTypes) != null, logger).FirstOrDefault();
                 if (foundType == null)
                 {
                     return null;
@@ -114,7 +114,7 @@ namespace Orleans.Runtime
             try
             {
                 var assembly = Assembly.Load(new AssemblyName(assemblyName));
-                var foundType = TypeUtils.GetTypes(assembly, type => typeof(T).IsAssignableFrom(type)).First();
+                var foundType = TypeUtils.GetTypes(assembly, type => typeof(T).IsAssignableFrom(type), logger).First();
 
                 return (T)Activator.CreateInstance(foundType, true);
             }

--- a/src/Orleans/AssemblyLoader/AssemblyProcessor.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyProcessor.cs
@@ -122,25 +122,7 @@ namespace Orleans.Runtime
 
             // Process each type in the assembly.
             var shouldProcessSerialization = SerializationManager.ShouldFindSerializationInfo(assembly);
-            TypeInfo[] assemblyTypes;
-            try
-            {
-                assemblyTypes = assembly.DefinedTypes.ToArray();
-            }
-            catch (Exception exception)
-            {
-                if (Logger.IsWarning)
-                {
-                    var message =
-                        string.Format(
-                            "AssemblyLoader encountered an exception loading types from assembly '{0}': {1}",
-                            assembly.FullName,
-                            exception);
-                    Logger.Warn(ErrorCode.Loader_TypeLoadError_5, message, exception);
-                }
-
-                return;
-            }
+            var assemblyTypes = TypeUtils.GetDefinedTypes(assembly, Logger).ToArray();
 
             // Process each type in the assembly.
             foreach (TypeInfo type in assemblyTypes)

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -447,47 +447,54 @@ namespace Orleans.Runtime
             return type.Assembly.ReflectionOnly ? type : ResolveReflectionOnlyType(type.AssemblyQualifiedName);
         }
 
-        public static IEnumerable<Type> GetTypes(Assembly assembly, Func<Type, bool> whereFunc)
+        public static IEnumerable<Type> GetTypes(Assembly assembly, Func<Type, bool> whereFunc, TraceLogger logger)
         {
-            if (assembly.IsDynamic)
-            {
-                return Enumerable.Empty<Type>();
-            }
-
-            IEnumerable<TypeInfo> definedTypes;
-            try
-            {
-                definedTypes = assembly.DefinedTypes;
-            }
-            catch (ReflectionTypeLoadException)
-            {
-                return Enumerable.Empty<Type>();
-            }
-
-            return definedTypes.Where(type => !type.GetTypeInfo().IsNestedPrivate && whereFunc(type));
+            return assembly.IsDynamic ? Enumerable.Empty<Type>() : GetDefinedTypes(assembly, logger).Where(type => !type.GetTypeInfo().IsNestedPrivate && whereFunc(type));
         }
 
-        public static IEnumerable<Type> GetTypes(Func<Type, bool> whereFunc)
+        public static IEnumerable<TypeInfo> GetDefinedTypes(Assembly assembly, TraceLogger logger)
+        {
+            try
+            {
+                return assembly.DefinedTypes;
+            }
+            catch (Exception exception)
+            {
+                if (logger.IsWarning)
+                {
+                    var message =
+                        string.Format(
+                            "AssemblyLoader encountered an exception loading types from assembly '{0}': {1}",
+                            assembly.FullName,
+                            exception);
+                    logger.Warn(ErrorCode.Loader_TypeLoadError_5, message, exception);
+                }
+
+                return Enumerable.Empty<TypeInfo>();
+            }
+        }
+
+        public static IEnumerable<Type> GetTypes(Func<Type, bool> whereFunc, TraceLogger logger)
         {
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             var result = new List<Type>();
             foreach (var assembly in assemblies)
             {
                 // there's no point in evaluating nested private types-- one of them fails to coerce to a reflection-only type anyhow.
-                var types = GetTypes(assembly, whereFunc);
+                var types = GetTypes(assembly, whereFunc, logger);
                 result.AddRange(types);
             }
             return result;
         }
 
-        public static IEnumerable<Type> GetTypes(List<string> assemblies, Func<Type, bool> whereFunc)
+        public static IEnumerable<Type> GetTypes(List<string> assemblies, Func<Type, bool> whereFunc, TraceLogger logger)
         {
             var currentAssemblies = AppDomain.CurrentDomain.GetAssemblies();
             var result = new List<Type>();
             foreach (var assembly in currentAssemblies.Where(loaded => !loaded.IsDynamic && assemblies.Contains(loaded.Location)))
             {
                 // there's no point in evaluating nested private types-- one of them fails to coerce to a reflection-only type anyhow.
-                var types = GetTypes(assembly, whereFunc);
+                var types = GetTypes(assembly, whereFunc, logger);
                 result.AddRange(types);
             }
             return result;

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -449,7 +449,22 @@ namespace Orleans.Runtime
 
         public static IEnumerable<Type> GetTypes(Assembly assembly, Func<Type, bool> whereFunc)
         {
-            return assembly.IsDynamic ? Enumerable.Empty<Type>() : assembly.DefinedTypes.Where(type => !type.GetTypeInfo().IsNestedPrivate && whereFunc(type));
+            if (assembly.IsDynamic)
+            {
+                return Enumerable.Empty<Type>();
+            }
+
+            IEnumerable<TypeInfo> definedTypes;
+            try
+            {
+                definedTypes = assembly.DefinedTypes;
+            }
+            catch (ReflectionTypeLoadException)
+            {
+                return Enumerable.Empty<Type>();
+            }
+
+            return definedTypes.Where(type => !type.GetTypeInfo().IsNestedPrivate && whereFunc(type));
         }
 
         public static IEnumerable<Type> GetTypes(Func<Type, bool> whereFunc)

--- a/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
+++ b/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
@@ -60,8 +60,8 @@ namespace Orleans.Runtime
         {
             var result = new Dictionary<string, GrainTypeData>();
             Type[] grainTypes = strict
-                ? TypeUtils.GetTypes(TypeUtils.IsConcreteGrainClass).ToArray()
-                : TypeUtils.GetTypes(discoveredAssemblyLocations, TypeUtils.IsConcreteGrainClass).ToArray();
+                ? TypeUtils.GetTypes(TypeUtils.IsConcreteGrainClass, logger).ToArray()
+                : TypeUtils.GetTypes(discoveredAssemblyLocations, TypeUtils.IsConcreteGrainClass, logger).ToArray();
 
             foreach (var grainType in grainTypes)
             {
@@ -106,8 +106,8 @@ namespace Orleans.Runtime
         {
             var result = new Dictionary<int, Type>();
             Type[] types = strict
-                ? TypeUtils.GetTypes(TypeUtils.IsGrainMethodInvokerType).ToArray()
-                : TypeUtils.GetTypes(discoveredAssemblyLocations, TypeUtils.IsGrainMethodInvokerType).ToArray();
+                ? TypeUtils.GetTypes(TypeUtils.IsGrainMethodInvokerType, logger).ToArray()
+                : TypeUtils.GetTypes(discoveredAssemblyLocations, TypeUtils.IsGrainMethodInvokerType, logger).ToArray();
 
             foreach (var type in types)
             {


### PR DESCRIPTION
Trying to address the problem I've raised in https://github.com/dotnet/orleans/issues/1517 . If the failing assembly (in my case `Microsoft.CodeAnalysis.Scripting`) is loaded into `AppDomain` (so it is returned in `AppDomain.CurrentDomain.GetAssemblies()`), then the silo is crashing on start.