### PR TITLE
Updating the nuget packaging scripts to add support for prerelease pa…

### DIFF
--- a/src/NuGet/CreateOrleansPackages.bat
+++ b/src/NuGet/CreateOrleansPackages.bat
@@ -8,6 +8,7 @@ set NUGET_EXE=%~dp0..\.nuget\nuget.exe
 set BASE_PATH=%1
 set VERSION=%2
 set SRC_DIR=%3
+set PRERELEASE_BUILD=%4
 IF %2 == "" set VERSION=%~dp0..\Build\Version.txt
 
 @echo CreateOrleansNugetPackages running in directory = %1
@@ -36,14 +37,24 @@ if EXIST "%VERSION%" (
     GOTO Usage
 )
 
-if not "%VERSION_BETA%" == "" ( set VERSION=%VERSION%-%VERSION_BETA% )
+if not "%VERSION_BETA%" == "" (
+    @echo VERSION_BETA=!VERSION_BETA!
+    set VERSION=%VERSION%-!VERSION_BETA!
+)
 
-@echo VERSION_BETA=%VERSION_BETA%
-@echo VERSION=%VERSION%
+if "%PRERELEASE_BUILD%" == "true" (
+    set VERSION_TYPE=Dev
+    set VERSION_TIMESTAMP=%date:~10,4%%date:~4,2%%date:~7,2%%time:~0,2%%time:~3,2%
+    @echo VERSION_TYPE = !VERSION_TYPE!
+    @echo VERSION_TIMESTAMP = !VERSION_TIMESTAMP!
+    set VERSION=%VERSION%-!VERSION_TYPE!!VERSION_TIMESTAMP!
+)
 
-@echo CreateOrleansNugetPackages: Version = %VERSION% -- Drop location = %BASE_PATH% -- SRC_DIR=%SRC_DIR%
+@echo VERSION=!VERSION!
 
-@set NUGET_PACK_OPTS= -Version %VERSION%
+@echo CreateOrleansNugetPackages: Version = !VERSION! -- Drop location = %BASE_PATH% -- SRC_DIR=%SRC_DIR%
+
+@set NUGET_PACK_OPTS= -Version !VERSION!
 @set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -NoPackageAnalysis
 @set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -BasePath "%BASE_PATH%" -Properties SRC_DIR=%SRC_DIR%
 REM @set NUGET_PACK_OPTS=%NUGET_PACK_OPTS% -Verbosity detailed


### PR DESCRIPTION
Updating the nuget packaging scripts to add support for prerelease packages. Running build.cmd will create output like the following.

Binaries\Nuget.Packages
  - Microsoft.Orleans.Core.1.3.0.nupkg
  - Microsoft.Orleans.Core.1.3.0.symbols.nupkg
  - ...
Binaries\Nuget.Packages\Prerelease
  - Microsoft.Orleans.Core.1.3.0-Dev201606091244.nupkg
  - Microsoft.Orleans.Core.1.3.0-Dev201606091244.symbols.nupkg
  - ...

Prerelease packages built like this are useful for testing package updates the nuget tools locally before creating a new official package. Each subsequent build will be identified as an update to the previous one.