### PR TITLE
fix: amending server programmatic configuration

### DIFF
--- a/Orleans-Configuration-Guide/Server-Configuration.md
+++ b/Orleans-Configuration-Guide/Server-Configuration.md
@@ -106,12 +106,8 @@ This is a reference only example and SHOULD NOT be used AS-IS - you may need to 
 ```csharp
 var dataConnection = "DefaultEndpointsProtocol=https;AccountName=MYACCOUNTNAME;AccountKey=MYACCOUNTKEY";
 
-var proxyEndpoint = RoleEnvironment.CurrentRoleInstance.InstanceEndpoints["OrleansProxyEndpoint"];
-var siloEndpoint = RoleEnvironment.CurrentRoleInstance.InstanceEndpoints["OrleansSiloEndpoint"];
-
 var config = new ClusterConfiguration
 {
-    PrimaryNode = siloEndpoint.IPEndpoint,
     Globals =
     {
         DeploymentId = RoleEnvironment.DeploymentId,
@@ -124,7 +120,6 @@ var config = new ClusterConfiguration
     Defaults =
     {
         PropagateActivityId = true,
-        ProxyGatewayEndpoint = proxyEndpoint.IPEndpoint,
         
         // Tracing
         DefaultTraceLevel = Severity.Info,


### PR DESCRIPTION
Correct me if I'm wrong but:
`PrimaryNode` and `ProxyGatewayEndpoint` must not be set in programmatic configuration for Azure. I spend half a day looking for incorrect config values (client and server were not able to talk to each other in local Azure Emulator) until figured out the culpit. 

It's still not clear for me when and why one need to configure these properties (do we need it for real deployment ? what functional load do these carry ? ) so I'd like to hear feedback from core devs about my 'guess' . Thanks in advance