### PR TITLE
[WIP] Using Microsoft.Extensions.Configuration and bindable configs for file formats.

### DIFF
--- a/src/Orleans/Configuration/New/ClientFactoryBuilder.cs
+++ b/src/Orleans/Configuration/New/ClientFactoryBuilder.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Xml;
+using Orleans.Providers;
+using System.Reflection;
+using System.Threading;
+using Orleans.Configuration.New;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.Runtime.Configuration.New
+{
+    /// <summary>
+    /// Orleans client configuration parameters.
+    /// </summary>
+    public class ClientFactoryBuilder
+    {
+        /// <summary>
+        /// The name of this client.
+        /// </summary>
+        public static string ClientName = "Client";
+        
+        private readonly DateTime creationTimestamp;
+
+        public string SourceFile { get; private set; }
+
+        /// <summary>
+        /// The list fo the gateways to use.
+        /// Each GatewayNode element specifies an outside grain client gateway node.
+        /// If outside (non-Orleans) clients are to connect to the Orleans system, then at least one gateway node must be specified.
+        /// Additional gateway nodes may be specified if desired, and will add some failure resilience and scalability.
+        /// If multiple gateways are specified, then each client will select one from the list at random.
+        /// </summary>
+        public List<IPEndPoint> Gateways { get; } = new List<IPEndPoint>();
+        /// <summary>
+        /// </summary>
+        public int PreferedGatewayIndex { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        public string DNSHostName { get; private set; } // This is a true host name, no IP address. It is NOT settable, equals Dns.GetHostName().
+        /// <summary>
+        /// </summary>
+        public TimeSpan GatewayListRefreshPeriod { get; set; }
+        
+        public LimitManager LimitManager { get; private set; }
+        /// <summary>
+        /// </summary>
+        public ClientConfiguration.GatewayProviderType GatewayProvider { get; set; }
+
+        private static readonly TimeSpan DEFAULT_GATEWAY_LIST_REFRESH_PERIOD = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// </summary>
+        public bool UseAzureSystemStore 
+        { 
+            get { 
+                return GatewayProvider == Configuration.ClientConfiguration.GatewayProviderType.AzureTable 
+                       && !String.IsNullOrWhiteSpace(Settings.SystemStore.DeploymentId) 
+                       && !String.IsNullOrWhiteSpace(Settings.SystemStore.DataConnectionString); 
+            } 
+        }
+
+        /// <summary>
+        /// </summary>
+        public bool UseSqlSystemStore
+        {
+            get
+            {
+                return GatewayProvider == Configuration.ClientConfiguration.GatewayProviderType.SqlServer
+                && !String.IsNullOrWhiteSpace(Settings.SystemStore.DeploymentId)
+                && !String.IsNullOrWhiteSpace(Settings.SystemStore.DataConnectionString);
+            }
+        }
+
+        private bool HasStaticGateways { get { return Gateways != null && Gateways.Count > 0; } }
+        /// <summary>
+        /// </summary>
+        public IDictionary<string, ProviderCategoryConfiguration> ProviderConfigurations { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        public ClientFactoryBuilder()
+        {
+            creationTimestamp = DateTime.UtcNow;
+            SourceFile = null;
+            PreferedGatewayIndex = -1;
+            Gateways = new List<IPEndPoint>();
+            DNSHostName = Dns.GetHostName();
+
+            GatewayListRefreshPeriod = DEFAULT_GATEWAY_LIST_REFRESH_PERIOD;
+            LimitManager = new LimitManager();
+            ProviderConfigurations = new Dictionary<string, ProviderCategoryConfiguration>();
+        }
+        
+        
+        public ClientFactorySettings Settings { get; private set; }
+
+        public void Build(ClientFactorySettings client)
+        {
+            Settings = client;
+
+            foreach(var gateway in Settings.Gateways)
+            {
+                Gateways.Add(gateway.ParseIPEndPoint().GetResult());
+                if (GatewayProvider == ClientConfiguration.GatewayProviderType.None)
+                {
+                    GatewayProvider = ClientConfiguration.GatewayProviderType.Config;
+                }
+            }
+                        
+            if (Settings.SystemStore.SystemStoreType.HasValue)
+            {
+                GatewayProvider = Settings.SystemStore.SystemStoreType.Value;
+            }
+            if (!string.IsNullOrEmpty(Settings.SystemStore.CustomGatewayProviderAssemblyName))
+            {
+                if (Settings.SystemStore.CustomGatewayProviderAssemblyName.EndsWith(".dll"))
+                    throw new FormatException("Use fully qualified assembly name for \"CustomGatewayProviderAssemblyName\"");
+                if (GatewayProvider != ClientConfiguration.GatewayProviderType.Custom)
+                    throw new FormatException("SystemStoreType should be \"Custom\" when CustomGatewayProviderAssemblyName is specified");
+            }
+            if (!string.IsNullOrEmpty(Settings.SystemStore.DataConnectionString))
+            { 
+                if (GatewayProvider == ClientConfiguration.GatewayProviderType.None)
+                {
+                    // Assume the connection string is for Azure storage if not explicitly specified
+                    GatewayProvider = ClientConfiguration.GatewayProviderType.AzureTable;
+                }
+            }
+                    
+                            //ConfigUtilities.ParseTelemetry(child);
+                       
+        }
+
+        /// <summary>
+        /// Registers a given type of <typeparamref name="T"/> where <typeparamref name="T"/> is stream provider
+        /// </summary>
+        /// <typeparam name="T">Non-abstract type which implements <see cref="Orleans.Streams.IStreamProvider"/> stream</typeparam>
+        /// <param name="providerName">Name of the stream provider</param>
+        /// <param name="properties">Properties that will be passed to stream provider upon initialization</param>
+        public void RegisterStreamProvider<T>(string providerName, IDictionary<string, string> properties = null) where T : Orleans.Streams.IStreamProvider
+        {
+            TypeInfo providerTypeInfo = typeof(T).GetTypeInfo();
+            if (providerTypeInfo.IsAbstract ||
+                providerTypeInfo.IsGenericType ||
+                !typeof(Orleans.Streams.IStreamProvider).IsAssignableFrom(typeof(T)))
+                throw new ArgumentException("Expected non-generic, non-abstract type which implements IStreamProvider interface", "typeof(T)");
+
+            ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, providerTypeInfo.FullName, providerName, properties);
+        }
+
+        /// <summary>
+        /// Registers a given stream provider.
+        /// </summary>
+        /// <param name="providerTypeFullName">Full name of the stream provider type</param>
+        /// <param name="providerName">Name of the stream provider</param>
+        /// <param name="properties">Properties that will be passed to the stream provider upon initialization </param>
+        public void RegisterStreamProvider(string providerTypeFullName, string providerName, IDictionary<string, string> properties = null)
+        {
+            ProviderConfigurationUtility.RegisterProvider(ProviderConfigurations, ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, providerTypeFullName, providerName, properties);
+        }
+
+        /// <summary>
+        /// Retrieves an existing provider configuration
+        /// </summary>
+        /// <param name="providerTypeFullName">Full name of the stream provider type</param>
+        /// <param name="providerName">Name of the stream provider</param>
+        /// <param name="config">The provider configuration, if exists</param>
+        /// <returns>True if a configuration for this provider already exists, false otherwise.</returns>
+        public bool TryGetProviderConfiguration(string providerTypeFullName, string providerName, out IProviderConfiguration config)
+        {
+            return ProviderConfigurationUtility.TryGetProviderConfiguration(ProviderConfigurations, providerTypeFullName, providerName, out config);
+        }
+
+        /// <summary>
+        /// Retrieves an enumeration of all currently configured provider configurations.
+        /// </summary>
+        /// <returns>An enumeration of all currently configured provider configurations.</returns>
+        public IEnumerable<IProviderConfiguration> GetAllProviderConfigurations()
+        {
+            return ProviderConfigurationUtility.GetAllProviderConfigurations(ProviderConfigurations);
+        }
+        
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("Platform version info:").Append(ConfigUtilities.RuntimeVersionInfo());
+            sb.Append("   Host: ").AppendLine(Dns.GetHostName());
+            sb.Append("   Processor Count: ").Append(System.Environment.ProcessorCount).AppendLine();
+
+            sb.AppendLine("Client Configuration:");
+            sb.Append("   Config File Name: ").AppendLine(string.IsNullOrEmpty(SourceFile) ? "" : Path.GetFullPath(SourceFile));
+            sb.Append("   Start time: ").AppendLine(LogFormatter.PrintDate(DateTime.UtcNow));
+            sb.Append("   Gateway Provider: ").Append(GatewayProvider);
+            if (GatewayProvider == Configuration.ClientConfiguration.GatewayProviderType.None)
+            {
+                sb.Append(".   Gateway Provider that will be used instead: ").Append(GatewayProviderToUse);
+            }
+            sb.AppendLine();
+            if (Gateways != null && Gateways.Count > 0 )
+            {
+                sb.AppendFormat("   Gateways[{0}]:", Gateways.Count).AppendLine();
+                foreach (var endpoint in Gateways)
+                {
+                    sb.Append("      ").AppendLine(endpoint.ToString());
+                }
+            }
+            else
+            {
+                sb.Append("   Gateways: ").AppendLine("Unspecified");
+            }
+            sb.Append("   Preferred Gateway Index: ").AppendLine(PreferedGatewayIndex.ToString());
+            if (Gateways != null && PreferedGatewayIndex >= 0 && PreferedGatewayIndex < Gateways.Count)
+            {
+                sb.Append("   Preferred Gateway Address: ").AppendLine(Gateways[PreferedGatewayIndex].ToString());
+            }
+            sb.Append("   GatewayListRefreshPeriod: ").Append(GatewayListRefreshPeriod).AppendLine();
+            if (!String.IsNullOrEmpty(Settings.SystemStore.DeploymentId) || !String.IsNullOrEmpty(Settings.SystemStore.DataConnectionString))
+            {
+                sb.Append("   Azure:").AppendLine();
+                sb.Append("      DeploymentId: ").Append(Settings.SystemStore.DeploymentId).AppendLine();
+                string dataConnectionInfo = ConfigUtilities.RedactConnectionStringInfo(Settings.SystemStore.DataConnectionString); // Don't print Azure account keys in log files
+                sb.Append("      DataConnectionString: ").Append(dataConnectionInfo).AppendLine();
+            }
+            if (!string.IsNullOrWhiteSpace(Settings.LocalAddress.Interface))
+            {
+                sb.Append("   Network Interface: ").AppendLine(Settings.LocalAddress.Interface);
+            }
+            if (Settings.LocalAddress.Port != 0)
+            {
+                sb.Append("   Network Port: ").Append(Settings.LocalAddress.Port).AppendLine();
+            }
+            sb.Append("   Preferred Address Family: ").AppendLine(Settings.LocalAddress.PreferredFamily.ToString());
+            sb.Append("   DNS Host Name: ").AppendLine(DNSHostName);
+            sb.Append("   Client Name: ").AppendLine(ClientName);
+            sb.Append(Settings.Tracing);
+            sb.Append(Settings.Statistics);
+            sb.Append(LimitManager);
+            sb.AppendFormat(base.ToString());
+            sb.Append("   .NET: ").AppendLine();
+            int workerThreads;
+            int completionPortThreads;
+            ThreadPool.GetMinThreads(out workerThreads, out completionPortThreads);
+            sb.AppendFormat("       .NET thread pool sizes - Min: Worker Threads={0} Completion Port Threads={1}", workerThreads, completionPortThreads).AppendLine();
+            ThreadPool.GetMaxThreads(out workerThreads, out completionPortThreads);
+            sb.AppendFormat("       .NET thread pool sizes - Max: Worker Threads={0} Completion Port Threads={1}", workerThreads, completionPortThreads).AppendLine();
+            sb.AppendFormat("   Providers:").AppendLine();
+            sb.Append(ProviderConfigurationUtility.PrintProviderConfigurations(ProviderConfigurations));
+            return sb.ToString();
+        }
+
+        internal Configuration.ClientConfiguration.GatewayProviderType GatewayProviderToUse
+        {
+            get
+            {
+                // order is important here for establishing defaults.
+                if (GatewayProvider != Configuration.ClientConfiguration.GatewayProviderType.None) return GatewayProvider;
+                if (UseAzureSystemStore) return Configuration.ClientConfiguration.GatewayProviderType.AzureTable;
+                return HasStaticGateways ? Configuration.ClientConfiguration.GatewayProviderType.Config : Configuration.ClientConfiguration.GatewayProviderType.None;
+            }
+        }
+
+        internal void CheckGatewayProviderSettings()
+        {
+            switch (GatewayProvider)
+            {
+                case Configuration.ClientConfiguration.GatewayProviderType.AzureTable:
+                    if (!UseAzureSystemStore)
+                        throw new ArgumentException("Config specifies Azure based GatewayProviderType, but Azure element is not specified or not complete.", "GatewayProvider");
+                    break;
+                case Configuration.ClientConfiguration.GatewayProviderType.Config:
+                    if (!HasStaticGateways)
+                        throw new ArgumentException("Config specifies Config based GatewayProviderType, but Gateway element(s) is/are not specified.", "GatewayProvider");
+                    break;
+                case Configuration.ClientConfiguration.GatewayProviderType.Custom:
+                    if (String.IsNullOrEmpty(Settings.SystemStore.CustomGatewayProviderAssemblyName))
+                        throw new ArgumentException("Config specifies Custom GatewayProviderType, but CustomGatewayProviderAssemblyName attribute is not specified", "GatewayProvider");
+                    break;
+                case Configuration.ClientConfiguration.GatewayProviderType.None:
+                    if (!UseAzureSystemStore && !HasStaticGateways)
+                        throw new ArgumentException("Config does not specify GatewayProviderType, and also does not have the adequate defaults: no Azure and or Gateway element(s) are specified.","GatewayProvider");
+                    break;
+                case Configuration.ClientConfiguration.GatewayProviderType.SqlServer:
+                    if (!UseSqlSystemStore)
+                        throw new ArgumentException("Config specifies SqlServer based GatewayProviderType, but DeploymentId or DataConnectionString are not specified or not complete.", "GatewayProvider");
+                    break;
+                case Configuration.ClientConfiguration.GatewayProviderType.ZooKeeper:
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Retuurns a ClientConfiguration object for connecting to a local silo (for testing).
+        /// </summary>
+        /// <param name="gatewayPort">Client gateway TCP port</param>
+        /// <returns>ClientConfiguration object that can be passed to GrainClient class for initialization</returns>
+        public static ClientConfiguration LocalhostSilo(int gatewayPort = 40000)
+        {
+            var config = new ClientConfiguration {GatewayProvider = Configuration.ClientConfiguration.GatewayProviderType.Config};
+            config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, gatewayPort));
+
+            return config;
+        }
+    }
+}

