### PR TITLE
Optimize CheckLength method

### DIFF
--- a/src/Orleans/Serialization/BinaryTokenStreamReader.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamReader.cs
@@ -19,14 +19,18 @@ namespace Orleans.Serialization
     public class BinaryTokenStreamReader
     {
         private readonly IList<ArraySegment<byte>> buffers;
+        private readonly int buffersCount;
         private int currentSegmentIndex;
         private ArraySegment<byte> currentSegment;
         private byte[] currentBuffer;
         private int currentOffset;
+        private int currentSegmentOffset;
+        private int currentSegmentCount;
         private int totalProcessedBytes;
         private readonly int totalLength;
 
         private static readonly ArraySegment<byte> emptySegment = new ArraySegment<byte>(new byte[0]);
+        private static readonly byte[] emptyByteArray = new byte[0];
 
         /// <summary>
         /// Create a new BinaryTokenStreamReader to read from the specified input byte array.
@@ -49,7 +53,10 @@ namespace Orleans.Serialization
             currentSegment = buffs[0];
             currentBuffer = currentSegment.Array;
             currentOffset = currentSegment.Offset;
+            currentSegmentOffset = currentOffset;
+            currentSegmentCount = currentSegment.Count;
             totalLength = buffs.Sum(b => b.Count);
+            buffersCount = buffs.Count;
             Trace("Starting new stream reader");
         }
 
@@ -63,7 +70,7 @@ namespace Orleans.Serialization
         }
 
         /// <summary> Current read position in the stream. </summary>
-        public int CurrentPosition { get { return currentOffset + totalProcessedBytes - currentSegment.Offset; } }
+        public int CurrentPosition => currentOffset + totalProcessedBytes - currentSegmentOffset;
 
         /// <summary>
         /// Creates a copy of the current stream reader.
@@ -78,34 +85,38 @@ namespace Orleans.Serialization
         {
             totalProcessedBytes += currentSegment.Count;
             currentSegmentIndex++;
-            if (currentSegmentIndex < buffers.Count)
+            if (currentSegmentIndex < buffersCount)
             {
                 currentSegment = buffers[currentSegmentIndex];
                 currentBuffer = currentSegment.Array;
                 currentOffset = currentSegment.Offset;
+                currentSegmentOffset = currentOffset;
+                currentSegmentCount = currentSegment.Count;
             }
             else
             {
                 currentSegment = emptySegment;
                 currentBuffer = null;
                 currentOffset = 0;
+                currentSegmentOffset = 0;
             }
         }
 
-        private ArraySegment<byte> CheckLength(int n)
+        private byte[] CheckLength(int n, out int offset)
         {
             bool ignore;
-            return CheckLength(n, out ignore);
+            return CheckLength(n, out offset, out ignore);
         }
 
-        private ArraySegment<byte> CheckLength(int n, out bool safeToUse)
+        private byte[] CheckLength(int n, out int offset, out bool safeToUse)
         {
             safeToUse = false;
+            offset = 0;
 
             if (n == 0)
             {
                 safeToUse = true;
-                return emptySegment;
+                return emptyByteArray;
             }
 
             if ((CurrentPosition + n > totalLength))
@@ -115,52 +126,52 @@ namespace Orleans.Serialization
                     CurrentPosition, n, totalLength));
             }
 
-            if (currentSegmentIndex >= buffers.Count)
+            if (currentSegmentIndex >= buffersCount)
             {
                 throw new SerializationException(
                     String.Format("Attempt to read past buffers.Count: currentSegmentIndex={0}, buffers.Count={1}.", currentSegmentIndex, buffers.Count));
             }
 
-            if (currentOffset == currentSegment.Offset + currentSegment.Count)
+            if (currentOffset == currentSegmentOffset + currentSegmentCount)
             {
                 StartNextSegment();
             }
 
-            if (currentOffset + n <= currentSegment.Offset + currentSegment.Count)
+            var nextOffset = currentOffset + n;
+            if (nextOffset <= currentSegmentOffset + currentSegmentCount)
             {
-                var result = new ArraySegment<byte>(currentBuffer, currentOffset, n);
-                currentOffset += n;
-                if (currentOffset >= currentSegment.Offset + currentSegment.Count)
-                {
-                    StartNextSegment();
-                }
-                return result;
+                offset = currentOffset;
+                currentOffset = nextOffset;
+                return currentBuffer;
             }
 
             var temp = new byte[n];
             var i = 0;
             while (i < n)
             {
-                var bytesFromThisBuffer = Math.Min(currentSegment.Offset + currentSegment.Count - currentOffset,
+                var segmentOffsetPlusCount = currentSegmentOffset + currentSegmentCount;
+                var bytesFromThisBuffer = Math.Min(segmentOffsetPlusCount - currentOffset,
                                                    n - i);
                 Buffer.BlockCopy(currentBuffer, currentOffset, temp, i, bytesFromThisBuffer);
                 i += bytesFromThisBuffer;
                 currentOffset += bytesFromThisBuffer;
-                if (currentOffset >= currentSegment.Offset + currentSegment.Count)
+                if (currentOffset >= segmentOffsetPlusCount)
                 {
                     StartNextSegment();
                 }
             }
             safeToUse = true;
-            return new ArraySegment<byte>(temp);
+            offset = 0;
+            return temp;
         }
 
         /// <summary> Read an <c>Int32</c> value from the stream. </summary>
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public int ReadInt()
         {
-            var buff = CheckLength(sizeof(int));
-            var val = BitConverter.ToInt32(buff.Array, buff.Offset);
+            int offset;
+            var buff = CheckLength(sizeof(int), out offset);
+            var val = BitConverter.ToInt32(buff, offset);
             Trace("--Read int {0}", val);
             return val;
         }
