### PR TITLE
Added ManagementGrain.GetDetailedHosts()

### DIFF
--- a/src/Orleans/SystemTargetInterfaces/IManagementGrain.cs
+++ b/src/Orleans/SystemTargetInterfaces/IManagementGrain.cs
@@ -19,6 +19,15 @@ namespace Orleans.Runtime
         /// <returns></returns>
         Task<Dictionary<SiloAddress, SiloStatus>> GetHosts(bool onlyActive = false);
 
+
+        /// <summary>
+        /// Get the list of silo hosts and membership information currently known about in this cluster.
+        /// </summary>
+        /// <param name="onlyActive">Whether data on just current active silos should be returned, 
+        /// or by default data for all current and previous silo instances [including those in Joining or Dead status].</param>
+        /// <returns></returns>
+        Task<MembershipEntry[]> GetDetailedHosts(bool onlyActive = false);
+
         /// <summary>
         /// Set the current log level for system runtime components.
         /// </summary>

--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -38,6 +38,26 @@ namespace Orleans.Runtime.Management
             return t;
         }
 
+        public async Task<MembershipEntry[]> GetDetailedHosts(bool onlyActive = false)
+        {
+            logger.Info("GetDetailedHosts onlyActive={0}", onlyActive);
+
+            var mTable = await GetMembershipTable();
+            var table = await mTable.ReadAll();
+
+            if (onlyActive)
+            {
+                return table.Members
+                    .Where(item => item.Item1.Status.Equals(SiloStatus.Active))
+                    .Select(x => x.Item1)
+                    .ToArray();
+            }
+
+            return table.Members
+                .Select(x => x.Item1)
+                .ToArray();
+        }
+
         public Task SetSystemLogLevel(SiloAddress[] siloAddresses, int traceLevel)
         {
             var silos = GetSiloAddresses(siloAddresses);

--- a/test/Tester/ManagementGrainTests.cs
+++ b/test/Tester/ManagementGrainTests.cs
@@ -45,6 +45,22 @@ namespace UnitTests.Management
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Management")]
+        public async Task GetDetailedHosts()
+        {
+            if (HostedCluster.SecondarySilos.Count == 0)
+            {
+                HostedCluster.StartAdditionalSilo();
+                await HostedCluster.WaitForLivenessToStabilizeAsync();
+            }
+
+            var numberOfActiveSilos = 1 + HostedCluster.SecondarySilos.Count; // Primary + secondaries
+            var siloStatuses = mgmtGrain.GetDetailedHosts(true).Result;
+            Assert.IsNotNull(siloStatuses, "Got some silo statuses");
+            Assert.AreEqual(numberOfActiveSilos, siloStatuses.Length, "Number of silo statuses");
+        }
+
+
+        [Fact, TestCategory("Functional"), TestCategory("Management")]
         public void GetSimpleGrainStatistics()
         {
             SimpleGrainStatistic[] stats = GetSimpleGrainStatistics("Initial");


### PR DESCRIPTION
This returns an array of `MembershipEntry`, for either active, or all silos.

See issue #1789