### PR TITLE
Cancellation token support

### DIFF
--- a/src/Orleans/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans/Configuration/MessagingConfiguration.cs
@@ -36,6 +36,11 @@ namespace Orleans.Runtime.Configuration
         /// Default is true.
         /// </summary>
         bool DropExpiredMessages { get; set; }
+        /// <summary>
+        /// The CancellationTokenHolderDeactivationDelay attribute specifies how long to keep an cancellation token holder grain after
+        /// cancel request. Default is 30 seconds
+        /// </summary>
+        TimeSpan CancellationTokenHolderDeactivationDelay { get; set; }
 
         /// <summary>
         /// The SiloSenderQueues attribute specifies the number of parallel queues and attendant threads used by the silo to send outbound
@@ -104,6 +109,7 @@ namespace Orleans.Runtime.Configuration
         public bool ResendOnTimeout { get; set; }
         public TimeSpan MaxSocketAge { get; set; }
         public bool DropExpiredMessages { get; set; }
+        public TimeSpan CancellationTokenHolderDeactivationDelay { get; set; }
 
         public int SiloSenderQueues { get; set; }
         public int GatewaySenderQueues { get; set; }
@@ -156,6 +162,7 @@ namespace Orleans.Runtime.Configuration
             ResendOnTimeout = DEFAULT_RESEND_ON_TIMEOUT;
             MaxSocketAge = DEFAULT_MAX_SOCKET_AGE;
             DropExpiredMessages = DEFAULT_DROP_EXPIRED_MESSAGES;
+            CancellationTokenHolderDeactivationDelay = Constants.DEFAULT_CANCELLATION_TOKEN_HOLDER_DEACTIVATION_DELAY;
 
             SiloSenderQueues = DEFAULT_SILO_SENDER_QUEUES;
             GatewaySenderQueues = DEFAULT_GATEWAY_SENDER_QUEUES;
@@ -192,6 +199,7 @@ namespace Orleans.Runtime.Configuration
             sb.AppendFormat("       Resend On Timeout: {0}", ResendOnTimeout).AppendLine();
             sb.AppendFormat("       Maximum Socket Age: {0}", MaxSocketAge).AppendLine();
             sb.AppendFormat("       Drop Expired Messages: {0}", DropExpiredMessages).AppendLine();
+            sb.AppendFormat("       Cancellation Token Holder Deactivation Delay: {0}", CancellationTokenHolderDeactivationDelay).AppendLine();
 
             if (isSiloConfig)
             {
@@ -249,6 +257,10 @@ namespace Orleans.Runtime.Configuration
                 DropExpiredMessages = ConfigUtilities.ParseBool(child.GetAttribute("DropExpiredMessages"),
                                                           "Invalid integer value for the DropExpiredMessages attribute on the Messaging element");
             }
