### PR TITLE
General code cleanup in preparation for CoreCLR

### DIFF
--- a/src/Orleans/Async/AsyncExecutorWithRetries.cs
+++ b/src/Orleans/Async/AsyncExecutorWithRetries.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Configuration;
 using System.Threading.Tasks;
 
 using Orleans.Runtime;

--- a/src/Orleans/Messaging/SocketManager.cs
+++ b/src/Orleans/Messaging/SocketManager.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading.Tasks;
 using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime
@@ -65,10 +67,18 @@ namespace Orleans.Runtime
                 s.NoDelay = true;
                 WriteConnectionPreemble(s, Constants.SiloDirectConnectionId); // Identifies this client as a direct silo-to-silo socket
                 // Start an asynch receive off of the socket to detect closure
-                var foo = new byte[4];
-                s.BeginReceive(foo, 0, 1, SocketFlags.None, ReceiveCallback,
-                    new Tuple<Socket, IPEndPoint, SocketManager>(s, target, this));
+                var receiveAsyncEventArgs = new SocketAsyncEventArgs
+                {
+                    BufferList = new List<ArraySegment<byte>> { new ArraySegment<byte>(new byte[4]) },
+                    UserToken = new Tuple<Socket, IPEndPoint, SocketManager>(s, target, this)
+                };
+                receiveAsyncEventArgs.Completed += ReceiveCallback;
+                bool receiveCompleted = s.ReceiveAsync(receiveAsyncEventArgs);
                 NetworkingStatisticsGroup.OnOpenedSendingSocket();
+                if (!receiveCompleted)
+                {
+                    ReceiveCallback(this, receiveAsyncEventArgs);
+                }
             }
             catch (Exception)
             {
@@ -112,32 +122,20 @@ namespace Orleans.Runtime
         // We start an asynch receive, with this callback, off of every send socket.
         // Since we should never see data coming in on these sockets, having the receive complete means that
         // the socket is in an unknown state and we should close it and try again.
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        private static void ReceiveCallback(IAsyncResult result)
+        private static void ReceiveCallback(object sender, SocketAsyncEventArgs socketAsyncEventArgs)
         {
+            var t = socketAsyncEventArgs.UserToken as Tuple<Socket, IPEndPoint, SocketManager>;
             try
             {
-                var t = result.AsyncState as Tuple<Socket, IPEndPoint, SocketManager>;
-                if (t == null) return;
-                if (!t.Item3.cache.ContainsKey(t.Item2)) return;
-
-                try
-                {
-                    t.Item1.EndReceive(result);
-                }
-                catch (Exception)
-                {
-                    // ignore
-                }
-                finally
-                {
-                    // Resolve potential race condition with this cache entry being updated since ContainsKey was called. TFS 180717.
-                    t.Item3.InvalidateEntry(t.Item2);
-                }
+                t?.Item3.InvalidateEntry(t.Item2);
             }
             catch (Exception ex)
             {
-                TraceLogger.GetLogger("SocketManager", TraceLogger.LoggerType.Runtime).Error(ErrorCode.Messaging_Socket_ReceiveError, String.Format("ReceiveCallback: {0}",result), ex);
+                TraceLogger.GetLogger("SocketManager", TraceLogger.LoggerType.Runtime).Error(ErrorCode.Messaging_Socket_ReceiveError, $"ReceiveCallback: {t?.Item2}", ex);
+            }
+            finally
+            {
+                socketAsyncEventArgs.Dispose();
             }
         }
 
@@ -204,7 +202,6 @@ namespace Orleans.Runtime
             {
                 // Ignore
             }
-
             try
             {
                 s.Dispose();

--- a/src/Orleans/Utils/Utils.cs
+++ b/src/Orleans/Utils/Utils.cs
@@ -311,31 +311,6 @@ namespace Orleans.Runtime
             return DateTime.UtcNow.Subtract(start);
         }
 
-        public static List<T> ObjectToList<T>(object data)
-        {
-            if (data is List<T>) return (List<T>) data;
-
-            T[] dataArray;
-            if (data is ArrayList)
-            {
-                dataArray = (T[]) (data as ArrayList).ToArray(typeof(T));
-            }
-            else if (data is ICollection<T>)
-            {
-                dataArray = (data as ICollection<T>).ToArray();
-            }
-            else
-            {
-                throw new InvalidCastException(string.Format(
-                    "Cannot convert type {0} to type List<{1}>",
-                    TypeUtils.GetFullName(data.GetType()),
-                    TypeUtils.GetFullName(typeof(T))));
-            }
-            var list = new List<T>();
-            list.AddRange(dataArray);
-            return list;
-        }
-
         public static List<Exception> FlattenAggregate(this Exception exc)
         {
             var result = new List<Exception>();
@@ -374,44 +349,6 @@ namespace Orleans.Runtime
             {
                 yield return batch; //batch.ToArray();
             }
-        }
-
-        internal static MethodInfo GetStaticMethodThroughReflection(string assemblyName, string className, string methodName, Type[] argumentTypes)
-        {
-            var asm = Assembly.Load(new AssemblyName(assemblyName));
-            if (asm == null)
-                throw new InvalidOperationException(string.Format("Cannot find assembly {0}", assemblyName));
-
-            var cl = asm.GetType(className);
-            if (cl == null)
-                throw new InvalidOperationException(string.Format("Cannot find class {0} in assembly {1}", className, assemblyName));
-
-            MethodInfo method;
-            method = argumentTypes == null
-                ? cl.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).Where(m=>m.Name == methodName).FirstOrDefault()
-                : cl.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, argumentTypes, null);
-
-            if (method == null)
-                throw new InvalidOperationException(string.Format("Cannot find static method {0} of class {1} in assembly {2}", methodName, className, assemblyName));
-
-            return method;
-        }
-
-        internal static object InvokeStaticMethodThroughReflection(string assemblyName, string className, string methodName, Type[] argumentTypes, object[] arguments)
-        {
-            var method = GetStaticMethodThroughReflection(assemblyName, className, methodName, argumentTypes);
-            return method.Invoke(null, arguments);
-        }
-
-        internal static Type LoadTypeThroughReflection(string assemblyName, string className)
-        {
-            var asm = Assembly.Load(new AssemblyName(assemblyName));
-            if (asm == null) throw new InvalidOperationException(string.Format("Cannot find assembly {0}", assemblyName));
-
-            var cl = asm.GetType(className);
-            if (cl == null) throw new InvalidOperationException(string.Format("Cannot find class {0} in assembly {1}", className, assemblyName));
-
-            return cl;
         }
     }
 }

