### PR TITLE
Azure storage 7.0 compatibility.

### DIFF
--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\RemindersTableManager.cs" />
     <Compile Include="Hosting\ServiceRuntimeWrapper.cs" />
+    <Compile Include="Storage\TableQueryFilterBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj">

--- a/src/OrleansAzureUtils/Storage/TableQueryFilterBuilder.cs
+++ b/src/OrleansAzureUtils/Storage/TableQueryFilterBuilder.cs
@@ -1,0 +1,43 @@
+﻿
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace Orleans.AzureUtils
+{
+    /// <summary>
+    /// Helper functions for building table queries.
+    /// </summary>
+    internal class TableQueryFilterBuilder
+    {
+        /// <summary>
+        /// Builds query string to match partitionkey
+        /// </summary>
+        /// <param name="partitionKey"></param>
+        /// <returns></returns>
+        public static string MatchPartitionKeyFilter(string partitionKey)
+        {
+            return TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, partitionKey);
+        }
+
+        /// <summary>
+        /// Builds query string to match rowkey
+        /// </summary>
+        /// <param name="rowKey"></param>
+        /// <returns></returns>
+        public static string MatchRowKeyFilter(string rowKey)
+        {
+            return TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.Equal, rowKey);
+        }
+
+        /// <summary>
+        /// Builds a query string that matches a specific partitionkey and rowkey.
+        /// </summary>
+        /// <param name="partitionKey"></param>
+        /// <param name="rowKey"></param>
+        /// <returns></returns>
+        public static string MatchPartitionKeyAndRowKeyFilter(string partitionKey, string rowKey)
+        {
+            return TableQuery.CombineFilters(MatchPartitionKeyFilter(partitionKey), TableOperators.And,
+                                      MatchRowKeyFilter(rowKey));
+        }
+    }
+}


### PR DESCRIPTION
Update Orleans azure utils to be compatible with WindowsAzure.Storeage 7.0.0

Addresses issue described in Error starting orleans on Azure with WindowsAzure.Storage 7.0.0 #1700 

The TableOperation.Retrieve api call arguments changed in 7.0.0 so we replaced retrieve call with a table query.