### PR TITLE
Fixes for non-Silo unit testing of  Grain<T> WriteStateAsync()

### DIFF
--- a/src/Orleans/Core/GrainStateStorageBridge.cs
+++ b/src/Orleans/Core/GrainStateStorageBridge.cs
@@ -12,11 +12,11 @@ namespace Orleans.Core
     internal class GrainStateStorageBridge : IStorage
     {
         private readonly IStorageProvider store;
-        private readonly IStatefulGrain grain;
-        private readonly Grain baseGrain;
+        private IStatefulGrain statefulGrain;
+        private Grain baseGrain;
         private readonly string grainTypeName;
 
-        public GrainStateStorageBridge(string grainTypeName, IStatefulGrain grain, IStorageProvider store)
+        public GrainStateStorageBridge(string grainTypeName, IStorageProvider store)
         {
             if (grainTypeName == null)
             {
@@ -26,14 +26,23 @@ namespace Orleans.Core
             {
                 throw new ArgumentNullException("store", "No storage provider supplied");
             }
-            if (grain == null || grain.GrainState == null)
-            {
-                throw new ArgumentNullException("grain.GrainState", "No grain state object supplied");
-            }
+           
             this.grainTypeName = grainTypeName;
-            this.grain = grain;
-            this.baseGrain = grain as Grain;
+           
+            this.baseGrain = statefulGrain as Grain;
             this.store = store;
+        }
+
+        internal void SetGrain(Grain grain)
+        {
+            statefulGrain = grain as IStatefulGrain;
+
+            if (statefulGrain?.GrainState == null)
+            {
+                throw new ArgumentNullException($"{nameof(grain)}", "No grain state object supplied");
+            }
+
+            this.baseGrain = grain;
         }
 
         /// <summary>
@@ -47,7 +56,7 @@ namespace Orleans.Core
             GrainReference grainRef = baseGrain.GrainReference;
             try
             {
-                await store.ReadStateAsync(grainTypeName, grainRef, grain.GrainState);
+                await store.ReadStateAsync(grainTypeName, grainRef, statefulGrain.GrainState);
 
                 StorageStatisticsGroup.OnStorageRead(store, grainTypeName, grainRef, sw.Elapsed);
             }
@@ -76,7 +85,7 @@ namespace Orleans.Core
             Exception errorOccurred;
             try
             {
-                await store.WriteStateAsync(grainTypeName, grainRef, grain.GrainState);
+                await store.WriteStateAsync(grainTypeName, grainRef, statefulGrain.GrainState);
                 StorageStatisticsGroup.OnStorageWrite(store, grainTypeName, grainRef, sw.Elapsed);
                 errorOccurred = null;
             }
@@ -130,10 +139,10 @@ namespace Orleans.Core
             try
             {
                 // Clear (most likely Delete) state from external storage
-                await store.ClearStateAsync(grainTypeName, grainRef, grain.GrainState);
+                await store.ClearStateAsync(grainTypeName, grainRef, statefulGrain.GrainState);
 
                 // Reset the in-memory copy of the state
-                grain.GrainState.State = Activator.CreateInstance(grain.GrainState.State.GetType());
+                statefulGrain.GrainState.State = Activator.CreateInstance(statefulGrain.GrainState.State.GetType());
 
                 // Update counters
                 StorageStatisticsGroup.OnStorageDelete(store, grainTypeName, grainRef, sw.Elapsed);

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -677,7 +677,12 @@ namespace Orleans.Runtime
                 else
                 {
                     SetupStorageProvider(grainType, data);
-                    grain = grainCreator.CreateGrainInstance(grainType, data.Identity, stateObjectType, data.StorageProvider);
+
+                    var storage = new GrainStateStorageBridge(grainType.FullName, data.StorageProvider);
+
+                    grain = grainCreator.CreateGrainInstance(grainType, data.Identity, stateObjectType, storage);
+
+                    storage.SetGrain(grain);
                 }
                 grain.Data = data;
                 data.SetGrainInstance(grain);

--- a/src/OrleansRuntime/Catalog/GrainCreator.cs
+++ b/src/OrleansRuntime/Catalog/GrainCreator.cs
@@ -60,10 +60,9 @@ namespace Orleans.Runtime
         /// <param name="grainType"></param>
         /// <param name="identity">Identity for the new grain</param>
         /// <param name="stateType">If the grain is a stateful grain, the type of the state it persists.</param>
-        /// <param name="storageProvider">If the grain is a stateful grain, the storage provider used to persist the state.</param>
+        /// <param name="storage">If the grain is a stateful grain, the storage used to persist the state.</param>
         /// <returns></returns>
-        public Grain CreateGrainInstance(Type grainType, IGrainIdentity identity, Type stateType,
-            IStorageProvider storageProvider)
+        public Grain CreateGrainInstance(Type grainType, IGrainIdentity identity, Type stateType, IStorage storage)
         {
             //Create a new instance of the grain
             var grain = CreateGrainInstance(grainType, identity);
@@ -72,8 +71,6 @@ namespace Orleans.Runtime
 
             if (statefulGrain == null)
                 return grain;
-
-            var storage = new GrainStateStorageBridge(grainType.FullName, statefulGrain, storageProvider);
 
             //Inject state and storage data into the grain
             statefulGrain.GrainState.State = Activator.CreateInstance(stateType);


### PR DESCRIPTION
During some of our non-silo testing we were encountering null pointer exceptions during WriteStateAsync(). This was due to the fact that the full runtime is not being initialized (since its a test) so there were some methods that were not checking for null values. This should fix all the Grain<T> issues encountered with the non-silo unit testing that was added in 1.2.2