### PR TITLE
A spike to concrete discussion on how to arrange tests

### DIFF
--- a/test/TesterInternal/StorageTests/SQLAdapter/temp/CommonPersistenceStorageTests.cs
+++ b/test/TesterInternal/StorageTests/SQLAdapter/temp/CommonPersistenceStorageTests.cs
@@ -1,0 +1,42 @@
+﻿using Orleans;
+using Orleans.Storage;
+using System.Threading.Tasks;
+
+namespace UnitTests.StorageTests.SQLAdapter.temp
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <remarks>This is currently empty as it is intended to server as a discussion point.</remarks>
+    public class CommonPersistenceStorageTests
+    {
+        private IStorageProvider Storage { get; }
+
+
+        public CommonPersistenceStorageTests(IStorageProvider storage)
+        {
+            Storage = storage;
+        }
+
+
+        public async Task Store_Read()
+        {
+            //await Storage.ReadStateAsync();
+            await TaskDone.Done;
+        }
+
+
+        public async Task Store_WriteRead()
+        {
+            //await Storage.WriteStateAsync();
+            await TaskDone.Done;
+        }
+
+
+        public async Task Store_Delete()
+        {
+            //await Storage.ClearStateAsync();
+            await TaskDone.Done;
+        }
+    }
+}

--- a/test/TesterInternal/StorageTests/SQLAdapter/temp/SqlServerPersistenceStorageTests.cs
+++ b/test/TesterInternal/StorageTests/SQLAdapter/temp/SqlServerPersistenceStorageTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UnitTests.StorageTests.SQLAdapter.temp
+{
+    /// <summary>
+    /// Persistence tests for SQL Server.
+    /// </summary>
+    public class SqlServerPersistenceStorageTests: IDisposable, IClassFixture<SqlServerFixture>
+    {
+        private CommonPersistenceStorageTests PersistenceStorageTests { get; set; }
+
+
+        public SqlServerPersistenceStorageTests(SqlServerFixture sqlServerFixture)
+        {
+            var persistenceStorage = sqlServerFixture.GetPersistenceStorage();
+            if(persistenceStorage != null)
+            {
+                PersistenceStorageTests = new CommonPersistenceStorageTests(persistenceStorage);
+            }
+
+            //XUnit.NET will automatically call this constructor before every test method run.
+            Skip.If(persistenceStorage == null, $"Persistence storage not defined for SQL Server in {sqlServerFixture.Invariants.Environment.Environment}.");
+        }
+
+
+        public void Dispose()
+        {
+            //XUnit.NET will automatically call this after every test method run. There is no need to always call this method.            
+        }
+
+        //Is there a way to avoid duplicating these theories across backends?
+        [Theory]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [TestCategory("Functional"), TestCategory("Temp_Persistence"), TestCategory("SqlServer")]
+        public Task PersistenceStorage_SqlServer_Read(int someValue)
+        {
+            return PersistenceStorageTests.Store_Read();
+        }
+
+
+        [SkippableFact]
+        [TestCategory("Functional"), TestCategory("Temp_Persistence"), TestCategory("SqlServer")]
+        public Task Store_WriteRead()
+        {
+            return PersistenceStorageTests.Store_WriteRead();
+        }
+
+
+        [SkippableFact]
+        [TestCategory("Functional"), TestCategory("Temp_Persistence"), TestCategory("SqlServer")]
+        public Task Store_Delete()
+        {
+            return PersistenceStorageTests.Store_Delete();
+        }
+    }
+}

--- a/test/TesterInternal/StorageTests/SQLAdapter/temp/SqlServerRelationalFixture.cs
+++ b/test/TesterInternal/StorageTests/SQLAdapter/temp/SqlServerRelationalFixture.cs
@@ -1,0 +1,57 @@
+﻿using Orleans;
+using Orleans.Runtime.MembershipService;
+using Orleans.SqlUtils.StorageProvider;
+using Orleans.Storage;
+using System;
+
+namespace UnitTests.StorageTests.SQLAdapter.temp
+{
+    /// <summary>
+    /// Sets up relational database. 
+    /// </summary>
+    public class SqlServerFixture: IDisposable
+    {               
+        public TestEnvironmentInvariant Invariants { get; } = new TestEnvironmentInvariant();
+
+        public SqlServerFixture()
+        {
+            //Call before tests using this fixture will be run.            
+        }
+
+
+        public void Dispose()
+        {
+            //Call after tests using this fixture have been run.            
+        }
+
+
+        /// <summary>
+        /// Returns a correct implementation of the persistence provider according to environment variables.
+        /// This could be SQL Server or MySQL or some other backend. Either requested by parameter
+        /// </summary>
+        public IStorageProvider GetPersistenceStorage()
+        {
+            //Make sure the environment invariants hold before trying to give a functioning SUT instantiation.
+            Invariants.EnsureSqlServerPersistenceEnvironment();
+
+            //TODO: This doesn't function yet. Uncomment null to check skipped tests if they aren't defined
+            //for the the given environment or if the feature hasn't been implemented yet.
+            //return null;
+            return new SqlStorageProvider();
+        }
+
+
+        /// <summary>
+        /// Returns a correct implementation of the persistence provider according to environment variables.
+        /// This could be SQL Server or MySQL or some other backend. Either requested by parameter
+        /// </summary>
+        public IMembershipTable GetMembershipTable()
+        {
+            //Make sure the environment invariants hold before trying to give a functioning SUT instantiation.
+            Invariants.EnsureSqlServerMembershipEnvironment();
+
+            //TODO: Not plugged in yet, for illustrative purposes.
+            return new SqlMembershipTable();
+        }
+    }
+}

