### PR TITLE
Update OrleansVSTools to 1.3.0

### DIFF
--- a/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
+++ b/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
@@ -193,76 +193,116 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\packages\Microsoft.Orleans.Core.1.2.0\Microsoft.Orleans.Core.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.Core.1.2.0.nupkg</Link>
+    <Content Include="..\packages\Microsoft.Orleans.Core.1.3.0\Microsoft.Orleans.Core.1.3.0.nupkg">
+      <Link>Packages\Microsoft.Orleans.Core.1.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\packages\Microsoft.Orleans.CounterControl.1.2.0\Microsoft.Orleans.CounterControl.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.CounterControl.1.2.0.nupkg</Link>
+    <Content Include="..\packages\Microsoft.Orleans.CounterControl.1.3.0\Microsoft.Orleans.CounterControl.1.3.0.nupkg">
+      <Link>Packages\Microsoft.Orleans.CounterControl.1.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\packages\Microsoft.Orleans.OrleansCodeGenerator.1.2.0\Microsoft.Orleans.OrleansCodeGenerator.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.OrleansCodeGenerator.1.2.0.nupkg</Link>
+    <Content Include="..\packages\Microsoft.Orleans.OrleansCodeGenerator.1.3.0\Microsoft.Orleans.OrleansCodeGenerator.1.3.0.nupkg">
+      <Link>Packages\Microsoft.Orleans.OrleansCodeGenerator.1.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\packages\Microsoft.Orleans.OrleansHost.1.2.0\Microsoft.Orleans.OrleansHost.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.OrleansHost.1.2.0.nupkg</Link>
+    <Content Include="..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.3.0\Microsoft.Orleans.OrleansCodeGenerator.Build.1.3.0.nupkg">
+      <Link>Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\packages\Microsoft.Orleans.OrleansProviders.1.2.0\Microsoft.Orleans.OrleansProviders.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.OrleansProviders.1.2.0.nupkg</Link>
+    <Content Include="..\packages\Microsoft.Orleans.OrleansHost.1.3.0\Microsoft.Orleans.OrleansHost.1.3.0.nupkg">
+      <Link>Packages\Microsoft.Orleans.OrleansHost.1.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\packages\Microsoft.Orleans.OrleansRuntime.1.2.0\Microsoft.Orleans.OrleansRuntime.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.OrleansRuntime.1.2.0.nupkg</Link>
+    <Content Include="..\packages\Microsoft.Orleans.OrleansProviders.1.3.0\Microsoft.Orleans.OrleansProviders.1.3.0.nupkg">
+      <Link>Packages\Microsoft.Orleans.OrleansProviders.1.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\packages\Microsoft.Orleans.Server.1.2.0\Microsoft.Orleans.Server.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.Server.1.2.0.nupkg</Link>
+    <Content Include="..\packages\Microsoft.Orleans.OrleansRuntime.1.3.0\Microsoft.Orleans.OrleansRuntime.1.3.0.nupkg">
+      <Link>Packages\Microsoft.Orleans.OrleansRuntime.1.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg">
+    <Content Include="..\packages\Microsoft.Orleans.Server.1.3.0\Microsoft.Orleans.Server.1.3.0.nupkg">
+      <Link>Packages\Microsoft.Orleans.Server.1.3.0.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg">
       <Link>Packages\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0\Microsoft.CodeAnalysis.Common.1.0.0.nupkg">
+    <Content Include="..\packages\Microsoft.CodeAnalysis.Common.1.0.0\Microsoft.CodeAnalysis.Common.1.0.0.nupkg">
       <Link>Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg">
+    <Content Include="..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg">
       <Link>Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\Microsoft.Extensions.DependencyInjection.1.0.0.nupkg">
+    <Content Include="..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\Microsoft.Extensions.DependencyInjection.1.0.0.nupkg">
       <Link>Packages\Microsoft.Extensions.DependencyInjection.1.0.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0.nupkg">
+    <Content Include="..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0.nupkg">
       <Link>Packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\Newtonsoft.Json.7.0.1\Newtonsoft.Json.7.0.1.nupkg">
