### PR TITLE
Add coverage for generic state parameter using Azure Storage (after #1897)

### DIFF
--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -233,7 +233,7 @@ namespace Orleans.Runtime
 
         public static Type[] GenericTypeArgsFromArgsString(string genericArgs)
         {
-            if (string.IsNullOrEmpty(genericArgs)) return new Type[] { };
+            if (string.IsNullOrEmpty(genericArgs)) return Type.EmptyTypes;
 
             var genericTypeDef = genericArgs.Replace("[]", "##"); // protect array arguments
 

--- a/test/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/TestGrainInterfaces/IGenericInterfaces.cs
@@ -35,7 +35,7 @@ namespace UnitTests.GrainInterfaces
     /// Long named grain type, which can cause issues in AzureTableStorage
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public interface ISimpleGenericGrainUsingAzureTableStorage<T> : IGrainWithGuidKey
+    public interface ISimpleGenericGrainUsingAzureStorageAndLongGrainName<T> : IGrainWithGuidKey
     {
         Task<T> EchoAsync(T entity);
 

--- a/test/TestGrains/GenericGrains.cs
+++ b/test/TestGrains/GenericGrains.cs
@@ -52,7 +52,7 @@ namespace UnitTests.Grains
     }
 
     [StorageProvider(ProviderName = "AzureStore")]
-    public class SimpleGenericGrainUsingAzureTableStorage<T> : Grain<SimpleGenericGrainState<T>>, ISimpleGenericGrainUsingAzureTableStorage<T>
+    public class SimpleGenericGrainUsingAzureStorageAndLongGrainName<T> : Grain<SimpleGenericGrainState<T>>, ISimpleGenericGrainUsingAzureStorageAndLongGrainName<T>
     {
         public async Task<T> EchoAsync(T entity)
         {

--- a/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
+++ b/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
@@ -37,7 +37,7 @@ namespace Tester.AzureUtils.General
         [SkippableFact, TestCategory("Functional")]
         public async Task Generic_OnAzureTableStorage_LongNamedGrain_EchoValue()
         {
-            var grain = this.fixture.GrainFactory.GetGrain<ISimpleGenericGrainUsingAzureTableStorage<int>>(Guid.NewGuid());
+            var grain = this.fixture.GrainFactory.GetGrain<ISimpleGenericGrainUsingAzureStorageAndLongGrainName<int>>(Guid.NewGuid());
             await grain.EchoAsync(42);
 
             await grain.ClearState();
@@ -83,7 +83,7 @@ namespace Tester.AzureUtils.General
         [SkippableFact, TestCategory("Functional")]
         public async Task Generic_OnAzureBlobStorage_LongNamedGrain_EchoValue()
         {
-            var grain = this.fixture.GrainFactory.GetGrain<ISimpleGenericGrainUsingAzureTableStorage<int>>(Guid.NewGuid());
+            var grain = this.fixture.GrainFactory.GetGrain<ISimpleGenericGrainUsingAzureStorageAndLongGrainName<int>>(Guid.NewGuid());
             await grain.EchoAsync(42);
 
             await grain.ClearState();

--- a/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
+++ b/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
@@ -35,19 +35,16 @@ namespace Tester.AzureUtils.General
             var grain = this.fixture.GrainFactory.GetGrain<ISimpleGenericGrainUsingAzureTableStorage<int>>(Guid.NewGuid());
             await grain.EchoAsync(42);
 
-            //ClearState() also exhibits the error, even with the shorter named grain
             await grain.ClearState();
         }
 
         [SkippableFact, TestCategory("Functional")]
-        //This test is identical to the one above, with a shorter name, and passes
         public async Task Generic_OnAzureTableStorage_ShortNamedGrain_EchoValue()
         {
             var grain = this.fixture.GrainFactory.GetGrain<ITinyNameGrain<int>>(Guid.NewGuid());
             await grain.EchoAsync(42);
 
-            //ClearState() also exhibits the error, even with the shorter named grain
-            //await grain.ClearState();
+            await grain.ClearState();
         }
     }
 }

--- a/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
+++ b/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Tester.AzureUtils.General
 {
     [TestCategory("Azure"), TestCategory("Generics")]
-    public class GenericGrainsInAzureStorageTests : OrleansTestingBase, IClassFixture<GenericGrainsInAzureStorageTests.Fixture>
+    public class GenericGrainsInAzureTableStorageTests : OrleansTestingBase, IClassFixture<GenericGrainsInAzureTableStorageTests.Fixture>
     {
         private readonly Fixture fixture;
 
@@ -23,7 +23,7 @@ namespace Tester.AzureUtils.General
             }
         }
 
-        public GenericGrainsInAzureStorageTests(Fixture fixture)
+        public GenericGrainsInAzureTableStorageTests(Fixture fixture)
         {
             fixture.EnsurePreconditionsMet();
             this.fixture = fixture;
@@ -40,6 +40,46 @@ namespace Tester.AzureUtils.General
 
         [SkippableFact, TestCategory("Functional")]
         public async Task Generic_OnAzureTableStorage_ShortNamedGrain_EchoValue()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ITinyNameGrain<int>>(Guid.NewGuid());
+            await grain.EchoAsync(42);
+
+            await grain.ClearState();
+        }
+    }
+
+    [TestCategory("Azure"), TestCategory("Generics")]
+    public class GenericGrainsInAzureBlobStorageTests : OrleansTestingBase, IClassFixture<GenericGrainsInAzureBlobStorageTests.Fixture>
+    {
+        private readonly Fixture fixture;
+
+        public class Fixture : BaseAzureTestClusterFixture
+        {
+            protected override TestCluster CreateTestCluster()
+            {
+                var options = new TestClusterOptions();
+                options.ClusterConfiguration.AddAzureBlobStorageProvider("AzureStore");
+                return new TestCluster(options);
+            }
+        }
+
+        public GenericGrainsInAzureBlobStorageTests(Fixture fixture)
+        {
+            fixture.EnsurePreconditionsMet();
+            this.fixture = fixture;
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Generic_OnAzureBlobStorage_LongNamedGrain_EchoValue()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ISimpleGenericGrainUsingAzureTableStorage<int>>(Guid.NewGuid());
+            await grain.EchoAsync(42);
+
+            await grain.ClearState();
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task Generic_OnAzureBlobStorage_ShortNamedGrain_EchoValue()
         {
             var grain = this.fixture.GrainFactory.GetGrain<ITinyNameGrain<int>>(Guid.NewGuid());
             await grain.EchoAsync(42);

--- a/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
+++ b/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
@@ -13,13 +13,18 @@ namespace Tester.AzureUtils.General
     {
         private readonly Fixture fixture;
 
-        public class Fixture : BaseAzureTestClusterFixture
+        public class Fixture : BaseTestClusterFixture
         {
             protected override TestCluster CreateTestCluster()
             {
                 var options = new TestClusterOptions();
                 options.ClusterConfiguration.AddAzureTableStorageProvider("AzureStore");
                 return new TestCluster(options);
+            }
+            protected override void CheckPreconditionsOrThrow()
+            {
+                base.CheckPreconditionsOrThrow();
+                StorageEmulatorUtilities.EnsureEmulatorIsNotUsed();
             }
         }
 
@@ -53,13 +58,19 @@ namespace Tester.AzureUtils.General
     {
         private readonly Fixture fixture;
 
-        public class Fixture : BaseAzureTestClusterFixture
+        public class Fixture : BaseTestClusterFixture
         {
             protected override TestCluster CreateTestCluster()
             {
                 var options = new TestClusterOptions();
                 options.ClusterConfiguration.AddAzureBlobStorageProvider("AzureStore");
                 return new TestCluster(options);
+            }
+
+            protected override void CheckPreconditionsOrThrow()
+            {
+                base.CheckPreconditionsOrThrow();
+                StorageEmulatorUtilities.EnsureEmulatorIsNotUsed();
             }
         }
 


### PR DESCRIPTION
While I was doing this minor cleanup, I encountered that this is still failing on the call to ClearState.
@Maarten88 do you know if this is still related to the grain type name or is this a new bug?

Both tests (with long and short name) are now failing, these are the details:

```
Test Name:  UnitTests.General.GenericGrainsInAzureStorageTests.Generic_OnAzureTableStorage_LongNamedGrain_EchoValue
Test FullName:  UnitTests.General.GenericGrainsInAzureStorageTests.Generic_OnAzureTableStorage_LongNamedGrain_EchoValue
Test Source:    D:\projects\OrleansVso\test\Tester\GenericGrainsInAzureStorageTests.cs : line 28
Test Outcome:   Failed
Test Duration:  0:00:00.286

Result StackTrace:  
Server stack trace: 
   at Orleans.Core.GrainStateStorageBridge.<ClearStateAsync>d__7.MoveNext() in D:\projects\OrleansVso\src\Orleans\Core\GrainStateStorageBridge.cs:line 147
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at UnitTests.Grains.SimpleGenericGrainUsingAzureTableStorage`1.<ClearState>d__1.MoveNext() in D:\projects\OrleansVso\test\TestGrains\GenericGrains.cs:line 69
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Orleans.PublicOrleansTaskExtensions.<BoxAwait>d__7.MoveNext() in D:\projects\OrleansVso\src\Orleans\Async\TaskExtensions.cs:line 128
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Orleans.Runtime.InsideRuntimeClient.<Invoke>d__57.MoveNext() in D:\projects\OrleansVso\src\OrleansRuntime\Core\InsideRuntimeClient.cs:line 395

Exception rethrown at [0]: 
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at UnitTests.General.GenericGrainsInAzureStorageTests.<Generic_OnAzureTableStorage_LongNamedGrain_EchoValue>d__1.MoveNext() in D:\projects\OrleansVso\test\Tester\GenericGrainsInAzureStorageTests.cs:line 32
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
----- Inner Stack Trace -----
   at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndExecuteAsync[T](IAsyncResult result)
   at Microsoft.WindowsAzure.Storage.Table.CloudTable.EndExecute(IAsyncResult asyncResult)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Orleans.AzureUtils.AzureTableDataManager`1.<UpdateTableEntryAsync>d__21.MoveNext() in D:\projects\OrleansVso\src\OrleansAzureUtils\Storage\AzureTableDataManager.cs:line 305
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Orleans.Storage.AzureTableStorage.GrainStateTableDataManager.<Write>d__9.MoveNext() in D:\projects\OrleansVso\src\OrleansAzureUtils\Providers\Storage\AzureTableStorage.cs:line 500
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Orleans.Storage.AzureTableStorage.<ClearStateAsync>d__33.MoveNext() in D:\projects\OrleansVso\src\OrleansAzureUtils\Providers\Storage\AzureTableStorage.cs:line 221
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Orleans.Core.GrainStateStorageBridge.<ClearStateAsync>d__7.MoveNext() in D:\projects\OrleansVso\src\Orleans\Core\GrainStateStorageBridge.cs:line 133
----- Inner Stack Trace -----
   at Microsoft.WindowsAzure.Storage.Table.Protocol.TableOperationHttpResponseParsers.TableOperationPreProcess(TableResult result, TableOperation operation, HttpWebResponse resp, Exception ex)
   at Microsoft.WindowsAzure.Storage.Table.TableOperation.<>c__DisplayClass13.<ReplaceImpl>b__12(RESTCommand`1 cmd, HttpWebResponse resp, Exception ex, OperationContext ctx)
   at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndGetResponse[T](IAsyncResult getResponseResult)
Result Message: 
Orleans.Runtime.OrleansException : Error from storage provider during ClearState for grain Type=UnitTests.Grains.SimpleGenericGrainUsingAzureTableStorage`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]] Pk=*grn/F4F91C41/4226a67b4367d6461eedf64f82301bad0303c6e2f4f91c41-0xC9D474F8 Id=GrainReference:*grn/F4F91C41/82301bad<[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]> Error=

Exc level 0: Microsoft.WindowsAzure.Storage.StorageException: The remote server returned an error: (400) Bad Request.
   at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndExecuteAsync[T](IAsyncResult result)
   at Microsoft.WindowsAzure.Storage.Table.CloudTable.EndExecute(IAsyncResult asyncResult)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Orleans.AzureUtils.AzureTableDataManager`1.<UpdateTableEntryAsync>d__21.MoveNext() in D:\projects\OrleansVso\src\OrleansAzureUtils\Storage\AzureTableDataManager.cs:line 305
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Orleans.Storage.AzureTableStorage.GrainStateTableDataManager.<Write>d__9.MoveNext() in D:\projects\OrleansVso\src\OrleansAzureUtils\Providers\Storage\AzureTableStorage.cs:line 500
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Orleans.Storage.AzureTableStorage.<ClearStateAsync>d__33.MoveNext() in D:\projects\OrleansVso\src\OrleansAzureUtils\Providers\Storage\AzureTableStorage.cs:line 221
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Orleans.Core.GrainStateStorageBridge.<ClearStateAsync>d__7.MoveNext() in D:\projects\OrleansVso\src\Orleans\Core\GrainStateStorageBridge.cs:line 133
Exc level 1: System.Net.WebException: The remote server returned an error: (400) Bad Request.
   at Microsoft.WindowsAzure.Storage.Table.Protocol.TableOperationHttpResponseParsers.TableOperationPreProcess(TableResult result, TableOperation operation, HttpWebResponse resp, Exception ex)
   at Microsoft.WindowsAzure.Storage.Table.TableOperation.<>c__DisplayClass13.<ReplaceImpl>b__12(RESTCommand`1 cmd, HttpWebResponse resp, Exception ex, OperationContext ctx)
   at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndGetResponse[T](IAsyncResult getResponseResult)
---- Microsoft.WindowsAzure.Storage.StorageException : The remote server returned an error: (400) Bad Request.
-------- System.Net.WebException : The remote server returned an error: (400) Bad Request.
```
