### PR TITLE
Event hub stream provider EventData to cached data mapping

### DIFF
--- a/src/Orleans/Streams/Core/StreamIdentity.cs
+++ b/src/Orleans/Streams/Core/StreamIdentity.cs
@@ -7,6 +7,7 @@ namespace Orleans.Streams
     /// Stream identity contains the public stream information use to uniquely identify a stream.
     /// Stream identities are only unique per stream provider.
     /// </summary>
+    [Serializable]
     public class StreamIdentity : IStreamIdentity
     {
         public StreamIdentity(Guid streamGuid, string streamNamespace)

--- a/src/OrleansProviders/Streams/Common/PooledCache/CachedMessageBlock.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/CachedMessageBlock.cs
@@ -62,7 +62,7 @@ namespace Orleans.Providers.Streams.Common
             return false;
         }
 
-        public StreamPosition Add<TQueueMessage>(TQueueMessage queueMessage, ICacheDataAdapter<TQueueMessage, TCachedMessage> dataAdapter) where TQueueMessage : class 
+        public StreamPosition Add<TQueueMessage>(TQueueMessage queueMessage, DateTime dequeueTimeUtc, ICacheDataAdapter<TQueueMessage, TCachedMessage> dataAdapter) where TQueueMessage : class 
         {
             if (queueMessage == null)
             {
@@ -74,7 +74,7 @@ namespace Orleans.Providers.Streams.Common
             }
 
             int index = writeIndex++;
-            return dataAdapter.QueueMessageToCachedMessage(ref cachedMessages[index], queueMessage);
+            return dataAdapter.QueueMessageToCachedMessage(ref cachedMessages[index], queueMessage, dequeueTimeUtc);
         }
 
         public TCachedMessage this[int index]

--- a/src/OrleansProviders/Streams/Common/PooledCache/CachedMessagePool.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/CachedMessagePool.cs
@@ -35,8 +35,9 @@ namespace Orleans.Providers.Streams.Common
         /// Allocates a message in a block and returns the block the message is in.
         /// </summary>
         /// <param name="queueMessage"></param>
+        /// <param name="dequeueTimeUtc"></param>
         /// <returns></returns>
-        public CachedMessageBlock<TCachedMessage> AllocateMessage(TQueueMessage queueMessage, out StreamPosition streamPosition)
+        public CachedMessageBlock<TCachedMessage> AllocateMessage(TQueueMessage queueMessage, DateTime dequeueTimeUtc, out StreamPosition streamPosition)
         {
             streamPosition = default(StreamPosition);
             if (queueMessage == null)
@@ -50,7 +51,7 @@ namespace Orleans.Providers.Streams.Common
                 currentMessageBlock = messagePool.Allocate();
             }
 
-            streamPosition = currentMessageBlock.Add(queueMessage, dataAdapter);
+            streamPosition = currentMessageBlock.Add(queueMessage, dequeueTimeUtc, dataAdapter);
 
             return currentMessageBlock;
         }

--- a/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
@@ -1,6 +1,5 @@
 ﻿
 using System;
-using Orleans.Runtime;
 using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.Common
@@ -17,7 +16,7 @@ namespace Orleans.Providers.Streams.Common
         where TQueueMessage : class
         where TCachedMessage : struct
     {
-        StreamPosition QueueMessageToCachedMessage(ref TCachedMessage cachedMessage, TQueueMessage queueMessage);
+        StreamPosition QueueMessageToCachedMessage(ref TCachedMessage cachedMessage, TQueueMessage queueMessage, DateTime dequeueTimeUtc);
         IBatchContainer GetBatchContainer(ref TCachedMessage cachedMessage);
         StreamSequenceToken GetSequenceToken(ref TCachedMessage cachedMessage);
         StreamPosition GetStreamPosition(TQueueMessage queueMessage);

--- a/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
@@ -260,7 +260,7 @@ namespace Orleans.Providers.Streams.Common
             return false;
         }
 
