### PR TITLE
Azure table storage provider returning null grain state - fixed

### DIFF
--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -149,7 +149,8 @@ namespace Orleans.Storage
                 var entity = record.Entity;
                 if (entity != null)
                 {
-                    grainState.State = ConvertFromStorageFormat(entity);
+                    var loadedState = ConvertFromStorageFormat(entity);
+                    grainState.State = loadedState ?? Activator.CreateInstance(grainState.State.GetType());
                     grainState.ETag = record.ETag;
                 }
             }


### PR DESCRIPTION
Azure table storage provider was returning null state object by default after clearing the grains state.
Added test case to reproduce problem.
Modified azure table storage provider to return default grain state if no state was found in the entity.