### PR TITLE
Stop adding content files in NuGet packages

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.Build.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.Build.nuspec
@@ -38,7 +38,5 @@
     <file src="Microsoft.CodeAnalysis.dll" target="tools" />
     <file src="System.Reflection.Metadata.dll" target="tools" />
     <file src="System.Collections.Immutable.dll" target="tools" />
-
-    <file src="EmptyFile.cs" target="content\Properties\orleans.codegen.cs" />
   </files>
 </package>

--- a/src/Orleans.SDK.targets
+++ b/src/Orleans.SDK.targets
@@ -41,7 +41,23 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </Otherwise>
   </Choose>
 
-    <!-- This target is run just before Clean for any Orleans project -->
+  <!-- include the codegen file in the project if it isn't there already -->
+  <Target Name="OrleansCodeGenerationFileInclude"
+          BeforeTargets="BeforeBuild">
+
+    <FindInList
+      List="@(Compile)"
+      ItemSpecToFind="Properties\orleans.codegen.cs"
+      CaseSensitive="false">
+      <Output TaskParameter="ItemFound" ItemName="CodegenCsAlreadyDefined"/>
+    </FindInList>
+
+    <ItemGroup Condition="'@(CodegenCsAlreadyDefined)'==''">
+      <Compile Include="Properties\orleans.codegen.cs" />
+    </ItemGroup>
+  </Target>
+
+  <!-- This target is run just before Clean for any Orleans project -->
   <Target Name="OrleansCodeGenerationClean"
           BeforeTargets="Clean"
           Condition="'$(OrleansCodeGenPrecompile)'!='true'"


### PR DESCRIPTION
See issue #1718 
Add build target to include Properties\orleans.codegen.cs in Compile ItemGroup if it's not already there.

Removed empty file from being added as content to Microsoft.Orleans.OrleansCodeGenerator.Build nuget package.