### PR TITLE
Updated Google.Protobuf dependency

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FSharp.Compiler.Tools" version="4.0.0.1" />
+  <package id="Google.Protobuf.Tools" version="3.0.0" />
   <package id="xunit.runner.console" version="2.1.0" />
   <package id="xunit.runner.visualstudio" version="2.1.0" />
 </packages>

--- a/src/OrleansGoogleUtils/project.json
+++ b/src/OrleansGoogleUtils/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Google.Protobuf": "3.0.0-alpha4"
+    "Google.Protobuf": "3.0.0"
   },
   "frameworks": {
     "net451": {}

--- a/test/Tester/SerializationTests/ProtobufSerializationTests/Addressbook.cs
+++ b/test/Tester/SerializationTests/ProtobufSerializationTests/Addressbook.cs
@@ -6,47 +6,52 @@
 using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
-namespace UnitTests.Serialization
-{
+using scg = global::System.Collections.Generic;
+namespace UnitTests.Serialization {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-  public static partial class Addressbook {
+  /// <summary>Holder for reflection information generated from addressbook.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  public static partial class AddressbookReflection {
 
     #region Descriptor
+    /// <summary>File descriptor for addressbook.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }
     private static pbr::FileDescriptor descriptor;
 
-    static Addressbook() {
+    static AddressbookReflection() {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
-            "ChFhZGRyZXNzYm9vay5wcm90bxIIdHV0b3JpYWwi1QEKBlBlcnNvbhIMCgRu", 
-            "YW1lGAEgASgJEgoKAmlkGAIgASgFEg0KBWVtYWlsGAMgASgJEiwKBnBob25l", 
-            "cxgEIAMoCzIcLnR1dG9yaWFsLlBlcnNvbi5QaG9uZU51bWJlchpHCgtQaG9u", 
-            "ZU51bWJlchIOCgZudW1iZXIYASABKAkSKAoEdHlwZRgCIAEoDjIaLnR1dG9y", 
-            "aWFsLlBlcnNvbi5QaG9uZVR5cGUiKwoJUGhvbmVUeXBlEgoKBk1PQklMRRAA", 
-            "EggKBEhPTUUQARIICgRXT1JLEAIiSAoLQWRkcmVzc0Jvb2sSIAoGcGVvcGxl", 
-            "GAEgAygLMhAudHV0b3JpYWwuUGVyc29uEhcKD2FkZHJlc3NCb29rTmFtZRgC", 
+            "ChFhZGRyZXNzYm9vay5wcm90bxIIdHV0b3JpYWwi1QEKBlBlcnNvbhIMCgRu",
+            "YW1lGAEgASgJEgoKAmlkGAIgASgFEg0KBWVtYWlsGAMgASgJEiwKBnBob25l",
+            "cxgEIAMoCzIcLnR1dG9yaWFsLlBlcnNvbi5QaG9uZU51bWJlchpHCgtQaG9u",
+            "ZU51bWJlchIOCgZudW1iZXIYASABKAkSKAoEdHlwZRgCIAEoDjIaLnR1dG9y",
+            "aWFsLlBlcnNvbi5QaG9uZVR5cGUiKwoJUGhvbmVUeXBlEgoKBk1PQklMRRAA",
+            "EggKBEhPTUUQARIICgRXT1JLEAIiSAoLQWRkcmVzc0Jvb2sSIAoGcGVvcGxl",
+            "GAEgAygLMhAudHV0b3JpYWwuUGVyc29uEhcKD2FkZHJlc3NCb29rTmFtZRgC",
             "IAEoCUIaqgIXVW5pdFRlc3RzLlNlcmlhbGl6YXRpb25iBnByb3RvMw=="));
-      descriptor = pbr::FileDescriptor.InternalBuildGeneratedFileFrom(descriptorData,
+      descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedCodeInfo(null, new pbr::GeneratedCodeInfo[] {
-            new pbr::GeneratedCodeInfo(typeof(global::UnitTests.Serialization.Person), new[]{ "Name", "Id", "Email", "Phones" }, null, new[]{ typeof(global::UnitTests.Serialization.Person.Types.PhoneType) }, new pbr::GeneratedCodeInfo[] { new pbr::GeneratedCodeInfo(typeof(global::UnitTests.Serialization.Person.Types.PhoneNumber), new[]{ "Number", "Type" }, null, null, null)}),
-            new pbr::GeneratedCodeInfo(typeof(global::UnitTests.Serialization.AddressBook), new[]{ "People", "AddressBookName" }, null, null, null)
+          new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
+            new pbr::GeneratedClrTypeInfo(typeof(global::UnitTests.Serialization.Person), global::UnitTests.Serialization.Person.Parser, new[]{ "Name", "Id", "Email", "Phones" }, null, new[]{ typeof(global::UnitTests.Serialization.Person.Types.PhoneType) }, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::UnitTests.Serialization.Person.Types.PhoneNumber), global::UnitTests.Serialization.Person.Types.PhoneNumber.Parser, new[]{ "Number", "Type" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::UnitTests.Serialization.AddressBook), global::UnitTests.Serialization.AddressBook.Parser, new[]{ "People", "AddressBookName" }, null, null, null)
           }));
     }
     #endregion
 
   }
   #region Messages
+  /// <summary>
+  ///  [START messages]
+  /// </summary>
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public sealed partial class Person : pb::IMessage<Person> {
     private static readonly pb::MessageParser<Person> _parser = new pb::MessageParser<Person>(() => new Person());
     public static pb::MessageParser<Person> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::UnitTests.Serialization.Addressbook.Descriptor.MessageTypes[0]; }
+      get { return global::UnitTests.Serialization.AddressbookReflection.Descriptor.MessageTypes[0]; }
     }
 
     pbr::MessageDescriptor pb::IMessage.Descriptor {
@@ -70,17 +75,22 @@ namespace UnitTests.Serialization
       return new Person(this);
     }
 
