### PR TITLE
EventHubStreamProvider flow control

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -140,6 +140,8 @@
     <Compile Include="Streams\PubSub\FaultedSubscriptionException.cs" />
     <Compile Include="Streams\PubSub\ImplicitStreamPubSub.cs" />
     <Compile Include="Streams\PubSub\StreamPubSubImpl.cs" />
+    <Compile Include="Streams\QueueAdapters\IQueueFlowController.cs" />
+    <Compile Include="Streams\QueueAdapters\AggregatedQueueFlowController.cs" />
     <Compile Include="Telemetry\Consumers\ConsoleTelemetryConsumer.cs" />
     <Compile Include="Telemetry\Consumers\FileTelemetryConsumer.cs" />
     <Compile Include="Telemetry\Consumers\TraceTelemetryConsumer.cs" />

--- a/src/Orleans/Streams/QueueAdapters/AggregatedQueueFlowController.cs
+++ b/src/Orleans/Streams/QueueAdapters/AggregatedQueueFlowController.cs
@@ -1,0 +1,22 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Orleans.Streams
+{
+    public class AggregatedQueueFlowController : List<IQueueFlowController>, IQueueFlowController
+    {
+        private readonly int defaultMaxAddCount;
+
+        public AggregatedQueueFlowController(int defaultMaxAddCount)
+        {
+            this.defaultMaxAddCount = defaultMaxAddCount;
+        }
+
+        public int GetMaxAddCount()
+        {
+            return this.Aggregate(defaultMaxAddCount, (count, fc) => Math.Min(count, fc.GetMaxAddCount()));
+        }
+    }
+}

--- a/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueCache.cs
@@ -3,13 +3,8 @@ using System.Collections.Generic;
 
 namespace Orleans.Streams
 {
-    public interface IQueueCache
+    public interface IQueueCache : IQueueFlowController
     {
-        /// <summary>
-        /// The limit of the maximum number of items that can be added to the cache in a single AddToCache operation.
-        /// </summary>
-        int MaxAddCount { get; }
-
         /// <summary>
         /// Add messages to the cache
         /// </summary>

--- a/src/Orleans/Streams/QueueAdapters/IQueueFlowController.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueFlowController.cs
@@ -1,0 +1,12 @@
+﻿
+
+namespace Orleans.Streams
+{
+    public interface IQueueFlowController
+    {
+        /// <summary>
+        /// The limit of the maximum number of items that can be added
+        /// </summary>
+        int GetMaxAddCount();
+    }
+}

--- a/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
@@ -34,6 +34,26 @@ namespace Orleans.Providers.Streams.Common
         private readonly ICacheDataAdapter<TQueueMessage, TCachedMessage> cacheDataAdapter;
         private readonly ICacheDataComparer<TCachedMessage> comparer;
 
+        public TCachedMessage? Newest
+        {
+            get
+            {
+                if (IsEmpty)
+                    return null;
+                return messageBlocks.First.Value.NewestMessage;
+            }
+        }
+
+        public TCachedMessage? Oldest
+        {
+            get
+            {
+                if (IsEmpty)
+                    return null;
+                return messageBlocks.Last.Value.OldestMessage;
+            }
+        }
+
         /// <summary>
         /// Called with the last item puraged after a cache purge has run.
         /// For ordered reliable queues we shouldn't need to notify on every purged event, only on the last event 

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
@@ -49,9 +49,9 @@ namespace Orleans.Providers.Streams.Common
             get { return cachedMessages.Count; }
         }
 
-        public int MaxAddCount
+        public int GetMaxAddCount()
         {
-            get { return CACHE_HISTOGRAM_MAX_BUCKET_SIZE; }
+            return CACHE_HISTOGRAM_MAX_BUCKET_SIZE;
         }
 
         public SimpleQueueCache(int cacheSize, Logger logger)

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -166,7 +166,7 @@ namespace Orleans.Providers.Streams.Generator
             }
         }
 
