### PR TITLE
Solve duplication of GrainInterfaceData class name.

### DIFF
--- a/src/Orleans/CodeGeneration/GrainFactoryBase.cs
+++ b/src/Orleans/CodeGeneration/GrainFactoryBase.cs
@@ -18,7 +18,7 @@ namespace Orleans.CodeGeneration
             string grainClassNamePrefix = null)
         {
             CheckRuntimeEnvironmentSetup();
-            if (!GrainInterfaceData.IsGrainType(interfaceType))
+            if (!GrainInterfaceUtils.IsGrainType(interfaceType))
             {
                 throw new ArgumentException("Cannot fabricate grain-reference for non-grain type: " + interfaceType.FullName);
             }

--- a/src/Orleans/CodeGeneration/GrainInterfaceUtils.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceUtils.cs
@@ -10,7 +10,7 @@ using Orleans.Concurrency;
 
 namespace Orleans.CodeGeneration
 {
-    internal static class GrainInterfaceData
+    internal static class GrainInterfaceUtils
     {
         [Serializable]
         internal class RulesViolationException : ArgumentException

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
 using Orleans.Runtime;
-using GrainInterfaceData = Orleans.CodeGeneration.GrainInterfaceData;
+using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
 
 namespace Orleans
 {
@@ -318,7 +318,7 @@ namespace Orleans
                     Expression.Constant(interfaceType),
                     createLambda,
                     grainRefParameter,
-                    Expression.Constant(GrainInterfaceData.GetGrainInterfaceId(interfaceType)));
+                    Expression.Constant(GrainInterfaceUtils.GetGrainInterfaceId(interfaceType)));
 
             // Compile and return the reference casting lambda.
             var lambda = Expression.Lambda<GrainReferenceCaster>(body, grainRefParameter);

--- a/src/Orleans/Core/InvocationMethodInfoMap.cs
+++ b/src/Orleans/Core/InvocationMethodInfoMap.cs
@@ -46,14 +46,14 @@ namespace Orleans
             Type implementationType)
         {
             // Get the interface mapping for the current implementation.
-            var interfaceTypes = GrainInterfaceData.GetRemoteInterfaces(implementationType);
+            var interfaceTypes = GrainInterfaceUtils.GetRemoteInterfaces(implementationType);
             var interfaceType = interfaceTypes[interfaceId];
             var interfaceMapping = implementationType.GetInterfaceMap(interfaceType);
 
             // Map the interface methods to implementation methods.
-            var interfaceMethods = GrainInterfaceData.GetMethods(interfaceType);
+            var interfaceMethods = GrainInterfaceUtils.GetMethods(interfaceType);
             return interfaceMethods.ToDictionary(
-                GrainInterfaceData.ComputeMethodId,
+                GrainInterfaceUtils.ComputeMethodId,
                 interfaceMethod => GetImplementingMethod(interfaceMethod, interfaceMapping));
         }
 

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -320,7 +320,7 @@
     <Compile Include="Messaging\ProxiedMessageCenter.cs" />
     <Compile Include="Messaging\SocketManager.cs" />
     <Compile Include="Async\ObserverSubscriptionManager.cs" />
-    <Compile Include="CodeGeneration\GrainInterfaceData.cs" />
+    <Compile Include="CodeGeneration\GrainInterfaceUtils.cs" />
     <Compile Include="IDs\ActivationAddress.cs" />
     <Compile Include="IDs\ActivationId.cs" />
     <Compile Include="Runtime\AsynchAgent.cs" />

--- a/src/Orleans/Streams/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans/Streams/PubSub/ImplicitStreamSubscriberTable.cs
@@ -189,7 +189,7 @@ namespace Orleans.Streams
             }
 
             // we'll need the class type code.
