### PR TITLE
Log more runtime statistics on the client.

### DIFF
--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Xml;
 using Orleans.Providers;
 using System.Reflection;
+using System.Threading;
 
 namespace Orleans.Runtime.Configuration
 {
@@ -459,6 +460,13 @@ namespace Orleans.Runtime.Configuration
             sb.Append(ConfigUtilities.IStatisticsConfigurationToString(this));
             sb.Append(LimitManager);
             sb.AppendFormat(base.ToString());
+            sb.Append("   .NET: ").AppendLine();
+            int workerThreads;
+            int completionPortThreads;
+            ThreadPool.GetMinThreads(out workerThreads, out completionPortThreads);
+            sb.AppendFormat("       .NET thread pool sizes - Min: Worker Threads={0} Completion Port Threads={1}", workerThreads, completionPortThreads).AppendLine();
+            ThreadPool.GetMaxThreads(out workerThreads, out completionPortThreads);
+            sb.AppendFormat("       .NET thread pool sizes - Max: Worker Threads={0} Completion Port Threads={1}", workerThreads, completionPortThreads).AppendLine();
             sb.AppendFormat("   Providers:").AppendLine();
             sb.Append(ProviderConfigurationUtility.PrintProviderConfigurations(ProviderConfigurations));
             return sb.ToString();

--- a/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
+++ b/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
@@ -12,16 +12,16 @@ namespace Orleans.Runtime
     {
         private static readonly TraceLogger logger = TraceLogger.GetLogger("RuntimeStatisticsGroup", TraceLogger.LoggerType.Runtime);
 
-        private PerformanceCounter cpuCounter;
-        private PerformanceCounter availableMemoryCounter;
+        private PerformanceCounter cpuCounterPF;
+        private PerformanceCounter availableMemoryCounterPF;
 #if LOG_MEMORY_PERF_COUNTERS
-        private PerformanceCounter timeInGC;
-        private PerformanceCounter[] genSizes;
-        private PerformanceCounter allocatedBytesPerSec;
-        private PerformanceCounter promotedMemoryFromGen1;
-        private PerformanceCounter numberOfInducedGCs;
-        private PerformanceCounter largeObjectHeapSize;
-        private PerformanceCounter promotedFinalizationMemoryFromGen0;
+        private PerformanceCounter timeInGCPF;
+        private PerformanceCounter[] genSizesPF;
+        private PerformanceCounter allocatedBytesPerSecPF;
+        private PerformanceCounter promotedMemoryFromGen1PF;
+        private PerformanceCounter numberOfInducedGCsPF;
+        private PerformanceCounter largeObjectHeapSizePF;
+        private PerformanceCounter promotedFinalizationMemoryFromGen0PF;
 #endif
         private SafeTimer cpuUsageTimer;
         private readonly TimeSpan CPU_CHECK_PERIOD = TimeSpan.FromSeconds(5);
@@ -39,7 +39,7 @@ namespace Orleans.Runtime
         ///
         /// <summary>Amount of memory available to processes running on the machine</summary>
         /// 
-        public long AvailableMemory { get { return availableMemoryCounter != null ? Convert.ToInt64(availableMemoryCounter.NextValue()) : 0; } }
+        public long AvailableMemory { get { return availableMemoryCounterPF != null ? Convert.ToInt64(availableMemoryCounterPF.NextValue()) : 0; } }
 
         public float CpuUsage { get; private set; }
 
@@ -56,7 +56,8 @@ namespace Orleans.Runtime
         {
             get
             {
-                return String.Format("gen0={0:0.00}, gen1={1:0.00}, gen2={2:0.00}", genSizes[0].NextValue() / 1024f, genSizes[1].NextValue() / 1024f, genSizes[2].NextValue() / 1024f);
+                if (genSizesPF == null) return String.Empty;
+                return String.Format("gen0={0:0.00}, gen1={1:0.00}, gen2={2:0.00}", genSizesPF[0].NextValue() / 1024f, genSizesPF[1].NextValue() / 1024f, genSizesPF[2].NextValue() / 1024f);
             }
         }
 #endif
@@ -81,21 +82,21 @@ namespace Orleans.Runtime
         {
             try
             {
-                cpuCounter = new PerformanceCounter("Processor", "% Processor Time", "_Total", true);
-                availableMemoryCounter = new PerformanceCounter("Memory", "Available Bytes", true); 
+                cpuCounterPF = new PerformanceCounter("Processor", "% Processor Time", "_Total", true);
+                availableMemoryCounterPF = new PerformanceCounter("Memory", "Available Bytes", true); 
 #if LOG_MEMORY_PERF_COUNTERS
                 string thisProcess = Process.GetCurrentProcess().ProcessName;
-                timeInGC = new PerformanceCounter(".NET CLR Memory", "% Time in GC", thisProcess, true);
-                genSizes = new PerformanceCounter[] { 
+                timeInGCPF = new PerformanceCounter(".NET CLR Memory", "% Time in GC", thisProcess, true);
+                genSizesPF = new PerformanceCounter[] { 
                     new PerformanceCounter(".NET CLR Memory", "Gen 0 heap size", thisProcess, true), 
                     new PerformanceCounter(".NET CLR Memory", "Gen 1 heap size", thisProcess, true), 
                     new PerformanceCounter(".NET CLR Memory", "Gen 2 heap size", thisProcess, true)
                 };
-                allocatedBytesPerSec = new PerformanceCounter(".NET CLR Memory", "Allocated Bytes/sec", thisProcess, true);
-                promotedMemoryFromGen1 = new PerformanceCounter(".NET CLR Memory", "Promoted Memory from Gen 1", thisProcess, true);
-                numberOfInducedGCs = new PerformanceCounter(".NET CLR Memory", "# Induced GC", thisProcess, true);
-                largeObjectHeapSize = new PerformanceCounter(".NET CLR Memory", "Large Object Heap size", thisProcess, true);
-                promotedFinalizationMemoryFromGen0 = new PerformanceCounter(".NET CLR Memory", "Promoted Finalization-Memory from Gen 0", thisProcess, true);
+                allocatedBytesPerSecPF = new PerformanceCounter(".NET CLR Memory", "Allocated Bytes/sec", thisProcess, true);
+                promotedMemoryFromGen1PF = new PerformanceCounter(".NET CLR Memory", "Promoted Memory from Gen 1", thisProcess, true);
+                numberOfInducedGCsPF = new PerformanceCounter(".NET CLR Memory", "# Induced GC", thisProcess, true);
+                largeObjectHeapSizePF = new PerformanceCounter(".NET CLR Memory", "Large Object Heap size", thisProcess, true);
+                promotedFinalizationMemoryFromGen0PF = new PerformanceCounter(".NET CLR Memory", "Promoted Finalization-Memory from Gen 0", thisProcess, true);
 #endif
                 
 #if !(DNXCORE50 || __MonoCS__)
@@ -132,14 +133,18 @@ namespace Orleans.Runtime
             {
                 logger.Warn(ErrorCode.PerfCounterNotRegistered,
                     "CPU & Memory perf counters did not initialize correctly - try repairing Windows perf counter config on this machine with 'lodctr /r' command");
-                return;
             }
 
-            cpuUsageTimer = new SafeTimer(CheckCpuUsage, null, CPU_CHECK_PERIOD, CPU_CHECK_PERIOD);
+            if (cpuCounterPF != null) {
+                cpuUsageTimer = new SafeTimer(CheckCpuUsage, null, CPU_CHECK_PERIOD, CPU_CHECK_PERIOD);
+            }
             try
             {
-                // Read initial value of CPU Usage counter
-                CpuUsage = cpuCounter.NextValue();
+                if (cpuCounterPF != null)
+                {
+                    // Read initial value of CPU Usage counter
+                    CpuUsage = cpuCounterPF.NextValue();
+                }
             }
             catch (InvalidOperationException)
             {
@@ -152,15 +157,32 @@ namespace Orleans.Runtime
 #if LOG_MEMORY_PERF_COUNTERS    // print GC stats in the silo log file.
             StringValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_GENCOLLECTIONCOUNT, () => GCGenCollectionCount);
             StringValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_GENSIZESKB, () => GCGenSizes);
-            FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PERCENTOFTIMEINGC, () => timeInGC.NextValue());
-            FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_ALLOCATEDBYTESINKBPERSEC, () => allocatedBytesPerSec.NextValue() / 1024f);
-            FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PROMOTEDMEMORYFROMGEN1KB, () => promotedMemoryFromGen1.NextValue() / 1024f);
-            FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_LARGEOBJECTHEAPSIZEKB, () => largeObjectHeapSize.NextValue() / 11024f);
-            FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PROMOTEDMEMORYFROMGEN0KB, () => promotedFinalizationMemoryFromGen0.NextValue() / 1024f);
-            FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_NUMBEROFINDUCEDGCS, () => numberOfInducedGCs.NextValue());
-
+            if (timeInGCPF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PERCENTOFTIMEINGC, () => timeInGCPF.NextValue());
+            }
+            if (allocatedBytesPerSecPF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_ALLOCATEDBYTESINKBPERSEC, () => allocatedBytesPerSecPF.NextValue() / 1024f);
+            }
+            if (promotedMemoryFromGen1PF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PROMOTEDMEMORYFROMGEN1KB, () => promotedMemoryFromGen1PF.NextValue() / 1024f);
+            }
+            if (largeObjectHeapSizePF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_LARGEOBJECTHEAPSIZEKB, () => largeObjectHeapSizePF.NextValue() / 11024f);
+            }
+            if (promotedFinalizationMemoryFromGen0PF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PROMOTEDMEMORYFROMGEN0KB, () => promotedFinalizationMemoryFromGen0PF.NextValue() / 1024f);
+            }
+            if (numberOfInducedGCsPF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_NUMBEROFINDUCEDGCS, () => numberOfInducedGCsPF.NextValue());
+            }
             IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_MEMORY_TOTALPHYSICALMEMORYMB, () => (TotalPhysicalMemory / 1024) / 1024);
