### PR TITLE
Optionally configure Dependency Injection container using delegate.

### DIFF
--- a/src/Orleans/Configuration/NodeConfiguration.cs
+++ b/src/Orleans/Configuration/NodeConfiguration.cs
@@ -9,6 +9,8 @@ using System.Xml;
 
 namespace Orleans.Runtime.Configuration
 {
+    using Microsoft.Extensions.DependencyInjection;
+
     /// <summary>
     /// Individual node-specific silo configuration parameters.
     /// </summary>
@@ -172,6 +174,11 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public string StartupTypeName { get; set; }
 
+        /// <summary>
+        /// Specifies the name of the Startup class in the configuration file.
+        /// </summary>
+        public Func<IServiceCollection, IServiceProvider> ServiceProviderBuilder { get; set; }
+
         public string StatisticsProviderName { get; set; }
         /// <summary>
         /// The MetricsTableWriteInterval attribute specifies the frequency of updating the metrics in Azure table.
@@ -329,6 +336,7 @@ namespace Orleans.Runtime.Configuration
             UseNagleAlgorithm = other.UseNagleAlgorithm;
 
             StartupTypeName = other.StartupTypeName;
+            ServiceProviderBuilder = other.ServiceProviderBuilder;
             AdditionalAssemblyDirectories = other.AdditionalAssemblyDirectories;
         }
 

--- a/src/Orleans/project.json
+++ b/src/Orleans/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "Newtonsoft.Json": "7.0.1"
+    "Newtonsoft.Json": "7.0.1",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0"
   },
   "frameworks": {
     "net451": {}

--- a/src/OrleansRuntime/Startup/StartupBuilder.cs
+++ b/src/OrleansRuntime/Startup/StartupBuilder.cs
@@ -2,24 +2,38 @@
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Runtime.MembershipService;
-using Orleans.Runtime.ReminderService;
 
 namespace Orleans.Runtime.Startup
 {
+    using Orleans.Runtime.Configuration;
+
     /// <summary>
     /// Configure dependency injection at startup
     /// </summary>
     internal class StartupBuilder
     {
-        internal static IServiceProvider ConfigureStartup(string startupTypeName, out bool usingCustomServiceProvider)
+        internal static IServiceProvider ConfigureStartup(NodeConfiguration config, Action<IServiceCollection> configureServices, out bool usingCustomServiceProvider)
         {
-            usingCustomServiceProvider = false;
-            IServiceCollection serviceCollection = new ServiceCollection();
+            if (config.ServiceProviderBuilder != null)
+            {
+                if (!string.IsNullOrWhiteSpace(config.StartupTypeName))
+                {
+                    throw new ArgumentException($"Only one of {nameof(config.ServiceProviderBuilder)} and {nameof(config.StartupTypeName)} may be specified.");
+                }
+
+                return ConfigureStartup(config.ServiceProviderBuilder, configureServices, out usingCustomServiceProvider);
+            }
+
+            return ConfigureStartup(config.StartupTypeName, configureServices, out usingCustomServiceProvider);
+        }
+
+        private static IServiceProvider ConfigureStartup(string startupTypeName, Action<IServiceCollection> configureServices, out bool usingCustomServiceProvider)
+        {
+            var hasValidServiceBuilderMethod = false;
             ConfigureServicesBuilder servicesMethod = null;
             Type startupType = null;
 
-            if (!String.IsNullOrWhiteSpace(startupTypeName))
+            if (!string.IsNullOrWhiteSpace(startupTypeName))
             {
                 startupType = Type.GetType(startupTypeName);
                 if (startupType == null)
@@ -30,30 +44,32 @@ namespace Orleans.Runtime.Startup
                 servicesMethod = FindConfigureServicesDelegate(startupType);
                 if (servicesMethod != null && !servicesMethod.MethodInfo.IsStatic)
                 {
-                    usingCustomServiceProvider = true;
+                    hasValidServiceBuilderMethod = true;
                 }
             }
-
-            RegisterSystemTypes(serviceCollection);
-
-            if (usingCustomServiceProvider)
+            Func<IServiceCollection, IServiceProvider> serviceProviderBuilder = null;
+            if (hasValidServiceBuilderMethod)
             {
                 var instance = Activator.CreateInstance(startupType);
-                return servicesMethod.Build(instance, serviceCollection);
+                serviceProviderBuilder = serviceCollection => servicesMethod.Build(instance, serviceCollection);
+            }
+
+            return ConfigureStartup(serviceProviderBuilder, configureServices, out usingCustomServiceProvider);
+        }
+
+        private static IServiceProvider ConfigureStartup(Func<IServiceCollection, IServiceProvider> serviceProviderBuilder, Action<IServiceCollection> configureServices, out bool usingCustomServiceProvider)
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+            configureServices(serviceCollection);
+
+            usingCustomServiceProvider = serviceProviderBuilder != null;
+            if (usingCustomServiceProvider)
+            {
+                return serviceProviderBuilder(serviceCollection);
             }
 
             return serviceCollection.BuildServiceProvider();
         }
-
-        private static void RegisterSystemTypes(IServiceCollection serviceCollection)
-        {
-            // Register the system classes and grains in this method.
-            // Note: this method will probably have to be moved out into the Silo class to include internal runtime types.
-
-            serviceCollection.AddTransient<GrainBasedMembershipTable>();
-            serviceCollection.AddTransient<GrainBasedReminderTable>();
-        }
-
         private static ConfigureServicesBuilder FindConfigureServicesDelegate(Type startupType)
         {
             var servicesMethod = FindMethod(startupType, "ConfigureServices", typeof(IServiceProvider), false);

--- a/src/OrleansTestingHost/AppDomainSiloCreator.cs
+++ b/src/OrleansTestingHost/AppDomainSiloCreator.cs
@@ -1,0 +1,22 @@
+namespace Orleans.TestingHost
+{
+    using System;
+
+    using Orleans.Runtime;
+    using Orleans.Runtime.Configuration;
+
+    public class AppDomainSiloCreator : MarshalByRefObject
+    {
+        public AppDomainSiloCreator(string siloName, Silo.SiloType type, ClusterConfiguration config)
+        {
+            this.Silo = new Silo(siloName, type, config);
+        }
+
+        protected AppDomainSiloCreator() { }
+
+        /// <summary>
+        /// Gets the silo instance.
+        /// </summary>
+        public Silo Silo { get; protected set; }
+    }
+}

--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -49,6 +49,7 @@
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AppDomainSiloCreator.cs" />
     <Compile Include="Extensions\ConfigurationExtensions.cs" />
     <Compile Include="Extensions\TestConfigurationExtensions.cs" />
     <Compile Include="OrleansTestSecrets.cs" />


### PR DESCRIPTION
This PR allows Dependency Injection to be configured using a delegate instead of only the `StartupTypeName` method used today. The existing method is still available. They are mutually exclusive and an exception will be thrown is a user tries to set both.

Delegate-based configuration allows for much more flexibility over the existing system, which requires the use of static variables to provide runtime configuration. Eg, how do I provide services from an existing container (maybe shared with ASP.NET) using the current system? The only answer I can come up with is to use global static variables - which clearly wont suffice.