### PR TITLE
Extension method for adding default "MemoryStore" persistence provider

### DIFF
--- a/src/Orleans/Configuration/ProviderConfiguration.cs
+++ b/src/Orleans/Configuration/ProviderConfiguration.cs
@@ -47,7 +47,7 @@ namespace Orleans.Runtime.Configuration
 
         public ProviderConfiguration(IDictionary<string, string> properties, string providerType, string name)
         {
-            this.properties = properties;
+            this.properties = properties ?? new Dictionary<string, string>(1);
             Type = providerType;
             Name = name;
         }
@@ -55,7 +55,7 @@ namespace Orleans.Runtime.Configuration
         // for testing purposes
         internal ProviderConfiguration(IDictionary<string, string> properties, IList<IProvider> childProviders)
         {
-            this.properties = properties;
+            this.properties = properties ?? new Dictionary<string, string>(1);
             this.childProviders = childProviders;
         }
 

--- a/src/OrleansProviders/ConfigExtensions.cs
+++ b/src/OrleansProviders/ConfigExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+
+
+namespace Orleans.Runtime.Configuration
+{
+    /// <summary>
+    /// Extension methods for configuration classes specific to OrleansProviders.dll 
+    /// </summary>
+    public static class ConfigExtensions
+    {
+        /// <summary>
+        /// Adds default storage provider named "MemoryStore" of type Orleans.Storage.MemoryStorage
+        /// </summary>
+        /// <param name="config">Cluster configuration object to add provider to</param>
+        /// <param name="providerName">Provider name</param>
+        /// <returns></returns>
+        public static void AddMemoryStorageProvider(this ClusterConfiguration config, string providerName = "MemoryStore")
+        {
+            config.Globals.RegisterStorageProvider<Storage.MemoryStorage>(providerName);
+        }
+    }
+}

--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConfigExtensions.cs" />
     <Compile Include="Streams\Common\PooledCache\CachedMessageBlock.cs" />
     <Compile Include="Streams\Common\PooledCache\FixedSizeObjectPool.cs" />
     <Compile Include="Streams\Common\PooledCache\FixedSizeBuffer.cs" />

--- a/src/OrleansVSTools/VSProjectSiloHost/OrleansHostWrapper.cs
+++ b/src/OrleansVSTools/VSProjectSiloHost/OrleansHostWrapper.cs
@@ -135,6 +135,7 @@ namespace $safeprojectname$
             }
 
             var config = ClusterConfiguration.LocalhostPrimarySilo();
+            config.AddMemoryStorageProvider();
             siloHost = new SiloHost(siloName, config);
 
             if (deploymentId != null)


### PR DESCRIPTION
Add an extension method for adding default "MemoryStore" persistence provider.
Update Dev/Test Host project template to use the extension method.
Allow null to be passed for provider properties.