### PR TITLE
Replace buffer pool underlying collection

### DIFF
--- a/src/Orleans/Messaging/BufferPool.cs
+++ b/src/Orleans/Messaging/BufferPool.cs
@@ -18,7 +18,7 @@ namespace Orleans.Runtime
         private readonly CounterStatistic droppedBufferCounter;
         private readonly CounterStatistic droppedTooLargeBufferCounter;
 
-        private int currentAllocatedBuffers;
+        private int currentBufferCount;
 
         public static BufferPool GlobalPool;
 
@@ -91,7 +91,7 @@ namespace Orleans.Runtime
             }
             else if (limitBuffersCount)
             {
-                Interlocked.Decrement(ref currentAllocatedBuffers);
+                Interlocked.Decrement(ref currentBufferCount);
             }
 
             checkedOutBufferCounter.Increment();
@@ -115,7 +115,7 @@ namespace Orleans.Runtime
         {
             if (buffer.Length == byteBufferSize)
             {
-                if (limitBuffersCount && currentAllocatedBuffers > maxBuffersCount)
+                if (limitBuffersCount && currentBufferCount > maxBuffersCount)
                 {
                     droppedBufferCounter.Increment();
                     return;
@@ -125,7 +125,7 @@ namespace Orleans.Runtime
 
                 if (limitBuffersCount)
                 {
-                    Interlocked.Increment(ref currentAllocatedBuffers);
+                    Interlocked.Increment(ref currentBufferCount);
                 }
 
                 checkedInBufferCounter.Increment();

--- a/src/Orleans/Messaging/BufferPool.cs
+++ b/src/Orleans/Messaging/BufferPool.cs
@@ -117,6 +117,7 @@ namespace Orleans.Runtime
             {
                 if (limitBuffersCount && currentAllocatedBuffers > maxBuffersCount)
                 {
+                    droppedBufferCounter.Increment();
                     return;
                 }
 


### PR DESCRIPTION
Currently used <code>BlockingCollection</code> takes quite a portion of serialization time:

(results from mini benchmark of roundtrip serialization of POCO)
![dottraceview64_2016-07-27_09-16-55](https://cloud.githubusercontent.com/assets/5787619/17165696/f166b180-53da-11e6-805e-953ca76c1cb1.png)

After replacing with <code>ConcurrentBag</code>:

![dottraceview64_2016-07-27_09-21-46](https://cloud.githubusercontent.com/assets/5787619/17165792/931e218e-53db-11e6-8f40-77c671309e0f.png)
(note, that <code>Release</code> method also disappeared from hot spots list)