-            if (availableMemoryCounter != null)
+            if (availableMemoryCounterPF != null)
             {
                 IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_MEMORY_AVAILABLEMEMORYMB, () => (AvailableMemory/ 1024) / 1024); // Round up
             }
@@ -192,9 +214,15 @@ namespace Orleans.Runtime
 
         private void CheckCpuUsage(object m)
         {
-            var currentUsage = cpuCounter.NextValue();
-            // We calculate a decaying average for CPU utilization
-            CpuUsage = (CpuUsage + 2 * currentUsage) / 3;
+            if (cpuCounterPF != null)
+            {
+                var currentUsage = cpuCounterPF.NextValue();
+                // We calculate a decaying average for CPU utilization
+                CpuUsage = (CpuUsage + 2 * currentUsage) / 3;
+            }else
+            {
+                CpuUsage = 0;
+            }
         }
 
         public void Stop()


### PR DESCRIPTION
Log .NET Thread Pool size on the client (to help diagnose issues like https://github.com/dotnet/orleans/issues/1775#issuecomment-220758439).

Also, `RuntimeStatistics` are not printed on the client if it fails to load CPU & Memory perf counters. `RuntimeStatistics` has a lot of usefull statistics that can still be printed even if perf counters are not available. So added null protection for each and every individual perf counter instead of failing the all together.