-            int implTypeCode = CodeGeneration.GrainInterfaceData.GetGrainClassTypeCode(grainClass);
+            int implTypeCode = CodeGeneration.GrainInterfaceUtils.GetGrainClassTypeCode(grainClass);
 
             foreach (string s in namespaces)
             {

--- a/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
+++ b/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
@@ -16,7 +16,7 @@ namespace Orleans.CodeGenerator
     using Orleans.CodeGenerator.Utilities;
     using Orleans.Runtime;
 
-    using GrainInterfaceData = Orleans.CodeGeneration.GrainInterfaceData;
+    using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
     using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
     /// <summary>
@@ -169,8 +169,8 @@ namespace Orleans.CodeGenerator
             ExpressionSyntax methodIdArgument,
             Func<MethodInfo, StatementSyntax[]> generateMethodHandler)
         {
-            var interfaces = GrainInterfaceData.GetRemoteInterfaces(grainType);
-            interfaces[GrainInterfaceData.GetGrainInterfaceId(grainType)] = grainType;
+            var interfaces = GrainInterfaceUtils.GetRemoteInterfaces(grainType);
+            interfaces[GrainInterfaceUtils.GetGrainInterfaceId(grainType)] = grainType;
 
             // Switch on interface id.
             var interfaceCases = new List<SwitchSectionSyntax>();
@@ -178,7 +178,7 @@ namespace Orleans.CodeGenerator
             {
                 var interfaceType = @interface.Value;
                 var interfaceId = @interface.Key;
-                var methods = GrainInterfaceData.GetMethods(interfaceType);
+                var methods = GrainInterfaceUtils.GetMethods(interfaceType);
 
                 var methodCases = new List<SwitchSectionSyntax>();
 
@@ -186,7 +186,7 @@ namespace Orleans.CodeGenerator
                 foreach (var method in methods)
                 {
                     // Generate switch case.
-                    var methodId = GrainInterfaceData.ComputeMethodId(method);
+                    var methodId = GrainInterfaceUtils.ComputeMethodId(method);
                     var methodType = method;
 
                     // Generate the switch label for this interface id.

--- a/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
@@ -17,7 +17,7 @@ namespace Orleans.CodeGenerator
     using Orleans.CodeGenerator.Utilities;
     using Orleans.Runtime;
 
-    using GrainInterfaceData = Orleans.CodeGeneration.GrainInterfaceData;
+    using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
     using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
     /// <summary>
@@ -51,7 +51,7 @@ namespace Orleans.CodeGenerator
                                    : new TypeParameterSyntax[0];
 
             // Create the special method invoker marker attribute.
-            var interfaceId = GrainInterfaceData.GetGrainInterfaceId(grainType);
+            var interfaceId = GrainInterfaceUtils.GetGrainInterfaceId(grainType);
             var interfaceIdArgument = SF.LiteralExpression(SyntaxKind.NumericLiteralExpression, SF.Literal(interfaceId));
             var grainTypeArgument = SF.TypeOfExpression(grainType.GetTypeSyntax(includeGenericParameters: false));
             var attributes = new List<AttributeSyntax>
@@ -104,7 +104,7 @@ namespace Orleans.CodeGenerator
             var property = TypeUtils.Member((IGrainMethodInvoker _) => _.InterfaceId);
             var returnValue = SF.LiteralExpression(
                 SyntaxKind.NumericLiteralExpression,
-                SF.Literal(GrainInterfaceData.GetGrainInterfaceId(grainType)));
+                SF.Literal(GrainInterfaceUtils.GetGrainInterfaceId(grainType)));
             return
                 SF.PropertyDeclaration(typeof(int).GetTypeSyntax(), property.Name)
                     .AddAccessorListAccessors(

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -15,7 +15,7 @@ namespace Orleans.CodeGenerator
     using Orleans.CodeGenerator.Utilities;
     using Orleans.Runtime;
 
-    using GrainInterfaceData = Orleans.CodeGeneration.GrainInterfaceData;
+    using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
     using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
     /// <summary>
@@ -131,12 +131,12 @@ namespace Orleans.CodeGenerator
         private static MemberDeclarationSyntax[] GenerateInvokeMethods(Type grainType, Action<Type> onEncounteredType)
         {
             var baseReference = SF.BaseExpression();
-            var methods = GrainInterfaceData.GetMethods(grainType);
+            var methods = GrainInterfaceUtils.GetMethods(grainType);
             var members = new List<MemberDeclarationSyntax>();
             foreach (var method in methods)
             {
                 onEncounteredType(method.ReturnType);
-                var methodId = GrainInterfaceData.ComputeMethodId(method);
+                var methodId = GrainInterfaceUtils.ComputeMethodId(method);
                 var methodIdArgument =
                     SF.Argument(SF.LiteralExpression(SyntaxKind.NumericLiteralExpression, SF.Literal(methodId)));
 
@@ -221,17 +221,17 @@ namespace Orleans.CodeGenerator
         private static ArgumentSyntax GetInvokeOptions(MethodInfo method)
         {
             var options = new List<ExpressionSyntax>();
-            if (GrainInterfaceData.IsReadOnly(method))
+            if (GrainInterfaceUtils.IsReadOnly(method))
             {
                 options.Add(typeof(InvokeMethodOptions).GetNameSyntax().Member(InvokeMethodOptions.ReadOnly.ToString()));
             }
 
-            if (GrainInterfaceData.IsUnordered(method))
+            if (GrainInterfaceUtils.IsUnordered(method))
             {
                 options.Add(typeof(InvokeMethodOptions).GetNameSyntax().Member(InvokeMethodOptions.Unordered.ToString()));
             }
 
-            if (GrainInterfaceData.IsAlwaysInterleave(method))
+            if (GrainInterfaceUtils.IsAlwaysInterleave(method))
             {
                 options.Add(typeof(InvokeMethodOptions).GetNameSyntax().Member(InvokeMethodOptions.AlwaysInterleave.ToString()));
             }
@@ -278,7 +278,7 @@ namespace Orleans.CodeGenerator
             var property = TypeUtils.Member((IGrainMethodInvoker _) => _.InterfaceId);
             var returnValue = SF.LiteralExpression(
                 SyntaxKind.NumericLiteralExpression,
-                SF.Literal(GrainInterfaceData.GetGrainInterfaceId(grainType)));
+                SF.Literal(GrainInterfaceUtils.GetGrainInterfaceId(grainType)));
             return
                 SF.PropertyDeclaration(typeof(int).GetTypeSyntax(), property.Name)
                     .AddAccessorListAccessors(
@@ -295,8 +295,8 @@ namespace Orleans.CodeGenerator
 
             var interfaceIds =
                 new HashSet<int>(
-                    new[] { GrainInterfaceData.GetGrainInterfaceId(grainType) }.Concat(
-                        GrainInterfaceData.GetRemoteInterfaces(grainType).Keys));
+                    new[] { GrainInterfaceUtils.GetGrainInterfaceId(grainType) }.Concat(
+                        GrainInterfaceUtils.GetRemoteInterfaces(grainType).Keys));
 
             var returnValue = default(BinaryExpressionSyntax);
             foreach (var interfaceId in interfaceIds)

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -14,7 +14,7 @@ namespace Orleans.CodeGenerator
     using Orleans.CodeGeneration;
     using Orleans.Runtime;
 
-    using GrainInterfaceData = Orleans.CodeGeneration.GrainInterfaceData;
+    using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
     using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
     /// <summary>
@@ -345,7 +345,7 @@ namespace Orleans.CodeGenerator
                         Logger.Verbose2("Generating code for: {0}", type.GetParseableName());
                     }
 
-                    if (GrainInterfaceData.IsGrainInterface(type))
+                    if (GrainInterfaceUtils.IsGrainInterface(type))
                     {
                         if (Logger.IsVerbose2)
                         {
@@ -354,7 +354,7 @@ namespace Orleans.CodeGenerator
                                 type.GetParseableName());
                         }
 
-                        GrainInterfaceData.ValidateInterfaceRules(type);
+                        GrainInterfaceUtils.ValidateInterfaceRules(type);
 
                         namespaceMembers.Add(GrainReferenceGenerator.GenerateClass(type, onEncounteredType));
                         namespaceMembers.Add(GrainMethodInvokerGenerator.GenerateClass(type));
@@ -433,7 +433,7 @@ namespace Orleans.CodeGenerator
             ConsiderGenericInterfacesArguments(typeInfo, module, targetAssembly, includedTypes);
 
             // Collect the types which require code generation.
-            if (GrainInterfaceData.IsGrainInterface(type))
+            if (GrainInterfaceUtils.IsGrainInterface(type))
             {
                 if (Logger.IsVerbose2) Logger.Verbose2("Will generate code for: {0}", type.GetParseableName());
 

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -10,7 +10,7 @@ namespace Orleans.CodeGenerator
     using Orleans.Runtime;
     using Orleans.Serialization;
 
-    using GrainInterfaceData = Orleans.CodeGeneration.GrainInterfaceData;
+    using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
 
     /// <summary>
     /// The serializer generation manager.
@@ -104,7 +104,7 @@ namespace Orleans.CodeGenerator
             }
 
             if (typeInfo.IsInterface || typeInfo.IsAbstract || t == typeof (object) || t == typeof (void)
-                || GrainInterfaceData.IsTaskType(t)) return false;
+                || GrainInterfaceUtils.IsTaskType(t)) return false;
 
             if (typeInfo.IsConstructedGenericType)
             {

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -545,7 +545,7 @@ namespace Orleans.Runtime
             if (maxEnqueuedRequestsLimit != null) return maxEnqueuedRequestsLimit;
             if (GrainInstanceType != null)
             {
-                string limitName = CodeGeneration.GrainInterfaceData.IsStatelessWorker(GrainInstanceType)
+                string limitName = CodeGeneration.GrainInterfaceUtils.IsStatelessWorker(GrainInstanceType)
                     ? LimitNames.LIMIT_MAX_ENQUEUED_REQUESTS_STATELESS_WORKER
                     : LimitNames.LIMIT_MAX_ENQUEUED_REQUESTS;
                 maxEnqueuedRequestsLimit = nodeConfiguration.LimitManager.GetLimit(limitName); // Cache for next time

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
@@ -46,7 +46,7 @@ namespace Orleans.Runtime
                 {
                     if (t == typeof(IAddressable)) continue;
 
-                    if (CodeGeneration.GrainInterfaceData.IsGrainInterface(t) && !interfaceTypes.Contains(t))
+                    if (CodeGeneration.GrainInterfaceUtils.IsGrainInterface(t) && !interfaceTypes.Contains(t))
                         interfaceTypes.Add(t);
                 }
 

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -153,7 +153,7 @@ namespace Orleans.Runtime
         {
             var grainClassCompleteName = TypeUtils.GetFullName(grainClass);
             var isGenericGrainClass = grainClass.ContainsGenericParameters;
-            var grainClassTypeCode = CodeGeneration.GrainInterfaceData.GetGrainClassTypeCode(grainClass);
+            var grainClassTypeCode = CodeGeneration.GrainInterfaceUtils.GetGrainClassTypeCode(grainClass);
             var placement = GrainTypeData.GetPlacementStrategy(grainClass);
             var registrationStrategy = GrainTypeData.GetMultiClusterRegistrationStrategy(grainClass);
 
@@ -162,7 +162,7 @@ namespace Orleans.Runtime
                 var ifaceCompleteName = TypeUtils.GetFullName(iface);
                 var ifaceName = TypeUtils.GetRawClassName(ifaceCompleteName);
                 var isPrimaryImplementor = IsPrimaryImplementor(grainClass, iface);
-                var ifaceId = CodeGeneration.GrainInterfaceData.GetGrainInterfaceId(iface);
+                var ifaceId = CodeGeneration.GrainInterfaceUtils.GetGrainInterfaceId(iface);
                 grainInterfaceMap.AddEntry(ifaceId, iface, grainClassTypeCode, ifaceName, grainClassCompleteName, 
                     grainClass.Assembly.CodeBase, isGenericGrainClass, placement, registrationStrategy, isPrimaryImplementor);
             }

--- a/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
+++ b/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
@@ -143,7 +143,7 @@ namespace Orleans.Runtime
                 var assemblyName = grainType.Type.Assembly.FullName.Split(',')[0];
                 if (!typeof(ISystemTarget).IsAssignableFrom(grainType.Type))
                 {
-                    int grainClassTypeCode = CodeGeneration.GrainInterfaceData.GetGrainClassTypeCode(grainType.Type);
+                    int grainClassTypeCode = CodeGeneration.GrainInterfaceUtils.GetGrainClassTypeCode(grainType.Type);
                     sb.AppendFormat("Grain class {0}.{1} [{2} (0x{3})] from {4}.dll implementing interfaces: ",
                         grainType.Type.Namespace,
                         TypeUtils.GetTemplatedName(grainType.Type),
@@ -159,9 +159,9 @@ namespace Orleans.Runtime
                         
                         sb.Append(iface.Namespace).Append(".").Append(TypeUtils.GetTemplatedName(iface));
 
-                        if (CodeGeneration.GrainInterfaceData.IsGrainType(iface))
+                        if (CodeGeneration.GrainInterfaceUtils.IsGrainType(iface))
                         {
-                            int ifaceTypeCode = CodeGeneration.GrainInterfaceData.GetGrainInterfaceId(iface);
+                            int ifaceTypeCode = CodeGeneration.GrainInterfaceUtils.GetGrainInterfaceId(iface);
                             sb.AppendFormat(" [{0} (0x{1})]", ifaceTypeCode, ifaceTypeCode.ToString("X"));
                         }
                         first = false;

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -203,11 +203,11 @@ namespace Orleans.Runtime.Providers
 
         private static IGrainExtensionMethodInvoker TryGetExtensionInvoker(Type handlerType)
         {
-            var interfaces = CodeGeneration.GrainInterfaceData.GetRemoteInterfaces(handlerType).Values;
+            var interfaces = CodeGeneration.GrainInterfaceUtils.GetRemoteInterfaces(handlerType).Values;
             if(interfaces.Count != 1)
                 throw new InvalidOperationException(String.Format("Extension type {0} implements more than one grain interface.", handlerType.FullName));
 
-            var interfaceId = CodeGeneration.GrainInterfaceData.ComputeInterfaceId(interfaces.First());
+            var interfaceId = CodeGeneration.GrainInterfaceUtils.ComputeInterfaceId(interfaces.First());
             var invoker = GrainTypeManager.Instance.GetInvoker(interfaceId);
             if (invoker != null)
                 return (IGrainExtensionMethodInvoker) invoker;

--- a/test/TesterInternal/General/InterfaceRules.cs
+++ b/test/TesterInternal/General/InterfaceRules.cs
@@ -6,7 +6,7 @@ using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using Orleans;
 using Orleans.Runtime;
 using UnitTests.Grains;
-using GrainInterfaceData = Orleans.CodeGeneration.GrainInterfaceData;
+using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -157,57 +157,57 @@ namespace UnitTests.General
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_VoidMethod()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(ITestGrain_VoidMethod)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_VoidMethod)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_IntMethod()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(ITestGrain_IntMethod)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_IntMethod)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_IntProperty()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(ITestGrain_IntProperty)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_IntProperty)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_PropertySetter()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(ITestGrain_PropertySetter)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_PropertySetter)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_Observer_NonVoidMethod()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(ITestObserver_NonVoidMethod)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(ITestObserver_NonVoidMethod)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_Observer_Property()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(ITestObserver_Property)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(ITestObserver_Property)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_OutArgument()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(ITestGrain_OutArgument)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_OutArgument)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_RefArgument()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(ITestGrain_RefArgument)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(ITestGrain_RefArgument)));
         }
 
         #endregion
