### PR TITLE
Allow liveness config in TestCluster

### DIFF
--- a/src/OrleansTestingHost/TestClusterOptions.cs
+++ b/src/OrleansTestingHost/TestClusterOptions.cs
@@ -113,10 +113,11 @@ namespace Orleans.TestingHost
             NodeConfiguration nodeConfig = config.GetOrCreateNodeConfigurationForSilo(siloName);
             nodeConfig.HostNameOrIPAddress = "loopback";
             nodeConfig.Port = baseSiloPort + instanceNumber;
-            nodeConfig.ProxyGatewayEndpoint = 
-                nodeConfig.ProxyGatewayEndpoint?.Address != null 
-                ? new IPEndPoint(nodeConfig.ProxyGatewayEndpoint.Address, baseGatewayPort + instanceNumber) 
-                : new IPEndPoint(config.Defaults.ProxyGatewayEndpoint.Address, baseGatewayPort + instanceNumber);
+            var proxyAddress = nodeConfig.ProxyGatewayEndpoint?.Address ?? config.Defaults.ProxyGatewayEndpoint?.Address;
+            if (proxyAddress != null)
+            {
+                nodeConfig.ProxyGatewayEndpoint = new IPEndPoint(proxyAddress, baseGatewayPort + instanceNumber);
+            }
 
             config.Overrides[siloName] = nodeConfig;
             return nodeConfig;
@@ -124,15 +125,41 @@ namespace Orleans.TestingHost
 
         public static ClientConfiguration BuildClientConfiguration(ClusterConfiguration clusterConfig)
         {
-            var config = new ClientConfiguration { GatewayProvider = ClientConfiguration.GatewayProviderType.Config };
+            var config = new ClientConfiguration();
             config.TraceFilePattern = clusterConfig.Defaults.TraceFilePattern;
             config.TraceToConsole = DefaultTraceToConsole;
-            config.Gateways.Add(clusterConfig.Overrides[Silo.PrimarySiloName].ProxyGatewayEndpoint);
-            foreach (var nodeConfiguration in clusterConfig.Overrides.Values.Where(x => x.SiloName != Silo.PrimarySiloName))
+            switch (clusterConfig.Globals.LivenessType)
             {
-                config.Gateways.Add(nodeConfiguration.ProxyGatewayEndpoint);
+                case GlobalConfiguration.LivenessProviderType.AzureTable:
+                    config.GatewayProvider = ClientConfiguration.GatewayProviderType.AzureTable;
+                    break;
+                case GlobalConfiguration.LivenessProviderType.SqlServer:
+                    config.GatewayProvider = ClientConfiguration.GatewayProviderType.SqlServer;
+                    break;
+                case GlobalConfiguration.LivenessProviderType.ZooKeeper:
+                    config.GatewayProvider = ClientConfiguration.GatewayProviderType.ZooKeeper;
+                    break;
+                case GlobalConfiguration.LivenessProviderType.Custom:
+                    config.GatewayProvider = ClientConfiguration.GatewayProviderType.Custom;
+                    config.CustomGatewayProviderAssemblyName = clusterConfig.Globals.MembershipTableAssembly;
+                    break;
+                case GlobalConfiguration.LivenessProviderType.NotSpecified:
+                case GlobalConfiguration.LivenessProviderType.MembershipTableGrain:
+                default:
+                    config.GatewayProvider = ClientConfiguration.GatewayProviderType.Config;
+                    var primaryProxyEndpoint = clusterConfig.Overrides[Silo.PrimarySiloName].ProxyGatewayEndpoint;
+                    if (primaryProxyEndpoint != null)
+                    {
+                        config.Gateways.Add(primaryProxyEndpoint);
+                    }
+                    foreach (var nodeConfiguration in clusterConfig.Overrides.Values.Where(x => x.SiloName != Silo.PrimarySiloName && x.ProxyGatewayEndpoint != null))
+                    {
+                        config.Gateways.Add(nodeConfiguration.ProxyGatewayEndpoint);
+                    }
+                    break;
             }
 
+            config.DataConnectionString = clusterConfig.Globals.DataConnectionString;
             config.PropagateActivityId = clusterConfig.Defaults.PropagateActivityId;
             config.DeploymentId = clusterConfig.Globals.DeploymentId;
             if (Debugger.IsAttached)
@@ -157,7 +184,7 @@ namespace Orleans.TestingHost
             string prefix = "testdepid-";
             int randomSuffix = ThreadSafeRandom.Next(1000);
             DateTime now = DateTime.UtcNow;
-            string DateTimeFormat = @"yyyy-MM-dd-HH\tmm-ss";
+            string DateTimeFormat = @"yyyy-MM-dd\tHH-mm-ss";
             string depId = $"{prefix}{now.ToString(DateTimeFormat, CultureInfo.InvariantCulture)}-{this.BaseSiloPort}-{randomSuffix}";
             return depId;
         }

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -196,25 +196,25 @@ namespace UnitTests.MembershipTests
             return new TestCluster(options);
         }
 
