### PR TITLE
Do not require explicitly registering grains in ServiceCollection

### DIFF
--- a/src/OrleansRuntime/Catalog/GrainCreator.cs
+++ b/src/OrleansRuntime/Catalog/GrainCreator.cs
@@ -33,7 +33,7 @@ namespace Orleans.Runtime
         public Grain CreateGrainInstance(Type grainType, IGrainIdentity identity)
         {
             var grain = _services != null
-                ? (Grain) _services.GetRequiredService(grainType)
+                ? (Grain) ActivatorUtilities.GetServiceOrCreateInstance(_services, grainType)
                 : (Grain) Activator.CreateInstance(grainType);
 
             // Inject runtime hooks into grain instance
@@ -48,6 +48,8 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="grainType"></param>
         /// <param name="identity">Identity for the new grain</param>
+        /// <param name="stateType">If the grain is a stateful grain, the type of the state it persists.</param>
+        /// <param name="storageProvider">If the grain is a stateful grain, the storage provider used to persist the state.</param>
         /// <returns></returns>
         public Grain CreateGrainInstance(Type grainType, IGrainIdentity identity, Type stateType,
             IStorageProvider storageProvider)

--- a/src/OrleansRuntime/Startup/StartupBuilder.cs
+++ b/src/OrleansRuntime/Startup/StartupBuilder.cs
@@ -58,11 +58,8 @@ namespace Orleans.Runtime.Startup
 
             IServiceCollection serviceCollection = new ServiceCollection();
 
-            serviceCollection.AddTransient<ManagementGrain>();
             serviceCollection.AddTransient<GrainBasedMembershipTable>();
             serviceCollection.AddTransient<GrainBasedReminderTable>();
-            serviceCollection.AddTransient<PubSubRendezvousGrain>();
-            serviceCollection.AddTransient<MemoryStorageGrain>();
 
             return serviceCollection;
         }

--- a/test/TestGrainInterfaces/ISimpleDIGrain.cs
+++ b/test/TestGrainInterfaces/ISimpleDIGrain.cs
@@ -6,5 +6,6 @@ namespace UnitTests.GrainInterfaces
     public interface ISimpleDIGrain : IGrainWithIntegerKey
     {
         Task<long> GetTicksFromService();
+        Task<string> GetStringValue();
     }
 }

--- a/test/Tester/DependencyInjectionGrainTests.cs
+++ b/test/Tester/DependencyInjectionGrainTests.cs
@@ -17,27 +17,51 @@ namespace UnitTests.General
         {
             protected override TestCluster CreateTestCluster()
             {
-                var options = new TestClusterOptions();
+                var options = new TestClusterOptions(1);
                 options.ClusterConfiguration.ApplyToAllNodes(nodeConfig => nodeConfig.StartupTypeName = typeof(TestStartup).AssemblyQualifiedName);
                 return new TestCluster(options);
             }
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional")]
-        public async Task DiTests_SimpleDiGrainGetGrain()
+        public async Task CanGetGrainWithInjectedDependencies()
         {
             ISimpleDIGrain grain = GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId());
             long ignored = await grain.GetTicksFromService();
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task CanResolveSingletonDependencies()
+        {
+            var grain1 = GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId());
+            var grain2 = GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId());
+
+            // the injected service will return the same value only if it's the same instance
+            Assert.Equal(
+                await grain1.GetStringValue(), 
+                await grain2.GetStringValue());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task CanGetExplictlyRegisteredGrain()
+        {
+            ISimpleDIGrain grain = GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId(), grainClassNamePrefix: "UnitTests.Grains.ExplicitlyRegistered");
+            long ignored = await grain.GetTicksFromService();
+            Assert.Equal(TestStartup.ExplicitlyRegistrationValue, await grain.GetStringValue());
         }
     }
 
     public class TestStartup
     {
+        public const string ExplicitlyRegistrationValue = "explict registration value";
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<IInjectedService, InjectedService>();
 
-            services.AddTransient<SimpleDIGrain>();
+            services.AddTransient<ExplicitlyRegisteredSimpleDIGrain>(
+                sp => new ExplicitlyRegisteredSimpleDIGrain(
+                    sp.GetRequiredService<IInjectedService>(),
+                    ExplicitlyRegistrationValue));
 
             return services.BuildServiceProvider();
         }


### PR DESCRIPTION
This is similar to MVC, where the framework is in charge of determining which concrete controller to resolve, and the user is not required to explicitly register the controller, only the dependencies used by the controller.
Grains in Orleans behave in a very similar way where as you can't explicitly register the mapping grain interface -> grain implementation in the container, and instead Orleans determines which concrete Grain implementation to instantiate. The user should not be responsible for registering all the grain implementations that were also already discovered by Orleans. This is boilerplate and non-intuitive (as you were forced to register the concrete type, not the mapping with the interface, which is not common when using DI and especially when you are implementing an interface for consumer to use).

This supersedes #1841, as there is no "fallback" if the registration isn't there, it is instead how it is supposed to work.

EDIT: I made it exactly like MVC's implementation, so that GrainCreator will not even consider explicit registrations for grains (or controllers in the MVC case).

Classes in MVC that are relevant to controller activation:
- [DefaultControllerActivator](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/Controllers/DefaultControllerActivator.cs)
- [TypeActivatorCache](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/Internal/TypeActivatorCache.cs)
- [ActivatorUtilities](https://github.com/aspnet/Common/blob/dev/src/Microsoft.Extensions.ActivatorUtilities.Sources/ActivatorUtilities.cs) and its [façade](https://github.com/aspnet/DependencyInjection/blob/master/src/Microsoft.Extensions.DependencyInjection.Abstractions/ActivatorUtilities.cs)