### PR TITLE
Upgrade to ServiceBus 3.3.2 and related changes.

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
@@ -22,8 +22,7 @@
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansProviders" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansAzureUtils" version="$version$" />
-      <dependency id="WindowsAzure.ServiceBus" version="3.2.2" />
-      <dependency id="WindowsAzure.Storage" version="5.0.2" />
+      <dependency id="WindowsAzure.ServiceBus" version="3.3.2" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
@@ -359,9 +359,9 @@ namespace Orleans.Providers.Streams.Common
         {
             if (IsEmpty)
             {
-                logger.Info("BlockPurged: cache empty");
+                logger.Verbose("BlockPurged: cache empty");
             }
-            logger.Info($"BlockPurged: PurgeCount: {startingItemCount - itemCount}, CacheSize: {itemCount}");
+            logger.Verbose($"BlockPurged: PurgeCount: {startingItemCount - itemCount}, CacheSize: {itemCount}");
         }
 
         private enum CursorStates

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
@@ -13,7 +13,7 @@ namespace Orleans.ServiceBus.Providers
     public static class EventDataExtensions
     {
         private const string EventDataPropertyStreamNamespaceKey = "StreamNamespace";
-        private static readonly string[] SkipProperties = { nameof(EventData.Offset), nameof(EventData.SequenceNumber), nameof(EventData.EnqueuedTimeUtc), EventDataPropertyStreamNamespaceKey };
+        private static readonly string[] SkipProperties = { EventDataPropertyStreamNamespaceKey };
 
         /// <summary>
         /// Adds stream namespace to the EventData

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -216,6 +216,7 @@ namespace Orleans.ServiceBus.Providers
 
         private static async Task<EventHubReceiver> CreateReceiver(EventHubPartitionConfig partitionConfig, string offset, Logger logger)
         {
+            bool offsetInclusive = true;
             EventHubClient client = EventHubClient.CreateFromConnectionString(partitionConfig.Hub.ConnectionString, partitionConfig.Hub.Path);
             EventHubConsumerGroup consumerGroup = client.GetConsumerGroup(partitionConfig.Hub.ConsumerGroup);
             if (partitionConfig.Hub.PrefetchCount.HasValue)
@@ -233,9 +234,10 @@ namespace Orleans.ServiceBus.Providers
                 PartitionRuntimeInformation patitionInfo =
                     await client.GetPartitionRuntimeInformationAsync(partitionConfig.Partition);
                 offset = patitionInfo.LastEnqueuedOffset;
+                offsetInclusive = false;
                 logger.Info("Starting to read latest messages from EventHub partition {0}-{1} at offset {2}", partitionConfig.Hub.Path, partitionConfig.Partition, offset);
             }
-            return await consumerGroup.CreateReceiverAsync(partitionConfig.Partition, offset, true);
+            return await consumerGroup.CreateReceiverAsync(partitionConfig.Partition, offset, offsetInclusive);
         }
 
         private class StreamActivityNotificationBatch : IBatchContainer

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -22,8 +22,19 @@ namespace Orleans.ServiceBus.Providers
         [JsonProperty]
         private readonly EventHubSequenceToken token;
 
+        /// <summary>
+        /// Stream identifier for the stream this batch is part of.
+        /// </summary>
         public Guid StreamGuid => eventHubMessage.StreamIdentity.Guid;
+
+        /// <summary>
+        /// Stream namespace for the stream this batch is part of.
+        /// </summary>
         public string StreamNamespace => eventHubMessage.StreamIdentity.Namespace;
+
+        /// <summary>
+        /// Stream Sequence Token for the start of this batch.
+        /// </summary>
         public StreamSequenceToken SequenceToken => token;
 
         // Payload is local cache of deserialized payloadBytes.  Should never be serialized as part of batch container.  During batch container serialization raw payloadBytes will always be used.
@@ -38,17 +49,31 @@ namespace Orleans.ServiceBus.Providers
             public Dictionary<string, object> RequestContext { get; set; }
         }
 