+    <Content Include="..\packages\Newtonsoft.Json.7.0.1\Newtonsoft.Json.7.0.1.nupkg">
       <Link>Packages\Newtonsoft.Json.7.0.1.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\System.Collections.Immutable.1.1.36\System.Collections.Immutable.1.1.36.nupkg">
+    <Content Include="..\packages\System.Collections.4.0.11\System.Collections.4.0.11.nupkg">
+      <Link>Packages\System.Collections.4.0.11.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+	<Content Include="..\packages\System.Collections.Concurrent.4.0.12\System.Collections.Concurrent.4.0.12.nupkg">
+      <Link>Packages\System.Collections.Concurrent.4.0.12.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+	<Content Include="..\packages\System.Collections.Immutable.1.1.36\System.Collections.Immutable.1.1.36.nupkg">
       <Link>Packages\System.Collections.Immutable.1.1.36.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\..\packages\System.Reflection.Metadata.1.0.21\System.Reflection.Metadata.1.0.21.nupkg">
+	<Content Include="..\packages\System.ComponentModel.4.0.1\System.ComponentModel.4.0.1.nupkg">
+      <Link>Packages\System.ComponentModel.4.0.1.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+	<Content Include="..\packages\System.Diagnostics.Debug.4.0.11\System.Diagnostics.Debug.4.0.11.nupkg">
+      <Link>Packages\System.Diagnostics.Debug.4.0.11.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+	<Content Include="..\packages\System.Globalization.4.0.11\System.Globalization.4.0.11.nupkg">
+      <Link>Packages\System.Globalization.4.0.11.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+	<Content Include="..\packages\System.Linq.4.1.0\System.Linq.4.1.0.nupkg">
+      <Link>Packages\System.Linq.4.1.0.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+	<Content Include="..\packages\System.Linq.Expressions.4.1.0\System.Linq.Expressions.4.1.0.nupkg">
+      <Link>Packages\System.Linq.Expressions.4.1.0.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+	<Content Include="..\packages\System.Reflection.4.1.0\System.Reflection.4.1.0.nupkg">
+      <Link>Packages\System.Reflection.4.1.0.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+	<Content Include="..\packages\System.Reflection.Metadata.1.0.21\System.Reflection.Metadata.1.0.21.nupkg">
       <Link>Packages\System.Reflection.Metadata.1.0.21.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\packages\Microsoft.Orleans.Templates.Grains.1.2.0\Microsoft.Orleans.Templates.Grains.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.Templates.Grains.1.2.0.nupkg</Link>
+	<Content Include="..\packages\System.Resources.ResourceManager.4.0.1\System.Resources.ResourceManager.4.0.1.nupkg">
+      <Link>Packages\System.Resources.ResourceManager.4.0.1.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\packages\Microsoft.Orleans.Templates.Interfaces.1.2.0\Microsoft.Orleans.Templates.Interfaces.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.Templates.Interfaces.1.2.0.nupkg</Link>
+	<Content Include="..\packages\System.Runtime.Extensions.4.1.0\System.Runtime.Extensions.4.1.0.nupkg">
+      <Link>Packages\System.Runtime.Extensions.4.1.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg">
-      <Link>Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg</Link>
+	<Content Include="..\packages\System.Threading.4.0.11\System.Threading.4.0.11.nupkg">
+      <Link>Packages\System.Threading.4.0.11.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+	<Content Include="..\packages\System.Threading.Tasks.4.0.11\System.Threading.Tasks.4.0.11.nupkg">
+      <Link>Packages\System.Threading.Tasks.4.0.11.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <None Include="OrleansVSTools.snk" />

--- a/src/OrleansVSTools/OrleansVSTools/packages.config
+++ b/src/OrleansVSTools/OrleansVSTools/packages.config
@@ -1,5 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.Core" version="1.3.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.CounterControl" version="1.3.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.3.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.3.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.OrleansHost" version="1.3.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.OrleansProviders" version="1.3.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.OrleansRuntime" version="1.3.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.Server" version="1.3.0" targetFramework="net451" />
   <package id="Microsoft.VisualStudio.Imaging" version="14.2.25123" targetFramework="net451" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net451" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.2.25123" targetFramework="net451" />
