### PR TITLE
Harden explicit subscription pubsub system

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -1026,6 +1026,11 @@ namespace Orleans
         StreamProvider_NoStreamForBatch             = StreamProviderManagerBase + 7,
         StreamProvider_ConsumerFailedToUnregister   = StreamProviderManagerBase + 8,
         Stream_ConsumerIsDead                       = StreamProviderManagerBase + 9,
+        Stream_RegisterProducerFailed               = StreamProviderManagerBase + 10,
+        Stream_UnegisterProducerFailed              = StreamProviderManagerBase + 11,
+        Stream_RegisterConsumerFailed               = StreamProviderManagerBase + 12,
+        Stream_UnregisterConsumerFailed             = StreamProviderManagerBase + 13,
+        Stream_SetSubscriptionToFaultedFailed       = StreamProviderManagerBase + 14,
 
         PersistentStreamPullingManagerBase = Runtime + 3500,
         PersistentStreamPullingManager_01 = PersistentStreamPullingManagerBase + 1,

--- a/src/OrleansProviders/Storage/MemoryStorage.cs
+++ b/src/OrleansProviders/Storage/MemoryStorage.cs
@@ -33,8 +33,8 @@ namespace Orleans.Storage
     [DebuggerDisplay("MemoryStore:{Name}")]
     public class MemoryStorage : IStorageProvider
     {
-        internal const int NumStorageGrainsDefaultValue = 10;
-        internal const string NumStorageGrainsPropertyName = "NumStorageGrains";
+        public const int NumStorageGrainsDefaultValue = 10;
+        public const string NumStorageGrainsPropertyName = "NumStorageGrains";
         private int numStorageGrains;
         private static int counter;
         private readonly int id;

--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -56,6 +56,11 @@
     <Compile Include="Extensions\TestConfigurationExtensions.cs" />
     <Compile Include="OrleansTestSecrets.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\orleans.codegen.cs" />
+    <Compile Include="TestStorageProviders\FaultInjectionStorageProvider.cs" />
+    <Compile Include="TestStorageProviders\FaultyMemoryStorage.cs" />
+    <Compile Include="TestStorageProviders\IStorageFaultGrain.cs" />
+    <Compile Include="TestStorageProviders\StorageFaultGrain.cs" />
     <Compile Include="Utils\AsyncResultHandle.cs" />
     <Compile Include="Utils\NoOpTestLogger.cs" />
     <Compile Include="Utils\StorageEmulator.cs" />
@@ -96,11 +101,25 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <!-- Begin Orleans: Without these lines the project won't build properly -->
+  <PropertyGroup>
+    <OrleansProjectType>Server</OrleansProjectType>
+  </PropertyGroup>
+  <!-- Set path to ClientGenerator.exe -->
+  <Choose>
+    <When Condition="'$(builduri)' != ''">
+      <PropertyGroup>
+        <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
+  <!--End Orleans -->
 </Project>

--- a/src/OrleansTestingHost/Properties/AssemblyInfo.cs
+++ b/src/OrleansTestingHost/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿
+using System;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using Orleans.CodeGeneration;
@@ -21,4 +21,3 @@ using Orleans.CodeGeneration;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("40ee3b00-d381-485f-9c69-ff706837deed")]
-[assembly: SkipCodeGeneration]