--- a/src/Orleans/Configuration/New/ClientFactorySettings.cs
+++ b/src/Orleans/Configuration/New/ClientFactorySettings.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Orleans.Configuration.New;
+
+namespace Orleans.Runtime.Configuration.New
+{
+    public class ClientFactorySettings
+    {
+
+        public Messaging Messaging { get; set; } = new Messaging();
+        public Tracing Tracing { get; set; } = new Tracing();
+        public Statistics Statistics { get; set; } = new Statistics();
+        public List<Gateway> Gateways { get; set; } = new List<Gateway>();
+        public SystemStore SystemStore { get; set; } = new SystemStore();
+        public List<LimitValue> Limits { get; set; } = new List<LimitValue>();
+        public LocalAddress LocalAddress { get; set; } = new LocalAddress();
+        
+    }
+}

--- a/src/Orleans/Configuration/New/Gateway.cs
+++ b/src/Orleans/Configuration/New/Gateway.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.Configuration.New
+{
+    public class Gateway
+    {
+        public string Address { get; set; }
+        public int? Port { get; set; }
+        public string Subnet { get; set; }
+        public string PreferredFamily { get; set; }
+
+        internal async Task<IPEndPoint> ParseIPEndPoint()
+        {
+            if (string.IsNullOrEmpty(Address)) throw new FormatException("Missing Address attribute");
+            if (Port == null) throw new FormatException("Missing Port attribute");
+            
+            var family = AddressFamily.InterNetwork;
+            byte[] subnet = null;
+            if (!string.IsNullOrEmpty(Subnet))
+            {
+                subnet = ConfigUtilities.ParseSubnet(Subnet, "Invalid subnet");
+            }
+            if (!string.IsNullOrEmpty(PreferredFamily))
+            {
+                family = ConfigUtilities.ParseEnum<AddressFamily>(PreferredFamily, "Invalid preferred addressing family");
+            }
+            IPAddress addr = await ClusterConfiguration.ResolveIPAddress(Address, subnet, family);
+            return new IPEndPoint(addr, Port.Value);
+        }
+    }
+}

