### PR TITLE
Allow certain tests to finish inconclusive

### DIFF
--- a/test/Tester/DeploymentTests/DeployTest.cs
+++ b/test/Tester/DeploymentTests/DeployTest.cs
@@ -34,11 +34,8 @@ namespace UnitTests
         }
 
         public DeployTest()
-        {        
-            //if (!RunningAsAdmin())
-            //{
-            //    Assert.Inconclusive("Cannot Run Test: The Orleans deployment PowerShell scripts require Visual Studio to be run with elevated privileges.");
-            //}
+        {     
+            //Skip.IfNot(RunningAsAdmin(), "Cannot Run Test: The Orleans deployment PowerShell scripts require Visual Studio to be run with elevated privileges.");
 
             // If the test does have elevated permission, make sure that it can run PowerShell scripts.
             Collection<PSObject> results = RunPowerShellCommand("Get-ExecutionPolicy");
@@ -51,7 +48,7 @@ namespace UnitTests
                 }
                 else
                 {
-                    Assert.Inconclusive("Cannot Run Test: The Orleans deployment PowerShell scripts require ExecutionPolicy be set to RemoteSigned.");
+                    throw new SkipException("Cannot Run Test: The Orleans deployment PowerShell scripts require ExecutionPolicy be set to RemoteSigned.");
                 }
             }
 
@@ -274,10 +271,7 @@ namespace UnitTests
                 // Pause to let Orleans get started up.
                 System.Threading.Thread.Sleep(9000);
                 orleansHostTestProcess = Process.GetProcessesByName("OrleansHost");
-                if (orleansHostTestProcess.Count() < 1)
-                {
-                    Assert.Inconclusive("Cannot Run Test: Could not start an OrleansHost necessary to test the StopOrleans.ps1 script.");
-                }
+                Skip.If(orleansHostTestProcess.Count() < 1, "Cannot Run Test: Could not start an OrleansHost necessary to test the StopOrleans.ps1 script.");
             }
 
             // Test script when Orleans Host is not running.
@@ -484,7 +478,7 @@ namespace UnitTests
             string pathValue = string.Empty;
             if (!File.Exists(Path.Combine(Directory.GetCurrentDirectory(), configFile)))
             {
-                Assert.Inconclusive("Cannot Run Test: Could not find configuration file {0}", configFile);
+                throw new SkipException("Cannot Run Test: Could not find configuration file " + configFile);
             }
             XDocument configDoc = XDocument.Load(configFile);
             Assert.IsNotNull(configDoc, string.Format("Could not load test configuration file: {0}", configFile));

--- a/test/Tester/TestUtils.cs
+++ b/test/Tester/TestUtils.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.TestingHost;
+using Xunit;
 
 namespace Tester
 {
@@ -35,7 +36,7 @@ namespace Tester
             {
                 string errorMsg = "Azure Storage Emulator could not be started.";
                 Console.WriteLine(errorMsg);
-                Assert.Inconclusive(errorMsg);
+                throw new SkipException(errorMsg);
             }
         }
 

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\src\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\src\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\build\net45\Xunit.SkippableFact.props" Condition="Exists('$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\build\net45\Xunit.SkippableFact.props')" />
+  <Import Project="$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -117,6 +118,10 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="xunit.abstractions">
       <HintPath>$(SolutionDir)packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
@@ -128,6 +133,10 @@
     </Reference>
     <Reference Include="xunit.execution.desktop">
       <HintPath>$(SolutionDir)packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Xunit.SkippableFact, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b2b52da82b58eb73, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\lib\net45\Xunit.SkippableFact.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -401,7 +410,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\src\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\src\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\build\net45\Xunit.SkippableFact.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\build\net45\Xunit.SkippableFact.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/Tester/packages.config
+++ b/test/Tester/packages.config
@@ -12,6 +12,7 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0-rc1-final" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="Validation" version="2.2.8" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
@@ -21,4 +22,5 @@
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net451" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net451" />
   <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net451" />
+  <package id="Xunit.SkippableFact" version="1.2.14" targetFramework="net451" />
 </packages>

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureStore.cs
@@ -410,7 +410,7 @@ namespace UnitTests.StorageTests
                 }
                 else
                 {
-                    Assert.Inconclusive(msg);
+                    throw new SkipException(msg);
                 }
             }
         }

