### PR TITLE
ClusterConfiguration extension for setting Startup class

### DIFF
--- a/src/Orleans/Configuration/ConfigurationExtensions.cs
+++ b/src/Orleans/Configuration/ConfigurationExtensions.cs
@@ -57,5 +57,22 @@ namespace Orleans.Runtime.Configuration
 
             return properties;
         }
+
+
+        /// <summary>
+        /// Configures all cluster nodes to use the specified startup class for dependency injection.
+        /// </summary>
+        /// <typeparam name="TStartup">Startup type</typeparam>
+        public static void UseStartupClass<TStartup>(this ClusterConfiguration config) 
+        {
+            var startupName = typeof(TStartup).AssemblyQualifiedName;
+
+            foreach(var nodeConfig in config.Overrides.Values) {
+                nodeConfig.StartupTypeName = startupName;
+            }
+
+            config.Defaults.StartupTypeName = startupName;
+        }
+
     }
 }

--- a/src/Orleans/Configuration/ConfigurationExtensions.cs
+++ b/src/Orleans/Configuration/ConfigurationExtensions.cs
@@ -63,7 +63,7 @@ namespace Orleans.Runtime.Configuration
         /// Configures all cluster nodes to use the specified startup class for dependency injection.
         /// </summary>
         /// <typeparam name="TStartup">Startup type</typeparam>
-        public static void UseStartupClass<TStartup>(this ClusterConfiguration config) 
+        public static void UseStartupType<TStartup>(this ClusterConfiguration config) 
         {
             var startupName = typeof(TStartup).AssemblyQualifiedName;
 

--- a/src/OrleansTestingHost/Extensions/ConfigurationExtensions.cs
+++ b/src/OrleansTestingHost/Extensions/ConfigurationExtensions.cs
@@ -31,5 +31,6 @@ namespace Orleans.Runtime.Configuration
                 yield return nodeConfiguration;
             }
         }
+
     }
 }

--- a/src/OrleansTestingHost/Extensions/ConfigurationExtensions.cs
+++ b/src/OrleansTestingHost/Extensions/ConfigurationExtensions.cs
@@ -31,6 +31,5 @@ namespace Orleans.Runtime.Configuration
                 yield return nodeConfiguration;
             }
         }
-
     }
 }


### PR DESCRIPTION
Just what you'd expect from the title, I'd suppose.

I was moaning a little bit on #1765 about configuring the startup class being non-obvious, especially in the context of ``TestCluster``, which prepopulates overrides.

So - a small helper extension method to set the ``StartupTypeName`` property on all nodes.