### PR TITLE
Change StaticGatewayListProvider to be Updatable.

### DIFF
--- a/src/Orleans/Messaging/GatewayProviderFactory.cs
+++ b/src/Orleans/Messaging/GatewayProviderFactory.cs
@@ -52,12 +52,13 @@ namespace Orleans.Messaging
     internal class StaticGatewayListProvider : IGatewayListProvider
     {
         private IList<Uri> knownGateways;
-
+        private ClientConfiguration config;
 
         #region Implementation of IGatewayListProvider
-        
+
         public Task InitializeGatewayListProvider(ClientConfiguration cfg, TraceLogger traceLogger)
         {
+            config = cfg;
             knownGateways = cfg.Gateways.Select(ep => ep.ToGatewayUri()).ToList();
             return TaskDone.Done;
         }
@@ -69,12 +70,12 @@ namespace Orleans.Messaging
 
         public TimeSpan MaxStaleness 
         {
-            get { return TimeSpan.MaxValue; }
+            get { return config.GatewayListRefreshPeriod; }
         }
 
         public bool IsUpdatable
         {
-            get { return false; }
+            get { return true; }
         }
 
         #endregion


### PR DESCRIPTION
Fixes https://github.com/dotnet/orleans/issues/1769.

The client should now reconnect at most one minute after silos restart. This can be shortened by changing `GatewayListRefreshPeriod` in the client config. 