### PR TITLE
TestingHost root namespace cleanup

### DIFF
--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -61,7 +61,7 @@
     <Compile Include="TestingClientOptions.cs" />
     <Compile Include="TestingSiloHost.cs" />
     <Compile Include="TestingSiloOptions.cs" />
-    <Compile Include="TestingUtils.cs" />
+    <Compile Include="Utils\TestingUtils.cs" />
     <Compile Include="Utils\ThreadSafeRandom.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -54,7 +54,7 @@
     <Compile Include="Extensions\TestConfigurationExtensions.cs" />
     <Compile Include="OrleansTestSecrets.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="AsyncResultHandle.cs" />
+    <Compile Include="Utils\AsyncResultHandle.cs" />
     <Compile Include="StorageEmulator.cs" />
     <Compile Include="StorageTestConstants.cs" />
     <Compile Include="SiloHandle.cs" />

--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -55,7 +55,7 @@
     <Compile Include="OrleansTestSecrets.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AsyncResultHandle.cs" />
-    <Compile Include="StorageEmulator.cs" />
+    <Compile Include="Utils\StorageEmulator.cs" />
     <Compile Include="StorageTestConstants.cs" />
     <Compile Include="SiloHandle.cs" />
     <Compile Include="TestingClientOptions.cs" />

--- a/src/OrleansTestingHost/Utils/AsyncResultHandle.cs
+++ b/src/OrleansTestingHost/Utils/AsyncResultHandle.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace Orleans.TestingHost
+namespace Orleans.TestingHost.Utils
 {
     /// <summary>
     /// This class is for internal testing use only.

--- a/src/OrleansTestingHost/Utils/StorageEmulator.cs
+++ b/src/OrleansTestingHost/Utils/StorageEmulator.cs
@@ -2,9 +2,8 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading;
 
-namespace Orleans.TestingHost
+namespace Orleans.TestingHost.Utils
 {
     /// <summary>
     /// A wrapper on Azure Storage Emulator.

--- a/src/OrleansTestingHost/Utils/TestingUtils.cs
+++ b/src/OrleansTestingHost/Utils/TestingUtils.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Orleans.TestingHost
+namespace Orleans.TestingHost.Utils
 {
     public static class TestingUtils
     {

--- a/test/Tester/ObserverTests.cs
+++ b/test/Tester/ObserverTests.cs
@@ -4,6 +4,7 @@ using Orleans.TestingHost;
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Orleans.TestingHost.Utils;
 using Tester;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;

--- a/test/Tester/SerializationTests/SerializationTests.DifferentTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.DifferentTypes.cs
@@ -5,6 +5,7 @@ using Xunit;
 using Orleans.Serialization;
 using System.Collections.Generic;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 
 namespace UnitTests.Serialization
 {

--- a/test/Tester/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Tester/StreamingTests/ClientStreamTestRunner.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Streams;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using UnitTests.GrainInterfaces;
 using Xunit;
 

--- a/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -9,6 +9,7 @@ using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using TestGrainInterfaces;
 using TestGrains;
 using Tester;

--- a/test/Tester/StreamingTests/DeactivationTestRunner.cs
+++ b/test/Tester/StreamingTests/DeactivationTestRunner.cs
@@ -5,6 +5,7 @@ using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.StreamingTests

--- a/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
+++ b/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
@@ -16,6 +16,7 @@ using Orleans.ServiceBus.Providers;
 using Orleans.Storage;
 using Orleans.Streams;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using TestGrainInterfaces;
 using TestGrains;
 using UnitTests.Grains;

--- a/test/Tester/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
+++ b/test/Tester/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using TestGrainInterfaces;
 using UnitTests.Grains;
 

--- a/test/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/test/Tester/StreamingTests/SampleStreamingTests.cs
@@ -5,6 +5,7 @@ using Orleans;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Runtime;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using Tester;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;

--- a/test/Tester/StreamingTests/StreamFilteringTests.cs
+++ b/test/Tester/StreamingTests/StreamFilteringTests.cs
@@ -10,6 +10,7 @@ using Orleans;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using UnitTests.GrainInterfaces;
 using UnitTests.StreamingTests;
 using UnitTests.Tester;

--- a/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
@@ -10,6 +10,7 @@ using Orleans;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Streams;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using TestGrainInterfaces;
 using TestGrains;
 using Tester;

--- a/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Orleans.TestingHost.Utils;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.StreamingTests

--- a/test/Tester/TestUtils.cs
+++ b/test/Tester/TestUtils.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using Xunit;
 
 namespace Tester

--- a/test/TesterInternal/General/Identifiertests.cs
+++ b/test/TesterInternal/General/Identifiertests.cs
@@ -7,6 +7,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/TesterInternal/OrleansRuntime/ExceptionsTests.cs
+++ b/test/TesterInternal/OrleansRuntime/ExceptionsTests.cs
@@ -6,6 +6,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using Xunit;
 
 namespace UnitTests.OrleansRuntime

--- a/test/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
+++ b/test/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
@@ -8,6 +8,7 @@ using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using Orleans;
 using Orleans.AzureUtils;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
+++ b/test/TesterInternal/StorageTests/AzureTableDataManagerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.WindowsAzure.Storage.Shared.Protocol;
 using Microsoft.WindowsAzure.Storage.Table.Protocol;
 using Orleans.AzureUtils;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using Xunit;
 
 namespace UnitTests.StorageTests

--- a/test/TesterInternal/StreamingTests/HaloStreamSubscribeTests.cs
+++ b/test/TesterInternal/StreamingTests/HaloStreamSubscribeTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using UnitTests.GrainInterfaces;
 using UnitTests.StreamingTests;
 using UnitTests.Tester;

--- a/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/TesterInternal/StreamingTests/SingleStreamTestRunner.cs
@@ -5,6 +5,7 @@ using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using Tester;
 using UnitTests.Grains;
 using UnitTests.Tester;


### PR DESCRIPTION
Moved some utilities to a non-root namespace (TestingHost.Utils) that already existed.