--- a/test/TesterInternal/StorageTests/RelationalStoreTests.cs
+++ b/test/TesterInternal/StorageTests/RelationalStoreTests.cs
@@ -79,7 +79,7 @@ namespace UnitTests.StorageTests.SQLAdapter
             }
         }
 
-        [Fact, TestCategory("Persistence"), TestCategory("MySql")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MySql")]
         public async Task Streaming_MySql_Test()
         {
             using(var tokenSource = new CancellationTokenSource(StreamCancellationTimeoutLimit))
@@ -96,7 +96,7 @@ namespace UnitTests.StorageTests.SQLAdapter
             await CancellationTokenTest(sqlServerStorage, CancellationTestTimeoutLimit);
         }
 
-        [Fact, TestCategory("Persistence"), TestCategory("MySql")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MySql")]
         public async Task CancellationToken_MySql_Test()
         {
             await CancellationTokenTest(mySqlStorage, CancellationTestTimeoutLimit);
@@ -104,7 +104,7 @@ namespace UnitTests.StorageTests.SQLAdapter
 
         private static Task<bool>[] InsertAndReadStreamsAndCheckMatch(RelationalStorageForTesting sut, int streamSize, int countOfStreams, CancellationToken cancellationToken)
         {
-            if (sut == null) Assert.Inconclusive("Database was not initialized correctly");
+            Skip.If(sut == null, "Database was not initialized correctly");
 
             //Stream in and steam out three binary streams in parallel.
             var streamChecks = new Task<bool>[countOfStreams];
@@ -127,7 +127,7 @@ namespace UnitTests.StorageTests.SQLAdapter
 
         private static async Task InsertIntoDatabaseUsingStream(RelationalStorageForTesting sut, int streamId, byte[] dataToInsert, CancellationToken cancellationToken)
         {
-            if (sut == null) Assert.Inconclusive("Database was not initialized correctly");
+            Skip.If(sut == null, "Database was not initialized correctly");
             //The dataToInsert could be inserted here directly, but it wouldn't be streamed.
             using (var ms = new MemoryStream(dataToInsert))
             {
@@ -155,7 +155,7 @@ namespace UnitTests.StorageTests.SQLAdapter
 
         private static async Task<StreamingTest> ReadFromDatabaseUsingAsyncStream(RelationalStorageForTesting sut, int streamId, CancellationToken cancellationToken)
         {
-            if (sut == null) Assert.Inconclusive("Database was not initialized correctly");
+            Skip.If(sut == null, "Database was not initialized correctly");
             return (await sut.Storage.ReadAsync(sut.StreamTestSelect, command =>
             {
                 var p = command.CreateParameter();
@@ -180,7 +180,7 @@ namespace UnitTests.StorageTests.SQLAdapter
 
         private static Task CancellationTokenTest(RelationalStorageForTesting sut, TimeSpan timeoutLimit)
         {
-            if (sut == null) Assert.Inconclusive("Database was not initialized correctly");
+            Skip.If(sut == null, "Database was not initialized correctly");
             using (var tokenSource = new CancellationTokenSource(timeoutLimit))
             {
                 try

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\src\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\src\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\build\net45\Xunit.SkippableFact.props" Condition="Exists('$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\build\net45\Xunit.SkippableFact.props')" />
+  <Import Project="$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +14,8 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -72,6 +75,10 @@
       <HintPath>$(SolutionDir)packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -101,6 +108,10 @@
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.XML" />
+    <Reference Include="Xunit.SkippableFact, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b2b52da82b58eb73, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\lib\net45\Xunit.SkippableFact.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CollectionFixtures.cs" />
@@ -452,6 +463,12 @@ set Configuration=$(Configuration)
 call "$(SolutionDir)Build\PostBuild.cmd"
 </PostBuildEvent>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\build\net45\Xunit.SkippableFact.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Xunit.SkippableFact.1.2.14\build\net45\Xunit.SkippableFact.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/TesterInternal/TimerTests/ReminderTests_AzureTable.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_AzureTable.cs
@@ -49,13 +49,13 @@ namespace UnitTests.TimerTests
 
         // Basic tests
 
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("Azure")]
         public async Task Rem_Azure_Basic_StopByRef()
         {
             await Test_Reminders_Basic_StopByRef();
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("Azure")]
         public async Task Rem_Azure_Basic_ListOps()
         {
             await Test_Reminders_Basic_ListOps();
@@ -63,14 +63,14 @@ namespace UnitTests.TimerTests
 
         // Single join tests ... multi grain, multi reminders
 
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("Azure")]
         public async Task Rem_Azure_1J_MultiGrainMultiReminders()
         {
             await Test_Reminders_1J_MultiGrainMultiReminders();
         }
 
         #region Basic test
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_Basic()
         {
             // start up a test grain and get the period that it's programmed to use.
@@ -91,7 +91,7 @@ namespace UnitTests.TimerTests
             Assert.AreEqual(last, curr, Time());
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_Basic_Restart()
         {
             IReminderTestGrain2 grain = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -119,7 +119,7 @@ namespace UnitTests.TimerTests
         #endregion
 
         #region Basic single grain multi reminders test
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_MultipleReminders()
         {
             IReminderTestGrain2 grain = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -128,7 +128,7 @@ namespace UnitTests.TimerTests
         #endregion
 
         #region Multiple joins ... multi grain, multi reminders
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_2J_MultiGrainMultiReminders()
         {
             IReminderTestGrain2 g1 = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -162,7 +162,7 @@ namespace UnitTests.TimerTests
         #endregion
 
         #region Multi grains multi reminders/grain test
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_MultiGrainMultiReminders()
         {
             IReminderTestGrain2 g1 = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -187,7 +187,7 @@ namespace UnitTests.TimerTests
 
         #region Secondary failure ... Basic test
 
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_1F_Basic()
         {
             IReminderTestGrain2 g1 = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -206,7 +206,7 @@ namespace UnitTests.TimerTests
         #endregion
 
         #region Multiple failures ... multiple grains
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_2F_MultiGrain()
         {
             List<SiloHandle> silos = this.HostedCluster.StartAdditionalSilos(2);
@@ -242,7 +242,7 @@ namespace UnitTests.TimerTests
         #endregion
 
         #region 1 join 1 failure simulateneously ... multiple grains
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_1F1J_MultiGrain()
         {
             List<SiloHandle> silos = this.HostedCluster.StartAdditionalSilos(1);
@@ -289,7 +289,7 @@ namespace UnitTests.TimerTests
         #endregion
 
         #region Register same reminder multiple times
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_RegisterSameReminderTwice()
         {
             IReminderTestGrain2 grain = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -303,7 +303,7 @@ namespace UnitTests.TimerTests
         #endregion
 
         #region Multiple grain types
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_GT_Basic()
         {
             IReminderTestGrain2 g1 = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -328,7 +328,7 @@ namespace UnitTests.TimerTests
             Assert.AreEqual(4, curr2, string.Format("{0} CopyGrain fault", Time()));
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_GT_1F1J_MultiGrain()
         {
             List<SiloHandle> silos = this.HostedCluster.StartAdditionalSilos(1);
@@ -373,7 +373,7 @@ namespace UnitTests.TimerTests
         #region Testing things that should fail
 
         #region Lower than allowed reminder period
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_Wrong_LowerThanAllowedPeriod()
         {
             IReminderTestGrain2 grain = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -383,7 +383,7 @@ namespace UnitTests.TimerTests
         #endregion
 
         #region The wrong reminder grain
-        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_Wrong_Grain()
         {
             IReminderGrainWrong grain = GrainClient.GrainFactory.GetGrain<IReminderGrainWrong>(0);

--- a/test/TesterInternal/TimerTests/ReminderTests_Base.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_Base.cs
@@ -357,11 +357,8 @@ namespace UnitTests.TimerTests
             logger.Info(sb.ToString());
 
             bool tickCountIsInsideRange = lowerLimit <= val && val <= upperLimit;
-            if (!tickCountIsInsideRange)
-            {
-                Assert.Inconclusive("AssertIsInRange: {0}  -- WHICH IS OUTSIDE RANGE.", sb);
-                // Not reached
-            }
+
+            Skip.IfNot(tickCountIsInsideRange, string.Format("AssertIsInRange: {0}  -- WHICH IS OUTSIDE RANGE.", sb));
         }
 
         protected async Task ExecuteWithRetries(Func<string, TimeSpan?, bool, Task> function, string reminderName, TimeSpan? period = null, bool validate = false)

--- a/test/TesterInternal/packages.config
+++ b/test/TesterInternal/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="Validation" version="2.2.8" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
@@ -17,4 +18,5 @@
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net451" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net451" />
   <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net451" />
+  <package id="Xunit.SkippableFact" version="1.2.14" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Basically skip them without failing the build.

This is to allow for either some harmless non-determinism, or finding whether a certain runtime dependency is installed where the test is running.