### PR TITLE
Set multiple inner exceptions to the resolver.

### DIFF
--- a/src/Orleans/Async/TaskExtensions.cs
+++ b/src/Orleans/Async/TaskExtensions.cs
@@ -141,7 +141,7 @@ namespace Orleans
         private static Task<object> TaskFromFaulted(Task task)
         {
             var completion = new TaskCompletionSource<object>();
-            completion.SetException(task.Exception.InnerException);
+            completion.SetException(task.Exception.InnerExceptions);
             return completion.Task;
         }
     }
@@ -303,7 +303,7 @@ namespace Orleans
                 {
                     if (t.IsFaulted)
                     {
-                        resolver.TrySetException(t.Exception.InnerException);
+                        resolver.TrySetException(t.Exception.InnerExceptions);
                     }
                     else if (t.IsCanceled)
                     {


### PR DESCRIPTION
https://github.com/dotnet/orleans/issues/1532#issuecomment-196405789;
This change does not affect current exception propagation behavior, but can become useful after TaskCompletionSource shuffling rework.