### PR TITLE
StatelessWorkerTests working with more than 1 silo in cluster

### DIFF
--- a/test/TestGrainInterfaces/IStatelessWorkerGrain.cs
+++ b/test/TestGrainInterfaces/IStatelessWorkerGrain.cs
@@ -8,6 +8,6 @@ namespace UnitTests.GrainInterfaces
     public interface IStatelessWorkerGrain : IGrainWithIntegerKey
     {
         Task LongCall();
-        Task<Tuple<Guid, List<Tuple<DateTime, DateTime>>>> GetCallStats();
+        Task<Tuple<Guid, string, List<Tuple<DateTime, DateTime>>>> GetCallStats();
     }
 }

--- a/test/TestGrains/StatelessWorkerGrain.cs
+++ b/test/TestGrains/StatelessWorkerGrain.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections;
 using Orleans;
 using Orleans.Concurrency;
 using Orleans.Runtime;
@@ -13,9 +11,11 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    [StatelessWorker(1)]
+    [StatelessWorker(MaxLocalWorkers)]
     public class StatelessWorkerGrain : Grain, IStatelessWorkerGrain
     {
+        public const int MaxLocalWorkers = 1;
+
         private Guid activationGuid;
         private readonly List<Tuple<DateTime, DateTime>> calls = new List<Tuple<DateTime, DateTime>>();
         private Logger logger;
@@ -48,8 +48,8 @@ namespace UnitTests.Grains
                 {
                     DateTime stop = DateTime.UtcNow;
                     calls.Add(new Tuple<DateTime, DateTime>(start, stop));
-                    logger.Info(((stop - start).TotalMilliseconds).ToString());
-                    logger.Info("Start {0}, stop {1}, duration {2}. #act {3}", LogFormatter.PrintDate(start), LogFormatter.PrintDate(stop), (stop - start), count);
+                    logger.Info((stop - start).TotalMilliseconds.ToString());
+                    logger.Info($"Start {LogFormatter.PrintDate(start)}, stop {LogFormatter.PrintDate(stop)}, duration {stop - start}. #act {count}");
                 });
         }
 
@@ -60,14 +60,17 @@ namespace UnitTests.Grains
         }
 
 
-        public Task<Tuple<Guid, List<Tuple<DateTime, DateTime>>>> GetCallStats()
+        public Task<Tuple<Guid, string, List<Tuple<DateTime, DateTime>>>> GetCallStats()
         {
             Thread.Sleep(200);
+            string silo = RuntimeIdentity;
+            List<Guid> ids;
             lock (allActivationIds)
             {
-                logger.Info("# allActivationIds {0}: {1}", allActivationIds.Count, Utils.EnumerableToString(allActivationIds));
+                ids = allActivationIds.ToList();
             }
-            return Task.FromResult(new Tuple<Guid, List<Tuple<DateTime, DateTime>>>(activationGuid, calls));
+            logger.Info($"# allActivationIds {ids.Count} for silo {silo}: {Utils.EnumerableToString(ids)}");
+            return Task.FromResult(Tuple.Create(activationGuid, silo, calls));
         }
     }
 }

--- a/test/Tester/StatelessWorkerTests.cs
+++ b/test/Tester/StatelessWorkerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Orleans;
@@ -8,21 +9,34 @@ using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
 using Orleans.Runtime;
 using Tester;