@@ -19,14 +32,19 @@
   <package id="Microsoft.VisualStudio.Utilities" version="14.2.25123" targetFramework="net451" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net451" />
   <package id="Microsoft.VSSDK.BuildTools" version="14.2.25201" targetFramework="net451" developmentDependency="true" />
-  <package id="Microsoft.Orleans.Core" version="1.2.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.CounterControl" version="1.2.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.2.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.OrleansHost" version="1.2.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.OrleansProviders" version="1.2.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.OrleansRuntime" version="1.2.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.Server" version="1.2.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.Templates.Grains" version="1.2.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.Templates.Interfaces" version="1.2.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.2.0" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net451" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net451" />
 </packages>

--- a/src/OrleansVSTools/OrleansVSTools/source.extension.vsixmanifest
+++ b/src/OrleansVSTools/OrleansVSTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="462db41f-31a4-48f0-834c-1bdcc0578511" Version="1.2.0" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="462db41f-31a4-48f0-834c-1bdcc0578511" Version="1.3.0" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Microsoft Orleans Tools for Visual Studio</DisplayName>
     <Description xml:space="preserve">Microsoft Orleans Tools for Visual Studio 2013, 2015
 C#, VB, F#  Project templates and item templates

--- a/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
+++ b/src/OrleansVSTools/VSProjectSiloHost/VSProjectSiloHost.vstemplate
@@ -27,19 +27,33 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
-      <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" />
-      <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" />
-      <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" />
-      <package id="Microsoft.Orleans.Core" version="1.2.0" />
-      <package id="Microsoft.Orleans.CounterControl" version="1.2.0" />
-      <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.2.0" />
-      <package id="Microsoft.Orleans.OrleansHost" version="1.2.0" />
-      <package id="Microsoft.Orleans.OrleansProviders" version="1.2.0" />
-      <package id="Microsoft.Orleans.OrleansRuntime" version="1.2.0" />
-      <package id="Microsoft.Orleans.Server" version="1.2.0" />
-      <package id="Newtonsoft.Json" version="7.0.1" />
-      <package id="System.Collections.Immutable" version="1.1.36" />
-      <package id="System.Reflection.Metadata" version="1.0.21" />
+      <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net451" />
+      <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net451" />
+      <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net451" />
+      <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net451" />
+      <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net451" />
+      <package id="Microsoft.Orleans.Core" version="1.3.0" targetFramework="net451" />
+      <package id="Microsoft.Orleans.CounterControl" version="1.3.0" targetFramework="net451" />
+      <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.3.0" targetFramework="net451" />
+      <package id="Microsoft.Orleans.OrleansHost" version="1.3.0" targetFramework="net451" />
+      <package id="Microsoft.Orleans.OrleansProviders" version="1.3.0" targetFramework="net451" />
+      <package id="Microsoft.Orleans.OrleansRuntime" version="1.3.0" targetFramework="net451" />
+      <package id="Microsoft.Orleans.Server" version="1.3.0" targetFramework="net451" />
+      <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
+      <package id="System.Collections" version="4.0.11" targetFramework="net451" />
+      <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
+      <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net451" />
+      <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
+      <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
+      <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
+      <package id="System.Linq" version="4.1.0" targetFramework="net451" />
+      <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net451" />
+      <package id="System.Reflection" version="4.1.0" targetFramework="net451" />
+      <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net451" />
+      <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net451" />
+      <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
+      <package id="System.Threading" version="4.0.11" targetFramework="net451" />
+      <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net451" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementation" d:TargetPath="|VSProjectTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
@@ -54,21 +68,34 @@
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterfaceVB" d:TargetPath="|VSProjectTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
       <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterfaceVB" d:TargetPath="|VSItemTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementationFSharp" d:TargetPath="|VSProjectTemplateGrainImplementationFSharp;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+      
       <Asset Type="Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.Extensions.DependencyInjection.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.Extensions.DependencyInjection.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0" d:Source="File" Path="Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.Core.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.CounterControl.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.CounterControl.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.OrleansHost.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansHost.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.OrleansProviders.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansProviders.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.OrleansRuntime.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansRuntime.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.Server.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Server.1.2.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Core.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.3.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.CounterControl.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.CounterControl.1.3.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.1.3.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansHost.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansHost.1.3.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansProviders.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansProviders.1.3.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansRuntime.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansRuntime.1.3.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Server.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Server.1.3.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Newtonsoft.Json.7.0.1.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.7.0.1.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Collections.4.0.11.nupkg" d:Source="File" Path="Packages\System.Collections.4.0.11.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Collections.Concurrent.4.0.12.nupkg" d:Source="File" Path="Packages\System.Collections.Concurrent.4.0.12.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.ComponentModel.4.0.1.nupkg" d:Source="File" Path="Packages\System.ComponentModel.4.0.1.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Diagnostics.Debug.4.0.1.nupkg" d:Source="File" Path="Packages\System.Diagnostics.Debug.4.0.1.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Globalization.4.0.1.nupkg" d:Source="File" Path="Packages\System.Globalization.4.0.1.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Linq.4.1.0.nupkg" d:Source="File" Path="Packages\System.Linq.4.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Linq.Expressions.4.1.0.nupkg" d:Source="File" Path="Packages\System.Linq.Expressions.4.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Reflection.4.1.0.nupkg" d:Source="File" Path="Packages\System.Reflection.4.1.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Resources.ResourceManager.4.0.1.nupkg" d:Source="File" Path="Packages\System.Resources.ResourceManager.4.0.1.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Runtime.Extension.4.1.0.nupkg" d:Source="File" Path="Packages\System.Runtime.Extension.4.1.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Threading.4.0.11.nupkg" d:Source="File" Path="Packages\System.Threading.4.0.11.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="System.Threading.Tasks.4.0.11.nupkg" d:Source="File" Path="Packages\System.Threading.Tasks.4.0.11.nupkg" d:VsixSubPath="Packages" />
     </Assets>
   </WizardData>
   

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementation/VSProjectTemplateGrainImplementation.vstemplate
@@ -28,8 +28,8 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
-      <package id="Microsoft.Orleans.Core" version="1.2.0" />
-      <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.2.0" />
+      <package id="Microsoft.Orleans.Core" version="1.3.0" />
+      <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.3.0" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainImplementation" d:TargetPath="|VSProjectTemplateGrainImplementation;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
@@ -42,8 +42,8 @@
       <Asset Type="Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.Core.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Core.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.3.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.Build.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.3.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Newtonsoft.Json.7.0.1.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.7.0.1.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementationFSharp/ProjectTemplate.fsproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementationFSharp/ProjectTemplate.fsproj
