### PR TITLE
Make Build.cmd support local build if VS SDK is not installed.

### DIFF
--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -4,26 +4,54 @@
 @ECHO off
 
 SET CMDHOME=%~dp0.
-if "%VisualStudioVersion%" == "" call "%VS140COMNTOOLS%VsDevCmd.bat"
 if "%VisualStudioVersion%" == "" (
-echo Could not find Visual Studio 14.0 in the system. Cannot continue.
-exit /b 1)
+    @REM Try to find VS command prompt init script
+    where /Q VsDevCmd.bat
+    if ERRORLEVEL 1 (
+        if exist "%VS140COMNTOOLS%" (
+            call "%VS140COMNTOOLS%VsDevCmd.bat"
+        )
+    ) else (
+        @REM VsDevCmd.bat is in PATH, so just exec it.
+        VsDevCmd.bat
+    )
+)
+if "%VisualStudioVersion%" == "" (
+    echo Could not determine Visual Studio version in the system. Cannot continue.
+    exit /b 1
+)
+@ECHO VisualStudioVersion = %VisualStudioVersion%
 
-rem Get path to MSBuild Binaries
+@REM Get path to MSBuild Binaries
 if exist "%ProgramFiles%\MSBuild\14.0\bin" SET MSBUILDEXEDIR=%ProgramFiles%\MSBuild\14.0\bin
 if exist "%ProgramFiles(x86)%\MSBuild\14.0\bin" SET MSBUILDEXEDIR=%ProgramFiles(x86)%\MSBuild\14.0\bin
-SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe
+
+@REM Can't multi-block if statement when check condition contains '(' and ')' char, so do as single line checks
+if NOT "%MSBUILDEXEDIR%" == "" SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe
+if NOT "%MSBUILDEXEDIR%" == "" GOTO :MsBuildFound
+
+@REM Try to find VS command prompt init script
+where /Q MsBuild.exe
+if ERRORLEVEL 1 (
+    echo Could not find MSBuild in the system. Cannot continue.
+    exit /b 1
+) else (
+    @REM MsBuild.exe is in PATH, so just use it.
+   SET MSBUILDEXE=MSBuild.exe
+ )
+:MsBuildFound
+@ECHO MsBuild Location = %MSBUILDEXE%
 
 SET VERSION_FILE=%CMDHOME%\Build\Version.txt
 
 if EXIST "%VERSION_FILE%" (
     @Echo Using version number from file %VERSION_FILE%
     FOR /F "usebackq tokens=1,2,3,4 delims=." %%i in (`type "%VERSION_FILE%"`) do set PRODUCT_VERSION=%%i.%%j.%%k
-	@Echo PRODUCT_VERSION=%PRODUCT_VERSION%
 ) else (
     @Echo ERROR: Unable to read version number from file %VERSION_FILE%
     SET PRODUCT_VERSION=1.0
 )
+@Echo PRODUCT_VERSION=%PRODUCT_VERSION%
 
 if "%builduri%" == "" set builduri=Build.cmd
 
@@ -51,10 +79,12 @@ SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
 set STEP=VSIX
 
-if "%BuildOrleansNuGet%" == "false" (
-    @echo Skipping building VSIX
-	@GOTO :EOF
+if "%VSSDK140Install%" == "" (
+    @echo Visual Studio 2015 SDK not installed - Skipping building VSIX
+    @GOTO :BuildFinished
 )
+
+@echo Build VSIX ============================
 
 set PROJ=%CMDHOME%\OrleansVSTools\OrleansVSTools.sln
 SET OutDir=%OutDir%\VSIX
@@ -62,6 +92,7 @@ SET OutDir=%OutDir%\VSIX
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD ok for VSIX package for %PROJ%
 
+:BuildFinished
 @echo ===== Build succeeded for %PROJ% =====
 @GOTO :EOF
 


### PR DESCRIPTION
~~~The `Build.cmd` script currently tries to check for MsBuild 14 (VS 2015) and stops / fails if it does not find it on the local machine, even though everything builds just fine with MsBuild 12 (VS 2013)~~~

~~~This change set is to tweak the logic in `Build.cmd` to allow either MsBuild 12 or 14, but still preferring to use 14 if installed.~~~

Also tweaks the logic about whether to build .vsix by using ev `BuildOrleansVsix` instead of overloading  `BuildOrleansNuGet` and defaults to not build .vsix unless `BuildOrleansVsix=true` so that things build cleanly on local machine for most developers who will only have Visual Studio / MsBuild installed and not the Visual Studio SDK.

~~~This change sets means that developers who have not yet upgraded to VS 2015 and are still using VS 2013 can still do command line build of Orleans locally.~~~