@@ -217,29 +217,29 @@ namespace UnitTests.General
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_ObserverGrain_VoidMethod()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_VoidMethod)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_VoidMethod)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_ObserverGrain_IntMethod()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_IntMethod)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_IntMethod)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_ObserverGrain_IntProperty()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_IntProperty)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_IntProperty)));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("CodeGen")]
         public void InterfaceRules_ObserverGrain_PropertySetter()
         {
-            Xunit.Assert.Throws<GrainInterfaceData.RulesViolationException>(() =>
-            GrainInterfaceData.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_PropertySetter)));
+            Xunit.Assert.Throws<GrainInterfaceUtils.RulesViolationException>(() =>
+            GrainInterfaceUtils.ValidateInterface(typeof(IInheritedGrain_ObserverGrain_PropertySetter)));
         }
 
         #endregion

--- a/test/TesterInternal/GrainReferenceCastTests.cs
+++ b/test/TesterInternal/GrainReferenceCastTests.cs
@@ -7,7 +7,7 @@ using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 using UnitTests.Grains;
 using Xunit;
-using GrainInterfaceData = Orleans.CodeGeneration.GrainInterfaceData;
+using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
 using UnitTests.Tester;
 
 namespace UnitTests
@@ -100,11 +100,11 @@ namespace UnitTests
             Type t1 = typeof(IGeneratorTestDerivedDerivedGrain);
             Type t2 = typeof(IGeneratorTestDerivedGrain2);
             Type t3 = typeof(IGeneratorTestGrain);
