### PR TITLE
EventHub stream provider time based message purge

### DIFF
--- a/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
@@ -50,9 +50,11 @@ namespace Orleans.Providers.Streams.Common
         /// Given a purge request, indicates if a cached message should be purged from the cache
         /// </summary>
         /// <param name="cachedMessage"></param>
+        /// <param name="newestCachedMessage"></param>
         /// <param name="purgeRequest"></param>
+        /// <param name="nowUtc"></param>
         /// <returns></returns>
-        bool ShouldPurge(ref TCachedMessage cachedMessage, IDisposable purgeRequest);
+        bool ShouldPurge(ref TCachedMessage cachedMessage, ref TCachedMessage newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc);
 
         /// <summary>
         /// Assignable purge action.  This is called when a purge request is triggered.

--- a/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
@@ -289,7 +289,7 @@ namespace Orleans.Providers.Streams.Common
                 throw new ArgumentNullException("message");
             }
 
-            PerformPendingPurges();
+            PerformPendingPurges(dequeueTimeUtc);
 
             StreamPosition streamPosition;
             // allocate message from pool
@@ -299,7 +299,8 @@ namespace Orleans.Providers.Streams.Common
             if (block != messageBlocks.FirstOrDefault())
                 messageBlocks.AddFirst(block.Node);
             itemCount++;
-            PerformPendingPurges();
+
+            PerformPendingPurges(dequeueTimeUtc);
 
             return streamPosition;
         }
@@ -313,25 +314,26 @@ namespace Orleans.Providers.Streams.Common
             purgeQueue.Enqueue(purgeRequest);
         }
 
-        private void PerformPendingPurges()
+        private void PerformPendingPurges(DateTime nowUtc)
         {
             IDisposable purgeRequest;
             if (purgeQueue.IsEmpty) return;
             while (purgeQueue.TryDequeue(out purgeRequest))
             {
                 int currentItemCount = itemCount;
-                PerformBlockPurge(purgeRequest);
+                PerformBlockPurge(purgeRequest, nowUtc);
                 ReportBlockPurge(currentItemCount);
             }
         }
 
-        private void PerformBlockPurge(IDisposable purgeRequest)
+        private void PerformBlockPurge(IDisposable purgeRequest, DateTime nowUtc)
         {
+            TCachedMessage neweswtMessageInCache = messageBlocks.First.Value.NewestMessage;
             TCachedMessage? lastMessagePurged = null;
             while (!IsEmpty)
             {
                 var oldestMessageInCache = messageBlocks.Last.Value.OldestMessage;
-                if (!cacheDataAdapter.ShouldPurge(ref oldestMessageInCache, purgeRequest))
+                if (!cacheDataAdapter.ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest, nowUtc))
                 {
                     break;
                 }

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -128,7 +128,7 @@ namespace Orleans.Providers.Streams.Generator
                 return new StreamPosition(new StreamIdentity(queueMessage.StreamGuid, queueMessage.StreamNamespace), queueMessage.RealToken);
             }
 
-            public bool ShouldPurge(ref CachedMessage cachedMessage, IDisposable purgeRequest)
+            public bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc)
             {
                 var purgedResource = (FixedSizeBuffer) purgeRequest;
                 // if we're purging our current buffer, don't use it any more

--- a/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
@@ -122,7 +122,7 @@ namespace Orleans.Providers.Streams.Memory
                     queueMessage.SequenceToken);
             }
 
-            public bool ShouldPurge(ref CachedMessage cachedMessage, IDisposable purgeRequest)
+            public bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc)
             {
                 var purgedResource = (FixedSizeBuffer) purgeRequest;
                 // if we're purging our current buffer, don't use it any more

--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Providers\Streams\EventHub\IEventHubSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubQueueCache.cs" />
     <Compile Include="Providers\Streams\EventHub\SegmentBuilder.cs" />
+    <Compile Include="Providers\Streams\EventHub\TimePurgePredicate.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OrleansAzureUtils\OrleansAzureUtils.csproj">

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -91,11 +91,12 @@ namespace Orleans.ServiceBus.Providers
                 checkpointerSettings = adapterConfig.GetCheckpointerSettings(providerConfig, serviceProvider);
                 CheckpointerFactory = partition => EventHubCheckpointer.Create(checkpointerSettings, adapterConfig.StreamProviderName, partition);
             }