+    /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private string name_ = "";
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
+    /// <summary>Field number for the "id" field.</summary>
     public const int IdFieldNumber = 2;
     private int id_;
+    /// <summary>
+    ///  Unique ID number for this person.
+    /// </summary>
     public int Id {
       get { return id_; }
       set {
@@ -88,15 +98,17 @@ namespace UnitTests.Serialization
       }
     }
 
+    /// <summary>Field number for the "email" field.</summary>
     public const int EmailFieldNumber = 3;
     private string email_ = "";
     public string Email {
       get { return email_; }
       set {
-        email_ = pb::Preconditions.CheckNotNull(value, "value");
+        email_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
+    /// <summary>Field number for the "phones" field.</summary>
     public const int PhonesFieldNumber = 4;
     private static readonly pb::FieldCodec<global::UnitTests.Serialization.Person.Types.PhoneNumber> _repeated_phones_codec
         = pb::FieldCodec.ForMessage(34, global::UnitTests.Serialization.Person.Types.PhoneNumber.Parser);
@@ -133,7 +145,7 @@ namespace UnitTests.Serialization
     }
 
     public override string ToString() {
-      return pb::JsonFormatter.Default.Format(this);
+      return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     public void WriteTo(pb::CodedOutputStream output) {
@@ -211,12 +223,13 @@ namespace UnitTests.Serialization
     }
 
     #region Nested types
+    /// <summary>Container for nested types declared in the Person message type.</summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       public enum PhoneType {
-        MOBILE = 0,
-        HOME = 1,
-        WORK = 2,
+        [pbr::OriginalName("MOBILE")] Mobile = 0,
+        [pbr::OriginalName("HOME")] Home = 1,
+        [pbr::OriginalName("WORK")] Work = 2,
       }
 
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
@@ -247,17 +260,19 @@ namespace UnitTests.Serialization
           return new PhoneNumber(this);
         }
 
+        /// <summary>Field number for the "number" field.</summary>
         public const int NumberFieldNumber = 1;
         private string number_ = "";
         public string Number {
           get { return number_; }
           set {
-            number_ = pb::Preconditions.CheckNotNull(value, "value");
+            number_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
           }
         }
 
+        /// <summary>Field number for the "type" field.</summary>
         public const int TypeFieldNumber = 2;