--- a/test/TestInternalGrains/StreamReliabilityTestGrains.cs
+++ b/test/TestInternalGrains/StreamReliabilityTestGrains.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -258,8 +257,7 @@ namespace UnitTests.Grains
 
         private void TryInitStream(Guid streamId, string providerName)
         {
-            Assert.IsNotNull(streamId, "Can't have null stream id");
-            Assert.IsNotNull(providerName, "Can't have null stream provider name");
+            if (providerName == null) throw new ArgumentNullException(nameof(providerName));
 
             State.StreamProviderName = providerName;
 

--- a/test/TesterInternal/CodeGeneratorTests.cs
+++ b/test/TesterInternal/CodeGeneratorTests.cs
@@ -71,28 +71,6 @@ namespace UnitTests.CodeGeneration
             Assert.IsTrue(TypeUtils.IsGrainMethod(meth), "Method " + meth.DeclaringType + "." + meth.Name + " should be a grain method");
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("CodeGen")]
-        public void CodeGen_ObjectTo_List()
-        {
-            List<String> list = new List<string> { "1", "2" };
-
-            ArrayList arrayList = new ArrayList(list);
-            List<String> list2 = Utils.ObjectToList<string>(arrayList);
-            CheckOutputList(list, list2);
-
-            string[] array = list.ToArray();
-            List<String> list3 = Utils.ObjectToList<string>(array);
-            CheckOutputList(list, list3);
-
-            List<string> listCopy = list.ToList();
-            List<String> list4 = Utils.ObjectToList<string>(listCopy);
-            CheckOutputList(list, list4);
-
-            IReadOnlyList<string> readOnlyList = list.ToList();
-            List<String> list5 = Utils.ObjectToList<string>(readOnlyList);
-            CheckOutputList(list, list5);
-        }
-
         private static void CheckOutputList(List<string> expected, List<string> actual)
         {
             Assert.AreEqual(expected.Count, actual.Count, "Output list size");

--- a/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
+++ b/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
@@ -21,8 +21,7 @@ namespace UnitTests.SerializerTests
             this.output = output;
             MessagingStatisticsGroup.Init(false);
 
-            var orleansConfig = new ClusterConfiguration();
-            orleansConfig.StandardLoad();
+            var orleansConfig = ClusterConfiguration.LocalhostPrimarySilo();
             BufferPool.InitGlobalBufferPool(orleansConfig.Globals);
 
             SerializationManager.InitializeForTesting();


### PR DESCRIPTION
While doing the CoreCLR migration (prototype), I found a few items that could be cleaned up even if we don't port to it yet.