### PR TITLE
Object Pools not pooling fix.

### DIFF
--- a/src/OrleansProviders/Streams/Common/PooledCache/CachedMessageBlock.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/CachedMessageBlock.cs
@@ -61,10 +61,8 @@ namespace Orleans.Providers.Streams.Common
         /// <summary>
         /// Block of cached messages
         /// </summary>
-        /// <param name="pool"></param>
         /// <param name="blockSize"></param>
-        public CachedMessageBlock(IObjectPool<CachedMessageBlock<TCachedMessage>> pool, int blockSize = DefaultCachedMessagesPerBlock)
-            : base(pool)
+        public CachedMessageBlock(int blockSize = DefaultCachedMessagesPerBlock)
         {
             this.blockSize = blockSize;
             cachedMessages = new TCachedMessage[blockSize];

--- a/src/OrleansProviders/Streams/Common/PooledCache/CachedMessagePool.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/CachedMessagePool.cs
@@ -28,7 +28,7 @@ namespace Orleans.Providers.Streams.Common
             }
             dataAdapter = cacheDataAdapter;
             messagePool = new ObjectPool<CachedMessageBlock<TCachedMessage>>(
-                pool => new CachedMessageBlock<TCachedMessage>(pool));
+                () => new CachedMessageBlock<TCachedMessage>());
         }
 
         /// <summary>

--- a/src/OrleansProviders/Streams/Common/PooledCache/FixedSizeBuffer.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/FixedSizeBuffer.cs
@@ -23,14 +23,8 @@ namespace Orleans.Providers.Streams.Common
         /// Manages access to a fixed size byte buffer.
         /// </summary>
         /// <param name="blockSize"></param>