@@ -169,8 +180,9 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public uint ReadUInt()
         {
-            var buff = CheckLength(sizeof(uint));
-            var val = BitConverter.ToUInt32(buff.Array, buff.Offset);
+            int offset;
+            var buff = CheckLength(sizeof(uint), out offset);
+            var val = BitConverter.ToUInt32(buff, offset);
             Trace("--Read uint {0}", val);
             return val;
         }
@@ -179,8 +191,9 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public short ReadShort()
         {
-            var buff = CheckLength(sizeof(short));
-            var val = BitConverter.ToInt16(buff.Array, buff.Offset);
+            int offset;
+            var buff = CheckLength(sizeof(short), out offset);
+            var val = BitConverter.ToInt16(buff, offset);
             Trace("--Read short {0}", val);
             return val;
         }
@@ -189,8 +202,9 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public ushort ReadUShort()
         {
-            var buff = CheckLength(sizeof(ushort));
-            var val = BitConverter.ToUInt16(buff.Array, buff.Offset);
+            int offset;
+            var buff = CheckLength(sizeof(ushort), out offset);
+            var val = BitConverter.ToUInt16(buff, offset);
             Trace("--Read ushort {0}", val);
             return val;
         }
@@ -199,8 +213,9 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public long ReadLong()
         {
-            var buff = CheckLength(sizeof(long));
-            var val = BitConverter.ToInt64(buff.Array, buff.Offset);
+            int offset;
+            var buff = CheckLength(sizeof(long), out offset);
+            var val = BitConverter.ToInt64(buff, offset);
             Trace("--Read long {0}", val);
             return val;
         }
@@ -209,8 +224,9 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public ulong ReadULong()
         {
-            var buff = CheckLength(sizeof(ulong));
-            var val = BitConverter.ToUInt64(buff.Array, buff.Offset);
+            int offset;
+            var buff = CheckLength(sizeof(ulong), out offset);
+            var val = BitConverter.ToUInt64(buff, offset);
             Trace("--Read ulong {0}", val);
             return val;
         }
@@ -219,8 +235,9 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public float ReadFloat()
         {
-            var buff = CheckLength(sizeof(float));
-            var val = BitConverter.ToSingle(buff.Array, buff.Offset);
+            int offset;
+            var buff = CheckLength(sizeof(float), out offset);
+            var val = BitConverter.ToSingle(buff, offset);
             Trace("--Read float {0}", val);
             return val;
         }
@@ -229,8 +246,9 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public double ReadDouble()
         {
-            var buff = CheckLength(sizeof(double));
-            var val = BitConverter.ToDouble(buff.Array, buff.Offset);
+            int offset;
+            var buff = CheckLength(sizeof(double), out offset);
+            var val = BitConverter.ToDouble(buff, offset);
             Trace("--Read double {0}", val);
             return val;
         }
@@ -239,13 +257,14 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public decimal ReadDecimal()
         {
-            var buff = CheckLength(4 * sizeof(int));
+            int offset;
+            var buff = CheckLength(4 * sizeof(int), out offset);
             var raw = new int[4];
             Trace("--Read decimal");
-            var n = buff.Offset;
+            var n = offset;
             for (var i = 0; i < 4; i++)
             {
-                raw[i] = BitConverter.ToInt32(buff.Array, n);
+                raw[i] = BitConverter.ToInt32(buff, n);
                 n += sizeof(int);
             }
             return new decimal(raw);
@@ -259,15 +278,16 @@ namespace Orleans.Serialization
             if (n == 0)
             {
                 Trace("--Read empty string");
-                return String.Empty;                
+                return String.Empty;
             }
 
             string s = null;
             // a length of -1 indicates that the string is null.
             if (-1 != n)
             {
-                var buff = CheckLength(n);
-                s = Encoding.UTF8.GetString(buff.Array, buff.Offset, n);
+                int offset;
+                var buff = CheckLength(n, out offset);
+                s = Encoding.UTF8.GetString(buff, offset, n);
             }
 
             Trace("--Read string '{0}'", s);
@@ -284,17 +304,19 @@ namespace Orleans.Serialization
                 return new byte[0];
             }
             bool safeToUse;
