### PR TITLE
Remove config filed from Server and Client NuGet packages

### DIFF
--- a/src/NuGet/Microsoft.Orleans.Client.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Client.nuspec
@@ -24,8 +24,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="ClientConfiguration.xml" target="content" />
     <file src="Configuration\OrleansConfiguration.xsd" target="tools\client" />
-    <file src="ClientInstall.ps1" target="tools\install.ps1" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.Server.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Server.nuspec
@@ -27,8 +27,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansConfiguration.xml" target="content" />
     <file src="Configuration\OrleansConfiguration.xsd" target="tools" />
-    <file src="ServerInstall.ps1" target="tools\install.ps1" />
   </files>
 </package>

--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -56,7 +56,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{014CD19F
 	ProjectSection(SolutionItems) = preProject
 		NuGet\BondSerializerInstall.ps1 = NuGet\BondSerializerInstall.ps1
 		NuGet\BondSerializerUninstall.ps1 = NuGet\BondSerializerUninstall.ps1
-		NuGet\ClientInstall.ps1 = NuGet\ClientInstall.ps1
 		NuGet\CreateOrleansPackages.bat = NuGet\CreateOrleansPackages.bat
 		NuGet\deprecated-templates-Install.ps1 = NuGet\deprecated-templates-Install.ps1
 		NuGet\deprecated-templates-Readme.txt = NuGet\deprecated-templates-Readme.txt
@@ -81,7 +80,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{014CD19F
 		NuGet\Microsoft.Orleans.Templates.Grains.nuspec-NoSymbols = NuGet\Microsoft.Orleans.Templates.Grains.nuspec-NoSymbols
 		NuGet\Microsoft.Orleans.Templates.Interfaces.nuspec-NoSymbols = NuGet\Microsoft.Orleans.Templates.Interfaces.nuspec-NoSymbols
 		NuGet\Microsoft.Orleans.TestingHost.nuspec = NuGet\Microsoft.Orleans.TestingHost.nuspec
-		NuGet\ServerInstall.ps1 = NuGet\ServerInstall.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SDK", "SDK", "{80801A64-30AD-4B07-801C-2479A87AC527}"


### PR DESCRIPTION
I see two reasons for removing config files from these NuGets.

1) When a config file is used a target project, an upgrade to these packages can overwrite its content.
2) We are moving to programmatic config in 1.2.0, and config files are being removed from all samples to avoid confusion.