### PR TITLE
Generic GrainReferences, Part II

### DIFF
--- a/src/Orleans/CodeGeneration/InvokeMethodRequest.cs
+++ b/src/Orleans/CodeGeneration/InvokeMethodRequest.cs
@@ -11,14 +11,19 @@ namespace Orleans.CodeGeneration
     {
         /// <summary> InterfaceId for this Invoke request. </summary>
         public int InterfaceId { get; private set; }
+        /// <summary> Full name of interface, including generic args - only used when interface is generic and InterfaceId is insufficient. </summary>
+        public string InterfaceGenArgs { get; private set; }
+
         /// <summary> MethodId for this Invoke request. </summary>
         public int MethodId { get; private set; }
+
         /// <summary> Arguments for this Invoke request. </summary>
         public object[] Arguments { get; private set; }
 
-        internal InvokeMethodRequest(int interfaceId, int methodId, object[] arguments)
+        internal InvokeMethodRequest(int interfaceId, string interfaceGenArgs, int methodId, object[] arguments)
         {
             InterfaceId = interfaceId;
+            InterfaceGenArgs = interfaceGenArgs;
             MethodId = methodId;
             Arguments = arguments;
         }

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -256,7 +256,7 @@ namespace Orleans.Runtime
         /// Return the name of the interface for this GrainReference. 
         /// Implemented in Orleans generated code.
         /// </summary>
-        public virtual string InterfaceName
+        public virtual string InterfaceName   //Just used for debug info
         {
             get
             {
@@ -316,7 +316,7 @@ namespace Orleans.Runtime
                 argsDeepCopy = (object[])SerializationManager.DeepCopy(arguments);
             }
             
-            var request = new InvokeMethodRequest(this.InterfaceId, methodId, argsDeepCopy);
+            var request = new InvokeMethodRequest(this.InterfaceId, this.GenericArguments, methodId, argsDeepCopy);
 
             if (IsUnordered)
                 options |= InvokeMethodOptions.Unordered;
@@ -349,7 +349,7 @@ namespace Orleans.Runtime
             bool isOneWayCall = ((options & InvokeMethodOptions.OneWay) != 0);
 
             var resolver = isOneWayCall ? null : new TaskCompletionSource<object>();
-            RuntimeClient.Current.SendRequest(this, request, resolver, ResponseCallback, debugContext, options, GenericArguments); //and doesn't this trigger activation too?
+            RuntimeClient.Current.SendRequest(this, request, resolver, ResponseCallback, debugContext, options, ActivatingGenArgs);
             return isOneWayCall ? null : resolver.Task;
         }
 

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -14,8 +14,8 @@ namespace Orleans.Runtime
     [Serializable]
     public class GrainReference : IAddressable, IEquatable<GrainReference>, ISerializable
     {
-        private readonly string genericArguments;
         private readonly GuidId observerId;
+        private readonly string genericArgs;
         
         [NonSerialized]
         private static readonly TraceLogger logger = TraceLogger.GetLogger("GrainReference", TraceLogger.LoggerType.Runtime);
@@ -33,7 +33,7 @@ namespace Orleans.Runtime
 
         internal GuidId ObserverId { get { return observerId; } }
         
-        private bool HasGenericArgument { get { return !String.IsNullOrEmpty(genericArguments); } }
+        internal bool HasGenericArgument { get { return !String.IsNullOrEmpty(GenericArguments); } }
 
         internal GrainId GrainId { get; private set; }
 
@@ -56,15 +56,15 @@ namespace Orleans.Runtime
         /// Constructs a reference to the grain with the specified Id.
         /// </summary>
         /// <param name="grainId">The Id of the grain to refer to.</param>
-        private GrainReference(GrainId grainId, string genericArgument, SiloAddress systemTargetSilo, GuidId observerId)
+        private GrainReference(GrainId grainId, string genericArguments, SiloAddress systemTargetSilo, GuidId observerId)
         {
             GrainId = grainId;
-            genericArguments = genericArgument;
+            genericArgs = genericArguments;
             SystemTargetSilo = systemTargetSilo;
             this.observerId = observerId;
-            if (String.IsNullOrEmpty(genericArgument))
+            if (String.IsNullOrEmpty(genericArguments))
             {
-                genericArguments = null; // always keep it null instead of empty.
+                genericArgs = null; // always keep it null instead of empty.
             }
 
             // SystemTarget checks
@@ -111,7 +111,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="other">The reference to copy.</param>
         protected GrainReference(GrainReference other)
-            : this(other.GrainId, other.genericArguments, other.SystemTargetSilo, other.ObserverId) { }
+            : this(other.GrainId, other.GenericArguments, other.SystemTargetSilo, other.ObserverId) { }
 
         #endregion
 
@@ -166,7 +166,7 @@ namespace Orleans.Runtime
             if (other == null)
                 return false;
 
-            if (genericArguments != other.genericArguments)
+            if (GenericArguments != other.GenericArguments)
                 return false;
             if (!GrainId.Equals(other.GrainId))
             {
@@ -268,7 +268,18 @@ namespace Orleans.Runtime
                 throw new InvalidOperationException("Should be overridden by subclass");
             }
         }
-
+        
+        /// <summary>
+        /// Return the generic type arguments of the interface as a string
+        /// Implemented in generated code.
+        /// </summary>
+        protected virtual string GenericArguments {
+            get 
+            {
+                return genericArgs;
+            }
+        }
+        
         /// <summary>
         /// Return the method name associated with the specified interfaceId and methodId values.
         /// </summary>
@@ -337,7 +348,7 @@ namespace Orleans.Runtime
             bool isOneWayCall = ((options & InvokeMethodOptions.OneWay) != 0);
 
             var resolver = isOneWayCall ? null : new TaskCompletionSource<object>();
-            RuntimeClient.Current.SendRequest(this, request, resolver, ResponseCallback, debugContext, options, genericArguments);
+            RuntimeClient.Current.SendRequest(this, request, resolver, ResponseCallback, debugContext, options, GenericArguments);
             return isOneWayCall ? null : resolver.Task;
         }
 
@@ -526,7 +537,7 @@ namespace Orleans.Runtime
             // store as null, serialize as empty.
             var genericArg = String.Empty;
             if (input.HasGenericArgument)
-                genericArg = input.genericArguments;
+                genericArg = input.GenericArguments;
             stream.Write(genericArg);
         }
 
