### PR TITLE
Fix #1869. Grain Extensions + method interception should function correctly

### DIFF
--- a/src/Orleans/CodeGeneration/IGrainMethodInvoker.cs
+++ b/src/Orleans/CodeGeneration/IGrainMethodInvoker.cs
@@ -35,4 +35,20 @@ namespace Orleans.CodeGeneration
         /// <returns>Value promise for the result of the method invoke.</returns>
         Task<object> Invoke(IGrainExtension extension, InvokeMethodRequest request);
     }
+
+    /// <summary>
+    /// Methods for querying a collection of grain extensions.
+    /// </summary>
+    public interface IGrainExtensionMap
+    {
+        /// <summary>
+        /// Gets the extension from this instance if it is available.
+        /// </summary>
+        /// <param name="interfaceId">The interface id.</param>
+        /// <param name="extension">The extension.</param>
+        /// <returns>
+        /// <see langword="true"/> if the extension is found, <see langword="false"/> otherwise.
+        /// </returns>
+        bool TryGetExtension(int interfaceId, out IGrainExtension extension);
+    }
 }

--- a/src/Orleans/Core/InterceptedMethodInvoker.cs
+++ b/src/Orleans/Core/InterceptedMethodInvoker.cs
@@ -20,18 +20,38 @@ namespace Orleans
         /// <summary>
         /// The grain's methods.
         /// </summary>
-        private readonly IReadOnlyDictionary<int, MethodInfo> methodInfos;
+        private readonly Dictionary<int, MethodInfo> methodInfos;
 
-        public InterceptedMethodInvoker(IGrainMethodInvoker invoker, IReadOnlyDictionary<int, MethodInfo> methodInfos)
+        /// <summary>
+        /// Constructs a new instance of the <see cref="InterceptedMethodInvoker"/> class.
+        /// </summary>
+        /// <param name="invoker">The underlying method invoker.</param>
+        /// <param name="methodInfos">
+        /// The mapping between method id and <see cref="MethodInfo"/> for each of the grain's methods.
+        /// </param>
+        public InterceptedMethodInvoker(IGrainMethodInvoker invoker, Dictionary<int, MethodInfo> methodInfos)
         {
             this.invoker = invoker;
             this.methodInfos = methodInfos;
         }
 
-        public int InterfaceId { get { return invoker.InterfaceId; } }
+        /// <summary>
+        /// Gets the interface id from the underlying invoker.
+        /// </summary>
+        public int InterfaceId => this.invoker.InterfaceId;
 
+        /// <summary>
+        /// Invoke a grain method.
+        /// Invoker classes in generated code implement this method to provide a method call jump-table to map invoke
+        /// data to a strongly typed call to the correct method on the correct interface.
+        /// </summary>
+        /// <param name="grain">Reference to the grain to be invoked.</param>
+        /// <param name="request">The request being invoked.</param>
+        /// <returns>Value promise for the result of the method invoke.</returns>
         public Task<object> Invoke(IAddressable grain, InvokeMethodRequest request)
         {
+            // If the grain implements IGrainInvokeInterceptor then call its implementation, passing
+            // the underlying invoker so that the grain can easily dispatch invocation to the correct method.
             var interceptor = grain as IGrainInvokeInterceptor;
             if (interceptor != null)
             {
@@ -39,9 +59,18 @@ namespace Orleans
                 return interceptor.Invoke(methodInfo, request, this.invoker);
             }
 
+            // Otherwise, call the underlying invoker directly.
             return this.invoker.Invoke(grain, request);
         }
 
