### PR TITLE
Copy GrainFactory to new TestingSiloHost instance when not starting fresh

### DIFF
--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -584,6 +584,7 @@ namespace Orleans.TestingHost
                     this.ClientConfig = runningInstance.ClientConfig;
                     this.DeploymentId = runningInstance.DeploymentId;
                     this.DeploymentIdPrefix = runningInstance.DeploymentIdPrefix;
+                    this.GrainFactory = runningInstance.GrainFactory;
                     this.additionalSilos.AddRange(runningInstance.additionalSilos);
                     foreach (var additionalAssembly in runningInstance.additionalAssemblies)
                     {

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -215,6 +215,7 @@
     <Compile Include="StreamingTests\StreamFilteringTests.cs" />
     <Compile Include="StreamingTests\StreamGeneratorProviderTests.cs" />
     <Compile Include="StreamingTests\SubscriptionMultiplicityTestRunner.cs" />
+    <Compile Include="TestingHost\TestingSiloHostTests.cs" />
     <Compile Include="TestStreamProviders\Controllable\ControllableTestStreamProvider.cs" />
     <Compile Include="TestUtils.cs" />
   </ItemGroup>

--- a/test/Tester/TestingHost/TestingSiloHostTests.cs
+++ b/test/Tester/TestingHost/TestingSiloHostTests.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using Orleans.TestingHost;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace Tester.TestingHost
+{
+    public class TestingSiloHostTests
+    {
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Testing")]
+        public async Task AllowClusterReuseBetweenInvocations()
+        {
+            try
+            {
+                var host = new TestingSiloHost(startFreshOrleans: true);
+                var initialDeploymentId = host.DeploymentId;
+                var initialSilo = host.Primary.Silo;
+                var grain = host.GrainFactory.GetGrain<ISimpleGrain>(TestUtils.GetRandomGrainId());
+                await grain.GetA();
+
+                host = new TestingSiloHost(startFreshOrleans: false);
+                Assert.Equal(initialDeploymentId, host.DeploymentId);
+                Assert.Same(initialSilo, host.Primary.Silo);
+                grain = host.GrainFactory.GetGrain<ISimpleGrain>(TestUtils.GetRandomGrainId());
+                await grain.GetA();
+            }
+            finally
+            {
+                TestingSiloHost.StopAllSilosIfRunning();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This was a regression since 1.1.3, where the GrainFactory was available for the first test method that runs, but not for the subsequent, when not starting a fresh Orleans cluster.