### PR TITLE
Stream consumers on lost clients

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -1024,6 +1024,7 @@ namespace Orleans
         Stream_ProducerIsDead                       = StreamProviderManagerBase + 6,
         StreamProvider_NoStreamForBatch             = StreamProviderManagerBase + 7,
         StreamProvider_ConsumerFailedToUnregister   = StreamProviderManagerBase + 8,
+        Stream_ConsumerIsDead                       = StreamProviderManagerBase + 9,
 
         PersistentStreamPullingManagerBase = Runtime + 3500,
         PersistentStreamPullingManager_01 = PersistentStreamPullingManagerBase + 1,

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
@@ -48,7 +48,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         private async Task<ISet<PubSubSubscriptionState>> RegisterProducer()
         {
             var tup = await providerRuntime.BindExtension<SimpleMessageStreamProducerExtension, IStreamProducerExtension>(
-                () => new SimpleMessageStreamProducerExtension(providerRuntime, fireAndForgetDelivery));
+                () => new SimpleMessageStreamProducerExtension(providerRuntime, pubSub, fireAndForgetDelivery));
 
             myExtension = tup.Item1;
             myGrainReference = tup.Item2;

--- a/src/OrleansAzureUtils/Providers/Streams/PersistentStreams/StreamDeliveryFailureEntity.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/PersistentStreams/StreamDeliveryFailureEntity.cs
@@ -40,7 +40,15 @@ namespace Orleans.Providers.Streams.PersistentStreams
         /// </summary>
         public virtual void SetPartitionKey(string deploymentId)
         {
-            PartitionKey = String.Format("DeliveryFailure_{0}_{1}", StreamProviderName, deploymentId);
+            PartitionKey = MakeDefaultPartitionKey(StreamProviderName, deploymentId);
+        }
+
+        /// <summary>
+        /// Default partition key
+        /// </summary>
+        public static string MakeDefaultPartitionKey(string streamProviderName, string deploymentId)
+        {
+            return $"DeliveryFailure_{streamProviderName}_{deploymentId}";
         }
 
         /// <summary>
@@ -48,7 +56,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
         /// </summary>
         public virtual void SetRowkey()
         {
-            RowKey = String.Format("{0:x16}_{1}", ReverseOrderTimestampTicks(), Guid.NewGuid());
+            RowKey = $"{ReverseOrderTimestampTicks():x16}_{Guid.NewGuid()}";
         }
 
         /// <summary>
@@ -79,20 +87,20 @@ namespace Orleans.Providers.Streams.PersistentStreams
         ///  key with some other field (stream namespace?).
         /// </remarks>
         /// <returns></returns>
-        static protected long ReverseOrderTimestampTicks()
+        protected static long ReverseOrderTimestampTicks()
         {
             var now = DateTime.UtcNow;
             return DateTime.MaxValue.Ticks - now.Ticks;
         }
 
-        static private byte[] GetTokenBytes(StreamSequenceToken token)
+        private static byte[] GetTokenBytes(StreamSequenceToken token)
         {
             var bodyStream = new BinaryTokenStreamWriter();
             SerializationManager.Serialize(token, bodyStream);
             return bodyStream.ToByteArray();
         }
 
-        static private StreamSequenceToken TokenFromBytes(byte[] bytes)
+        private static StreamSequenceToken TokenFromBytes(byte[] bytes)
         {
             var stream = new BinaryTokenStreamReader(bytes);
             return SerializationManager.Deserialize<StreamSequenceToken>(stream);

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -501,7 +501,7 @@ namespace Orleans.Runtime
             }
             catch (Exception ex)
             {
-                if (!(ex.GetBaseException() is KeyNotFoundException))
+                if (ShouldLogError(ex))
                 {
                     logger.Error(ErrorCode.Dispatcher_SelectTarget_Failed,
                         String.Format("SelectTarget failed with {0}", ex.Message),
@@ -510,6 +510,12 @@ namespace Orleans.Runtime
                 MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedError(message, "SelectTarget failed");
                 RejectMessage(message, Message.RejectionTypes.Unrecoverable, ex);
             }
+        }
+
+        private bool ShouldLogError(Exception ex)
+        {
+            return !(ex.GetBaseException() is KeyNotFoundException) &&
+                   !(ex.GetBaseException() is ClientNotAvailableException);
         }
 
         // this is a compatibility method for portions of the code base that don't use

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/SegmentBuilder.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/SegmentBuilder.cs
@@ -80,7 +80,7 @@ namespace Orleans.ServiceBus.Providers
             else
             {
                 var bytes = new byte[str.Length * sizeof(char)];
-                Array.Copy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
+                Buffer.BlockCopy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
                 Append(segment, ref writerOffset, bytes);
             }
         }
