### PR TITLE
Reduce Task<T>/continuation usage in GrainReference/GrainFactory

### DIFF
--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -158,16 +158,16 @@ namespace Orleans
         public Task<TGrainObserverInterface> CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
             where TGrainObserverInterface : IGrainObserver
         {
-            return CreateObjectReferenceImpl<TGrainObserverInterface>(obj);
+            return Task.FromResult(CreateObjectReferenceImpl<TGrainObserverInterface>(obj));
         }
 
-        internal Task<TGrainObserverInterface> CreateObjectReference<TGrainObserverInterface>(IAddressable obj)
+        internal TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IAddressable obj)
                 where TGrainObserverInterface : IAddressable
         {
             return CreateObjectReferenceImpl<TGrainObserverInterface>(obj);
         }
 
-        private Task<TGrainObserverInterface> CreateObjectReferenceImpl<TGrainObserverInterface>(IAddressable obj)
+        private TGrainObserverInterface CreateObjectReferenceImpl<TGrainObserverInterface>(IAddressable obj)
         {
             var interfaceType = typeof(TGrainObserverInterface);
             var interfaceTypeInfo = interfaceType.GetTypeInfo();
@@ -204,9 +204,7 @@ namespace Orleans
                         interfaceType));
             }
 
-            return
-                GrainReference.CreateObjectReference(obj, invoker)
-                    .ContinueWith(result => this.Cast<TGrainObserverInterface>(result.GetAwaiter().GetResult()));
+            return Cast<TGrainObserverInterface>(RuntimeClient.Current.CreateObjectReference(obj, invoker));
         }
 
         /// <summary>
@@ -220,7 +218,8 @@ namespace Orleans
         public Task DeleteObjectReference<TGrainObserverInterface>(
             IGrainObserver obj) where TGrainObserverInterface : IGrainObserver
         {
-            return GrainReference.DeleteObjectReference(obj);
+            RuntimeClient.Current.DeleteObjectReference(obj);
+            return TaskDone.Done;
         }
 
         private static IGrainMethodInvoker MakeInvoker(Type interfaceType)

--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -137,9 +137,9 @@ namespace Orleans.Providers
                 else
                 { 
                     extension = newExtensionFunc();
-                    var obj = ((Orleans.GrainFactory)this.GrainFactory).CreateObjectReference<TExtensionInterface>(extension);
+                    var obj = ((GrainFactory)this.GrainFactory).CreateObjectReference<TExtensionInterface>(extension);
 
-                    addressable = (IAddressable) await (Task<TExtensionInterface>) obj;
+                    addressable = obj;
 
                     if (null == addressable)
                     {

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -133,23 +133,6 @@ namespace Orleans.Runtime
             return new GrainReference(grainId, null, null, observerId);
         }
 
-        /// <summary>
-        /// Called from generated code.
-        /// </summary>
-        public static Task<GrainReference> CreateObjectReference(IAddressable o, IGrainMethodInvoker invoker)
-        {
-            return Task.FromResult(RuntimeClient.Current.CreateObjectReference(o, invoker));
-        }
-
-        /// <summary>
-        /// Called from generated code.
-        /// </summary>
-        public static Task DeleteObjectReference(IAddressable observer)
-        {
-            RuntimeClient.Current.DeleteObjectReference(observer);
-            return TaskDone.Done;
-        }
-
         #endregion
 
         /// <summary>

--- a/test/TesterInternal/ClientAddressableTests.cs
+++ b/test/TesterInternal/ClientAddressableTests.cs
@@ -73,14 +73,14 @@ namespace UnitTests
         {
             var myOb = new MyPseudoGrain();
             this.anchor = myOb;
-            var myRef = await ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
+            var myRef = ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
             var proxy = GrainClient.GrainFactory.GetGrain<IClientAddressableTestGrain>(GetRandomGrainId());
             const string expected = "o hai!";
             await proxy.SetTarget(myRef);
             var actual = await proxy.HappyPath(expected);
             Assert.AreEqual(expected, actual);
 
-            await GrainReference.DeleteObjectReference(myRef);
+            RuntimeClient.Current.DeleteObjectReference(myRef);
         }
 
         [Fact, TestCategory("ClientAddressable"), TestCategory("Functional")]
@@ -90,7 +90,7 @@ namespace UnitTests
 
             var myOb = new MyPseudoGrain();
             this.anchor = myOb;
-            var myRef = await ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
+            var myRef = ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
             var proxy = GrainClient.GrainFactory.GetGrain<IClientAddressableTestGrain>(GetRandomGrainId());
             await proxy.SetTarget(myRef);
 
@@ -98,7 +98,7 @@ namespace UnitTests
                 proxy.SadPath(message)
             );
 
-            await GrainReference.DeleteObjectReference(myRef);
+            RuntimeClient.Current.DeleteObjectReference(myRef);
         }
 
         [Fact, TestCategory("ClientAddressable"), TestCategory("Functional")]
@@ -106,7 +106,7 @@ namespace UnitTests
         {
             var myOb = new MyProducer();
             this.anchor = myOb;
-            var myRef = await ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestProducer>(myOb);
+            var myRef = ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestProducer>(myOb);
             var rendez = GrainClient.GrainFactory.GetGrain<IClientAddressableTestRendezvousGrain>(0);
             var consumer = GrainClient.GrainFactory.GetGrain<IClientAddressableTestConsumer>(0);
 
@@ -115,7 +115,7 @@ namespace UnitTests
             var n = await consumer.PollProducer();
             Assert.AreEqual(1, n);
 
-            await GrainReference.DeleteObjectReference(myRef);
+            RuntimeClient.Current.DeleteObjectReference(myRef);
         }
 
         [Fact, TestCategory("ClientAddressable"), TestCategory("Functional")]
@@ -125,12 +125,12 @@ namespace UnitTests
 
             var myOb = new MyPseudoGrain();
             this.anchor = myOb;
-            var myRef = await ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
+            var myRef = ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
             var proxy = GrainClient.GrainFactory.GetGrain<IClientAddressableTestGrain>(GetRandomGrainId());
             await proxy.SetTarget(myRef);
             await proxy.MicroSerialStressTest(iterationCount);
 
-            await GrainReference.DeleteObjectReference(myRef);
+            RuntimeClient.Current.DeleteObjectReference(myRef);
         }
 
         [Fact, TestCategory("ClientAddressable"), TestCategory("Functional")]
@@ -140,12 +140,12 @@ namespace UnitTests
 
             var myOb = new MyPseudoGrain();
             this.anchor = myOb;
-            var myRef = await ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
+            var myRef = ((GrainFactory)GrainClient.GrainFactory).CreateObjectReference<IClientAddressableTestClientObject>(myOb);
             var proxy = GrainClient.GrainFactory.GetGrain<IClientAddressableTestGrain>(GetRandomGrainId());
             await proxy.SetTarget(myRef);
             await proxy.MicroParallelStressTest(iterationCount);
 
-            await GrainReference.DeleteObjectReference(myRef);
+            RuntimeClient.Current.DeleteObjectReference(myRef);
 
             myOb.VerifyNumbers(iterationCount);
         }


### PR DESCRIPTION
Minor cleanup to reduce some redundant Task usage.