+        /// <summary>
+        /// Batch container that deliveres events from cached EventHub data associated with an orleans stream
+        /// </summary>
+        /// <param name="eventHubMessage"></param>
         public EventHubBatchContainer(EventHubMessage eventHubMessage)
         {
             this.eventHubMessage = eventHubMessage;
             token = new EventHubSequenceToken(eventHubMessage.Offset, eventHubMessage.SequenceNumber, 0);
         }
 
+        /// <summary>
+        /// Gets events of a specific type from the batch.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
         public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
         {
             return Payload.Events.Cast<T>().Select((e, i) => Tuple.Create<T, StreamSequenceToken>(e, new EventHubSequenceToken(token.EventHubOffset, token.SequenceNumber, i)));
         }
 
+        /// <summary>
+        /// Gives an opportunity to IBatchContainer to set any data in the RequestContext before this IBatchContainer is sent to consumers.
+        /// It can be the data that was set at the time event was generated and enqueued into the persistent provider or any other data.
+        /// </summary>
+        /// <returns>True if the RequestContext was indeed modified, false otherwise.</returns>
         public bool ImportRequestContext()
         {
             if (Payload.RequestContext != null)
@@ -59,6 +84,9 @@ namespace Orleans.ServiceBus.Providers
             return false;
         }
 
