### PR TITLE
Remove ActivationState enum boxing

### DIFF
--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -296,7 +296,7 @@ namespace Orleans.Runtime
         /// <returns></returns>
         private bool ActivationMayAcceptRequest(ActivationData targetActivation, Message incoming)
         {
-            if (!targetActivation.State.Equals(ActivationState.Valid)) return false;
+            if (targetActivation.State != ActivationState.Valid) return false;
             if (!targetActivation.IsCurrentlyExecuting) return true;
             return CanInterleave(targetActivation, incoming);
         }
@@ -648,7 +648,7 @@ namespace Orleans.Runtime
             }
 #endif
             // don't run any messages if activation is not ready or deactivating
-            if (!activation.State.Equals(ActivationState.Valid)) return;
+            if (activation.State != ActivationState.Valid) return;
 
             bool runLoop;
             do

--- a/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
@@ -124,7 +124,7 @@ namespace Orleans.Runtime.Messaging
                     lock (targetActivation)
                     {
                         var target = targetActivation; // to avoid a warning about nulling targetActivation under a lock on it
-                        if (target.State.Equals(ActivationState.Valid))
+                        if (target.State == ActivationState.Valid)
                         {
                             var overloadException = target.CheckOverloaded(Log);
                             if (overloadException != null)


### PR DESCRIPTION
Due to virtual method calls on value type <code>ActivationState</code> instance is being boxed. 

![dotmemory64_2016-07-18_18-28-49](https://cloud.githubusercontent.com/assets/5787619/16920228/844238ac-4d15-11e6-9a0e-1e34a722d293.png)

(numbers per 10k grain method calls) 