### PR TITLE
Fix bug with generic state parameter caused by inconsistent use of grainClassName / genericArgument / genericInterface

### DIFF
--- a/src/Orleans/CodeGeneration/GrainFactoryBase.cs
+++ b/src/Orleans/CodeGeneration/GrainFactoryBase.cs
@@ -26,7 +26,7 @@ namespace Orleans.CodeGeneration
             GrainId grainId = getGrainId(implementation);
 
             var typeInfo = interfaceType.GetTypeInfo();
-            return GrainReference.FromGrainId(grainId, typeInfo.IsGenericType ? typeInfo.UnderlyingSystemType.FullName : null);
+            return GrainReference.FromGrainId(grainId, typeInfo.IsGenericType ? TypeUtils.GenericTypeArgsString(typeInfo.UnderlyingSystemType.FullName) : null);
         }
 
         /// <summary>

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -221,9 +221,16 @@ namespace Orleans.Runtime
             return i <= 0 ? typeName : typeName.Substring(0, i);
         }
 
-        public static Type[] GenericTypeArgs(string className)
+        public static Type[] GenericTypeArgsFromClassName(string className)
         {
-            var genericTypeDef = GenericTypeArgsString(className).Replace("[]", "##"); // protect array arguments
+            return GenericTypeArgsFromArgsString(GenericTypeArgsString(className));
+        }
+
+        public static Type[] GenericTypeArgsFromArgsString(string genericArgs)
+        {
+            if (string.IsNullOrEmpty(genericArgs)) return new Type[] { };
+
+            var genericTypeDef = genericArgs.Replace("[]", "##"); // protect array arguments
 
             return InnerGenericTypeArgs(genericTypeDef);
         }

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -422,8 +422,8 @@
     <Message Text="[OrleansDllBootstrapUsingCodeGen] - Compiling Orleans.dll for bootstrap" Importance="high" />
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" Properties="Bootstrap=true;BootstrapOutputPath=$(BootstrapOutputPath);DefineConstants=$(ExcludeCodeGen)" UnloadProjectsOnCompletion="true" UseResultsCache="false" />
     <Message Text="[OrleansDllBootstrapUsingCodeGen] - Compiling code generators for bootstrap" Importance="high" />
-    <MSBuild Projects="$(SolutionDir)\OrleansCodeGenerator\OrleansCodeGenerator.csproj" Targets="Build" Properties="Bootstrap=true;BootstrapOutputPath=$(BootstrapOutputPath);OutputPath=$(BootstrapOutputPath);OutDir=$(BootstrapOutputPath);DefineConstants=$(ExcludeCodeGen)" UnloadProjectsOnCompletion="true" UseResultsCache="false" />
-    <MSBuild Projects="$(SolutionDir)\ClientGenerator\ClientGenerator.csproj" Targets="Build" Properties="Bootstrap=true;BootstrapOutputPath=$(BootstrapOutputPath);OutputPath=$(BootstrapOutputPath);OutDir=$(BootstrapOutputPath);DefineConstants=$(ExcludeCodeGen)" UnloadProjectsOnCompletion="true" UseResultsCache="false" />
+    <MSBuild Projects="$(ProjectDir)\..\OrleansCodeGenerator\OrleansCodeGenerator.csproj" Targets="Build" Properties="Bootstrap=true;BootstrapOutputPath=$(BootstrapOutputPath);OutputPath=$(BootstrapOutputPath);OutDir=$(BootstrapOutputPath);DefineConstants=$(ExcludeCodeGen)" UnloadProjectsOnCompletion="true" UseResultsCache="false" />
+    <MSBuild Projects="$(ProjectDir)\..\ClientGenerator\ClientGenerator.csproj" Targets="Build" Properties="Bootstrap=true;BootstrapOutputPath=$(BootstrapOutputPath);OutputPath=$(BootstrapOutputPath);OutDir=$(BootstrapOutputPath);DefineConstants=$(ExcludeCodeGen)" UnloadProjectsOnCompletion="true" UseResultsCache="false" />
     <!-- Finally invoke code generator on the recently built Orleans.dll -->
     <Message Text="[OrleansDllBootstrapUsingCodeGen] - Preprocessing $(TargetName)$(TargetExt) with ClientGenerator.exe" Importance="high" />
     <PropertyGroup>

--- a/src/Orleans/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans/Runtime/GrainInterfaceMap.cs
@@ -357,7 +357,7 @@ namespace Orleans.Runtime
         private readonly GrainInterfaceMap.GrainInterfaceData interfaceData;
         [NonSerialized]
         private readonly Dictionary<string, string> genericClassNames;
-        
+
         private readonly PlacementStrategy placementStrategy;
         private readonly MultiClusterRegistrationStrategy registrationStrategy;
         private readonly bool isGeneric;

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -441,7 +441,7 @@ namespace Orleans.Runtime
 
                 if (typeCode != 0)
                 {
-                    GetGrainTypeInfo(typeCode, out actualGrainType, out placement, out activationStrategy);
+                    GetGrainTypeInfo(typeCode, out actualGrainType, out placement, out activationStrategy, genericArguments);
                 }
                 else
                 {
@@ -485,11 +485,8 @@ namespace Orleans.Runtime
             return result;
         }
 
-        private void SetupActivationInstance(ActivationData result, string grainType, string genericInterface)
+        private void SetupActivationInstance(ActivationData result, string grainType, string genericArguments)
         {
-            var genericArguments = String.IsNullOrEmpty(genericInterface) ? null
-                : TypeUtils.GenericTypeArgsString(genericInterface);
-
             lock (result)
             {
                 if (result.GrainInstance == null)
@@ -499,7 +496,7 @@ namespace Orleans.Runtime
             }
         }
 