-        private global::UnitTests.Serialization.Person.Types.PhoneType type_ = global::UnitTests.Serialization.Person.Types.PhoneType.MOBILE;
+        private global::UnitTests.Serialization.Person.Types.PhoneType type_ = 0;
         public global::UnitTests.Serialization.Person.Types.PhoneType Type {
           get { return type_; }
           set {
@@ -284,12 +299,12 @@ namespace UnitTests.Serialization
         public override int GetHashCode() {
           int hash = 1;
           if (Number.Length != 0) hash ^= Number.GetHashCode();
-          if (Type != global::UnitTests.Serialization.Person.Types.PhoneType.MOBILE) hash ^= Type.GetHashCode();
+          if (Type != 0) hash ^= Type.GetHashCode();
           return hash;
         }
 
         public override string ToString() {
-          return pb::JsonFormatter.Default.Format(this);
+          return pb::JsonFormatter.ToDiagnosticString(this);
         }
 
         public void WriteTo(pb::CodedOutputStream output) {
@@ -297,7 +312,7 @@ namespace UnitTests.Serialization
             output.WriteRawTag(10);
             output.WriteString(Number);
           }
-          if (Type != global::UnitTests.Serialization.Person.Types.PhoneType.MOBILE) {
+          if (Type != 0) {
             output.WriteRawTag(16);
             output.WriteEnum((int) Type);
           }
@@ -308,7 +323,7 @@ namespace UnitTests.Serialization
           if (Number.Length != 0) {
             size += 1 + pb::CodedOutputStream.ComputeStringSize(Number);
           }
-          if (Type != global::UnitTests.Serialization.Person.Types.PhoneType.MOBILE) {
+          if (Type != 0) {
             size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Type);
           }
           return size;
@@ -321,7 +336,7 @@ namespace UnitTests.Serialization
           if (other.Number.Length != 0) {
             Number = other.Number;
           }
-          if (other.Type != global::UnitTests.Serialization.Person.Types.PhoneType.MOBILE) {
+          if (other.Type != 0) {
             Type = other.Type;
           }
         }
@@ -352,13 +367,16 @@ namespace UnitTests.Serialization
 
   }
 
+  /// <summary>
+  ///  Our address book file is just one of these.
+  /// </summary>
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public sealed partial class AddressBook : pb::IMessage<AddressBook> {
     private static readonly pb::MessageParser<AddressBook> _parser = new pb::MessageParser<AddressBook>(() => new AddressBook());
     public static pb::MessageParser<AddressBook> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::UnitTests.Serialization.Addressbook.Descriptor.MessageTypes[1]; }
+      get { return global::UnitTests.Serialization.AddressbookReflection.Descriptor.MessageTypes[1]; }
     }
 
     pbr::MessageDescriptor pb::IMessage.Descriptor {
@@ -380,6 +398,7 @@ namespace UnitTests.Serialization
       return new AddressBook(this);
     }
 
+    /// <summary>Field number for the "people" field.</summary>
     public const int PeopleFieldNumber = 1;
     private static readonly pb::FieldCodec<global::UnitTests.Serialization.Person> _repeated_people_codec
         = pb::FieldCodec.ForMessage(10, global::UnitTests.Serialization.Person.Parser);
@@ -388,12 +407,16 @@ namespace UnitTests.Serialization
       get { return people_; }
     }
 
+    /// <summary>Field number for the "addressBookName" field.</summary>
     public const int AddressBookNameFieldNumber = 2;
     private string addressBookName_ = "";