--- a/src/OrleansTestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
+++ b/src/OrleansTestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
@@ -1,0 +1,120 @@
+﻿
+using System;
+using System.Threading.Tasks;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace Orleans.TestingHost
+{
+    /// <summary>
+    /// Fault injection decorator for storage providers.  This allows users to inject storage exceptions to test error handling scenarios.
+    /// </summary>
+    /// <typeparam name="TStorage"></typeparam>
+    public class FaultInjectionStorageProvider<TStorage> : IStorageProvider
+        where TStorage : IStorageProvider, new()
+    {
+        private readonly TStorage realStorageProvider;
+        private IGrainFactory grainFactory;
+        /// <summary>The name of this provider instance, as given to it in the config.</summary>
+        public string Name => realStorageProvider.Name;
+
+        /// <summary>Logger used by this storage provider instance.</summary>
+        /// <returns>Reference to the Logger object used by this provider.</returns>
+        /// <seealso cref="Logger"/>
+        public Logger Log { get; private set; }
+        
+        /// <summary>
+        /// Default conststructor which creates the decorated storage provider
+        /// </summary>
+        public FaultInjectionStorageProvider()
+        {
+            realStorageProvider = new TStorage();
+        }
+
+        /// <summary>
+        /// Initializes the decorated storage provider.
+        /// </summary>
+        /// <param name="name">Name assigned for this provider</param>
+        /// <param name="providerRuntime">Callback for accessing system functions in the Provider Runtime</param>
+        /// <param name="config">Configuration metadata to be used for this provider instance</param>
+        /// <returns>Completion promise Task for the inttialization work for this provider</returns>
+        public async Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
+        {
+            grainFactory = providerRuntime.GrainFactory;
+            await realStorageProvider.Init(name, providerRuntime, config);
+            Log = realStorageProvider.Log.GetSubLogger("-FaultInjection");
+            Log.Info($"Initialized fault injection for storage provider {Name}");
+        }
+
+        /// <summary>Close function for this provider instance.</summary>
+        /// <returns>Completion promise for the Close operation on this provider.</returns>
+        public async Task Close()
+        {
+                await realStorageProvider.Close();
+        }
+
+        /// <summary>Faults if exception is provided, otherwise calls through to  decorated storage provider.</summary>
+        /// <param name="grainType">Type of this grain [fully qualified class name]</param>
+        /// <param name="grainReference">Grain reference object for this grain.</param>
+        /// <param name="grainState">State data object to be populated for this grain.</param>
+        /// <returns>Completion promise for the Read operation on the specified grain.</returns>
+        public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        {
+            IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
+            try
+            {
+                await faultGrain.OnRead(grainReference);
+            }
+            catch (Exception)
+            {
+                Log.Info($"Fault injected for ReadState for grain {grainReference} of type {grainType}, ");
+                throw;
+            }
+            Log.Info($"ReadState for grain {grainReference} of type {grainType}");
+            await realStorageProvider.ReadStateAsync(grainType, grainReference, grainState);
+        }
+
+        /// <summary>Faults if exception is provided, otherwise calls through to  decorated storage provider.</summary>
+        /// <param name="grainType">Type of this grain [fully qualified class name]</param>
+        /// <param name="grainReference">Grain reference object for this grain.</param>
+        /// <param name="grainState">State data object to be written for this grain.</param>
+        /// <returns>Completion promise for the Write operation on the specified grain.</returns>
+        public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        {
+            IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
+            try
+            {
+                await faultGrain.OnWrite(grainReference);
+            }
+            catch (Exception)
+            {
+                Log.Info($"Fault injected for WriteState for grain {grainReference} of type {grainType}");
+                throw;
+            }
+            Log.Info($"WriteState for grain {grainReference} of type {grainType}");
+            await realStorageProvider.WriteStateAsync(grainType, grainReference, grainState);
+        }
+
+        /// <summary>Faults if exception is provided, otherwise calls through to  decorated storage provider.</summary>
+        /// <param name="grainType">Type of this grain [fully qualified class name]</param>
+        /// <param name="grainReference">Grain reference object for this grain.</param>
+        /// <param name="grainState">Copy of last-known state data object for this grain.</param>
+        /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
+        public async Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        {
+            IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
+            try
+            {
+                await faultGrain.OnClear(grainReference);
+            }
+            catch (Exception)
+            {
+                Log.Info($"Fault injected for ClearState for grain {grainReference} of type {grainType}");
+                throw;
+            }
+            Log.Info($"ClearState for grain {grainReference} of type {grainType}");
+            await realStorageProvider.ClearStateAsync(grainType, grainReference, grainState);
+        }
+    }
+}

