### PR TITLE
Throw meaningful exception if grain timer is created outside grain context

### DIFF
--- a/src/OrleansRuntime/Core/GrainTimer.cs
+++ b/src/OrleansRuntime/Core/GrainTimer.cs
@@ -24,7 +24,8 @@ namespace Orleans.Runtime
 
         private GrainTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period, string name)
         {
-            var ctxt = RuntimeContext.Current.ActivationContext;
+            var ctxt = RuntimeContext.CurrentActivationContext;
+            InsideRuntimeClient.Current.Scheduler.CheckSchedulingContextValidity(ctxt);
             activationData = (ActivationData) RuntimeClient.Current.CurrentActivationData;
 
             this.Name = name;

--- a/src/OrleansRuntime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/OrleansRuntime/Scheduler/OrleansTaskScheduler.cs
@@ -267,7 +267,10 @@ namespace Orleans.Runtime.Scheduler
         {
             if (context == null)
             {
-                throw new InvalidSchedulingContextException("CheckSchedulingContextValidity was called on a null SchedulingContext.");
+                throw new InvalidSchedulingContextException(
+                    "CheckSchedulingContextValidity was called on a null SchedulingContext."
+                     + "Please make sure you are not trying to create a Timer from outside Orleans Task Scheduler, "
+                     + "which will be the case if you create it inside Task.Run.");
             }
             GetWorkItemGroup(context); // GetWorkItemGroup throws for Invalid context
         }


### PR DESCRIPTION
To prevent cases like https://github.com/dotnet/orleans/issues/1824