@@ -123,7 +123,7 @@ namespace Orleans.ServiceBus.Providers
                 return string.Empty;
             }
             var chars = new char[size / sizeof(char)];
-            Array.Copy(segment.Array, segment.Offset + readerOffset, chars, 0, size);
+            Buffer.BlockCopy(segment.Array, segment.Offset + readerOffset, chars, 0, size);
             readerOffset += size;
             return new string(chars);
         }

--- a/test/TestGrains/SampleStreamingGrain.cs
+++ b/test/TestGrains/SampleStreamingGrain.cs
@@ -99,12 +99,12 @@ namespace UnitTests.Grains
             return producerTimer != null? Fire(): TaskDone.Done;
         }
 
-        private Task Fire([CallerMemberName] string caller = null)
+        private async Task Fire([CallerMemberName] string caller = null)
         {
+            RequestContext.Set(RequestContextKey, RequestContextValue);
+            await producer.OnNextAsync(numProducedItems);
             numProducedItems++;
             logger.Info("{0} (item={1})", caller, numProducedItems);
-            RequestContext.Set(RequestContextKey, RequestContextValue);
-            return producer.OnNextAsync(numProducedItems);
         }
 
         public override Task OnDeactivateAsync()

--- a/test/Tester/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Tester/StreamingTests/ClientStreamTestRunner.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Streams;
@@ -6,11 +7,13 @@ using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
 using UnitTests.GrainInterfaces;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Tester.StreamingTests
 {
     public class ClientStreamTestRunner
     {
+        private static readonly Func<Task<int>> DefaultDeliveryFailureCount = () => Task.FromResult(0); 
         private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(30);
 
         private readonly TestCluster testHost;
@@ -39,6 +42,73 @@ namespace Tester.StreamingTests
             await ProduceEventsFromClient(streamProviderName, streamGuid, streamNamespace, eventsProduced);
         }
 
+        public async Task StreamConsumerOnDroppedClientTest(string streamProviderName, string streamNamespace, ITestOutputHelper output, Func<Task<int>> getDeliveryFailureCount = null, bool waitForRetryTimeouts = false)
+        {
+            getDeliveryFailureCount = getDeliveryFailureCount ?? DefaultDeliveryFailureCount;
+
+            Guid streamGuid = Guid.NewGuid();
+            int eventCount = 0;
+
+            // become stream consumers
+            await SubscribeToStream(streamProviderName, streamGuid, streamNamespace,
+                (e, t) => { eventCount++; return TaskDone.Done; });
+
+            // setup producer
+            var producer = GrainClient.GrainFactory.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+
+            // produce some events
+            await producer.StartPeriodicProducing();
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
+            await producer.StopPeriodicProducing();
+
+            // check counts
+            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(() => Task.FromResult(eventCount), producer.GetNumberProduced, lastTry), _timeout);
+
+            // Hard kill client
+            testHost.KillClient();
+
+            // make sure dead client has had time to drop
+            await Task.Delay(testHost.ClusterConfiguration.Globals.ClientDropTimeout + TimeSpan.FromSeconds(5));
+
+            // initialize new client
+            testHost.InitializeClient();
+
+            eventCount = 0;
+
+            // become stream consumers
+            await SubscribeToStream(streamProviderName, streamGuid, streamNamespace,
+                (e, t) => { eventCount++; return TaskDone.Done; });
+
+            // setup producer
+            producer = GrainClient.GrainFactory.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+
+            // produce more events
+            await producer.StartPeriodicProducing();
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
+            await producer.StopPeriodicProducing();
+
+            // give strem retry policy time to fail
+            if (waitForRetryTimeouts)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(90));
+            }
+
+            // check counts
+            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(() => Task.FromResult(eventCount), producer.GetNumberProduced, lastTry), _timeout);
+            int deliveryFailureCount = await getDeliveryFailureCount();
+            Assert.Equal(0, deliveryFailureCount);
+        }
+
+        private Task SubscribeToStream(string streamProviderName, Guid streamGuid, string streamNamespace,
+            Func<int, StreamSequenceToken, Task> onNextAsync)
+        {
+            IStreamProvider streamProvider = GrainClient.GetStreamProvider(streamProviderName);
+            IAsyncObservable<int> stream = streamProvider.GetStream<int>(streamGuid, streamNamespace);
+            return stream.SubscribeAsync(onNextAsync);
+        }
+
         private async Task ProduceEventsFromClient(string streamProviderName, Guid streamGuid, string streamNamespace, int eventsProduced)
         {
             // get reference to a consumer
@@ -51,7 +121,7 @@ namespace Tester.StreamingTests
             await GenerateEvents(streamProviderName, streamGuid, streamNamespace, eventsProduced);
 
             // make sure all went well
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(consumer, eventsProduced, lastTry), _timeout);
+            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(() => consumer.GetNumberConsumed(), () => Task.FromResult(eventsProduced), lastTry), _timeout);
         }
 
         private async Task GenerateEvents(string streamProviderName, Guid streamGuid, string streamNamespace, int produceCount)