@@ -585,7 +596,7 @@ namespace Orleans.Runtime
                 return String.Format("{0}:{1}/{2}", OBSERVER_ID_STR, GrainId, observerId);
             }
             return String.Format("{0}:{1}{2}", GRAIN_REFERENCE_STR, GrainId,
-                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", genericArguments)); 
+                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", GenericArguments)); 
         }
 
         internal string ToDetailedString()
@@ -599,7 +610,7 @@ namespace Orleans.Runtime
                 return String.Format("{0}:{1}/{2}", OBSERVER_ID_STR, GrainId.ToDetailedString(), observerId.ToDetailedString());
             }
             return String.Format("{0}:{1}{2}", GRAIN_REFERENCE_STR, GrainId.ToDetailedString(),
-                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", genericArguments)); 
+                   !HasGenericArgument ? String.Empty : String.Format("<{0}>", GenericArguments)); 
         }
 
 
@@ -616,7 +627,7 @@ namespace Orleans.Runtime
             }
             if (HasGenericArgument)
             {
-                return String.Format("{0}={1} {2}={3}", GRAIN_REFERENCE_STR, GrainId.ToParsableString(), GENERIC_ARGUMENTS_STR, genericArguments);
+                return String.Format("{0}={1} {2}={3}", GRAIN_REFERENCE_STR, GrainId.ToParsableString(), GENERIC_ARGUMENTS_STR, GenericArguments);
             }
             return String.Format("{0}={1}", GRAIN_REFERENCE_STR, GrainId.ToParsableString());
         }
@@ -682,7 +693,7 @@ namespace Orleans.Runtime
             }
             string genericArg = String.Empty;
             if (HasGenericArgument)
-                genericArg = genericArguments;
+                genericArg = GenericArguments;
             info.AddValue("GenericArguments", genericArg, typeof(string));
         }
 
@@ -705,9 +716,22 @@ namespace Orleans.Runtime
             var genericArg = info.GetString("GenericArguments");
             if (String.IsNullOrEmpty(genericArg))
                 genericArg = null;
-            genericArguments = genericArg;
+            genericArgs = genericArg;
         }
 
         #endregion
+
+
+        #region Testing
+        
+        internal string GenericArgumentsForTesting {
+            get {
+                return this.GenericArguments;
+            }
+        }
+
+        #endregion
+
     }
+    
 }

--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -1454,6 +1454,7 @@ namespace Orleans.Serialization
             var request = (InvokeMethodRequest)obj;
 
             stream.Write(request.InterfaceId);
+            stream.Write(request.InterfaceGenArgs);
             stream.Write(request.MethodId);
             stream.Write(request.Arguments != null ? request.Arguments.Length : 0);
             if (request.Arguments != null)