--- a/src/OrleansTestingHost/TestStorageProviders/FaultyMemoryStorage.cs
+++ b/src/OrleansTestingHost/TestStorageProviders/FaultyMemoryStorage.cs
@@ -1,0 +1,45 @@
+﻿
+using System;
+using System.Collections.Generic;
+using Orleans.Runtime.Configuration;
+using Orleans.Storage;
+
+namespace Orleans.TestingHost
+{
+    /// <summary>
+    /// A memory storage provider that supports injection of storage exceptions.
+    /// </summary>
+    public class FaultyMemoryStorage : FaultInjectionStorageProvider<MemoryStorage>
+    {
+    }
+
+    /// <summary>
+    /// Extension methods for configuring a FaultyMemoryStorage 
+    /// </summary>
+    public static class FaultInjectionStorageProviderConfigurationExtensions
+    {
+        /// <summary>
+        /// Adds a storage provider of type <see cref="FaultyMemoryStorage"/>
+        /// </summary>
+        /// <param name="config">The cluster configuration object to add provider to.</param>
+        /// <param name="providerName">The provider name.</param>
+        /// <param name="numStorageGrains">The number of storage grains to use.</param>
+        public static void AddFaultyMemoryStorageProvider(
+            this ClusterConfiguration config,
+            string providerName = "FaultyMemoryStore",
+            int numStorageGrains = MemoryStorage.NumStorageGrainsDefaultValue)
+        {
+            //TODO: find a way to share the provider configuration setup so we don't have duplicate code.
+
+            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
+
+            var properties = new Dictionary<string, string>
+            {
+                { MemoryStorage.NumStorageGrainsPropertyName, numStorageGrains.ToString() },
+            };
+
+            config.Globals.RegisterStorageProvider<FaultyMemoryStorage>(providerName, properties);
+        }
+    }
+
+}

--- a/src/OrleansTestingHost/TestStorageProviders/IStorageFaultGrain.cs
+++ b/src/OrleansTestingHost/TestStorageProviders/IStorageFaultGrain.cs
@@ -1,0 +1,54 @@
+﻿
+using System;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace Orleans.TestingHost
+{
+    /// <summary>
+    /// Grain that tracks storage exceptions to be injected.
+    /// </summary>
+    public interface IStorageFaultGrain : IGrainWithStringKey
+    {
+        /// <summary>
+        /// Adds a storage exception to be thrown when the referenced grain reads state from a storage provider
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        Task AddFaultOnRead(GrainReference grainReference, Exception exception);
+        /// <summary>
+        /// Adds a storage exception to be thrown when the referenced grain writes state to a storage provider
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        Task AddFaultOnWrite(GrainReference grainReference, Exception exception);
+        /// <summary>
+        /// Adds a storage exception to be thrown when the referenced grain clears state in a storage provider
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        Task AddFaultOnClear(GrainReference grainReference, Exception exception);
+
+        /// <summary>
+        /// Throws a storage exception if one has been added for the grain reference for reading.
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <returns></returns>
+        Task OnRead(GrainReference grainReference);
+        /// <summary>
+        /// Throws a storage exception if one has been added for the grain reference for writing.
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <returns></returns>
+        Task OnWrite(GrainReference grainReference);
+        /// <summary>
+        /// Throws a storage exception if one has been added for the grain reference for clearing state.
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <returns></returns>
+        Task OnClear(GrainReference grainReference);
+    }
+}

