### PR TITLE
Starts Azure storage emulator on local persistence tests

### DIFF
--- a/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureBlobStore.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureBlobStore.cs
@@ -25,6 +25,8 @@ namespace UnitTests.StorageTests
         {
             protected override TestingSiloHost CreateClusterHost()
             {
+                TestUtils.CheckForAzureStorage();
+
                 Guid serviceId = Guid.NewGuid();
                 return new TestingSiloHost(new TestingSiloOptions
                 {

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureTableStore.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureTableStore.cs
@@ -28,6 +28,8 @@ namespace UnitTests.StorageTests
         {
             protected override TestingSiloHost CreateClusterHost()
             {
+                TestUtils.CheckForAzureStorage();
+
                 Guid serviceId = Guid.NewGuid();
                 return new TestingSiloHost(new TestingSiloOptions
                 {


### PR DESCRIPTION
Starts the Azure storage emulator for persistence tests on local
development. If the emulator is not on and persistence tests are
started individually, the tests hang quite a while without any
indication as of the reason while starting the silo.