-            
+
             if (CacheFactory == null)
             {
                 var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
-                CacheFactory = (partition,checkpointer,cacheLogger) => new EventHubQueueCache(checkpointer, bufferPool, cacheLogger);
+                var timePurge = new TimePurgePredicate(adapterConfig.DataMinTimeInCache, adapterConfig.DataMaxAgeInCache);
+                CacheFactory = (partition,checkpointer,cacheLogger) => new EventHubQueueCache(checkpointer, bufferPool, timePurge, cacheLogger);
             }
 
             if (StreamFailureHandlerFactory == null)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -126,6 +126,7 @@ namespace Orleans.ServiceBus.Providers
     public class EventHubDataAdapter : ICacheDataAdapter<EventData, CachedEventHubMessage>
     {
         private readonly IObjectPool<FixedSizeBuffer> bufferPool;
+        private readonly TimePurgePredicate timePurage;
         private FixedSizeBuffer currentBuffer;
 
         /// <summary>
@@ -137,13 +138,15 @@ namespace Orleans.ServiceBus.Providers
         /// Cache data adapter that adapts EventHub's EventData to CachedEventHubMessage used in cache
         /// </summary>
         /// <param name="bufferPool"></param>
-        public EventHubDataAdapter(IObjectPool<FixedSizeBuffer> bufferPool)
+        /// <param name="timePurage"></param>
+        public EventHubDataAdapter(IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurage = null)
         {
             if (bufferPool == null)
             {
                 throw new ArgumentNullException("bufferPool");
             }
             this.bufferPool = bufferPool;
+            this.timePurage = timePurage ?? TimePurgePredicate.Default;
         }
 
         /// <summary>
@@ -213,16 +216,28 @@ namespace Orleans.ServiceBus.Providers
         /// Given a purge request, indicates if a cached message should be purged from the cache
         /// </summary>
         /// <param name="cachedMessage"></param>
+        /// <param name="newestCachedMessage"></param>
         /// <param name="purgeRequest"></param>
+        /// <param name="nowUtc"></param>
         /// <returns></returns>
-        public bool ShouldPurge(ref CachedEventHubMessage cachedMessage, IDisposable purgeRequest)
+        public bool ShouldPurge(ref CachedEventHubMessage cachedMessage, ref CachedEventHubMessage newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc)
         {
-            var purgedResource = (FixedSizeBuffer) purgeRequest;
             // if we're purging our current buffer, don't use it any more
+            var purgedResource = (FixedSizeBuffer)purgeRequest;
             if (currentBuffer != null && currentBuffer.Id == purgedResource.Id)
             {
                 currentBuffer = null;
             }
+
+            TimeSpan timeInService = nowUtc - cachedMessage.DequeueTimeUtc;
+            TimeSpan relativeAge = newestCachedMessage.EnqueueTimeUtc - cachedMessage.EnqueueTimeUtc;
+
+            return ShouldPurgeFromResource(ref cachedMessage, purgedResource) || timePurage.ShouldPurgFromTime(timeInService, relativeAge);
+        }
+
+        private static bool ShouldPurgeFromResource(ref CachedEventHubMessage cachedMessage, FixedSizeBuffer purgedResource)
+        {
+            // if message is from this resource, purge
             return cachedMessage.Segment.Array == purgedResource.Id;
         }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -143,7 +143,7 @@ namespace Orleans.ServiceBus.Providers
         {
             if (bufferPool == null)
             {
-                throw new ArgumentNullException("bufferPool");
+                throw new ArgumentNullException(nameof(bufferPool));
             }
             this.bufferPool = bufferPool;
             this.timePurage = timePurage ?? TimePurgePredicate.Default;
@@ -229,10 +229,11 @@ namespace Orleans.ServiceBus.Providers
                 currentBuffer = null;
             }
 
-            TimeSpan timeInService = nowUtc - cachedMessage.DequeueTimeUtc;
+            TimeSpan timeInCache = nowUtc - cachedMessage.DequeueTimeUtc;
+            // age of message relative to the most recent event in the cache.
             TimeSpan relativeAge = newestCachedMessage.EnqueueTimeUtc - cachedMessage.EnqueueTimeUtc;
 
-            return ShouldPurgeFromResource(ref cachedMessage, purgedResource) || timePurage.ShouldPurgFromTime(timeInService, relativeAge);
+            return ShouldPurgeFromResource(ref cachedMessage, purgedResource) || timePurage.ShouldPurgFromTime(timeInCache, relativeAge);
         }
 
         private static bool ShouldPurgeFromResource(ref CachedEventHubMessage cachedMessage, FixedSizeBuffer purgedResource)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -216,9 +216,10 @@ namespace Orleans.ServiceBus.Providers
         /// </summary>
         /// <param name="checkpointer"></param>
         /// <param name="bufferPool"></param>