@@ -1468,6 +1469,7 @@ namespace Orleans.Serialization
         internal static object DeserializeInvokeMethodRequest(Type expected, BinaryTokenStreamReader stream)
         {
             int iid = stream.ReadInt();
+            string genArgs = stream.ReadString();
             int mid = stream.ReadInt();
 
             int argCount = stream.ReadInt();
@@ -1482,7 +1484,7 @@ namespace Orleans.Serialization
                 }
             }
 
-            return new InvokeMethodRequest(iid, mid, args);
+            return new InvokeMethodRequest(iid, genArgs, mid, args);
         }
 
         internal static object CopyInvokeMethodRequest(object original)
@@ -1499,7 +1501,7 @@ namespace Orleans.Serialization
                 }
             }
 
-            var result = new InvokeMethodRequest(request.InterfaceId, request.MethodId, args);
+            var result = new InvokeMethodRequest(request.InterfaceId, request.InterfaceGenArgs, request.MethodId, args);
             SerializationContext.Current.RecordObject(original, result);
             return result;
         }

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -80,6 +80,8 @@ namespace Orleans.CodeGenerator
                     .AddMembers(
                         GenerateInterfaceIdProperty(grainType),
                         GenerateInterfaceNameProperty(grainType),
+                        GenerateGenericArgumentsStaticField(grainType),
+                        GenerateGenericArgumentsProperty(grainType),
                         GenerateIsCompatibleMethod(grainType),
                         GenerateGetMethodNameMethod(grainType))
                     .AddMembers(GenerateInvokeMethods(grainType, onEncounteredType))
@@ -328,6 +330,37 @@ namespace Orleans.CodeGenerator
                             .AddBodyStatements(SF.ReturnStatement(returnValue)))
                     .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.OverrideKeyword));
         }
