### PR TITLE
Fixed Json serialization of  Stream Filter Predicates.

### DIFF
--- a/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
+++ b/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
@@ -13,7 +13,7 @@ namespace Orleans.Streams
     /// Predicate filter functions must be staic (non-abstract) methods, so full class name and method name are sufficient info to rehydrate.
     /// </summary>
     [Serializable]
-    internal class FilterPredicateWrapperData : IStreamFilterPredicateWrapper
+    internal class FilterPredicateWrapperData : IStreamFilterPredicateWrapper, ISerializable
     {
         public object FilterData { get; private set; }
 

--- a/src/Orleans/Streams/Predicates/OrFilter.cs
+++ b/src/Orleans/Streams/Predicates/OrFilter.cs
@@ -8,7 +8,7 @@ namespace Orleans.Streams
     /// This class is a [Serializable] holder for a logical-or composite predicate function.
     /// </summary>
     [Serializable]
-    internal class OrFilter : IStreamFilterPredicateWrapper
+    internal class OrFilter : IStreamFilterPredicateWrapper, ISerializable
     {
         public object FilterData
         {


### PR DESCRIPTION
I believe it fixes https://github.com/dotnet/orleans/issues/836.
The filters were serialized correctly to Json, via defining ISerializable interface methods. There was just a missing declaration by the type as implementing ISerializable, so this serialization code was ignored.