### PR TITLE
Increased column Statistic in OrleansStatisticsTable to 512

### DIFF
--- a/src/OrleansSQLUtils/CreateOrleansTables_SqlServer.sql
+++ b/src/OrleansSQLUtils/CreateOrleansTables_SqlServer.sql
@@ -161,7 +161,7 @@ BEGIN
 		[Name] NVARCHAR(150) NULL, 
 		[IsDelta] BIT NOT NULL, 
 		[StatValue] NVARCHAR(1024) NOT NULL,
-		[Statistic] NVARCHAR(250) NOT NULL,
+		[Statistic] NVARCHAR(512) NOT NULL,
 
 		CONSTRAINT OrleansStatisticsTable_OrleansStatisticsTableId PRIMARY KEY([OrleansStatisticsTableId])	
 	);


### PR DESCRIPTION
Some statistics can exceed the 250 characters, esp. with long domain
names, created for [#1628](https://github.com/dotnet/orleans/issues/1628)