### PR TITLE
Remove unnecessary NuGet warning

### DIFF
--- a/src/Orleans/Orleans.nuget.targets
+++ b/src/Orleans/Orleans.nuget.targets
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="EmitMSBuildWarning" BeforeTargets="Build">
-    <Warning Text="Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored." />
-  </Target>
-</Project>


### PR DESCRIPTION
Everytime we build Orleans (from within VS or using scripts) we get that warning twice, that is harmless.
I believe this was added by mistake, as it was added in PR #832 (specifically commit 79ece4ba3a93970bae148d2a50284664dd22d7b6), that has nothing to do with the warning at hand.
Ping @jkonecki since he added that commit and maybe wants to keep the change.