### PR TITLE
Change TextWriter.Close to Dispose

### DIFF
--- a/src/Orleans/Telemetry/Consumers/FileTelemetryConsumer.cs
+++ b/src/Orleans/Telemetry/Consumers/FileTelemetryConsumer.cs
@@ -70,7 +70,8 @@ namespace Orleans.Runtime
                         return;
                     }
                     _logOutput.Flush();
-                    _logOutput.Close();
+                    _logOutput.Dispose();
+                    _logOutput = null;
                 }
             }
             catch (Exception exc)


### PR DESCRIPTION
This is for CoreCLR compatibility.

Similar to #609 but in the new TelemetryConsumers API