### PR TITLE
Fix HaloStreamSubscribeTests concurrency issue

### DIFF
--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
@@ -15,12 +15,11 @@ namespace Orleans.Providers.Streams.AzureQueue
     public class AzureQueueStreamProviderUtils
     {
         /// <summary>
-        /// Helper method for testing.
+        /// Helper method for testing. Deletes all the queues used by the specifed stream provider.
         /// </summary>
-        /// <param name="providerName"></param>
-        /// <param name="deploymentId"></param>
-        /// <param name="storageConnectionString"></param>
-        /// <returns></returns>
+        /// <param name="providerName">The Azure Queue stream privider name.</param>
+        /// <param name="deploymentId">The deployment ID hosting the stream provider.</param>
+        /// <param name="storageConnectionString">The azure storage connection string.</param>
         public static async Task DeleteAllUsedAzureQueues(string providerName, string deploymentId, string storageConnectionString)
         {
             if (deploymentId != null)
@@ -33,6 +32,30 @@ namespace Orleans.Providers.Streams.AzureQueue
                 {
                     var manager = new AzureQueueDataManager(queueId.ToString(), deploymentId, storageConnectionString);
                     deleteTasks.Add(manager.DeleteQueue());
+                }
+
+                await Task.WhenAll(deleteTasks);
+            }
+        }
+
+        /// <summary>
+        /// Helper method for testing. Clears all messages in all the queues used by the specifed stream provider.
+        /// </summary>
+        /// <param name="providerName">The Azure Queue stream privider name.</param>
+        /// <param name="deploymentId">The deployment ID hosting the stream provider.</param>
+        /// <param name="storageConnectionString">The azure storage connection string.</param>
+        public static async Task ClearAllUsedAzureQueues(string providerName, string deploymentId, string storageConnectionString)
+        {
+            if (deploymentId != null)
+            {
+                var queueMapper = new HashRingBasedStreamQueueMapper(AzureQueueAdapterFactory.DEFAULT_NUM_QUEUES, providerName);
+                List<QueueId> allQueues = queueMapper.GetAllQueues().ToList();
+
+                var deleteTasks = new List<Task>();
+                foreach (var queueId in allQueues)
+                {
+                    var manager = new AzureQueueDataManager(queueId.ToString(), deploymentId, storageConnectionString);
+                    deleteTasks.Add(manager.ClearQueue());
                 }
 
                 await Task.WhenAll(deleteTasks);

--- a/src/OrleansAzureUtils/Storage/AzureQueueDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/AzureQueueDataManager.cs
@@ -162,7 +162,9 @@ namespace Orleans.AzureUtils
             if (logger.IsVerbose2) logger.Verbose2("Clearing a queue: {0}", QueueName);
             try
             {
-                await Task.Factory.FromAsync(queue.BeginClear, queue.EndClear, null);
+                // that way we don't have first to create the queue to be able later to delete it.
+                CloudQueue queueRef = queue ?? queueOperationsClient.GetQueueReference(QueueName);
+                await Task.Factory.FromAsync(queueRef.BeginClear, queueRef.EndClear, null);
                 logger.Info(ErrorCode.AzureQueue_05, "Cleared Azure Queue {0}", QueueName);
             }
             catch (Exception exc)


### PR DESCRIPTION
Clears all the messages in the queue between tests, and only deletes the queue after the entire fixture completes.

Otherwise it was trying to delete the queues without restarting the cluster, and sometimes would get conflicts (409) when trying to re-create the queues while it was still deleting.