### PR TITLE
Temp fix to make VSO build works

### DIFF
--- a/src/OrleansPSUtils/OrleansPSUtils.csproj
+++ b/src/OrleansPSUtils/OrleansPSUtils.csproj
@@ -107,6 +107,6 @@
   </Target>
   -->
   <Target Name="AfterBuild">
-        <UpdateVersion InputFilename="$(SolutionDir)Build\Version.txt" OutputFilename="$(OutputPath)Orleans.psd1" />
+        <UpdateVersion InputFilename="$(SolutionDir)Build\Version.txt" OutputFilename="$(OutDir)Orleans.psd1" />
   </Target>
 </Project>


### PR DESCRIPTION
Following #1990

Build using `Build.cmd` and VS will build as expected the project in a dedicated subfolder, but not in VSO (it will share the same output folder as the other projects)