--- a/test/TesterInternal/StorageTests/SQLAdapter/temp/TestEnvironmentInformation.cs
+++ b/test/TesterInternal/StorageTests/SQLAdapter/temp/TestEnvironmentInformation.cs
@@ -1,0 +1,39 @@
+﻿namespace UnitTests.StorageTests.SQLAdapter.temp
+{
+    /// <summary>
+    /// Enumeration of the supported test environment configurations.
+    /// </summary>
+    public enum SupportedTestConfigurations
+    {
+        None                        = 0,
+        Development                 = 1,
+        Jenkins                     = 2,
+        VisualStudioTeamServices    = 3
+    }
+
+
+    /// <summary>
+    /// Gathers information to be utilized in variables from path and elsewhere.
+    /// </summary>
+    public sealed class TestEnvironmentInformation
+    {
+        public SupportedTestConfigurations Environment { get; private set; }
+
+        public bool HasSqlServer { get; private set; }
+
+        public bool HasMySql { get; private set; }
+
+        public bool HasAzureStorageEmulator { get; private set; }
+
+
+        public TestEnvironmentInformation()
+        {
+            //This is hardcoded here, but in reality would be read from, e.g.,
+            //environment variables and elsewhere.
+            Environment = SupportedTestConfigurations.Development;
+            HasSqlServer = true;
+            HasMySql = true;
+            HasAzureStorageEmulator = true;
+        }
+    }
+}

