### PR TITLE
Use Json Format for PubSub storage in some Azure Queue streaming tests.

### DIFF
--- a/src/TesterInternal/Config_AzureStreamProviders.xml
+++ b/src/TesterInternal/Config_AzureStreamProviders.xml
@@ -4,7 +4,7 @@
     <StorageProviders>
       <Provider Type="Orleans.Storage.MemoryStorage" Name="MemoryStore" NumStorageGrains="1"/>
       <Provider Type="Orleans.Storage.AzureTableStorage" Name="AzureStore"  DeleteStateOnClear="true"/>
-      <Provider Type="Orleans.Storage.AzureTableStorage" Name="PubSubStore"  DeleteStateOnClear="true" UseJsonFormat="false"/>
+      <Provider Type="Orleans.Storage.AzureTableStorage" Name="PubSubStore"  DeleteStateOnClear="true" UseJsonFormat="true"/>
     </StorageProviders>
     <StreamProviders>
         <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider" Name="SMSProvider" FireAndForgetDelivery="false"/>


### PR DESCRIPTION
Changed some selected streaming tests to `UseJsonFormat=true` for `PubSubStore`, to improve test coverage for Json pub sub state.