--- a/src/Orleans/Configuration/New/LocalAddress.cs
+++ b/src/Orleans/Configuration/New/LocalAddress.cs
@@ -1,0 +1,28 @@
+﻿using System.Net.Sockets;
+
+namespace Orleans.Configuration.New
+{
+    public class LocalAddress
+    {
+        public LocalAddress()
+        {
+            PreferredFamily = AddressFamily.InterNetwork;
+            Interface = null;
+            Port = 0;
+        }
+
+        /// <summary>
+        /// </summary>
+        public AddressFamily PreferredFamily { get; set; }
+        
+        /// <summary>
+        /// The Interface attribute specifies the name of the network interface to use to work out an IP address for this machine.
+        /// </summary>
+        public string Interface { get; set; }
+        /// <summary>
+        /// The Port attribute specifies the specific listen port for this client machine.
+        /// If value is zero, then a random machine-assigned port number will be used.
+        /// </summary>
+        public int Port { get; set; }
+    }
+}

--- a/src/Orleans/Configuration/New/Messaging.cs
+++ b/src/Orleans/Configuration/New/Messaging.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Xml;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.Runtime.Configuration.New
+{
+    /// <summary>
+    /// Messaging configuration that are common to client and silo.
+    /// </summary>
+    [Serializable]
+    public class Messaging
+    {
+        public TimeSpan ResponseTimeout { get; set; }
+        public int MaxResendCount { get; set; }
+        public bool ResendOnTimeout { get; set; }
+        public TimeSpan MaxSocketAge { get; set; }
+        public bool DropExpiredMessages { get; set; }
+
+        public int SiloSenderQueues { get; set; }
+        public int GatewaySenderQueues { get; set; }
+        public int ClientSenderBuckets { get; set; }
+        public TimeSpan ClientDropTimeout { get; set; }
+        public bool UseStandardSerializer { get; set; }
+        public bool UseJsonFallbackSerializer { get; set; }
+
+        public int BufferPoolBufferSize { get; set; }
+        public int BufferPoolMaxSize { get; set; }
+        public int BufferPoolPreallocationSize { get; set; }
+
+        public bool UseMessageBatching { get; set; }
+        public int MaxMessageBatchingSize { get; set; }
+
+        /// <summary>
+        /// The MaxForwardCount attribute specifies the maximal number of times a message is being forwared from one silo to another.
+        /// Forwarding is used internally by the tuntime as a recovery mechanism when silos fail and the membership is unstable.
+        /// In such times the messages might not be routed correctly to destination, and runtime attempts to forward such messages a number of times before rejecting them.
+        /// </summary>
+        public int MaxForwardCount { get; set; }
+
+        public List<string> SerializationProviders { get; set; } = new List<string>();
+        internal double RejectionInjectionRate { get; set; }
+        internal double MessageLossInjectionRate { get; set; }
+
+        private static readonly TimeSpan DEFAULT_MAX_SOCKET_AGE = TimeSpan.MaxValue;
+        internal const int DEFAULT_MAX_FORWARD_COUNT = 2;
+        private const bool DEFAULT_RESEND_ON_TIMEOUT = false;
+        private const bool DEFAULT_USE_STANDARD_SERIALIZER = false;
+        private static readonly int DEFAULT_SILO_SENDER_QUEUES = Environment.ProcessorCount;
+        private static readonly int DEFAULT_GATEWAY_SENDER_QUEUES = Environment.ProcessorCount;
+        private static readonly int DEFAULT_CLIENT_SENDER_BUCKETS = (int)Math.Pow(2, 13);
+
+        private const int DEFAULT_BUFFER_POOL_BUFFER_SIZE = 4 * 1024;
+        private const int DEFAULT_BUFFER_POOL_MAX_SIZE = 10000;
+        private const int DEFAULT_BUFFER_POOL_PREALLOCATION_SIZE = 250;
+        private const bool DEFAULT_DROP_EXPIRED_MESSAGES = true;
+        private const double DEFAULT_ERROR_INJECTION_RATE = 0.0;
+        private const bool DEFAULT_USE_MESSAGE_BATCHING = false;
+        private const int DEFAULT_MAX_MESSAGE_BATCH_SIZE = 10;
+
+        private readonly bool isSiloConfig;
+
+        public Messaging()
+        {
+            //TODO: fix
+            isSiloConfig = false;
+
+            ResponseTimeout = Constants.DEFAULT_RESPONSE_TIMEOUT;
+            MaxResendCount = 0;
+            ResendOnTimeout = DEFAULT_RESEND_ON_TIMEOUT;
+            MaxSocketAge = DEFAULT_MAX_SOCKET_AGE;
+            DropExpiredMessages = DEFAULT_DROP_EXPIRED_MESSAGES;
+
+            SiloSenderQueues = DEFAULT_SILO_SENDER_QUEUES;
+            GatewaySenderQueues = DEFAULT_GATEWAY_SENDER_QUEUES;
+            ClientSenderBuckets = DEFAULT_CLIENT_SENDER_BUCKETS;
+            ClientDropTimeout = Constants.DEFAULT_CLIENT_DROP_TIMEOUT;
+            UseStandardSerializer = DEFAULT_USE_STANDARD_SERIALIZER;
+
+            BufferPoolBufferSize = DEFAULT_BUFFER_POOL_BUFFER_SIZE;
+            BufferPoolMaxSize = DEFAULT_BUFFER_POOL_MAX_SIZE;
+            BufferPoolPreallocationSize = DEFAULT_BUFFER_POOL_PREALLOCATION_SIZE;
+
+            if (isSiloConfig)
+            {
+                MaxForwardCount = DEFAULT_MAX_FORWARD_COUNT;
+                RejectionInjectionRate = DEFAULT_ERROR_INJECTION_RATE;
+                MessageLossInjectionRate = DEFAULT_ERROR_INJECTION_RATE;
+            }
+            else
+            {
+                MaxForwardCount = 0;
+                RejectionInjectionRate = 0.0;
+                MessageLossInjectionRate = 0.0;
+            }
+            UseMessageBatching = DEFAULT_USE_MESSAGE_BATCHING;
+            MaxMessageBatchingSize = DEFAULT_MAX_MESSAGE_BATCH_SIZE;
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.AppendFormat("   Messaging:").AppendLine();
+            sb.AppendFormat("       Response timeout: {0}", ResponseTimeout).AppendLine();
+            sb.AppendFormat("       Maximum resend count: {0}", MaxResendCount).AppendLine();
+            sb.AppendFormat("       Resend On Timeout: {0}", ResendOnTimeout).AppendLine();
+            sb.AppendFormat("       Maximum Socket Age: {0}", MaxSocketAge).AppendLine();
+            sb.AppendFormat("       Drop Expired Messages: {0}", DropExpiredMessages).AppendLine();
+
+            if (isSiloConfig)
+            {
+                sb.AppendFormat("       Silo Sender queues: {0}", SiloSenderQueues).AppendLine();
+                sb.AppendFormat("       Gateway Sender queues: {0}", GatewaySenderQueues).AppendLine();
+                sb.AppendFormat("       Client Drop Timeout: {0}", ClientDropTimeout).AppendLine();
+            }
+            else
+            {
+                sb.AppendFormat("       Client Sender Buckets: {0}", ClientSenderBuckets).AppendLine();
+            }
+            sb.AppendFormat("       Use standard (.NET) serializer: {0}", UseStandardSerializer)
+                .AppendLine(isSiloConfig ? "" : "   [NOTE: This *MUST* match the setting on the server or nothing will work!]");
+            sb.AppendFormat("       Use fallback json serializer: {0}", UseJsonFallbackSerializer)
+                .AppendLine(isSiloConfig ? "" : "   [NOTE: This *MUST* match the setting on the server or nothing will work!]");
+            sb.AppendFormat("       Buffer Pool Buffer Size: {0}", BufferPoolBufferSize).AppendLine();
+            sb.AppendFormat("       Buffer Pool Max Size: {0}", BufferPoolMaxSize).AppendLine();
+            sb.AppendFormat("       Buffer Pool Preallocation Size: {0}", BufferPoolPreallocationSize).AppendLine();
+            sb.AppendFormat("       Use Message Batching: {0}", UseMessageBatching).AppendLine();
+            sb.AppendFormat("       Max Message Batching Size: {0}", MaxMessageBatchingSize).AppendLine();
+
+            if (isSiloConfig)
+            {
+                sb.AppendFormat("       Maximum forward count: {0}", MaxForwardCount).AppendLine();
+            }
+
+            SerializationProviders.ForEach(sp =>
+                sb.AppendFormat("       Serialization provider: {0}", sp).AppendLine());
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Orleans/Configuration/New/Statistics.cs
+++ b/src/Orleans/Configuration/New/Statistics.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Text;
+
+namespace Orleans.Runtime.Configuration.New
+{
+    /// <summary>
+    /// Statistics Configuration that are common to client and silo.
+    /// </summary>
+    public class Statistics
+    {
+        private static readonly TimeSpan DEFAULT_STATS_METRICS_TABLE_WRITE_PERIOD = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan DEFAULT_STATS_PERF_COUNTERS_WRITE_PERIOD = Constants.INFINITE_TIMESPAN;
+        private static readonly TimeSpan DEFAULT_STATS_LOG_WRITE_PERIOD = TimeSpan.FromMinutes(5);
+
+        public Statistics()
+        {
+            ProviderName = null;
+            MetricsTableWriteInterval = DEFAULT_STATS_METRICS_TABLE_WRITE_PERIOD;
+            PerfCountersWriteInterval = DEFAULT_STATS_PERF_COUNTERS_WRITE_PERIOD;
+            LogWriteInterval = DEFAULT_STATS_LOG_WRITE_PERIOD;
+            WriteLogStatisticsToTable = true;
+            CollectionLevel = NodeConfiguration.DEFAULT_STATS_COLLECTION_LEVEL;
+        }
+        public TimeSpan MetricsTableWriteInterval { get; set; }
+        public TimeSpan PerfCountersWriteInterval { get; set; }
+        public TimeSpan LogWriteInterval { get; set; }
+        public bool WriteLogStatisticsToTable { get; set; }
+        public StatisticsLevel CollectionLevel { get; set; }
+
+        public string ProviderName { get; set; }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("   Statistics: ").AppendLine();
+            sb.Append("     MetricsTableWriteInterval: ").Append(MetricsTableWriteInterval).AppendLine();
+            sb.Append("     PerfCounterWriteInterval: ").Append(PerfCountersWriteInterval).AppendLine();
+            sb.Append("     LogWriteInterval: ").Append(LogWriteInterval).AppendLine();
+            sb.Append("     WriteLogStatisticsToTable: ").Append(WriteLogStatisticsToTable).AppendLine();
+            sb.Append("     StatisticsCollectionLevel: ").Append(CollectionLevel).AppendLine();
+#if TRACK_DETAILED_STATS
+            sb.Append("     TRACK_DETAILED_STATS: true").AppendLine();
+#endif
+            if (!string.IsNullOrEmpty(ProviderName))
+                sb.Append("     StatisticsProviderName:").Append(ProviderName).AppendLine();
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Orleans/Configuration/New/SystemStore.cs
+++ b/src/Orleans/Configuration/New/SystemStore.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.Configuration.New
+{
+    public class SystemStore
+    {
+        public SystemStore()
+        {
+            DeploymentId = Environment.UserName;
+            DataConnectionString = "";
+            // Assume the ado invariant is for sql server storage if not explicitly specified
+            AdoInvariant = Constants.INVARIANT_NAME_SQL_SERVER;
+        }
+
+        public ClientConfiguration.GatewayProviderType? SystemStoreType { get; set; }
+        public string CustomGatewayProviderAssemblyName { get; set; }
+
+        /// <summary>
+        /// Specifies a unique identifier of this deployment.
+        /// If the silos are deployed on Azure (run as workers roles), deployment id is set automatically by Azure runtime, 
+        /// accessible to the role via RoleEnvironment.DeploymentId static variable and is passed to the silo automatically by the role via config. 
+        /// So if the silos are run as Azure roles this variable should not be specified in the OrleansConfiguration.xml (it will be overwritten if specified).
+        /// If the silos are deployed on the cluster and not as Azure roles, this variable should be set by a deployment script in the OrleansConfiguration.xml file.
+        /// </summary>
+        public string DeploymentId { get; set; }
+        /// <summary>
+        /// Specifies the connection string for the gateway provider.
+        /// If the silos are deployed on Azure (run as workers roles), DataConnectionString may be specified via RoleEnvironment.GetConfigurationSettingValue("DataConnectionString");
+        /// In such a case it is taken from there and passed to the silo automatically by the role via config.
+        /// So if the silos are run as Azure roles and this config is specified via RoleEnvironment, 
+        /// this variable should not be specified in the OrleansConfiguration.xml (it will be overwritten if specified).
+        /// If the silos are deployed on the cluster and not as Azure roles,  this variable should be set in the OrleansConfiguration.xml file.
+        /// If not set at all, DevelopmentStorageAccount will be used.
+        /// </summary>
+        public string DataConnectionString { get; set; }
+
+        /// <summary>
+        /// When using ADO, identifies the underlying data provider for the gateway provider. This three-part naming syntax is also used when creating a new factory 
+        /// and for identifying the provider in an application configuration file so that the provider name, along with its associated 
+        /// connection string, can be retrieved at run time. https://msdn.microsoft.com/en-us/library/dd0w4a2z%28v=vs.110%29.aspx
+        /// </summary>
+        public string AdoInvariant { get; set; }
+    }
+}

--- a/src/Orleans/Configuration/New/TraceLevelOverride.cs
+++ b/src/Orleans/Configuration/New/TraceLevelOverride.cs
@@ -1,0 +1,8 @@
+namespace Orleans.Runtime.Configuration.New
+{
+    public class TraceLevelOverride
+    {
+        public string LogPrefix { get; set; }
+        public Severity TraceLevel { get; set; }
+    }
+}

--- a/src/Orleans/Configuration/New/Tracing.cs
+++ b/src/Orleans/Configuration/New/Tracing.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Orleans.Runtime.Configuration.New
+{
+    /// <summary>
+    /// The TracingConfiguration type contains various tracing-related configuration parameters.
+    /// For production use, the default value of these parameters should be fine.
+    /// </summary>
+    public class Tracing
+    {
+        private string traceFilePattern;
+
+        public Tracing()
+        {
+            DefaultTraceLevel = Severity.Info;
+            TraceToConsole = true;
+            TraceFilePattern = "{0}-{1}.log";
+            LargeMessageWarningThreshold = Constants.LARGE_OBJECT_HEAP_THRESHOLD;
+            PropagateActivityId = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
+            BulkMessageLimit = Constants.DEFAULT_LOGGER_BULK_MESSAGE_LIMIT;
+        }
+
+        /// <summary>
+        /// The DefaultTraceLevel attribute specifies the default tracing level for all Orleans loggers, unless overridden by
+        /// a specific TraceLevelOverride element.
+        /// The default level is Info if this attribute does not appear.
+        /// </summary>
+        public Severity DefaultTraceLevel { get; set; }
+        /// <summary>
+        /// The TraceFileName attribute specifies the name of a file that trace output should be written to.
+        /// </summary>
+        public  string TraceFileName { get; set; }
+        /// <summary>
+        /// The TraceFilePattern attribute specifies the pattern name of a file that trace output should be written to.
+        /// </summary>
+        public string TraceFilePattern
+        { 
+            get { return traceFilePattern; }
+            set
+            {
+                traceFilePattern = value;
+                //ConfigUtilities.SetTraceFileName(this, ClientName, this.creationTimestamp);
+            }
+        } 
+        /// <summary>
+        /// The TraceLevelOverride element provides a mechanism to allow the tracing level to be set differently for different
+        /// parts of the Orleans system.
+        /// The tracing level for a logger is set based on a prefix match on the logger's name.
+        /// TraceLevelOverrides are applied in length order; that is, the override with the longest matching
+        /// LogPrefix takes precedence and specifies the tracing level for all matching loggers.
+        /// </summary>
+        public  List<TraceLevelOverride> TraceLevelOverrides { get; set; } = new List<TraceLevelOverride>();
+        /// <summary>
+        /// The TraceToConsole attribute specifies whether trace output should be written to the console.
+        /// The default is not to write trace data to the console.
+        /// </summary>
+        public  bool TraceToConsole { get; set; }
+        /// <summary>
+        /// The LargeMessageWarningThreshold attribute specifies when to generate a warning trace message for large messages.
+        /// </summary>
+        public  int LargeMessageWarningThreshold { get; set; }
+        /// <summary>
+        /// The PropagateActivityId attribute specifies whether the value of Tracing.CorrelationManager.ActivityId should be propagated into grain calls, to support E2E tracing.
+        /// The default is not to propagate ActivityId.
+        /// </summary>
+        public  bool PropagateActivityId { get; set; }
+        /// <summary>
+        /// The BulkMessageLimit attribute specifies how to bulk (aggregate) trace messages with identical erro code.
+        /// </summary>
+        public  int BulkMessageLimit { get; set; }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("   Tracing: ").AppendLine();
+            sb.Append("     Default Trace Level: ").Append(DefaultTraceLevel).AppendLine();
+            if (TraceLevelOverrides.Count > 0)
+            {
+                sb.Append("     TraceLevelOverrides:").AppendLine();
+                foreach (var over in TraceLevelOverrides)
+                {
+                    sb.Append("         ").Append(over.LogPrefix).Append(" ==> ").Append(over.TraceLevel.ToString()).AppendLine();
+                }
+            }
+            else
+            {
+                sb.Append("     TraceLevelOverrides: None").AppendLine();
+            }
+            sb.Append("     Trace to Console: ").Append(TraceToConsole).AppendLine();
+            sb.Append("     Trace File Name: ").Append(string.IsNullOrWhiteSpace(TraceFileName) ? "" : Path.GetFullPath(TraceFileName)).AppendLine();
+            sb.Append("     LargeMessageWarningThreshold: ").Append(LargeMessageWarningThreshold).AppendLine();
+            sb.Append("     PropagateActivityId: ").Append(PropagateActivityId).AppendLine();
+            sb.Append("     BulkMessageLimit: ").Append(BulkMessageLimit).AppendLine();
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -76,6 +76,15 @@
     <Compile Include="Async\TaskUtility.cs" />
     <Compile Include="Async\UnobservedExceptionsHandlerClass.cs" />
     <Compile Include="Async\TaskExtensions.cs" />
+    <Compile Include="Configuration\New\ClientFactoryBuilder.cs" />
+    <Compile Include="Configuration\New\ClientFactorySettings.cs" />
+    <Compile Include="Configuration\New\Gateway.cs" />
+    <Compile Include="Configuration\New\LocalAddress.cs" />
+    <Compile Include="Configuration\New\Messaging.cs" />
+    <Compile Include="Configuration\New\Statistics.cs" />
+    <Compile Include="Configuration\New\SystemStore.cs" />
+    <Compile Include="Configuration\New\TraceLevelOverride.cs" />
+    <Compile Include="Configuration\New\Tracing.cs" />
     <Compile Include="Logging\LoggerExtensions.cs" />
     <Compile Include="Logging\LoggerImpl.cs" />
     <Compile Include="Logging\LogFormatter.cs" />

--- a/test/TesterInternal/ClientConfig_StreamProviders_New.json
+++ b/test/TesterInternal/ClientConfig_StreamProviders_New.json
@@ -1,0 +1,62 @@
+﻿{
+    "Gateways": [
+        {
+            "Address": "localhost",
+            "Port": "40000",
+            "Proxied": "true"
+        },
+        {
+            "Address": "localhost",
+            "Port": "40001",
+            "Proxied": "true"
+        }
+    ],
+    "Tracing": {
+        "DefaultTraceLevel": "Info",
+        "TraceToConsole": "false",
+        "TraceFileName": "{0}-{1}.log",
+        "BulkMessageLimit": "1000",
+        "TraceLevelOverrides": [
+            {
+                "LogPrefix": "Runtime",
+                "TraceLevel": "Info"
+            },
+            {
+                "LogPrefix": "Application",
+                "TraceLevel": "Info"
+            },
+            {
+                "LogPrefix": "Tetris",
+                "TraceLevel": "Info"
+            },
+            {
+                "LogPrefix": "AssemblyLoader",
+                "TraceLevel": "Warning"
+            }
+        ]
+    },
+    "Statistics": {
+        "MetricsTableWriteInterval": "00:05:00",
+        "PerfCounterWriteInterval": "00:00:30",
+        "LogWriteInterval": "00:05:00",
+        "CollectionLevel": "Info"
+    },
+    "Messaging": {
+        "ResponseTimeout": "00:00:30",
+        "ClientSenderBuckets": "8192",
+        "MaxResendCount": "0",
+        "UseMessageBatching": "false",
+        "MaxMessageBatchingSize": "100"
+    },
+    "StreamProviders": [
+        {
+            "Type": "Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider",
+            "Name": "SMSProvider",
+            "FireAndForgetDelivery": "false"
+        },
+        {
+            "Type": "Orleans.Providers.Streams.AzureQueue.AzureQueueStreamProvider",
+            "Name": "AzureQueueProvider"
+        }
+    ]
+}

--- a/test/TesterInternal/ClientConfig_StreamProviders_New.xml
+++ b/test/TesterInternal/ClientConfig_StreamProviders_New.xml
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ClientConfiguration>
+    <Gateways>
+        <Gateway1 Address="localhost"
+                 Port="40000"
+                 Proxied="true" />
+        <Gateway2 Address="localhost"
+                 Port="40001"
+                 Proxied="true" />
+    </Gateways>
+    <Tracing DefaultTraceLevel="Info"
+             TraceToConsole="false"
+             TraceFileName="{0}-{1}.log"
+             BulkMessageLimit="1000">
+        <TraceLevelOverrides>
+            <TraceLevelOverride1 LogPrefix="Runtime"
+                                TraceLevel="Info" />
+            <TraceLevelOverride2 LogPrefix="Application"
+                                TraceLevel="Info" />
+            <TraceLevelOverride3 LogPrefix="Tetris"
+                                TraceLevel="Info" />
+            <TraceLevelOverride4 LogPrefix="AssemblyLoader"
+                                TraceLevel="Warning" />
+        </TraceLevelOverrides>
+    </Tracing>
+    <Statistics MetricsTableWriteInterval="00:05:00"
+                PerfCounterWriteInterval="00:00:30"
+                LogWriteInterval="00:05:00"
+                CollectionLevel="Info" />
+    <Messaging ResponseTimeout="00:00:30"
+               ClientSenderBuckets="8192"
+               MaxResendCount="0"
+               UseMessageBatching="false"
+               MaxMessageBatchingSize="100" />
+    <StreamProviders>
+        <Provider1 Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider"
+                  Name="SMSProvider"
+                  FireAndForgetDelivery="false" />
+        <Provider2 Type="Orleans.Providers.Streams.AzureQueue.AzureQueueStreamProvider"
+                  Name="AzureQueueProvider" />
+    </StreamProviders>
+</ClientConfiguration>
+

--- a/test/TesterInternal/ConfigTests.cs
+++ b/test/TesterInternal/ConfigTests.cs
@@ -3,10 +3,12 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using Microsoft.Extensions.Configuration;
 using Orleans;
 using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Configuration.New;
 using Orleans.Runtime.Host;
 using Orleans.TestingHost;
 using UnitTests.StorageTests;
@@ -342,6 +344,60 @@ namespace UnitTests
             cfg.TraceFilePattern = null;
             output.WriteLine(cfg.ToString());
            Assert.Null(cfg.TraceFileName); // TraceFileName should be null
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Config"), TestCategory("Logger")]
+        public void ClientConfig_StreamProviders_New_Xml()
+        {
+            LogManager.UnInitialize();
+
+            string filename = "ClientConfig_StreamProviders_New.xml";
+
+            var settings = new ClientFactorySettings();
+            var configBuilder = new ConfigurationBuilder();
+            configBuilder.AddXmlFile(filename);
+            var config = configBuilder.Build();
+            config.Bind(settings);
+
+            ValidateSettings(settings);
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Config"), TestCategory("Logger")]
+        public void ClientConfig_StreamProviders_New_Json()
+        {
+            LogManager.UnInitialize();
+
+            string filename = "ClientConfig_StreamProviders_New.json";
+
+            var settings = new ClientFactorySettings();
+            var configBuilder = new ConfigurationBuilder();
+            configBuilder.AddJsonFile(filename);
+            var config = configBuilder.Build();
+            config.Bind(settings);
+
+            ValidateSettings(settings);
+        }
+
+        private void ValidateSettings(ClientFactorySettings settings)
+        {
+            Assert.Equal("localhost", settings.Gateways[0].Address);
+            Assert.Equal(40000, settings.Gateways[0].Port);
+            Assert.Equal("localhost", settings.Gateways[1].Address);
+            Assert.Equal(40001, settings.Gateways[1].Port);
+
+            Assert.Equal(Severity.Info, settings.Tracing.DefaultTraceLevel);
+            Assert.Equal(false, settings.Tracing.TraceToConsole);
+            Assert.Equal("{0}-{1}.log", settings.Tracing.TraceFileName);
+            Assert.Equal(1000, settings.Tracing.BulkMessageLimit);
+
+            Assert.Equal("Tetris", settings.Tracing.TraceLevelOverrides[2].LogPrefix);
+            Assert.Equal(Severity.Info, settings.Tracing.TraceLevelOverrides[2].TraceLevel);
+
+
+            Assert.Equal(TimeSpan.FromMinutes(5), settings.Statistics.MetricsTableWriteInterval);
+            Assert.Equal(TimeSpan.FromMinutes(5), settings.Statistics.LogWriteInterval);
+
+            Assert.Equal(100, settings.Messaging.MaxMessageBatchingSize);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Config"), TestCategory("Logger")]

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -297,6 +297,12 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="ReadMe.md" />
+    <None Include="ClientConfig_StreamProviders_New.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <Content Include="ClientConfig_StreamProviders_New.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Config_AdditionalAssemblies.xml">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/test/TesterInternal/project.json
+++ b/test/TesterInternal/project.json
@@ -1,7 +1,10 @@
-{
+﻿{
   "dependencies": {
     "FSharp.Core": "4.0.0.1",
-    "Newtonsoft.Json": "7.0.1",
+    "Microsoft.Extensions.Configuration.Binder": "1.0.0",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0",
+    "Microsoft.Extensions.Configuration.Xml": "1.0.0",
+    "Newtonsoft.Json": "9.0.1",
     "WindowsAzure.Storage": "7.0.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",


### PR DESCRIPTION
Addressing issue: https://github.com/dotnet/orleans/issues/2030

I started with something ugly and basic. I guess I want a pre-review before I keep going down this route.

Goal: Make configuration bindable so any file type can be used. Need to separate logic and data.
Changes:

Started creating replacement config heirarchy for Grain Clients.
- Remove Xml/File loading
- Added binding tests for xml and json
- Xml format has to change.
Bindable files:
https://github.com/adamhathcock/orleans/tree/new_config_2/src/Orleans/Configuration/New

Old xml: https://github.com/adamhathcock/orleans/blob/new_config_2/test/TesterInternal/ClientConfig_StreamProviders.xml
New xml: https://github.com/adamhathcock/orleans/blob/new_config_2/test/TesterInternal/ClientConfig_StreamProviders_New.xml
New json: 
https://github.com/adamhathcock/orleans/blob/new_config_2/test/TesterInternal/ClientConfig_StreamProviders_New.json

Oh yeah, the actual tests I added:https://github.com/adamhathcock/orleans/blob/new_config_2/test/TesterInternal/ConfigTests.cs#L350

The stuff is far from complete but large TODOs that I see:

- Make more bindable configs
- Build out a ClientFactoryBuilder to take file configs and runtime config then once Build is called then the config is immutable. The act of building will do the logic that is current baked all over the config classes.
- ClientFactory will create GrainClient objects
- Add shortcut/helper methods to make the above process easy.

This involves touching a lot of stuff. If M.E.Logging was used then large sections of config would go away (e.g. Trace stuff) I think. But I'd port it over anyway for now.