+            CancellationTokenHolderDeactivationDelay = child.HasAttribute("CancellationTokenHolderDeactivationDelay")
+                                   ? ConfigUtilities.ParseTimeSpan(child.GetAttribute("CancellationTokenHolderDeactivationDelay"),
+                                                              "Invalid CancellationTokenHolderDeactivationDelay")
+                                   : Constants.DEFAULT_CANCELLATION_TOKEN_HOLDER_DEACTIVATION_DELAY;
             //--
             if (isSiloConfig)
             {

--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -338,6 +338,7 @@ namespace Orleans
         Runtime_Error_100329 = Runtime + 329,
         Runtime_Error_100330 = Runtime + 330,
         Runtime_Error_100331 = Runtime + 331,
+        Runtime_Error_100332 = Runtime + 332,
 
         SiloBase                        = Runtime + 400,
         SiloStarting                    = SiloBase + 1,

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -75,6 +75,8 @@
     <Compile Include="Async\AsyncExecutorWithRetries.cs" />
     <Compile Include="Async\AsyncLock.cs" />
     <Compile Include="Async\AsyncPipeline.cs" />
+    <Compile Include="Threading\GCObserver.cs" />
+    <Compile Include="Threading\CancellationTokenWrapper.cs" />
     <Compile Include="Async\TaskUtility.cs" />
     <Compile Include="Async\UnobservedExceptionsHandlerClass.cs" />
     <Compile Include="Async\TaskExtensions.cs" />
@@ -150,6 +152,9 @@
     <Compile Include="Telemetry\ITraceTelemetryConsumer.cs" />
     <Compile Include="Telemetry\Severity.cs" />
     <Compile Include="Telemetry\TraceParserUtils.cs" />
+    <Compile Include="Threading\CancellationTokenHolderGrain.cs" />
+    <Compile Include="Threading\ICancellationTokenHolderGrain.cs" />
+    <Compile Include="Threading\CancellationTokenManager.cs" />
     <Compile Include="Timers\IReminderRegistry.cs" />
     <Compile Include="Runtime\IRuntimeClient.cs" />
     <Compile Include="Runtime\IGrainExtension.cs" />

--- a/src/Orleans/Runtime/Constants.cs
+++ b/src/Orleans/Runtime/Constants.cs
@@ -51,6 +51,11 @@ namespace Orleans.Runtime
         public static readonly TimeSpan DEFAULT_RESPONSE_TIMEOUT = Debugger.IsAttached ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(30);
 
         /// <summary>
+        /// The delay after a cancellation token holder grain will be marked for collection.
+        /// </summary>
+        public static readonly TimeSpan DEFAULT_CANCELLATION_TOKEN_HOLDER_DEACTIVATION_DELAY = Debugger.IsAttached ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(30);
+
+        /// <summary>
         /// Minimum period for registering a reminder ... we want to enforce a lower bound
         /// </summary>
         public static readonly TimeSpan MinReminderPeriod = TimeSpan.FromMinutes(1); // increase this period, reminders are supposed to be less frequent ... we use 2 seconds just to reduce the running time of the unit tests

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Orleans.Serialization;
 using Orleans.CodeGeneration;
+using Orleans.Threading;
 
 namespace Orleans.Runtime
 {
@@ -405,11 +406,30 @@ namespace Orleans.Runtime
 
             if (!response.ExceptionFlag)
             {
+                if (response.Data is CancellationTokenWrapper)
+                {
+                    UnwrapCancellationToken(context, response);
+                    return;
+                }
+
                 context.TrySetResult(response.Data);
             }
             else
             {
                 context.TrySetException(response.Exception);
+            }
+        }
+
+        private static void UnwrapCancellationToken(TaskCompletionSource<object> context, Response response)
+        {
+            var orleansTokenWrapper = (CancellationTokenWrapper) response.Data;
+            if (orleansTokenWrapper.WentThroughSerialization && !orleansTokenWrapper.CancellationToken.IsCancellationRequested)
+            {
+                context.TrySetResult(CancellationTokenManager.GetCancellationToken(orleansTokenWrapper.Id).GetResult());
+            }
+            else
+            {
+                context.TrySetResult(orleansTokenWrapper.CancellationToken);
             }
         }
 

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -15,6 +15,7 @@ using Orleans.Storage;
 using Orleans.Runtime.Configuration;
 using System.Collections.Concurrent;
 using Orleans.Streams;
+using Orleans.Threading;
 
 namespace Orleans
 {
@@ -132,6 +133,8 @@ namespace Orleans
             if (!TraceLogger.IsInitialized) TraceLogger.Initialize(config);
             StatisticsCollector.Initialize(config);
             SerializationManager.Initialize(config.UseStandardSerializer, cfg.SerializationProviders, config.UseJsonFallbackSerializer);
+            CancellationTokenManager.Initialize(config);
+
             logger = TraceLogger.GetLogger("OutsideRuntimeClient", TraceLogger.LoggerType.Runtime);
             appLogger = TraceLogger.GetLogger("Application", TraceLogger.LoggerType.Application);
 
@@ -578,6 +581,7 @@ namespace Orleans
             Justification = "CallbackData is IDisposable but instances exist beyond lifetime of this method so cannot Dispose yet.")]
         public void SendRequest(GrainReference target, InvokeMethodRequest request, TaskCompletionSource<object> context, Action<Message, TaskCompletionSource<object>> callback, string debugContext = null, InvokeMethodOptions options = InvokeMethodOptions.None, string genericArguments = null)
         {
+            CancellationTokenManager.WrapCancellationTokens(request.Arguments);
             var message = Message.CreateMessage(request, options);
             SendRequestMessage(target, message, context, callback, debugContext, options, genericArguments);
         }

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -18,6 +18,7 @@ using Orleans.Runtime.Configuration;
 using Newtonsoft.Json;
 using Orleans.Providers;
 using System.Runtime.Serialization.Formatters;
