### PR TITLE
Use IGrainTypeResolver instead of GrainInterfaceMap

### DIFF
--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -275,7 +275,7 @@ namespace Orleans.Messaging
             }
         }
 
-        public Task<GrainInterfaceMap> GetTypeCodeMap(GrainFactory grainFactory)
+        public Task<IGrainTypeResolver> GetTypeCodeMap(GrainFactory grainFactory)
         {
             var silo = GetLiveGatewaySiloAddress();
             return GetTypeManager(silo, grainFactory).GetTypeCodeMap(silo);

--- a/src/Orleans/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans/Runtime/GrainInterfaceMap.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
 using Orleans.GrainDirectory;
 
 namespace Orleans.Runtime

--- a/src/Orleans/Runtime/ITypeManager.cs
+++ b/src/Orleans/Runtime/ITypeManager.cs
@@ -8,7 +8,7 @@ namespace Orleans.Runtime
     /// </summary>
     internal interface ITypeManager : ISystemTarget
     {
-        Task<GrainInterfaceMap> GetTypeCodeMap(SiloAddress silo);
+        Task<IGrainTypeResolver> GetTypeCodeMap(SiloAddress silo);
 
         Task<Streams.ImplicitStreamSubscriberTable> GetImplicitStreamSubscriberTable(SiloAddress silo);
     }

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -40,7 +40,7 @@ namespace Orleans
 
         internal ClientStatisticsManager ClientStatistics;
         private readonly GrainId clientId;
-        private GrainInterfaceMap grainInterfaceMap;
+        private IGrainTypeResolver grainInterfaceMap;
         private readonly ThreadTrackingStatistic incomingMessagesThreadTimeTracking;
 
         // initTimeout used to be AzureTableDefaultPolicies.TableCreationTimeout, which was 3 min

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime
         private readonly InterceptedMethodInvokerCache interceptedMethodInvokerCache = new InterceptedMethodInvokerCache();
         public TimeSpan ResponseTimeout { get; private set; }
         private readonly GrainTypeManager typeManager;
-        private GrainInterfaceMap grainInterfaceMap;
+        private IGrainTypeResolver grainInterfaceMap;
 
         internal readonly IConsistentRingProvider ConsistentRingProvider;
         

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -192,7 +192,7 @@ namespace Orleans.Runtime
             return grainTypes.TryGetValue(name, out result);
         }
 
-        internal GrainInterfaceMap GetTypeCodeMap()
+        internal IGrainTypeResolver GetTypeCodeMap()
         {
             // the map is immutable at this point
             return grainInterfaceMap;

--- a/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime
         }
 
 
-        public Task<GrainInterfaceMap> GetTypeCodeMap(SiloAddress silo)
+        public Task<IGrainTypeResolver> GetTypeCodeMap(SiloAddress silo)
         {
             return Task.FromResult(grainTypeManager.GetTypeCodeMap());
         }


### PR DESCRIPTION
Trivial change to use the `IGrainTypeResolver` interface over the concrete `GrainInterfaceMap` where applicable.

There are many places where similar cleanups can be made. These changes may help with moving towards a more dependency-injection-friendly model.