### PR TITLE
Client Streaming Tests

### DIFF
--- a/src/Orleans/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans/Configuration/MessagingConfiguration.cs
@@ -58,6 +58,10 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         int ClientSenderBuckets { get; set; }
         /// <summary>
+        ///  This is the period of time a gateway will wait before dropping a disconnected client.
+        /// </summary>
+        TimeSpan ClientDropTimeout { get; set; }
+        /// <summary>
         /// The UseStandardSerializer attribute, if provided and set to "true", forces the use of the standard .NET serializer instead
         /// of the custom Orleans serializer.
         /// This parameter is intended for use only for testing and troubleshooting.
@@ -108,6 +112,7 @@ namespace Orleans.Runtime.Configuration
         public int SiloSenderQueues { get; set; }
         public int GatewaySenderQueues { get; set; }
         public int ClientSenderBuckets { get; set; }
+        public TimeSpan ClientDropTimeout { get; set; }
         public bool UseStandardSerializer { get; set; }
         public bool UseJsonFallbackSerializer { get; set; }
 
@@ -160,6 +165,7 @@ namespace Orleans.Runtime.Configuration
             SiloSenderQueues = DEFAULT_SILO_SENDER_QUEUES;
             GatewaySenderQueues = DEFAULT_GATEWAY_SENDER_QUEUES;
             ClientSenderBuckets = DEFAULT_CLIENT_SENDER_BUCKETS;
+            ClientDropTimeout = Constants.DEFAULT_CLIENT_DROP_TIMEOUT;
             UseStandardSerializer = DEFAULT_USE_STANDARD_SERIALIZER;
 
             BufferPoolBufferSize = DEFAULT_BUFFER_POOL_BUFFER_SIZE;
@@ -197,6 +203,7 @@ namespace Orleans.Runtime.Configuration
             {
                 sb.AppendFormat("       Silo Sender queues: {0}", SiloSenderQueues).AppendLine();
                 sb.AppendFormat("       Gateway Sender queues: {0}", GatewaySenderQueues).AppendLine();
+                sb.AppendFormat("       Client Drop Timeout: {0}", ClientDropTimeout).AppendLine();
             }
             else
             {
@@ -262,6 +269,10 @@ namespace Orleans.Runtime.Configuration
                     GatewaySenderQueues = ConfigUtilities.ParseInt(child.GetAttribute("GatewaySenderQueues"),
                                                             "Invalid integer value for the GatewaySenderQueues attribute on the Messaging element");
                 }
+                ClientDropTimeout = child.HasAttribute("ClientDropTimeout")
+                                          ? ConfigUtilities.ParseTimeSpan(child.GetAttribute("ClientDropTimeout"),
+                                                                     "Invalid ClientDropTimeout")
+                                          : Constants.DEFAULT_CLIENT_DROP_TIMEOUT;
             }
             else
             {

--- a/src/Orleans/Core/GrainClient.cs
+++ b/src/Orleans/Core/GrainClient.cs
@@ -277,11 +277,22 @@ namespace Orleans
         }
 
         /// <summary>
+        /// Test hook to uninitialize client without cleanup
+        /// </summary>
+        public static void HardKill()
+        {
+            lock (initLock)
+            {
+                InternalUninitialize(false);
+            }
+        }
+
+        /// <summary>
         /// This is the lock free version of uninitilize so we can share 
         /// it between the public method and error paths inside initialize.
         /// This should only be called inside a lock(initLock) block.
         /// </summary>
-        private static void InternalUninitialize()
+        private static void InternalUninitialize(bool cleanup = true)
         {
             // Update this first so IsInitialized immediately begins returning
             // false.  Since this method should be protected externally by 
@@ -293,7 +304,7 @@ namespace Orleans
             {
                 try
                 {
-                    RuntimeClient.Current.Reset();
+                    RuntimeClient.Current.Reset(cleanup);
                 }
                 catch (Exception) { }
 

--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -55,13 +55,16 @@ namespace Orleans.Providers
             return streamDirectory;
         }
 
-        public async Task Reset()
+        public async Task Reset(bool cleanup = true)
         {
             if (streamDirectory != null)
             {
                 var tmp = streamDirectory;
                 streamDirectory = null; // null streamDirectory now, just to make sure we call cleanup only once, in all cases.
-                await tmp.Cleanup(true, true);
+                if (cleanup)
+                {
+                    await tmp.Cleanup(true, true);
+                }
             }
         }
 

--- a/src/Orleans/Runtime/Constants.cs
+++ b/src/Orleans/Runtime/Constants.cs
@@ -65,6 +65,8 @@ namespace Orleans.Runtime
 
         public const int DEFAULT_LOGGER_BULK_MESSAGE_LIMIT = 5;
 
+        public static readonly TimeSpan DEFAULT_CLIENT_DROP_TIMEOUT = TimeSpan.FromMinutes(1);
+
         private static readonly Dictionary<GrainId, string> singletonSystemTargetNames = new Dictionary<GrainId, string>
         {
             {DirectoryServiceId, "DirectoryService"},

--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -59,7 +59,7 @@ namespace Orleans.Runtime
 
         Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context, string activityName);
 
-        void Reset();
+        void Reset(bool cleanup);
 
         GrainReference CreateObjectReference(IAddressable obj, IGrainMethodInvoker invoker);
 

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -679,7 +679,7 @@ namespace Orleans
             callbacks.TryRemove(id, out ignore);
         }
 
