### PR TITLE
Fix grain base class in documentation

### DIFF
--- a/Samples-Overview/Hello-World.md
+++ b/Samples-Overview/Hello-World.md
@@ -20,7 +20,7 @@ public interface IHello : Orleans.IGrain
 This is simple enough, and we can see that all replies must be represented as a Task or Task<T> in communication interfaces. The implementation, found in HelloGrain.cs, is similarly trivial:
 
 ``` csharp
-public class HelloGrain : Orleans.GrainBase, HelloWorldInterfaces.IHello
+public class HelloGrain : Orleans.Grain, HelloWorldInterfaces.IHello
 {
     Task<string> HelloWorldInterfaces.IHello.SayHello(string greeting)
     {

--- a/Step-by-step-Tutorials/Actor-Identity.md
+++ b/Step-by-step-Tutorials/Actor-Identity.md
@@ -109,7 +109,7 @@ var grain = GrainClient.GrainFactory.GetGrain<IExample>(0, "a string!");
 To access the compound key in the grain, we can call an overload on the `GetPrimaryKey` method:
 
 ``` csharp
-public class ExampleGrain : Orleans.GrainBase, IExampleGrain
+public class ExampleGrain : Orleans.Grain, IExampleGrain
 {
     public Task Hello()
     {


### PR DESCRIPTION
Looks like GrainBase class was removed but documentation hasn't been updated
Put correct grain base class.