### PR TITLE
Corrections in Step-by-step Tutorials:

### DIFF
--- a/Step-by-step-Tutorials/A-Service-is-a-Collection-of-Communicating-Actors.md
+++ b/Step-by-step-Tutorials/A-Service-is-a-Collection-of-Communicating-Actors.md
@@ -56,7 +56,7 @@ With these two interfaces as our starting point, the implementation classes are 
 Here's what it looks like:
 
 ``` csharp
-public class Employee : Grain, Interfaces.IEmployee
+public class Employee : Grain, IEmployee
 {
     public Task<int> GetLevel()
     {
@@ -125,7 +125,7 @@ In the client _(Program.cs)_, we can add a few lines to create a couple of emplo
 
 ``` csharp
 // Orleans comes with a rich XML and programmatic configuration. Here we're just going to set up with basic programmatic config
-var config = Orleans.Runtime.Configuration.ClientConfiguration.LocalhostSilo();
+var config = Orleans.Runtime.Configuration.ClientConfiguration.LocalhostSilo(30000);
 GrainClient.Initialize(config);
 
 var grainFactory = GrainClient.GrainFactory;

--- a/Step-by-step-Tutorials/Concurrency.md
+++ b/Step-by-step-Tutorials/Concurrency.md
@@ -74,10 +74,10 @@ m1.AddDirectReport(e0).Wait();
 ```
 
 When we run this code, the first "Thanks!" greeting is received.
-However, when this message is responded to this we get a 30 second pause, then warnings appear in the log and we're told the grain is about to break it's promise.
+However, when this message is responded to this we get a 30 second pause (or 10 minutes when the debugger is attached), then warnings appear in the log and we're told the grain is about to break it's promise.
 
-    1 said: Welcome to my team!
-    0 said: Thanks!
+    7b66f830-8d81-49fc-b8fc-279af6924bd3 said: Welcome to my team!
+    ce14310a-8500-4b2f-a21b-b4b23eb48d0d said: Thanks!    
     [2014-03-12 15:25:37.398 GMT    31      WARNING 100157  CallbackData    127.0.0.1:11111]        Response did
     not arrive on time in 00:00:30 for message: Request
     S127.0.0.1:11111:132333898*grn/906ECA4C/00000001@68e2b3ab->S127.0.0.1:11111:132333898*grn/D9BB797F/00000000@c24c4187 #13: MyGrainInterfaces1.IEmployee:Greeting(). Target History is: <S127.0.0.1:11111:132333898:*grn/D9BB797F/00000000:@c24c4187>.
@@ -93,14 +93,14 @@ Grain 0 sends a message to grain 1.
 In that call grain 1 sends a message back to grain 0.
 However, grain 0 can't process it because it's awaiting the first message, so it gets queued.
 The await can't complete until the second message is returned, so we've entered a state that we can't escape from.
-Orleans waits for 30 seconds, then kills the request.
+Orleans waits for 30 seconds (10 minutes with the debugger), then kills the request.
 
 Orleans offers us a way to deal with this, by marking the grain `[Reentrant]`, which means that additional calls may be made while the grain is waiting for a task to complete, resulting in interleaved execution.
 
 
 ``` csharp
 [Reentrant]
-public class Employee : Orleans.Grain, Interfaces.IEmployee
+public class Employee : Grain, IEmployee
 {
     ...
 }
@@ -109,10 +109,10 @@ public class Employee : Orleans.Grain, Interfaces.IEmployee
 We see that the sample works, and Orleans is able to interleave the grain calls:
 
  ```
- 1 said: Welcome to my team!
- 0 said: Thanks!
- 1 said: Thanks!
- 0 said: Thanks!
+ aaadb551-7dde-4dbe-82ce-1a5f2547babe said: Welcome to my team!
+ 63e4d07c-ac50-4012-ba50-5b5cf54e4e45 said: Thanks!
+ aaadb551-7dde-4dbe-82ce-1a5f2547babe said: Thanks!
+ 63e4d07c-ac50-4012-ba50-5b5cf54e4e45 said: Thanks!
  ```
 
 ## Messages

