### PR TITLE
Remove allocations caused by string.Format in GetFullName method

### DIFF
--- a/src/Orleans/Timers/SafeTimerBase.cs
+++ b/src/Orleans/Timers/SafeTimerBase.cs
@@ -118,15 +118,12 @@ namespace Orleans.Runtime
         private string GetFullName()
         {
             // the type information is really useless and just too long. 
-            string name;
             if (syncCallbackFunc != null)
-                name = "sync";
-            else if (asynTaskCallback != null)
-                name = "asynTask";
-            else
-                throw new InvalidOperationException("invalid SafeTimerBase state");
+                return "sync.SafeTimerBase";
+            if (asynTaskCallback != null)
+                return "asynTask.SafeTimerBase";
 
-            return String.Format("{0}.SafeTimerBase", name);
+            throw new InvalidOperationException("invalid SafeTimerBase state");
         }
 
         public bool CheckTimerFreeze(DateTime lastCheckTime, Func<string> callerName)


### PR DESCRIPTION
String format in SafeTimer's method was causing memory allocations on each call, replaced with raw strings. 

![timeline64_2016-07-16_18-28-33](https://cloud.githubusercontent.com/assets/5787619/16896240/73f147b6-4b96-11e6-829f-06ce9d0a0ca6.png)
