### PR TITLE
Rename InstanceName to SiloName.

### DIFF
--- a/src/Orleans/Streams/PersistentStreams/IDeploymentConfiguration.cs
+++ b/src/Orleans/Streams/PersistentStreams/IDeploymentConfiguration.cs
@@ -11,6 +11,6 @@ namespace Orleans.Streams
         /// Get the silo instance names for all configured silos
         /// </summary>
         /// <returns></returns>
-        IList<string> GetAllSiloInstanceNames();
+        IList<string> GetAllSiloNames();
     }
 }

--- a/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
@@ -152,7 +152,7 @@ namespace Orleans
                {
                    if (x.Item1.Status.Equals(SiloStatus.Dead)) return 1; // put Deads at the end
                    if (y.Item1.Status.Equals(SiloStatus.Dead)) return -1; // put Deads at the end
-                   return String.Compare(x.Item1.InstanceName, y.Item1.InstanceName, StringComparison.Ordinal);
+                   return String.Compare(x.Item1.SiloName, y.Item1.SiloName, StringComparison.Ordinal);
                });
             Members = list.AsReadOnly();
             Version = version;
@@ -238,10 +238,10 @@ namespace Orleans
 
         public string HostName { get; set; }          
         public SiloStatus Status { get; set; }          
-        public int ProxyPort { get; set; }                   
+        public int ProxyPort { get; set; }
 
-        public string RoleName { get; set; }              // Optional - only for Azure role
-        public string InstanceName { get; set; }          // Optional - only for Azure role
+        public string RoleName { get; set; }           // Optional - only for Azure role  
+        public string SiloName { get; set; }
         public int UpdateZone { get; set; }            // Optional - only for Azure role
         public int FaultZone { get; set; }             // Optional - only for Azure role
 
@@ -271,7 +271,7 @@ namespace Orleans
             ProxyPort = updatedSiloEntry.ProxyPort;
 
             RoleName = updatedSiloEntry.RoleName;
-            InstanceName = updatedSiloEntry.InstanceName;
+            SiloName = updatedSiloEntry.SiloName;
             UpdateZone = updatedSiloEntry.UpdateZone;
             FaultZone = updatedSiloEntry.FaultZone;
 
@@ -305,7 +305,7 @@ namespace Orleans
 
         public override string ToString()
         {
-            return string.Format("SiloAddress={0} InstanceName={1} Status={2}", SiloAddress.ToLongString(), InstanceName, Status);
+            return string.Format("SiloAddress={0} SiloName={1} Status={2}", SiloAddress.ToLongString(), SiloName, Status);
         }
 
         internal string ToFullString(bool full = false)
@@ -319,10 +319,10 @@ namespace Orleans
             List<DateTime> timestamps = SuspectTimes == null
                 ? null
                 : SuspectTimes.Select(tuple => tuple.Item2).ToList();
-            return string.Format("[SiloAddress={0} InstanceName={1} Status={2} HostName={3} ProxyPort={4} " +
+            return string.Format("[SiloAddress={0} SiloName={1} Status={2} HostName={3} ProxyPort={4} " +
                                  "RoleName={5} UpdateZone={6} FaultZone={7} StartTime = {8} IAmAliveTime = {9} {10} {11}]",
                 SiloAddress.ToLongString(),
-                InstanceName,
+                SiloName,
                 Status,
                 HostName,
                 ProxyPort,

--- a/src/OrleansAzureUtils/Hosting/AzureSilo.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureSilo.cs
@@ -132,8 +132,8 @@ namespace Orleans.Runtime.Host
                 HostName = host.Config.GetOrCreateNodeConfigurationForSilo(host.Name).DNSHostName,
                 ProxyPort = (proxyEndpoint != null ? proxyEndpoint.Port : 0).ToString(CultureInfo.InvariantCulture),
 
-                RoleName = serviceRuntimeWrapper.RoleName, 
-                InstanceName = instanceName,
+                RoleName = serviceRuntimeWrapper.RoleName,
+                SiloName = instanceName,
                 UpdateZone = serviceRuntimeWrapper.UpdateDomain.ToString(CultureInfo.InvariantCulture),
                 FaultZone = serviceRuntimeWrapper.FaultDomain.ToString(CultureInfo.InvariantCulture),
                 StartTime = TraceLogger.PrintDate(DateTime.UtcNow),

--- a/src/OrleansAzureUtils/Hosting/ServiceRuntimeWrapper.cs
+++ b/src/OrleansAzureUtils/Hosting/ServiceRuntimeWrapper.cs
@@ -123,7 +123,7 @@ namespace Orleans.Runtime.Host
             }
         }
 
