### PR TITLE
Generic reference casting

### DIFF
--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -12,7 +12,7 @@ namespace Orleans.Runtime
     /// This is the base class for all typed grain references.
     /// </summary>
     [Serializable]
-    public class GrainReference : IAddressable, IEquatable<GrainReference>, ISerializable, IGrainReferenceInternal
+    public class GrainReference : IAddressable, IEquatable<GrainReference>, ISerializable
     {
         private readonly GuidId observerId;
         private readonly string genericArgs;
@@ -717,19 +717,17 @@ namespace Orleans.Runtime
 
         #endregion
 
-        //used for testing
-        string IGrainReferenceInternal.GenericArguments {
+
+        #region Testing
+        
+        internal string GenericArgumentsForTesting {
             get {
                 return this.GenericArguments;
             }
         }
+
+        #endregion
+
     }
-
-
-
-    internal interface IGrainReferenceInternal
-    {
-        string GenericArguments { get; }
-    }
-
+    
 }

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -12,10 +12,10 @@ namespace Orleans.Runtime
     /// This is the base class for all typed grain references.
     /// </summary>
     [Serializable]
-    public class GrainReference : IAddressable, IEquatable<GrainReference>, ISerializable
+    public class GrainReference : IAddressable, IEquatable<GrainReference>, ISerializable, IGrainReferenceInternal
     {
-        private readonly string genericArguments;
         private readonly GuidId observerId;
+        private readonly string genericArgs;
         
         [NonSerialized]
         private static readonly TraceLogger logger = TraceLogger.GetLogger("GrainReference", TraceLogger.LoggerType.Runtime);
@@ -33,7 +33,7 @@ namespace Orleans.Runtime
 
         internal GuidId ObserverId { get { return observerId; } }
         
-        private bool HasGenericArgument { get { return !String.IsNullOrEmpty(genericArguments); } }
+        internal bool HasGenericArgument { get { return !String.IsNullOrEmpty(GenericArguments); } }
 
         internal GrainId GrainId { get; private set; }
 
@@ -56,15 +56,15 @@ namespace Orleans.Runtime
         /// Constructs a reference to the grain with the specified Id.
         /// </summary>
         /// <param name="grainId">The Id of the grain to refer to.</param>
-        private GrainReference(GrainId grainId, string genericArgument, SiloAddress systemTargetSilo, GuidId observerId)
+        private GrainReference(GrainId grainId, string genericArguments, SiloAddress systemTargetSilo, GuidId observerId)
         {
             GrainId = grainId;
-            genericArguments = genericArgument;
+            genericArgs = genericArguments;
             SystemTargetSilo = systemTargetSilo;
             this.observerId = observerId;
-            if (String.IsNullOrEmpty(genericArgument))
+            if (String.IsNullOrEmpty(genericArguments))
             {
-                genericArguments = null; // always keep it null instead of empty.
+                genericArgs = null; // always keep it null instead of empty.
             }
 
             // SystemTarget checks
@@ -111,7 +111,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="other">The reference to copy.</param>
         protected GrainReference(GrainReference other)
-            : this(other.GrainId, other.genericArguments, other.SystemTargetSilo, other.ObserverId) { }
+            : this(other.GrainId, other.GenericArguments, other.SystemTargetSilo, other.ObserverId) { }
 
         #endregion
 
@@ -166,7 +166,7 @@ namespace Orleans.Runtime
             if (other == null)
                 return false;
 
-            if (genericArguments != other.genericArguments)
+            if (GenericArguments != other.GenericArguments)
                 return false;
             if (!GrainId.Equals(other.GrainId))
             {
@@ -268,7 +268,18 @@ namespace Orleans.Runtime
                 throw new InvalidOperationException("Should be overridden by subclass");
             }
         }
-
+        
+        /// <summary>
+        /// Return the generic type arguments of the interface as a string
+        /// Implemented in generated code.
+        /// </summary>
+        protected virtual string GenericArguments {
+            get 
+            {
+                return genericArgs;
+            }
+        }
+        
         /// <summary>
         /// Return the method name associated with the specified interfaceId and methodId values.
         /// </summary>
@@ -337,7 +348,7 @@ namespace Orleans.Runtime
             bool isOneWayCall = ((options & InvokeMethodOptions.OneWay) != 0);
 
             var resolver = isOneWayCall ? null : new TaskCompletionSource<object>();
-            RuntimeClient.Current.SendRequest(this, request, resolver, ResponseCallback, debugContext, options, genericArguments);
+            RuntimeClient.Current.SendRequest(this, request, resolver, ResponseCallback, debugContext, options, GenericArguments);
             return isOneWayCall ? null : resolver.Task;
         }
 
