### PR TITLE
Remove debug context string allocations

### DIFF
--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -330,14 +330,7 @@ namespace Orleans.Runtime
                 }
                 else
                 {
-                    int hash = 17;
-                    unchecked
-                    {
-                        hash = hash * 23 + InterfaceName.GetHashCode();
-                        hash = hash * 23 + InterfaceId;
-                        hash = hash * 23 + request.MethodId;
-                    }
-
+                    var hash = InterfaceId ^ request.MethodId;
                     if (!debugContexts.TryGetValue(hash, out debugContext))
                     {
                         debugContext = GetDebugContext(this.InterfaceName, GetMethodName(this.InterfaceId, request.MethodId), request.Arguments);

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -21,6 +22,9 @@ namespace Orleans.Runtime
         
         [NonSerialized]
         private static readonly Logger logger = LogManager.GetLogger("GrainReference", LoggerType.Runtime);
+
+        [NonSerialized]
+        private static ConcurrentDictionary<int, string> debugContexts = new ConcurrentDictionary<int, string>();
 
         [NonSerialized] private const bool USE_DEBUG_CONTEXT = true;
 
@@ -320,7 +324,26 @@ namespace Orleans.Runtime
         {
             if (debugContext == null && USE_DEBUG_CONTEXT)
             {
-                debugContext = string.Intern(GetDebugContext(this.InterfaceName, GetMethodName(this.InterfaceId, request.MethodId), request.Arguments));
+                if (USE_DEBUG_CONTEXT_PARAMS)
+                {
+                    debugContext = GetDebugContext(this.InterfaceName, GetMethodName(this.InterfaceId, request.MethodId), request.Arguments);
+                }
+                else
+                {
+                    int hash = 17;
+                    unchecked
+                    {
+                        hash = hash * 23 + InterfaceName.GetHashCode();
+                        hash = hash * 23 + InterfaceId;
+                        hash = hash * 23 + request.MethodId;
+                    }
+
+                    if (!debugContexts.TryGetValue(hash, out debugContext))
+                    {
+                        debugContext = GetDebugContext(this.InterfaceName, GetMethodName(this.InterfaceId, request.MethodId), request.Arguments);
+                        debugContexts[hash] = debugContext;
+                    }
+                }
             }
 
             // Call any registered client pre-call interceptor function.


### PR DESCRIPTION
Debug context string allocations is one of the major memory traffic creators:

![timeline64_2016-07-17_15-44-24](https://cloud.githubusercontent.com/assets/5787619/16900795/3ddee96a-4c38-11e6-922d-fa35eb028f73.png)

Adding of interning in https://github.com/dotnet/orleans/pull/1084 only partially mitigated the issue. 

Caching of this string will not only reduce memory pressure, but also reduce CPU time spent in this method (according to benchmarking of composing string every time vs getting it from <code>ConcurrentDictionary</code> - the latter shows 3x better performance) 

Profile results after change:

![timeline64_2016-07-17_16-01-46](https://cloud.githubusercontent.com/assets/5787619/16900809/8416b26e-4c38-11e6-891d-8a58e8e9d379.png)

(The newly appeared dictionary initialize allocations on second result is due to first profile snapshot was created on build with https://github.com/dotnet/orleans/pull/1946, and the second one - without) 

