### PR TITLE
Remove static singleton Instance property from RoslynCodeGenerator

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -15,6 +15,8 @@ namespace Orleans.CodeGeneration
     /// </summary>
     public class GrainClientGenerator : MarshalByRefObject
     {
+        private static readonly RoslynCodeGenerator CodeGenerator = new RoslynCodeGenerator();
+
         [Serializable]
         internal class CodeGenOptions
         {
@@ -31,7 +33,6 @@ namespace Orleans.CodeGeneration
             public string SourcesDir;
         }
 
-
         [Serializable]
         internal class GrainClientGeneratorFlags
         {
@@ -39,7 +40,6 @@ namespace Orleans.CodeGeneration
 
             internal static bool FailOnPathNotFound = false;
         }
-
 
         private static readonly int[] suppressCompilerWarnings =
         {
@@ -115,13 +115,12 @@ namespace Orleans.CodeGeneration
                 Path.GetFileNameWithoutExtension(options.InputLib.Name) + ".codegen.cs");
             ConsoleText.WriteStatus("Orleans-CodeGen - Generating file {0}", outputFileName);
 
-            var codeGenerator = RoslynCodeGenerator.Instance;
             SerializationManager.RegisterBuiltInSerializers();
             using (var sourceWriter = new StreamWriter(outputFileName))
             {
                 sourceWriter.WriteLine("#if !EXCLUDE_CODEGEN");
                 DisableWarnings(sourceWriter, suppressCompilerWarnings);
-                sourceWriter.WriteLine(codeGenerator.GenerateSourceForAssembly(grainAssembly));
+                sourceWriter.WriteLine(CodeGenerator.GenerateSourceForAssembly(grainAssembly));
                 RestoreWarnings(sourceWriter, suppressCompilerWarnings);
                 sourceWriter.WriteLine("#endif");
             }

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -39,22 +39,6 @@ namespace Orleans.CodeGenerator
         private static readonly SerializerGenerationManager SerializerGenerationManager = new SerializerGenerationManager();
 
         /// <summary>
-        /// The static instance.
-        /// </summary>
-        private static readonly RoslynCodeGenerator StaticInstance = new RoslynCodeGenerator();
-
-        /// <summary>
-        /// Gets the static instance.
-        /// </summary>
-        public static RoslynCodeGenerator Instance
-        {
-            get
-            {
-                return StaticInstance;
-            }
-        }
-
-        /// <summary>
         /// Adds a pre-generated assembly.
         /// </summary>
         /// <param name="targetAssemblyName">


### PR DESCRIPTION
Tiny change to clean up the use of a singleton in `RoslynCodeGenerator` which was only referenced by `ClientGenerator`.

This just moves the static to the code which uses it.