-        public StreamPosition Add(TQueueMessage message)
+        public StreamPosition Add(TQueueMessage message, DateTime dequeueTimeUtc)
         {
             if (message == null)
             {
@@ -271,7 +271,7 @@ namespace Orleans.Providers.Streams.Common
 
             StreamPosition streamPosition;
             // allocate message from pool
-            CachedMessageBlock<TCachedMessage> block = pool.AllocateMessage(message, out streamPosition);
+            CachedMessageBlock<TCachedMessage> block = pool.AllocateMessage(message, dequeueTimeUtc, out streamPosition);
 
             // If new block, add message block to linked list
             if (block != messageBlocks.FirstOrDefault())

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -64,7 +64,7 @@ namespace Orleans.Providers.Streams.Generator
                 this.bufferPool = bufferPool;
             }
 
-            public StreamPosition QueueMessageToCachedMessage(ref CachedMessage cachedMessage, GeneratedBatchContainer queueMessage)
+            public StreamPosition QueueMessageToCachedMessage(ref CachedMessage cachedMessage, GeneratedBatchContainer queueMessage, DateTime dequeueTimeUtc)
             {
                 StreamPosition setreamPosition = GetStreamPosition(queueMessage);
                 cachedMessage.StreamGuid = setreamPosition.StreamIdentity.Guid;
@@ -178,9 +178,10 @@ namespace Orleans.Providers.Streams.Generator
 
         public void AddToCache(IList<IBatchContainer> messages)
         {
+            DateTime dequeueTimeUtc = DateTime.UtcNow;
             foreach (IBatchContainer container in messages)
             {
-                cache.Add(container as GeneratedBatchContainer);
+                cache.Add(container as GeneratedBatchContainer, dequeueTimeUtc);
             }
         }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
@@ -1,5 +1,8 @@
 ﻿
+using System;
+using System.Collections.Generic;
 using Microsoft.ServiceBus.Messaging;
+using Orleans.Serialization;
 
 namespace Orleans.ServiceBus.Providers
 {
@@ -23,6 +26,19 @@ namespace Orleans.ServiceBus.Providers
                 return (string)namespaceObj;
             }
             return null;
+        }
+
+        public static byte[] SerializeProperties(this IDictionary<string, object> properties)
+        {
+            var writeStream = new BinaryTokenStreamWriter();
+            SerializationManager.Serialize(properties, writeStream);
+            return writeStream.ToByteArray();
+        }
+
+        public static IDictionary<string, object> DeserializeProperties(this ArraySegment<byte> bytes)
+        {
+            var stream = new BinaryTokenStreamReader(bytes);
+            return SerializationManager.Deserialize<IDictionary<string, object>>(stream);
         }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -66,9 +66,10 @@ namespace Orleans.ServiceBus.Providers
             {
                 return batches;
             }
+            DateTime dequeueTimeUtc = DateTime.UtcNow;
             foreach (EventData message in messages)
             {
-                StreamPosition streamPosition = cache.Add(message);
+                StreamPosition streamPosition = cache.Add(message, dequeueTimeUtc);
                 batches.Add(new StreamActivityNotificationBatch(streamPosition.StreamIdentity.Guid,
                     streamPosition.StreamIdentity.Namespace, streamPosition.SequenceToken));
             }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -60,9 +60,9 @@ namespace Orleans.ServiceBus.Providers
             return cachePressureMonitor.IsUnderPressure() ? 0 : defaultMaxAddCount;
         }
 
-        public StreamPosition Add(EventData message)
+        public StreamPosition Add(EventData message, DateTime dequeueTimeUtc)
         {
-            return cache.Add(message);
+            return cache.Add(message, dequeueTimeUtc);
         }
 
         public object GetCursor(IStreamIdentity streamIdentity, StreamSequenceToken sequenceToken)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -21,7 +21,7 @@ namespace Orleans.ServiceBus.Providers
     ///   and ordering of aplication layer events within an EventHub message.
     /// </summary>
     [Serializable]
