### PR TITLE
Persistent Stream Provider initialization timeout fix.

### DIFF
--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -87,7 +87,7 @@ namespace Orleans.Streams
             return OrleansTaskExtentions.WrapInTask(() => InitializeInternal(qAdapter.Value, queueAdapterCache.Value, failureHandler.Value));
         }
 
-        public void InitializeInternal(IQueueAdapter qAdapter, IQueueAdapterCache queueAdapterCache, IStreamFailureHandler failureHandler)
+        private void InitializeInternal(IQueueAdapter qAdapter, IQueueAdapterCache queueAdapterCache, IStreamFailureHandler failureHandler)
         {
             logger.Info(ErrorCode.PersistentStreamPullingAgent_02, "Init of {0} {1} on silo {2} for queue {3}.",
                 GetType().Name, GrainId.ToDetailedString(), Silo, QueueId.ToStringWithHashCode());

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -31,7 +31,7 @@ namespace Orleans.Streams
         private IDisposable timer;
 
         internal readonly QueueId QueueId;
-        private Task recieverInitTask;
+        private Task receiverInitTask;
         private bool IsShutdown => timer == null;
         private string StatisticUniquePostfix => streamProviderName + "." + QueueId;
 
@@ -122,9 +122,9 @@ namespace Orleans.Streams
 
             try
             {
-                recieverInitTask = OrleansTaskExtentions.SafeExecute(() => receiver.Initialize(config.InitQueueTimeout))
+                receiverInitTask = OrleansTaskExtentions.SafeExecute(() => receiver.Initialize(config.InitQueueTimeout))
                     .LogException(logger, ErrorCode.PersistentStreamPullingAgent_03, $"QueueAdapterReceiver {QueueId.ToStringWithHashCode()} failed to Initialize.");
-                recieverInitTask.Ignore();
+                receiverInitTask.Ignore();
             }
             catch
             {
@@ -151,13 +151,13 @@ namespace Orleans.Streams
                 Utils.SafeExecute(tmp.Dispose);
             }
 
-            Task localRecieverInitTask = recieverInitTask;
-            recieverInitTask = null;
-            if (localRecieverInitTask != null)
+            Task localReceiverInitTask = receiverInitTask;
+            receiverInitTask = null;
+            if (localReceiverInitTask != null)
             { 
                 try
                 {
-                    await localRecieverInitTask;
+                    await localReceiverInitTask;
                 }
                 catch (Exception)
                 {
@@ -325,11 +325,11 @@ namespace Orleans.Streams
         {
             try
             {
-                Task localrecieverInitTask = recieverInitTask;
-                if (localrecieverInitTask != null)
+                Task localReceiverInitTask = receiverInitTask;
+                if (localReceiverInitTask != null)
                 {
-                    await localrecieverInitTask;
-                    recieverInitTask = null;
+                    await localReceiverInitTask;
+                    receiverInitTask = null;
                 }
 
                 var myQueueId = (QueueId)(state);


### PR DESCRIPTION
Persistent stream provider can timeout during initialization if many queues are configured.  To address this, we don't await receiver initialization any more.  Receiver initialization was always allowed to fail, in which case re-initialization was necessary.  Now we no longer await it since we don't handle the exception anyway.