-            int id1 = GrainInterfaceData.GetGrainInterfaceId(t1);
-            int id2 = GrainInterfaceData.GetGrainInterfaceId(t2);
-            int id3 = GrainInterfaceData.GetGrainInterfaceId(t3); 
+            int id1 = GrainInterfaceUtils.GetGrainInterfaceId(t1);
+            int id2 = GrainInterfaceUtils.GetGrainInterfaceId(t2);
+            int id3 = GrainInterfaceUtils.GetGrainInterfaceId(t3); 
 
-            var interfaces = GrainInterfaceData.GetRemoteInterfaces(typeof(IGeneratorTestDerivedDerivedGrain));
+            var interfaces = GrainInterfaceUtils.GetRemoteInterfaces(typeof(IGeneratorTestDerivedDerivedGrain));
             Assert.IsNotNull(interfaces);
             Assert.AreEqual(3, interfaces.Keys.Count);
             Assert.IsTrue(interfaces.Keys.Contains(id1), "id1 is present");
@@ -116,7 +116,7 @@ namespace UnitTests
         public void CastCheckExpectedCompatIds()
         {
             Type t = typeof(ISimpleGrain);
-            int expectedInterfaceId = GrainInterfaceData.GetGrainInterfaceId(t);
+            int expectedInterfaceId = GrainInterfaceUtils.GetGrainInterfaceId(t);
             GrainReference grain = (GrainReference)GrainClient.GrainFactory.GetGrain<ISimpleGrain>(random.Next(), SimpleGrain.SimpleGrainNamePrefix);
             Assert.IsTrue(grain.IsCompatible(expectedInterfaceId));
         }