-    internal class EventHubSequenceToken : EventSequenceToken, IEventHubPartitionLocation
+    public class EventHubSequenceToken : EventSequenceToken, IEventHubPartitionLocation
     {
         public string EventHubOffset { get; private set; }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -11,7 +11,7 @@ namespace Orleans.ServiceBus.Providers
     /// </summary>
     public interface IEventHubQueueCache : IQueueFlowController, IDisposable
     {
-        StreamPosition Add(EventData message);
+        StreamPosition Add(EventData message, DateTime dequeueTimeUtc);
         object GetCursor(IStreamIdentity streamIdentity, StreamSequenceToken sequenceToken);
         bool TryGetNextMessage(object cursorObj, out IBatchContainer message);
     }

--- a/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,6 +7,7 @@ using Microsoft.WindowsAzure.Storage.Table;
 using Orleans;
 using Orleans.AzureUtils;
 using Orleans.Providers.Streams.Generator;
+using Orleans.Runtime.Configuration;
 using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
 using Orleans.TestingHost;
@@ -44,6 +46,7 @@ namespace UnitTests.StreamingTests
             {
                 var options = new TestClusterOptions(2);
                 // register stream provider
+                options.ClusterConfiguration.AddMemoryStorageProvider("Default");
                 options.ClusterConfiguration.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
                 options.ClientConfiguration.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
                 return new TestCluster(options);

--- a/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
@@ -70,7 +70,7 @@ namespace UnitTests.OrleansRuntime.Streams
         {
             public Action<IDisposable> PurgeAction { private get; set; }
 
-            public StreamPosition QueueMessageToCachedMessage(ref TestCachedMessage cachedMessage, TestQueueMessage queueMessage)
+            public StreamPosition QueueMessageToCachedMessage(ref TestCachedMessage cachedMessage, TestQueueMessage queueMessage, DateTime dequeueTimeUtc)
             {
                 StreamPosition streamPosition = GetStreamPosition(queueMessage);
                 cachedMessage.StreamGuid = streamPosition.StreamIdentity.Guid;
@@ -264,7 +264,7 @@ namespace UnitTests.OrleansRuntime.Streams
             Assert.AreEqual(last, block.NewestMessageIndex);
             Assert.IsTrue(block.HasCapacity);
 
-            block.Add(message, dataAdapter);
+            block.Add(message, DateTime.UtcNow, dataAdapter);
             last++;
 
             Assert.AreEqual(first > last, block.IsEmpty);

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -94,7 +94,7 @@ namespace UnitTests.OrleansRuntime.Streams
                 this.bufferPool = bufferPool;
             }
 
-            public StreamPosition QueueMessageToCachedMessage(ref TestCachedMessage cachedMessage, TestQueueMessage queueMessage)
+            public StreamPosition QueueMessageToCachedMessage(ref TestCachedMessage cachedMessage, TestQueueMessage queueMessage, DateTime dequeueTimeUtc)
             {
                 StreamPosition streamPosition = GetStreamPosition(queueMessage);
                 cachedMessage.StreamGuid = streamPosition.StreamIdentity.Guid;
@@ -228,7 +228,7 @@ namespace UnitTests.OrleansRuntime.Streams
                     StreamGuid = i % 2 == 0 ? stream1.Guid : stream2.Guid,
                     StreamNamespace = StreamNamespace,
                     SequenceNumber = sequenceNumber++,
-                });
+                }, DateTime.UtcNow);
             }
 
             // get cursor for stream1, walk all the events in the stream using the cursor
@@ -269,7 +269,7 @@ namespace UnitTests.OrleansRuntime.Streams
                         StreamGuid = i % 2 == 0 ? stream1.Guid : stream2.Guid,
                         StreamNamespace = StreamNamespace,
                         SequenceNumber = sequenceNumber++,
-                    });
+                    }, DateTime.UtcNow);
                 }
 
                 // walk all the events in the stream using the cursor
@@ -329,7 +329,7 @@ namespace UnitTests.OrleansRuntime.Streams
                     StreamGuid = streamId.Guid,
                     StreamNamespace = StreamNamespace,
                     SequenceNumber = sequenceNumber++,
-                });
+                }, DateTime.UtcNow);
             }
 
             // now that there is data, and the cursor should point to data older than in the cache, using cursor should throw
@@ -368,7 +368,7 @@ namespace UnitTests.OrleansRuntime.Streams
                 StreamGuid = streamId.Guid,
                 StreamNamespace = StreamNamespace,
                 SequenceNumber = sequenceNumber++,
-            });
+            }, DateTime.UtcNow);
             // After purge, use of cursor should throw.
             ex = null;
             try


### PR DESCRIPTION
All data from EventHub EventData is now cached.

EventHubDataAdapter now supports a EventData-like data structure when converting data from cache for delivery.

Dequeue time has been added to cached data to track how long messages have been in the cache.
