### PR TITLE
Log special error msg when silo fails to join due to initial connectivity problems.

### DIFF
--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -193,6 +193,10 @@ namespace Orleans.Runtime.Configuration
         /// Whether to use the gossip optimization to speed up spreading liveness information.
         /// </summary>
         public bool UseLivenessGossip { get; set; }
+        /// <summary>
+        /// Whether new silo that joins the cluster has to validate the initial connectivity with all other Active silos.
+        /// </summary>
+        public bool ValidateInitialConnectivity { get; set; }
 
         /// <summary>
         /// Service Id.
@@ -454,6 +458,7 @@ namespace Orleans.Runtime.Configuration
         private const int DEFAULT_LIVENESS_NUM_VOTES_FOR_DEATH_DECLARATION = 2;
         private const int DEFAULT_LIVENESS_NUM_TABLE_I_AM_ALIVE_LIMIT = 2;
         private const bool DEFAULT_LIVENESS_USE_LIVENESS_GOSSIP = true;
+        private const bool DEFAULT_VALIDATE_INITIAL_CONNECTIVITY = true;
         private const int DEFAULT_MAX_MULTICLUSTER_GATEWAYS = 10;
         private static readonly TimeSpan DEFAULT_BACKGROUND_GOSSIP_INTERVAL = TimeSpan.FromSeconds(30);
         private const int DEFAULT_LIVENESS_EXPECTED_CLUSTER_SIZE = 20;
@@ -495,6 +500,7 @@ namespace Orleans.Runtime.Configuration
             NumVotesForDeathDeclaration = DEFAULT_LIVENESS_NUM_VOTES_FOR_DEATH_DECLARATION;
             NumMissedTableIAmAliveLimit = DEFAULT_LIVENESS_NUM_TABLE_I_AM_ALIVE_LIMIT;
             UseLivenessGossip = DEFAULT_LIVENESS_USE_LIVENESS_GOSSIP;
+            ValidateInitialConnectivity = DEFAULT_VALIDATE_INITIAL_CONNECTIVITY;
             MaxJoinAttemptTime = DEFAULT_LIVENESS_MAX_JOIN_ATTEMPT_TIME;
             MaxMultiClusterGateways = DEFAULT_MAX_MULTICLUSTER_GATEWAYS;
             BackgroundGossipInterval = DEFAULT_BACKGROUND_GOSSIP_INTERVAL;
@@ -560,6 +566,7 @@ namespace Orleans.Runtime.Configuration
             sb.AppendFormat("      NumProbedSilos: {0}", NumProbedSilos).AppendLine();
             sb.AppendFormat("      NumVotesForDeathDeclaration: {0}", NumVotesForDeathDeclaration).AppendLine();
             sb.AppendFormat("      UseLivenessGossip: {0}", UseLivenessGossip).AppendLine();
+            sb.AppendFormat("      ValidateInitialConnectivity: {0}", ValidateInitialConnectivity).AppendLine();
             sb.AppendFormat("      IAmAliveTablePublishTimeout: {0}", IAmAliveTablePublishTimeout).AppendLine();
             sb.AppendFormat("      NumMissedTableIAmAliveLimit: {0}", NumMissedTableIAmAliveLimit).AppendLine();
             sb.AppendFormat("      MaxJoinAttemptTime: {0}", MaxJoinAttemptTime).AppendLine();
@@ -677,6 +684,11 @@ namespace Orleans.Runtime.Configuration
                         {
                             UseLivenessGossip = ConfigUtilities.ParseBool(child.GetAttribute("UseLivenessGossip"),
                                 "Invalid boolean value for the UseLivenessGossip attribute on the Liveness element");
+                        }
+                        if (child.HasAttribute("ValidateInitialConnectivity"))
+                        {
+                            ValidateInitialConnectivity = ConfigUtilities.ParseBool(child.GetAttribute("ValidateInitialConnectivity"),
+                                "Invalid boolean value for the ValidateInitialConnectivity attribute on the Liveness element");
                         }
                         if (child.HasAttribute("IAmAliveTablePublishTimeout"))
                         {

--- a/src/Orleans/Configuration/OrleansConfiguration.xsd
+++ b/src/Orleans/Configuration/OrleansConfiguration.xsd
@@ -478,6 +478,13 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="ValidateInitialConnectivity" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Whether new silo that joins the cluster has to validate the initial connectivity with all other Active silos before being allowed to join the cluster.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="IAmAliveTablePublishTimeout" type="tns:TimeSpan" use="optional">
       <xs:annotation>
         <xs:documentation>

--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -495,8 +495,9 @@ namespace Orleans
         MembershipGossipSendFailure            = MembershipBase + 56,
         MembershipTimerProcessingFailure       = MembershipBase + 57,
         MembershipSendPingFailure              = MembershipBase + 58,
-        MembershipUpdateIAmAliveFailure          = MembershipBase + 59,
+        MembershipUpdateIAmAliveFailure        = MembershipBase + 59,
         MembershipStartingIAmAliveTimer        = MembershipBase + 60,
+        MembershipJoiningPreconditionFailure   = MembershipBase + 61,
 
         NSMembershipStarting                   = MembershipBase + 70,
         NSMembershipBecomeActive               = MembershipBase + 71,

--- a/src/OrleansRuntime/MembershipService/MembershipOracle.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipOracle.cs
@@ -35,6 +35,7 @@ namespace Orleans.Runtime.MembershipService
 
         public string SiloName { get { return membershipOracleData.SiloName; } }
         public SiloAddress SiloAddress { get { return membershipOracleData.MyAddress; } }
+        private TimeSpan AllowedIAmAliveMissPeriod { get { return orleansConfig.Globals.IAmAliveTablePublishTimeout.Multiply(orleansConfig.Globals.NumMissedTableIAmAliveLimit); } }
 
         internal MembershipOracle(Silo silo, IMembershipTable membershipTable)
             : base(Constants.MembershipOracleId, silo.SiloAddress)
@@ -373,7 +374,8 @@ namespace Orleans.Runtime.MembershipService
                 }
                 else
                 {
-                    errorString = String.Format("-Silo {0} failed to update its status to {1} in the table due to precondition failures after {2} attempts.", MyAddress.ToLongString(), status, numCalls);
+                    errorString = String.Format("-Silo {0} failed to update its status to {1} in the Membership table due to write contention on the table after {2} attempts.",
+                        MyAddress.ToLongString(), status, numCalls);
                     logger.Error(ErrorCode.MembershipFailedToWriteConditional, errorString);
                     throw new OrleansException(errorString);
                 }
