### PR TITLE
Generic edge case tests

### DIFF
--- a/test/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/TestGrainInterfaces/IGenericInterfaces.cs
@@ -230,4 +230,73 @@ namespace UnitTests.GrainInterfaces
 
 
 
+
+    namespace Generic.EdgeCases
+    {
+        public interface IBasicGrain : IGrainWithGuidKey
+        {
+            Task<string> Hello();
+            Task<string[]> ConcreteGenArgTypeNames();
+        }
+
+
+        public interface IGrainWithTwoGenArgs<T1, T2> : IBasicGrain
+        { }
+
+        public interface IGrainWithThreeGenArgs<T1, T2, T3> : IBasicGrain
+        { }
+
+        public interface IGrainReceivingRepeatedGenArgs<T1, T2> : IBasicGrain
+        { }
+
+        
+        public interface IPartiallySpecifyingInterface<T> : IGrainWithTwoGenArgs<T, int>
+        { }
+        
+
+        public interface IReceivingRepeatedGenArgsAmongstOthers<T1, T2, T3> : IBasicGrain
+        { }
+
+
+        public interface IReceivingRepeatedGenArgsFromOtherInterface<T1, T2, T3> : IBasicGrain
+        { }
+
+        public interface ISpecifyingGenArgsRepeatedlyToParentInterface<T> : IReceivingRepeatedGenArgsFromOtherInterface<T, T, T>
+        { }
+
+
+        public interface IReceivingRearrangedGenArgs<T1, T2> : IBasicGrain
+        { }
+
+
+
+        public interface IReceivingRearrangedGenArgsViaCast<T1, T2> : IBasicGrain
+        { }
+
+        public interface ISpecifyingRearrangedGenArgsToParentInterface<T1, T2> : IReceivingRearrangedGenArgsViaCast<T2, T1>
+        { }
+
+
+        public interface IArbitraryInterface<T1, T2> : IBasicGrain
+        { }
+
+        public interface IInterfaceUnrelatedToConcreteGenArgs<T> : IBasicGrain
+        { }
+
+
+        public interface IInterfaceTakingFurtherSpecializedGenArg<T> : IBasicGrain
+        { }
+
+
+        public interface IAnotherReceivingFurtherSpecializedGenArg<T> : IBasicGrain
+        { }
+
+        public interface IYetOneMoreReceivingFurtherSpecializedGenArg<T> : IBasicGrain
+        { }
+
+
+    }
+
+
+
 }

--- a/test/TestGrains/GenericGrains.cs
+++ b/test/TestGrains/GenericGrains.cs
@@ -644,9 +644,7 @@ namespace UnitTests.Grains
         }
     }
 
