### PR TITLE
[On Hold] Upgrade Roslyn NuGets from 1.0.0 to 1.1.0

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
@@ -19,7 +19,7 @@
     <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
     <dependencies>
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
-      <dependency id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" />
+      <dependency id="Microsoft.CodeAnalysis.CSharp" version="1.1.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansCodeGenerator/OrleansCodeGenerator.csproj
+++ b/src/OrleansCodeGenerator/OrleansCodeGenerator.csproj
@@ -37,22 +37,22 @@
     <DefineConstants>$(DefineConstants);EXCLUDE_CODEGEN</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>$(SolutionDir)packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.1.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>$(SolutionDir)packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.1.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>$(SolutionDir)packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>$(SolutionDir)packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -85,6 +85,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/OrleansCodeGenerator/packages.config
+++ b/src/OrleansCodeGenerator/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net451" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net451" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.1.0" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.1.0" targetFramework="net451" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net451" />
+  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="net451" />
 </packages>

--- a/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
+++ b/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
@@ -216,16 +216,16 @@
       <Link>Packages\Microsoft.Orleans.Server.1.2.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg">
-      <Link>Packages\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg</Link>
+    <Content Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\Microsoft.CodeAnalysis.Analyzers.1.1.0.nupkg">
+      <Link>Packages\Microsoft.CodeAnalysis.Analyzers.1.1.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0\Microsoft.CodeAnalysis.Common.1.0.0.nupkg">
-      <Link>Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg</Link>
+    <Content Include="..\..\packages\Microsoft.CodeAnalysis.Common.1.1.0\Microsoft.CodeAnalysis.Common.1.1.0.nupkg">
+      <Link>Packages\Microsoft.CodeAnalysis.Common.1.1.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg">
-      <Link>Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg</Link>
+    <Content Include="..\..\packages\Microsoft.CodeAnalysis.CSharp.1.1.0\Microsoft.CodeAnalysis.CSharp.1.1.0.nupkg">
+      <Link>Packages\Microsoft.CodeAnalysis.CSharp.1.1.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0-rc1-final\Microsoft.Extensions.DependencyInjection.1.0.0-rc1-final.nupkg">
@@ -240,12 +240,12 @@
       <Link>Packages\Newtonsoft.Json.7.0.1.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\System.Collections.Immutable.1.1.36\System.Collections.Immutable.1.1.36.nupkg">
-      <Link>Packages\System.Collections.Immutable.1.1.36.nupkg</Link>
+    <Content Include="..\..\packages\System.Collections.Immutable.1.1.37\System.Collections.Immutable.1.1.37.nupkg">
+      <Link>Packages\System.Collections.Immutable.1.1.37.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\System.Reflection.Metadata.1.0.21\System.Reflection.Metadata.1.0.21.nupkg">
-      <Link>Packages\System.Reflection.Metadata.1.0.21.nupkg</Link>
+    <Content Include="..\..\packages\System.Reflection.Metadata.1.1.0\System.Reflection.Metadata.1.1.0.nupkg">
+      <Link>Packages\System.Reflection.Metadata.1.1.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="..\..\..\Binaries\NuGet.Packages\Microsoft.Orleans.Templates.Grains.1.2.0.nupkg">


### PR DESCRIPTION
This resolve the issue of Roslyn code analyzer generating a warning *"Analyzer 'Microsoft.CodeAnalysis.CSharp.Analyzers.FixAnalyzers.CSharpFixerWithFixAllAnalyzer' threw an exception of type 'System.TypeInitializationException'"* in any project that adds Microsoft.Orleans.Client or Microsoft.Orleans.Server NuGet packlages.

Note that the latest version of the Roslyn NuGet packages is 1.1.1, but it explodes the dependencies into CoreCLR style individual system assemblies. Because of that I for now only upgraded to 1.1.0 that does not do that.