### PR TITLE
Use GetUninitializedObject with Reflection in coreclr

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyLoaderPathNameCriterion.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoaderPathNameCriterion.cs
@@ -15,9 +15,6 @@ namespace Orleans.Runtime
             return new AssemblyLoaderPathNameCriterion(predicate);
         }
 
-        // constructor used by serializator
-        private AssemblyLoaderPathNameCriterion() : base(null) { }
-
         private AssemblyLoaderPathNameCriterion(Predicate predicate) :
             base((object input, out IEnumerable<string> complaints) =>
                     predicate((string)input, out complaints))

--- a/src/Orleans/Logging/TraceLogger.cs
+++ b/src/Orleans/Logging/TraceLogger.cs
@@ -161,9 +161,6 @@ namespace Orleans.Runtime
             BulkMessageLimit = Constants.DEFAULT_LOGGER_BULK_MESSAGE_LIMIT;
         }
 
-        // constructor used by serializator
-        private TraceLogger() {}
-
         /// <summary>
         /// Constructs a TraceLogger with the given name and type.
         /// </summary>

--- a/src/Orleans/Streams/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamSubscriptionHandleImpl.cs
@@ -24,9 +24,6 @@ namespace Orleans.Streams
         public override IStreamIdentity StreamIdentity { get { return streamImpl; } }
         public override Guid HandleId { get { return subscriptionId.Guid; } }
 
-        // constructor used by serializator
-        private StreamSubscriptionHandleImpl() { }
-
         public StreamSubscriptionHandleImpl(GuidId subscriptionId, StreamImpl<T> streamImpl, bool isRewindable)
             : this(subscriptionId, null, streamImpl, isRewindable, null, null)
         {

--- a/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
+++ b/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
@@ -27,9 +27,6 @@ namespace Orleans.Streams
         [NonSerialized]
         private StreamFilterPredicate predicateFunc;
 
-        // constructor used by serializator
-        private FilterPredicateWrapperData() { }
-
         internal FilterPredicateWrapperData(object filterData, StreamFilterPredicate pred)
         {
             CheckFilterPredicateFunc(pred); // Assert expected pre-conditions are always true.

--- a/src/OrleansCodeGenerator/Utilities/SyntaxFactoryExtensions.cs
+++ b/src/OrleansCodeGenerator/Utilities/SyntaxFactoryExtensions.cs
@@ -6,7 +6,6 @@ namespace Orleans.CodeGenerator.Utilities
     using System.Linq.Expressions;
     using System.Reflection;
 
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -126,42 +125,6 @@ namespace Orleans.CodeGenerator.Utilities
             }
 
             return SyntaxFactory.ParenthesizedExpression(bindingFlagsBinaryExpression);
-        }
-
-        /// <summary>
-        /// Returns <see cref="ArrayCreationExpressionSyntax"/> representing the array creation form of <paramref name="arrayType"/>.
-        /// </summary>
-        /// <param name="separatedSyntaxList">
-        /// Args used in initialization.
-        /// </param>
-        /// <param name="arrayType">
-        /// The array type.
-        /// </param>
-        /// <returns>
-        /// <see cref="ArrayCreationExpressionSyntax"/> representing the array creation form of <paramref name="arrayType"/>.
-        /// </returns>
-        public static ArrayCreationExpressionSyntax GetArrayCreationWithInitializerSyntax(this SeparatedSyntaxList<ExpressionSyntax> separatedSyntaxList, TypeSyntax arrayType)
-        {
-            var arrayRankSizes =
-                new SeparatedSyntaxList<ExpressionSyntax>().Add(SyntaxFactory.OmittedArraySizeExpression(
-                    SyntaxFactory.Token(SyntaxKind.OmittedArraySizeExpressionToken)));
-
-            var arrayRankSpecifier = SyntaxFactory.ArrayRankSpecifier(
-                SyntaxFactory.Token(SyntaxKind.OpenBracketToken),
-                arrayRankSizes,
-                SyntaxFactory.Token(SyntaxKind.CloseBracketToken));
-
-            var arrayRankSpecifierSyntaxList = new SyntaxList<ArrayRankSpecifierSyntax>().Add(arrayRankSpecifier);
-
-            var arrayCreationExpressionSyntax = SyntaxFactory.ArrayCreationExpression(
-                SyntaxFactory.Token(SyntaxKind.NewKeyword),
-                SyntaxFactory.ArrayType(arrayType, arrayRankSpecifierSyntaxList),
-                SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression,
-                    SyntaxFactory.Token(SyntaxKind.OpenBraceToken),
-                    separatedSyntaxList,
-                    SyntaxFactory.Token(SyntaxKind.CloseBraceToken)));
-
-            return arrayCreationExpressionSyntax;
         }
 
         /// <summary>

--- a/test/TestGrains/GenericGrains.cs
+++ b/test/TestGrains/GenericGrains.cs
@@ -6,6 +6,7 @@ using Orleans.Concurrency;
 using Orleans.Providers;
 using UnitTests.GrainInterfaces;
 using System.Globalization;
+using System.Reflection;
 using Orleans.CodeGeneration;
 
 namespace UnitTests.Grains
@@ -679,11 +680,11 @@ namespace UnitTests.Grains
 
 
             Type GetImmediateSubclass(Type subject) {
-                if(subject.BaseType == typeof(BasicGrain)) {
+                if(subject.GetTypeInfo().BaseType == typeof(BasicGrain)) {
                     return subject;
                 }
 
-                return GetImmediateSubclass(subject.BaseType);
+                return GetImmediateSubclass(subject.GetTypeInfo().BaseType);
             }
         }
 


### PR DESCRIPTION
Revert #1122 that uses Activator.CreateInstance() instead of FormatterServices.GetUninitializedObject().
Use reflection to get to this internal method when in CoreCLR.