### PR TITLE
Prevent reusing same port when starting a silo

### DIFF
--- a/src/Orleans/Messaging/SocketManager.cs
+++ b/src/Orleans/Messaging/SocketManager.cs
@@ -30,7 +30,6 @@ namespace Orleans.Runtime
             {
                 // Prep the socket so it will reset on close
                 s.LingerState = new LingerOption(true, 0);
-                s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                 // And bind it to the address
                 s.Bind(address);
             }


### PR DESCRIPTION
This PR originally contained 2 changes, but splitted them up so that #1589 could be merged without waiting for a decision on this one.

Disallows starting a new silo sharing the same address as other processes. Not sure if there are unknown side effects for this change, but for sure it was extremely hard to find that there were leaked silos still running (as they started without failure), as it makes it completely non-deterministic to know where calls will land if there are 2 silos from different test deployments running at the same time.

I'm OK not merging this PR if we foresee issues with the change though, but in theory it makes it more straightforward to troubleshoot issues.