-            var buff = CheckLength(count, out safeToUse);
+
+            int offset;
+            var buff = CheckLength(count, out offset, out safeToUse);
             Trace("--Read byte array of length {0}", count);
             if (!safeToUse)
             {
                 var result = new byte[count];
-                Array.Copy(buff.Array, buff.Offset, result, 0, count);
+                Array.Copy(buff, offset, result, 0, count);
                 return result;
             }
             else
             {
-                return buff.Array;
+                return buff;
             }
         }
 
@@ -308,8 +330,10 @@ namespace Orleans.Serialization
             {
                 throw new ArgumentOutOfRangeException("count", "Reading into an array that is too small");
             }
-            var buff = CheckLength(count);
-            Buffer.BlockCopy(buff.Array, buff.Offset, destination, offset, count);
+
+            var buffOffset = 0;
+            var buff = CheckLength(count, out buffOffset);
+            Buffer.BlockCopy(buff, buffOffset, destination, offset, count);
         }
 
         /// <summary> Read an <c>char</c> value from the stream. </summary>
@@ -324,29 +348,32 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public byte ReadByte()
         {
-            var buff = CheckLength(1);
+            int offset;
+            var buff = CheckLength(1, out offset);
             Trace("--Read byte");
-            return buff.Array[buff.Offset];
+            return buff[offset];
         }
 
         /// <summary> Read an <c>sbyte</c> value from the stream. </summary>
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public sbyte ReadSByte()
         {
-            var buff = CheckLength(1);
+            int offset;
+            var buff = CheckLength(1, out offset);
             Trace("--Read sbyte");
-            return unchecked((sbyte)(buff.Array[buff.Offset]));
+            return unchecked((sbyte)(buff[offset]));
         }
 
         /// <summary> Read an <c>IPAddress</c> value from the stream. </summary>
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public IPAddress ReadIPAddress()
         {
-            var buff = CheckLength(16);
+            int offset;
+            var buff = CheckLength(16, out offset);
             bool v4 = true;
             for (var i = 0; i < 12; i++)
             {
-                if (buff.Array[buff.Offset + i] != 0)
+                if (buff[offset + i] != 0)
                 {
                     v4 = false;
                     break;
@@ -358,7 +385,7 @@ namespace Orleans.Serialization
                 var v4Bytes = new byte[4];
                 for (var i = 0; i < 4; i++)
                 {
-                    v4Bytes[i] = buff.Array[buff.Offset + 12 + i];
+                    v4Bytes[i] = buff[offset + 12 + i];
                 }
                 return new IPAddress(v4Bytes);
             }
@@ -367,7 +394,7 @@ namespace Orleans.Serialization
                 var v6Bytes = new byte[16];
                 for (var i = 0; i < 16; i++)
                 {
-                    v6Bytes[i] = buff.Array[buff.Offset + i];
+                    v6Bytes[i] = buff[offset + i];
                 }
                 return new IPAddress(v6Bytes);
             }
@@ -425,7 +452,7 @@ namespace Orleans.Serialization
         internal MultiClusterStatus ReadMultiClusterStatus()
         {
             byte val = ReadByte();
-            return (MultiClusterStatus) val;
+            return (MultiClusterStatus)val;
         }
 
         /// <summary> Read an <c>ActivationAddress</c> value from the stream. </summary>
@@ -453,8 +480,9 @@ namespace Orleans.Serialization
         /// <param name="n">Number of bytes to read.</param>
         public void ReadBlockInto(Array array, int n)
         {
-            var buff = CheckLength(n);
-            Buffer.BlockCopy(buff.Array, buff.Offset, array, 0, n);
+            int offset;
+            var buff = CheckLength(n, out offset);
+            Buffer.BlockCopy(buff, offset, array, 0, n);
             Trace("--Read block of {0} bytes", n);
         }
 
@@ -474,9 +502,10 @@ namespace Orleans.Serialization
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         internal SerializationTokenType ReadToken()
         {
-            var buff = CheckLength(1);
-            Trace("--Read token {0}", (SerializationTokenType)buff.Array[buff.Offset]);
-            return (SerializationTokenType)buff.Array[buff.Offset];
+            int offset;
+            var buff = CheckLength(1, out offset);
+            Trace("--Read token {0}", (SerializationTokenType)buff[offset]);
+            return (SerializationTokenType)buff[offset];
         }
 
         internal bool TryReadSimpleType(out object result, out SerializationTokenType token)


### PR DESCRIPTION
BinaryTokenStreamReader's <code>CheckLength</code> method takes ~21% of deserialization time (tested on simple POCO) due to excessive usage of <code>ArraySegment</code>'s properties: <code>Offset</code>, <code>Array</code> and <code>Count</code>.

![dottraceview64_2016-07-30_00-11-32](https://cloud.githubusercontent.com/assets/5787619/17269302/5cba5ad0-564d-11e6-9bca-0bb27c09644c.png)

During rewrite was removed repeatable accessing of the properties and unnecessary construction of the <code>ArraySegment</code> on each call. 

Results after:

![dottraceview64_2016-07-30_00-06-32](https://cloud.githubusercontent.com/assets/5787619/17269307/71eec648-564d-11e6-8f2e-f40ea9cab58b.png)