@@ -522,7 +533,7 @@ namespace Orleans.Runtime
             // store as null, serialize as empty.
             var genericArg = String.Empty;
             if (input.HasGenericArgument)
-                genericArg = input.genericArguments;
+                genericArg = input.GenericArguments;
             stream.Write(genericArg);
         }
 
@@ -581,7 +592,7 @@ namespace Orleans.Runtime
                 return String.Format("{0}:{1}/{2}", OBSERVER_ID_STR, GrainId, observerId);
             }
             return String.Format("{0}:{1}{2}", GRAIN_REFERENCE_STR, GrainId,
-                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", genericArguments)); 
+                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", GenericArguments)); 
         }
 
         internal string ToDetailedString()
@@ -595,7 +606,7 @@ namespace Orleans.Runtime
                 return String.Format("{0}:{1}/{2}", OBSERVER_ID_STR, GrainId.ToDetailedString(), observerId.ToDetailedString());
             }
             return String.Format("{0}:{1}{2}", GRAIN_REFERENCE_STR, GrainId.ToDetailedString(),
-                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", genericArguments)); 
+                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", GenericArguments)); 
         }
 
 
@@ -612,7 +623,7 @@ namespace Orleans.Runtime
             }
             if (HasGenericArgument)
             {
-                return String.Format("{0}={1} {2}={3}", GRAIN_REFERENCE_STR, GrainId.ToParsableString(), GENERIC_ARGUMENTS_STR, genericArguments);
+                return String.Format("{0}={1} {2}={3}", GRAIN_REFERENCE_STR, GrainId.ToParsableString(), GENERIC_ARGUMENTS_STR, GenericArguments);
             }
             return String.Format("{0}={1}", GRAIN_REFERENCE_STR, GrainId.ToParsableString());
         }
@@ -678,7 +689,7 @@ namespace Orleans.Runtime
             }
             string genericArg = String.Empty;
             if (HasGenericArgument)
-                genericArg = genericArguments;
+                genericArg = GenericArguments;
             info.AddValue("GenericArguments", genericArg, typeof(string));
         }
 
@@ -701,9 +712,24 @@ namespace Orleans.Runtime
             var genericArg = info.GetString("GenericArguments");
             if (String.IsNullOrEmpty(genericArg))
                 genericArg = null;
-            genericArguments = genericArg;
+            genericArgs = genericArg;
         }
 
         #endregion
+
+        //used for testing
+        string IGrainReferenceInternal.GenericArguments {
+            get {
+                return this.GenericArguments;
+            }
+        }
     }
+
+
+
+    internal interface IGrainReferenceInternal
+    {
+        string GenericArguments { get; }
+    }
+
 }

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -80,6 +80,7 @@ namespace Orleans.CodeGenerator
                     .AddMembers(
                         GenerateInterfaceIdProperty(grainType),
                         GenerateInterfaceNameProperty(grainType),
+                        GenerateGenericArgumentsProperty(grainType),
                         GenerateIsCompatibleMethod(grainType),
                         GenerateGetMethodNameMethod(grainType))
                     .AddMembers(GenerateInvokeMethods(grainType, onEncounteredType))