-        public IList<string> GetAllSiloInstanceNames()
+        public IList<string> GetAllSiloNames()
         {
             dynamic instances = role.Instances;
             var list = new List<string>();

--- a/src/OrleansAzureUtils/Storage/AzureBasedMembershipTable.cs
+++ b/src/OrleansAzureUtils/Storage/AzureBasedMembershipTable.cs
@@ -198,7 +198,15 @@ namespace Orleans.Runtime.MembershipService
             parse.SiloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Parse(tableEntry.Address), port), gen);
 
             parse.RoleName = tableEntry.RoleName;
-            parse.InstanceName = tableEntry.InstanceName;
+            if (!string.IsNullOrEmpty(tableEntry.SiloName))
+            {
+                parse.SiloName = tableEntry.SiloName;
+            }else if (!string.IsNullOrEmpty(tableEntry.InstanceName))
+            {
+                // this is for backward compatability: in a mixed cluster of old and new version,
+                // some entries will have the old InstanceName column.
+                parse.SiloName = tableEntry.InstanceName;
+            }
             if (!string.IsNullOrEmpty(tableEntry.UpdateZone))
                 parse.UpdateZone = int.Parse(tableEntry.UpdateZone);
 
@@ -251,7 +259,10 @@ namespace Orleans.Runtime.MembershipService
                 Status = memEntry.Status.ToString(),
                 ProxyPort = memEntry.ProxyPort.ToString(CultureInfo.InvariantCulture),
                 RoleName = memEntry.RoleName,
-                InstanceName = memEntry.InstanceName,
+                SiloName = memEntry.SiloName,
+                // this is for backward compatability: in a mixed cluster of old and new version,
+                // we need to populate both columns.
+                InstanceName = memEntry.SiloName,
                 UpdateZone = memEntry.UpdateZone.ToString(CultureInfo.InvariantCulture),
                 FaultZone = memEntry.FaultZone.ToString(CultureInfo.InvariantCulture),
                 StartTime = TraceLogger.PrintDate(memEntry.StartTime),

--- a/src/OrleansAzureUtils/Storage/OrleansSiloInstanceManager.cs
+++ b/src/OrleansAzureUtils/Storage/OrleansSiloInstanceManager.cs
@@ -25,7 +25,8 @@ namespace Orleans.AzureUtils
         public string ProxyPort { get; set; }       // Optional
 
         public string RoleName { get; set; }        // Optional - only for Azure role
-        public string InstanceName { get; set; }    // Optional - only for Azure role
+        public string SiloName { get; set; }
+        public string InstanceName { get; set; }    // For backward compatability we leave the old column, untill all clients update the code to new version.
         public string UpdateZone { get; set; }         // Optional - only for Azure role
         public string FaultZone { get; set; }          // Optional - only for Azure role
 
@@ -98,7 +99,7 @@ namespace Orleans.AzureUtils
                 sb.Append(" ProxyPort=").Append(ProxyPort);
 
                 if (!string.IsNullOrEmpty(RoleName)) sb.Append(" RoleName=").Append(RoleName);
-                sb.Append(" Instance=").Append(InstanceName);
+                sb.Append(" SiloName=").Append(SiloName);
                 sb.Append(" UpgradeZone=").Append(UpdateZone);
                 sb.Append(" FaultZone=").Append(FaultZone);
 
