### PR TITLE
Add dependency NuGet packages to Dev/Test Host template

### DIFF
--- a/src/OrleansVSTools/VSProjectSiloHost/OrleansHostWrapper.cs
+++ b/src/OrleansVSTools/VSProjectSiloHost/OrleansHostWrapper.cs
@@ -150,7 +150,6 @@ namespace $safeprojectname$
     orleans host [<siloName> [<configFile>]] [DeploymentId=<idString>] [/debug]
 Where:
     <siloName>      - Name of this silo in the Config file list (optional)
-    <configFile>    - Path to the Config file to use (optional)
     DeploymentId=<idString> 
                     - Which deployment group this host instance should run in (optional)");
         }

--- a/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
+++ b/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
@@ -27,6 +27,9 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
+      <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" />
+      <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" />
+      <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" />
       <package id="Microsoft.Orleans.Core" version="1.2.0" />
       <package id="Microsoft.Orleans.CounterControl" version="1.2.0" />
       <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.2.0" />
@@ -34,6 +37,9 @@
       <package id="Microsoft.Orleans.OrleansProviders" version="1.2.0" />
       <package id="Microsoft.Orleans.OrleansRuntime" version="1.2.0" />
       <package id="Microsoft.Orleans.Server" version="1.2.0" />
+      <package id="Newtonsoft.Json" version="7.0.1" />
+      <package id="System.Collections.Immutable" version="1.1.36" />
+      <package id="System.Reflection.Metadata" version="1.0.21" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementation" d:TargetPath="|VSProjectTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />


### PR DESCRIPTION
VS does not pull the dependency NuGets automatically. So we need to add them explicitly to the project template.