@@ -39,7 +39,7 @@
     </Reference>
     <Reference Include="Orleans">
       <Private>False</Private>
-      <HintPath>$(SolutionDir)packages\Microsoft.Orleans.Core.1.2.0\lib\net45\Orleans.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Orleans.Core.1.3.0\lib\net451\Orleans.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementationFSharp/VSProjectTemplateGrainImplementation.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementationFSharp/VSProjectTemplateGrainImplementation.vstemplate
@@ -26,14 +26,14 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
-      <package id="Microsoft.Orleans.Core" version="1.2.0" />
+      <package id="Microsoft.Orleans.Core" version="1.3.0" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterface" d:TargetPath="|VSProjectTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
       <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterface" d:TargetPath="|VSItemTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterfaceVB" d:TargetPath="|VSProjectTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
       <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterfaceVB" d:TargetPath="|VSItemTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-      <Asset Type="Microsoft.Orleans.Core.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.2.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Core.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.3.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Newtonsoft.Json.7.0.1.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.7.0.1.nupkg" d:VsixSubPath="Packages" />
     </Assets>
   </WizardData>

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementationVB/ProjectTemplate.vbproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementationVB/ProjectTemplate.vbproj
@@ -41,7 +41,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Orleans">
       <Private>False</Private>