+        /// <summary>
+        /// Decide whether this batch should be sent to the specified target.
+        /// </summary>
         public bool ShouldDeliver(IStreamIdentity stream, object filterData, StreamFilterPredicate shouldReceiveFunc)
         {
             return true;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -241,7 +241,7 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="newestItem"></param>
         protected override void OnPurge(CachedEventHubMessage? lastItemPurged, CachedEventHubMessage? newestItem)
         {
-            if (log.IsInfo && lastItemPurged.HasValue && newestItem.HasValue)
+            if (log.IsVerbose && lastItemPurged.HasValue && newestItem.HasValue)
             {
                 log.Verbose($"CachePeriod: EnqueueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.EnqueueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.EnqueueTimeUtc)}, DequeueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.DequeueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.DequeueTimeUtc)}");
             }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -243,7 +243,7 @@ namespace Orleans.ServiceBus.Providers
         {
             if (log.IsInfo && lastItemPurged.HasValue && newestItem.HasValue)
             {
-                log.Info($"CachePeriod: EnqueueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.EnqueueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.EnqueueTimeUtc)}, DequeueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.DequeueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.DequeueTimeUtc)}");
+                log.Verbose($"CachePeriod: EnqueueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.EnqueueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.EnqueueTimeUtc)}, DequeueTimeUtc: {LogFormatter.PrintDate(lastItemPurged.Value.DequeueTimeUtc)} to {LogFormatter.PrintDate(newestItem.Value.DequeueTimeUtc)}");
             }
         }
 

--- a/src/OrleansServiceBus/project.json
+++ b/src/OrleansServiceBus/project.json
@@ -1,8 +1,8 @@
-{
+﻿{
   "dependencies": {
     "Microsoft.WindowsAzure.ConfigurationManager": "3.1.0",
     "Newtonsoft.Json": "7.0.1",
-    "WindowsAzure.ServiceBus": "3.2.2",
+    "WindowsAzure.ServiceBus": "3.3.2",
     "WindowsAzure.Storage": "7.0.0"
   },
   "frameworks": {

--- a/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -45,7 +45,8 @@ namespace UnitTests.StreamingTests
         {
             protected override TestCluster CreateTestCluster()
             {
-                var options = new TestClusterOptions(2);
+                // poor fault injection requires grain instances stay on same host, so only single host for this test
+                var options = new TestClusterOptions(1);
                 // register stream provider
                 options.ClusterConfiguration.AddMemoryStorageProvider("Default");
                 options.ClusterConfiguration.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());

--- a/test/Tester/project.json
+++ b/test/Tester/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "dependencies": {
     "Bond.Runtime.CSharp": "3.0.7",
     "FluentAssertions": "4.0.0",
@@ -6,12 +6,12 @@
     "Google.Protobuf": "3.0.0-alpha4",
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Newtonsoft.Json": "7.0.1",
-    "WindowsAzure.ServiceBus": "3.2.2",
+    "System.Management.Automation.dll": "10.0.10586",
+    "WindowsAzure.ServiceBus": "3.3.2",
     "WindowsAzure.Storage": "7.0.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14",
-    "System.Management.Automation.dll": "10.0.10586"
+    "Xunit.SkippableFact": "1.2.14"
   },
   "frameworks": {
     "net451": {}

--- a/test/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
+++ b/test/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
@@ -79,10 +79,10 @@ namespace UnitTests.StorageTests
         public void AzureTableDataManagerStressTests_ReadAllTableEntities()
         {
             const string testName = "AzureTableDataManagerStressTests_ReadAllTableEntities";
-            const int iterations = 1000;
+            const int iterations = 2000;
 
             // Write some data
-            WriteAlot_Async(testName, 1, iterations, iterations);
+            WriteAlot_Async(testName, 3, iterations, iterations);
 
             Stopwatch sw = Stopwatch.StartNew();
 
@@ -94,6 +94,11 @@ namespace UnitTests.StorageTests
             output.WriteLine("AzureTable_ReadAllTableEntities completed. ReadAll {0} entries in {1} at {2} RPS", count, sw.Elapsed, count / sw.Elapsed.TotalSeconds);
 
             Assert.True(count >= iterations, $"ReadAllshould return some data: Found={count}");
+
+            sw = Stopwatch.StartNew();
+            manager.ClearTableAsync().WaitWithThrow(AzureTableDefaultPolicies.TableCreationTimeout);
+            sw.Stop();
+            output.WriteLine("AzureTable_ReadAllTableEntities clear. Cleared table of {0} entries in {1} at {2} RPS", count, sw.Elapsed, count / sw.Elapsed.TotalSeconds);
         }
 
         private void WriteAlot_Async(string testName, int numPartitions, int iterations, int batchSize)

--- a/test/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
+++ b/test/TesterInternal/StorageTests/AzureTableDataManagerStressTests.cs
@@ -75,6 +75,27 @@ namespace UnitTests.StorageTests
             Assert.True(count >= iterations, $"ReadAllshould return some data: Found={count}");
         }
 
+        [Fact, TestCategory("Azure"), TestCategory("Storage"), TestCategory("Stress")]
+        public void AzureTableDataManagerStressTests_ReadAllTableEntities()
+        {
+            const string testName = "AzureTableDataManagerStressTests_ReadAllTableEntities";
+            const int iterations = 1000;
+
+            // Write some data
+            WriteAlot_Async(testName, 1, iterations, iterations);
+
+            Stopwatch sw = Stopwatch.StartNew();
+
+            var data = manager.ReadAllTableEntriesAsync()
+                .WaitForResultWithThrow(AzureTableDefaultPolicies.TableCreationTimeout).Select(tuple => tuple.Item1);
+
+            sw.Stop();
+            int count = data.Count();
+            output.WriteLine("AzureTable_ReadAllTableEntities completed. ReadAll {0} entries in {1} at {2} RPS", count, sw.Elapsed, count / sw.Elapsed.TotalSeconds);
+
+            Assert.True(count >= iterations, $"ReadAllshould return some data: Found={count}");
+        }
+
         private void WriteAlot_Async(string testName, int numPartitions, int iterations, int batchSize)
         {
             output.WriteLine("Iterations={0}, Batch={1}, Partitions={2}", iterations, batchSize, numPartitions);


### PR DESCRIPTION
- Upgrade to SERVICEBUS 3.3.2
- New EventData keeps eventdata properties and user properties in different bags, which caused PartitionKey property to be lost when data passed through cache. - fixed
- Azure storage read table call was failing, but was never noticed because there was no testing.  Added testing and fixed storage layer.
- Azure clear table call expected single partition.  Didn't work if there were multiple partitions in the table. -fixed.
- EventHub reciever, when reading from 'now', was reading from the last data in the queue, rather than all future data.  -fixed
- EventHub recovery test was intermittently failing because it was using two silos, but poor fault injection requires that grains stay on same silo.  -fixed.