### PR TITLE
Eliminate closure allocations

### DIFF
--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -82,7 +82,7 @@ namespace Orleans.Serialization
 
         private static bool IsTypeFieldsShallowCopyable(TypeInfo typeInfo)
         {
-            return typeInfo.GetFields().All(f => !(f.FieldType == typeInfo) && IsOrleansShallowCopyable(f.FieldType));
+            return typeInfo.GetFields().All(f => !(f.FieldType.IsEquivalentTo(typeInfo)) && IsOrleansShallowCopyable(f.FieldType));
         }
 
         internal static bool IsSpecializationOf(this Type t, Type match)

--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -71,13 +71,18 @@ namespace Orleans.Serialization
 
             if (typeInfo.IsValueType && !typeInfo.IsGenericType && !typeInfo.IsGenericTypeDefinition)
             {
-                result = typeInfo.GetFields().All(f => !(f.FieldType == t) && IsOrleansShallowCopyable(f.FieldType));
+                result = IsTypeFieldsShallowCopyable(typeInfo);
                 shallowCopyableTypes[t] = result;
                 return result;
             }
 
             shallowCopyableTypes[t] = false;
             return false;
+        }
+
+        private static bool IsTypeFieldsShallowCopyable(TypeInfo typeInfo)
+        {
+            return typeInfo.GetFields().All(f => !(f.FieldType == typeInfo) && IsOrleansShallowCopyable(f.FieldType));
         }
 
         internal static bool IsSpecializationOf(this Type t, Type match)


### PR DESCRIPTION
On each <code>IsOrleansShallowCopyable</code> call closure was allocated because of delegate that captured <code>Type</code> variable. 

![dotmemory64_2016-07-19_20-20-44](https://cloud.githubusercontent.com/assets/5787619/16959653/c7869476-4dee-11e6-9106-92a12dee8b36.png)