-
-
-
+        
     public class IndepedentlyConcretizedGenericGrain : Grain, IIndependentlyConcretizedGenericGrain<string>, IIndependentlyConcretizedGrain
     {
         public Task<string> Hello() {
@@ -655,5 +653,85 @@ namespace UnitTests.Grains
     }
 
 
+
+
+    namespace Generic.EdgeCases
+    {
+        using System.Linq;
+        using UnitTests.GrainInterfaces.Generic.EdgeCases;
+
+
+        public abstract class BasicGrain : Grain
+        {
+            public Task<string> Hello() {
+                return Task.FromResult("Hello!");
+            }
+
+            public Task<string[]> ConcreteGenArgTypeNames() {
+                var grainType = GetImmediateSubclass(this.GetType());
+
+                return Task.FromResult(
+                                grainType.GetGenericArguments()
+                                            .Select(t => t.FullName)
+                                            .ToArray()
+                                );
+            }
+
+
+            Type GetImmediateSubclass(Type subject) {
+                if(subject.BaseType == typeof(BasicGrain)) {
+                    return subject;
+                }
+
+                return GetImmediateSubclass(subject.BaseType);
+            }
+        }
+
+
+
+        public class PartiallySpecifyingGrain<T> : BasicGrain, IGrainWithTwoGenArgs<string, T>
+        { }
+
+
+        public class GrainWithPartiallySpecifyingInterface<T> : BasicGrain, IPartiallySpecifyingInterface<T>
+        { }
+
+
+        public class GrainSpecifyingSameGenArgTwice<T> : BasicGrain, IGrainReceivingRepeatedGenArgs<T, T>
+        { }
+
+
+        public class SpecifyingRepeatedGenArgsAmongstOthers<T1, T2> : BasicGrain, IReceivingRepeatedGenArgsAmongstOthers<T2, T1, T2>
+        { }
+
+        public class GrainForTestingCastingBetweenInterfacesWithReusedGenArgs : BasicGrain, ISpecifyingGenArgsRepeatedlyToParentInterface<bool>
+        { }
+
+
+        public class SpecifyingSameGenArgsButRearranged<T1, T2> : BasicGrain, IReceivingRearrangedGenArgs<T2, T1>
+        { }
+
+
+        public class GrainForTestingCastingWithRearrangedGenArgs<T1, T2> : BasicGrain, ISpecifyingRearrangedGenArgsToParentInterface<T1, T2>
+        { }
+
+
+        public class GrainWithGenArgsUnrelatedToFullySpecifiedGenericInterface<T1, T2> : BasicGrain, IArbitraryInterface<T1, T2>, IInterfaceUnrelatedToConcreteGenArgs<float>
+        { }
+
+
+        public class GrainSupplyingFurtherSpecializedGenArg<T> : BasicGrain, IInterfaceTakingFurtherSpecializedGenArg<List<T>>
+        { }
+
+        public class GrainSupplyingGenArgSpecializedIntoArray<T> : BasicGrain, IInterfaceTakingFurtherSpecializedGenArg<T[]>
+        { }
+
+
+        public class GrainForCastingBetweenInterfacesOfFurtherSpecializedGenArgs<T>
+            : BasicGrain, IAnotherReceivingFurtherSpecializedGenArg<List<T>>, IYetOneMoreReceivingFurtherSpecializedGenArg<T[]>
+        { }
+
+
+    }
 
 }