-        public void Reset()
+        public void Reset(bool cleanup)
         {
             Utils.SafeExecute(() =>
             {
@@ -693,7 +693,7 @@ namespace Orleans
             {
                 if (clientProviderRuntime != null)
                 {
-                    clientProviderRuntime.Reset().WaitWithThrow(resetTimeout);
+                    clientProviderRuntime.Reset(cleanup).WaitWithThrow(resetTimeout);
                 }
             }, logger, "Client.clientProviderRuntime.Reset");
             Utils.SafeExecute(() =>

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -641,7 +641,7 @@ namespace Orleans.Runtime
             await OrleansTaskScheduler.Instance.QueueNamedTask(asyncFunction, context, activityName);
         }
 
-        public void Reset()
+        public void Reset(bool cleanup)
         {
             throw new InvalidOperationException();
         }

--- a/test/Tester/StreamingTests/AQClientStreamTests.cs
+++ b/test/Tester/StreamingTests/AQClientStreamTests.cs
@@ -1,0 +1,63 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Runtime.Configuration;
+using Orleans.TestingHost;
+using UnitTests.Tester;
+using Xunit;
+
+namespace Tester.StreamingTests
+{
+    public class AQClientStreamTests : HostedTestClusterPerTest
+    {
+        private const string AQStreamProviderName = "AzureQueueProvider";
+        private const string StreamNamespace = "AQSubscriptionMultiplicityTestsNamespace";
+
+        private ClientStreamTestRunner runner;
+
+        public override TestingSiloHost CreateSiloHost()
+        {
+            var siloHost = new TestingSiloHost(
+                new TestingSiloOptions
+                {
+                    SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
+                    AdjustConfig = config =>
+                    {
+                        config.AddMemoryStorageProvider("PubSubStore");
+                        config.Globals.RegisterStreamProvider<AzureQueueStreamProvider>(AQStreamProviderName);
+                        config.Globals.ClientDropTimeout = TimeSpan.FromSeconds(5);
+                    }
+                }, new TestingClientOptions
+                {
+                    AdjustConfig = config =>
+                    {
+                        config.RegisterStreamProvider<AzureQueueStreamProvider>(AQStreamProviderName,
+                            new Dictionary<string, string>());
+                        config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 40001));
+                    }
+                });
+
+            runner = new ClientStreamTestRunner(siloHost);
+            return siloHost;
+        }
+
+        public override void Dispose()
+        {
+            var deploymentId = HostedCluster.DeploymentId;
+            base.Dispose();
+            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(AQStreamProviderName, deploymentId,
+                StorageTestConstants.DataConnectionString).Wait();
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Storage"), TestCategory("Streaming")]
+        public async Task AQStreamProducerOnDroppedClientTest()
+        {
+            logger.Info("************************ AQStreamProducerOnDroppedClientTest *********************************");
+            await runner.StreamProducerOnDroppedClientTest(AQStreamProviderName, StreamNamespace);
+        }
+    }
+}

--- a/test/Tester/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Tester/StreamingTests/ClientStreamTestRunner.cs
@@ -1,0 +1,75 @@
+﻿
+using System;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace Tester.StreamingTests
+{
+    public class ClientStreamTestRunner
+    {
+        private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(30);
+
+        private readonly TestingSiloHost testHost;
+        public ClientStreamTestRunner(TestingSiloHost testHost)
+        {
+            this.testHost = testHost;
+        }
+
+        public async Task StreamProducerOnDroppedClientTest(string streamProviderName, string streamNamespace)
+        {
+            const int eventsProduced = 10;
+            Guid streamGuid = Guid.NewGuid();
+
+            await ProduceEventsFromClient(streamProviderName, streamGuid, streamNamespace, eventsProduced);
+
+            // Hard kill client
+            testHost.KillClient();
+
+            // make sure dead client has had time to drop
+            await Task.Delay(testHost.Globals.ClientDropTimeout + TimeSpan.FromSeconds(5));
+
+            // initialize new client
+            testHost.InitializeClient();
+
+            // run test again.
+            await ProduceEventsFromClient(streamProviderName, streamGuid, streamNamespace, eventsProduced);
+        }
+
+        private async Task ProduceEventsFromClient(string streamProviderName, Guid streamGuid, string streamNamespace, int eventsProduced)
+        {
+            // get reference to a consumer
+            var consumer = GrainClient.GrainFactory.GetGrain<ISampleStreaming_ConsumerGrain>(Guid.NewGuid());
+
+            // subscribe
+            await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
+
+            // generate events
+            await GenerateEvents(streamProviderName, streamGuid, streamNamespace, eventsProduced);
+
+            // make sure all went well
+            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(consumer, eventsProduced, lastTry), _timeout);
+        }
+
+        private async Task GenerateEvents(string streamProviderName, Guid streamGuid, string streamNamespace, int produceCount)
+        {
+            IStreamProvider streamProvider = GrainClient.GetStreamProvider(streamProviderName);
+            IAsyncObserver<int> observer = streamProvider.GetStream<int>(streamGuid, streamNamespace);
+            for (int i = 0; i < produceCount; i++)
+            {
+                await observer.OnNextAsync(i);
+            }
+        }
+
+        private async Task<bool> CheckCounters(ISampleStreaming_ConsumerGrain consumer, int eventsProduced, bool assertIsTrue)
+        {
+            var numConsumed = await consumer.GetNumberConsumed();
+            if (!assertIsTrue) return eventsProduced == numConsumed;
+            Assert.Equal(eventsProduced, numConsumed);
+            return true;
+        }
+    }
+}

