### PR TITLE
[On Hold] Add symbols to NuGet packages

### DIFF
--- a/src/NuGet/CreateOrleansPackages.bat
+++ b/src/NuGet/CreateOrleansPackages.bat
@@ -49,7 +49,7 @@ if not "%VERSION_BETA%" == "" ( set VERSION=%VERSION%-%VERSION_BETA% )
 REM @set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -Verbosity detailed
 
 FOR %%G IN ("%~dp0*.nuspec") DO (
-  "%NUGET_EXE%" pack "%%G" %NUGET_PACK_OPTS% -Symbols
+  "%NUGET_EXE%" pack "%%G" %NUGET_PACK_OPTS%
   if ERRORLEVEL 1 EXIT /B 1
 )
 

--- a/src/NuGet/Microsoft.Orleans.Core.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Core.nuspec
@@ -25,6 +25,5 @@
     <file src="Orleans.dll" target="lib\net451" />
     <file src="Orleans.pdb" target="lib\net451" />
 	  <file src="Orleans.xml" target="lib\net451" />
-    <file src="$SRC_DIR$Orleans\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
+++ b/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
@@ -28,6 +28,5 @@
     <file src="OrleansCounterControl.exe" target="lib\net451" />
     <file src="OrleansCounterControl.pdb" target="lib\net451" />
     <file src="OrleansCounterControl.exe.config" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansCounterControl\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.EventSourcing.nuspec
+++ b/src/NuGet/Microsoft.Orleans.EventSourcing.nuspec
@@ -25,6 +25,5 @@
     <file src="OrleansEventSourcing.dll" target="lib\net451" />
     <file src="OrleansEventSourcing.pdb" target="lib\net451" />
     <file src="OrleansEventSourcing.xml" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansEventSourcing\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -29,6 +29,5 @@
     <file src="OrleansAzureUtils.dll" target="lib\net451" />
     <file src="OrleansAzureUtils.pdb" target="lib\net451" />
     <file src="OrleansAzureUtils.xml" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansAzureUtils\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
@@ -24,6 +24,5 @@
   </metadata>
   <files>
     <file src="OrleansCodeGenerator.dll" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansCodeGenerator\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
@@ -26,6 +26,5 @@
     <file src="OrleansHost.exe" target="lib\net451" />
     <file src="OrleansHost.pdb" target="lib\net451" />
     <file src="OrleansHost.exe.config" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansHost\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
@@ -26,6 +26,5 @@
     <file src="OrleansManager.pdb" target="lib\net451" />
     <file src="OrleansManager.exe.config" target="lib\net451" />
     <file src="ClientConfiguration.xml" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansManager\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
@@ -24,6 +24,5 @@
   <files>
     <file src="OrleansProviders.dll" target="lib\net451" />
     <file src="OrleansProviders.pdb" target="lib\net451" />    
-    <file src="$SRC_DIR$OrleansProviders\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
@@ -24,9 +24,7 @@
   <files>
     <file src="OrleansRuntime.dll" target="lib\net451" />
     <file src="OrleansRuntime.pdb" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansRuntime\**\*.cs" target="src" />
     <file src="OrleansDependencyInjection.dll" target="lib\net451" />
     <file src="OrleansDependencyInjection.pdb" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansDependencyInjection\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
@@ -29,6 +29,5 @@
   <files>
     <file src="OrleansServiceBus.dll" target="lib\net451" />
     <file src="OrleansServiceBus.pdb" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansServiceBus\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -26,6 +26,5 @@
   <files>
     <file src="OrleansZooKeeperUtils.dll" target="lib\net451" />
     <file src="OrleansZooKeeperUtils.pdb" target="lib\net451" />
-    <file src="$SRC_DIR$OrleansZooKeeperUtils\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.Serialization.Bond.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Serialization.Bond.nuspec
@@ -29,6 +29,5 @@
     <file src="OrleansBondUtils.xml" target="lib\net451" />
     <file src="BondSerializerInstall.ps1" target="tools\Install.ps1" />
     <file src="BondSerializerUninstall.ps1" target="tools\Uninstall.ps1" />
-    <file src="$SRC_DIR$OrleansBondUtils\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
@@ -26,7 +26,5 @@
   <files>
     <file src="OrleansTestingHost.dll" target="lib\net451" />
     <file src="OrleansTestingHost.pdb" target="lib\net451" />
-    
-    <file src="$SRC_DIR$OrleansTestingHost\**\*.cs" target="src" />
   </files>
 </package>


### PR DESCRIPTION
With SymbolSource.org being completely down and symbols package we publish disappearing in a black hole, the only viable solution at the moment appears to be to include symbols into the NuGet packages themselves.

PDBs were already included in the .nuspec files. This change only removes sources from them and removes the "-Symbols" flag from the "nuget.exe pack" command. As a result, PDBs end up in the main packages instead of the separate symbols packages.