### PR TITLE
Memory Storage eTag enforcement less strict.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,8 @@ The idea is to track end-user facing changes as they occur.*
   - Do not deactivate Stateless Workers upon grain directory partition shutdown #1838
   - Other minor bug fixes #1823
 
+### [v1.2.3]
+- Bugfix: Memory Storage provider properly enforces etags for any state that has been added or removed, but does not enforce etags for newly added state. #1885
 
 ### [v1.2.2]
 - Bugfix: Memory Storage provider no longer throws NullReferenceException after the grain state is cleared. #1804

--- a/test/Tester/MemoryStorageProviderTests.cs
+++ b/test/Tester/MemoryStorageProviderTests.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Storage;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
 using Xunit;
-using Tester;
 
 namespace UnitTests.StorageTests
 {
@@ -40,6 +41,83 @@ namespace UnitTests.StorageTests
             Assert.Equal(2, names.Count);
             Assert.Equal("Bob", names[0]);
             Assert.Equal("Alice", names[1]);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Storage")]
+        public async Task MemoryStorageGrainEnforcesEtagsTest()
+        {
+            var memoryStorageGrain = GrainClient.GrainFactory.GetGrain<IMemoryStorageGrain>(random.Next());
+
+            // Delete grain state from empty grain, should be safe.
+            await memoryStorageGrain.DeleteStateAsync("stateStore", "grainStoreKey", "eTag");
+
+            // Read grain state from empty grain, should be safe, but return nothing.
+            IGrainState grainState = await memoryStorageGrain.ReadStateAsync("stateStore", "grainStoreKey");
+            Assert.Null(grainState);
+
+            // write state with etag, when there is nothing in storage.  Most storage should fail this, but memory storage should succeed.
+            await memoryStorageGrain.WriteStateAsync("grainType", "grainId", TestGrainState.CreateRandom());
+
+            // write new state with null etag
+            string newEtag = await memoryStorageGrain.WriteStateAsync("grain", "id", TestGrainState.CreateWithEtag(null));
+            Assert.NotNull(newEtag);
+
+            // try to write new state with null etag;
+            await Assert.ThrowsAsync<InconsistentStateException>(() => memoryStorageGrain.WriteStateAsync("grain", "id", TestGrainState.CreateWithEtag(null)));
+
+            // try to write new state with different etag;
+            await Assert.ThrowsAsync<InconsistentStateException>(() => memoryStorageGrain.WriteStateAsync("grain", "id", TestGrainState.CreateWithEtag(newEtag+"a")));
+
+            // Write new state with good etag;
+            string latestEtag = await memoryStorageGrain.WriteStateAsync("grain", "id", TestGrainState.CreateWithEtag(newEtag));
+            Assert.NotNull(latestEtag);
+
+            // try delete state with null etag
+            await Assert.ThrowsAsync<InconsistentStateException>(() => memoryStorageGrain.DeleteStateAsync("grain", "id", null));
+
+            // try delete state with wrong etag
+            await Assert.ThrowsAsync<InconsistentStateException>(() => memoryStorageGrain.DeleteStateAsync("grain", "id", latestEtag+"a"));
+
+            // delete state
+            await memoryStorageGrain.DeleteStateAsync("grain", "id", latestEtag);
+
+            // Read grain deleted grain state, should be safe, but return nothing.
+            grainState = await memoryStorageGrain.ReadStateAsync("grain", "id");
+            Assert.Null(grainState);
+
+            // try delete already deleted grain state
+            await Assert.ThrowsAsync<InconsistentStateException>(() => memoryStorageGrain.DeleteStateAsync("grain", "id", latestEtag));
+
+            // try to write state to deleted state.
+            await Assert.ThrowsAsync<InconsistentStateException>(() => memoryStorageGrain.WriteStateAsync("grain", "id", TestGrainState.CreateWithEtag(latestEtag)));
+
+            // Make sure we can write new state to a deleted state
+            await memoryStorageGrain.WriteStateAsync("grain", "id", TestGrainState.CreateWithEtag(null));
+        }
+
+        [Serializable]
+        private class TestGrainState : IGrainState
+        {
+            public static IGrainState CreateRandom()
+            {
+                return new TestGrainState
+                {
+                    State = random.Next(),
+                    ETag = random.Next().ToString()
+                };
+            }
+
+            public static IGrainState CreateWithEtag(string eTag)
+            {
+                return new TestGrainState
+                {
+                    State = random.Next(),
+                    ETag = eTag
+                };
+            }
+
+            public object State { get; set; }
+            public string ETag { get; set; }
         }
     }
 }


### PR DESCRIPTION
Since memory storage keeps state in a grain that could be lost during silo crashes, it’s eTag enforcement has been reduced to allows state with etags to be written even if the grain has no knowledge of that state.