### PR TITLE
Avoid lingering silo in tests when restarting them

### DIFF
--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -277,8 +277,6 @@ namespace Orleans.TestingHost
                     restartedAdditionalSilos.Add(restartedSilo);
                 }
             }
-            additionalSilos.Clear();
-            additionalSilos.AddRange(restartedAdditionalSilos);
         }
 
         /// <summary>
@@ -399,16 +397,17 @@ namespace Orleans.TestingHost
                 StopOrleansSilo(instance, true);
                 var newInstance = StartOrleansSilo(type, options, InstanceCounter++);
 
-                if (type == Silo.SiloType.Primary)
+                if (Primary == instance)
                 {
                     Primary = newInstance;
                 }
-                else if (type == Silo.SiloType.Secondary)
+                else if (Secondary == instance)
                 {
                     Secondary = newInstance;
                 }
                 else
                 {
+                    additionalSilos.Remove(instance);
                     additionalSilos.Add(newInstance);
                 }
 


### PR DESCRIPTION
Track the correct additional silo when restarting it. Otherwise the original Secondary silo does not leak and stays running forever.

The `RestartSilo` method had a bug that if you restarted an "additional silo" (of type `Seconday` anyway), then the original Secondary silo would be leaked and running in the background, so clients that connected explicitly to it by adding a gateway to the secondary, were sometimes sending request to the old leaked silo of a different deployment.

I extracted the commit from PR #1583 as this one is safe to merge, where as whether we prevent reusing the same port might need some more discussion (or we might decide to not change the current behavior).