-        public int MaxAddCount { get { return 100; } }
+        public int GetMaxAddCount() { return 100; }
 
         public void AddToCache(IList<IBatchContainer> messages)
         {

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -312,7 +312,7 @@ namespace Orleans.Streams
                 if (IsShutdown) return; // timer was already removed, last tick
                 
                 IQueueAdapterReceiver rcvr = receiver;
-                int maxCacheAddCount = queueCache != null ? queueCache.MaxAddCount : QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG;
+                int maxCacheAddCount = queueCache != null ? queueCache.GetMaxAddCount() : QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG;
 
                 // loop through the queue until it is empty.
                 while (!IsShutdown) // timer will be set to null when we are asked to shudown. 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -9,7 +9,6 @@ using Orleans.Providers;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
-using OrleansServiceBus.Providers.Streams.EventHub;
 
 namespace Orleans.ServiceBus.Providers
 {

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -5,6 +5,12 @@ using Orleans.Providers.Streams.Common;
 
 namespace Orleans.ServiceBus.Providers
 {
+    public interface IEventHubPartitionLocation
+    {
+        string EventHubOffset { get; }
+        long SequenceNumber { get; }
+    }
+
     /// <summary>
     /// Event Hub messages consist of a batch of application layer events, so EventHub tokens contain three pieces of information.
     /// EventHubOffset - this is a unique value per partition that is used to start reading from this message in the partition.
@@ -15,7 +21,7 @@ namespace Orleans.ServiceBus.Providers
     ///   and ordering of aplication layer events within an EventHub message.
     /// </summary>
     [Serializable]
-    internal class EventHubSequenceToken : EventSequenceToken
+    internal class EventHubSequenceToken : EventSequenceToken, IEventHubPartitionLocation
     {
         public string EventHubOffset { get; private set; }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -5,7 +5,7 @@ using Orleans.Streams;
 
 namespace Orleans.ServiceBus.Providers
 {
-    public interface IEventHubQueueCache : IDisposable
+    public interface IEventHubQueueCache : IQueueFlowController, IDisposable
     {
         void Add(EventData message);
         object GetCursor(IStreamIdentity streamIdentity, StreamSequenceToken sequenceToken);

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubSettings.cs
@@ -8,6 +8,13 @@ namespace Orleans.ServiceBus.Providers
         string ConsumerGroup { get; }
         string Path { get; }
         int? PrefetchCount { get; }
+
+        /// <summary>
+        /// Indicates if stream provider should read all new data in partition, or from start of partition.
+        /// True - read all new data added to partition.
+        /// False - start reading from beginning of partition.
+        /// Note: If checkpoints are used, stream provider will always begin reading from most recent checkpoint.
+        /// </summary>
         bool StartFromNow { get; }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/SegmentBuilder.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/SegmentBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 
 namespace Orleans.ServiceBus.Providers
 {
@@ -45,11 +46,11 @@ namespace Orleans.ServiceBus.Providers
                 throw new ArgumentNullException("bytes");
             }
 
-            Buffer.BlockCopy(BitConverter.GetBytes(bytes.Length), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+            Array.Copy(BitConverter.GetBytes(bytes.Length), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
             writerOffset += sizeof(int);
             if (bytes.Length != 0)
             {
-                Buffer.BlockCopy(bytes, 0, segment.Array, segment.Offset + writerOffset, bytes.Length);
+                Array.Copy(bytes, 0, segment.Array, segment.Offset + writerOffset, bytes.Length);
                 writerOffset += bytes.Length;
             }
         }
@@ -68,18 +69,18 @@ namespace Orleans.ServiceBus.Providers
             }
             if (str == null)
             {
-                Buffer.BlockCopy(BitConverter.GetBytes(-1), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+                Array.Copy(BitConverter.GetBytes(-1), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
                 writerOffset += sizeof(int);
             }
             else if (string.IsNullOrEmpty(str))
             {
-                Buffer.BlockCopy(BitConverter.GetBytes(0), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
+                Array.Copy(BitConverter.GetBytes(0), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
                 writerOffset += sizeof(int);
             }
             else
             {
                 var bytes = new byte[str.Length * sizeof(char)];
-                Buffer.BlockCopy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
+                Array.Copy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
                 Append(segment, ref writerOffset, bytes);
             }
         }
@@ -122,7 +123,7 @@ namespace Orleans.ServiceBus.Providers
                 return string.Empty;
             }
             var chars = new char[size / sizeof(char)];
-            Buffer.BlockCopy(segment.Array, segment.Offset + readerOffset, chars, 0, size);
+            Array.Copy(segment.Array, segment.Offset + readerOffset, chars, 0, size);
             readerOffset += size;
             return new string(chars);
         }


### PR DESCRIPTION
Introduced basic flow control mechanism to Persistent Stream Provider's adapter.
Added minimal flow control to EventHubStreamProvider that uses relative positions of cursors in cache to detect risk of cache miss errors, and reduces read rate in those cases.

Possible flow control mechanisms under consideration:
Load Shedding - Use silo load shedding detection to turn off queue readers.
Event/Second upper bound - Use configurable max event per second read rate.

This change minimally addresses Flow Control described in Recoverable Event Hub Persistent Stream Provider - Part 2 #1454 