--- a/Step-by-step-Tutorials/Declarative-Persistence.md
+++ b/Step-by-step-Tutorials/Declarative-Persistence.md
@@ -65,9 +65,11 @@ siloHost = new SiloHost(siloName, config);
 ```
 
 If this is hosted in Azure Cloud Services, then one can use:
+
 ```csharp
 config.AddAzureBlobStorageProvider("AzureStore");
 ```
+
 and it will pick up the same connection string used in `config.Globals.DataConnectionString`.
 
 The `MemoryStorage` provider is fairly uninteresting, since it doesn't actually provide any permanent storage; it's intended for debugging persistent grains while having no access to a persistent store.

--- a/Step-by-step-Tutorials/Interaction-with-Libraries-and-Services.md
+++ b/Step-by-step-Tutorials/Interaction-with-Libraries-and-Services.md
@@ -67,14 +67,18 @@ public class StockGrain : Orleans.Grain, IStockGrain
 Next create some client code to connect to the Orleans Silo, and retrieve the grain state:
 
 ``` csharp
-GrainClient.Initialize("LocalConfiguration.xml");
+Console.WriteLine("Waiting for Orleans Silo to start. Press Enter to proceed...");
+Console.ReadLine();
+
+var config = Orleans.Runtime.Configuration.ClientConfiguration.LocalhostSilo(30000);
+GrainClient.Initialize(config);
 
 // retrieve the MSFT stock
 var grain = GrainClient.GrainFactory.GetGrain<IStockGrain>("MSFT");
 var price = grain.GetPrice().Result;
 Console.WriteLine(price);
 
-Console.ReadKey();
+Console.ReadLine();
 ```
 
 When we start the local silo, and run the application, we should see the stock value written out

--- a/Step-by-step-Tutorials/My-First-Orleans-Application.md
+++ b/Step-by-step-Tutorials/My-First-Orleans-Application.md
@@ -25,7 +25,7 @@ Typically, you will run one silo per machine, but it sometimes make sense to run
 
 ## Getting Started
 
-After starting either Visual Studio 2012 or 2013, go to create a new project.
+After starting Visual Studio, go to create a new project.
 Under "Visual C#," you should see the following:
 
 ![](../Images/New DevTest 1.PNG)

--- a/Step-by-step-Tutorials/Running-in-a-Stand-alone-Silo.md
+++ b/Step-by-step-Tutorials/Running-in-a-Stand-alone-Silo.md
@@ -37,7 +37,9 @@ static void Main(string[] args)
 }
 ```
 
-Now you should add reference to Microsoft.Orleans.Server NuGet package to your collection project and then in its project properties in Debug tab set the bin/Debug/OrleansHost.exe or bin/Release/OrleansHost.exe file as startup program for your collections class library. You also need to change the client gateway port in the OrleansConfiguration.xml file added to the collection project by Microsoft.Orleans.Server to match the programmatically defined `config` object, which is `30000`. if OrleansConfiguration.xml does not exist, you can create one using the instruction in [Minimal Orleans Application tutorial](Minimal-Orleans-Application#host--orleansconfigurationxml). Then, open OrleansConfiguration.xml, find the `ProxyingGateway` element inside its Defaults section, and change it to.
+Now you should add reference to Microsoft.Orleans.Server NuGet package to your collection project and then in its project properties in Debug tab set the bin/Debug/OrleansHost.exe or bin/Release/OrleansHost.exe file as startup program for your collections class library. Try to not mix NuGet package versions, make sure all Orlean packages are aligned in the solution.
+
+You also need to add a OrleansConfiguration.xml file, you can create it using the instruction in [Minimal Orleans Application tutorial](Minimal-Orleans-Application#host--orleansconfigurationxml). Then, in this file, make sure that the `ProxyingGateway` element inside its Defaults section matches this value:
 
 ```xml
 <ProxyingGateway Address="localhost" Port="30000" />


### PR DESCRIPTION
- Removing reference of old Visual Studio version
- Rephrase the Silo configuration and add a warning on NuGet package versions
- Adding missing port in client example
- Modify traces to show GUID and warn that timeout are longer when using a debugger
- Update example in 'Interaction with Libraries and Services'
- Fix typo in 'Declarative Persistence'