### PR TITLE
VSIX cleanup

### DIFF
--- a/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
+++ b/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
@@ -29,6 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <DeployExtension>False</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/OrleansVSTools/VSProjectSiloHost/ProjectTemplate.csproj
+++ b/src/OrleansVSTools/VSProjectSiloHost/ProjectTemplate.csproj
@@ -33,9 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System"/>
-    $if$ ($targetframeworkversion$ >= 4.0)
     <Reference Include="Microsoft.CSharp"/>
-    $endif$
     <Reference Include="System.Core"/>
     <Reference Include="System.Data"/>
     <Reference Include="System.Data.DataSetExtensions"/>

--- a/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
+++ b/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
@@ -29,11 +29,6 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
-      <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" />
-      <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" />
-      <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" />
-      <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0-rc1-final" />
-      <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0-rc1-final" />
       <package id="Microsoft.Orleans.Core" version="1.2.0" />
       <package id="Microsoft.Orleans.CounterControl" version="1.2.0" />
       <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.2.0" />
@@ -41,9 +36,6 @@
       <package id="Microsoft.Orleans.OrleansProviders" version="1.2.0" />
       <package id="Microsoft.Orleans.OrleansRuntime" version="1.2.0" />
       <package id="Microsoft.Orleans.Server" version="1.2.0" />
-      <package id="Newtonsoft.Json" version="7.0.1" />
-      <package id="System.Collections.Immutable" version="1.1.36" />
-      <package id="System.Reflection.Metadata" version="1.0.21" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementation" d:TargetPath="|VSProjectTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementation/ProjectTemplate.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementation/ProjectTemplate.csproj
@@ -46,7 +46,6 @@
     <Compile Include="Properties\orleans.codegen.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.vstemplate
@@ -28,14 +28,8 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
-      <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" />
-      <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" />
-      <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" />
       <package id="Microsoft.Orleans.Core" version="1.2.0" />
       <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.2.0" />
-      <package id="Newtonsoft.Json" version="7.0.1" />
-      <package id="System.Collections.Immutable" version="1.1.36" />
-      <package id="System.Reflection.Metadata" version="1.0.21" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementation" d:TargetPath="|VSProjectTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterface/ProjectTemplate.csproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterface/ProjectTemplate.csproj
@@ -46,7 +46,6 @@
     <Compile Include="Properties\orleans.codegen.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0\build\Microsoft.Orleans.OrleansCodeGenerator.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.vstemplate
@@ -28,14 +28,8 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
-      <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" />
-      <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" />
-      <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" />
       <package id="Microsoft.Orleans.Core" version="1.2.0" />
       <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.2.0" />
-      <package id="Newtonsoft.Json" version="7.0.1" />
-      <package id="System.Collections.Immutable" version="1.1.36" />
-      <package id="System.Reflection.Metadata" version="1.0.21" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterface" d:TargetPath="|VSProjectTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />


### PR DESCRIPTION
Remove unnecessary NuGet references. Some of them cause build warnings.
Turn off deployment of the VSIX at the end of build.
Remove explicit references to Microsoft.Orleans.OrleansCodeGenerator.Build.targets from .csproj files that duplicate ones added by Microsoft.Orleans.OrleansCodeGenerator.Build NuGet package.