+        /// <summary>
+        /// Returns the method info for the provided <paramref name="methodId"/>, or <see langword="null"/> if not
+        /// found.
+        /// </summary>
+        /// <param name="methodId">The method id.</param>
+        /// <returns>
+        /// The method info for the provided <paramref name="methodId"/>, or <see langword="null"/> if not found.
+        /// </returns>
         public MethodInfo GetMethodInfo(int methodId)
         {
             // Attempt to retrieve the implementation's MethodInfo.

--- a/src/Orleans/Core/InterceptedMethodInvokerCache.cs
+++ b/src/Orleans/Core/InterceptedMethodInvokerCache.cs
@@ -4,10 +4,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Orleans.CodeGeneration;
+using Orleans.Runtime;
 
 namespace Orleans
 {
-    internal class InvocationMethodInfoMap
+    /// <summary>
+    /// Maintains a map between grain classes and corresponding <see cref="InterceptedMethodInvoker"/> instances.
+    /// </summary>
+    internal class InterceptedMethodInvokerCache
     {
         /// <summary>
         /// The map from implementation types to interface ids to invoker.
@@ -15,7 +19,20 @@ namespace Orleans
         private readonly ConcurrentDictionary<Type, ConcurrentDictionary<int, InterceptedMethodInvoker>> invokers =
             new ConcurrentDictionary<Type, ConcurrentDictionary<int, InterceptedMethodInvoker>>();
 
-        public InterceptedMethodInvoker GetInterceptedMethodInvoker(Type implementationType, int interfaceId, IGrainMethodInvoker invoker)
+        /// <summary>
+        /// Returns a grain method invoker which calls the grain's implementation of <see cref="IGrainInvokeInterceptor"/>
+        /// if it exists, otherwise calling the provided <paramref name="invoker"/> directly.
+        /// </summary>
+        /// <param name="implementationType">The grain type.</param>
+        /// <param name="interfaceId">The interface id.</param>
+        /// <param name="invoker">
+        /// The underlying invoker, which will be passed to the grain's <see cref="IGrainInvokeInterceptor.Invoke"/>
+        /// method.
+        /// </param>
+        /// <returns>
+        /// A grain method invoker which calls the grain's implementation of <see cref="IGrainInvokeInterceptor"/>.
+        /// </returns>
+        public InterceptedMethodInvoker GetOrCreate(Type implementationType, int interfaceId, IGrainMethodInvoker invoker)
         {
             var implementation = invokers.GetOrAdd(
                 implementationType,
@@ -30,18 +47,44 @@ namespace Orleans
             // Create a mapping between the interface and the implementation.
             return implementation.GetOrAdd(
                 interfaceId,
-                _ =>
-                    new InterceptedMethodInvoker(invoker,
-                        GetInterfaceToImplementationMap(interfaceId, implementationType)));
+                _ => CreateInterceptedMethodInvoker(implementationType, interfaceId, invoker));
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="InterceptedMethodInvoker"/> for the provided values.
+        /// </summary>
+        /// <param name="implementationType">The grain type.</param>
+        /// <param name="interfaceId">The interface id.</param>
+        /// <param name="invoker">The invoker.</param>
+        /// <returns>A new <see cref="InterceptedMethodInvoker"/> for the provided values.</returns>
+        private static InterceptedMethodInvoker CreateInterceptedMethodInvoker(
+            Type implementationType,
+            int interfaceId,
+            IGrainMethodInvoker invoker)
+        {
+            // If a grain extension is being invoked, the implementation map must match the methods on the extension
+            // and not the grain implementation.
+            var extensionMap = invoker as IGrainExtensionMap;
+            if (extensionMap != null)
+            {
+                IGrainExtension extension;
+                if (extensionMap.TryGetExtension(interfaceId, out extension))
+                {
+                    implementationType = extension.GetType();
+                }
+            }
+
+            var implementationMap = GetInterfaceToImplementationMap(interfaceId, implementationType);
+            return new InterceptedMethodInvoker(invoker, implementationMap);
         }
 
         /// <summary>
         /// Maps the provided <paramref name="interfaceId"/> to the provided <paramref name="implementationType"/>.
         /// </summary>
-        /// <param name="interfaceType">The interface type.</param>
+        /// <param name="interfaceId">The interface id.</param>
         /// <param name="implementationType">The implementation type.</param>
         /// <returns>The mapped interface.</returns>
-        private static IReadOnlyDictionary<int, MethodInfo> GetInterfaceToImplementationMap(
+        private static Dictionary<int, MethodInfo> GetInterfaceToImplementationMap(
             int interfaceId,
             Type implementationType)
         {

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -101,7 +101,7 @@
     <Compile Include="Configuration\ConfigurationExtensions.cs" />
     <Compile Include="Core\IGrainInvokeInterceptor.cs" />
     <Compile Include="Core\InterceptedMethodInvoker.cs" />
-    <Compile Include="Core\InvocationMethodInfoMap.cs" />
+    <Compile Include="Core\InterceptedMethodInvokerCache.cs" />
     <Compile Include="Core\IStatefulGrain.cs" />
     <Compile Include="GrainDirectory\MultiClusterStatus.cs" />
     <Compile Include="Runtime\RingRange.cs" />

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -25,7 +25,7 @@ namespace Orleans.Runtime
         // defined for the grain class.
         // Note that in all cases we never have more than one copy of an actual invoker;
         // we may have a ExtensionInvoker per activation, in the worst case.
-        private class ExtensionInvoker : IGrainMethodInvoker
+        private class ExtensionInvoker : IGrainMethodInvoker, IGrainExtensionMap
         {
             // Because calls to ExtensionInvoker are allways made within the activation context,
             // we rely on the single-threading guarantee of the runtime and do not protect the map with a lock.
@@ -122,6 +122,29 @@ namespace Orleans.Runtime
             public int InterfaceId
             {
                 get { return 0; } // 0 indicates an extension invoker that may have multiple intefaces inplemented by extensions.
+            }
+
+            /// <summary>
+            /// Gets the extension from this instance if it is available.
+            /// </summary>
+            /// <param name="interfaceId">The interface id.</param>
+            /// <param name="extension">The extension.</param>
+            /// <returns>
+            /// <see langword="true"/> if the extension is found, <see langword="false"/> otherwise.
+            /// </returns>
+            public bool TryGetExtension(int interfaceId, out IGrainExtension extension)
+            {
+                Tuple<IGrainExtension, IGrainExtensionMethodInvoker> value;
+                if (extensionMap != null && extensionMap.TryGetValue(interfaceId, out value))
+                {
+                    extension = value.Item1;
+                }
+                else
+                {
+                    extension = null;
+                }
+
+                return extension != null;
             }
         }
 

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -37,7 +37,7 @@ namespace Orleans.Runtime
         private readonly List<IDisposable> disposables;
         private readonly ConcurrentDictionary<CorrelationId, CallbackData> callbacks;
         
-        private readonly InvocationMethodInfoMap invocationMethodInfoMap = new InvocationMethodInfoMap();
+        private readonly InterceptedMethodInvokerCache interceptedMethodInvokerCache = new InterceptedMethodInvokerCache();
         public TimeSpan ResponseTimeout { get; private set; }
         private readonly GrainTypeManager typeManager;
         private GrainInterfaceMap grainInterfaceMap;
@@ -365,35 +365,7 @@ namespace Orleans.Runtime
                         throw exc;
                     }
 
-                    // If the target has a grain-level interceptor or there is a silo-level interceptor, intercept the call.
-                    var shouldCallSiloWideInterceptor = SiloProviderRuntime.Instance.GetInvokeInterceptor() != null && target is IGrain;
-                    var intercepted = target as IGrainInvokeInterceptor;
-                    if (intercepted != null || shouldCallSiloWideInterceptor)
-                    {
-                        // Fetch the method info for the intercepted call.
-                        var implementationInvoker =
-                            invocationMethodInfoMap.GetInterceptedMethodInvoker(target.GetType(), request.InterfaceId,
-                                invoker);
-                        var methodInfo = implementationInvoker.GetMethodInfo(request.MethodId);
-                        if (shouldCallSiloWideInterceptor)
-                        {
-                            // There is a silo-level interceptor and possibly a grain-level interceptor.
-                            var runtime = SiloProviderRuntime.Instance;
-                            resultObject =
-                                await runtime.CallInvokeInterceptor(methodInfo, request, target, implementationInvoker);
-                        }
-                        else
-                        {
-                            // The grain has an interceptor, but there is no silo-wide interceptor.
-                            resultObject = await intercepted.Invoke(methodInfo, request, invoker);
-                        }
-                    }
-                    else
-                    {
-						// The call is not intercepted.
-                        // TODO: this await here is just grabbing the first exception of the AggregateException. As a framework we shouldn't do that.
-                        resultObject = await invoker.Invoke(target, request);
-                    }
+                    resultObject = await InvokeWithInterceptors(target, request, invoker);
                 }
                 catch (Exception exc1)
                 {
@@ -419,6 +391,48 @@ namespace Orleans.Runtime
                 if (message.Direction != Message.Directions.OneWay)
                     SafeSendExceptionResponse(message, exc2);             
             }
+        }
+
+        private Task<object> InvokeWithInterceptors(IAddressable target, InvokeMethodRequest request, IGrainMethodInvoker invoker)
+        {
+            // If the target has a grain-level interceptor or there is a silo-level interceptor, intercept the
+            // call.
+            var siloWideInterceptor = SiloProviderRuntime.Instance.GetInvokeInterceptor();
+            var grainWithInterceptor = target as IGrainInvokeInterceptor;
+            
+            // Silo-wide interceptors do not operate on system targets.
+            var hasSiloWideInterceptor = siloWideInterceptor != null && target is IGrain;
+            var hasGrainLevelInterceptor = grainWithInterceptor != null;
+            
+            if (!hasGrainLevelInterceptor && !hasSiloWideInterceptor)
+            {
+                // The call is not intercepted at either the silo or the grain level, so call the invoker
+                // directly.
+                return invoker.Invoke(target, request);
+            }
+
+            // Get an invoker which delegates to the grain's IGrainInvocationInterceptor implementation.
+            // If the grain does not implement IGrainInvocationInterceptor, then the invoker simply delegates
+            // calls to the provided invoker.
+            var interceptedMethodInvoker = interceptedMethodInvokerCache.GetOrCreate(
+                target.GetType(),
+                request.InterfaceId,
+                invoker);
+            var methodInfo = interceptedMethodInvoker.GetMethodInfo(request.MethodId);
+            if (hasSiloWideInterceptor)
+            {
+                // There is a silo-level interceptor and possibly a grain-level interceptor.
+                // As a minor optimization, only pass the intercepted invoker if there is a grain-level
+                // interceptor.
+                return siloWideInterceptor(
+                    methodInfo,
+                    request,
+                    (IGrain)target,
+                    hasGrainLevelInterceptor ? interceptedMethodInvoker : invoker);
+            }
+
+            // The grain has an invoke method, but there is no silo-wide interceptor.
+            return grainWithInterceptor.Invoke(methodInfo, request, invoker);
         }
 
         private void SafeSendResponse(Message message, object resultObject)

--- a/test/TestGrainInterfaces/IStreamInterceptionGrain.cs
+++ b/test/TestGrainInterfaces/IStreamInterceptionGrain.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.GrainInterfaces
+{
+    public interface IStreamInterceptionGrain : IGrainWithGuidKey
+    {
+        Task<int> GetLastStreamValue();
+    }
+}

--- a/test/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/test/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -114,6 +114,7 @@
     <Compile Include="ILivenessTestGrain.cs" />
     <Compile Include="IStreamingGrain.cs" />
     <Compile Include="IStreamingImmutabilityTestGrain.cs" />
+    <Compile Include="IStreamInterceptionGrain.cs" />
     <Compile Include="IStreamLifecycleTestGrains.cs" />
     <Compile Include="IStreamLifecycleTestInternalGrains.cs" />
     <Compile Include="IStreamReliabilityTestGrains.cs" />

--- a/test/TestGrains/StreamInterceptionGrain.cs
+++ b/test/TestGrains/StreamInterceptionGrain.cs
@@ -1,0 +1,45 @@
+﻿using System.Reflection;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.CodeGeneration;
+using Orleans.Streams;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains
+{
+    [ImplicitStreamSubscription("InterceptedStream")]
+    public class StreamInterceptionGrain : Grain, IStreamInterceptionGrain, IGrainInvokeInterceptor
+    {
+        private int lastStreamValue;
+
+        public async Task<object> Invoke(MethodInfo methodInfo, InvokeMethodRequest request, IGrainMethodInvoker invoker)
+        {
+            var initialLastStreamValue = this.lastStreamValue;
+            var result = await invoker.Invoke(this, request);
+
+            // If the last stream value changed after the invoke, then the stream must have produced a value, double
+            // it for testing purposes.
+            if (this.lastStreamValue != initialLastStreamValue)
+            {
+                this.lastStreamValue *= 2;
+            }
+
+            return result;
+        }
+
+        public override async Task OnActivateAsync()
+        {
+            var streams = this.GetStreamProvider("SMSProvider");
+            var stream = streams.GetStream<int>(this.GetPrimaryKey(), "InterceptedStream");
+            await stream.SubscribeAsync(
+                (value, token) =>
+                {
+                    this.lastStreamValue = value;
+                    return TaskDone.Done;
+                });
+            await base.OnActivateAsync();
+        }
+
+        public Task<int> GetLastStreamValue() => Task.FromResult(this.lastStreamValue);
+    }
+}

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -122,6 +122,7 @@
     <Compile Include="LivenessTestGrain.cs" />
     <Compile Include="SpecializedSimpleGenericGrain.cs" />
     <Compile Include="StreamCheckpoint.cs" />
+    <Compile Include="StreamInterceptionGrain.cs" />
     <Compile Include="ValueTypeTestGrain.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR addresses #1869, allowing method interception to function correctly when grain extensions (such as streams) are invoked.

Additionally, comments and naming were (hopefully) improved in the relevant code.

The approach is to give `ActivationData.ExtensionInvoker` a new interface, `IGrainExtensionMap`, which can then be queried when creating the `InterceptedMethodInvoker` for that extension. I've marked the crux of the change with a comment in the change list.

cc @gabikliot - I'd like your opinion on my approach here.