### PR TITLE
NuGet metadata fixes (and Servicebus package update)

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
@@ -23,6 +23,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="OrleansCodeGenerator.XML" target="lib\net451" />
     <file src="OrleansCodeGenerator.dll" target="lib\net451" />
     <file src="$SRC_DIR$OrleansCodeGenerator\**\*.cs" target="src" />
   </files>

--- a/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
@@ -22,7 +22,7 @@
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansProviders" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansAzureUtils" version="$version$" />
-      <dependency id="WindowsAzure.ServiceBus" version="3.0.8" />
+      <dependency id="WindowsAzure.ServiceBus" version="3.2.0" />
       <dependency id="WindowsAzure.Storage" version="5.0.2" />
     </dependencies>
   </metadata>

--- a/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
@@ -27,6 +27,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="OrleansServiceBus.XML" target="lib\net451" />
     <file src="OrleansServiceBus.dll" target="lib\net451" />
     <file src="OrleansServiceBus.pdb" target="lib\net451" />
     <file src="$SRC_DIR$OrleansServiceBus\**\*.cs" target="src" />

--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -24,6 +24,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="OrleansZooKeeperUtils.XML" target="lib\net451" />
     <file src="OrleansZooKeeperUtils.dll" target="lib\net451" />
     <file src="OrleansZooKeeperUtils.pdb" target="lib\net451" />
     <file src="$SRC_DIR$OrleansZooKeeperUtils\**\*.cs" target="src" />

--- a/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
@@ -24,6 +24,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="OrleansTestingHost.XML" target="lib\net451" />
     <file src="OrleansTestingHost.dll" target="lib\net451" />
     <file src="OrleansTestingHost.pdb" target="lib\net451" />
     

--- a/src/OrleansCodeGenerator/OrleansCodeGenerator.csproj
+++ b/src/OrleansCodeGenerator/OrleansCodeGenerator.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\OrleansCodeGenerator.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\OrleansCodeGenerator.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Bootstrap)' == 'true'">
     <OutputPath>$(BootstrapOutputPath)</OutputPath>

--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\OrleansServiceBus.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\OrleansServiceBus.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.KeyVault.Core">

--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -47,7 +47,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus">
-      <HintPath>$(SolutionDir)packages\WindowsAzure.ServiceBus.3.0.8\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.ServiceBus.3.2.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration">
@@ -114,6 +114,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/OrleansServiceBus/app.config
+++ b/src/OrleansServiceBus/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/OrleansServiceBus/packages.config
+++ b/src/OrleansServiceBus/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
-  <package id="WindowsAzure.ServiceBus" version="3.0.8" targetFramework="net45" />
+  <package id="WindowsAzure.ServiceBus" version="3.2.0" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net451" />
 </packages>

--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <WarningsAsErrors>4014</WarningsAsErrors>
+    <DocumentationFile>bin\Debug\OrleansTestingHost.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <WarningsAsErrors>4014</WarningsAsErrors>
+    <DocumentationFile>bin\Release\OrleansTestingHost.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">

--- a/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
+++ b/src/OrleansZooKeeperUtils/OrleansZooKeeperUtils.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <WarningsAsErrors>4014</WarningsAsErrors>
+    <DocumentationFile>bin\Debug\OrleansZooKeeperUtils.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\OrleansZooKeeperUtils.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -94,7 +94,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus">
-      <HintPath>..\..\src\packages\WindowsAzure.ServiceBus.3.0.8\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\WindowsAzure.ServiceBus.3.2.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">

--- a/test/Tester/packages.config
+++ b/test/Tester/packages.config
@@ -13,7 +13,7 @@
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
   <package id="Validation" version="2.2.8" targetFramework="net451" />
-  <package id="WindowsAzure.ServiceBus" version="3.0.8" targetFramework="net451" />
+  <package id="WindowsAzure.ServiceBus" version="3.2.0" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />


### PR DESCRIPTION
Fixes to include XML docs in the remaining nuget packages.
Also updated the dependency on WindowsAzure.ServiceBus package, since it's non-breaking but fixes some important bugs.