### PR TITLE
Avoid SiloStatus enum boxing

### DIFF
--- a/src/Orleans/Runtime/SiloStatus.cs
+++ b/src/Orleans/Runtime/SiloStatus.cs
@@ -39,7 +39,7 @@
         /// </summary>
         public static bool IsTerminating(this SiloStatus siloStatus)
         {
-            return siloStatus.Equals(SiloStatus.ShuttingDown) || siloStatus.Equals(SiloStatus.Stopping) || siloStatus.Equals(SiloStatus.Dead);
+            return siloStatus == SiloStatus.ShuttingDown || siloStatus == SiloStatus.Stopping || siloStatus == SiloStatus.Dead;
         }
     }
 }

--- a/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans/SystemTargetInterfaces/IMembershipTable.cs
@@ -150,8 +150,8 @@ namespace Orleans
             list.Sort(
                (x, y) =>
                {
-                   if (x.Item1.Status.Equals(SiloStatus.Dead)) return 1; // put Deads at the end
-                   if (y.Item1.Status.Equals(SiloStatus.Dead)) return -1; // put Deads at the end
+                   if (x.Item1.Status == SiloStatus.Dead) return 1; // put Deads at the end
+                   if (y.Item1.Status == SiloStatus.Dead) return -1; // put Deads at the end
                    return String.Compare(x.Item1.SiloName, y.Item1.SiloName, StringComparison.Ordinal);
                });
             Members = list.AsReadOnly();

--- a/src/OrleansRuntime/ConsistentRing/ConsistentRingProvider.cs
+++ b/src/OrleansRuntime/ConsistentRing/ConsistentRingProvider.cs
@@ -300,7 +300,7 @@ namespace Orleans.Runtime.ConsistentRing
                 {
                     RemoveServer(updatedSilo);
                 }
-                else if (status.Equals(SiloStatus.Active))      // do not do anything with SiloStatus.Created or SiloStatus.Joining -- wait until it actually becomes active
+                else if (status == SiloStatus.Active)      // do not do anything with SiloStatus.Created or SiloStatus.Joining -- wait until it actually becomes active
                 {
                     AddServer(updatedSilo);
                 }

--- a/src/OrleansRuntime/ConsistentRing/VirtualBucketsRingProvider.cs
+++ b/src/OrleansRuntime/ConsistentRing/VirtualBucketsRingProvider.cs
@@ -232,7 +232,7 @@ namespace Orleans.Runtime.ConsistentRing
                 {
                     RemoveServer(updatedSilo);
                 }
-                else if (status.Equals(SiloStatus.Active))      // do not do anything with SiloStatus.Created or SiloStatus.Joining -- wait until it actually becomes active
+                else if (status == SiloStatus.Active)      // do not do anything with SiloStatus.Created or SiloStatus.Joining -- wait until it actually becomes active
                 {
                     AddServer(updatedSilo);
                 }

--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -30,7 +30,7 @@ namespace Orleans.Runtime.Management
             var table = await mTable.ReadAll();
             
             var t = onlyActive ? 
-                table.Members.Where(item => item.Item1.Status.Equals(SiloStatus.Active)).ToDictionary(item => item.Item1.SiloAddress, item => item.Item1.Status) :
+                table.Members.Where(item => item.Item1.Status == SiloStatus.Active).ToDictionary(item => item.Item1.SiloAddress, item => item.Item1.Status) :
                 table.Members.ToDictionary(item => item.Item1.SiloAddress, item => item.Item1.Status);
             return t;
         }
@@ -45,7 +45,7 @@ namespace Orleans.Runtime.Management
             if (onlyActive)
             {
                 return table.Members
-                    .Where(item => item.Item1.Status.Equals(SiloStatus.Active))
+                    .Where(item => item.Item1.Status == SiloStatus.Active)
                     .Select(x => x.Item1)
                     .ToArray();
             }