+using Orleans.Threading;
 
 namespace Orleans.Serialization
 {
@@ -273,6 +274,7 @@ namespace Orleans.Serialization
             Register(typeof(ActivationAddress), BuiltInTypes.CopyActivationAddress, BuiltInTypes.SerializeActivationAddress, BuiltInTypes.DeserializeActivationAddress);
             Register(typeof(CorrelationId), BuiltInTypes.CopyCorrelationId, BuiltInTypes.SerializeCorrelationId, BuiltInTypes.DeserializeCorrelationId);
             Register(typeof(SiloAddress), BuiltInTypes.CopySiloAddress, BuiltInTypes.SerializeSiloAddress, BuiltInTypes.DeserializeSiloAddress);
+            Register(typeof(CancellationTokenWrapper), BuiltInTypes.CopyCancellationTokenWrapper, BuiltInTypes.SerializeCancellationTokenWrapper, BuiltInTypes.DeserializeCancellationTokenWrapper);
 
             // Type names that we need to recognize for generic parameters
             Register(typeof(bool));

--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text;
-
+using System.Threading;
 using Orleans.Runtime;
 using Orleans.Concurrency;
 
@@ -43,7 +43,7 @@ namespace Orleans.Serialization
         {
             var typeInfo = t.GetTypeInfo();
             if (typeInfo.IsPrimitive || typeInfo.IsEnum || t == typeof (string) || t == typeof (DateTime) || t == typeof (Decimal) ||
-                t == typeof (Immutable<>))
+                t == typeof (Immutable<>) || t == typeof(CancellationToken))
                 return true;
 
             if (typeInfo.GetCustomAttributes(typeof (ImmutableAttribute), false).Length > 0) 

--- a/src/Orleans/Threading/CancellationTokenHolderGrain.cs
+++ b/src/Orleans/Threading/CancellationTokenHolderGrain.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Placement;
+using Orleans.Runtime;
+
+namespace Orleans.Threading
+{
+    [PreferLocalPlacement]
+    internal class CancellationTokenHolderGrain : Grain, ICancellationTokenHolderGrain
+    {
+        private CancellationTokenSource _cancellationTokenSource;
+        private bool _collectionScheduled;
+        private TimeSpan _safetyCautionLimit = TimeSpan.FromSeconds(1);
+
+        public override Task OnActivateAsync()
+        {
+            DelayDeactivation(TimeSpan.FromDays(5));
+            _cancellationTokenSource = new CancellationTokenSource();
+            return TaskDone.Done;
+        }
+
+        public Task<CancellationToken> GetCancellationToken()
+        {
+            return Task.FromResult(_cancellationTokenSource.Token);
+        }
+
+        public Task Cancel(TimeSpan deactivationDelay)
+        {
+            _cancellationTokenSource.Cancel();
+            DelayDeactivation(deactivationDelay.Add(_safetyCautionLimit));
+            _collectionScheduled = true;
+            return TaskDone.Done;
+        }
+
+        public Task Dispose()
+        {
+            if (!_collectionScheduled)
+            {
+                DelayDeactivation(Constants.DEFAULT_CANCELLATION_TOKEN_HOLDER_DEACTIVATION_DELAY);
+                _collectionScheduled = true;
+            }
+
+            return TaskDone.Done;
+        }
+
+        public override Task OnDeactivateAsync()
+        {
+            _cancellationTokenSource.Dispose();
+            return base.OnDeactivateAsync();
+        }
+    }
+}

--- a/src/Orleans/Threading/CancellationTokenManager.cs
+++ b/src/Orleans/Threading/CancellationTokenManager.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.Threading
+{
+    /// <summary>
+    /// Rationale: on invoking the GrainReference method the CancellationTokens from method signature being wrapped in CancellationTokenWrapper.
+    /// If request is local - before invoking of actual grain method it's just being unwrapped.
+    /// For the remote case: on message serialization subscription on token cancel event,  
+    /// which will cancel linked CancellationTokenSource located in the CancellationTokenHolderGrain, is being created, 
+    /// after deserialization of the wrapper the abovementioned grain will be allocated on same silo with called grain,
+    /// and wrapper will be replaced with actual token from holder grain. If CancellationTokenHolderGrain cancel 
+    /// method was called before grain's allocation there is a possibility that it will be allocated on another silo than target,
+    /// and it will lead to another token's roundtrip.
+    /// </summary>
+    internal static class CancellationTokenManager
+    {
+        private static TimeSpan _cancellationTokenHolderGrainDeactivationDelay;
+
+        public static void Initialize(MessagingConfiguration config)
+        {
+            _cancellationTokenHolderGrainDeactivationDelay = config.CancellationTokenHolderDeactivationDelay;
+        }
+
+        /// <summary>
+        /// Wraps found cancellation tokens into instances of type CancellationTokenWrapper
+        /// </summary>
+        /// <param name="arguments"></param>
+        public static void WrapCancellationTokens(object[] arguments)
+        {
+            if (arguments == null) return;
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                var argument = arguments[i];
+                if (argument is CancellationToken)
+                {
+                    arguments[i] = WrapCancellationToken((CancellationToken)argument);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wraps cancellation token into CancellationTokenWrapper
+        /// </summary>
+        /// <param name="ct"> Cancellation token to be wrapped</param>
+        /// <returns>CancellationTokenWrapper</returns>
+        public static CancellationTokenWrapper WrapCancellationToken(CancellationToken ct)
+        {
+            var tokenId = Guid.NewGuid();
+            return new CancellationTokenWrapper(tokenId, ct);
+        }
+
+        /// <summary>
+        /// Retrieves cancellation token from holder grain
+        /// </summary>
+        /// <param name="tokenId"> Id of token to be retrieved</param>
+        /// <returns></returns>
+        public static Task<CancellationToken> GetCancellationToken(Guid tokenId)
+        {
+            return RuntimeClient.Current.InternalGrainFactory.GetGrain<ICancellationTokenHolderGrain>(tokenId).GetCancellationToken();
+        }
+
+        internal static void RegisterTokenCallbacks(CancellationToken ct, Guid tokenId)
+        {
+            if (!ct.CanBeCanceled) return;
+            ct.Register((f) => Cancel(tokenId).Ignore(), new GCObserver(() => Dispose(tokenId).Ignore()));
+        }
+
+        private static async Task Cancel(Guid tokenId)
+        {
+            try
+            {
+                await RuntimeClient.Current.InternalGrainFactory.GetGrain<ICancellationTokenHolderGrain>(tokenId)
+                    .Cancel(_cancellationTokenHolderGrainDeactivationDelay);
+            }
+            catch (Exception ex)
+            {
+                var logger = TraceLogger.GetLogger("CancellationTokenManager", TraceLogger.LoggerType.Runtime);
+                if (logger.IsWarning)
+                {
+                    logger.Warn(ErrorCode.Runtime_Error_100332, "Remote token cancellation failed", ex);
+                }
+            }
+        }
+
+        private static async Task Dispose(Guid tokenId)
+        {
+            await RuntimeClient.Current.InternalGrainFactory.GetGrain<ICancellationTokenHolderGrain>(tokenId).Dispose();
+        }
+    }
+}

--- a/src/Orleans/Threading/CancellationTokenWrapper.cs
+++ b/src/Orleans/Threading/CancellationTokenWrapper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading;
+
+namespace Orleans.Threading
+{
+    /// <summary>
+    /// Used as replacement of CancellationToken during network roundtrips
+    /// </summary>
+    [Serializable]
+    internal class CancellationTokenWrapper
+    {
+        public CancellationTokenWrapper(Guid id, CancellationToken cancellationToken)
+            : this(id)
+        {
+            CancellationToken = cancellationToken;
+        }
+        public CancellationTokenWrapper(Guid id)
+            : this()
+        {
+            Id = id;
+        }
+
+        public CancellationTokenWrapper()
+        {
+            WentThroughSerialization = false;
+        }
+
+        /// <summary>
+        /// Unique id of concrete token
+        /// </summary>
+        public Guid Id { get; private set; }
+
+        /// <summary>
+        /// Cancellation token
+        /// </summary>
+        public CancellationToken CancellationToken { get; private set; }
+
+        /// <summary>
+        /// Shows whether wrapper went though serialization process
+        /// </summary>
+        public bool WentThroughSerialization { get; set; }
+    }
+}

--- a/src/Orleans/Threading/GCObserver.cs
+++ b/src/Orleans/Threading/GCObserver.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Orleans.Threading
+{
+    // Instance that can be attached to custom object in order to track it's end of life
+    internal class GCObserver
+    {
+        private readonly Action onFinalization;
+
+        /// <param name="onFinalization">Action that will be executed on finalization</param>
+        public GCObserver(Action onFinalization)
+        {
+            this.onFinalization = onFinalization;
+        }
+
+        ~GCObserver()
+        {
+            try
+            {
+                onFinalization();
+            }
+            catch
+            {
+                // no guarantees here
+            }
+        }
+    }
+}

--- a/src/Orleans/Threading/ICancellationTokenHolderGrain.cs
+++ b/src/Orleans/Threading/ICancellationTokenHolderGrain.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Threading
+{
+    // Grain that serves as cancellation token source holder
+    internal interface ICancellationTokenHolderGrain : IGrainWithGuidKey
+    {
+        Task<CancellationToken> GetCancellationToken();
+        Task Cancel(TimeSpan deactivationDelay);
+        Task Dispose();
+    }
+}

--- a/src/OrleansRuntime/Core/InsideGrainClient.cs
+++ b/src/OrleansRuntime/Core/InsideGrainClient.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -16,6 +17,7 @@ using Orleans.Runtime.ConsistentRing;
 using Orleans.Serialization;
 using Orleans.Storage;
 using Orleans.Streams;
+using Orleans.Threading;
 using Orleans.Runtime.Providers;
 
 
@@ -99,6 +101,7 @@ namespace Orleans.Runtime
             InvokeMethodOptions options,
             string genericArguments = null)
         {
+            CancellationTokenManager.WrapCancellationTokens(request.Arguments);
             var message = Message.CreateMessage(request, options);
             SendRequestMessage(target, message, context, callback, debugContext, options, genericArguments);
         }
@@ -336,6 +339,27 @@ namespace Orleans.Runtime
                 try
                 {
                     var request = (InvokeMethodRequest) message.BodyObject;
+                    if (request.Arguments != null)
+                    {
+                        for (var i = 0; i < request.Arguments.Length; i++)
+                        {
+                            var arg = request.Arguments[i];
+                            if (!(arg is CancellationTokenWrapper)) continue;
+
+                            // essentially unwrapping tokens that were previouly wrapped before request send;
+                            // inlined in order to avoid awaiting in general case
+                            var orleansTokenWrapper = ((CancellationTokenWrapper)arg);
+                            if (orleansTokenWrapper.WentThroughSerialization
+                                && !orleansTokenWrapper.CancellationToken.IsCancellationRequested)
+                            {
+                                request.Arguments[i] = await CancellationTokenManager.GetCancellationToken(orleansTokenWrapper.Id);
+                            }
+                            else
+                            {
+                                request.Arguments[i] = orleansTokenWrapper.CancellationToken;
+                            }
+                        }
+                    }
 
                     var invoker = invokable.GetInvoker(request.InterfaceId, message.GenericGrainType);
 
@@ -403,6 +427,10 @@ namespace Orleans.Runtime
                 }
 
                 if (message.Direction == Message.Directions.OneWay) return;
+                if (resultObject is CancellationToken)
+                {
+                    resultObject = CancellationTokenManager.WrapCancellationToken((CancellationToken)resultObject);
+                }
 
                 SafeSendResponse(message, resultObject);
             }

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -225,6 +225,7 @@ namespace Orleans.Runtime
 
             BufferPool.InitGlobalBufferPool(globalConfig);
             PlacementStrategy.Initialize(globalConfig);
+            Threading.CancellationTokenManager.Initialize(globalConfig);
 
             UnobservedExceptionsHandlerClass.SetUnobservedExceptionHandler(UnobservedExceptionHandler);
             AppDomain.CurrentDomain.UnhandledException +=

--- a/test/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/TestGrainInterfaces/IGenericInterfaces.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
 
@@ -184,8 +185,12 @@ namespace UnitTests.GrainInterfaces
     public interface ILongRunningTaskGrain<T> : IGrainWithGuidKey
     {
         Task<string> GetRuntimeInstanceId();
+        Task LongWait(CancellationToken tc, TimeSpan delay);
         Task<T> LongRunningTask(T t, TimeSpan delay);
         Task<T> CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, T t, TimeSpan delay);
+        Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, CancellationToken tc, TimeSpan delay);
+        Task CallOtherLongRunningTaskWithLocalToken(ILongRunningTaskGrain<T> target, TimeSpan delay,
+            TimeSpan delayBeforeCancel);
     }
 
     public interface IGenericGrainWithConstraints<A, B, C> : IGrainWithStringKey

