### PR TITLE
MemoryStorage bug fix when calling Clear state

### DIFF
--- a/src/OrleansProviders/Storage/MemoryStorage.cs
+++ b/src/OrleansProviders/Storage/MemoryStorage.cs
@@ -139,6 +139,7 @@ namespace Orleans.Storage
             string key = HierarchicalKeyStore.MakeStoreKey(keys);
             IMemoryStorageGrain storageGrain = GetStorageGrain(key);
             await storageGrain.DeleteStateAsync(STATE_STORE_NAME, key, grainState.ETag);
+            grainState.ETag = null;
         }
 
         #endregion

--- a/src/OrleansRuntime/Storage/MemoryStorageGrain.cs
+++ b/src/OrleansRuntime/Storage/MemoryStorageGrain.cs
@@ -132,7 +132,7 @@ namespace Orleans.Storage
                 {
                     if (receivedEtag != currentETag)
                     {
-                        string error = string.Format("Etag mismatch during {0} for grain {1}: Expected = {2} Received = {3}", operation, grainStoreKey, currentETag, receivedEtag);
+                        string error = string.Format("Etag mismatch during {0} for grain {1}: Expected = {2} Received = {3}", operation, grainStoreKey, currentETag ?? "null", receivedEtag);
                         logger.Warn(0, error);
                         throw new InconsistentStateException(error);
                     }

--- a/test/TestGrainInterfaces/IPersistenceTestGrains.cs
+++ b/test/TestGrainInterfaces/IPersistenceTestGrains.cs
@@ -35,6 +35,7 @@ namespace UnitTests.GrainInterfaces
         Task<int> GetValue();
         Task DoWrite(int val);
         Task<int> DoRead();
+        Task DoDelete();
     }
 
     public interface IAzureStorageTestGrain : IGrainWithGuidKey

--- a/test/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/TestInternalGrains/PersistenceTestGrains.cs
@@ -376,6 +376,11 @@ namespace UnitTests.Grains
             return State.Field1;
         }
 
+        public Task DoDelete()
+        {
+            return ClearStateAsync();
+        }
+
         [Serializable]
         public class NestedPersistenceTestGrainState
         {

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -277,6 +277,20 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(2, val, "Value after Re-Read");
         }
 
+        [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MemoryStore")]
+        public async Task MemoryStore_Delete()
+        {
+            Guid id = Guid.NewGuid();
+            var grain = GrainClient.GrainFactory.GetGrain<IMemoryStorageTestGrain>(id);
+            await grain.DoWrite(1);
+            await grain.DoDelete();
+            int val = await grain.GetValue(); // Should this throw instead?
+            Assert.AreEqual(0, val, "Value after Delete");
+            await grain.DoWrite(2);
+            val = await grain.GetValue();
+            Assert.AreEqual(2, val, "Value after Delete + New Write");
+        }
+
         [Fact, TestCategory("Stress"), TestCategory("CorePerf"), TestCategory("Persistence"), TestCategory("MemoryStore")]
         public async Task MemoryStore_Stress_Read()
         {


### PR DESCRIPTION
MemoryStorage had eTag mismatch when clearing the state and subsequently writing to it.
Previous to 1.2.1 this was actually throwing a cryptic NullReferenceException instead, but commit a1d35959 partially addressed it (but not the etag mismatch).