### PR TITLE
Test helpers

### DIFF
--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -135,6 +135,7 @@ namespace Orleans.Runtime
         private readonly IntValueStatistic inProcessRequests;
         private readonly CounterStatistic collectionCounter;
         private readonly IGrainRuntime grainRuntime;
+        private readonly GrainCreator grainCreator;
 
         internal Catalog(
             GrainId grainId, 
@@ -158,6 +159,9 @@ namespace Orleans.Runtime
             this.grainRuntime = grainRuntime;
             collectionNumber = 0;
             destroyActivationsNumber = 0;
+
+            // TODO: Change back to GetRequiredService after stable Microsoft.Framework.DependencyInjection is released and can be referenced here
+            grainCreator = new GrainCreator(grainRuntime, Runtime.Silo.CurrentSilo.Services);
 
             logger = TraceLogger.GetLogger("Catalog", TraceLogger.LoggerType.Runtime);
             this.config = config.Globals;
@@ -654,14 +658,8 @@ namespace Orleans.Runtime
 
             Type grainType = grainTypeData.Type;
 
-            // TODO: Change back to GetRequiredService after stable Microsoft.Framework.DependencyInjection is released and can be referenced here
-            var services = Runtime.Silo.CurrentSilo.Services;
-            var grain = services != null
-                ? (Grain) services.GetService(grainType)
-                : (Grain) Activator.CreateInstance(grainType);
-
-            // Inject runtime hooks into grain instance
-            grain.Runtime = grainRuntime;
+            //Create a new instance of the given grain type
+            var grain = grainCreator.CreateGrainInstance(grainType, data.Identity);
             grain.Data = data;
 
             Type stateObjectType = grainTypeData.StateObjectType;
@@ -673,7 +671,6 @@ namespace Orleans.Runtime
             
             lock (data)
             {
-                grain.Identity = data.Identity;
                 data.SetGrainInstance(grain);
                 var statefulGrain = grain as IStatefulGrain;
                 if (statefulGrain != null)

--- a/src/OrleansRuntime/Catalog/GrainCreator.cs
+++ b/src/OrleansRuntime/Catalog/GrainCreator.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Core;
+using Orleans.GrainDirectory;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Helper classes used to create local instances of grains.
+    /// </summary>
+    public class GrainCreator
+    {
+        private readonly IGrainRuntime _grainRuntime;
+        private readonly IServiceProvider _services;
+
+        /// <summary>
+        /// Instantiate a new instance of a <see cref="GrainCreator"/>
+        /// </summary>
+        /// <param name="grainRuntime">Runtime to use for all new grains</param>
+        /// <param name="services">(Optional) Service provider used to create new grains</param>
+        public GrainCreator(IGrainRuntime grainRuntime, IServiceProvider services = null)
+        {
+            _grainRuntime = grainRuntime;
+            _services = services;
+        }
+
+        /// <summary>
+        /// Create a new instance of a grain
+        /// </summary>
+        /// <param name="grainType"></param>
+        /// <param name="identity">Identity for the new grain</param>
+        /// <returns></returns>
+        public Grain CreateGrainInstance(Type grainType, IGrainIdentity identity)
+        {
+            var grain = _services != null
+                ? (Grain) _services.GetService(grainType)
+                : (Grain) Activator.CreateInstance(grainType);
+
+            // Inject runtime hooks into grain instance
+            grain.Runtime = _grainRuntime;
+            grain.Identity = identity;
+
+            return grain;
+        }
+    }
+}

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Catalog\ActivationState.cs" />
+    <Compile Include="Catalog\GrainCreator.cs" />
     <Compile Include="Counters\PerfCounterConfigData.cs" />
     <Compile Include="GrainDirectory\MultiClusterRegistration\RegistrarManager.cs" />
     <Compile Include="GrainDirectory\MultiClusterRegistration\ClusterLocalRegistrar.cs" />


### PR DESCRIPTION
Added a grain creator class that further enables unit testing grains without the need for a full silo. This enables the same behavior of the test only constructor ` protected Grain(IGrainIdentity identity, IGrainRuntime runtime)` , but doesnt force developers to add test specific code to their production grains. I plan to add Grain<T> as well, but I wanted to get the discussion started.