@@ -384,8 +386,9 @@ namespace Orleans.Runtime.MembershipService
                 {
                     errorString = String.Format("-Silo {0} failed to update its status to {1} in the table due to failures (socket failures or table read/write failures) after {2} attempts: {3}", MyAddress.ToLongString(), status, numCalls, exc.Message);
                     logger.Error(ErrorCode.MembershipFailedToWrite, errorString);
+                    throw new OrleansException(errorString, exc);
                 }
-                throw new OrleansException(errorString, exc);
+                throw;
             }
         }
 
@@ -438,7 +441,7 @@ namespace Orleans.Runtime.MembershipService
             myEntry.Status = newStatus;
             myEntry.IAmAliveTime = now;
 
-            if (newStatus.Equals(SiloStatus.Active))
+            if (newStatus.Equals(SiloStatus.Active) && orleansConfig.Globals.ValidateInitialConnectivity)
                 await GetJoiningPreconditionPromise(table);
             
             TableVersion next = table.Version.Next();
@@ -448,7 +451,7 @@ namespace Orleans.Runtime.MembershipService
             return await membershipTableProvider.InsertRow(myEntry, next);
         }
 
-        private Task GetJoiningPreconditionPromise(MembershipTableData table)
+        private async Task GetJoiningPreconditionPromise(MembershipTableData table)
         {
             // send pings to all Active nodes, that are known to be alive
             List<MembershipEntry> members = table.Members.Select(tuple => tuple.Item1).Where(
@@ -478,7 +481,18 @@ namespace Orleans.Runtime.MembershipService
                         return true;
                     }));
             }
-            return Task.WhenAll(pingPromises);
+            try
+            {
+                await Task.WhenAll(pingPromises);
+            } catch (Exception)
+            {
+                logger.Error(ErrorCode.MembershipJoiningPreconditionFailure, 
+                    String.Format("-Failed to get ping responses from all {0} silos that are currently listed as Active in the Membership table. " + 
+                                    "Newly joining silos validate connectivity with all pre-existing silos that are listed as Active in the table " +
+                                    "and have written I Am Alive in the table in the last {1} period, before they are allowed to join the cluster. Active silos are: {2}",
+                        members.Count, AllowedIAmAliveMissPeriod, Utils.EnumerableToString(members, entry => entry.ToFullString(true))));
+                throw;
+            }
         }
 
         #endregion
@@ -539,13 +553,12 @@ namespace Orleans.Runtime.MembershipService
         private bool HasMissedIAmAlives(MembershipEntry entry, bool writeWarning)
         {
             var now = LogFormatter.ParseDate(LogFormatter.PrintDate(DateTime.UtcNow));
-            var allowedIAmAliveMissPeriod = orleansConfig.Globals.IAmAliveTablePublishTimeout.Multiply(orleansConfig.Globals.NumMissedTableIAmAliveLimit);
             var lastIAmAlive = entry.IAmAliveTime;
 
             if (entry.IAmAliveTime.Equals(default(DateTime)))
                 lastIAmAlive = entry.StartTime; // he has not written first IAmAlive yet, use its start time instead.
 
-            if (now - lastIAmAlive <= allowedIAmAliveMissPeriod) return false;
+            if (now - lastIAmAlive <= AllowedIAmAliveMissPeriod) return false;
 
             if (writeWarning)
             {
@@ -555,7 +568,7 @@ namespace Orleans.Runtime.MembershipService
                         lastIAmAlive,
                         now,
                         now - lastIAmAlive,
-                        allowedIAmAliveMissPeriod));
+                        AllowedIAmAliveMissPeriod));
             }
             return true;
         }


### PR DESCRIPTION
Addresses https://github.com/dotnet/orleans/issues/1862.
Also added configuration that allows to disable ValidateInitialConnectivity . Still by default it is on for now.

One issue with the error msg is that it is currently logged in the place where the connectivity check fails, but this particular reason is not propagated back in the exception that eventually is thrown from Silo.Start. Doing this is a bit harder since the connectivity logic is executed fro within a general purpose async retry mechanism that has a time limit on the number of retries and eventuality it fails with Timeout Exception (and that is the exception that is thrown from Silo.Start). So if we wanted to throw out the original exception that caused lets say the last iteration of the retry loop to fail, it will require some changes to this retry mechanism. Looks like so far only logging the explicit msg will be enough.