### PR TITLE
Include test adapter as a packages.config reference

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="FSharp.Compiler.Tools" version="4.0.0.1" />
   <package id="xunit.runner.console" version="2.1.0" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" />
 </packages>

--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -50,6 +50,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{856B8FB9-194E-4F5C-9D9D-A35EB82387FC}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{014CD19F-3112-4AF6-927E-8C88F3EA556A}"


### PR DESCRIPTION
Looks like VSO builds do not find the xUnit VS test adapter if it's using a nuget v3 reference (as it searches for adapter inside the packages folder, which is no longer used with project.json).