### PR TITLE
Add GetPrimaryKeyString extension method for IAddressable

### DIFF
--- a/src/Orleans/Core/GrainExtensions.cs
+++ b/src/Orleans/Core/GrainExtensions.cs
@@ -130,6 +130,7 @@ namespace Orleans
         {
             return GetGrainId(grain).GetPrimaryKeyLong();
         }
+
         /// <summary>
         /// Returns the Guid representation of a grain primary key.
         /// </summary>
@@ -149,6 +150,16 @@ namespace Orleans
         public static Guid GetPrimaryKey(this IAddressable grain)
         {
             return GetGrainId(grain).GetPrimaryKey();
+        }
+
+        /// <summary>
+        /// Returns the string primary key of the grain.
+        /// </summary>
+        /// <param name="grain">The grain to find the primary key for.</param>
+        /// <returns>A string representing the primary key for this grain.</returns>
+        public static string GetPrimaryKeyString(this IAddressable grain)
+        {
+            return GetGrainId(grain).GetPrimaryKeyString();
         }
 
         public static long GetPrimaryKeyLong(this IGrain grain, out string keyExt)

--- a/test/Tester/KeyExtensionTests.cs
+++ b/test/Tester/KeyExtensionTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using Orleans;
+using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
 using Xunit;
@@ -109,6 +110,25 @@ namespace UnitTests.General
             var remoteGrainRef = await localGrainRef.GetGrainReference();
 
             Assert.AreEqual(localGrainRef, remoteGrainRef, "Mismatched grain ID.");
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        public void GetPrimaryKeyStringOnGrainReference()
+        {
+            const string key = "foo";
+
+            var grain = GrainClient.GrainFactory.GetGrain<IStringGrain>(key);
+            var key2 = ((GrainReference) grain).GetPrimaryKeyString();
+
+            Assert.AreEqual(key, key2, "Unexpected key was returned.");
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        public void GetPrimaryKeyStringOnWrongGrainReference()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ISimpleGrain>(0);
+            var key = ((GrainReference)grain).GetPrimaryKeyString();
+            Assert.IsNull(key);
         }
     }
 }


### PR DESCRIPTION
This is only for API completion. `Guid GetPrimaryKey(this IAddressable grain, out string keyExt)` already does the same but in a cruder form.