@@ -261,14 +262,14 @@ namespace Orleans.AzureUtils
                 {
                     if (e1 == null) return (e2 == null) ? 0 : -1;
                     if (e2 == null) return (e1 == null) ? 0 : 1;
-                    if (e1.InstanceName == null) return (e2.InstanceName == null) ? 0 : -1;
-                    if (e2.InstanceName == null) return (e1.InstanceName == null) ? 0 : 1;
-                    return String.CompareOrdinal(e1.InstanceName, e2.InstanceName);
+                    if (e1.SiloName == null) return (e2.SiloName == null) ? 0 : -1;
+                    if (e2.SiloName == null) return (e1.SiloName == null) ? 0 : 1;
+                    return String.CompareOrdinal(e1.SiloName, e2.SiloName);
                 });
             foreach (SiloInstanceTableEntry entry in entries)
             {
                 sb.AppendLine(String.Format("[IP {0}:{1}:{2}, {3}, Instance={4}, Status={5}]", entry.Address, entry.Port, entry.Generation,
-                    entry.HostName, entry.InstanceName, entry.Status));
+                    entry.HostName, entry.SiloName, entry.Status));
             }
             return sb.ToString();
         }

--- a/src/OrleansConsulUtils/SerializableMembershipTypes.cs
+++ b/src/OrleansConsulUtils/SerializableMembershipTypes.cs
@@ -55,6 +55,9 @@ namespace Orleans.Runtime.Host
         public SiloStatus Status { get; set; }
 
         [JsonProperty]
+        public String SiloName { get; set; }
+
+        [JsonProperty]
         public List<SuspectingSilo> SuspectingSilos { get; set; }
 
         [JsonConstructor]
@@ -136,6 +139,7 @@ namespace Orleans.Runtime.Host
                 ProxyPort = entry.ProxyPort,
                 StartTime = entry.StartTime,
                 Status = entry.Status,
+                SiloName = entry.SiloName,
                 SuspectingSilos = entry.SuspectTimes.Select(silo => new SuspectingSilo { Id = silo.Item1.ToParsableString(), Time = silo.Item2 }).ToList()
             };
 
@@ -168,10 +172,10 @@ namespace Orleans.Runtime.Host
                 StartTime = siloRegistration.StartTime,
                 SuspectTimes = siloRegistration.SuspectingSilos.Select(silo => new Tuple<SiloAddress, DateTime>(SiloAddress.FromParsableString(silo.Id), silo.Time)).ToList(),
                 IAmAliveTime = siloRegistration.IAmAliveTime,
+                SiloName = siloRegistration.SiloName,
 
                 // Optional - only for Azure role so initialised here
                 RoleName = String.Empty,
-                InstanceName = String.Empty,
                 UpdateZone = 0,
                 FaultZone = 0
             };

--- a/src/OrleansRuntime/MembershipService/MembershipOracle.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipOracle.cs
@@ -91,10 +91,10 @@ namespace Orleans.Runtime.MembershipService
             if (logger.IsVerbose) logger.Verbose("-ReadAll Membership table {0}", table.ToString());
             CheckMissedIAmAlives(table);
 
-            string myInstanceName = nodeConfig.SiloName;
+            string mySiloName = nodeConfig.SiloName;
             MembershipEntry mostRecentPreviousEntry = null;
             // look for silo instances that are same as me, find most recent with Generation before me.