@@ -328,6 +329,23 @@ namespace Orleans.CodeGenerator
                             .AddBodyStatements(SF.ReturnStatement(returnValue)))
                     .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.OverrideKeyword));
         }
+
+
+        private static MemberDeclarationSyntax GenerateGenericArgumentsProperty(Type grainType) 
+        {
+            return
+                SF.PropertyDeclaration(typeof(string).GetTypeSyntax(), "GenericArguments")
+                    .AddAccessorListAccessors(
+                        SF.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                            .AddBodyStatements(
+                                SF.ReturnStatement(
+                                    grainType.IsGenericTypeDefinition 
+                                        ? (ExpressionSyntax)SF.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SF.TypeOfExpression(grainType.GetTypeSyntax()), "FullName".ToIdentifierName())
+                                        : SF.DefaultExpression(typeof(string).GetTypeSyntax())
+                                )))
+                    .AddModifiers(SF.Token(SyntaxKind.ProtectedKeyword), SF.Token(SyntaxKind.OverrideKeyword));
+        }
+        
 
         private static MethodDeclarationSyntax GenerateGetMethodNameMethod(Type grainType)
         {

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -80,6 +80,7 @@ namespace Orleans.CodeGenerator
                     .AddMembers(
                         GenerateInterfaceIdProperty(grainType),
                         GenerateInterfaceNameProperty(grainType),
+                        GenerateGenericArgumentsStaticField(grainType),
                         GenerateGenericArgumentsProperty(grainType),
                         GenerateIsCompatibleMethod(grainType),
                         GenerateGetMethodNameMethod(grainType))
@@ -331,6 +332,23 @@ namespace Orleans.CodeGenerator
         }
 
 
+        private static MemberDeclarationSyntax GenerateGenericArgumentsStaticField(Type grainType) {
+            return
+                SF.FieldDeclaration(
+                        SF.VariableDeclaration(typeof(string).GetTypeSyntax())
+                            .AddVariables(
+                                SF.VariableDeclarator("genericArgs")
+                                    .WithInitializer(
+                                        SF.EqualsValueClause(
+                                            grainType.IsGenericTypeDefinition
+                                                ? (ExpressionSyntax)SF.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SF.TypeOfExpression(grainType.GetTypeSyntax()), "FullName".ToIdentifierName())
+                                                : SF.DefaultExpression(typeof(string).GetTypeSyntax())
+                                        )))
+                        )
+                    .AddModifiers(SF.Token(SyntaxKind.PrivateKeyword), SF.Token(SyntaxKind.StaticKeyword));
+        }
+
+
         private static MemberDeclarationSyntax GenerateGenericArgumentsProperty(Type grainType) 
         {
             return
@@ -338,11 +356,8 @@ namespace Orleans.CodeGenerator
                     .AddAccessorListAccessors(
                         SF.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
                             .AddBodyStatements(
-                                SF.ReturnStatement(
-                                    grainType.IsGenericTypeDefinition 
-                                        ? (ExpressionSyntax)SF.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SF.TypeOfExpression(grainType.GetTypeSyntax()), "FullName".ToIdentifierName())
-                                        : SF.DefaultExpression(typeof(string).GetTypeSyntax())
-                                )))
+                                SF.ReturnStatement(SF.IdentifierName("genericArgs"))
+                                ))
                     .AddModifiers(SF.Token(SyntaxKind.ProtectedKeyword), SF.Token(SyntaxKind.OverrideKeyword));
         }
         

--- a/test/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/TestGrainInterfaces/IGenericInterfaces.cs
@@ -197,4 +197,16 @@ namespace UnitTests.GrainInterfaces
 
         Task<C> RoundTrip(C value);
     }
+
+    public interface INonGenericCastableGrain : IGrainWithGuidKey
+    {
+
+    }
+
+    public interface ISomeGenericGrain<T> : IGrainWithGuidKey
+    {
+        Task<string> Hello();
+    }
+
+
 }