--- a/src/OrleansTestingHost/TestStorageProviders/StorageFaultGrain.cs
+++ b/src/OrleansTestingHost/TestStorageProviders/StorageFaultGrain.cs
@@ -1,0 +1,121 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace Orleans.TestingHost
+{
+    /// <summary>
+    /// Grain that tracks storage exceptions to be injected.
+    /// </summary>
+    public class StorageFaultGrain : Grain, IStorageFaultGrain
+    {
+        private Logger logger;
+        private Dictionary<GrainReference, Exception> readFaults;
+        private Dictionary<GrainReference, Exception> writeFaults;
+        private Dictionary<GrainReference, Exception> clearfaults;
+
+        /// <summary>
+        /// This method is called at the end of the process of activating a grain.
+        /// It is called before any messages have been dispatched to the grain.
+        /// For grains with declared persistent state, this method is called after the State property has been populated.
+        /// </summary>
+        public override async Task OnActivateAsync()
+        {
+            await base.OnActivateAsync();
+            logger = GetLogger($"{typeof (StorageFaultGrain).Name}-{IdentityString}-{RuntimeIdentity}");
+            readFaults = new Dictionary<GrainReference, Exception>();
+            writeFaults = new Dictionary<GrainReference, Exception>();
+            clearfaults = new Dictionary<GrainReference, Exception>();
+            logger.Info("Activate.");
+        }
+
+        /// <summary>
+        /// Adds a storage exception to be thrown when the referenced grain reads state from a storage provider
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        public Task AddFaultOnRead(GrainReference grainReference, Exception exception)
+        {
+            readFaults.Add(grainReference, exception);
+            logger.Info($"Added ReadState fault for {grainReference}.");
+            return TaskDone.Done;
+        }
+
+        /// <summary>
+        /// Adds a storage exception to be thrown when the referenced grain writes state to a storage provider
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        public Task AddFaultOnWrite(GrainReference grainReference, Exception exception)
+        {
+            writeFaults.Add(grainReference, exception);
+            logger.Info($"Added WriteState fault for {grainReference}.");
+            return TaskDone.Done;
+        }
+
+        /// <summary>
+        /// Adds a storage exception to be thrown when the referenced grain clears state in a storage provider
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        public Task AddFaultOnClear(GrainReference grainReference, Exception exception)
+        {
+            clearfaults.Add(grainReference, exception);
+            logger.Info($"Added ClearState fault for {grainReference}.");
+            return TaskDone.Done;
+        }
+
+        /// <summary>
+        /// Throws a storage exception if one has been added for the grain reference for reading.
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <returns></returns>
+        public Task OnRead(GrainReference grainReference)
+        {
+            Exception exception;
+            if (readFaults.TryGetValue(grainReference, out exception))
+            {
+                readFaults.Remove(grainReference);
+                throw exception;
+            }
+            return TaskDone.Done;
+        }
+
+        /// <summary>
+        /// Throws a storage exception if one has been added for the grain reference for writing.
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <returns></returns>
+        public Task OnWrite(GrainReference grainReference)
+        {
+            Exception exception;
+            if (writeFaults.TryGetValue(grainReference, out exception))
+            {
+                writeFaults.Remove(grainReference);
+                throw exception;
+            }
+            return TaskDone.Done;
+        }
+
+        /// <summary>
+        /// Throws a storage exception if one has been added for the grain reference for clearing state.
+        /// </summary>
+        /// <param name="grainReference"></param>
+        /// <returns></returns>
+        public Task OnClear(GrainReference grainReference)
+        {
+            Exception exception;
+            if (clearfaults.TryGetValue(grainReference, out exception))
+            {
+                clearfaults.Remove(grainReference);
+                throw exception;
+            }
+            return TaskDone.Done;
+        }
+    }
+}