-            foreach (MembershipEntry entry in table.Members.Select(tuple => tuple.Item1).Where(data => myInstanceName.Equals(data.InstanceName)))
+            foreach (MembershipEntry entry in table.Members.Select(tuple => tuple.Item1).Where(data => mySiloName.Equals(data.SiloName)))
             {
                 bool iAmLater = MyAddress.Generation.CompareTo(entry.SiloAddress.Generation) > 0;
                 // more recent
@@ -107,14 +107,14 @@ namespace Orleans.Runtime.MembershipService
                 bool physicalHostChanged = !myHostname.Equals(mostRecentPreviousEntry.HostName) || !MyAddress.Endpoint.Equals(mostRecentPreviousEntry.SiloAddress.Endpoint);
                 if (physicalHostChanged)
                 {
-                    string error = String.Format("Silo instance {0} migrated from host {1} silo address {2} to host {3} silo address {4}.",
-                        myInstanceName, myHostname, MyAddress.ToLongString(), mostRecentPreviousEntry.HostName, mostRecentPreviousEntry.SiloAddress.ToLongString());
+                    string error = String.Format("Silo {0} migrated from host {1} silo address {2} to host {3} silo address {4}.",
+                        mySiloName, myHostname, MyAddress.ToLongString(), mostRecentPreviousEntry.HostName, mostRecentPreviousEntry.SiloAddress.ToLongString());
                     logger.Warn(ErrorCode.MembershipNodeMigrated, error);
                 }
                 else
                 {
-                    string error = String.Format("Silo instance {0} restarted on same host {1} New silo address = {2} Previous silo address = {3}",
-                        myInstanceName, myHostname, MyAddress.ToLongString(), mostRecentPreviousEntry.SiloAddress.ToLongString());
+                    string error = String.Format("Silo {0} restarted on same host {1} New silo address = {2} Previous silo address = {3}",
+                        mySiloName, myHostname, MyAddress.ToLongString(), mostRecentPreviousEntry.SiloAddress.ToLongString());
                     logger.Warn(ErrorCode.MembershipNodeRestarted, error);
                 }
             }

--- a/src/OrleansRuntime/MembershipService/MembershipOracleData.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipOracleData.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime.MembershipService
             // make copies
             var tmpLocalTableCopy = GetSiloStatuses(st => true, true); // all the silos including me.
             var tmpLocalTableCopyOnlyActive = GetSiloStatuses(st => st.Equals(SiloStatus.Active), true);    // only active silos including me.
-            var tmpLocalTableNamesCopy = localTable.ToDictionary(pair => pair.Key, pair => pair.Value.InstanceName);   // all the silos excluding me.
+            var tmpLocalTableNamesCopy = localTable.ToDictionary(pair => pair.Key, pair => pair.Value.SiloName);   // all the silos excluding me.
 
             CurrentStatus = status;
 
@@ -176,7 +176,7 @@ namespace Orleans.Runtime.MembershipService
                 SiloAddress = myAddress,
 
                 HostName = myHostname,
-                InstanceName = nodeConf.SiloName,
+                SiloName = nodeConf.SiloName,
 
                 Status = myStatus,
                 ProxyPort = (nodeConf.IsGatewayNode ? nodeConf.ProxyGatewayEndpoint.Port : 0),
@@ -196,7 +196,7 @@ namespace Orleans.Runtime.MembershipService
 
             localTableCopy = GetSiloStatuses(status => true, true); // all the silos including me.
             localTableCopyOnlyActive = GetSiloStatuses(status => status.Equals(SiloStatus.Active), true);    // only active silos including me.
-            localNamesTableCopy = localTable.ToDictionary(pair => pair.Key, pair => pair.Value.InstanceName);   // all the silos excluding me.
+            localNamesTableCopy = localTable.ToDictionary(pair => pair.Key, pair => pair.Value.SiloName);   // all the silos excluding me.
 
             if (logger.IsVerbose) logger.Verbose("-Updated my local view of {0} status. It is now {1}.", entry.SiloAddress.ToLongString(), GetSiloStatus(entry.SiloAddress));
 

--- a/src/OrleansRuntime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
@@ -182,7 +182,7 @@ namespace Orleans.Streams
         /// </summary>
         private BestFitBalancer<string, QueueId> GetBalancer()
         {
-            var allSiloNames = deploymentConfig.GetAllSiloInstanceNames();
+            var allSiloNames = deploymentConfig.GetAllSiloNames();
             // rebuild balancer with new list of instance names
             return new BestFitBalancer<string, QueueId>(allSiloNames, allQueues);
         }

--- a/src/OrleansRuntime/Streams/QueueBalancer/StaticClusterDeploymentConfiguration.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/StaticClusterDeploymentConfiguration.cs
@@ -21,7 +21,7 @@ namespace Orleans.Streams
             _clusterConfiguration = clusterConfiguration;
         }
 
-        public IList<string> GetAllSiloInstanceNames()
+        public IList<string> GetAllSiloNames()
         {
             return _clusterConfiguration.Overrides.Keys.ToList();
         }