+
+
+        private static MemberDeclarationSyntax GenerateGenericArgumentsStaticField(Type grainType) {
+            return
+                SF.FieldDeclaration(
+                        SF.VariableDeclaration(typeof(string).GetTypeSyntax())
+                            .AddVariables(
+                                SF.VariableDeclarator("genericArgs")
+                                    .WithInitializer(
+                                        SF.EqualsValueClause(
+                                            grainType.IsGenericTypeDefinition
+                                                ? (ExpressionSyntax)SF.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SF.TypeOfExpression(grainType.GetTypeSyntax()), "FullName".ToIdentifierName())
+                                                : SF.DefaultExpression(typeof(string).GetTypeSyntax())
+                                        )))
+                        )
+                    .AddModifiers(SF.Token(SyntaxKind.PrivateKeyword), SF.Token(SyntaxKind.StaticKeyword));
+        }
+
+
+        private static MemberDeclarationSyntax GenerateGenericArgumentsProperty(Type grainType) 
+        {
+            return
+                SF.PropertyDeclaration(typeof(string).GetTypeSyntax(), "GenericArguments")
+                    .AddAccessorListAccessors(
+                        SF.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                            .AddBodyStatements(
+                                SF.ReturnStatement(SF.IdentifierName("genericArgs"))
+                                ))
+                    .AddModifiers(SF.Token(SyntaxKind.ProtectedKeyword), SF.Token(SyntaxKind.OverrideKeyword));
+        }
+        
 
         private static MethodDeclarationSyntax GenerateGetMethodNameMethod(Type grainType)
         {

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -352,7 +352,7 @@ namespace Orleans.CodeGenerator
         private static MemberDeclarationSyntax GenerateGenericArgumentsProperty(Type grainType) 
         {
             return
-                SF.PropertyDeclaration(typeof(string).GetTypeSyntax(), "GenericArguments")
+                SF.PropertyDeclaration(typeof(string).GetTypeSyntax(), "GenericArgumentsInner")
                     .AddAccessorListAccessors(
                         SF.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
                             .AddBodyStatements(

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -337,7 +337,7 @@ namespace Orleans.Runtime
                 {
                     var request = (InvokeMethodRequest) message.BodyObject;
 
-                    var invoker = invokable.GetInvoker(request.InterfaceId, message.GenericGrainType);
+                    var invoker = invokable.GetInvoker(request.InterfaceId, request.InterfaceGenArgs);
 
                     if (invoker is IGrainExtensionMethodInvoker
                         && !(target is IGrainExtension))

--- a/test/Tester/GenericGrainTests.cs
+++ b/test/Tester/GenericGrainTests.cs
@@ -654,7 +654,7 @@ namespace UnitTests.General
             Assert.AreEqual(1, result);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/orleans/issues/1655 Casting from non-generic to generic interface fails with an obscure error message"), TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
+        [Fact(/*Skip = "https://github.com/dotnet/orleans/issues/1655 Casting from non-generic to generic interface fails with an obscure error message"*/), TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
         public async Task Generic_CastToGenericInterfaceAfterActivation() 
         {
             var grain = GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
@@ -667,7 +667,7 @@ namespace UnitTests.General
             Assert.AreEqual(result, "Hello!");
         }
 
-        [Fact(Skip= "https://github.com/dotnet/orleans/issues/1655 Casting from non-generic to generic interface fails with an obscure error message"), TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
+        [Fact(/*Skip= "https://github.com/dotnet/orleans/issues/1655 Casting from non-generic to generic interface fails with an obscure error message"*/), TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
         public async Task Generic_CastToDifferentlyConcretizedGenericInterfaceBeforeActivation() {
             var grain = GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
 

--- a/test/TesterInternal/GrainReferenceCastTests.cs
+++ b/test/TesterInternal/GrainReferenceCastTests.cs
@@ -9,6 +9,7 @@ using UnitTests.Grains;
 using Xunit;
 using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
 using UnitTests.Tester;
+using System.Reflection;
 
 namespace UnitTests
 {
@@ -452,5 +453,19 @@ namespace UnitTests
             isNullStr = cast.StringSet("b").ContinueWith((_) => grain.StringIsNullOrEmpty()).Unwrap();
             Assert.IsFalse(isNullStr.Result, "Value should not be null after cast.SetString(b)");
         }
+
+        
+        [Fact, TestCategory("Functional"), TestCategory("Generics"), TestCategory("Cast"), TestCategory("GrainReference")]
+        public void CastToGenericInterfaceSetsArgsOnReference() 
+        {
+            var grain = GrainFactory.GetGrain<INonGenericCastableGrain>(Guid.NewGuid());
+
+            var castRef = (GrainReference)grain.AsReference<ISomeGenericGrain<string>>();
+
+            Assert.AreEqual(
+                typeof(ISomeGenericGrain<string>).GetTypeInfo().UnderlyingSystemType.FullName, 
+                castRef.GenericArgumentsForTesting);
+        }
+        
     }
 }

--- a/test/TesterInternal/GrainReferenceCastTests.cs
+++ b/test/TesterInternal/GrainReferenceCastTests.cs
@@ -464,7 +464,7 @@ namespace UnitTests
 
             Assert.AreEqual(
                 typeof(ISomeGenericGrain<string>).GetTypeInfo().UnderlyingSystemType.FullName, 
-                castRef.GenericArgumentsForTesting);
+                castRef.GenericArguments);
         }
         
     }

--- a/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
+++ b/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
@@ -36,7 +36,7 @@ namespace UnitTests.SerializerTests
 
         private void RunTest(int numItems)
         {
-            InvokeMethodRequest request = new InvokeMethodRequest(0, 0, null);
+            InvokeMethodRequest request = new InvokeMethodRequest(0, null, 0, null);
             Message resp = Message.CreateMessage(request, InvokeMethodOptions.None);
             resp.Id = new CorrelationId();
             resp.SendingSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 200), 0);


### PR DESCRIPTION
Hi,

This is, I suppose, a speculative Pull Request, in that, firstly, it modifies internal components I'm wary of changing without prior discussion, and, secondly, the expanded behaviour it provides is currently surplus to requirements, given the (understandably) defensive limitation of support for generics.

But, nevertheless:

- GrainReferences now have two properties for two sets of generic arguments: ``ActivatingGenArgs`` and ``CurrentGenArgs``. These replace the single, ambiguous ``GenericArguments`` property. 

- ``ActivatingGenArgs`` supplies the gen args of the generic interface first requested. Even after subsequent casts, it is these that should be used for activation. These supplement the typecode encoded within the ``GrainId``.

- ``CurrentGenArgs`` supplies the gen args of the current interface implemented by the particular ``GrainReference``. These supplement the typecode passed on method-invocation by ``InvokeMethodRequest.InterfaceId``.

- ``InvokeMethodRequest`` has been expanded to carry the ``CurrentGenArgs`` of the invoking reference. This is then used at the destination to summon the right ``MethodInvoker``.

- Meanwhile, the ``ActivatingGenArgs`` are still passed on invocation alongside the ``InvokeMethodRequest`` object, and are picked up by the activating agent, as previously.

The upshot is, that, apart from in the type-matching process and in codegen, different gen args can live alongside each other in relative harmony. 

This is intended as a slightly less half-baked sequel to #1604.