### PR TITLE
Refactored grain props slightly, fixing null ServiceProvider problem

### DIFF
--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -26,19 +26,17 @@ namespace Orleans
 
         internal GrainReference GrainReference { get { return Data.GrainReference; } }
 
-        internal IGrainRuntime Runtime
+        internal IGrainRuntime Runtime { get; set; }
+
+        protected IGrainFactory GrainFactory 
         {
-            get { return runtime; }
-            set
-            {
-                runtime = value;
-                GrainFactory = value.GrainFactory;
-            }
+            get { return Runtime.GrainFactory; }
         }
 
-        protected IGrainFactory GrainFactory { get; private set; }
-
-        protected IServiceProvider ServiceProvider { get; private set; }
+        protected IServiceProvider ServiceProvider 
+        {
+            get { return Runtime.ServiceProvider; }
+        }
 
         internal IGrainIdentity Identity;
 
@@ -61,8 +59,6 @@ namespace Orleans
         {
             Identity = identity;
             Runtime = runtime;
-            GrainFactory = runtime.GrainFactory;
-            ServiceProvider = runtime.ServiceProvider;
         }
 
         


### PR DESCRIPTION
Hello,

Grain.ServiceProvider wasn't being set when the parameterless ctor was used. 

I've made the Grain.GrainFactory and Grain.ServiceProvider props delegate directly to the grain runtime, so that their values don't have to be set in two separate places.