### PR TITLE
Fix for strange bug

### DIFF
--- a/src/OrleansBondUtils/BondSerializer.cs
+++ b/src/OrleansBondUtils/BondSerializer.cs
@@ -19,9 +19,9 @@ namespace Orleans.Serialization
     /// </summary>
     public class BondSerializer : IExternalSerializer
     {
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, ClonerInfo> ClonerInfoDictionary = new ConcurrentDictionary<RuntimeTypeHandle, ClonerInfo>();
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, BondTypeSerializer> SerializerDictionary = new ConcurrentDictionary<RuntimeTypeHandle, BondTypeSerializer>();
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, BondTypeDeserializer> DeserializerDictionary = new ConcurrentDictionary<RuntimeTypeHandle, BondTypeDeserializer>();
+        private static ConcurrentDictionary<RuntimeTypeHandle, ClonerInfo> ClonerInfoDictionary;
+        private static ConcurrentDictionary<RuntimeTypeHandle, BondTypeSerializer> SerializerDictionary;
+        private static ConcurrentDictionary<RuntimeTypeHandle, BondTypeDeserializer> DeserializerDictionary;
 
         private TraceLogger logger;
 
@@ -110,6 +110,9 @@ namespace Orleans.Serialization
         /// <param name="logger">The logger to use to capture any serialization events</param>
         public void Initialize(TraceLogger logger)
         {
+            ClonerInfoDictionary = new ConcurrentDictionary<RuntimeTypeHandle, ClonerInfo>();
+            SerializerDictionary = new ConcurrentDictionary<RuntimeTypeHandle, BondTypeSerializer>();
+            DeserializerDictionary = new ConcurrentDictionary<RuntimeTypeHandle, BondTypeDeserializer>();
             this.logger = logger;
         }
 


### PR DESCRIPTION
Sometimes, the static readonly members aren't initialized prior to being accessed in the IsSupportedType() method.  This shouldn't be possible as far as I know. This is a workaround to the problem.