### PR TITLE
Include troubleshooting link in SiloUnavailableException

### DIFF
--- a/src/Orleans/Runtime/CallbackData.cs
+++ b/src/Orleans/Runtime/CallbackData.cs
@@ -41,9 +41,9 @@ namespace Orleans.Runtime
             IMessagingConfiguration config)
         {
             // We are never called without a callback func, but best to double check.
-            if (callback == null) throw new ArgumentNullException("callback");
+            if (callback == null) throw new ArgumentNullException(nameof(callback));
             // We are never called without a resend func, but best to double check.
-            if (resendFunc == null) throw new ArgumentNullException("resendFunc");
+            if (resendFunc == null) throw new ArgumentNullException(nameof(resendFunc));
 
             this.callback = callback;
             this.resendFunc = resendFunc;
@@ -61,7 +61,7 @@ namespace Orleans.Runtime
         public void StartTimer(TimeSpan time)
         {
             if (time < TimeSpan.Zero)
-                throw new ArgumentOutOfRangeException("time", "The timeout parameter is negative.");
+                throw new ArgumentOutOfRangeException(nameof(time), "The timeout parameter is negative.");
             timeout = time;
             if (StatisticsCollector.CollectApplicationRequestsStats)
             {
@@ -93,9 +93,8 @@ namespace Orleans.Runtime
             var msg = Message; // Local working copy
 
             string messageHistory = msg.GetTargetHistory();
-            string errorMsg = String.Format("Response did not arrive on time in {0} for message: {1}. Target History is: {2}",
-                                timeout, msg, messageHistory);
-            logger.Warn(ErrorCode.Runtime_Error_100157, "{0}. About to break its promise.", errorMsg);
+            string errorMsg = $"Response did not arrive on time in {timeout} for message: {msg}. Target History is: {messageHistory}.";
+            logger.Warn(ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
 
             var error = msg.CreatePromptExceptionResponse(new TimeoutException(errorMsg));
             OnFail(msg, error, "OnTimeout - Resend {0} for {1}", true);
@@ -108,9 +107,9 @@ namespace Orleans.Runtime
 
             var msg = Message;
             var messageHistory = msg.GetTargetHistory();
-            string errorMsg = string.Format("The target silo became unavailable for message: {0}. Target History is: {1}",
-                                 msg, messageHistory);
-            logger.Warn(ErrorCode.Runtime_Error_100157, "{0}. About to break its promise.", errorMsg);
+            string errorMsg = 
+                $"The target silo became unavailable for message: {msg}. Target History is: {messageHistory}. See {Constants.TroubleshootingHelpLink} for troubleshooting help.";
+            logger.Warn(ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
 
             var error = msg.CreatePromptExceptionResponse(new SiloUnavailableException(errorMsg));
             OnFail(msg, error, "On silo fail - Resend {0} for {1}");
@@ -139,10 +138,7 @@ namespace Orleans.Runtime
                 {
                     timeSinceIssued.Stop();
                 }
-                if (unregister != null)
-                {
-                    unregister();
-                }     
+                unregister?.Invoke();
             }
             if (StatisticsCollector.CollectApplicationRequestsStats)
             {
@@ -162,9 +158,9 @@ namespace Orleans.Runtime
         {
             try
             {
-                if (timer != null)
+                var tmp = timer;
+                if (tmp != null)
                 {
-                    var tmp = timer;
                     timer = null;
                     tmp.Dispose();
                 }
@@ -192,10 +188,7 @@ namespace Orleans.Runtime
                     timeSinceIssued.Stop();
                 }
 
-                if (unregister != null)
-                {
-                    unregister();
-                }
+                unregister?.Invoke();
             }
             
             if (StatisticsCollector.CollectApplicationRequestsStats)

--- a/src/Orleans/Runtime/Constants.cs
+++ b/src/Orleans/Runtime/Constants.cs
@@ -26,6 +26,8 @@ namespace Orleans.Runtime
 
         public const string ORLEANS_ZOOKEEPER_UTILS_DLL = "OrleansZooKeeperUtils";
 
+        public const string TroubleshootingHelpLink = "https://aka.ms/orleans-troubleshooting";
+
         public static readonly GrainId DirectoryServiceId = GrainId.GetSystemTargetGrainId(10);
         public static readonly GrainId DirectoryCacheValidatorId = GrainId.GetSystemTargetGrainId(11);
         public static readonly GrainId SiloControlId = GrainId.GetSystemTargetGrainId(12);


### PR DESCRIPTION
This is because it is the most common exception people see coming from the client when Orleans is misconfigured.
We can start adding these kind of changes in the future, but this is probably a good first step.
Currently https://aka.ms/orleans-troubleshooting is just pointing to the FAQ page, but we have @malavika1 working on a specific troubleshooting page and she'll have a PR shortly (and we plan to merge it before we release new nugets). Then I'll update aka.ms to redirect to that one.