### PR TITLE
added ability to throw exceptions that occur when starting silo

### DIFF
--- a/src/OrleansRuntime/Silo/SiloHost.cs
+++ b/src/OrleansRuntime/Silo/SiloHost.cs
@@ -114,9 +114,9 @@ namespace Orleans.Runtime.Host
         /// </summary>
         public void InitializeOrleansSilo()
         {
-    #if DEBUG
+#if DEBUG
             AssemblyLoaderUtils.EnableAssemblyLoadTracing();
-    #endif
+#endif
 
             try
             {
@@ -143,13 +143,13 @@ namespace Orleans.Runtime.Host
         /// Start this silo.
         /// </summary>
         /// <returns></returns>
-        public bool StartOrleansSilo()
+        public bool StartOrleansSilo(bool catchExceptions = true)
         {
             try
             {
                 if (string.IsNullOrEmpty(Thread.CurrentThread.Name))
                     Thread.CurrentThread.Name = this.GetType().Name;
-                
+
                 if (orleans != null)
                 {
                     var shutdownEventName = Config.Defaults.SiloShutdownEventName ?? Name + "-Shutdown";
@@ -171,15 +171,15 @@ namespace Orleans.Runtime.Host
 
                     // Wait for the shutdown event, and trigger a graceful shutdown if we receive it.
 
-                    var shutdownThread = new Thread( o =>
-                        {
-                            shutdownEvent.WaitOne();
-                            logger.Info(ErrorCode.SiloShutdownEventReceived, "Received a shutdown event. Starting graceful shutdown.");
-                            orleans.Shutdown();
-                        });
+                    var shutdownThread = new Thread(o =>
+                       {
+                           shutdownEvent.WaitOne();
+                           logger.Info(ErrorCode.SiloShutdownEventReceived, "Received a shutdown event. Starting graceful shutdown.");
+                           orleans.Shutdown();
+                       });
                     shutdownThread.IsBackground = true;
                     shutdownThread.Start();
-                    
+
                     var startupEventName = Name;
                     logger.Info(ErrorCode.SiloStartupEventName, "Silo startup event name: {0}", startupEventName);
 
@@ -204,10 +204,15 @@ namespace Orleans.Runtime.Host
             }
             catch (Exception exc)
             {
-                ReportStartupError(exc);
-                orleans = null;
-                IsStarted = false;
-                return false;
+                if (catchExceptions)
+                {
+                    ReportStartupError(exc);
+                    orleans = null;
+                    IsStarted = false;
+                    return false;
+                }
+                else
+                    throw;
             }
 
             return true;
@@ -231,31 +236,31 @@ namespace Orleans.Runtime.Host
             if (orleans != null) orleans.Shutdown();
         }
 
-		/// <summary>
-		/// Wait for this silo to shutdown.
-		/// </summary>
-		/// <remarks>
-		/// Note: This method call will block execution of current thread, 
-		/// and will not return control back to the caller until the silo is shutdown.
-		/// </remarks>
-		public void WaitForOrleansSiloShutdown()
-		{
-			WaitForOrleansSiloShutdownImpl();
-		}
+        /// <summary>
+        /// Wait for this silo to shutdown.
+        /// </summary>
+        /// <remarks>
+        /// Note: This method call will block execution of current thread, 
+        /// and will not return control back to the caller until the silo is shutdown.
+        /// </remarks>
+        public void WaitForOrleansSiloShutdown()
+        {
+            WaitForOrleansSiloShutdownImpl();
+        }
 
-		/// <summary>
-		/// Wait for this silo to shutdown or to be stopped with provided cancellation token.
-		/// </summary>
-		/// <param name="cancellationToken">Cancellation token.</param>
-		/// <remarks>
-		/// Note: This method call will block execution of current thread, 
-		/// and will not return control back to the caller until the silo is shutdown or 
-		/// an external request for cancellation has been issued.
-		/// </remarks>
-		public void WaitForOrleansSiloShutdown(CancellationToken cancellationToken)
-		{
-			WaitForOrleansSiloShutdownImpl(cancellationToken);
-		}
+        /// <summary>
+        /// Wait for this silo to shutdown or to be stopped with provided cancellation token.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <remarks>
+        /// Note: This method call will block execution of current thread, 
+        /// and will not return control back to the caller until the silo is shutdown or 
+        /// an external request for cancellation has been issued.
+        /// </remarks>
+        public void WaitForOrleansSiloShutdown(CancellationToken cancellationToken)
+        {
+            WaitForOrleansSiloShutdownImpl(cancellationToken);
+        }
 
         /// <summary>
         /// Set the DeploymentId for this silo, 
@@ -266,13 +271,13 @@ namespace Orleans.Runtime.Host
         /// <param name="connectionString">Azure connection string to use the silo system data.</param>
         public void SetDeploymentId(string deploymentId, string connectionString)
         {
-            logger.Info(ErrorCode.SiloSetDeploymentId, "Setting Deployment Id to {0} and data connection string to {1}", 
+            logger.Info(ErrorCode.SiloSetDeploymentId, "Setting Deployment Id to {0} and data connection string to {1}",
                 deploymentId, ConfigUtilities.RedactConnectionStringInfo(connectionString));
 
             Config.Globals.DeploymentId = deploymentId;
             Config.Globals.DataConnectionString = connectionString;
         }
-        
+
         /// <summary>
         /// Set the main endpoint address for this silo,
         /// plus the silo generation value to be used to distinguish this silo instance
@@ -445,11 +450,11 @@ namespace Orleans.Runtime.Host
 
             if (Verbose > 0)
                 Config.Defaults.DefaultTraceLevel = (Severity.Verbose - 1 + Verbose);
-            
+
 
             if (!String.IsNullOrEmpty(DeploymentId))
                 Config.Globals.DeploymentId = DeploymentId;
-            
+
             if (string.IsNullOrWhiteSpace(Name))
                 throw new ArgumentException("SiloName not defined - cannot initialize config");
 
@@ -473,46 +478,46 @@ namespace Orleans.Runtime.Host
             logger = TraceLogger.GetLogger("OrleansSiloHost", TraceLogger.LoggerType.Runtime);
         }
 
-		/// <summary>
-		/// Helper to wait for this silo to shutdown or to be stopped via a cancellation token.
-		/// </summary>
-		/// <param name="cancellationToken">Optional cancellation token.</param>
-		/// <remarks>
-		/// Note: This method call will block execution of current thread, 
-		/// and will not return control back to the caller until the silo is shutdown or 
-		/// an external request for cancellation has been issued.
-		/// </remarks>
-		private void WaitForOrleansSiloShutdownImpl(CancellationToken? cancellationToken = null)
-		{
-			if (!IsStarted)
-				throw new InvalidOperationException("Cannot wait for silo " + this.Name + " since it was not started successfully previously.");
+        /// <summary>
+        /// Helper to wait for this silo to shutdown or to be stopped via a cancellation token.
+        /// </summary>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <remarks>
+        /// Note: This method call will block execution of current thread, 
+        /// and will not return control back to the caller until the silo is shutdown or 
+        /// an external request for cancellation has been issued.
+        /// </remarks>
+        private void WaitForOrleansSiloShutdownImpl(CancellationToken? cancellationToken = null)
+        {
+            if (!IsStarted)
+                throw new InvalidOperationException("Cannot wait for silo " + this.Name + " since it was not started successfully previously.");
 
-			if (startupEvent != null)
-				startupEvent.Reset();
-			else
-				throw new InvalidOperationException("Cannot wait for silo " + this.Name + " due to prior initialization error");
+            if (startupEvent != null)
+                startupEvent.Reset();
+            else
+                throw new InvalidOperationException("Cannot wait for silo " + this.Name + " due to prior initialization error");
 
-			if (orleans != null)
-			{
-				// Intercept cancellation to initiate silo stop
-				if (cancellationToken.HasValue)
-					cancellationToken.Value.Register(HandleExternalCancellation);
+            if (orleans != null)
+            {
+                // Intercept cancellation to initiate silo stop
+                if (cancellationToken.HasValue)
+                    cancellationToken.Value.Register(HandleExternalCancellation);
 
-				orleans.SiloTerminatedEvent.WaitOne();
-			}
-			else
-				throw new InvalidOperationException("Cannot wait for silo " + this.Name + " due to prior initialization error");
-		}
+                orleans.SiloTerminatedEvent.WaitOne();
+            }
+            else
+                throw new InvalidOperationException("Cannot wait for silo " + this.Name + " due to prior initialization error");
+        }
 
-		/// <summary>
-		/// Handle the silo stop request coming from an external cancellation token.
-		/// </summary>
-		private void HandleExternalCancellation()
-		{
-			// Try to perform gracefull shutdown of Silo when we a cancellation request has been made
-			logger.Info(ErrorCode.SiloStopping, "External cancellation triggered, starting to shutdown silo.");
+        /// <summary>
+        /// Handle the silo stop request coming from an external cancellation token.
+        /// </summary>
+        private void HandleExternalCancellation()
+        {
+            // Try to perform gracefull shutdown of Silo when we a cancellation request has been made
+            logger.Info(ErrorCode.SiloStopping, "External cancellation triggered, starting to shutdown silo.");
             ShutdownOrleansSilo();
-		}
+        }
 
         /// <summary>
         /// Called when this silo is being Disposed by .NET runtime.


### PR DESCRIPTION
I ran across this a few times where StartOrleansSilo just returns false, and I don't get any info about why, so with this, we can choose to receive any exceptions that are thrown.