--- a/test/Tester/GenericGrainTests.cs
+++ b/test/Tester/GenericGrainTests.cs
@@ -765,7 +765,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task PartiallySpecifyingGenericGrainFulfilsInterface() 
+        public async Task Generic_PartiallySpecifyingGenericGrainFulfilsInterface() 
         {
             var grain = GrainFactory.GetGrain<IGrainWithTwoGenArgs<string, int>>(Guid.NewGuid());
 
@@ -791,7 +791,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task GenericGrainCanReuseOwnGenArgRepeatedly() 
+        public async Task Generic_GenericGrainCanReuseOwnGenArgRepeatedly() 
         {
             //resolves correctly but can't be activated: too many gen args supplied for concrete class
 
@@ -806,7 +806,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task PartiallySpecifyingGenericInterfaceIsCastable() 
+        public async Task Generic_PartiallySpecifyingGenericInterfaceIsCastable() 
         {
             var grain = GrainFactory.GetGrain<IPartiallySpecifyingInterface<string>>(Guid.NewGuid());
 
@@ -821,7 +821,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task PartiallySpecifyingGenericInterfaceIsCastable_Activating() 
+        public async Task Generic_PartiallySpecifyingGenericInterfaceIsCastable_Activating() 
         {
             var grain = GrainFactory.GetGrain<IPartiallySpecifyingInterface<string>>(Guid.NewGuid());
 
@@ -844,7 +844,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task RepeatedRearrangedGenArgsResolved() 
+        public async Task Generic_RepeatedRearrangedGenArgsResolved() 
         {
             //again resolves to the correct generic type definition, but fails on activation as too many args
             //gen args aren't being properly inferred from matched concrete type
@@ -872,7 +872,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task RepeatedGenArgsWorkAmongstInterfacesInTypeResolution() 
+        public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInTypeResolution() 
         {
             var grain = GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
 
@@ -885,7 +885,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task RepeatedGenArgsWorkAmongstInterfacesInCasting() 
+        public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInCasting() 
         {
             var grain = GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
 
@@ -900,7 +900,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task RepeatedGenArgsWorkAmongstInterfacesInCasting_Activating() 
+        public async Task Generic_RepeatedGenArgsWorkAmongstInterfacesInCasting_Activating() 
         {
             //Only errors on invocation: wrong arity again
 
@@ -923,7 +923,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task RearrangedGenArgsOfCorrectArityAreResolved() 
+        public async Task Generic_RearrangedGenArgsOfCorrectArityAreResolved() 
         {
             var grain = GrainFactory.GetGrain<IReceivingRearrangedGenArgs<int, long>>(Guid.NewGuid());
 
@@ -948,7 +948,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task RearrangedGenArgsOfCorrectNumberAreCastable() 
+        public async Task Generic_RearrangedGenArgsOfCorrectNumberAreCastable() 
         {
             var grain = GrainFactory.GetGrain<ISpecifyingRearrangedGenArgsToParentInterface<int, long>>(Guid.NewGuid());
 
@@ -963,7 +963,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task RearrangedGenArgsOfCorrectNumberAreCastable_Activating() 
+        public async Task Generic_RearrangedGenArgsOfCorrectNumberAreCastable_Activating() 
         {
             var grain = GrainFactory.GetGrain<ISpecifyingRearrangedGenArgsToParentInterface<int, long>>(Guid.NewGuid());
 
@@ -1032,7 +1032,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs() {
+        public async Task Generic_CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs() {
             var grain = GrainFactory.GetGrain<IArbitraryInterface<int, long>>(Guid.NewGuid());
 
             await grain.Hello();
@@ -1045,7 +1045,7 @@ namespace UnitTests.General
         }
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs_Activating() {
+        public async Task Generic_CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs_Activating() {
             var grain = GrainFactory.GetGrain<IArbitraryInterface<int, long>>(Guid.NewGuid());
 
             var castRef = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
@@ -1069,7 +1069,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task GenArgsCanBeFurtherSpecialized() {
+        public async Task Generic_GenArgsCanBeFurtherSpecialized() {
             var grain = GrainFactory.GetGrain<IInterfaceTakingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
 
             var concreteGenArgs = await GetConcreteGenArgs(grain);
@@ -1080,7 +1080,7 @@ namespace UnitTests.General
         }
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task GenArgsCanBeFurtherSpecializedIntoArrays() {
+        public async Task Generic_GenArgsCanBeFurtherSpecializedIntoArrays() {
             var grain = GrainFactory.GetGrain<IInterfaceTakingFurtherSpecializedGenArg<long[]>>(Guid.NewGuid());
 
             var concreteGenArgs = await GetConcreteGenArgs(grain);
@@ -1104,7 +1104,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task CanCastBetweenInterfacesWithFurtherSpecializedGenArgs() {
+        public async Task Generic_CanCastBetweenInterfacesWithFurtherSpecializedGenArgs() {
             var grain = GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
 
             await grain.Hello();
@@ -1118,7 +1118,7 @@ namespace UnitTests.General
 
 
         [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
-        public async Task CanCastBetweenInterfacesWithFurtherSpecializedGenArgs_Activating() {
+        public async Task Generic_CanCastBetweenInterfacesWithFurtherSpecializedGenArgs_Activating() {
             var grain = GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
 
             var castRef = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();

--- a/test/Tester/GenericGrainTests.cs
+++ b/test/Tester/GenericGrainTests.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using TestGrainInterfaces;
 using Xunit;
 using Tester;
+using System.Linq;
 
 namespace UnitTests.General
 {
@@ -700,4 +701,435 @@ namespace UnitTests.General
             Assert.AreEqual(result, "Hello!");
         }
     }
+
+
+    public class GenericEdgeCases : HostedTestClusterEnsureDefaultStarted
+    {
+        public interface IBasicGrain : IGrainWithGuidKey
+        {
+            Task<string> Hello();
+            Task<string[]> ConcreteGenArgTypeNames();
+        }
+
+        public abstract class BasicGrain : Grain
+        {
+            public Task<string> Hello() {
+                return Task.FromResult("Hello!");
+            }
+
+            public Task<string[]> ConcreteGenArgTypeNames() 
+            {
+                var grainType = GetImmediateSubclass(this.GetType());
+
+                return Task.FromResult(
+                                grainType.GetGenericArguments()
+                                            .Select(t => t.FullName)
+                                            .ToArray()
+                                );
+            }
+
+
+            Type GetImmediateSubclass(Type subject) 
+            {
+                if(subject.BaseType == typeof(BasicGrain)) {
+                    return subject;
+                }
+
+                return GetImmediateSubclass(subject.BaseType);
+            }
+        }
+
+        static async Task<Type[]> GetConcreteGenArgs(IBasicGrain @this) 
+        {
+            var genArgTypeNames = await @this.ConcreteGenArgTypeNames();
+
+            return genArgTypeNames.Select(n => Type.GetType(n))
+                                    .ToArray();
+        }
+
+
+
+
+        public interface IGrainWithTwoGenArgs<T1, T2> : IBasicGrain
+        { }
+
+        public interface IGrainWithThreeGenArgs<T1, T2, T3> : IBasicGrain
+        { }
+
+        public interface IGrainReceivingRepeatedGenArgs<T1, T2> : IBasicGrain
+        { }
+
+
+        public class PartiallySpecifyingGrain<T> : BasicGrain, IGrainWithTwoGenArgs<string, T>
+        { }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task PartiallySpecifyingGenericGrainFulfilsInterface() 
+        {
+            var grain = GrainFactory.GetGrain<IGrainWithTwoGenArgs<string, int>>(Guid.NewGuid());
+
+            var concreteGenArgs = await GetConcreteGenArgs(grain);
+
+            Assert.IsTrue(
+                    concreteGenArgs.SequenceEqual(new[] { typeof(int) })
+                    );
+        }
+
+
+
+
+        public interface IPartiallySpecifyingInterface<T> : IGrainWithTwoGenArgs<T, int>
+        { }
+
+        public class GrainWithPartiallySpecifyingInterface<T> : BasicGrain, IPartiallySpecifyingInterface<T>
+        { }
+
+
+        public class GrainSpecifyingSameGenArgTwice<T> : BasicGrain, IGrainReceivingRepeatedGenArgs<T, T>
+        { }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task GenericGrainCanReuseOwnGenArgRepeatedly() 
+        {
+            //resolves correctly but can't be activated: too many gen args supplied for concrete class
+
+            var grain = GrainFactory.GetGrain<IGrainReceivingRepeatedGenArgs<int, int>>(Guid.NewGuid());
+
+            var concreteGenArgs = await GetConcreteGenArgs(grain);
+
+            Assert.IsTrue(
+                    concreteGenArgs.SequenceEqual(new[] { typeof(int) })
+                    );
+        }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task PartiallySpecifyingGenericInterfaceIsCastable() 
+        {
+            var grain = GrainFactory.GetGrain<IPartiallySpecifyingInterface<string>>(Guid.NewGuid());
+
+            await grain.Hello();
+
+            var castRef = grain.AsReference<IGrainWithTwoGenArgs<string, int>>();
+
+            var response = await castRef.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task PartiallySpecifyingGenericInterfaceIsCastable_Activating() 
+        {
+            var grain = GrainFactory.GetGrain<IPartiallySpecifyingInterface<string>>(Guid.NewGuid());
+
+            var castRef = grain.AsReference<IGrainWithTwoGenArgs<string, int>>();
+
+            var response = await castRef.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+
+
+
+
+        public interface IReceivingRepeatedGenArgsAmongstOthers<T1, T2, T3> : IBasicGrain
+        { }
+
+        public class SpecifyingRepeatedGenArgsAmongstOthers<T1, T2> : BasicGrain, IReceivingRepeatedGenArgsAmongstOthers<T2, T1, T2>
+        { }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task RepeatedRearrangedGenArgsResolved() 
+        {
+            //again resolves to the correct generic type definition, but fails on activation as too many args
+            //gen args aren't being properly inferred from matched concrete type
+
+            var grain = GrainFactory.GetGrain<IReceivingRepeatedGenArgsAmongstOthers<int, string, int>>(Guid.NewGuid());
+
+            var concreteGenArgs = await GetConcreteGenArgs(grain);
+
+            Assert.IsTrue(
+                    concreteGenArgs.SequenceEqual(new[] { typeof(string), typeof(int) })
+                    );
+        }
+
+
+
+
+        public interface IReceivingRepeatedGenArgsFromOtherInterface<T1, T2, T3> : IBasicGrain
+        { }
+
+        public interface ISpecifyingGenArgsRepeatedlyToParentInterface<T> : IReceivingRepeatedGenArgsFromOtherInterface<T, T, T>
+        { }
+
+        public class GrainForTestingCastingBetweenInterfacesWithReusedGenArgs : BasicGrain, ISpecifyingGenArgsRepeatedlyToParentInterface<bool>
+        { }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task RepeatedGenArgsWorkAmongstInterfacesInTypeResolution() 
+        {
+            var grain = GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
+
+            var concreteGenArgs = await GetConcreteGenArgs(grain);
+
+            Assert.IsTrue(
+                    concreteGenArgs.SequenceEqual(Enumerable.Empty<Type>())
+                    );
+        }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task RepeatedGenArgsWorkAmongstInterfacesInCasting() 
+        {
+            var grain = GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
+
+            await grain.Hello();
+
+            var castRef = grain.AsReference<ISpecifyingGenArgsRepeatedlyToParentInterface<bool>>();
+
+            var response = await castRef.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task RepeatedGenArgsWorkAmongstInterfacesInCasting_Activating() 
+        {
+            //Only errors on invocation: wrong arity again
+
+            var grain = GrainFactory.GetGrain<IReceivingRepeatedGenArgsFromOtherInterface<bool, bool, bool>>(Guid.NewGuid());
+
+            var castRef = grain.AsReference<ISpecifyingGenArgsRepeatedlyToParentInterface<bool>>();
+
+            var response = await castRef.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+
+
+        public interface IReceivingRearrangedGenArgs<T1, T2> : IBasicGrain
+        { }
+
+        public class SpecifyingSameGenArgsButRearranged<T1, T2> : BasicGrain, IReceivingRearrangedGenArgs<T2, T1>
+        { }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task RearrangedGenArgsOfCorrectArityAreResolved() 
+        {
+            var grain = GrainFactory.GetGrain<IReceivingRearrangedGenArgs<int, long>>(Guid.NewGuid());
+
+            var concreteGenArgs = await GetConcreteGenArgs(grain);
+
+            Assert.IsTrue(
+                    concreteGenArgs.SequenceEqual(new[] { typeof(long), typeof(int) })
+                    );
+        }
+
+
+
+
+        public interface IReceivingRearrangedGenArgsViaCast<T1, T2> : IBasicGrain
+        { }
+
+        public interface ISpecifyingRearrangedGenArgsToParentInterface<T1, T2> : IReceivingRearrangedGenArgsViaCast<T2, T1>
+        { }
+
+        public class GrainForTestingCastingWithRearrangedGenArgs<T1, T2> : BasicGrain, ISpecifyingRearrangedGenArgsToParentInterface<T1, T2>
+        { }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task RearrangedGenArgsOfCorrectNumberAreCastable() 
+        {
+            var grain = GrainFactory.GetGrain<ISpecifyingRearrangedGenArgsToParentInterface<int, long>>(Guid.NewGuid());
+
+            await grain.Hello();
+
+            var castRef = grain.AsReference<IReceivingRearrangedGenArgsViaCast<long, int>>();
+
+            var response = await castRef.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task RearrangedGenArgsOfCorrectNumberAreCastable_Activating() 
+        {
+            var grain = GrainFactory.GetGrain<ISpecifyingRearrangedGenArgsToParentInterface<int, long>>(Guid.NewGuid());
+
+            var castRef = grain.AsReference<IReceivingRearrangedGenArgsViaCast<long, int>>();
+
+            var response = await castRef.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+
+
+        //**************************************************************************************************************
+        //**************************************************************************************************************
+
+        //Below must be commented out, as supplying multiple fully-specified generic interfaces
+        //to a class causes the codegen to fall over, stopping all other tests from working.
+
+        //See new test here of the bit causing the issue - type info conflation:  
+        //UnitTests.CodeGeneration.CodeGeneratorTests.CodeGen_EncounteredFullySpecifiedInterfacesAreEncodedDistinctly()
+
+
+        //public interface IFullySpecifiedGenericInterface<T> : IBasicGrain
+        //{ }
+
+        //public interface IDerivedFromMultipleSpecializationsOfSameInterface : IFullySpecifiedGenericInterface<int>, IFullySpecifiedGenericInterface<long>
+        //{ }
+
+        //public class GrainFulfillingMultipleSpecializationsOfSameInterfaceViaIntermediate : BasicGrain, IDerivedFromMultipleSpecializationsOfSameInterface
+        //{ }
+
+
+        //[Fact, TestCategory("Generics")]
+        //public async Task CastingBetweenFullySpecifiedGenericInterfaces() 
+        //{
+        //    //Is this legitimate? Solely in the realm of virtual grain interfaces - no special knowledge of implementation implicated, only of interface hierarchy
+
+        //    //codegen falling over: duplicate key when both specializations are matched to same concrete type
+
+        //    var grain = GrainFactory.GetGrain<IDerivedFromMultipleSpecializationsOfSameInterface>(Guid.NewGuid());
+
+        //    await grain.Hello();
+
+        //    var castRef = grain.AsReference<IFullySpecifiedGenericInterface<int>>();
+
+        //    await castRef.Hello();
+
+        //    var castRef2 = castRef.AsReference<IFullySpecifiedGenericInterface<long>>();
+
+        //    await castRef2.Hello();
+        //}
+
+        //*******************************************************************************************************
+
+
+
+
+        public interface IArbitraryInterface<T1, T2> : IBasicGrain
+        { }
+
+        public interface IInterfaceUnrelatedToConcreteGenArgs<T> : IBasicGrain
+        { }
+
+        public class GrainWithGenArgsUnrelatedToFullySpecifiedGenericInterface<T1, T2> : BasicGrain, IArbitraryInterface<T1, T2>, IInterfaceUnrelatedToConcreteGenArgs<float>
+        { }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs() {
+            var grain = GrainFactory.GetGrain<IArbitraryInterface<int, long>>(Guid.NewGuid());
+
+            await grain.Hello();
+
+            var castRef = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
+
+            var response = await grain.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task CanCastToFullySpecifiedInterfaceUnrelatedToConcreteGenArgs_Activating() {
+            var grain = GrainFactory.GetGrain<IArbitraryInterface<int, long>>(Guid.NewGuid());
+
+            var castRef = grain.AsReference<IInterfaceUnrelatedToConcreteGenArgs<float>>();
+
+            var response = await grain.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+
+
+
+        public interface IInterfaceTakingFurtherSpecializedGenArg<T> : IBasicGrain
+        { }
+
+        public class GrainSupplyingFurtherSpecializedGenArg<T> : BasicGrain, IInterfaceTakingFurtherSpecializedGenArg<List<T>>
+        { }
+
+        public class GrainSupplyingGenArgSpecializedIntoArray<T> : BasicGrain, IInterfaceTakingFurtherSpecializedGenArg<T[]>
+        { }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task GenArgsCanBeFurtherSpecialized() {
+            var grain = GrainFactory.GetGrain<IInterfaceTakingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
+
+            var concreteGenArgs = await GetConcreteGenArgs(grain);
+
+            Assert.IsTrue(
+                    concreteGenArgs.SequenceEqual(new[] { typeof(int) })
+                    );
+        }
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task GenArgsCanBeFurtherSpecializedIntoArrays() {
+            var grain = GrainFactory.GetGrain<IInterfaceTakingFurtherSpecializedGenArg<long[]>>(Guid.NewGuid());
+
+            var concreteGenArgs = await GetConcreteGenArgs(grain);
+
+            Assert.IsTrue(
+                    concreteGenArgs.SequenceEqual(new[] { typeof(long) })
+                    );
+        }
+
+
+
+        public interface IAnotherReceivingFurtherSpecializedGenArg<T> : IBasicGrain
+        { }
+
+        public interface IYetOneMoreReceivingFurtherSpecializedGenArg<T> : IBasicGrain
+        { }
+
+        public class GrainForCastingBetweenInterfacesOfFurtherSpecializedGenArgs<T>
+            : BasicGrain, IAnotherReceivingFurtherSpecializedGenArg<List<T>>, IYetOneMoreReceivingFurtherSpecializedGenArg<T[]>
+        { }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task CanCastBetweenInterfacesWithFurtherSpecializedGenArgs() {
+            var grain = GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
+
+            await grain.Hello();
+
+            var castRef = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();
+
+            var response = await grain.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Generics")]
+        public async Task CanCastBetweenInterfacesWithFurtherSpecializedGenArgs_Activating() {
+            var grain = GrainFactory.GetGrain<IAnotherReceivingFurtherSpecializedGenArg<List<int>>>(Guid.NewGuid());
+
+            var castRef = grain.AsReference<IYetOneMoreReceivingFurtherSpecializedGenArg<int[]>>();
+
+            var response = await grain.Hello();
+
+            Assert.AreEqual(response, "Hello!");
+        }
+
+    }
+
+
+
 }

--- a/test/TesterInternal/CodeGeneratorTests.cs
+++ b/test/TesterInternal/CodeGeneratorTests.cs
@@ -7,6 +7,7 @@ using Orleans;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 using Xunit;
+using Orleans.CodeGeneration;
 
 // ReSharper disable ConvertToConstant.Local
 
@@ -101,6 +102,22 @@ namespace UnitTests.CodeGeneration
                 Assert.AreEqual(expected[i], actual[i], "Output list element #{0}", i);
             }
         }
+
+
+
+        public interface IFullySpecified<T> : IGrain
+        { }
+
+        [Fact(Skip = "Currently unsupported"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Generics")]
+        public void CodeGen_EncounteredFullySpecifiedInterfacesAreEncodedDistinctly() 
+        {
+            var id1 = GrainInterfaceUtils.ComputeInterfaceId(typeof(IFullySpecified<int>));
+            var id2 = GrainInterfaceUtils.ComputeInterfaceId(typeof(IFullySpecified<long>));
+
+            Assert.AreNotEqual(id1, id2);
+        }
+
+
     }
 }
 


### PR DESCRIPTION
Just spent an enjoyable evening writing out loads of pedantic generics tests, most of which are contrived edge cases, but are nevertheless in the spirit of normal .NET type behaviour. They all fail except for a couple, and all have been given the 'skip' argument. I've tried to generally cover concrete type resolution, and casting between references, both before and after activation.

I reckon they should all - in a perfect world - work. In an imperfect world, some should perhaps be "cleanly disallowed".

#1604 may interfere with many of them, but only one of the tests is solved by reverting it.

A point of interest is that one class declaration breaks the codegen, and has had to be commented out for any other tests to function. I've not looked into this properly, but suspect it's to do with some dictionary within RoslynCodeGen being keyed on interface typecode - and when the below class declaration is encountered, duplicate typecodes are produced and an exception is raised:

``class GrainClass : IGenericGrain<int>, IGenericGrain<string>``