--- a/test/Tester/StreamingTests/EHClientStreamTests.cs
+++ b/test/Tester/StreamingTests/EHClientStreamTests.cs
@@ -1,0 +1,93 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Table;
+using Orleans.AzureUtils;
+using Orleans.Runtime.Configuration;
+using Orleans.ServiceBus.Providers;
+using Orleans.TestingHost;
+using UnitTests.Tester;
+using Xunit;
+
+namespace Tester.StreamingTests
+{
+    public class EHClientStreamTests : HostedTestClusterPerTest
+    {
+        private const string StreamProviderName = "EventHubStreamProvider";
+        private const string StreamNamespace = "StreamNamespace";
+        private const string EHPath = "ehorleanstest";
+        private const string EHConsumerGroup = "orleansnightly";
+        private const string EHCheckpointTable = "ehcheckpoint";
+        private static readonly string CheckpointNamespace = Guid.NewGuid().ToString();
+
+        private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
+                EHConsumerGroup, EHPath);
+
+        private static readonly EventHubStreamProviderConfig ProviderConfig =
+            new EventHubStreamProviderConfig(StreamProviderName, 3);
+
+        private static readonly EventHubCheckpointerSettings CheckpointerSettings =
+            new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable,
+                CheckpointNamespace,
+                TimeSpan.FromSeconds(10));
+
+        private ClientStreamTestRunner runner;
+
+        public override TestingSiloHost CreateSiloHost()
+        {
+            var siloHost = new TestingSiloHost(new TestingSiloOptions
+            {
+                StartFreshOrleans = true,
+                SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
+                AdjustConfig = AdjustConfig
+            }, new TestingClientOptions
+            {
+                AdjustConfig = AdjustConfig
+            });
+            runner = new ClientStreamTestRunner(siloHost);
+            return siloHost;
+        }
+
+        public override void Dispose()
+        {
+            var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString);
+            dataManager.InitTableAsync().Wait();
+            dataManager.DeleteTableAsync().Wait();
+            base.Dispose();
+        }
+
+        [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
+        public async Task EHStreamProducerOnDroppedClientTest()
+        {
+            logger.Info("************************ EHStreamProducerOnDroppedClientTest *********************************");
+            await runner.StreamProducerOnDroppedClientTest(StreamProviderName, StreamNamespace);
+        }
+        
+        private static void AdjustConfig(ClusterConfiguration config)
+        {
+            // register stream provider
+            config.AddMemoryStorageProvider("PubSubStore");
+            config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
+            config.Globals.ClientDropTimeout = TimeSpan.FromSeconds(5);
+        }
+
+        private static void AdjustConfig(ClientConfiguration config)
+        {
+            config.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
+            config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 40001));
+        }
+
+        private static Dictionary<string, string> BuildProviderSettings()
+        {
+            var settings = new Dictionary<string, string>();
+            // get initial settings from configs
+            ProviderConfig.WriteProperties(settings);
+            EventHubConfig.WriteProperties(settings);
+            CheckpointerSettings.WriteProperties(settings);
+            return settings;
+        }
+    }
+}