--- a/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
+++ b/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
@@ -1,0 +1,217 @@
+﻿
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using Tester;
+using UnitTests.Tester;
+
+namespace UnitTests.StreamingTests
+{
+    public class PubSubRendezvousGrainTests : OrleansTestingBase, IClassFixture<PubSubRendezvousGrainTests.Fixture>
+    {
+        private class Fixture : BaseTestClusterFixture
+        {
+            protected override TestCluster CreateTestCluster()
+            {
+                var options = new TestClusterOptions(2);
+                options.ClusterConfiguration.AddFaultyMemoryStorageProvider("PubSubStore");
+                return new TestCluster(options);
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
+        public async Task RegisterConsumerFaultTest()
+        {
+            logger.Info("************************ RegisterConsumerFaultTest *********************************");
+            var streamId = StreamId.GetStreamId(Guid.NewGuid(), "ProviderName", "StreamNamespace");
+            var pubSubGrain = GrainClient.GrainFactory.GetGrain<IPubSubRendezvousGrain>(
+                streamId.Guid,
+                keyExtension: streamId.ProviderName + "_" + streamId.Namespace);
+            var faultGrain = GrainClient.GrainFactory.GetGrain<IStorageFaultGrain>(typeof(PubSubRendezvousGrain).FullName);
+
+            // clean call, to make sure everything is happy and pubsub has state.
+            await pubSubGrain.RegisterConsumer(GuidId.GetGuidId(Guid.NewGuid()), streamId, null, null);
+            int consumers = await pubSubGrain.ConsumerCount(streamId);
+            Assert.Equal(1, consumers);
+
+            // inject fault
+            await faultGrain.AddFaultOnWrite(pubSubGrain as GrainReference, new ApplicationException("Write"));
+
+            // expect exception when registering a new consumer
+            await Assert.ThrowsAsync<OrleansException>(
+                    () => pubSubGrain.RegisterConsumer(GuidId.GetGuidId(Guid.NewGuid()), streamId, null, null));
+
+            // pubsub grain should recover and still function
+            await pubSubGrain.RegisterConsumer(GuidId.GetGuidId(Guid.NewGuid()), streamId, null, null);
+            consumers = await pubSubGrain.ConsumerCount(streamId);
+            Assert.Equal(2, consumers);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
+        public async Task UnregisterConsumerFaultTest()
+        {
+            logger.Info("************************ UnregisterConsumerFaultTest *********************************");
+            var streamId = StreamId.GetStreamId(Guid.NewGuid(), "ProviderName", "StreamNamespace");
+            var pubSubGrain = GrainClient.GrainFactory.GetGrain<IPubSubRendezvousGrain>(
+                streamId.Guid,
+                keyExtension: streamId.ProviderName + "_" + streamId.Namespace);
+            var faultGrain = GrainClient.GrainFactory.GetGrain<IStorageFaultGrain>(typeof(PubSubRendezvousGrain).FullName);
+
+            // Add two consumers so when we remove the first it does a storage write, not a storage clear.
+            GuidId subscriptionId1 = GuidId.GetGuidId(Guid.NewGuid());
+            GuidId subscriptionId2 = GuidId.GetGuidId(Guid.NewGuid());
+            await pubSubGrain.RegisterConsumer(subscriptionId1, streamId, null, null);
+            await pubSubGrain.RegisterConsumer(subscriptionId2, streamId, null, null);
+            int consumers = await pubSubGrain.ConsumerCount(streamId);
+            Assert.Equal(2, consumers);
+
+            // inject fault
+            await faultGrain.AddFaultOnWrite(pubSubGrain as GrainReference, new ApplicationException("Write"));
+
+            // expect exception when unregistering a consumer
+            await Assert.ThrowsAsync<OrleansException>(
+                    () => pubSubGrain.UnregisterConsumer(subscriptionId1, streamId));
+
+            // pubsub grain should recover and still function
+            await pubSubGrain.UnregisterConsumer(subscriptionId1, streamId);
+            consumers = await pubSubGrain.ConsumerCount(streamId);
+            Assert.Equal(1, consumers);
+
+            // inject clear fault, because removing last consumer should trigger a clear storage call.
+            await faultGrain.AddFaultOnClear(pubSubGrain as GrainReference, new ApplicationException("Write"));
+
+            // expect exception when unregistering a consumer
+            await Assert.ThrowsAsync<OrleansException>(
+                    () => pubSubGrain.UnregisterConsumer(subscriptionId2, streamId));
+
+            // pubsub grain should recover and still function
+            await pubSubGrain.UnregisterConsumer(subscriptionId2, streamId);
+            consumers = await pubSubGrain.ConsumerCount(streamId);
+            Assert.Equal(0, consumers);
+        }
+
+        /// <summary>
+        /// This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension in the producer management calls.
+        /// TODO: Fix rendezvous implementation.
+        /// </summary>
+        /// <returns></returns>
+        [Fact(Skip = "This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
+        public async Task RegisterProducerFaultTest()
+        {
+            logger.Info("************************ RegisterProducerFaultTest *********************************");
+            var streamId = StreamId.GetStreamId(Guid.NewGuid(), "ProviderName", "StreamNamespace");
+            var pubSubGrain = GrainClient.GrainFactory.GetGrain<IPubSubRendezvousGrain>(
+                streamId.Guid,
+                keyExtension: streamId.ProviderName + "_" + streamId.Namespace);
+            var faultGrain = GrainClient.GrainFactory.GetGrain<IStorageFaultGrain>(typeof(PubSubRendezvousGrain).FullName);
+
+            // clean call, to make sure everything is happy and pubsub has state.
+            await pubSubGrain.RegisterProducer(streamId, null);
+            int producers = await pubSubGrain.ProducerCount(streamId);
+            Assert.Equal(1, producers);
+
+            // inject fault
+            await faultGrain.AddFaultOnWrite(pubSubGrain as GrainReference, new ApplicationException("Write"));
+
+            // expect exception when registering a new producer
+            await Assert.ThrowsAsync<OrleansException>(
+                    () => pubSubGrain.RegisterProducer(streamId, null));
+
+            // pubsub grain should recover and still function
+            await pubSubGrain.RegisterProducer(streamId, null);
+            producers = await pubSubGrain.ProducerCount(streamId);
+            Assert.Equal(2, producers);
+        }
+
+        /// <summary>
+        /// This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension in the producer management calls.
+        /// TODO: Fix rendezvous implementation.
+        /// </summary>
+        [Fact(Skip = "This test fails because the producer must be grain reference which is not implied by the IStreamProducerExtension"), TestCategory("BVT"), TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
+        public async Task UnregisterProducerFaultTest()
+        {
+            logger.Info("************************ UnregisterProducerFaultTest *********************************");
+            var streamId = StreamId.GetStreamId(Guid.NewGuid(), "ProviderName", "StreamNamespace");
+            var pubSubGrain = GrainClient.GrainFactory.GetGrain<IPubSubRendezvousGrain>(
+                streamId.Guid,
+                keyExtension: streamId.ProviderName + "_" + streamId.Namespace);
+            var faultGrain = GrainClient.GrainFactory.GetGrain<IStorageFaultGrain>(typeof(PubSubRendezvousGrain).FullName);
+
+            IStreamProducerExtension firstProducer = new DummyStreamProducerExtension();
+            IStreamProducerExtension secondProducer = new DummyStreamProducerExtension();
+            // Add two producers so when we remove the first it does a storage write, not a storage clear.
+            await pubSubGrain.RegisterProducer(streamId, firstProducer);
+            await pubSubGrain.RegisterProducer(streamId, secondProducer);
+            int producers = await pubSubGrain.ProducerCount(streamId);
+            Assert.Equal(2, producers);
+
+            // inject fault
+            await faultGrain.AddFaultOnWrite(pubSubGrain as GrainReference, new ApplicationException("Write"));
+
+            // expect exception when unregistering a producer
+            await Assert.ThrowsAsync<OrleansException>(
+                    () => pubSubGrain.UnregisterProducer(streamId, firstProducer));
+
+            // pubsub grain should recover and still function
+            await pubSubGrain.UnregisterProducer(streamId, firstProducer);
+            producers = await pubSubGrain.ProducerCount(streamId);
+            Assert.Equal(1, producers);
+
+            // inject clear fault, because removing last producers should trigger a clear storage call.
+            await faultGrain.AddFaultOnClear(pubSubGrain as GrainReference, new ApplicationException("Write"));
+
+            // expect exception when unregistering a consumer
+            await Assert.ThrowsAsync<OrleansException>(
+                    () => pubSubGrain.UnregisterProducer(streamId, secondProducer));
+
+            // pubsub grain should recover and still function
+            await pubSubGrain.UnregisterProducer(streamId, secondProducer);
+            producers = await pubSubGrain.ConsumerCount(streamId);
+            Assert.Equal(0, producers);
+        }
+
+        [Serializable]
+        private class DummyStreamProducerExtension : IStreamProducerExtension
+        {
+            private readonly Guid id;
+
+            public DummyStreamProducerExtension()
+            {
+                id = Guid.NewGuid();
+            }
+
+            public Task AddSubscriber(GuidId subscriptionId, StreamId streamId, IStreamConsumerExtension streamConsumer,
+                IStreamFilterPredicateWrapper filter)
+            {
+                return TaskDone.Done;
+            }
+
+            public Task RemoveSubscriber(GuidId subscriptionId, StreamId streamId)
+            {
+                return TaskDone.Done;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != GetType()) return false;
+                return Equals((DummyStreamProducerExtension)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return id.GetHashCode();
+            }
+
+            private bool Equals(DummyStreamProducerExtension other)
+            {
+                return id.Equals(other.id);
+            }
+        }
+    }
+}

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -118,6 +118,7 @@
     <Compile Include="ConnectionStringFixture.cs" />
     <Compile Include="HostedTestClusterBase.cs" />
     <Compile Include="OrleansRuntime\Streams\SubscriptionMarkerTests.cs" />
+    <Compile Include="StreamingTests\PubSubRendezvousGrainTests.cs" />
     <Compile Include="SqlStatisticsPublisherTests\SqlStatisticsPublisherTestsBase.cs" />
     <Compile Include="StorageTests\AzureStorageBasicTestFixture.cs" />
     <Compile Include="CodeGeneratorTests_TakeSerializedData.cs" />


### PR DESCRIPTION
Storage errors could previously put the grain into a bad state.
Now errors trigger the grain to deactivate and reload clean state in next call.

Added tests.
Note: Tests for adding/removing producers fail because pubsub system implementation does not respect interface.