-      <HintPath>$(SolutionDir)packages\Microsoft.Orleans.Core.1.2.0\lib\net45\Orleans.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Orleans.Core.1.3.0\lib\net451\Orleans.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/src/OrleansVSTools/VSProjectTemplateGrainImplementationVB/VSProjectTemplateGrainImplementationVB.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainImplementationVB/VSProjectTemplateGrainImplementationVB.vstemplate
@@ -30,14 +30,14 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
-      <package id="Microsoft.Orleans.Core" version="1.2.0" />
+      <package id="Microsoft.Orleans.Core" version="1.3.0" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterface" d:TargetPath="|VSProjectTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
       <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterface" d:TargetPath="|VSItemTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterfaceVB" d:TargetPath="|VSProjectTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
       <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterfaceVB" d:TargetPath="|VSItemTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-      <Asset Type="Microsoft.Orleans.Core.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.2.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Core.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.3.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Newtonsoft.Json.7.0.1.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.7.0.1.nupkg" d:VsixSubPath="Packages" />
     </Assets>
   </WizardData>

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterface/VSProjectTemplateGrainInterface.vstemplate
@@ -28,8 +28,8 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
-      <package id="Microsoft.Orleans.Core" version="1.2.0" />
-      <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.2.0" />
+      <package id="Microsoft.Orleans.Core" version="1.3.0" />
+      <package id="Microsoft.Orleans.OrleansCodeGenerator.Build" version="1.3.0" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterface" d:TargetPath="|VSProjectTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
@@ -39,8 +39,8 @@
       <Asset Type="Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Analyzers.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.Common.1.0.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:Source="File" Path="Packages\Microsoft.CodeAnalysis.CSharp.1.0.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.Core.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.2.0.nupkg" d:VsixSubPath="Packages" />
-      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.2.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Core.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.3.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.OrleansCodeGenerator.Build.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.OrleansCodeGenerator.Build.1.3.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Newtonsoft.Json.7.0.1.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.7.0.1.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Collections.Immutable.1.1.36.nupkg" d:Source="File" Path="Packages\System.Collections.Immutable.1.1.36.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="System.Reflection.Metadata.1.0.21.nupkg" d:Source="File" Path="Packages\System.Reflection.Metadata.1.0.21.nupkg" d:VsixSubPath="Packages" />

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterfaceVB/ProjectTemplate.vbproj
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterfaceVB/ProjectTemplate.vbproj
@@ -45,7 +45,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Orleans">
       <Private>False</Private>
-      <HintPath>$(SolutionDir)packages\Microsoft.Orleans.Core.1.2.0\lib\net45\Orleans.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Microsoft.Orleans.Core.1.3.0\lib\net451\Orleans.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/src/OrleansVSTools/VSProjectTemplateGrainInterfaceVB/VSProjectTemplateGrainInterfaceVB.vstemplate
+++ b/src/OrleansVSTools/VSProjectTemplateGrainInterfaceVB/VSProjectTemplateGrainInterfaceVB.vstemplate
@@ -30,14 +30,14 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="462db41f-31a4-48f0-834c-1bdcc0578511">
-      <package id="Microsoft.Orleans.Core" version="1.2.0" />
+      <package id="Microsoft.Orleans.Core" version="1.3.0" />
     </packages>
     <Assets>
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterface" d:TargetPath="|VSProjectTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
       <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterface" d:TargetPath="|VSItemTemplateGrainInterface;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
       <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="VSProjectTemplateGrainInterfaceVB" d:TargetPath="|VSProjectTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
       <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="VSItemTemplateGrainInterfaceVB" d:TargetPath="|VSItemTemplateGrainInterfaceVB;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-      <Asset Type="Microsoft.Orleans.Core.1.2.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.2.0.nupkg" d:VsixSubPath="Packages" />
+      <Asset Type="Microsoft.Orleans.Core.1.3.0.nupkg" d:Source="File" Path="Packages\Microsoft.Orleans.Core.1.3.0.nupkg" d:VsixSubPath="Packages" />
       <Asset Type="Newtonsoft.Json.7.0.1.nupkg" d:Source="File" Path="Packages\Newtonsoft.Json.7.0.1.nupkg" d:VsixSubPath="Packages" />
     </Assets>
   </WizardData>


### PR DESCRIPTION
- Update OrleansVSTools to 1.3.0
- Also fix missing dependencies in OrleansVSTools.
    They were only working before by piggybacking on Orleans solution packages which will be removed with project.json.