+using UnitTests.Grains;
+using Xunit.Abstractions;
 
 namespace UnitTests.General
 {
     public class StatelessWorkerTests : HostedTestClusterEnsureDefaultStarted
     {
-        private readonly int ExpectedMaxLocalActivations = 1; // System.Environment.ProcessorCount;
+        private readonly int ExpectedMaxLocalActivations = StatelessWorkerGrain.MaxLocalWorkers; // System.Environment.ProcessorCount;
+        private readonly ITestOutputHelper output;
+
+        public StatelessWorkerTests(DefaultClusterFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            this.output = output;
+        }
 
         [Fact, TestCategory("Functional"), TestCategory("StatelessWorker")]
-        public async Task StatelessWorker()
+        public async Task StatelessWorkerActivationsPerSiloDoNotExceedMaxLocalWorkersCount()
         {
-            IStatelessWorkerGrain grain = GrainClient.GrainFactory.GetGrain<IStatelessWorkerGrain>(0);
+            var gatewaysCount = HostedCluster.ClientConfiguration.Gateways.Count;
+            // do extra calls to trigger activation of ExpectedMaxLocalActivations local activations
+            int numberOfCalls = ExpectedMaxLocalActivations * 3 * gatewaysCount; 
+
+            IStatelessWorkerGrain grain = GrainClient.GrainFactory.GetGrain<IStatelessWorkerGrain>(GetRandomGrainId());
             List<Task> promises = new List<Task>();
 
-            for (int i = 0; i < ExpectedMaxLocalActivations * 3; i++)
-                promises.Add(grain.LongCall()); // trigger activation of ExpectedMaxLocalActivations local activations
+            // warmup
+            for (int i = 0; i < gatewaysCount; i++)
+                promises.Add(grain.LongCall()); 
             await Task.WhenAll(promises);
 
             await Task.Delay(2000);
@@ -30,36 +44,64 @@ namespace UnitTests.General
             promises.Clear();
             var stopwatch = Stopwatch.StartNew();
 
-            for (int i = 0; i < ExpectedMaxLocalActivations * 3; i++)
+            for (int i = 0; i < numberOfCalls; i++)
                 promises.Add(grain.LongCall());
             await Task.WhenAll(promises);
 
             stopwatch.Stop();
 
-            //Assert.True(stopwatch.Elapsed > TimeSpan.FromSeconds(19.5), "50 requests with a 2 second processing time shouldn't take less than 20 seconds on 10 activations. But it took " + stopwatch.Elapsed);
-
             promises.Clear();
-            for (int i = 0; i < ExpectedMaxLocalActivations * 3; i++)
-                promises.Add(grain.GetCallStats());  // gather stats
+
+            var statsTasks = new List<Task<Tuple<Guid, string, List<Tuple<DateTime, DateTime>>>>>();
+            for (int i = 0; i < numberOfCalls; i++)
+                statsTasks.Add(grain.GetCallStats());  // gather stats
             await Task.WhenAll(promises);
 
-            HashSet<Guid> activations = new HashSet<Guid>();
-            foreach (var promise in promises)
+            var responsesPerSilo = statsTasks.Select(t => t.Result).GroupBy(s => s.Item2);
+            foreach (var siloGroup in responsesPerSilo)
             {
-                Tuple<Guid, List<Tuple<DateTime, DateTime>>> response = await (Task<Tuple<Guid, List<Tuple<DateTime, DateTime>>>>)promise;
+                var silo = siloGroup.Key;
 
-                if (activations.Contains(response.Item1))
-                    continue; // duplicate response from the same activation
+                HashSet<Guid> activations = new HashSet<Guid>();
 
-                activations.Add(response.Item1);
+                foreach (var response in siloGroup)
+                {
+                    if (activations.Contains(response.Item1))
+                        continue; // duplicate response from the same activation
 
-                logger.Info(" {0}: Activation {1}", activations.Count, response.Item1);
-                int count = 1;
-                foreach (Tuple<DateTime, DateTime> call in response.Item2)
-                    logger.Info("\t{0}: {1} - {2}", count++, LogFormatter.PrintDate(call.Item1), LogFormatter.PrintDate(call.Item2));
+                    activations.Add(response.Item1);
+
+                    output.WriteLine($"Silo {silo} with {activations.Count} activations: Activation {response.Item1}");
+                    int count = 1;
+                    foreach (Tuple<DateTime, DateTime> call in response.Item3)
+                        output.WriteLine($"\t{count++}: {LogFormatter.PrintDate(call.Item1)} - {LogFormatter.PrintDate(call.Item2)}");
+                }
+
+                Assert.True(activations.Count <= ExpectedMaxLocalActivations, $"activations.Count = {activations.Count} in silo {silo} but expected no more than {ExpectedMaxLocalActivations}");
+            }
+        }
+
+        [SkippableFact(Skip = "Skipping test for now, since there seems to be a bug"), TestCategory("Functional"), TestCategory("StatelessWorker")]
+        public async Task StatelessWorkerFastActivationsDontFailInMultiSiloDeployment()
+        {
+            var gatewaysCount = HostedCluster.ClientConfiguration.Gateways.Count;
+
+            if (gatewaysCount < 2)
+            {
+                throw new SkipException("This test was created to run with more than 1 gateway. 2 is the default at the time of this writing");
             }
 
-            Assert.True(activations.Count <= ExpectedMaxLocalActivations, "activations.Count = " + activations.Count + " but expected no more than " + ExpectedMaxLocalActivations);
+            // do extra calls to trigger activation of ExpectedMaxLocalActivations local activations
+            int numberOfCalls = ExpectedMaxLocalActivations * 3 * gatewaysCount;
+
+            IStatelessWorkerGrain grain = GrainClient.GrainFactory.GetGrain<IStatelessWorkerGrain>(GetRandomGrainId());
+            List<Task> promises = new List<Task>();
+            
+            for (int i = 0; i < numberOfCalls; i++)
+                promises.Add(grain.LongCall());
+            await Task.WhenAll(promises);
+
+            // Calls should not have thrown ForwardingFailed exceptions.
         }
     }
 }


### PR DESCRIPTION
Tests stopped working after we made the default to run with 2 silos in the test cluster (so we were seeing 2 activations: 1 per silo).

As I was fixing this, I noticed that there is some non-deterministic behavior when we enqueue several calls to the same stateless worker when it wasn't activated before. Did not fix the bug, just created the repro test.