### PR TITLE
Stacktrace preservation when sending exception to a remote process.

### DIFF
--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -434,11 +435,34 @@ namespace Orleans.Runtime
             }
         }
 
+        private static readonly Lazy<Func<Exception, Exception>> prepForRemotingLazy = 
+            new Lazy<Func<Exception, Exception>>(() =>
+            {
+                ParameterExpression exceptionParameter = Expression.Parameter(typeof(Exception));
+                MethodCallExpression prepForRemotingCall = Expression.Call(exceptionParameter, "PrepForRemoting", Type.EmptyTypes);
+                Expression<Func<Exception, Exception>> lambda = Expression.Lambda<Func<Exception, Exception>>(prepForRemotingCall, exceptionParameter);
+                Func<Exception, Exception> func = lambda.Compile();
+                return func;
+            });
+
+        private static Exception PrepareForRemoting(Exception exception)
+        {
+            // Call the Exception.PrepForRemoting internal method, which preserves the original stack when the exception
+            // is rethrown at the remote site (and appends the call site stacktrace). If this is not done, then when the
+            // exception is rethrown the original stacktrace is entire replaced.
+            // Note: another commonly used approach since .NET 4.5 is to use ExceptionDispatchInfo.Capture(ex).Throw()
+            // but that involves rethrowing the exception in-place, which is not what we want here, but could in theory
+            // be done at the receiving end with some rework (could be tackled when we reopen #875 Avoid unnecessary use of TCS).
+            prepForRemotingLazy.Value.Invoke(exception);
+            return exception;
+        }
+
         private void SafeSendExceptionResponse(Message message, Exception ex)
         {
             try
             {
-                SendResponse(message, Response.ExceptionResponse((Exception)SerializationManager.DeepCopy(ex)));
+                var copiedException = PrepareForRemoting((Exception)SerializationManager.DeepCopy(ex));
+                SendResponse(message, Response.ExceptionResponse(copiedException));
             }
             catch (Exception exc1)
             {

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
@@ -43,6 +44,25 @@ namespace UnitTests.General
             Assert.IsAssignableFrom<InvalidOperationException>(exception);
             Assert.Equal("Test exception", exception.Message);
             Assert.Contains("ThrowsInvalidOperationException", exception.StackTrace);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task ExceptionContainsOriginalStackTraceWhenRethrowingLocally()
+        {
+            IExceptionGrain grain = GrainFactory.GetGrain<IExceptionGrain>(GetRandomGrainId());
+            try
+            {
+                // Use await to force the exception to be rethrown and validate that the remote stack trace is still present
+                await grain.ThrowsInvalidOperationException();
+                Assert.True(false, "should have thrown");
+            }
+            catch (InvalidOperationException exception)
+            {
+                output.WriteLine(exception.ToString());
+                Assert.IsAssignableFrom<InvalidOperationException>(exception);
+                Assert.Equal("Test exception", exception.Message);
+                Assert.Contains("ThrowsInvalidOperationException", exception.StackTrace);
+            }
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional")]


### PR DESCRIPTION
Previously the stacktrace was being sent along the exception remotely, but as soon as the client awaited the grain call, the exception was being re-thrown on the caller side and the original stacktrace was being wiped out.
This prepares the exception to be able to be re-thrown at a remote place without wiping out the stacktrace when that's done.