@@ -64,9 +134,10 @@ namespace Tester.StreamingTests
             }
         }
 
-        private async Task<bool> CheckCounters(ISampleStreaming_ConsumerGrain consumer, int eventsProduced, bool assertIsTrue)
+        private async Task<bool> CheckCounters(Func<Task<int>> getConsumed, Func<Task<int>> getProduced, bool assertIsTrue)
         {
-            var numConsumed = await consumer.GetNumberConsumed();
+            int eventsProduced = await getProduced();
+            int numConsumed = await getConsumed();
             if (!assertIsTrue) return eventsProduced == numConsumed;
             Assert.Equal(eventsProduced, numConsumed);
             return true;

--- a/test/Tester/StreamingTests/SMSClientStreamTests.cs
+++ b/test/Tester/StreamingTests/SMSClientStreamTests.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿
+using System;
 using System.Threading.Tasks;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using UnitTests.StreamingTests;
 using UnitTests.Tester;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Tester.StreamingTests
 {
@@ -12,7 +14,14 @@ namespace Tester.StreamingTests
     {
         private const string SMSStreamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
         private const string StreamNamespace = "SMSDeactivationTestsNamespace";
-        private ClientStreamTestRunner runner;
+        private readonly ITestOutputHelper output;
+        private readonly ClientStreamTestRunner runner;
+
+        public SMSClientStreamTests(ITestOutputHelper output)
+        {
+            this.output = output;
+            runner = new ClientStreamTestRunner(this.HostedCluster);
+        }
 
         public override TestCluster CreateTestCluster()
         {
@@ -25,16 +34,18 @@ namespace Tester.StreamingTests
             return new TestCluster(options);
         }
 
-        public SMSClientStreamTests()
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task SMSStreamProducerOnDroppedClientTest()
         {
-            runner = new ClientStreamTestRunner(this.HostedCluster);
+            logger.Info("************************ SMSStreamProducerOnDroppedClientTest *********************************");
+            await runner.StreamProducerOnDroppedClientTest(SMSStreamProviderName, StreamNamespace);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task MSMStreamProducerOnDroppedClientTest()
+        public async Task SMSStreamConsumerOnDroppedClientTest()
         {
-            logger.Info("************************ SMSDeactivationTest *********************************");
-            await runner.StreamProducerOnDroppedClientTest(SMSStreamProviderName, StreamNamespace);
+            logger.Info("************************ SMSStreamConsumerOnDroppedClientTest *********************************");
+            await runner.StreamConsumerOnDroppedClientTest(SMSStreamProviderName, StreamNamespace, output);
         }
     }
 }

--- a/test/Tester/TestStreamProviders/AzureQueue/TestAzureQueueStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/AzureQueue/TestAzureQueueStreamProvider.cs
@@ -1,0 +1,17 @@
+﻿
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Providers.Streams.Common;
+
+namespace Tester.TestStreamProviders.AzureQueue
+{
+    public class TestAzureQueueStreamProvider : PersistentStreamProvider<TestAzureQueueStreamProvider.AdapterFactory>
+    {
+        public class AdapterFactory : AzureQueueAdapterFactory
+        {
+            public AdapterFactory()
+            {
+                StreamFailureHandlerFactory = qid => TestAzureTableStorageStreamFailureHandler.Create();
+            }
+        }
+    }
+}

--- a/test/Tester/TestStreamProviders/EventHub/TestEventHubStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/EventHub/TestEventHubStreamProvider.cs
@@ -1,0 +1,17 @@
+﻿
+using Orleans.Providers.Streams.Common;
+using Orleans.ServiceBus.Providers;
+
+namespace Tester.TestStreamProviders.EventHub
+{
+    public class TestEventHubStreamProvider : PersistentStreamProvider<TestEventHubStreamProvider.AdapterFactory>
+    {
+        public class AdapterFactory : EventHubAdapterFactory
+        {
+            public AdapterFactory()
+            {
+                StreamFailureHandlerFactory = qid => TestAzureTableStorageStreamFailureHandler.Create();
+            }
+        }
+    }
+}

--- a/test/Tester/TestStreamProviders/TestAzureTableStorageStreamFailureHandler.cs
+++ b/test/Tester/TestStreamProviders/TestAzureTableStorageStreamFailureHandler.cs
@@ -1,0 +1,49 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Table;
+using Orleans.AzureUtils;
+using Orleans.Providers.Streams.PersistentStreams;
+using Orleans.Streams;
+using Orleans.TestingHost;
+
+namespace Tester.TestStreamProviders
+{
+    public class TestAzureTableStorageStreamFailureHandler : AzureTableStorageStreamFailureHandler<StreamDeliveryFailureEntity>
+    {
+        private const string TableName = "TestStreamFailures";
+        private const string DeploymentId = "TestDeployment";
+
+        private TestAzureTableStorageStreamFailureHandler()
+            : base(false, DeploymentId, TableName, StorageTestConstants.DataConnectionString)
+        {
+        }
+
+        public static async Task<IStreamFailureHandler> Create()
+        {
+            var failureHandler = new TestAzureTableStorageStreamFailureHandler();
+            await failureHandler.InitAsync();
+            return failureHandler;
+        }
+
+        public static async Task<int> GetDeliveryFailureCount(string streamProviderName)
+        {
+            var dataManager = new AzureTableDataManager<TableEntity>(TableName, StorageTestConstants.DataConnectionString);
+            dataManager.InitTableAsync().Wait();
+            IEnumerable<Tuple<TableEntity, string>> deliveryErrors =
+                await
+                    dataManager.ReadAllTableEntriesForPartitionAsync(
+                        StreamDeliveryFailureEntity.MakeDefaultPartitionKey(streamProviderName, DeploymentId));
+            return deliveryErrors.Count();
+        }
+
+        public static async Task DeleteAll()
+        {
+            var dataManager = new AzureTableDataManager<TableEntity>(TableName, StorageTestConstants.DataConnectionString);
+            await dataManager.InitTableAsync();
+            await dataManager.DeleteTableAsync();
+        }
+    }
+}

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -215,8 +215,11 @@
     <Compile Include="StreamingTests\StreamFilteringTests.cs" />
     <Compile Include="StreamingTests\StreamGeneratorProviderTests.cs" />
     <Compile Include="StreamingTests\SubscriptionMultiplicityTestRunner.cs" />
+    <Compile Include="TestStreamProviders\AzureQueue\TestAzureQueueStreamProvider.cs" />
     <Compile Include="TestingHost\TestingSiloHostTests.cs" />
     <Compile Include="TestStreamProviders\Controllable\ControllableTestStreamProvider.cs" />
+    <Compile Include="TestStreamProviders\EventHub\TestEventHubStreamProvider.cs" />
+    <Compile Include="TestStreamProviders\TestAzureTableStorageStreamFailureHandler.cs" />
     <Compile Include="TestUtils.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Added basic tests demonstrating issues with losing clients that are consuming from streams.
Fixed sms and azure queue and event hub stream providers to handle delivery failures to loss clients.
Azure queue test is disabled as it does not work well yet due to issues unrelated to this PR or client stream consumers.