-        //[Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Membership"), TestCategory("Gabi")]
+        [Fact, TestCategory("Functional"), TestCategory("Membership")]
         public async Task Liveness_Grain_1()
         {
             await Do_Liveness_OracleTest_1();
         }
 
-        //[Fact, TestCategory("Functional"), TestCategory("Membership")]
+        [Fact, TestCategory("Functional"), TestCategory("Membership")]
         public async Task Liveness_Grain_2_Restart_GW()
         {
             await Do_Liveness_OracleTest_2(1);
         }
 
-        //[Fact, TestCategory("Functional"), TestCategory("Membership")]
+        [Fact, TestCategory("Functional"), TestCategory("Membership")]
         public async Task Liveness_Grain_3_Restart_Silo_1()
         {
             await Do_Liveness_OracleTest_2(2);
         }
 
-        //[Fact, TestCategory("Functional"), TestCategory("Membership")]
+        [Fact, TestCategory("Functional"), TestCategory("Membership")]
         public async Task Liveness_Grain_4_Kill_Silo_1_With_Timers()
         {
             await Do_Liveness_OracleTest_2(2, false, true);
@@ -239,6 +239,8 @@ namespace UnitTests.MembershipTests
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.Globals.DataConnectionString = StorageTestConstants.DataConnectionString;
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
+            options.ClusterConfiguration.PrimaryNode = null;
+            options.ClusterConfiguration.Globals.SeedNodes.Clear();
             return new TestCluster(options);
         }
 
@@ -248,7 +250,7 @@ namespace UnitTests.MembershipTests
             await Do_Liveness_OracleTest_1();
         }
 
-        //[Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
         public async Task Liveness_Azure_2_Restart_Primary()
         {
             await Do_Liveness_OracleTest_2(0);
@@ -266,7 +268,7 @@ namespace UnitTests.MembershipTests
             await Do_Liveness_OracleTest_2(2);
         }
 
-        // [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
         public async Task Liveness_Azure_5_Kill_Silo_1_With_Timers()
         {
             await Do_Liveness_OracleTest_2(2, false, true);
@@ -284,10 +286,12 @@ namespace UnitTests.MembershipTests
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.Globals.DataConnectionString = StorageTestConstants.GetZooKeeperConnectionString();
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.ZooKeeper;
+            options.ClusterConfiguration.PrimaryNode = null;
+            options.ClusterConfiguration.Globals.SeedNodes.Clear();
             return new TestCluster(options);
         }
 
-        [Fact,  TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_1()
         {
             await Do_Liveness_OracleTest_1();
@@ -330,6 +334,8 @@ namespace UnitTests.MembershipTests
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.Globals.DataConnectionString = relationalStorage.CurrentConnectionString;
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.SqlServer;
+            options.ClusterConfiguration.PrimaryNode = null;
+            options.ClusterConfiguration.Globals.SeedNodes.Clear();
             return new TestCluster(options);
         }
 
@@ -377,6 +383,8 @@ namespace UnitTests.MembershipTests
             options.ClusterConfiguration.Globals.DataConnectionString = relationalStorage.CurrentConnectionString;
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.SqlServer;
             options.ClusterConfiguration.Globals.AdoInvariant = AdoNetInvariants.InvariantNameMySql;
+            options.ClusterConfiguration.PrimaryNode = null;
+            options.ClusterConfiguration.Globals.SeedNodes.Clear();
             return new TestCluster(options);
         }
 


### PR DESCRIPTION
when creating the client configuration from the cluster config.
Also fixed the deployment name to separate date from time correctly