### PR TITLE
ClientNotAvailableException 

### DIFF
--- a/src/Orleans/Core/Exceptions.cs
+++ b/src/Orleans/Core/Exceptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using Orleans.Core;
 
 namespace Orleans.Runtime
 {
@@ -173,6 +174,21 @@ namespace Orleans.Runtime
         public InvalidSchedulingContextException(string message, Exception innerException) : base(message, innerException) { }
 
         protected InvalidSchedulingContextException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        { }
+    }
+
+    /// <summary>
+    /// Indicates that a client is not longer reachable.
+    /// </summary>
+    [Serializable]
+    public class ClientNotAvailableException : OrleansException
+    {
+        internal ClientNotAvailableException(IGrainIdentity clientId) : base("No activation for client " + clientId) { }
+        internal ClientNotAvailableException(string msg) : base(msg) { }
+        internal ClientNotAvailableException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected ClientNotAvailableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
     }

--- a/src/OrleansRuntime/Placement/PlacementDirectorsManager.cs
+++ b/src/OrleansRuntime/Placement/PlacementDirectorsManager.cs
@@ -55,7 +55,7 @@ namespace Orleans.Runtime.Placement
                 var res = await clientObserversPlacementDirector.OnSelectActivation(strategy, targetGrain, context);
                 if (res == null)
                 {
-                    throw new KeyNotFoundException("No activation for client " + targetGrain);
+                    throw new ClientNotAvailableException(targetGrain);
                 }
                 return res;
             }


### PR DESCRIPTION
Replaced generic KeyNotFoundException with more specific ClientNotAvailableException to indicate that the target client is no longer connected to the cluster.

This change was pulled from #1429 and is part of addressing issues #1421, and  #982