--- a/test/Tester/StreamingTests/SMSClientStreamTests.cs
+++ b/test/Tester/StreamingTests/SMSClientStreamTests.cs
@@ -1,0 +1,56 @@
+﻿
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Orleans.Providers.Streams.SimpleMessageStream;
+using Orleans.Runtime.Configuration;
+using Orleans.TestingHost;
+using UnitTests.Tester;
+using Xunit;
+
+namespace Tester.StreamingTests
+{
+    public class SMSClientStreamTests : HostedTestClusterPerTest
+    {
+        private const string SMSStreamProviderName = "SMSProvider";
+        private const string StreamNamespace = "SMSDeactivationTestsNamespace";
+        private ClientStreamTestRunner runner;
+
+        public override TestingSiloHost CreateSiloHost()
+        {
+            var siloOptions = new TestingSiloOptions
+            {
+                StartFreshOrleans = true,
+                StartSecondary = false,
+                SiloConfigFile = new FileInfo("OrleansConfigurationForTesting.xml"),
+                AdjustConfig = config =>
+                {
+                    config.AddMemoryStorageProvider("PubSubStore");
+                    config.Globals.RegisterStreamProvider<SimpleMessageStreamProvider>(SMSStreamProviderName);
+                    config.Globals.ClientDropTimeout = TimeSpan.FromSeconds(5);
+                }
+            };
+
+            var clientOptions = new TestingClientOptions
+            {
+                ClientConfigFile = new FileInfo("ClientConfigurationForTesting.xml"),
+                AdjustConfig = config =>
+                {
+                    config.RegisterStreamProvider<SimpleMessageStreamProvider>(SMSStreamProviderName);
+                }
+            };
+
+            var testHost = new TestingSiloHost(siloOptions, clientOptions);
+            runner = new ClientStreamTestRunner(testHost);
+
+            return testHost;
+        }
+
+        [Fact(Skip="Pending PR #1429"), TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task MSMStreamProducerOnDroppedClientTest()
+        {
+            logger.Info("************************ SMSDeactivationTest *********************************");
+            await runner.StreamProducerOnDroppedClientTest(SMSStreamProviderName, StreamNamespace);
+        }
+    }
+}

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -145,6 +145,9 @@
     <Compile Include="BaseClusterFixture.cs" />
     <Compile Include="General\JsonGrainTests.cs" />
     <Compile Include="SerializationTests\DeepCopyTests.cs" />
+    <Compile Include="StreamingTests\AQClientStreamTests.cs" />
+    <Compile Include="StreamingTests\ClientStreamTestRunner.cs" />
+    <Compile Include="StreamingTests\EHClientStreamTests.cs" />
     <Compile Include="StreamingTests\EHImplicitSubscriptionStreamRecoveryTests.cs" />
     <Compile Include="StreamingTests\EHStreamProviderCheckpointTests.cs" />
     <Compile Include="BasicActivationTests.cs" />
@@ -206,6 +209,7 @@
     <Compile Include="StreamingTests\DelayedQueueRebalancingTests.cs" />
     <Compile Include="StreamingTests\ImplicitSubscritionRecoverableStreamTestRunner.cs" />
     <Compile Include="StreamingTests\SampleStreamingTests.cs" />
+    <Compile Include="StreamingTests\SMSClientStreamTests.cs" />
     <Compile Include="StreamingTests\SMSDeactivationTests.cs" />
     <Compile Include="StreamingTests\SMSSubscriptionMultiplicityTests.cs" />
     <Compile Include="StreamingTests\StreamFilteringTests.cs" />


### PR DESCRIPTION
Added tests to reproduce issues #1421, and #982
Issue only applies to SMS, but applied test to all supported stream providers for test coverage reasons.

- Updated test framework so tests could shutdown or hard kill grain client as well as initialize new grain client.
- Added client stream test runner with one test
    - StreamProducerOnDroppedClientTest
    - Will add more as needed.
- Added SMS stream client tests using test runner
- Added AzureQueue stream client tests using test runner
- Added EventHub stream client tests using test runner