### PR TITLE
Default testcluster size

### DIFF
--- a/src/OrleansTestingHost/TestClusterOptions.cs
+++ b/src/OrleansTestingHost/TestClusterOptions.cs
@@ -32,7 +32,7 @@ namespace Orleans.TestingHost
             this.BaseGatewayPort = ThreadSafeRandom.Next(40000, 50000);
         }
 
-        public static short DefaultInitialSilosCount { get; set; } = 1;
+        public static short DefaultInitialSilosCount { get; set; } = 2;
         public static bool DefaultTraceToConsole { get; set; } = true;
         public static string DefaultLogsFolder { get; set; } = "logs";
 

--- a/src/Test.cmd
+++ b/src/Test.cmd
@@ -13,7 +13,7 @@ pushd "%CMDHOME%"
 SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
 set TESTS=%OutDir%\Tester.dll %OutDir%\TesterInternal.dll
-if []==[%TEST_FILTERS%] set TEST_FILTERS=-trait "Category=BVT"
+if []==[%TEST_FILTERS%] set TEST_FILTERS=-trait "Category=BVT" -trait "Category=SlowBVT"
 
 @Echo Test assemblies = %TESTS%
 @Echo Test filters = %TEST_FILTERS%

--- a/src/TestAll.cmd
+++ b/src/TestAll.cmd
@@ -7,7 +7,7 @@ set CMDHOME=%CMDHOME:~0,-1%
 
 @REM Due to more of Windows .cmd script parameter passing quirks, we can't pass this value as cmdline argument, 
 @REM  so we need to pass it in through the back door as environment variable, scoped by setlocal
-set TEST_FILTERS=-trait "Category=BVT" -trait "Category=Functional"
+set TEST_FILTERS=-trait "Category=BVT" -trait "Category=SlowBVT" -trait "Category=Functional"
 
 @REM Note: We transfer _complete_ control to the Test.cmd script here because we don't use CALL.
 

--- a/test/Tester/ObserverTests.cs
+++ b/test/Tester/ObserverTests.cs
@@ -1,11 +1,9 @@
 using Orleans;
 using Orleans.Runtime;
-using Orleans.TestingHost;
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Orleans.TestingHost.Utils;
-using Tester;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
 using Xunit;
@@ -106,7 +104,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
         public async Task ObserverTest_DoubleSubscriptionSameReference()
         {
             TestInitialize();
@@ -154,7 +152,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
         public async Task ObserverTest_SubscribeUnsubscribe()
         {
             TestInitialize();
@@ -246,8 +244,7 @@ namespace UnitTests.General
                 result.Done = true;
         }
 
-
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
         public async Task ObserverTest_DeleteObject()
         {
             TestInitialize();
@@ -310,10 +307,7 @@ namespace UnitTests.General
             public void StateChanged(int a, int b)
             {
                 GrainClient.Logger.Verbose("SimpleGrainObserver.StateChanged a={0} b={1}", a, b);
-                if (action != null)
-                {
-                    action(a, b, result);
-                }
+                action?.Invoke(a, b, result);
             }
 
             #endregion

--- a/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -61,7 +61,7 @@ namespace UnitTests.StreamingTests
                 Fixture.StreamProviderName);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task Recoverable100EventStreamsWithTransientErrorsTest()
         {
             logger.Info("************************ Recoverable100EventStreamsWithTransientErrorsTest *********************************");
@@ -71,7 +71,7 @@ namespace UnitTests.StreamingTests
                 100);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task Recoverable100EventStreamsWith1NonTransientErrorTest()
         {
             logger.Info("************************ Recoverable100EventStreamsWith1NonTransientErrorTest *********************************");

--- a/test/Tester/StreamingTests/SMSClientStreamTests.cs
+++ b/test/Tester/StreamingTests/SMSClientStreamTests.cs
@@ -35,14 +35,14 @@ namespace Tester.StreamingTests
             return new TestCluster(options);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSStreamProducerOnDroppedClientTest()
         {
             logger.Info("************************ SMSStreamProducerOnDroppedClientTest *********************************");
             await runner.StreamProducerOnDroppedClientTest(SMSStreamProviderName, StreamNamespace);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]
         public async Task SMSStreamConsumerOnDroppedClientTest()
         {
             logger.Info("************************ SMSStreamConsumerOnDroppedClientTest *********************************");

--- a/test/Tester/TestingHost/TestingSiloHostTests.cs
+++ b/test/Tester/TestingHost/TestingSiloHostTests.cs
@@ -7,7 +7,7 @@ namespace Tester.TestingHost
 {
     public class TestingSiloHostTests
     {
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Testing")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Testing")]
         public async Task AllowClusterReuseBetweenInvocations()
         {
             try

--- a/test/TesterInternal/GatewaySelectionTest.cs
+++ b/test/TesterInternal/GatewaySelectionTest.cs
@@ -49,7 +49,7 @@ namespace UnitTests.MessageCenterTests
             Test_GatewaySelection(listProvider);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Gateway")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Gateway")]
         public void GatewaySelection_ClientInit_EmptyList()
         {
             var cfg = new ClientConfiguration();

--- a/test/TesterInternal/General/Identifiertests.cs
+++ b/test/TesterInternal/General/Identifiertests.cs
@@ -142,7 +142,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void GrainId_ToFromPrintableString()
         {
             Guid guid = Guid.NewGuid();


### PR DESCRIPTION
* Default to 2 silos being started in the TestCluster.
This is to spot serialization issues that don't occur in a 1 silo deployment that just does deep copying.

* Demoted some very slow tests from BVT to Functional.
They are still being run by our CI server, just not every time a dev wants to run all BVTs or for every pull request.
This should shave off a couple of minutes from our BVT run
