### PR TITLE
Exception stacktrace preservation

### DIFF
--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -295,7 +295,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Called from generated code.
         /// </summary>
-        protected async Task<T> InvokeMethodAsync<T>(int methodId, object[] arguments, InvokeMethodOptions options = InvokeMethodOptions.None, SiloAddress silo = null)
+        protected Task<T> InvokeMethodAsync<T>(int methodId, object[] arguments, InvokeMethodOptions options = InvokeMethodOptions.None, SiloAddress silo = null)
         {
             object[] argsDeepCopy = null;
             if (arguments != null)
@@ -313,11 +313,17 @@ namespace Orleans.Runtime
 
             if (resultTask == null)
             {
-                return default(T);
+                if (typeof(T) == typeof(object))
+                {
+                    // optimize for most common case when using one way calls.
+                    return PublicOrleansTaskExtensions.CompletedTask as Task<T>;
+                }
+
+                return Task.FromResult(default(T));
             }
 
             resultTask = OrleansTaskExtentions.ConvertTaskViaTcs(resultTask);
-            return (T) await resultTask;
+            return resultTask.Unbox<T>();
         }
 
         #endregion

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -384,7 +384,8 @@ namespace Orleans.Runtime
                     }
                     else
                     {
-                        // The call is not intercepted.
+						// The call is not intercepted.
+                        // TODO: this await here is just grabbing the first exception of the AggregateException. As a framework we shouldn't do that.
                         resultObject = await invoker.Invoke(target, request);
                     }
                 }

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Threading.Tasks;
-using FluentAssertions.Collections;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace UnitTests.General
 {
@@ -12,6 +12,13 @@ namespace UnitTests.General
     /// </summary>
     public class ExceptionPropagationTests : HostedTestClusterEnsureDefaultStarted
     {
+        private readonly ITestOutputHelper output;
+
+        public ExceptionPropagationTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
         [Fact, TestCategory("BVT"), TestCategory("Functional")]
         public async Task BasicExceptionPropagation()
         {
@@ -19,7 +26,23 @@ namespace UnitTests.General
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => grain.ThrowsInvalidOperationException());
 
+            output.WriteLine(exception.ToString());
             Assert.Equal("Test exception", exception.Message);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public void ExceptionContainsOriginalStackTrace()
+        {
+            IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
+            // Explicitly using .Wait() instead of await the task to avoid any modification of the inner exception
+            var aggEx = Assert.Throws<AggregateException>(
+                () => grain.ThrowsInvalidOperationException().Wait());
+
+            var exception = aggEx.InnerException;
+            output.WriteLine(exception.ToString());
+            Assert.IsAssignableFrom<InvalidOperationException>(exception);
+            Assert.Equal("Test exception", exception.Message);
+            Assert.Contains("ThrowsInvalidOperationException", exception.StackTrace);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional")]
@@ -95,16 +118,23 @@ namespace UnitTests.General
             IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
             var grainCall = grain.ThrowsMultipleExceptionsAggregatedInFaultedTask();
 
-            // use Wait() so that we get the entire AggregateException ('await' would just catch the first inner exception)
-            var exception = Assert.Throws<AggregateException>(
-                () => grainCall.Wait());
-
-            // make sure that all exceptions in the task are present, and not just the first one.
-            Assert.Equal(2, exception.InnerExceptions.Count);
-            var firstEx = Assert.IsAssignableFrom<InvalidOperationException>(exception.InnerExceptions[0]);
-            Assert.Equal("Test exception 1", firstEx.Message);
-            var secondEx = Assert.IsAssignableFrom<InvalidOperationException>(exception.InnerExceptions[1]);
-            Assert.Equal("Test exception 2", secondEx.Message);
+            try
+            {
+                // use Wait() so that we get the entire AggregateException ('await' would just catch the first inner exception)
+                // Do not use Assert.Throws to avoid any tampering of the AggregateException itself from the test framework
+                grainCall.Wait();
+                Assert.True(false, "Expected AggregateException");
+            }
+            catch (AggregateException exception)
+            {
+                output.WriteLine(exception.ToString());
+                // make sure that all exceptions in the task are present, and not just the first one.
+                Assert.Equal(2, exception.InnerExceptions.Count);
+                var firstEx = Assert.IsAssignableFrom<InvalidOperationException>(exception.InnerExceptions[0]);
+                Assert.Equal("Test exception 1", firstEx.Message);
+                var secondEx = Assert.IsAssignableFrom<InvalidOperationException>(exception.InnerExceptions[1]);
+                Assert.Equal("Test exception 2", secondEx.Message);
+            }
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional")]

--- a/test/Tester/GenericGrainTests.cs
+++ b/test/Tester/GenericGrainTests.cs
@@ -265,6 +265,24 @@ namespace UnitTests.General
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        public void Generic_SimpleGrainControlFlow_Blocking()
+        {
+            var a = random.Next(100);
+            var b = a + 1;
+            var expected = a + "x" + b;
+
+            var grain = GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
+
+            // explicitly use .Wait() and .Result to make sure the client does not deadlock in these cases.
+            grain.SetA(a).Wait();
+
+            grain.SetB(b).Wait();
+
+            Task<string> stringPromise = grain.GetAxB();
+            Assert.AreEqual(expected, stringPromise.Result);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task Generic_SimpleGrainDataFlow()
         {
             var a = random.Next(100);


### PR DESCRIPTION
Preserve remote stacktrace when propagating exception to the caller.
Previous to this change the entire remote exception would be lost, making it very hard to troubleshoot issues. We broke the stacktrace propagation with change 3560de8b when we started propagating the original exception to the caller instead of AggregateException (included in 1.2.0).