### PR TITLE
GrainCreator fallback on Activator.CreateInstance

### DIFF
--- a/src/OrleansRuntime/Catalog/GrainCreator.cs
+++ b/src/OrleansRuntime/Catalog/GrainCreator.cs
@@ -36,10 +36,12 @@ namespace Orleans.Runtime
         /// <returns></returns>
         public Grain CreateGrainInstance(Type grainType, IGrainIdentity identity)
         {
-            var grain = _services != null
-                ? (Grain) _services.GetService(grainType)
-                : (Grain) Activator.CreateInstance(grainType);
+            var grain = (Grain)_services?.GetService(grainType);
 
+            if(grain == null) {
+                grain = (Grain)Activator.CreateInstance(grainType);
+            }
+            
             // Inject runtime hooks into grain instance
             grain.Runtime = _grainRuntime;
             grain.Identity = identity;
@@ -67,7 +69,7 @@ namespace Orleans.Runtime
             var storage = new GrainStateStorageBridge(grainType.FullName, statefulGrain, storageProvider);
 
             //Inject state and storage data into the grain
-            statefulGrain.GrainState.State = Activator.CreateInstance(stateType); ;
+            statefulGrain.GrainState.State = Activator.CreateInstance(stateType);
             statefulGrain.SetStorage(storage);
 
             return grain;


### PR DESCRIPTION
With DI set up, all grains are created via ``Silo.Services``. This works nicely when wired up to StructureMap, which happily injects into any ad hoc types you request from it - and probably does for many other containers also. 

But there's a bit of an issue if you go for the default option of directly using the ``IServiceCollection`` passed to your ``Startup`` class: it requires all candidates for injection to be explicitly registered, and so all requests for Grains from the runtime will return null (and throw obscure exceptions) unless each potential grain type has been manually registered with the container. This manual registration is obviously a drag.

Should ``GrainCreator`` just fallback on its original behaviour if the DI container can't help it out?
