### PR TITLE
fix liveness tests for Sql Server, MySql and ZK

### DIFF
--- a/src/OrleansSQLUtils/OrleansSQLUtils.csproj
+++ b/src/OrleansSQLUtils/OrleansSQLUtils.csproj
@@ -107,7 +107,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="CreateOrleansTables_MySql.sql" />
+    <Content Include="CreateOrleansTables_MySql.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="CreateOrleansTables_SqlServer.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -282,36 +282,36 @@ namespace UnitTests.MembershipTests
         public override TestCluster CreateTestCluster()
         {
             var options = new TestClusterOptions(2);
-            options.ClusterConfiguration.Globals.DataConnectionString = StorageTestConstants.DataConnectionString;
+            options.ClusterConfiguration.Globals.DataConnectionString = StorageTestConstants.GetZooKeeperConnectionString();
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.ZooKeeper;
             return new TestCluster(options);
         }
 
-        //[Fact,  TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [Fact,  TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_1()
         {
             await Do_Liveness_OracleTest_1();
         }
 
-        //[Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_2_Restart_Primary()
         {
             await Do_Liveness_OracleTest_2(0);
         }
 
-        //[Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_3_Restart_GW()
         {
             await Do_Liveness_OracleTest_2(1);
         }
 
-        //[Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_4_Restart_Silo_1()
         {
             await Do_Liveness_OracleTest_2(2);
         }
 
-        //[Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_5_Kill_Silo_1_With_Timers()
         {
             await Do_Liveness_OracleTest_2(2, false, true);
@@ -333,32 +333,79 @@ namespace UnitTests.MembershipTests
             return new TestCluster(options);
         }
 
-        //[Fact, TestCategory("Membership"), TestCategory("SqlServer")]
-        public async Task Liveness_Sql_1()
+        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        public async Task Liveness_SqlServer_1()
         {
             await Do_Liveness_OracleTest_1();
         }
 
-        //[Fact, TestCategory("Membership"), TestCategory("SqlServer")]
-        public async Task Liveness_Sql_2_Restart_Primary()
+        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        public async Task Liveness_SqlServer_2_Restart_Primary()
         {
             await Do_Liveness_OracleTest_2(0);
         }
 
-        //[Fact, TestCategory("Membership"), TestCategory("SqlServer")]
-        public async Task Liveness_Sql_3_Restartl_GW()
+        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        public async Task Liveness_SqlServer_3_Restartl_GW()
         {
             await Do_Liveness_OracleTest_2(1);
         }
 
-        //[Fact, TestCategory("Membership"), TestCategory("SqlServer")]
-        public async Task Liveness_Sql_4_Restart_Silo_1()
+        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        public async Task Liveness_SqlServer_4_Restart_Silo_1()
         {
             await Do_Liveness_OracleTest_2(2);
         }
 
-        //[Fact, TestCategory("Membership"), TestCategory("SqlServer")]
-        public async Task Liveness_Sql_5_Kill_Silo_1_With_Timers()
+        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        public async Task Liveness_SqlServer_5_Kill_Silo_1_With_Timers()
+        {
+            await Do_Liveness_OracleTest_2(2, false, true);
+        }
+    }
+
+    public class LivenessTests_MySql : LivenessTestsBase
+    {
+        public const string TestDatabaseName = "OrleansTest";
+        public LivenessTests_MySql(ITestOutputHelper output) : base(output)
+        {
+        }
+        public override TestCluster CreateTestCluster()
+        {
+            var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameMySql, TestDatabaseName).Result;
+            var options = new TestClusterOptions(2);
+            options.ClusterConfiguration.Globals.DataConnectionString = relationalStorage.CurrentConnectionString;
+            options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.SqlServer;
+            options.ClusterConfiguration.Globals.AdoInvariant = AdoNetInvariants.InvariantNameMySql;
+            return new TestCluster(options);
+        }
+
+        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        public async Task Liveness_MySql_1()
+        {
+            await Do_Liveness_OracleTest_1();
+        }
+
+        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        public async Task Liveness_MySql_2_Restart_Primary()
+        {
+            await Do_Liveness_OracleTest_2(0);
+        }
+
+        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        public async Task Liveness_MySql_3_Restartl_GW()
+        {
+            await Do_Liveness_OracleTest_2(1);
+        }
+
+        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        public async Task Liveness_MySql_4_Restart_Silo_1()
+        {
+            await Do_Liveness_OracleTest_2(2);
+        }
+
+        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        public async Task Liveness_MySql_5_Kill_Silo_1_With_Timers()
         {
             await Do_Liveness_OracleTest_2(2, false, true);
         }

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -336,6 +336,10 @@
       <Project>{40ee3b00-d381-485f-9c69-ff706837deed}</Project>
       <Name>OrleansTestingHost</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\OrleansZooKeeperUtils\OrleansZooKeeperUtils.csproj">
+      <Project>{45918dd2-53d9-4b27-bc6b-17c197dbc645}</Project>
+      <Name>OrleansZooKeeperUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Orleans\Orleans.csproj">
       <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
       <Name>Orleans</Name>


### PR DESCRIPTION
With these minor changes, liveness tests pass successfully on Sql Server, MySql and ZK.
I hope bugs like  #1725 are a thing of the past.