### PR TITLE
Avoid dictionary allocation on creation of grain instance

### DIFF
--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -630,8 +630,7 @@ namespace Orleans.Runtime
         private void CreateGrainInstance(string grainTypeName, ActivationData data, string genericArguments)
         {
             string grainClassName;
-            var interfaceToClassMap = GrainTypeManager.GetGrainInterfaceToClassMap();
-            if (!interfaceToClassMap.TryGetValue(grainTypeName, out grainClassName))
+            if (!GrainTypeManager.TryGetPrimaryImplementation(grainTypeName, out grainClassName))
             {
                 // Lookup from grain type code
                 var typeCode = data.Grain.GetTypeCode();

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -68,6 +68,11 @@ namespace Orleans.Runtime
             return grainInterfaceMap.GetPrimaryImplementations();
         }
 
+        internal bool TryGetPrimaryImplementation(string grainInterface, out string grainClass)
+        {
+            return grainInterfaceMap.TryGetPrimaryImplementation(grainInterface, out grainClass);
+        }
+
         internal GrainTypeData this[string className]
         {
             get


### PR DESCRIPTION
On each grain activation dictionary was allocated, presumably for the sake of immutability,
 but its only usage is at https://github.com/dotnet/orleans/blob/master/src/OrleansRuntime/Catalog/Catalog.cs#L634.


![dottraceview64_2016-07-29_00-29-00](https://cloud.githubusercontent.com/assets/5787619/17230224/bd04b9d8-5523-11e6-8565-2c2dd304296d.png)