+    /// <summary>
+    ///  the name of this address book
+    /// </summary>
     public string AddressBookName {
       get { return addressBookName_; }
       set {
-        addressBookName_ = pb::Preconditions.CheckNotNull(value, "value");
+        addressBookName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -421,7 +444,7 @@ namespace UnitTests.Serialization
     }
 
     public override string ToString() {
-      return pb::JsonFormatter.Default.Format(this);
+      return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     public void WriteTo(pb::CodedOutputStream output) {

--- a/test/Tester/SerializationTests/ProtobufSerializationTests/Counter.cs
+++ b/test/Tester/SerializationTests/ProtobufSerializationTests/Counter.cs
@@ -4,46 +4,48 @@
 #region Designer generated code
 
 using pb = global::Google.Protobuf;
+using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
-namespace UnitTests.Serialization
-{
+using scg = global::System.Collections.Generic;
+namespace UnitTests.Serialization {
 
-    namespace Proto
-    {
+  /// <summary>Holder for reflection information generated from counter.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  public static partial class CounterReflection {
 
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-    public static partial class Counter {
-
-      #region Descriptor
-      public static pbr::FileDescriptor Descriptor {
-        get { return descriptor; }
-      }
-      private static pbr::FileDescriptor descriptor;
-
-      static Counter() {
-        byte[] descriptorData = global::System.Convert.FromBase64String(
-            string.Concat(
-              "Cg1jb3VudGVyLnByb3RvEgh0dXRvcmlhbCIjCgdDb3VudGVyEgwKBG5hbWUY", 
-              "ASABKAkSCgoCaWQYAiABKAVCGqoCF1VuaXRUZXN0cy5TZXJpYWxpemF0aW9u", 
-              "YgZwcm90bzM="));
-        descriptor = pbr::FileDescriptor.InternalBuildGeneratedFileFrom(descriptorData,
-            new pbr::FileDescriptor[] { },
-            new pbr::GeneratedCodeInfo(null, new pbr::GeneratedCodeInfo[] {
-              new pbr::GeneratedCodeInfo(typeof(global::UnitTests.Serialization.Counter), new[]{ "Name", "Id" }, null, null, null)
-            }));
-      }
-      #endregion
-
+    #region Descriptor
+    /// <summary>File descriptor for counter.proto</summary>
+    public static pbr::FileDescriptor Descriptor {
+      get { return descriptor; }
     }
+    private static pbr::FileDescriptor descriptor;
+
+    static CounterReflection() {
+      byte[] descriptorData = global::System.Convert.FromBase64String(
+          string.Concat(
+            "Cg1jb3VudGVyLnByb3RvEgh0dXRvcmlhbCIjCgdDb3VudGVyEgwKBG5hbWUY",
+            "ASABKAkSCgoCaWQYAiABKAVCGqoCF1VuaXRUZXN0cy5TZXJpYWxpemF0aW9u",
+            "YgZwcm90bzM="));
+      descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
+          new pbr::FileDescriptor[] { },
+          new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
+            new pbr::GeneratedClrTypeInfo(typeof(global::UnitTests.Serialization.Counter), global::UnitTests.Serialization.Counter.Parser, new[]{ "Name", "Id" }, null, null, null)
+          }));
+    }
+    #endregion
+
   }
   #region Messages
+  /// <summary>
+  ///  [START messages]
+  /// </summary>
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public sealed partial class Counter : pb::IMessage<Counter> {
     private static readonly pb::MessageParser<Counter> _parser = new pb::MessageParser<Counter>(() => new Counter());
     public static pb::MessageParser<Counter> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::UnitTests.Serialization.Proto.Counter.Descriptor.MessageTypes[0]; }
+      get { return global::UnitTests.Serialization.CounterReflection.Descriptor.MessageTypes[0]; }
     }
 
     pbr::MessageDescriptor pb::IMessage.Descriptor {
@@ -65,15 +67,17 @@ namespace UnitTests.Serialization
       return new Counter(this);
     }
 
+    /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private string name_ = "";
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
+    /// <summary>Field number for the "id" field.</summary>
     public const int IdFieldNumber = 2;
     private int id_;
     public int Id {
@@ -107,7 +111,7 @@ namespace UnitTests.Serialization
     }
 
     public override string ToString() {
-      return pb::JsonFormatter.Default.Format(this);
+      return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     public void WriteTo(pb::CodedOutputStream output) {

--- a/test/Tester/SerializationTests/ProtobufSerializationTests/GenerateProtos.cmd
+++ b/test/Tester/SerializationTests/ProtobufSerializationTests/GenerateProtos.cmd
@@ -5,7 +5,7 @@ REM Have to explicitely list all .proto files as arguments
 @echo on
 
 SET CMDHOME=%~dp0
-SET PROTOCEXE="%CMDHOME%\..\..\..\packages\Google.Protobuf.3.0.0-alpha4\tools\protoc.exe"
+SET PROTOCEXE="%CMDHOME%\..\..\..\..\src\packages\Google.Protobuf.Tools.3.0.0\tools\windows_x64\protoc.exe"
 SET PROTO_FILES_LIST=%CMDHOME%\addressbook.proto  %CMDHOME%\counter.proto
 
 %PROTOCEXE% --csharp_out=. --proto_path=%CMDHOME%   %PROTO_FILES_LIST%

--- a/test/Tester/project.json
+++ b/test/Tester/project.json
@@ -3,7 +3,7 @@
     "Bond.Runtime.CSharp": "3.0.7",
     "FluentAssertions": "4.0.0",
     "FSharp.Core": "4.0.0.1",
-    "Google.Protobuf": "3.0.0-alpha4",
+    "Google.Protobuf": "3.0.0",
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Newtonsoft.Json": "7.0.1",
     "System.Management.Automation.dll": "10.0.10586",


### PR DESCRIPTION
This PR updates the Google.Protobuf dependency to a non-prerelease version.

There is a problem with this PR, though. The "GenerateProtos.cmd" script has a hard coded dependency on the "protoc.exe" utility. In the prerelease versions, "protoc.exe" was included in the Google.Protobuf package. It appears They have split the utility into its own package, Google.Protobuf.Tools.

I am still learning about the changes that project.json brings to projects. In particular, it appears that adding Google.Protobuf.Tools as a dependency won't work as it had previously. The "protoc.exe" utility doesn't appear to be extracted into a packages folder within the solution. It's not clear to me how a tool can be called from a script with this new package structure. Any suggestions are welcome, and I am happy to amend this PR.