### PR TITLE
Added option to perform provider commands quietly

### DIFF
--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -203,7 +203,10 @@ namespace Orleans.Runtime.Management
         private async Task<object[]> ExecutePerSiloCall(Func<ISiloControl, Task<object>> action, string actionToLog)
         {
             var silos = await GetHosts(true);
-            logger.Info("Executing {0} against {1}", actionToLog, Utils.EnumerableToString(silos.Keys));
+
+            if(logger.IsVerbose) {
+                logger.Verbose("Executing {0} against {1}", actionToLog, Utils.EnumerableToString(silos.Keys));
+            }
 
             var actionPromises = new List<Task<object>>();
             foreach (SiloAddress siloAddress in silos.Keys.ToArray())


### PR DESCRIPTION
Half-way down #610 it's quietly suggested that ``IManagementGrain.SendControlCommandToProvider`` could be exploited to message between silos in a slightly more chatty manner than initially intended - communicating cache invalidations, for instance.

This is all well and good, but the current implementation logs once per message, which has the potential to get quite noisy.

So - I've added an optional parameter to the signature to bypass logging.