### PR TITLE
Fix null reference exception in azure reminder service

### DIFF
--- a/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
+++ b/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
@@ -144,7 +144,7 @@ namespace Orleans.Runtime.ReminderService
             {
                 if (logger.IsVerbose) logger.Verbose("ReadRow grainRef = {0} reminderName = {1}", grainRef, reminderName);
                 var result = await remTableManager.FindReminderEntry(grainRef, reminderName);
-                return ConvertFromTableEntry(result.Item1, result.Item2);
+                return result == null ? null : ConvertFromTableEntry(result.Item1, result.Item2);
             }
             catch (Exception exc)
             {

--- a/test/TesterInternal/TimerTests/ReminderTests_AzureTable.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_AzureTable.cs
@@ -69,6 +69,12 @@ namespace UnitTests.TimerTests
             await Test_Reminders_1J_MultiGrainMultiReminders();
         }
 
+        [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService"), TestCategory("Azure")]
+        public async Task Rem_Azure_ReminderNotFound()
+        {
+            await Test_Reminders_ReminderNotFound();
+        }
+
         #region Basic test
         [SkippableFact, TestCategory("Functional"), TestCategory("ReminderService")]
         public async Task Rem_Azure_Basic()

--- a/test/TesterInternal/TimerTests/ReminderTests_Base.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_Base.cs
@@ -166,6 +166,15 @@ namespace UnitTests.TimerTests
         }
         #endregion
 
+        public async Task Test_Reminders_ReminderNotFound()
+        {
+            IReminderTestGrain2 g1 = GrainClient.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+
+            // request a reminder that does not exist
+            IGrainReminder reminder = await g1.GetReminderObject("blarg");
+            Assert.IsNull(reminder, "reminder != null");
+        }
+
         #endregion
 
         #region Multiple joins ... multi grain, multi reminders

--- a/test/TesterInternal/TimerTests/ReminderTests_SqlServer.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_SqlServer.cs
@@ -62,6 +62,12 @@ namespace UnitTests.TimerTests
         {
             await Test_Reminders_1J_MultiGrainMultiReminders();
         }
+
+        [Fact, TestCategory("ReminderService"), TestCategory("SqlServer")]
+        public async Task Rem_Sql_ReminderNotFound()
+        {
+            await Test_Reminders_ReminderNotFound();
+        }
     }
 #endif
 

--- a/test/TesterInternal/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_TableGrain.cs
@@ -65,6 +65,12 @@ namespace UnitTests.TimerTests
         {
             await Test_Reminders_1J_MultiGrainMultiReminders();
         }
+
+        [Fact, TestCategory("Functional"), TestCategory("ReminderService")]
+        public async Task Rem_Grain_ReminderNotFounds()
+        {
+            await Test_Reminders_ReminderNotFound();
+        }
     }
 
 }


### PR DESCRIPTION
Code was encountering a null reference exception from azure reminder service when requesting a reminder that did not exist.

Added test requesting a reminder that does not exist.
Updated code to return null rather then throw a null reference exception if reminder is not found.