--- a/test/TestGrains/GenericGrains.cs
+++ b/test/TestGrains/GenericGrains.cs
@@ -6,7 +6,7 @@ using Orleans.Concurrency;
 using Orleans.Providers;
 using UnitTests.GrainInterfaces;
 using System.Globalization;
-using Orleans.CodeGeneration;
+using System.Threading;
 
 namespace UnitTests.Grains
 {
@@ -585,6 +585,25 @@ namespace UnitTests.Grains
             return await target.LongRunningTask(t, delay);
         }
 
+        public async Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, CancellationToken tc, TimeSpan delay)
+        {
+            await target.LongWait(tc, delay);
+        }
+
+        public async Task CallOtherLongRunningTaskWithLocalToken(ILongRunningTaskGrain<T> target, TimeSpan delay, TimeSpan delayBeforeCancel)
+        {
+            var tcs = new CancellationTokenSource();
+            var task = target.LongWait(tcs.Token, delay);
+            await Task.Delay(delayBeforeCancel);
+            tcs.Cancel();
+            await task;
+        }
+
+        public async Task LongWait(CancellationToken tc, TimeSpan delay)
+        {
+            await Task.Delay(delay, tc);
+        }
+        
         public async Task<T> LongRunningTask(T t, TimeSpan delay)
         {
             await Task.Delay(delay);

--- a/test/Tester/CancellationTests/CancellationTokenPassingTests.cs
+++ b/test/Tester/CancellationTests/CancellationTokenPassingTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.TestingHost;
+using UnitTests.GrainInterfaces;
+using Xunit;
+using UnitTests.Tester;
+
+namespace UnitTests.MembershipTests
+{
+    public class CancellationTokenPassingTests : HostedTestClusterPerTest
+    {
+        private double[] cancellationDelaysInMS = { 0, 0.1, 0.5, 1, 20, 500, 1000 };
+
+        public override TestingSiloHost CreateSiloHost()
+        {
+            return new TestingSiloHost(new TestingSiloOptions
+            {
+                StartFreshOrleans = true,
+                StartPrimary = true,
+                StartSecondary = true,
+                AdjustConfig = config =>
+                {
+                    config.Globals.DefaultPlacementStrategy = "ActivationCountBasedPlacement";
+                }
+            });
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task GrainTaskCancellation()
+        {
+            foreach (var delay in cancellationDelaysInMS.Select(TimeSpan.FromMilliseconds))
+            {
+                var grain = HostedCluster.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+                var tcs = new CancellationTokenSource();
+                var wait = grain.LongWait(tcs.Token, TimeSpan.FromSeconds(10));
+                await Task.Delay(delay);
+                tcs.Cancel();
+                await Xunit.Assert.ThrowsAsync<TaskCanceledException>(() => wait);
+            }
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task PreCancelledTokenPassing()
+        {
+            var grain = HostedCluster.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+            var tcs = new CancellationTokenSource();
+            tcs.Cancel();
+            var wait = grain.LongWait(tcs.Token, TimeSpan.FromSeconds(10));
+            await Assert.ThrowsAsync<TaskCanceledException>(() => wait);
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task InterSiloClientCancellationTokenPassing()
+        {
+            foreach (var delay in cancellationDelaysInMS.Select(TimeSpan.FromMilliseconds))
+            {
+                var grains = await GetGrains<bool>();
+                var grain = grains.Item1;
+                var target = grains.Item2;
+                var tcs = new CancellationTokenSource();
+                var wait = grain.CallOtherLongRunningTask(target, tcs.Token, TimeSpan.FromSeconds(10));
+                await Task.Delay(delay);
+                tcs.Cancel();
+                await Assert.ThrowsAsync<TaskCanceledException>(() => wait);
+            }
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task InterSiloGrainCancellation()
+        {
+            await GrainGrainCancellation(true);
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task InSiloGrainCancellation()
+        {
+            await GrainGrainCancellation(false);
+        }
+
+        private async Task GrainGrainCancellation(bool interSilo)
+        {
+            foreach (var delay in cancellationDelaysInMS)
+            {
+                var grains = await GetGrains<bool>(interSilo);
+                var grain = grains.Item1;
+                var target = grains.Item2;
+                var wait = grain.CallOtherLongRunningTaskWithLocalToken(target, TimeSpan.FromSeconds(10),
+                    TimeSpan.FromMilliseconds(delay));
+                await Xunit.Assert.ThrowsAsync<TaskCanceledException>(() => wait);
+            }
+        }
+
+        private async Task<Tuple<ILongRunningTaskGrain<T1>, ILongRunningTaskGrain<T1>>> GetGrains<T1>(bool placeOnDifferentSilos = true)
+        {
+            var grain = HostedCluster.GrainFactory.GetGrain<ILongRunningTaskGrain<T1>>(Guid.NewGuid());
+            var instanceId = await grain.GetRuntimeInstanceId();
+            var target = HostedCluster.GrainFactory.GetGrain<ILongRunningTaskGrain<T1>>(Guid.NewGuid());
+            var targetInstanceId = await target.GetRuntimeInstanceId();
+            if (placeOnDifferentSilos)
+            {
+                while (instanceId.Equals(targetInstanceId))
+                {
+                    target = HostedCluster.GrainFactory.GetGrain<ILongRunningTaskGrain<T1>>(Guid.NewGuid());
+                    targetInstanceId = await target.GetRuntimeInstanceId();
+                }
+            }
+            else
+            {
+                while (!instanceId.Equals(targetInstanceId))
+                {
+                    target = HostedCluster.GrainFactory.GetGrain<ILongRunningTaskGrain<T1>>(Guid.NewGuid());
+                    targetInstanceId = await target.GetRuntimeInstanceId();
+                }
+            }
+
+            return new Tuple<ILongRunningTaskGrain<T1>, ILongRunningTaskGrain<T1>>(grain, target);
+        }
+    }
+}

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -131,6 +131,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CancellationTests\CancellationTokenPassingTests.cs" />
     <Compile Include="CollectionFixtures.cs" />
     <Compile Include="MethodInterceptionTests.cs" />
     <Compile Include="BaseClusterFixture.cs" />


### PR DESCRIPTION
#1516; 
Made through inspecting grain method arguments, wrapping found cancellation tokens and subscribing cancellation of tokens on crossing domain bounds. 
Added costs for general case - two grain method arguments array iterations with type checking. 
For consumer in case of in-silo token passing there's cost of 2 wrappers allocations, wich is neglectable. For remote case - mostly it will be the same as if user cancelled remote `TaskCompetitionSource` by himself: 1 grain call, but when token gets cancelled after grain call message serialization and before its deserialization there will be 2 grain calls (token holder grain will be allocated on different silo). 