### PR TITLE
Fixing table storage provider when binary data is being read as Base64 string

### DIFF
--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -332,10 +332,23 @@ namespace Orleans.Storage
                 EntityProperty dataProperty;
                 if (entity.Properties.TryGetValue(binaryDataPropertyName, out dataProperty))
                 {
-                    var data = dataProperty.BinaryValue;
-                    if (data != null && data.Length > 0)
+                    switch (dataProperty.PropertyType)
                     {
-                        yield return data;
+                        case EdmType.Binary:
+                            var binaryValue = dataProperty.BinaryValue;
+                            if (binaryValue != null && binaryValue.Length > 0)
+                            {
+                                yield return binaryValue;
+                            }
+                            break;
+
+                        case EdmType.String:
+                            var stringValue = dataProperty.StringValue;
+                            if (!string.IsNullOrEmpty(stringValue))
+                            {
+                                yield return Convert.FromBase64String(stringValue);
+                            }
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
Trying to fix the issue caused by https://github.com/dotnet/orleans/pull/1539. When the table entity is read as `DynamicTableEntity`, its binary data properties are returned as Base64 strings. While I don't understand this behavior, this PR should fix the problem.