### PR TITLE
Add helper methods to AzureClient and AzureSilo for easier programmatic config

### DIFF
--- a/src/OrleansAzureUtils/Hosting/AzureClient.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Threading;
 using Orleans.Runtime.Configuration;
 
@@ -74,6 +75,22 @@ namespace Orleans.Runtime.Host
             GrainClient.Uninitialize();
         }
 
+        /// <summary>
+        /// Returns default client configuration object for passing to AzureClient.
+        /// </summary>
+        /// <returns></returns>
+        public static ClientConfiguration DefaultConfiguration()
+        {
+            var config = new ClientConfiguration
+            {
+                GatewayProvider = ClientConfiguration.GatewayProviderType.AzureTable,
+                DeploymentId = GetDeploymentId(),
+                DataConnectionString = GetDataConnectionString(),
+            };
+            
+            return config;
+        }
+
         #region Internal implementation of client initialization processing
 
         private static void InitializeImpl_FromFile(FileInfo configFile)
@@ -123,12 +140,12 @@ namespace Orleans.Runtime.Host
             InitializeImpl_FromConfig(config);
         }
 
-        private static string GetDeploymentId()
+        internal static string GetDeploymentId()
         {
             return GrainClient.TestOnlyNoConnect ? "FakeDeploymentId" : serviceRuntimeWrapper.DeploymentId;
         }
 
-        private static string GetDataConnectionString()
+        internal static string GetDataConnectionString()
         {
             return GrainClient.TestOnlyNoConnect
                 ? "FakeConnectionString"

--- a/src/OrleansAzureUtils/Hosting/AzureSilo.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureSilo.cs
@@ -61,6 +61,17 @@ namespace Orleans.Runtime.Host
             logger = TraceLogger.GetLogger("OrleansAzureSilo", TraceLogger.LoggerType.Runtime);
         }
 
+        public static ClusterConfiguration DefaultConfiguration()
+        {
+            var config = new ClusterConfiguration();
+
+            config.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
+            config.Globals.DeploymentId = AzureClient.GetDeploymentId();
+            config.Globals.DataConnectionString = AzureClient.GetDataConnectionString();
+
+            return config;
+        }
+
         #region Azure RoleEntryPoint methods
 
         /// <summary>


### PR DESCRIPTION
Add AzureClient.DefaultAzureConfig() and AzureSilo.DefaultAzureConfig() helper methods.

Usage examples are in https://github.com/sergeybykov/orleans/blob/sample/Samples/AzureWebSample/WebRole/Default.aspx.cs#L16 and https://github.com/sergeybykov/orleans/blob/sample/Samples/AzureWebSample/OrleansAzureSilos/WorkerRole.cs#L49.