@@ -129,9 +129,9 @@ namespace UnitTests
             Type t1 = typeof(IGeneratorTestDerivedDerivedGrain);
             Type t2 = typeof(IGeneratorTestDerivedGrain2);
             Type t3 = typeof(IGeneratorTestGrain);
-            int id1 = GrainInterfaceData.GetGrainInterfaceId(t1);
-            int id2 = GrainInterfaceData.GetGrainInterfaceId(t2);
-            int id3 = GrainInterfaceData.GetGrainInterfaceId(t3);
+            int id1 = GrainInterfaceUtils.GetGrainInterfaceId(t1);
+            int id2 = GrainInterfaceUtils.GetGrainInterfaceId(t2);
+            int id3 = GrainInterfaceUtils.GetGrainInterfaceId(t3);
             GrainReference grain = (GrainReference) GrainClient.GrainFactory.GetGrain<IGeneratorTestDerivedDerivedGrain>(GetRandomGrainId());
             Assert.IsTrue(grain.IsCompatible(id1));
             Assert.IsTrue(grain.IsCompatible(id2));
@@ -148,7 +148,7 @@ namespace UnitTests
                 typeof(Boolean),
                 null,
                 grain,
-                GrainInterfaceData.GetGrainInterfaceId(t));
+                GrainInterfaceUtils.GetGrainInterfaceId(t));
             Assert.Fail("Exception should have been raised");
             });
         }


### PR DESCRIPTION
Fixes #1570.
Renamed `Orleans.CodeGeneration.GrainInterfaceData` to `Orleans.CodeGeneration.GrainInterfaceUtils`, as realy more appropriate to this class - it has no data and only static helper/utility functions.

Moved `Orleans.Runtime.GrainInterfaceData` to be inside `Orleans.Runtime.GrainInterfaceMap`, as it is only used inside the  `GrainInterfaceMap`. So now it is: `Orleans.Runtime.GrainInterfaceMap.GrainInterfaceData`.