### PR TITLE
Fix to Azure Queue Stream provider ordering bug.

### DIFF
--- a/src/Orleans/Streams/Internal/StreamConsumer.cs
+++ b/src/Orleans/Streams/Internal/StreamConsumer.cs
@@ -141,7 +141,7 @@ namespace Orleans.Streams
             await BindExtensionLazy();
 
             List<GuidId> subscriptionIds = await pubSub.GetAllSubscriptions(stream.StreamId, myGrainReference);
-            return subscriptionIds.Select(id => new StreamSubscriptionHandleImpl<T>(id, stream))
+            return subscriptionIds.Select(id => new StreamSubscriptionHandleImpl<T>(id, stream, IsRewindable))
                                   .ToList<StreamSubscriptionHandle<T>>();
         }
 
@@ -191,7 +191,7 @@ namespace Orleans.Streams
                     {
                         if (logger.IsVerbose) logger.Verbose("BindExtensionLazy - Binding local extension to stream runtime={0}", providerRuntime);
                         var tup = await providerRuntime.BindExtension<StreamConsumerExtension, IStreamConsumerExtension>(
-                            () => new StreamConsumerExtension(providerRuntime));
+                            () => new StreamConsumerExtension(providerRuntime, IsRewindable));
                         myExtension = tup.Item1;
                         myGrainReference = tup.Item2;
                         if (logger.IsVerbose) logger.Verbose("BindExtensionLazy - Connected Extension={0} GrainRef={1}", myExtension, myGrainReference);                        

--- a/test/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -228,7 +228,7 @@ namespace UnitTests.Grains
             myExtensionReference = StreamConsumerExtensionFactory.Cast(this.AsReference());
 #else
             var tup = await SiloProviderRuntime.Instance.BindExtension<StreamConsumerExtension, IStreamConsumerExtension>(
-                        () => new StreamConsumerExtension(SiloProviderRuntime.Instance));
+                        () => new StreamConsumerExtension(SiloProviderRuntime.Instance, _streamProvider.IsRewindable));
             StreamConsumerExtension myExtension = tup.Item1;
             myExtensionReference = tup.Item2;
 #endif
@@ -518,6 +518,6 @@ namespace UnitTests.Grains
 
     internal class ClosedTypeStreamSubscriptionHandle : StreamSubscriptionHandleImpl<StreamSubscriptionHandleArg>
     {
-        public ClosedTypeStreamSubscriptionHandle() : base(null, null) { /* not a subject to the creation */ }
+        public ClosedTypeStreamSubscriptionHandle() : base(null, null, false) { /* not a subject to the creation */ }
     }
 }

--- a/test/TestInternalGrains/StreamLifecycleTestInternalGrains.cs
+++ b/test/TestInternalGrains/StreamLifecycleTestInternalGrains.cs
@@ -66,7 +66,7 @@ namespace UnitTests.Grains
             myExtensionReference = StreamConsumerExtensionFactory.Cast(this.AsReference());
 #else
             var tup = await SiloProviderRuntime.Instance.BindExtension<StreamConsumerExtension, IStreamConsumerExtension>(
-                        () => new StreamConsumerExtension(SiloProviderRuntime.Instance));
+                        () => new StreamConsumerExtension(SiloProviderRuntime.Instance, _streamProvider.IsRewindable));
             StreamConsumerExtension myExtension = tup.Item1;
             myExtensionReference = tup.Item2;
 #endif


### PR DESCRIPTION
As described in https://github.com/dotnet/orleans/issues/1615, Azure Queue Stream Provider was erroneously trying to establish and guarantee ordered delivery, which resulted in lost data.

Azure Queue Stream Provider does not guarantee ordered delivery (since the underlying Azure Queue does not), and thus should not even attempt to.

This fix conditions the delivery checks ("the handshake protocol") to only ordered stream providers.
I re-used the notion of Rewindable stream provider, since it seems that ordered and rewindable would always be the same - if provider does not guarantee order, it cannot be rewinded, and the opposite. At least as of now, AQST and SMS are both non rewindable and non ordered, while EHST is both rewindable and ordered, and thus I think there is no need (at least for now) to introduce a new concept of `IsOrdered`  stream provider.