+        /// <param name="timePurge"></param>
         /// <param name="logger"></param>
-        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, IObjectPool<FixedSizeBuffer> bufferPool, Logger logger)
-            : this(checkpointer, new EventHubDataAdapter(bufferPool), logger)
+        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, Logger logger)
+            : this(checkpointer, new EventHubDataAdapter(bufferPool, timePurge), logger)
         {
         }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderConfig.cs
@@ -6,35 +6,116 @@ using Orleans.Providers;
 
 namespace Orleans.ServiceBus.Providers
 {
+    /// <summary>
+    /// Configuration class for EventHubStreamProvider.
+    /// </summary>
     public class EventHubStreamProviderConfig
     {
+        /// <summary>
+        /// Stream provider name.  This setting is required.
+        /// </summary>
+        public string StreamProviderName { get; }
+
+        /// <summary>
+        /// EventHubSettingsType setting name.
+        /// </summary>
         public const string EventHubConfigTypeName = "EventHubSettingsType";
+        /// <summary>
+        /// EventHub configuration type.  Type must conform to IEventHubSettings interface.
+        /// </summary>
         public Type EventHubSettingsType { get; set; }
 
+        /// <summary>
+        /// CheckpointerSettingsType setting name.
+        /// </summary>
         public const string CheckpointerSettingsTypeName = "CheckpointerSettingsType";
+        /// <summary>
+        /// Checkpoint settings type.  Type must conform to ICheckpointerSettings interface.
+        /// </summary>
         public Type CheckpointerSettingsType { get; set; }
 
-        public string StreamProviderName { get; private set; }
-
+        /// <summary>
+        /// CacheSizeMb setting name.
+        /// </summary>
         public const string CacheSizeMbName = "CacheSizeMb";
         private const int DefaultCacheSizeMb = 128; // default to 128mb cache.
-        public int CacheSizeMb { get; private set; }
-
-        public EventHubStreamProviderConfig(string streamProviderName, int cacheSizeMb = DefaultCacheSizeMb)
+        private int? cacheSizeMb;
+        /// <summary>
+        /// Cache size in megabytes.
+        /// </summary>
+        public int CacheSizeMb
         {
-            StreamProviderName = streamProviderName;
-            CacheSizeMb = cacheSizeMb;
+            get { return cacheSizeMb ?? DefaultCacheSizeMb; }
+            set { cacheSizeMb = value; }
         }
 
+        /// <summary>
+        /// DataMinTimeInCache setting name.
+        /// </summary>
+        public const string DataMinTimeInCacheName = "DataMinTimeInCache";
+        private static readonly TimeSpan DefaultDataMinTimeInCache = TimeSpan.FromMinutes(5);
+        private TimeSpan? dataMinTimeInCache;
+        /// <summary>
+        /// Minimum time message will stay in cache before it is available for time based purge.
+        /// </summary>
+        public TimeSpan DataMinTimeInCache
+        {
+            get { return dataMinTimeInCache ?? DefaultDataMinTimeInCache; }
+            set { dataMinTimeInCache = value; }
+        }
+
+        /// <summary>
+        /// DataMaxAgeInCache setting name.
+        /// </summary>
+        public const string DataMaxAgeInCacheName = "DataMaxAgeInCache";
+        private static readonly TimeSpan DefaultDataMaxAgeInCache = TimeSpan.FromMinutes(30);
+        private TimeSpan? dataMaxAgeInCache;
+        /// <summary>
+        /// Difference in time between the newest and oldest messages in the cache.  Any messages older than this will be purged from the cache.
+        /// </summary>
+        public TimeSpan DataMaxAgeInCache
+        {
+            get { return dataMaxAgeInCache ?? DefaultDataMaxAgeInCache; }
+            set { dataMaxAgeInCache = value; }
+        }
+
+        /// <summary>
+        /// Constructor.  Requires provider name.
+        /// </summary>
+        /// <param name="streamProviderName"></param>
+        public EventHubStreamProviderConfig(string streamProviderName)
+        {
+            StreamProviderName = streamProviderName;
+        }
+
+        /// <summary>
+        /// Writes settings into a property bag.
+        /// </summary>
+        /// <param name="properties"></param>
         public void WriteProperties(Dictionary<string, string> properties)
         {
             if (EventHubSettingsType != null)
                 properties.Add(EventHubConfigTypeName, EventHubSettingsType.AssemblyQualifiedName);
             if (CheckpointerSettingsType != null)
                 properties.Add(CheckpointerSettingsTypeName, CheckpointerSettingsType.AssemblyQualifiedName);
-            properties.Add(CacheSizeMbName, CacheSizeMb.ToString(CultureInfo.InvariantCulture));
+            if (cacheSizeMb.HasValue)
+            {
+                properties.Add(CacheSizeMbName, CacheSizeMb.ToString(CultureInfo.InvariantCulture));
+            }
+            if (dataMinTimeInCache.HasValue)
+            {
+                properties.Add(DataMinTimeInCacheName, DataMinTimeInCache.ToString());
+            }
+            if (dataMaxAgeInCache.HasValue)
+            {
+                properties.Add(DataMaxAgeInCacheName, DataMaxAgeInCache.ToString());
+            }
         }
 
+        /// <summary>
+        /// Read settings from provider configuration.
+        /// </summary>
+        /// <param name="providerConfiguration"></param>
         public void PopulateFromProviderConfig(IProviderConfiguration providerConfiguration)
         {
             EventHubSettingsType = providerConfiguration.GetTypeProperty(EventHubConfigTypeName, null);
@@ -44,8 +125,16 @@ namespace Orleans.ServiceBus.Providers
                 throw new ArgumentOutOfRangeException("providerConfiguration", "StreamProviderName not set.");
             }
             CacheSizeMb = providerConfiguration.GetIntProperty(CacheSizeMbName, DefaultCacheSizeMb);
+            DataMinTimeInCache = providerConfiguration.GetTimeSpanProperty(DataMinTimeInCacheName, DefaultDataMinTimeInCache);
+            DataMaxAgeInCache = providerConfiguration.GetTimeSpanProperty(DataMaxAgeInCacheName, DefaultDataMaxAgeInCache);
         }
 
+        /// <summary>
+        /// Aquire configured IEventHubSettings class
+        /// </summary>
+        /// <param name="providerConfig"></param>
+        /// <param name="serviceProvider"></param>
+        /// <returns></returns>
         public IEventHubSettings GetEventHubSettings(IProviderConfiguration providerConfig, IServiceProvider serviceProvider)
         {
             // if no event hub settings type is provided, use EventHubSettings and get populate settings from providerConfig
@@ -62,14 +151,17 @@ namespace Orleans.ServiceBus.Providers
 
             // if settings is an EventHubSettings class, populate settings from providerConfig
             var settings = hubSettings as EventHubSettings;
-            if (settings != null)
-            {
-                settings.PopulateFromProviderConfig(providerConfig);
-            }
+            settings?.PopulateFromProviderConfig(providerConfig);
 
             return hubSettings;
         }
 
+        /// <summary>
+        /// Aquire configured ICheckpointerSettings class
+        /// </summary>
+        /// <param name="providerConfig"></param>
+        /// <param name="serviceProvider"></param>
+        /// <returns></returns>
         public ICheckpointerSettings GetCheckpointerSettings(IProviderConfiguration providerConfig, IServiceProvider serviceProvider)
         {
             // if no checkpointer settings type is provided, use EventHubCheckpointerSettings and get populate settings from providerConfig
@@ -86,10 +178,7 @@ namespace Orleans.ServiceBus.Providers
 
             // if settings is an EventHubCheckpointerSettings class, populate settings from providerConfig
             var settings = checkpointerSettings as EventHubCheckpointerSettings;
-            if (settings != null)
-            {
-                settings.PopulateFromProviderConfig(providerConfig);
-            }
+            settings?.PopulateFromProviderConfig(providerConfig);
 
             return checkpointerSettings;
         }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/TimePurgePredicate.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/TimePurgePredicate.cs
@@ -1,0 +1,43 @@
+﻿
+using System;
+
+namespace Orleans.ServiceBus.Providers
+{
+    /// <summary>
+    /// Determines if data should be purged based off time.
+    /// </summary>
+    public class TimePurgePredicate
+    {
+        private readonly TimeSpan minTimeInCache;
+        private readonly TimeSpan maxRelativeMessageAge;
+
+        /// <summary>
+        /// Default time purge predicate never purges by time.
+        /// </summary>
+        public static readonly TimePurgePredicate Default = new TimePurgePredicate(TimeSpan.MinValue, TimeSpan.MaxValue);
+
+        /// <summary>
+        /// Contructor
+        /// </summary>
+        /// <param name="minTimeInCache">minimum time data should be keept in cache, unless purged due to data size.</param>
+        /// <param name="maxRelativeMessageAge">maximum age of data to keep in the cache</param>
+        public TimePurgePredicate(TimeSpan minTimeInCache, TimeSpan maxRelativeMessageAge)
+        {
+            this.minTimeInCache = minTimeInCache;
+            this.maxRelativeMessageAge = maxRelativeMessageAge;
+        }
+
+        /// <summary>
+        /// Checks to see if the message should be purged.
+        /// Message should be purged if it has been in the queue longer than the minTimeInCache, but it's relative age is greater than maxRelativeMessageAge.
+        /// </summary>
+        /// <param name="timeInService">amount of time message has been in this service</param>
+        /// <param name="relativeAge">Age of message relative to the most recent events read</param>
+        /// <returns></returns>
+        public bool ShouldPurgFromTime(TimeSpan timeInService, TimeSpan relativeAge)
+        {
+            // if time in cache exceeds the minimum and age of data is greater than max allowed, purge
+            return timeInService > minTimeInCache && relativeAge > maxRelativeMessageAge;
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/TimePurgePredicate.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/TimePurgePredicate.cs
@@ -29,15 +29,15 @@ namespace Orleans.ServiceBus.Providers
 
         /// <summary>
         /// Checks to see if the message should be purged.
-        /// Message should be purged if it has been in the queue longer than the minTimeInCache, but it's relative age is greater than maxRelativeMessageAge.
+        /// Message should be purged if its relative age is greater than maxRelativeMessageAge and has been in the cache longer than the minTimeInCache.
         /// </summary>
-        /// <param name="timeInService">amount of time message has been in this service</param>
+        /// <param name="timeInCache">amount of time message has been in this cache</param>
         /// <param name="relativeAge">Age of message relative to the most recent events read</param>
         /// <returns></returns>
-        public bool ShouldPurgFromTime(TimeSpan timeInService, TimeSpan relativeAge)
+        public bool ShouldPurgFromTime(TimeSpan timeInCache, TimeSpan relativeAge)
         {
             // if time in cache exceeds the minimum and age of data is greater than max allowed, purge
-            return timeInService > minTimeInCache && relativeAge > maxRelativeMessageAge;
+            return timeInCache > minTimeInCache && relativeAge > maxRelativeMessageAge;
         }
     }
 }

--- a/test/Tester/StreamingTests/EHClientStreamTests.cs
+++ b/test/Tester/StreamingTests/EHClientStreamTests.cs
@@ -29,7 +29,7 @@ namespace Tester.StreamingTests
                 EHConsumerGroup, EHPath);
 
         private static readonly EventHubStreamProviderConfig ProviderConfig =
-            new EventHubStreamProviderConfig(StreamProviderName, 3);
+            new EventHubStreamProviderConfig(StreamProviderName) { CacheSizeMb = 3 };
 
         private static readonly EventHubCheckpointerSettings CheckpointerSettings =
             new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable,

--- a/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
+++ b/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
@@ -34,7 +34,7 @@ namespace UnitTests.StreamingTests
             EHConsumerGroup, EHPath);
 
         private static readonly EventHubStreamProviderConfig ProviderConfig =
