### PR TITLE
CoreCLR Support: fix #1782 - use TypeInfo instead of Type in codegen

### DIFF
--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -402,7 +402,7 @@ namespace Orleans.CodeGenerator
                 members.Add(
                     SF.NamespaceDeclaration(SF.ParseName(group.Key))
                         .AddUsings(
-                            TypeUtils.GetNamespaces(typeof(TaskUtility), typeof(GrainExtensions))
+                            TypeUtils.GetNamespaces(typeof(TaskUtility), typeof(GrainExtensions), typeof(IntrospectionExtensions))
                                 .Select(_ => SF.UsingDirective(SF.ParseName(_)))
                                 .ToArray())
                         .AddMembers(namespaceMembers.ToArray()));

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -330,7 +330,8 @@ namespace Orleans.CodeGenerator
             var result = new List<MemberDeclarationSyntax>();
 
             // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-            Expression<Action<Type>> getField = _ => _.GetField(string.Empty, BindingFlags.Default);
+            Expression<Action<TypeInfo>> getField = _ => _.GetField(string.Empty, BindingFlags.Default);
+            Expression<Action<Type>> getTypeInfo = _ => _.GetTypeInfo();
             Expression<Action> getGetter = () => SerializationManager.GetGetter(default(FieldInfo));
             Expression<Action> getReferenceSetter = () => SerializationManager.GetReferenceSetter(default(FieldInfo));
             Expression<Action> getValueSetter = () => SerializationManager.GetValueSetter(default(FieldInfo));
@@ -346,7 +347,7 @@ namespace Orleans.CodeGenerator
             foreach (var field in fields)
             {
                 var fieldInfo =
-                    getField.Invoke(SF.TypeOfExpression(field.FieldInfo.DeclaringType.GetTypeSyntax()))
+                    getField.Invoke(getTypeInfo.Invoke(SF.TypeOfExpression(field.FieldInfo.DeclaringType.GetTypeSyntax())))
                         .AddArgumentListArguments(
                             SF.Argument(field.FieldInfo.Name.GetLiteralExpression()),
                             SF.Argument(bindingFlags));


### PR DESCRIPTION
Fixes #1782.

Simple change, we use `GetTypeInfo()` to when creating the field accessors for generated serializer classes.

Since `GetTypeInfo` is an extension method, we also import `System.Reflection`. This is not anticipated to cause any ambiguity since we use fully qualified type names everywhere. If this becomes a problem we can certainly call `GetTypeInfo` as a static/non-extension method.