### PR TITLE
EventHub stream provider partition checkpoint corruption fix

### DIFF
--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ServiceBus.Messaging;
 using Orleans.Serialization;
 
@@ -12,6 +13,7 @@ namespace Orleans.ServiceBus.Providers
     public static class EventDataExtensions
     {
         public const string EventDataPropertyStreamNamespaceKey = "StreamNamespace";
+        private static readonly string[] SkipProperties = { nameof(EventData.Offset), nameof(EventData.SequenceNumber), nameof(EventData.EnqueuedTimeUtc), EventDataPropertyStreamNamespaceKey };
 
         public static void SetStreamNamespaceProperty(this EventData eventData, string streamNamespace)
         {
@@ -31,14 +33,14 @@ namespace Orleans.ServiceBus.Providers
         public static byte[] SerializeProperties(this IDictionary<string, object> properties)
         {
             var writeStream = new BinaryTokenStreamWriter();
-            SerializationManager.Serialize(properties, writeStream);
+            SerializationManager.Serialize(properties.Where(kvp => !SkipProperties.Contains(kvp.Key)).ToList(), writeStream);
             return writeStream.ToByteArray();
         }
 
         public static IDictionary<string, object> DeserializeProperties(this ArraySegment<byte> bytes)
         {
             var stream = new BinaryTokenStreamReader(bytes);
-            return SerializationManager.Deserialize<IDictionary<string, object>>(stream);
+            return SerializationManager.Deserialize<List<KeyValuePair<string, object>>>(stream).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -32,14 +32,12 @@ namespace Orleans.ServiceBus.Providers
         {
             int readOffset = 0;
             StreamIdentity = new StreamIdentity(cachedMessage.StreamGuid, SegmentBuilder.ReadNextString(cachedMessage.Segment, ref readOffset));
+            Offset = SegmentBuilder.ReadNextString(cachedMessage.Segment, ref readOffset);
             SequenceNumber = cachedMessage.SequenceNumber;
             EnqueueTimeUtc = cachedMessage.EnqueueTimeUtc;
             DequeueTimeUtc = cachedMessage.DequeueTimeUtc;
             Properties = SegmentBuilder.ReadNextBytes(cachedMessage.Segment, ref readOffset).DeserializeProperties();
             object offsetObj;
-            Offset = Properties.TryGetValue("Offset", out offsetObj)
-                ? offsetObj as string
-                : default(string);
             PartitionKey = Properties.TryGetValue("PartitionKey", out offsetObj)
                 ? offsetObj as string
                 : default(string);
@@ -175,6 +173,7 @@ namespace Orleans.ServiceBus.Providers
             byte[] payload = queueMessage.GetBytes();
             // get size of namespace, offset, properties, and payload
             int size = SegmentBuilder.CalculateAppendSize(streamPosition.StreamIdentity.Namespace) +
+            SegmentBuilder.CalculateAppendSize(queueMessage.Offset) +
             SegmentBuilder.CalculateAppendSize(propertiesBytes) +
             SegmentBuilder.CalculateAppendSize(payload);
 
@@ -184,6 +183,7 @@ namespace Orleans.ServiceBus.Providers
             // encode namespace, offset, properties and payload into segment
             int writeOffset = 0;
             SegmentBuilder.Append(segment, ref writeOffset, streamPosition.StreamIdentity.Namespace);
+            SegmentBuilder.Append(segment, ref writeOffset, queueMessage.Offset);
             SegmentBuilder.Append(segment, ref writeOffset, propertiesBytes);
             SegmentBuilder.Append(segment, ref writeOffset, payload);
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -127,6 +127,7 @@ namespace Orleans.ServiceBus.Providers
 
         protected override string GetOffset(CachedEventHubMessage lastItemPurged)
         {
+            // TODO figure out how to get this from the adapter
             int readOffset = 0;
             SegmentBuilder.ReadNextString(lastItemPurged.Segment, ref readOffset); // read namespace, not needed so throw away.
             return SegmentBuilder.ReadNextString(lastItemPurged.Segment, ref readOffset); // read offset

--- a/test/Tester/StreamingTests/EHClientStreamTests.cs
+++ b/test/Tester/StreamingTests/EHClientStreamTests.cs
@@ -57,7 +57,7 @@ namespace Tester.StreamingTests
             base.Dispose();
             var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString);
             dataManager.InitTableAsync().Wait();
-            dataManager.DeleteTableAsync().Wait();
+            dataManager.ClearTableAsync().Wait();
             TestAzureTableStorageStreamFailureHandler.DeleteAll().Wait();
         }
 

--- a/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -57,7 +57,7 @@ namespace UnitTests.StreamingTests
                 base.Dispose();
                 var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString);
                 dataManager.InitTableAsync().Wait();
-                dataManager.DeleteTableAsync().Wait();
+                dataManager.ClearTableAsync().Wait();
             }
 
             private static Dictionary<string, string> BuildProviderSettings()

--- a/test/Tester/StreamingTests/EHStreamPerPartitionTests.cs
+++ b/test/Tester/StreamingTests/EHStreamPerPartitionTests.cs
@@ -54,7 +54,7 @@ namespace UnitTests.StreamingTests
                 base.Dispose();
                 var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString);
                 dataManager.InitTableAsync().Wait();
-                dataManager.DeleteTableAsync().Wait();
+                dataManager.ClearTableAsync().Wait();
             }
 
             private static Dictionary<string, string> BuildProviderSettings()

--- a/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
+++ b/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
@@ -66,7 +66,7 @@ namespace UnitTests.StreamingTests
         {
             var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString);
             dataManager.InitTableAsync().Wait();
-            dataManager.DeleteTableAsync().Wait();
+            dataManager.ClearTableAsync().Wait();
             base.Dispose();
         }
 
@@ -76,12 +76,12 @@ namespace UnitTests.StreamingTests
             try
             {
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
-                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream, assertIsTrue), TimeSpan.FromSeconds(30));
+                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream, assertIsTrue), TimeSpan.FromSeconds(60));
 
                 await RestartAgents();
 
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
-                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, assertIsTrue), TimeSpan.FromSeconds(30));
+                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, assertIsTrue), TimeSpan.FromSeconds(90));
             }
             finally
             {
@@ -96,7 +96,7 @@ namespace UnitTests.StreamingTests
             try
             {
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 0);
-                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream, assertIsTrue), TimeSpan.FromSeconds(30));
+                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream, assertIsTrue), TimeSpan.FromSeconds(60));
 
                 HostedCluster.RestartSilo(HostedCluster.SecondarySilos[0]);
                 await HostedCluster.WaitForLivenessToStabilizeAsync();

--- a/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
@@ -52,7 +52,7 @@ namespace UnitTests.StreamingTests
                 base.Dispose();
                 var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString);
                 dataManager.InitTableAsync().Wait();
-                dataManager.DeleteTableAsync().Wait();
+                dataManager.ClearTableAsync().Wait();
             }
 
             private static void AdjustClusterConfiguration(ClusterConfiguration config)


### PR DESCRIPTION
The EventHub stream provider partition checkpoints were being corrupted due to a change to the way the offset was being stored in the cache.

Offset is now stored consistently and in an accessible way for the checkpointing.
This bug was masked by timing issues in the tests, so test cleanup and timeouts have been modified.