### PR TITLE
GetAllSubscriptionHandles fix for implicit subscriptions

### DIFF
--- a/src/Orleans/Streams/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans/Streams/PubSub/ImplicitStreamPubSub.cs
@@ -64,11 +64,7 @@ namespace Orleans.Streams
 
         public Task<List<GuidId>> GetAllSubscriptions(StreamId streamId, IStreamConsumerExtension streamConsumer)
         {
-            if (!IsImplicitSubscriber(streamConsumer, streamId))
-            {
-                throw new ArgumentOutOfRangeException(streamId.ToString(), "Only implicit subscriptions are supported.");
-            }
-            return Task.FromResult(new List<GuidId> { GuidId.GetGuidId(streamConsumer.GetPrimaryKey()) });
+            return Task.FromResult(new List<GuidId> { CreateSubscriptionId(streamId, streamConsumer) });
         }
 
         internal bool IsImplicitSubscriber(IAddressable addressable, StreamId streamId)

--- a/test/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
@@ -91,8 +91,10 @@ namespace TestGrains
 
             var streamProvider = GetStreamProvider(GeneratedStreamTestConstants.StreamProviderName);
             stream = streamProvider.GetStream<GeneratedEvent>(State.StreamGuid, State.StreamNamespace);
-
-            await stream.SubscribeAsync(OnNextAsync, OnErrorAsync, State.RecoveryToken);
+            foreach (StreamSubscriptionHandle<GeneratedEvent> handle in await stream.GetAllSubscriptionHandles())
+            {
+                await handle.ResumeAsync(OnNextAsync, OnErrorAsync, State.RecoveryToken);
+            }
         }
 
         private async Task OnNextAsync(GeneratedEvent evt, StreamSequenceToken sequenceToken)


### PR DESCRIPTION
When using implicit subscriptions, the subscription Id in handles returned by GetAllSubscriptionHandles was incorrect.

- Implicit subscription recovery test was updated to resume processing using GetAllSubscriptionHandles to exercise code path and reproduce the problem.
- Subscription Id generation was fixed.

Thanks @skalpin, @sergeybykov