--- a/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
@@ -371,7 +371,7 @@ namespace Orleans.Runtime.GrainDirectory
             // This silo's status has changed
             if (Equals(updatedSilo, MyAddress))
             {
-                if (status == SiloStatus.Stopping || status.Equals(SiloStatus.ShuttingDown))
+                if (status == SiloStatus.Stopping || status == SiloStatus.ShuttingDown)
                 {
                     // QueueAction up the "Stop" to run on a system turn
                     Scheduler.QueueAction(() => Stop(true), CacheValidator.SchedulingContext).Ignore();
@@ -389,7 +389,7 @@ namespace Orleans.Runtime.GrainDirectory
                     // QueueAction up the "Remove" to run on a system turn
                     Scheduler.QueueAction(() => RemoveServer(updatedSilo, status), CacheValidator.SchedulingContext).Ignore();
                 }
-                else if (status.Equals(SiloStatus.Active))      // do not do anything with SiloStatus.Starting -- wait until it actually becomes active
+                else if (status == SiloStatus.Active)      // do not do anything with SiloStatus.Starting -- wait until it actually becomes active
                 {
                     // QueueAction up the "Remove" to run on a system turn
                     Scheduler.QueueAction(() => AddServer(updatedSilo), CacheValidator.SchedulingContext).Ignore();

--- a/src/OrleansRuntime/MembershipService/MembershipOracle.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipOracle.cs
@@ -253,7 +253,7 @@ namespace Orleans.Runtime.MembershipService
 
         private bool IsFunctionalMBR(SiloStatus status)
         {
-            return status.Equals(SiloStatus.Active) || status.Equals(SiloStatus.ShuttingDown) || status.Equals(SiloStatus.Stopping);
+            return status == SiloStatus.Active || status == SiloStatus.ShuttingDown || status == SiloStatus.Stopping;
         }
 
         public bool IsFunctionalDirectory(SiloAddress silo)
@@ -400,7 +400,7 @@ namespace Orleans.Runtime.MembershipService
         private async Task<bool> TryUpdateMyStatusGlobalOnce(SiloStatus newStatus)
         {
             MembershipTableData table;
-            if (newStatus.Equals(SiloStatus.Active))
+            if (newStatus == SiloStatus.Active)
             {
                 table = await membershipTableProvider.ReadAll();
             }
@@ -440,7 +440,7 @@ namespace Orleans.Runtime.MembershipService
             myEntry.Status = newStatus;
             myEntry.IAmAliveTime = now;
 
-            if (newStatus.Equals(SiloStatus.Active) && orleansConfig.Globals.ValidateInitialConnectivity)
+            if (newStatus == SiloStatus.Active && orleansConfig.Globals.ValidateInitialConnectivity)
                 await GetJoiningPreconditionPromise(table);
             
             TableVersion next = table.Version.Next();
@@ -454,12 +454,12 @@ namespace Orleans.Runtime.MembershipService
         {
             // send pings to all Active nodes, that are known to be alive
             List<MembershipEntry> members = table.Members.Select(tuple => tuple.Item1).Where(
-                entry => entry.Status.Equals(SiloStatus.Active) &&
+                entry => entry.Status == SiloStatus.Active &&
                         !entry.SiloAddress.Equals(MyAddress) &&
                         !HasMissedIAmAlives(entry, false)).ToList();
 
             logger.LogWithoutBulkingAndTruncating(Severity.Info, ErrorCode.MembershipSendingPreJoinPing, "About to send pings to {0} nodes in order to validate communication in the Joining state. Pinged nodes = {1}",
-                members.Count, Utils.EnumerableToString(members, entry => entry.ToFullString(true)));
+                members.Count.ToString(), Utils.EnumerableToString(members, entry => entry.ToFullString(true)));
 
             var pingPromises = new List<Task>();
             foreach (var entry in members)
@@ -543,7 +543,7 @@ namespace Orleans.Runtime.MembershipService
         {
             foreach (var entry in table.Members.Select(tuple => tuple.Item1).
                                                             Where(entry => !entry.SiloAddress.Equals(MyAddress)).
-                                                            Where(entry => entry.Status.Equals(SiloStatus.Active)))
+                                                            Where(entry => entry.Status == SiloStatus.Active))
             {
                 HasMissedIAmAlives(entry, true);
             }
@@ -959,20 +959,20 @@ namespace Orleans.Runtime.MembershipService
             // get all valid (non-expired) votes
             var freshVotes = entry.GetFreshVotes(orleansConfig.Globals.DeathVoteExpirationTimeout);
 
-            if (logger.IsVerbose2) logger.Verbose2("-Current number of fresh Voters for {0} is {1}", silo.ToLongString(), freshVotes.Count);
+            if (logger.IsVerbose2) logger.Verbose2("-Current number of fresh Voters for {0} is {1}", silo.ToLongString(), freshVotes.Count.ToString());
 
             if (freshVotes.Count >= orleansConfig.Globals.NumVotesForDeathDeclaration)
             {
                 // this should not happen ...
                 var str = String.Format("-Silo {0} is suspected by {1} which is more or equal than {2}, but is not marked as dead. This is a bug!!!",
-                    entry.SiloAddress.ToLongString(), freshVotes.Count, orleansConfig.Globals.NumVotesForDeathDeclaration);
+                    entry.SiloAddress.ToLongString(), freshVotes.Count.ToString(), orleansConfig.Globals.NumVotesForDeathDeclaration.ToString());
                 logger.Error(ErrorCode.Runtime_Error_100053, str);
                 KillMyselfLocally("Found a bug 1! Will commit suicide.");
                 return false;
             }
 
             // handle the corner case when the number of active silos is very small (then my only vote is enough)
-            int activeSilos = membershipOracleData.GetSiloStatuses(status => status.Equals(SiloStatus.Active), true).Count;
+            int activeSilos = membershipOracleData.GetSiloStatuses(status => status == SiloStatus.Active, true).Count;
             // find if I have already voted
             int myVoteIndex = freshVotes.FindIndex(voter => MyAddress.Equals(voter.Item1));
 

--- a/src/OrleansRuntime/MembershipService/MembershipOracleData.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipOracleData.cs
@@ -70,7 +70,7 @@ namespace Orleans.Runtime.MembershipService
             {
                 if (!localTableCopy.TryGetValue(siloAddress, out status))
                 {
-                    if (CurrentStatus.Equals(SiloStatus.Active))
+                    if (CurrentStatus == SiloStatus.Active)
                         if (logger.IsVerbose) logger.Verbose(ErrorCode.Runtime_Error_100209, "-The given siloAddress {0} is not registered in this MembershipOracle.", siloAddress.ToLongString());
                     status = SiloStatus.None;
                 }
@@ -129,14 +129,14 @@ namespace Orleans.Runtime.MembershipService
 
             // make copies
             var tmpLocalTableCopy = GetSiloStatuses(st => true, true); // all the silos including me.
-            var tmpLocalTableCopyOnlyActive = GetSiloStatuses(st => st.Equals(SiloStatus.Active), true);    // only active silos including me.
+            var tmpLocalTableCopyOnlyActive = GetSiloStatuses(st => st == SiloStatus.Active, true);    // only active silos including me.
             var tmpLocalTableNamesCopy = localTable.ToDictionary(pair => pair.Key, pair => pair.Value.SiloName);   // all the silos excluding me.
 
             CurrentStatus = status;
 
             tmpLocalTableCopy[MyAddress] = status;
 
-            if (status.Equals(SiloStatus.Active))
+            if (status == SiloStatus.Active)
             {
                 tmpLocalTableCopyOnlyActive[MyAddress] = status;
             }
@@ -218,7 +218,7 @@ namespace Orleans.Runtime.MembershipService
             if (!TryUpdateStatus(entry)) return false;
 
             localTableCopy = GetSiloStatuses(status => true, true); // all the silos including me.
-            localTableCopyOnlyActive = GetSiloStatuses(status => status.Equals(SiloStatus.Active), true);    // only active silos including me.
+            localTableCopyOnlyActive = GetSiloStatuses(status => status == SiloStatus.Active, true);    // only active silos including me.
             localNamesTableCopy = localTable.ToDictionary(pair => pair.Key, pair => pair.Value.SiloName);   // all the silos excluding me.
 
             if (this.multiClusterActive)

--- a/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
+++ b/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
@@ -90,7 +90,7 @@ namespace Orleans.Runtime
         public Task UpdateRuntimeStatistics(SiloAddress siloAddress, SiloRuntimeStatistics siloStats)
         {
             if (logger.IsVerbose) logger.Verbose("UpdateRuntimeStatistics from {0}", siloAddress);
-            if (!silo.LocalSiloStatusOracle.GetApproximateSiloStatus(siloAddress).Equals(SiloStatus.Active))
+            if (silo.LocalSiloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
                 return TaskDone.Done;
 
             SiloRuntimeStatistics old;

--- a/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -83,7 +83,7 @@ namespace Orleans.Streams
         {
             var grainRef = producer as GrainReference;
             if (grainRef !=null && grainRef.GrainId.IsSystemTarget && grainRef.IsInitializedSystemTarget)
-                return RuntimeClient.Current.GetSiloStatus(grainRef.SystemTargetSilo).Equals(SiloStatus.Active);
+                return RuntimeClient.Current.GetSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Active;
             
             return true;
         }
@@ -92,7 +92,7 @@ namespace Orleans.Streams
         {
             var grainRef = producer as GrainReference;
             if (grainRef != null && grainRef.GrainId.IsSystemTarget && grainRef.IsInitializedSystemTarget)
-                return RuntimeClient.Current.GetSiloStatus(grainRef.SystemTargetSilo).Equals(SiloStatus.Dead);
+                return RuntimeClient.Current.GetSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Dead;
             
             return false;
         }

--- a/src/OrleansRuntime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
+++ b/src/OrleansRuntime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
@@ -84,7 +84,7 @@ namespace Orleans.Streams
         /// <param name="status">new silo status</param>
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
         {
-            if (status.Equals(SiloStatus.Dead))
+            if (status == SiloStatus.Dead)
             {
                 // just clean up garbage from immatureSilos.
                 bool ignore;

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -59,9 +59,9 @@ namespace UnitTests.MembershipTests
                 IPEndPoint silo = pair.Key.Endpoint;
                 if (silo.Equals(address))
                 {
-                    Assert.True(pair.Value.Equals(SiloStatus.ShuttingDown)
-                        || pair.Value.Equals(SiloStatus.Stopping)
-                        || pair.Value.Equals(SiloStatus.Dead),
+                    Assert.True(pair.Value == SiloStatus.ShuttingDown
+                        || pair.Value == SiloStatus.Stopping
+                        || pair.Value == SiloStatus.Dead,
                         string.Format("SiloStatus for {0} should now be ShuttingDown or Stopping or Dead instead of {1}", silo, pair.Value));
                 }
                 else


### PR DESCRIPTION
Using of the <code>Equals</code> on enum causes boxing:

![devenv_2016-08-04_21-37-00](https://cloud.githubusercontent.com/assets/5787619/17414260/6e5dbe3c-5a8d-11e6-9595-b4a7b3f08239.png)

Removed all instances of it's usages on <code>SiloStatus</code> enum. 