### PR TITLE
Improved BaseJSONProvider in storage samples a bit

### DIFF
--- a/Samples/StorageProviders/StorageProviders/BaseJSONStorageProvider.cs
+++ b/Samples/StorageProviders/StorageProviders/BaseJSONStorageProvider.cs
@@ -80,9 +80,10 @@ namespace Samples.StorageProviders
         /// <returns>Completion promise for this operation.</returns>
         public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
         {
+            if (DataManager == null) throw new ArgumentException("DataManager property not initialized");
+
             var grainTypeName = grainType.Split('.').Last();
 
-            if (DataManager == null) throw new ArgumentException("DataManager property not initialized");
             var entityData = await DataManager.Read(grainTypeName, grainReference.ToKeyString());
             if (entityData != null)
             {
@@ -99,9 +100,10 @@ namespace Samples.StorageProviders
         /// <returns>Completion promise for this operation.</returns>
         public Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
         {
-            var grainTypeName = grainType.Split('.').Last();
-
             if (DataManager == null) throw new ArgumentException("DataManager property not initialized");
+
+            var grainTypeName = grainType.Split('.').Last();
+            
             var entityData = ConvertToStorageFormat(grainState);
             return DataManager.Write(grainTypeName, grainReference.ToKeyString(), entityData);
         }
@@ -115,9 +117,10 @@ namespace Samples.StorageProviders
         /// <returns></returns>
         public Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
         {
-            var grainTypeName = grainType.Split('.').Last();
-
             if (DataManager == null) throw new ArgumentException("DataManager property not initialized");
+
+            var grainTypeName = grainType.Split('.').Last();
+            
             DataManager.Delete(grainTypeName, grainReference.ToKeyString());
             return TaskDone.Done;
         }


### PR DESCRIPTION
Was just roaming around and saw this.
It's not a big deal since most of the times the conditions are met and this is only a sample but still i was reading it and felt changing it.

Previously it first was trying to get the type name resolved by splitting the string with "." and then check for DataManager to see if it's null or not and throw an exception if it was. Potentially it was wasted time doing string processing and it is always more clear to check pre-conditions before anything else.