### PR TITLE
WIP:Let make disscusion from #1092 more concrete

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Streams\QueueAdapters\AggregatedQueueFlowController.cs" />
     <Compile Include="Telemetry\Consumers\ConsoleTelemetryConsumer.cs" />
     <Compile Include="Telemetry\Consumers\FileTelemetryConsumer.cs" />
+    <Compile Include="Telemetry\Consumers\OrleansLegacyConsumer.cs" />
     <Compile Include="Telemetry\Consumers\TraceTelemetryConsumer.cs" />
     <Compile Include="Telemetry\IDependencyTelemetryConsumer.cs" />
     <Compile Include="Telemetry\IEventTelemetryConsumer.cs" />

--- a/src/Orleans/Telemetry/Consumers/OrleansLegacyConsumer.cs
+++ b/src/Orleans/Telemetry/Consumers/OrleansLegacyConsumer.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using Orleans.Runtime;
+
+namespace Orleans.Telemetry.Consumers
+{
+    public class OrleansLegacyConsumer : IMetricTelemetryConsumer
+    { 
+        public void Flush()
+        {
+           
+        }
+
+        public void Close()
+        {
+            
+        }
+
+        public void TrackMetric(string name, double value, IDictionary<string, string> properties = null)
+        {
+            CounterStatistic.FindOrCreate(new StatisticName(name)).IncrementBy((long)value);
+        }
+
+        public void TrackMetric(string name, TimeSpan value, IDictionary<string, string> properties = null)
+        {
+            CounterStatistic.FindOrCreate(new StatisticName(name)).IncrementBy(value.Ticks);
+        }
+
+        public void IncrementMetric(string name)
+        {
+            CounterStatistic.FindOrCreate(new StatisticName(name)).Increment();
+        }
+
+        public void IncrementMetric(string name, double value)
+        {
+            CounterStatistic.FindOrCreate(new StatisticName(name)).IncrementBy((long)value);
+        }
+
+        public void DecrementMetric(string name)
+        {
+            CounterStatistic.FindOrCreate(new StatisticName(name)).DecrementBy(1);
+        }
+
+        public void DecrementMetric(string name, double value)
+        {
+            CounterStatistic.FindOrCreate(new StatisticName(name)).DecrementBy((long)value); 
+        }
+    }
+}

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -555,7 +555,7 @@ namespace Orleans.Runtime
             message.SetTargetPlacement(placementResult);
             if (placementResult.IsNewPlacement)
             {
-                CounterStatistic.FindOrCreate(StatisticNames.DISPATCHER_NEW_PLACEMENT).Increment();
+                logger.IncrementMetric(StatisticNames.DISPATCHER_NEW_PLACEMENT.Name);                
             }
             if (logger.IsVerbose2) logger.Verbose2(ErrorCode.Dispatcher_AddressMsg_SelectTarget, "AddressMessage Placement SelectTarget {0}", message);
        }


### PR DESCRIPTION
In #1092 we talked allot about how to merge Telemetry API and Orleans counters. Here is a minimal sample change showing a simplest way to achieve that we talked about. As you can see it possible to wrap **subset** of Orleans counters with Telemetry API even now if we replaces direct calls to CounterStatistic with calls to Logger.IncrementMetric that will call all enabled Telemetry API providers including the existing CounterStatistic.

It will not cover all PULL based Orleans counters but it is a step forward. Is it a path we want to take?  Let's talk.