-        private async Task InitActivation(ActivationData activation, string grainType, string genericInterface, Dictionary<string, object> requestContextData)
+        private async Task InitActivation(ActivationData activation, string grainType, string genericArguments, Dictionary<string, object> requestContextData)
         {
             // We've created a dummy activation, which we'll eventually return, but in the meantime we'll queue up (or perform promptly)
             // the operations required to turn the "dummy" activation into a real activation
@@ -514,7 +511,7 @@ namespace Orleans.Runtime
                 await RegisterActivationInGrainDirectoryAndValidate(activation);
 
                 initStage = 2;
-                await SetupActivationState(activation, grainType);                
+                await SetupActivationState(activation, String.IsNullOrEmpty(genericArguments) ? grainType : $"{grainType}[{genericArguments}]");
 
                 initStage = 3;
                 await InvokeActivate(activation, requestContextData);

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -85,8 +85,8 @@ namespace Orleans.Runtime
                 ActivationData target = catalog.GetOrCreateActivation(
                     message.TargetAddress, 
                     message.IsNewPlacement, 
-                    message.NewGrainType, 
-                    message.GenericGrainType, 
+                    message.NewGrainType,
+                    String.IsNullOrEmpty(message.GenericGrainType) ? null : message.GenericGrainType, 
                     message.RequestContextData,
                     out ignore);
 

--- a/test/Tester/GenericGrainTests.cs
+++ b/test/Tester/GenericGrainTests.cs
@@ -282,6 +282,24 @@ namespace UnitTests.General
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
+        public void Generic_SimpleGrainControlFlow_Blocking()
+        {
+            var a = random.Next(100);
+            var b = a + 1;
+            var expected = a + "x" + b;
+
+            var grain = GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
+
+            // explicitly use .Wait() and .Result to make sure the client does not deadlock in these cases.
+            grain.SetA(a).Wait();
+
+            grain.SetB(b).Wait();
+
+            Task<string> stringPromise = grain.GetAxB();
+            Assert.AreEqual(expected, stringPromise.Result);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task Generic_SimpleGrainDataFlow()
         {
             var a = random.Next(100);

--- a/test/Tester/GenericGrainTests.cs
+++ b/test/Tester/GenericGrainTests.cs
@@ -282,24 +282,6 @@ namespace UnitTests.General
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
-        public void Generic_SimpleGrainControlFlow_Blocking()
-        {
-            var a = random.Next(100);
-            var b = a + 1;
-            var expected = a + "x" + b;
-
-            var grain = GrainFactory.GetGrain<ISimpleGenericGrain1<int>>(grainId++);
-
-            // explicitly use .Wait() and .Result to make sure the client does not deadlock in these cases.
-            grain.SetA(a).Wait();
-
-            grain.SetB(b).Wait();
-
-            Task<string> stringPromise = grain.GetAxB();
-            Assert.AreEqual(expected, stringPromise.Result);
-        }
-
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task Generic_SimpleGrainDataFlow()
         {
             var a = random.Next(100);
@@ -732,7 +714,7 @@ namespace UnitTests.General
             Assert.Equal(result, "Hello!");
         }
         
-        [Fact(Skip= "https://github.com/dotnet/orleans/issues/1656 Casting from generic to non-generic interface fails with an obscure error message"), TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
+        [Fact, TestCategory("Functional"), TestCategory("Cast"), TestCategory("Generics")]
         public async Task Generic_CastGenericInterfaceToNonGenericInterfaceBeforeActivation() {
             var grain = GrainFactory.GetGrain<IGenericCastableGrain<string>>(Guid.NewGuid());
 

--- a/test/Tester/GenericGrainsInAzureStorageTests.cs
+++ b/test/Tester/GenericGrainsInAzureStorageTests.cs
@@ -23,8 +23,7 @@ namespace UnitTests.General
             }
         }
 
-        [Fact(Skip = "Ignored"), TestCategory("Azure"), TestCategory("Functional"), TestCategory("Generics")]
-        //This test currently fails, because the name of the interface is too long
+        [Fact, TestCategory("Azure"), TestCategory("Functional"), TestCategory("Generics")]
         public async Task Generic_OnAzureTableStorage_LongNamedGrain_EchoValue()
         {
             var grain = GrainFactory.GetGrain<ISimpleGenericGrainUsingAzureTableStorage<int>>(Guid.NewGuid());

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -149,7 +149,7 @@ namespace UnitTests.StorageTests
             Assert.AreEqual(initialValue, readValue, "Read previously stored value");
         }
 
-        [Fact(Skip = "Currently failing"), TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Generics")]
+        [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Generics")]
         public async Task Persistence_Grain_Activate_StoredValue_Generic() 
         {
             const string providerName = "test1";


### PR DESCRIPTION
After lots of debugging on an issue I have with a generic grain that uses storage, I think that this change fixes the issue. The genericArgument was used inconsistently, and sometimes contained the genericInterface value. Also the grainClass parameter did not include the genericArguments during setup of the state, causing the grainType parameter in the first ReadStateAsync to be incorrect.

I moved the location where the conversion was made from SetupActivationInstance() into catalog.GetOrCreateActivation(), passed genericArguments in some functions and fixed the naming.

I think this fixes several bugs, including #1579.

Please test thoroughly, this "works on my machine" but the change might do things that I don't really understand and this is my first pull request on orleans.