### PR TITLE
Updating EventHubAdapterFactory for extensibility.

### DIFF
--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProvider.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProviderConfig.cs" />
     <Compile Include="Providers\Streams\EventHub\ICheckpointerSettings.cs" />
+    <Compile Include="Providers\Streams\EventHub\IEventHubQueueMapper.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubQueueCache.cs" />
     <Compile Include="Providers\Streams\EventHub\SegmentBuilder.cs" />

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -35,7 +35,7 @@ namespace Orleans.ServiceBus.Providers
         protected Func<string, IStreamQueueCheckpointer<string>, IEventHubQueueCache> CacheFactory { get; set; }
         protected Func<string, Task<IStreamQueueCheckpointer<string>>> CheckpointerFactory { get; set; }
         protected Func<string, Task<IStreamFailureHandler>> StreamFailureHandlerFactory { get; set; }
-        protected Func<string[], Task<IEventHubQueueMapper>> QueueMapperFactory { get; set; }
+        protected Func<string[], IEventHubQueueMapper> QueueMapperFactory { get; set; }
         
         /// <summary>
         /// Factory initialization.
@@ -83,7 +83,7 @@ namespace Orleans.ServiceBus.Providers
 
             if (QueueMapperFactory == null)
             {
-                QueueMapperFactory = partitions => Task.FromResult<IEventHubQueueMapper>(new EventHubQueueMapper(partitionIds, adapterConfig.StreamProviderName));
+                QueueMapperFactory = partitions => new EventHubQueueMapper(partitionIds, adapterConfig.StreamProviderName);
             }
         }
 
@@ -92,7 +92,7 @@ namespace Orleans.ServiceBus.Providers
             if (streamQueueMapper == null)
             {
                 partitionIds = await GetPartitionIdsAsync();
-                streamQueueMapper = await QueueMapperFactory(partitionIds);
+                streamQueueMapper = QueueMapperFactory(partitionIds);
             }
             return this;
         }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueMapper.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueMapper.cs
@@ -7,11 +7,11 @@ using Orleans.Streams;
 
 namespace Orleans.ServiceBus.Providers
 {
-    internal class EventHubQueueMapper : HashRingBasedStreamQueueMapper
+    public class EventHubQueueMapper : HashRingBasedStreamQueueMapper, IEventHubQueueMapper
     {
         private readonly Dictionary<QueueId, string> partitionDictionary = new Dictionary<QueueId, string>();
 
-        internal EventHubQueueMapper(string[] partitionIds, string queueNamePrefix)
+        public EventHubQueueMapper(string[] partitionIds, string queueNamePrefix)
             : base(partitionIds.Length, queueNamePrefix)
         {
             QueueId[] queues = GetAllQueues().ToArray();

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueMapper.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueMapper.cs
@@ -1,0 +1,12 @@
+﻿using Orleans.Streams;
+
+namespace Orleans.ServiceBus.Providers
+{
+    /// <summary>
+    /// Stream queue mapper that maps Event Hub partitions to <see cref="QueueId"/>s
+    /// </summary>
+    public interface IEventHubQueueMapper : IStreamQueueMapper
+    {
+        string QueueToPartition(QueueId queue);
+    }
+}


### PR DESCRIPTION
- Making the provider config a protected member that can be accessed in derived factory types
- Making the QueueMapper public so custom implementations can be authored in derived types