-        /// <param name="pool"></param>
-        public FixedSizeBuffer(int blockSize, IObjectPool<FixedSizeBuffer> pool)
-            : base(pool)
+        public FixedSizeBuffer(int blockSize)
         {
-            if (pool == null)
-            {
-                throw new ArgumentNullException("pool");
-            }
             if (blockSize < 0)
             {
                 throw new ArgumentOutOfRangeException("blockSize", "blockSize must be positive value.");

--- a/src/OrleansProviders/Streams/Common/PooledCache/FixedSizeObjectPool.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/FixedSizeObjectPool.cs
@@ -28,7 +28,7 @@ namespace Orleans.Providers.Streams.Common
         /// </summary>
         /// <param name="poolSize"></param>
         /// <param name="factoryFunc"></param>
-        public FixedSizeObjectPool(int poolSize, Func<IObjectPool<T>,T> factoryFunc)
+        public FixedSizeObjectPool(int poolSize, Func<T> factoryFunc)
             : base(factoryFunc, poolSize)
         {
             if (poolSize < MinObjectCount)

--- a/src/OrleansProviders/Streams/Common/PooledCache/IObjectPool.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/IObjectPool.cs
@@ -30,22 +30,15 @@ namespace Orleans.Providers.Streams.Common
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public abstract class PooledResource<T> : IDisposable
-        where T : class, IDisposable
+        where T : PooledResource<T>, IDisposable
     {
         private IObjectPool<T> pool;
 
         /// <summary>
-        /// Pooled resource that is from the provided pool
+        /// The pool to return this resource to upon disposal.
+        /// A pool must set this property upon resource allocation.
         /// </summary>
-        /// <param name="pool"></param>
-        protected PooledResource(IObjectPool<T> pool)
-        {
-            if (pool == null)
-            {
-                throw new ArgumentNullException("pool");
-            }
-            this.pool = pool;
-        }
+        public IObjectPool<T> Pool { set { pool = value; } }
 
         /// <summary>
         /// If this object is to be used in a fixed size object pool, this call should be
@@ -65,7 +58,7 @@ namespace Orleans.Providers.Streams.Common
             if (localPool != null)
             {
                 OnResetState();
-                localPool.Free(this as T);
+                localPool.Free((T)this);
             }
         }
 

--- a/src/OrleansProviders/Streams/Common/PooledCache/ObjectPool.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ObjectPool.cs
@@ -13,14 +13,14 @@ namespace Orleans.Providers.Streams.Common
     {
         private const int DefaultPoolCapacity = 1 << 10; // 1k
         private readonly Stack<T> pool;
-        private readonly Func<IObjectPool<T>, T> factoryFunc;
+        private readonly Func<T> factoryFunc;
 
         /// <summary>
         /// Simple object pool
         /// </summary>
-        /// <param name="factoryFunc"></param>
-        /// <param name="initialCapacity"></param>
-        public ObjectPool(Func<IObjectPool<T>, T> factoryFunc, int initialCapacity = DefaultPoolCapacity)
+        /// <param name="factoryFunc">Function used to create new resources of type T</param>
+        /// <param name="initialCapacity">Initial number of items to allocate</param>
+        public ObjectPool(Func<T> factoryFunc, int initialCapacity = DefaultPoolCapacity)
         {
             if (factoryFunc == null)
             {
@@ -40,9 +40,11 @@ namespace Orleans.Providers.Streams.Common
         /// <returns></returns>
         public virtual T Allocate()
         {
-            return pool.Count != 0
+            var resource = pool.Count != 0
                 ? pool.Pop()
-                : factoryFunc(this);
+                : factoryFunc();
+            resource.Pool = this;
+            return resource;
         }
 
         /// <summary>

--- a/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
@@ -76,7 +76,7 @@ namespace Orleans.Providers.Streams.Generator
                 generatorConfig.PopulateFromProviderConfig(providerConfig);
             }
             // 10 meg buffer pool.  10 1 meg blocks
-            bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(10, pool => new FixedSizeBuffer(1<<20, pool));
+            bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(10, () => new FixedSizeBuffer(1<<20));
         }
 
         /// <summary>

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -95,7 +95,7 @@ namespace Orleans.ServiceBus.Providers
             
             if (CacheFactory == null)
             {
-                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, pool => new FixedSizeBuffer(1 << 20, pool));
+                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
                 CacheFactory = (partition,checkpointer,cacheLogger) => new EventHubQueueCache(checkpointer, bufferPool, cacheLogger);
             }
 

--- a/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
@@ -20,7 +20,7 @@ namespace Tester.TestStreamProviders.EventHub
 
             private IEventHubQueueCache CreateQueueCache(string partition, IStreamQueueCheckpointer<string> checkpointer, Logger log)
             {
-                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, pool => new FixedSizeBuffer(1 << 20, pool));
+                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
                 var dataAdapter = new CachedDataAdapter(partition, bufferPool);
                 return new EventHubQueueCache(checkpointer, dataAdapter, log);
             }

--- a/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using Orleans.Providers.Streams.Common;
 using Orleans.Streams;
-using UnitTests.StreamingTests;
 using Xunit;
 
 namespace UnitTests.OrleansRuntime.Streams
@@ -115,7 +114,7 @@ namespace UnitTests.OrleansRuntime.Streams
         {
             public CachedMessageBlock<TestCachedMessage> Allocate()
             {
-                return new CachedMessageBlock<TestCachedMessage>(this, TestBlockSize);
+                return new CachedMessageBlock<TestCachedMessage>(TestBlockSize){Pool = this};
             }
 
             public void Free(CachedMessageBlock<TestCachedMessage> resource)

--- a/test/TesterInternal/OrleansRuntime/Streams/FixedSizeBufferTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/FixedSizeBufferTests.cs
@@ -18,7 +18,7 @@ namespace UnitTests.OrleansRuntime.Streams
             public FixedSizeBuffer Allocate()
             {
                 Allocated++;
-                return new FixedSizeBuffer(TestBlockSize, this);
+                return new FixedSizeBuffer(TestBlockSize) {Pool = this};
             }
 
             public void Free(FixedSizeBuffer resource)

--- a/test/TesterInternal/OrleansRuntime/Streams/FixedSizeObjectPoolTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/FixedSizeObjectPoolTests.cs
@@ -1,5 +1,4 @@
 ﻿
-using System;
 using System.Linq;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using Orleans.Providers.Streams.Common;
@@ -11,25 +10,14 @@ namespace UnitTests.OrleansRuntime.Streams
     {
         private class Accumulator
         {
-            public int CurrentlyAllocated { get; set; }
             public int MaxAllocated { get; set; }
 
         }
         private class TestPooledResource : PooledResource<TestPooledResource>
         {
-            private readonly Accumulator accumulator;
-
-            public TestPooledResource(IObjectPool<TestPooledResource> pool, Accumulator accumulator)
-                : base(pool)
+            public TestPooledResource(Accumulator accumulator)
             {
-                this.accumulator = accumulator;
-                this.accumulator.CurrentlyAllocated++;
-                this.accumulator.MaxAllocated = Math.Max(this.accumulator.MaxAllocated, this.accumulator.CurrentlyAllocated);
-            }
-
-            public override void OnResetState()
-            {
-                this.accumulator.CurrentlyAllocated--;
+                accumulator.MaxAllocated++;
             }
         }
 
@@ -37,24 +25,23 @@ namespace UnitTests.OrleansRuntime.Streams
         public void Alloc1Free1Test()
         {
             var accumulator = new Accumulator();
-            IObjectPool<TestPooledResource> pool = new FixedSizeObjectPool<TestPooledResource>(10, p => new TestPooledResource(p, accumulator));
+            IObjectPool<TestPooledResource> pool = new FixedSizeObjectPool<TestPooledResource>(10, () => new TestPooledResource(accumulator));
 
-            // Allocate and free 10 items
-            for (int i = 0; i < 10; i++)
+            // Allocate and free 20 items
+            for (int i = 0; i < 20; i++)
             {
                 TestPooledResource resource = pool.Allocate();
                 resource.Dispose();
             }
             // only 1 at a time was ever allocated, so max allocated should be 1
             Assert.AreEqual(1, accumulator.MaxAllocated);
-            Assert.AreEqual(0, accumulator.CurrentlyAllocated);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public void Alloc10Free1Test()
         {
             var accumulator = new Accumulator();
-            IObjectPool<TestPooledResource> pool = new FixedSizeObjectPool<TestPooledResource>(10, p => new TestPooledResource(p, accumulator));
+            IObjectPool<TestPooledResource> pool = new FixedSizeObjectPool<TestPooledResource>(10, () => new TestPooledResource(accumulator));
 
             // Allocate 10 items
             var resources = Enumerable.Range(0, 10).Select(i => pool.Allocate()).ToList();
@@ -64,7 +51,6 @@ namespace UnitTests.OrleansRuntime.Streams
 
             // pool was pre-populated with 10, so max allocated should be 10
             Assert.AreEqual(10, accumulator.MaxAllocated);
-            Assert.AreEqual(0, accumulator.CurrentlyAllocated);
 
             // Allocate and free 10 items
             for (int i = 0; i < 10; i++)
@@ -75,40 +61,36 @@ namespace UnitTests.OrleansRuntime.Streams
 
             // only 1 at a time was ever allocated, but pool was pre-populated with 10, so max allocated should be 10
             Assert.AreEqual(10, accumulator.MaxAllocated);
-            Assert.AreEqual(0, accumulator.CurrentlyAllocated);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public void Alloc50Max10Test()
         {
             var accumulator = new Accumulator();
-            IObjectPool<TestPooledResource> pool = new FixedSizeObjectPool<TestPooledResource>(10, p => new TestPooledResource(p, accumulator));
+            IObjectPool<TestPooledResource> pool = new FixedSizeObjectPool<TestPooledResource>(10, () => new TestPooledResource(accumulator));
 
             // Allocate 50 items
             var resources = Enumerable.Range(0, 50).Select(i => pool.Allocate()).ToList();
 
             // pool was set to max of 10, so max allocated should be 10
             Assert.AreEqual(10, accumulator.MaxAllocated);
-            Assert.AreEqual(10, accumulator.CurrentlyAllocated);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public void Alloc50Max10DoubleFreeTest()
         {
             var accumulator = new Accumulator();
-            IObjectPool<TestPooledResource> pool = new FixedSizeObjectPool<TestPooledResource>(10, p => new TestPooledResource(p, accumulator));
+            IObjectPool<TestPooledResource> pool = new FixedSizeObjectPool<TestPooledResource>(10, () => new TestPooledResource(accumulator));
 
             // Allocate 50 items
             var resources = Enumerable.Range(0, 50).Select(i => pool.Allocate()).ToList();
 
             // pool was set to max of 10, so max allocated should be 10
             Assert.AreEqual(10, accumulator.MaxAllocated);
-            Assert.AreEqual(10, accumulator.CurrentlyAllocated);
 
             // free 50, note that 40 of these should already be freeded
             resources.ForEach(r => r.Dispose());
             Assert.AreEqual(10, accumulator.MaxAllocated);
-            Assert.AreEqual(0, accumulator.CurrentlyAllocated);
         }
     }
 }

--- a/test/TesterInternal/OrleansRuntime/Streams/ObjectPoolTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/ObjectPoolTests.cs
@@ -19,7 +19,9 @@ namespace UnitTests.OrleansRuntime.Streams
         {
             private readonly Accumulator accumulator;
 
-            public TestPooledResource(IObjectPool<TestPooledResource> pool, Accumulator accumulator) : base(pool)
+            public int AllocationCount { get; private set; }
+
+            public TestPooledResource(Accumulator accumulator)
             {
                 this.accumulator = accumulator;
                 this.accumulator.CurrentlyAllocated++;
@@ -29,6 +31,7 @@ namespace UnitTests.OrleansRuntime.Streams
             public override void OnResetState()
             {
                 accumulator.CurrentlyAllocated--;
+                AllocationCount++;
             }
         }
 
@@ -36,7 +39,7 @@ namespace UnitTests.OrleansRuntime.Streams
         public void Alloc1Free1Test()
         {
             var accumulator = new Accumulator();
-            IObjectPool<TestPooledResource> pool = new ObjectPool<TestPooledResource>(p => new TestPooledResource(p, accumulator), 0);
+            IObjectPool<TestPooledResource> pool = new ObjectPool<TestPooledResource>(() => new TestPooledResource(accumulator), 0);
             // Allocate and free 10 items
             for (int i = 0; i < 10; i++)
             {
@@ -51,7 +54,7 @@ namespace UnitTests.OrleansRuntime.Streams
         public void Alloc10Free1Test()
         {
             var accumulator = new Accumulator();
-            IObjectPool<TestPooledResource> pool = new ObjectPool<TestPooledResource>(p => new TestPooledResource(p,accumulator), 10);
+            IObjectPool<TestPooledResource> pool = new ObjectPool<TestPooledResource>(() => new TestPooledResource(accumulator), 10);
 
             // Allocate 10 items
             var resources = Enumerable.Range(0, 10).Select(i => pool.Allocate()) .ToList();
@@ -72,5 +75,42 @@ namespace UnitTests.OrleansRuntime.Streams
             // only 1 at a time was ever allocated, but pool was pre-populated with 10, so max allocated should be 10
             Assert.AreEqual(10, accumulator.MaxAllocated);
         }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void ReuseResourceTest()
+        {
+            const int DefaultPoolSize = 10;
+            const int WorkngSet = 20;
+            var accumulator = new Accumulator();
+            IObjectPool<TestPooledResource> pool = new ObjectPool<TestPooledResource>(() => new TestPooledResource(accumulator), DefaultPoolSize);
+
+            for (int i = 0; i < 5; i++)
+            {
+                // Allocate WorkngSet items
+                var resources = Enumerable.Range(0, WorkngSet).Select(v => pool.Allocate()).ToList();
+
+                resources.Reverse(); // reversing alloca to maintain order when disposed
+
+                // free WorkngSet
+                resources.ForEach(r => r.Dispose());
+
+                // pool was pre-populated with WorkngSet, so max allocated should be 10
+                Assert.AreEqual(WorkngSet, accumulator.MaxAllocated);
+
+                // Allocate and free 5 items
+                for (int j = 0; j < 5; j++)
+                {
+                    TestPooledResource resource = pool.Allocate();
+                    int expectedAllocationCount = (i*(5 + 1)) // allocations accumulated in previous loops
+                                                  + (j + 1); // allocations accumulated in this loop
+                    Assert.AreEqual(expectedAllocationCount, resource.AllocationCount);
+                    resource.Dispose();
+                }
+
+                // only 1 at a time was ever allocated, but pool was pre-populated with WorkngSet, so max allocated should be 10
+                Assert.AreEqual(WorkngSet, accumulator.MaxAllocated);
+            }
+        }
+
     }
 }

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -165,7 +165,7 @@ namespace UnitTests.OrleansRuntime.Streams
         {
             // 10 buffers of 1k each
             public TestBlockPool()
-                : base(PooledBufferCount, pool => new FixedSizeBuffer(PooledBufferSize, pool))
+                : base(PooledBufferCount, () => new FixedSizeBuffer(PooledBufferSize))
             {
             }
 


### PR DESCRIPTION
Object pool was not resetting pool in the resource, so resources were only being reused once, then released.  Pooling was not pooling.

Special thanks to @dVakulen for finding this.

