### PR TITLE
[WIP] Fix storage for generic grains in a way that is backward-compatible for normal grains

### DIFF
--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{013DFD29-E1DB-4968-A67B-C2342E6F5B6E}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
+++ b/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
@@ -6,6 +6,7 @@ using Microsoft.WindowsAzure.Storage.Queue;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Microsoft.WindowsAzure.Storage.Shared.Protocol;
 using Orleans.Runtime;
+using System.Text;
 
 namespace Orleans.AzureUtils
 {
@@ -274,16 +275,24 @@ namespace Orleans.AzureUtils
         {
             // Remove any characters that can't be used in Azure PartitionKey or RowKey values
             // http://www.jamestharpe.com/web-development/azure-table-service-character-combinations-disallowed-in-partitionkey-rowkey/
-            key = key
-                .Replace('/', '_')        // Forward slash
-                .Replace('\\', '_')       // Backslash
-                .Replace('#', '_')        // Pound sign
-                .Replace('?', '_');       // Question mark
+            var sb = new StringBuilder();
+            foreach (var c in key)
+            {
+                if (c == '/'
+                        || c == '\\'
+                        || c == '#'
+                        || c == '/'
+                        || c == '?'
+                        || char.IsControl(c))
+                    sb.Append('_');
+                else
+                    sb.Append(c);
+            }
 
-            if (key.Length >= 1024)
+            if (sb.Length >= 1024)
                 throw new ArgumentException(string.Format("Key length {0} is too long to be an Azure table key. Key={1}", key.Length, key));
 
-            return key;
+            return sb.ToString();
         }
 
 

--- a/test/Tester/GenericGrainsInAzureStorageTests.cs
+++ b/test/Tester/GenericGrainsInAzureStorageTests.cs
@@ -30,7 +30,7 @@ namespace UnitTests.General
             await grain.EchoAsync(42);
 
             //ClearState() also exhibits the error, even with the shorter named grain
-            //await grain.ClearState();
+            await grain.ClearState();
         }
 
         [Fact, TestCategory("Azure"), TestCategory("Functional"), TestCategory("Generics")]


### PR DESCRIPTION
This change is in response to a question in #1915 from @jdom 

For generic grains (which have a long partition key) this sets the rowkey to String.Empty so that ClearStateAsync works. Only ClearState was affected, it seems ReadState and WriteState worked with the long key.

I'm not sure about this one myself: it fixes the problem but I'm not sure I understand the Azure table storage behavior w.r.t how it deals with long keys containing special characters. A better fix would be to change the internal handling of generic arguments by removing the qualified assembly name, making it much shorter. Yet another option would be to change grainReference.ToKeyString() to return a shorter key for generic grains.

This change changes the storage key values for generic grains with previous versions. Normal grains should be unaffected.