--- a/test/TesterInternal/StorageTests/SQLAdapter/temp/TestEnvironmentInvariant.cs
+++ b/test/TesterInternal/StorageTests/SQLAdapter/temp/TestEnvironmentInvariant.cs
@@ -1,0 +1,105 @@
+﻿using Orleans.SqlUtils;
+using Orleans.TestingHost.Utils;
+using System;
+using System.Threading;
+using UnitTests.General;
+
+namespace UnitTests.StorageTests.SQLAdapter.temp
+{
+    /// <summary>
+    /// This enforces the necessary environment invariants hold before starting to run tests.
+    /// This servers as a class or object invariant for the test environment.
+    /// </summary>
+    public class TestEnvironmentInvariant
+    {
+        //TODO: Note in the following example some tests could be run in the same database too.
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>The creation logic should take the connection string as a parameter. This would allow changing it according to then environment.
+        /// It could be retrieved from an environment specific places, like Key Vault.</remarks>
+        private Lazy<RelationalStorageForTesting> SqlServerMembershipTestStorage { get; } = new Lazy<RelationalStorageForTesting>(() => RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, "OrleansMembershipTests").GetAwaiter().GetResult(), LazyThreadSafetyMode.ExecutionAndPublication);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>The creation logic should take the connection string as a parameter. This would allow changing it according to then environment.
+        /// It could be retrieved from an environment specific places, like Key Vault.</remarks>
+        private Lazy<RelationalStorageForTesting> SqlServerPersistenceTestStorage { get; } = new Lazy<RelationalStorageForTesting>(() => RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, "OrleansPersistenceTests").GetAwaiter().GetResult(), LazyThreadSafetyMode.ExecutionAndPublication);
+
+
+        public TestEnvironmentInformation Environment { get; } = new TestEnvironmentInformation();
+
+
+        public TestEnvironmentInvariant() { }
+
+
+        public RelationalStorageForTesting EnsureSqlServerMembershipEnvironment()
+        {                                                
+            switch(Environment.Environment)
+            {
+                case(SupportedTestConfigurations.Development):
+                {
+                    return SqlServerPersistenceTestStorage.Value;
+                }
+                case(SupportedTestConfigurations.Jenkins):
+                case(SupportedTestConfigurations.VisualStudioTeamServices):
+                default: { break; }
+            }                       
+
+            return null;
+        }
+
+
+        public RelationalStorageForTesting EnsureSqlServerPersistenceEnvironment()
+        {
+            switch(Environment.Environment)
+            {
+                case(SupportedTestConfigurations.Development):
+                {
+                    return SqlServerMembershipTestStorage.Value;
+                }
+                case (SupportedTestConfigurations.Jenkins):
+                case (SupportedTestConfigurations.VisualStudioTeamServices):
+                default: { break; }
+            }
+
+            return null;
+        }
+
+
+        public bool TryEnsureMySqlEnvironment()
+        {
+            switch(Environment.Environment)
+            {
+                case(SupportedTestConfigurations.Development):
+                case(SupportedTestConfigurations.Jenkins):
+                case(SupportedTestConfigurations.VisualStudioTeamServices):
+                default: { break; }
+            }
+
+            return true;
+        }
+
+
+        public bool TryEnsureTableStorageEnvironment()
+        {                         
+            //NOTE: In development environment Table Storage and Blob Storage would
+            //share a common setup routine which would be starting the emulator and
+            //perhaps cleaning up previous testing instances.
+            switch(Environment.Environment)
+            {
+                case(SupportedTestConfigurations.Development):
+                {
+                    return StorageEmulator.TryStart();
+                }
+                case(SupportedTestConfigurations.Jenkins):
+                case(SupportedTestConfigurations.VisualStudioTeamServices):
+                default: { break; }
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -126,6 +126,11 @@
     <Compile Include="StorageTests\PersistenceGrainTests_AzureBlobStore.cs" />
     <Compile Include="StorageTests\PersistenceGrainTests_AzureTableStore.cs" />
     <Compile Include="StorageTests\RelationalStoreTests.cs" />
+    <Compile Include="StorageTests\SQLAdapter\temp\TestEnvironmentInvariant.cs" />
+    <Compile Include="StorageTests\SQLAdapter\temp\CommonPersistenceStorageTests.cs" />
+    <Compile Include="StorageTests\SQLAdapter\temp\SqlServerRelationalFixture.cs" />
+    <Compile Include="StorageTests\SQLAdapter\temp\SqlServerPersistenceStorageTests.cs" />
+    <Compile Include="StorageTests\SQLAdapter\temp\TestEnvironmentInformation.cs" />
     <Compile Include="StreamingTests\AQStreamingTests.cs" />
     <Compile Include="AssemblyLoaderTests.cs" />
     <Compile Include="AsynchAgentRestartTest.cs" />


### PR DESCRIPTION
Spike started from https://github.com/dotnet/orleans/pull/1682. Personally I would like to have a direction on how to arrange relational persistence tests. Even if only one and making more work on other PRs to improve test coverage. This is provided as a more concrete piece for discussion to suss out concrete ideas.

**Goals**

1. Make it more clear, I hope, on how to setup the test environment before a certain type of tests is being run. Here is done by a specific class [TestEnvironmentInvariant](https://github.com/dotnet/orleans/pull/1682/files#diff-4b8eb4bc30b3f20f1d850ea8cbdf9fc5R10). It has specific invariant methods, such as [EnsureSqlServerMembershipEnvironment](https://github.com/dotnet/orleans/pull/1682/files#diff-4b8eb4bc30b3f20f1d850ea8cbdf9fc5R38) that can be called prior to running a certain type of tests to ensure the test environment invariants hold, i.e. it the prerequisites for the given type of tests are set up correctly. It uses information from [TestEnvironmentInformation](https://github.com/dotnet/orleans/pull/1682/files#diff-a0630db3acf1d2e9ce2c4751bb908aecR18) to check in environment specific way. As one can guess from this, the invariants are checked in a rather granular way, more on reasons shortly. One should be able to choose granularity by writing a suitably named function and a corresponding implementation.

2. Make the environment and test class combinations visible. The comment [here](https://github.com/dotnet/orleans/pull/1682/files#diff-4b8eb4bc30b3f20f1d850ea8cbdf9fc5R20) has that the connection string could be had in environment specific way from anywhere, even from Key Vault. This example setup is simplified and shows just a development machine setup, but I believe could be expanded to handle any situation (and the logic can reuse internal setup logic).

3. Make it possible to run any combination of tests in any environment. As for an example for relational, it looks that this way would allow one to use LocalDb if choosing testing on hosted builds (e.g. LocalDb on VSTS) and/or SQL Server Azure and MySQL deployed on Azure in some other builds. Then either or both on development machine builds.

4. Allow the various types of tests excute in parallel. This might make way to arrange baseline tests being ran on every build, at leas on every merge on master branch, quickly for feedback across backend implementations. Maybe even stress testing in parallel.

5. The [type of tests](https://github.com/dotnet/orleans/pull/1682/files#diff-ad03ee34d41fdc70f2e76349d83994f7R11) could be defined [like this](https://github.com/dotnet/orleans/pull/1682/files#diff-ad03ee34d41fdc70f2e76349d83994f7R11). A specific type of implementation exercising them could look [like this](https://github.com/dotnet/orleans/pull/1682/files#diff-f4072915d9b3c68d5db2ade8763f93c9R10). That is, it delegates the parameters to tests that all the implementations share. Instance data can be stored (in the common tests class) and specific backend types (like SQL Server) can define extra tests.