--- a/src/OrleansZooKeeperUtils/MembershipSerializerSettings.cs
+++ b/src/OrleansZooKeeperUtils/MembershipSerializerSettings.cs
@@ -30,7 +30,8 @@ namespace Orleans.Runtime.Host
                 writer.WriteStartObject();
                 writer.WritePropertyName("SiloAddress"); serializer.Serialize(writer, me.SiloAddress);
                 writer.WritePropertyName("HostName"); writer.WriteValue(me.HostName);
-                writer.WritePropertyName("InstanceName"); writer.WriteValue(me.InstanceName);
+                writer.WritePropertyName("SiloName"); writer.WriteValue(me.SiloName);
+                writer.WritePropertyName("InstanceName"); writer.WriteValue(me.SiloName);
                 writer.WritePropertyName("Status"); serializer.Serialize(writer, me.Status);
                 writer.WritePropertyName("ProxyPort"); writer.WriteValue(me.ProxyPort);
                 writer.WritePropertyName("StartTime"); writer.WriteValue(me.StartTime);
@@ -46,7 +47,7 @@ namespace Orleans.Runtime.Host
                 {
                     SiloAddress = jo["SiloAddress"].ToObject<SiloAddress>(serializer),
                     HostName = jo["HostName"].ToObject<string>(),
-                    InstanceName = jo["InstanceName"].ToObject<string>(),
+                    SiloName = (jo["SiloName"] ?? jo["InstanceName"]).ToObject<string>(),
                     Status = jo["Status"].ToObject<SiloStatus>(serializer),
                     ProxyPort = jo["ProxyPort"].Value<int>(),
                     StartTime = jo["StartTime"].Value<DateTime>(),

--- a/test/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
+++ b/test/TesterInternal/StorageTests/SiloInstanceTableManagerTests.cs
@@ -234,7 +234,7 @@ namespace UnitTests.StorageTests
                 ProxyPort = "30000",
 
                 RoleName = "MyRole",
-                InstanceName = "MyInstance",
+                SiloName = "MyInstance",
                 UpdateZone = "0",
                 FaultZone = "0",
                 StartTime = TraceLogger.PrintDate(DateTime.UtcNow),
@@ -268,7 +268,7 @@ namespace UnitTests.StorageTests
             //Assert.AreEqual(referenceEntry.Status, entry.Status, "Status");
             Assert.AreEqual(referenceEntry.ProxyPort, entry.ProxyPort, "ProxyPort");
             Assert.AreEqual(referenceEntry.RoleName, entry.RoleName, "RoleName");
-            Assert.AreEqual(referenceEntry.InstanceName, entry.InstanceName, "InstanceName");
+            Assert.AreEqual(referenceEntry.SiloName, entry.SiloName, "SiloName");
             Assert.AreEqual(referenceEntry.UpdateZone, entry.UpdateZone, "UpdateZone");
             Assert.AreEqual(referenceEntry.FaultZone, entry.FaultZone, "FaultZone");
             Assert.AreEqual(referenceEntry.StartTime, entry.StartTime, "StartTime");


### PR DESCRIPTION
Addresses https://github.com/dotnet/orleans/issues/1738.

One important issue to watch is backward compatibility: since InstanceName  is persisted, what will happen if we suddenly rename it to SiloName? Our clients should work without experiencing any pain, for example without needing to fully stop the cluster and delete the whole table.

I addressed backward compatibility issue on Azure. I kept both columns in the table. New silo will write its SiloName into both columns, and when reading entries of other silos it will try to parse SiloName from either of the columns. 
I believe this will allow a mixed cluster (with old and new version) to co-exist. However, I have not tested that. In general, in other systems, this is a rather complicated and delicate issue that has to be dealt with great caution and usually solved strategically (as opposite to my "one-off" solution here). 

As for SQL and ZK and Consul - I have not addressed backward compatibility there. 
SQL does not currently have InstanceName at all, so it should not be a problem.
Consul does not populate InstanceName at all, so it should not be a problem.
ZK is the only one that needs to be dealt with.