### PR TITLE
Service Provider is no longer required by EventHubAdapter

### DIFF
--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -76,7 +76,6 @@ namespace Orleans.ServiceBus.Providers
             if (providerCfg == null) throw new ArgumentNullException("providerCfg");
             if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException("providerName");
             if (log == null) throw new ArgumentNullException("log");
-            if (svcProvider == null) throw new ArgumentNullException("svcProvider");
 
             providerConfig = providerCfg;
             serviceProvider = svcProvider;


### PR DESCRIPTION
Removed argument check.