### PR TITLE
Add note about WeakReference

### DIFF
--- a/Getting-Started-With-Orleans/Observers.md
+++ b/Getting-Started-With-Orleans/Observers.md
@@ -105,6 +105,8 @@ await friend.Subscribe(obj);
 
 Now whenever our grain on the server calls the `SendUpdateMessage` method, all subscribed clients will receive the message. In our client code, the `Chat` instance in variable `c` will receive the message and output it to the console.
 
+**Note:** Objects passed to `CreateObjectReference` are held via a [`WeakReference<T>`](https://msdn.microsoft.com/en-us/library/system.weakreference) and will therefore be garbage collected if no other references exist. Users should maintain a reference for each observer which they do not want to be collected.
+
 **Note:** Support for observers might be removed in a future version and replaced with a Simple Message Stream [SMS](http://dotnet.github.io/orleans/Orleans-Streams/), which can support the same concept with more power, flexibility, and reliability.
 
 ## Next


### PR DESCRIPTION
`CreateObjectReference` uses a `WeakReference` for observers, so users should ensure they hold their own reference to each client object.

Unless I'm missing something.