### PR TITLE
Improve codegen attributes KnownType, GenerateSerializer, KnownAssembly

### DIFF
--- a/src/Orleans/CodeGeneration/ConsiderForCodeGenerationAttribute.cs
+++ b/src/Orleans/CodeGeneration/ConsiderForCodeGenerationAttribute.cs
@@ -3,18 +3,25 @@ namespace Orleans.CodeGeneration
     using System;
     
     /// <summary>
-    /// Abstract base class for attributes that effect code generation of types.
+    /// The attribute which informs the code generator that code should be generated for this type.
     /// </summary>
-    public abstract class ConsiderForCodeGenerationAttribute : Attribute
+    public class ConsiderForCodeGenerationAttribute : Attribute
     {
-        protected ConsiderForCodeGenerationAttribute(Type type, bool generateSerializer)
+        protected ConsiderForCodeGenerationAttribute(Type type, bool throwOnFailure = false)
         {
             this.Type = type;
-            this.GenerateSerializer = generateSerializer;
+            this.ThrowOnFailure = throwOnFailure;
         }
 
+        /// <summary>
+        /// Gets the type which should be considered for code generation.
+        /// </summary>
         public Type Type { get; private set; }
-        public bool GenerateSerializer { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to throw if code was not generated for the specified type.
+        /// </summary>
+        public bool ThrowOnFailure { get; private set; }
     }
 
     /// <summary>
@@ -23,12 +30,12 @@ namespace Orleans.CodeGeneration
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public sealed class KnownTypeAttribute : ConsiderForCodeGenerationAttribute
     {
-        public KnownTypeAttribute(Type type) : base(type, false){}
+        public KnownTypeAttribute(Type type) : base(type){}
     }
 
     /// <summary>
     /// The attribute which informs the code generator that code should be generated for this type.
-    /// Forces generation of type serializer.
+    /// Forces generation of type serializer, throwing if a serializer could not be generated.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public sealed class GenerateSerializerAttribute : ConsiderForCodeGenerationAttribute

--- a/src/Orleans/CodeGeneration/KnownAssemblyAttribute.cs
+++ b/src/Orleans/CodeGeneration/KnownAssemblyAttribute.cs
@@ -23,5 +23,12 @@ namespace Orleans.CodeGeneration
         /// Gets or sets the assembly to include in code generation.
         /// </summary>
         public Assembly Assembly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to assume that all types in the specified assembly are
+        /// serializable.
+        /// </summary>
+        /// <remarks>This is equivalent to specifying <see cref="KnownTypeAttribute"/> for all types.</remarks>
+        public bool TreatTypesAsSerializable { get; set; }
     }
 }

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -290,12 +290,15 @@ namespace Orleans.CodeGenerator
 
             var members = new List<MemberDeclarationSyntax>();
 
-            // If any KnownAssemblies have been specified, include them during code generation.
-            var knownAssemblies =
-                assemblies.SelectMany(_ => _.GetCustomAttributes<KnownAssemblyAttribute>())
-                    .Select(_ => _.Assembly)
-                    .Distinct()
-                    .ToSet();
+            // Include assemblies which are marked as included.
+            var knownAssemblyAttributes = new Dictionary<Assembly, KnownAssemblyAttribute>();
+            var knownAssemblies = new HashSet<Assembly>();
+            foreach (var attribute in assemblies.SelectMany(asm => asm.GetCustomAttributes<KnownAssemblyAttribute>()))
+            {
+                knownAssemblyAttributes[attribute.Assembly] = attribute;
+                knownAssemblies.Add(attribute.Assembly);
+            }
+
             if (knownAssemblies.Count > 0)
             {
                 knownAssemblies.UnionWith(assemblies);
@@ -309,12 +312,21 @@ namespace Orleans.CodeGenerator
                 var assembly = assemblies[i];
                 foreach (var attribute in assembly.GetCustomAttributes<ConsiderForCodeGenerationAttribute>())
                 {
-                    ConsiderType(attribute.Type, runtime, targetAssembly, includedTypes, attribute.GenerateSerializer);
+                    ConsiderType(attribute.Type, runtime, targetAssembly, includedTypes, true);
+                    if (attribute.ThrowOnFailure && !SerializerGenerationManager.IsTypeRecorded(attribute.Type))
+                    {
+                        throw new CodeGenerationException(
+                            $"Found {attribute.GetType().Name} for type {attribute.Type.GetParseableName()}, but code"
+                            + " could not be generated. Ensure that the type is accessible.");
+                    }
                 }
 
+                KnownAssemblyAttribute knownAssemblyAttribute;
+                var treatAsSerializable = knownAssemblyAttributes.TryGetValue(assembly, out knownAssemblyAttribute)
+                                          && knownAssemblyAttribute.TreatTypesAsSerializable;
                 foreach (var type in assembly.DefinedTypes)
                 {
-                    ConsiderType(type, runtime, targetAssembly, includedTypes);
+                    ConsiderType(type, runtime, targetAssembly, includedTypes, treatAsSerializable);
                 }
             }
 
@@ -424,7 +436,9 @@ namespace Orleans.CodeGenerator
 
             // If a type was encountered which can be accessed and is marked as [Serializable], process it for serialization.
             if (treatAsSerializeable || typeInfo.IsSerializable)
+            {
                 RecordType(type, module, targetAssembly, includedTypes);
+            }
             
             ConsiderGenericBaseTypeArguments(typeInfo, module, targetAssembly, includedTypes);
             ConsiderGenericInterfacesArguments(typeInfo, module, targetAssembly, includedTypes);
@@ -433,7 +447,7 @@ namespace Orleans.CodeGenerator
             if (GrainInterfaceUtils.IsGrainInterface(type))
             {
                 if (Logger.IsVerbose2) Logger.Verbose2("Will generate code for: {0}", type.GetParseableName());
-
+                
                 includedTypes.Add(type);
             }
         }
@@ -441,7 +455,9 @@ namespace Orleans.CodeGenerator
         private static void RecordType(Type type, Module module, Assembly targetAssembly, ISet<Type> includedTypes)
         {
             if (SerializerGenerationManager.RecordTypeToGenerate(type, module, targetAssembly))
+            {
                 includedTypes.Add(type);
+            }
         }
 
         private static void ConsiderGenericBaseTypeArguments(

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -65,7 +65,11 @@ namespace Orleans.CodeGenerator
 
             Log = LogManager.GetLogger(typeof(SerializerGenerationManager).Name);
         }
-        
+        internal bool IsTypeRecorded(Type type)
+        {
+            return this.TypesToProcess.Contains(type) || this.ProcessedTypes.Contains(type);
+        }
+
         internal bool RecordTypeToGenerate(Type t, Module module, Assembly targetAssembly)
         {
             if (TypeUtilities.IsTypeIsInaccessibleForSerialization(t, module, targetAssembly))


### PR DESCRIPTION
This introduces the following changes, as discussed with @sergeybykov, @jdom, and @galvesribeiro.

* `[KnownType]` generates serializers for that type as if the type had `[Serializable]`
* `[GenerateSerializer]` is the same as `[KnownType]`, except that it throws if serializers wont be generated
* `[KnownAssembly]` has a property, `TreatTypesAsSerializable` to generate serializers for all types, equivalent to specifying `[KnownType]` for all types.