-            new EventHubStreamProviderConfig(StreamProviderName, 3);
+            new EventHubStreamProviderConfig(StreamProviderName) { CacheSizeMb = 3 };
 
         private static readonly EventHubCheckpointerSettings CheckpointerSettings =
             new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,

--- a/test/Tester/StreamingTests/TimePurgePredicateTests.cs
+++ b/test/Tester/StreamingTests/TimePurgePredicateTests.cs
@@ -7,11 +7,11 @@ namespace UnitTests.StreamingTests
 {
     public class TimePurgePredicateTests
     {
-        private static readonly TimeSpan minTimeInCache = TimeSpan.FromMinutes(5);
-        private static readonly TimeSpan maxRelitiveAgeInCache = TimeSpan.FromMinutes(30);
-        private static readonly TimePurgePredicate timePurge = new TimePurgePredicate(minTimeInCache, maxRelitiveAgeInCache);
-        private static readonly DateTime cacheMaxEnqueTime = new DateTime(2000, 3, 12, 10, 13, 32);
-        private static readonly DateTime nowUtc = DateTime.UtcNow;
+        private static readonly TimeSpan MinTimeInCache = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan MaxRelitiveAgeInCache = TimeSpan.FromMinutes(30);
+        private static readonly TimePurgePredicate TimePurge = new TimePurgePredicate(MinTimeInCache, MaxRelitiveAgeInCache);
+        private static readonly DateTime CacheMaxEnqueTime = new DateTime(2000, 3, 12, 10, 13, 32);
+        private static readonly DateTime NowUtc = DateTime.UtcNow;
 
         /// <summary>
         /// Message has not been in cache long enough to purge, and message age is not old enough to purge
@@ -19,11 +19,11 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public void TimePurgePredicate_NoPurgeThreshold_Tests()
         {
-            DateTime messageEnqueTime = cacheMaxEnqueTime - maxRelitiveAgeInCache;
-            DateTime timeRead = nowUtc - minTimeInCache;
-            TimeSpan timeInService = nowUtc - timeRead;
-            TimeSpan relativeAge = cacheMaxEnqueTime - messageEnqueTime;
-            Assert.Equal(false, timePurge.ShouldPurgFromTime(timeInService, relativeAge));
+            DateTime messageEnqueTime = CacheMaxEnqueTime - MaxRelitiveAgeInCache;
+            DateTime timeRead = NowUtc - MinTimeInCache;
+            TimeSpan timeInCache = NowUtc - timeRead;
+            TimeSpan relativeAge = CacheMaxEnqueTime - messageEnqueTime;
+            Assert.Equal(false, TimePurge.ShouldPurgFromTime(timeInCache, relativeAge));
         }
 
         /// <summary>
@@ -32,11 +32,11 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public void TimePurgePredicate_PurgeDataThreshold_Tests()
         {
-            DateTime messageEnqueTime = cacheMaxEnqueTime - maxRelitiveAgeInCache - TimeSpan.FromTicks(1);
-            DateTime timeRead = nowUtc - minTimeInCache - TimeSpan.FromTicks(1);
-            TimeSpan timeInService = nowUtc - timeRead;
-            TimeSpan relativeAge = cacheMaxEnqueTime - messageEnqueTime;
-            Assert.Equal(true, timePurge.ShouldPurgFromTime(timeInService, relativeAge));
+            DateTime messageEnqueTime = CacheMaxEnqueTime - MaxRelitiveAgeInCache - TimeSpan.FromTicks(1);
+            DateTime timeRead = NowUtc - MinTimeInCache - TimeSpan.FromTicks(1);
+            TimeSpan timeInCache = NowUtc - timeRead;
+            TimeSpan relativeAge = CacheMaxEnqueTime - messageEnqueTime;
+            Assert.Equal(true, TimePurge.ShouldPurgFromTime(timeInCache, relativeAge));
         }
 
         /// <summary>
@@ -45,11 +45,11 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public void TimePurgePredicate_NoPurgeAgeThreshold_Tests()
         {
-            DateTime messageEnqueTime = cacheMaxEnqueTime - maxRelitiveAgeInCache;
-            DateTime timeRead = nowUtc - minTimeInCache - TimeSpan.FromTicks(1);
-            TimeSpan timeInService = nowUtc - timeRead;
-            TimeSpan relativeAge = cacheMaxEnqueTime - messageEnqueTime;
-            Assert.Equal(false, timePurge.ShouldPurgFromTime(timeInService, relativeAge));
+            DateTime messageEnqueTime = CacheMaxEnqueTime - MaxRelitiveAgeInCache;
+            DateTime timeRead = NowUtc - MinTimeInCache - TimeSpan.FromTicks(1);
+            TimeSpan timeInCache = NowUtc - timeRead;
+            TimeSpan relativeAge = CacheMaxEnqueTime - messageEnqueTime;
+            Assert.Equal(false, TimePurge.ShouldPurgFromTime(timeInCache, relativeAge));
         }
 
         /// <summary>
@@ -58,11 +58,11 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public void TimePurgePredicate_NoPurgeTimeInCacheThreshold_Tests()
         {
-            DateTime messageEnqueTime = cacheMaxEnqueTime - maxRelitiveAgeInCache - TimeSpan.FromTicks(1);
-            DateTime timeRead = nowUtc - minTimeInCache;
-            TimeSpan timeInService = nowUtc - timeRead;
-            TimeSpan relativeAge = cacheMaxEnqueTime - messageEnqueTime;
-            Assert.Equal(false, timePurge.ShouldPurgFromTime(timeInService, relativeAge));
+            DateTime messageEnqueTime = CacheMaxEnqueTime - MaxRelitiveAgeInCache - TimeSpan.FromTicks(1);
+            DateTime timeRead = NowUtc - MinTimeInCache;
+            TimeSpan timeInCache = NowUtc - timeRead;
+            TimeSpan relativeAge = CacheMaxEnqueTime - messageEnqueTime;
+            Assert.Equal(false, TimePurge.ShouldPurgFromTime(timeInCache, relativeAge));
         }
 
         /// <summary>

--- a/test/Tester/StreamingTests/TimePurgePredicateTests.cs
+++ b/test/Tester/StreamingTests/TimePurgePredicateTests.cs
@@ -1,0 +1,77 @@
+﻿
+using System;
+using Orleans.ServiceBus.Providers;
+using Xunit;
+
+namespace UnitTests.StreamingTests
+{
+    public class TimePurgePredicateTests
+    {
+        private static readonly TimeSpan minTimeInCache = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan maxRelitiveAgeInCache = TimeSpan.FromMinutes(30);
+        private static readonly TimePurgePredicate timePurge = new TimePurgePredicate(minTimeInCache, maxRelitiveAgeInCache);
+        private static readonly DateTime cacheMaxEnqueTime = new DateTime(2000, 3, 12, 10, 13, 32);
+        private static readonly DateTime nowUtc = DateTime.UtcNow;
+
+        /// <summary>
+        /// Message has not been in cache long enough to purge, and message age is not old enough to purge
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void TimePurgePredicate_NoPurgeThreshold_Tests()
+        {
+            DateTime messageEnqueTime = cacheMaxEnqueTime - maxRelitiveAgeInCache;
+            DateTime timeRead = nowUtc - minTimeInCache;
+            TimeSpan timeInService = nowUtc - timeRead;
+            TimeSpan relativeAge = cacheMaxEnqueTime - messageEnqueTime;
+            Assert.Equal(false, timePurge.ShouldPurgFromTime(timeInService, relativeAge));
+        }
+
+        /// <summary>
+        /// Message has been in cache long enough to purge, and message age is old enough to purge
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void TimePurgePredicate_PurgeDataThreshold_Tests()
+        {
+            DateTime messageEnqueTime = cacheMaxEnqueTime - maxRelitiveAgeInCache - TimeSpan.FromTicks(1);
+            DateTime timeRead = nowUtc - minTimeInCache - TimeSpan.FromTicks(1);
+            TimeSpan timeInService = nowUtc - timeRead;
+            TimeSpan relativeAge = cacheMaxEnqueTime - messageEnqueTime;
+            Assert.Equal(true, timePurge.ShouldPurgFromTime(timeInService, relativeAge));
+        }
+
+        /// <summary>
+        /// Message has been in cache long enough to purge, but message age is not old enough to purge
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void TimePurgePredicate_NoPurgeAgeThreshold_Tests()
+        {
+            DateTime messageEnqueTime = cacheMaxEnqueTime - maxRelitiveAgeInCache;
+            DateTime timeRead = nowUtc - minTimeInCache - TimeSpan.FromTicks(1);
+            TimeSpan timeInService = nowUtc - timeRead;
+            TimeSpan relativeAge = cacheMaxEnqueTime - messageEnqueTime;
+            Assert.Equal(false, timePurge.ShouldPurgFromTime(timeInService, relativeAge));
+        }
+
+        /// <summary>
+        /// Message has not been in cache long enough to purge, but message age is old enough to purge
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void TimePurgePredicate_NoPurgeTimeInCacheThreshold_Tests()
+        {
+            DateTime messageEnqueTime = cacheMaxEnqueTime - maxRelitiveAgeInCache - TimeSpan.FromTicks(1);
+            DateTime timeRead = nowUtc - minTimeInCache;
+            TimeSpan timeInService = nowUtc - timeRead;
+            TimeSpan relativeAge = cacheMaxEnqueTime - messageEnqueTime;
+            Assert.Equal(false, timePurge.ShouldPurgFromTime(timeInService, relativeAge));
+        }
+
+        /// <summary>
+        /// Default time purge should not purge
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void TimePurgePredicate_DefaultNeverPurges_Tests()
+        {
+            Assert.Equal(false, TimePurgePredicate.Default.ShouldPurgFromTime(TimeSpan.Zero, TimeSpan.MaxValue));
+        }
+    }
+}

--- a/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
@@ -13,6 +13,8 @@ namespace Tester.TestStreamProviders.EventHub
     {
         public class AdapterFactory : EventHubAdapterFactory
         {
+            private TimePurgePredicate timePurgePredicate = null;
+
             public AdapterFactory()
             {
                 CacheFactory = CreateQueueCache;
@@ -20,8 +22,12 @@ namespace Tester.TestStreamProviders.EventHub
 
             private IEventHubQueueCache CreateQueueCache(string partition, IStreamQueueCheckpointer<string> checkpointer, Logger log)
             {
+                if (timePurgePredicate != null)
+                {
+                    timePurgePredicate = new TimePurgePredicate(adapterConfig.DataMinTimeInCache, adapterConfig.DataMaxAgeInCache);
+                }
                 var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
-                var dataAdapter = new CachedDataAdapter(partition, bufferPool);
+                var dataAdapter = new CachedDataAdapter(partition, bufferPool, timePurgePredicate);
                 return new EventHubQueueCache(checkpointer, dataAdapter, log);
             }
         }
@@ -30,12 +36,11 @@ namespace Tester.TestStreamProviders.EventHub
         {
             private readonly Guid partitionStreamGuid;
 
-            public CachedDataAdapter(string partitionKey, IObjectPool<FixedSizeBuffer> bufferPool)
-                : base(bufferPool)
+            public CachedDataAdapter(string partitionKey, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge)
+                : base(bufferPool, timePurge)
             {
                 partitionStreamGuid = GetPartitionGuid(partitionKey);
             }
-
 
             public override StreamPosition GetStreamPosition(EventData queueMessage)
             {

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -130,6 +130,7 @@
     <Compile Include="StreamingTests\StreamFilteringTests.cs" />
     <Compile Include="StreamingTests\StreamGeneratorProviderTests.cs" />
     <Compile Include="StreamingTests\SubscriptionMultiplicityTestRunner.cs" />
+    <Compile Include="StreamingTests\TimePurgePredicateTests.cs" />
     <Compile Include="TestStreamProviders\AzureQueue\TestAzureQueueStreamProvider.cs" />
     <Compile Include="TestingHost\TestingSiloHostTests.cs" />
     <Compile Include="TestStreamProviders\Controllable\ControllableTestStreamProvider.cs" />

--- a/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
@@ -28,7 +28,7 @@ namespace UnitTests.OrleansRuntime.Streams
         private class TestBatchContainer : IBatchContainer
         {
             public Guid StreamGuid { get; set; }
-            public string StreamNamespace { get { return null; }}
+            public string StreamNamespace => null;
             public StreamSequenceToken SequenceToken { get; set; }
 
             public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
@@ -98,12 +98,7 @@ namespace UnitTests.OrleansRuntime.Streams
                 return new StreamPosition(streamIdentity, sequenceToken);
             }
 
-            public bool IsInStream(ref TestCachedMessage cachedMessage, Guid streamGuid, string streamNamespace)
-            {
-                return cachedMessage.StreamGuid == streamGuid && streamNamespace == null;
-            }
-
-            public bool ShouldPurge(ref TestCachedMessage cachedMessage, IDisposable purgeRequest)
+            public bool ShouldPurge(ref TestCachedMessage cachedMessage, ref TestCachedMessage newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Added time based message purge to EventHub stream provider message cache.

In addition to purging messages by cache size, a message are now purged if it is a configured period of time older than the newest data in the cache, and has been in the cache a minimum configured amount of time.