--- a/test/TestGrains/GenericGrains.cs
+++ b/test/TestGrains/GenericGrains.cs
@@ -623,4 +623,14 @@ namespace UnitTests.Grains
             return Task.FromResult(value);
         }
     }
+
+
+    public class NonGenericCastableGrain : Grain, INonGenericCastableGrain, ISomeGenericGrain<string>
+    {
+        Task<string> ISomeGenericGrain<string>.Hello() {
+            return Task.FromResult("Hello!");
+        }
+    }
+
+
 }

--- a/test/Tester/GenericGrainTests.cs
+++ b/test/Tester/GenericGrainTests.cs
@@ -641,7 +641,7 @@ namespace UnitTests.General
             var grain = GrainFactory.GetGrain<ICircularStateTestGrain>(primaryKey: grainId, keyExtension: grainId.ToString("N"));
             var c1 = await grain.GetState();
         }
-
+                
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task Generic_GrainWithTypeConstraints()
         {
@@ -653,5 +653,18 @@ namespace UnitTests.General
             result = await grain.GetCount();
             Assert.AreEqual(1, result);
         }
+
+        [Fact, TestCategory("Functional"), TestCategory("Generics")]
+        public async Task Generic_CastToGenericInterfaceAndCallMethod() 
+        {
+            var grain = GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
+
+            var castRef = grain.AsReference<ISomeGenericGrain<string>>();
+
+            var result = await castRef.Hello();
+
+            Assert.AreEqual(result, "Hello!");
+        }
+
     }
 }

--- a/test/TesterInternal/GrainReferenceCastTests.cs
+++ b/test/TesterInternal/GrainReferenceCastTests.cs
@@ -9,6 +9,7 @@ using UnitTests.Grains;
 using Xunit;
 using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
 using UnitTests.Tester;
+using System.Reflection;
 
 namespace UnitTests
 {
@@ -452,5 +453,19 @@ namespace UnitTests
             isNullStr = cast.StringSet("b").ContinueWith((_) => grain.StringIsNullOrEmpty()).Unwrap();
             Assert.IsFalse(isNullStr.Result, "Value should not be null after cast.SetString(b)");
         }
+
+        
+        [Fact, TestCategory("Functional"), TestCategory("Generics"), TestCategory("Cast"), TestCategory("GrainReference")]
+        public void CastToGenericInterfaceSetsArgsOnReference() 
+        {
+            var grain = GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
+
+            var castRef = (GrainReference)grain.AsReference<ISomeGenericGrain<string>>();
+
+            Assert.AreEqual(
+                typeof(ISomeGenericGrain<string>).GetTypeInfo().UnderlyingSystemType.FullName, 
+                ((IGrainReferenceInternal)castRef).GenericArguments);
+        }
+        
     }
 }

--- a/test/TesterInternal/GrainReferenceCastTests.cs
+++ b/test/TesterInternal/GrainReferenceCastTests.cs
@@ -464,7 +464,7 @@ namespace UnitTests
 
             Assert.AreEqual(
                 typeof(ISomeGenericGrain<string>).GetTypeInfo().UnderlyingSystemType.FullName, 
-                ((IGrainReferenceInternal)castRef).GenericArguments);
+                castRef.GenericArgumentsForTesting);
         }
         
     }


### PR DESCRIPTION
Hello,

I've stumbled across another generics-related bug: calling `IGrain.AsReference()` to cast to another, generic grain interface results in an unusable `GrainReference` with the `genericArguments` field unchanged from that of the original reference.

I've had a go at a PR for fixing this, which gets the generated reference classes to override a protected `GenericArguments` property on the base `GrainReference`, much as the `InterfaceName` is overridden currently, but without the public surface.

Hopefully this is all reasonable - I'm a bit mindful of messing with internal components without prior discussion, but am also fairly eager to contribute, so thought I'd give it a go.