### PR TITLE
Update assembly versions to match release version

### DIFF
--- a/src/Build/GlobalAssemblyInfo.cs
+++ b/src/Build/GlobalAssemblyInfo.cs
@@ -3,6 +3,6 @@ using System.Reflection;
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Orleans")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation 2015")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
 [assembly: AssemblyFileVersion("1.2.0.0")]
 [assembly: AssemblyInformationalVersion("1.2.0.0")]

--- a/src/Build/GlobalAssemblyInfo.fs
+++ b/src/Build/GlobalAssemblyInfo.fs
@@ -5,7 +5,7 @@ open System.Reflection
 [<assembly: AssemblyCompany("Microsoft Corporation")>]
 [<assembly: AssemblyProduct("Orleans")>]
 [<assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation 2015")>]
-[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyVersion("1.2.0.0")>]
 [<assembly: AssemblyFileVersion("1.2.0.0")>]
 [<assembly: AssemblyInformationalVersion("1.2.0.0")>]
 

--- a/src/OrleansCounterControl/app.manifest
+++ b/src/OrleansCounterControl/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <assemblyIdentity version="1.0.0.0" name="OrleansCounterControl.exe"/>
+  <assemblyIdentity version="1.2.0.0" name="OrleansCounterControl.exe"/>
   <description>Orleans Counter Control program</description>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>


### PR DESCRIPTION
We haven't updated assembly version in prior releases. We need to do that for releases with breaking changes, so that version mismatches are easier to detect.