### PR TITLE
Minor .NET Standard compatibility fixes

### DIFF
--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -1040,6 +1040,54 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Get a public or non-public constructor that matches the constructor arguments signature
+        /// </summary>
+        /// <param name="type">The type to use.</param>
+        /// <param name="constructorArguments">The constructor argument types to match for the signature.</param>
+        /// <returns>A constructor that matches the signature or <see langword="null"/>.</returns>
+        public static ConstructorInfo GetConstructorThatMatches(Type type, Type[] constructorArguments)
+        {
+#if NETSTANDARD
+            var candidates = type.GetTypeInfo().GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            foreach (ConstructorInfo candidate in candidates)
+            {
+                if (ConstructorMatches(candidate, constructorArguments))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+#else
+            var constructorInfo = type.GetConstructor(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                constructorArguments,
+                null);
+            return constructorInfo;
+#endif
+        }
+
+        private static bool ConstructorMatches(ConstructorInfo candidate, Type[] constructorArguments)
+        {
+            ParameterInfo[] parameters = candidate.GetParameters();
+            if (parameters.Length == constructorArguments.Length)
+            {
+                for (int i = 0; i < constructorArguments.Length; i++)
+                {
+                    if (parameters[i].ParameterType != constructorArguments[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Returns a value indicating whether or not the provided assembly is the Orleans assembly or references it.
         /// </summary>
         /// <param name="assembly">The assembly.</param>

--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -460,6 +460,7 @@ namespace Orleans.Runtime.Configuration
             sb.Append(ConfigUtilities.IStatisticsConfigurationToString(this));
             sb.Append(LimitManager);
             sb.AppendFormat(base.ToString());
+#if !NETSTANDARD
             sb.Append("   .NET: ").AppendLine();
             int workerThreads;
             int completionPortThreads;
@@ -467,6 +468,7 @@ namespace Orleans.Runtime.Configuration
             sb.AppendFormat("       .NET thread pool sizes - Min: Worker Threads={0} Completion Port Threads={1}", workerThreads, completionPortThreads).AppendLine();
             ThreadPool.GetMaxThreads(out workerThreads, out completionPortThreads);
             sb.AppendFormat("       .NET thread pool sizes - Max: Worker Threads={0} Completion Port Threads={1}", workerThreads, completionPortThreads).AppendLine();
+#endif
             sb.AppendFormat("   Providers:").AppendLine();
             sb.Append(ProviderConfigurationUtility.PrintProviderConfigurations(ProviderConfigurations));
             return sb.ToString();

--- a/src/Orleans/Configuration/ConfigUtilities.cs
+++ b/src/Orleans/Configuration/ConfigUtilities.cs
@@ -619,9 +619,12 @@ namespace Orleans.Runtime.Configuration
         public static string RuntimeVersionInfo()
         {
             var sb = new StringBuilder();
+#if !NETSTANDARD
+			// TODO: could use Microsoft.Extensions.PlatformAbstractions package to get this info
             sb.Append("   .NET version: ").AppendLine(Environment.Version.ToString());
             sb.Append("   Is .NET 4.5=").AppendLine(IsNet45OrNewer().ToString());
             sb.Append("   OS version: ").AppendLine(Environment.OSVersion.ToString());
+#endif
             sb.AppendFormat("   GC Type={0} GCLatencyMode={1}",
                               GCSettings.IsServerGC ? "Server" : "Client",
                               Enum.GetName(typeof(GCLatencyMode), GCSettings.LatencyMode))

--- a/src/Orleans/Logging/LogManager.cs
+++ b/src/Orleans/Logging/LogManager.cs
@@ -432,8 +432,9 @@ namespace Orleans.Runtime
                 var process = Process.GetCurrentProcess();
 
                 // It is safe to call DangerousGetHandle() here because the process is already crashing.
+                var handle = GetProcessHandle(process);
                 NativeMethods.MiniDumpWriteDump(
-                    process.Handle,
+                    handle,
                     process.Id,
                     stream.SafeFileHandle.DangerousGetHandle(),
                     dumpType,
@@ -443,6 +444,15 @@ namespace Orleans.Runtime
             }
 
             return new FileInfo(dumpFileName);
+        }
+
+        private static IntPtr GetProcessHandle(Process process)
+        {
+#if NETSTANDARD
+            return process.SafeHandle.DangerousGetHandle();
+#else
+            return process.Handle;
+#endif
         }
 
         /// <summary>

--- a/src/Orleans/Logging/LogManager.cs
+++ b/src/Orleans/Logging/LogManager.cs
@@ -422,7 +422,12 @@ namespace Orleans.Runtime
         {
             const string dateFormat = "yyyy-MM-dd-HH-mm-ss-fffZ"; // Example: 2010-09-02-09-50-43-341Z
 
-            var thisAssembly = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
+            var thisAssembly = Assembly.GetEntryAssembly()
+#if !NETSTANDARD
+                ?? Assembly.GetCallingAssembly()
+#endif
+                ?? typeof(LogManager)
+                .GetTypeInfo().Assembly;
 
             var dumpFileName = $@"{thisAssembly.GetName().Name}-MiniDump-{DateTime.UtcNow.ToString(dateFormat,
                     CultureInfo.InvariantCulture)}.dmp";

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -549,7 +549,7 @@ namespace Orleans.Runtime
             response.RejectionType = type;
             response.RejectionInfo = info;
             response.BodyObject = ex;
-            if (logger.IsVerbose) logger.Verbose("Creating {0} rejection with info '{1}' for {2} at:" + Environment.NewLine + "{3}", type, info, this, new System.Diagnostics.StackTrace(true));
+            if (logger.IsVerbose) logger.Verbose("Creating {0} rejection with info '{1}' for {2} at:" + Environment.NewLine + "{3}", type, info, this, Utils.GetStackTrace());
             return response;
         }
 

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -306,6 +306,7 @@ namespace Orleans.Messaging
 #endif
                 return msg;
             }
+#if !NETSTANDARD
             catch (ThreadAbortException exc)
             {
                 // Silo may be shutting-down, so downgrade to verbose log
@@ -313,6 +314,7 @@ namespace Orleans.Messaging
                 Thread.ResetAbort();
                 return null;
             }
+#endif
             catch (OperationCanceledException exc)
             {
                 logger.Verbose(ErrorCode.ProxyClient_OperationCancelled, "Received operation cancelled exception -- exiting. {0}", exc);
@@ -380,7 +382,7 @@ namespace Orleans.Messaging
             throw new NotImplementedException("Reconnect");
         }
 
-        #region Random IMessageCenter stuff
+#region Random IMessageCenter stuff
 
         public int SendQueueLength
         {
@@ -392,7 +394,7 @@ namespace Orleans.Messaging
             get { return 0; }
         }
 
-        #endregion
+#endregion
 
         private ITypeManager GetTypeManager(SiloAddress destination, GrainFactory grainFactory)
         {

--- a/src/Orleans/Messaging/SocketManager.cs
+++ b/src/Orleans/Messaging/SocketManager.cs
@@ -193,7 +193,7 @@ namespace Orleans.Runtime
                 // Ignore
             }
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD
             try
             {
                 s.Disconnect(false);

--- a/src/Orleans/Messaging/SocketManager.cs
+++ b/src/Orleans/Messaging/SocketManager.cs
@@ -193,6 +193,7 @@ namespace Orleans.Runtime
                 // Ignore
             }
 
+#if !NETSTANDARD1_6
             try
             {
                 s.Disconnect(false);
@@ -201,6 +202,7 @@ namespace Orleans.Runtime
             {
                 // Ignore
             }
+#endif
             try
             {
                 s.Dispose();

--- a/src/Orleans/Providers/ProviderLoader.cs
+++ b/src/Orleans/Providers/ProviderLoader.cs
@@ -221,18 +221,21 @@ namespace Orleans.Providers
                 if (fullConfig.Type != typeName) continue;
                 
                 // Found one! Now look for an appropriate constructor; try TProvider(string, Dictionary<string,string>) first
-                var constructor = t.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                    null, constructorBindingTypes, null);
+                var constructor = TypeUtils.GetConstructorThatMatches(t, constructorBindingTypes);
                 var parms = new object[] { typeName, entry.Properties };
 
                 if (constructor == null)
                 {
                     // See if there's a default constructor to use, if there's no two-parameter constructor
-                    constructor = t.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                        null, Type.EmptyTypes, null);
+                    constructor = TypeUtils.GetConstructorThatMatches(t, Type.EmptyTypes);
                     parms = new object[0];
                 }
-                if (constructor == null) continue;
+                if (constructor == null)
+                {
+                    logger.Warn(ErrorCode.Provider_InstanceConstructionError1, $"Accessible constructor does not exist for type {t.Name}");
+
+                    continue;
+                }
 
                 TProvider instance;
                 try

--- a/src/Orleans/Runtime/AsynchAgent.cs
+++ b/src/Orleans/Runtime/AsynchAgent.cs
@@ -50,7 +50,9 @@ namespace Orleans.Runtime
             State = ThreadState.Unstarted;
             OnFault = FaultBehavior.IgnoreFault;
             Log = LogManager.GetLogger(Name, LoggerType.Runtime);
+#if !NETSTANDARD
             AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
+#endif
 
 #if TRACK_DETAILED_STATS
             if (StatisticsCollector.CollectThreadTimeTrackingStats)
@@ -118,7 +120,9 @@ namespace Orleans.Runtime
                         State = ThreadState.Stopped;
                     }
                 }
+#if !NETSTANDARD
                 AppDomain.CurrentDomain.DomainUnload -= CurrentDomain_DomainUnload;
+#endif
             }
             catch (Exception exc)
             {
@@ -128,11 +132,13 @@ namespace Orleans.Runtime
             Log.Verbose("Stopped agent");
         }
 
+#if !NETSTANDARD
         public void Abort(object stateInfo)
         {
             if(t!=null)
                 t.Abort(stateInfo);
         }
+#endif
 
         public void Join(TimeSpan timeout)
         {
@@ -141,7 +147,7 @@ namespace Orleans.Runtime
                 var agentThread = t;
                 if (agentThread != null)
                 {
-                    bool joined = agentThread.Join(timeout);
+                    bool joined = agentThread.Join((int)timeout.TotalMilliseconds);
                     Log.Verbose("{0} the agent thread {1} after {2} time.", joined ? "Joined" : "Did not join", Name, timeout);
                 }
             }catch(Exception exc)
@@ -218,7 +224,7 @@ namespace Orleans.Runtime
             }
         }
 
-        #region IDisposable Members
+#region IDisposable Members
 
         public void Dispose()
         {
@@ -237,7 +243,7 @@ namespace Orleans.Runtime
             }
         }
 
-        #endregion
+#endregion
 
         public override string ToString()
         {

--- a/src/Orleans/Serialization/BinaryFormatterSerializer.cs
+++ b/src/Orleans/Serialization/BinaryFormatterSerializer.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using Orleans.Runtime;
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD
 namespace Orleans.Serialization
 {
     public class BinaryFormatterSerializer : IExternalSerializer

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -830,12 +830,7 @@ namespace Orleans.Serialization
                 typeInfo = type.GetTypeInfo();
             }
 
-            var constructor =
-                typeInfo.GetConstructor(
-                                BindingFlags.CreateInstance | BindingFlags.NonPublic | BindingFlags.Instance,
-                                null,
-                                new[] { typeof(GrainReference) },
-                                null);
+            var constructor = TypeUtils.GetConstructorThatMatches(type, new[] { typeof(GrainReference) });
 
             var ctorParam = Expression.Parameter(typeof(GrainReference), "grainRef");
             var lambda = Expression.Lambda(

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -72,7 +72,7 @@ namespace Orleans.Serialization
             set;
         }
 
-#if NETSTANDARD1_6
+#if NETSTANDARD
         // Workaround for CoreCLR where FormatterServices.GetUninitializedObject is not public (but might change in RTM so we could remove this then).
         private static readonly Func<Type, object> getUninitializedObjectDelegate =
             (Func<Type, object>)
@@ -173,7 +173,7 @@ namespace Orleans.Serialization
             RegisterBuiltInSerializers();
             UseStandardSerializer = useStandardSerializer;
 
-#if NETSTANDARD1_6
+#if NETSTANDARD
             if (!useJsonFallbackSerializer)
             {
                 logger.Warn(ErrorCode.SerMgr_UnavailableSerializer,
@@ -2009,7 +2009,7 @@ namespace Orleans.Serialization
             }
             else
             {
-#if NETSTANDARD1_6
+#if NETSTANDARD
                 throw new OrleansException("Can't use binary formatter as fallback serializer while running on .Net Core");
 #else
                 serializer = new BinaryFormatterSerializer();

--- a/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
+++ b/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
@@ -100,7 +100,7 @@ namespace Orleans.Runtime
                 promotedFinalizationMemoryFromGen0PF = new PerformanceCounter(".NET CLR Memory", "Promoted Finalization-Memory from Gen 0", thisProcess, true);
 #endif
                 
-#if !(NETSTANDARD1_6 || __MonoCS__)
+#if !(NETSTANDARD || __MonoCS__)
                 //.NET on Windows without mono
                 const string Query = "SELECT Capacity FROM Win32_PhysicalMemory";
                 var searcher = new ManagementObjectSearcher(Query);
@@ -116,7 +116,7 @@ namespace Orleans.Runtime
                 //Cross platform mono
                 var totalPhysicalMemory = new PerformanceCounter("Mono Memory", "Total Physical Memory");
                 TotalPhysicalMemory = Convert.ToInt64(totalPhysicalMemory.NextValue());
-#elif NETSTANDARD1_6
+#elif NETSTANDARD
                 //Cross platform CoreCLR
 #endif
                 countersAvailable = true;

--- a/src/Orleans/Utils/Utils.cs
+++ b/src/Orleans/Utils/Utils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -348,6 +349,23 @@ namespace Orleans.Runtime
             {
                 yield return batch; //batch.ToArray();
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string GetStackTrace(int skipFrames = 0)
+        {
+            skipFrames += 1; //skip this method from the stack trace
+#if NETSTANDARD
+            skipFrames += 2; //skip the 2 Environment.StackTrace related methods.
+            var stackTrace = Environment.StackTrace;
+            for (int i = 0; i < skipFrames; i++)
+            {
+                stackTrace = stackTrace.Substring(stackTrace.IndexOf(Environment.NewLine) + Environment.NewLine.Length);
+            }
+            return stackTrace;
+#else
+            return new System.Diagnostics.StackTrace(skipFrames).ToString();
+#endif
         }
     }
 }

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -460,7 +460,7 @@ namespace Orleans.CodeGenerator
             {
                 // Create an unformatted object.
                 Expression<Func<object>> getUninitializedObject =
-#if NETSTANDARD1_6
+#if NETSTANDARD
                     () => SerializationManager.GetUninitializedObjectWithFormatterServices(default(Type));
 #else
                     () => FormatterServices.GetUninitializedObject(default(Type));

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -170,7 +170,7 @@ namespace Orleans.Runtime
 
             var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
             if (context == null && !oneWay)
-                logger.Warn(ErrorCode.IGC_SendRequest_NullContext, "Null context {0}: {1}", message, new StackTrace());
+                logger.Warn(ErrorCode.IGC_SendRequest_NullContext, "Null context {0}: {1}", message, Utils.GetStackTrace());
 
             if (message.IsExpirableMessage(Config.Globals))
                 message.Expiration = DateTime.UtcNow + ResponseTimeout + Constants.MAXIMUM_CLOCK_SKEW;
@@ -355,7 +355,7 @@ namespace Orleans.Runtime
                         var exc = new GrainExtensionNotInstalledException(error);
                         string extraDebugInfo = null;
 #if DEBUG
-                        extraDebugInfo = new StackTrace().ToString();
+                        extraDebugInfo = Utils.GetStackTrace();
 #endif
                         logger.Warn(ErrorCode.Stream_ExtensionNotInstalled, 
                             string.Format("{0} for message {1} {2}", error, message, extraDebugInfo), exc);
@@ -767,7 +767,7 @@ namespace Orleans.Runtime
 
         public string CaptureRuntimeEnvironment()
         {
-            var callStack = new System.Diagnostics.StackTrace(1); // Don't include this method in stack trace
+            var callStack = Utils.GetStackTrace(1); // Don't include this method in stack trace
             return String.Format(
                   "   TaskScheduler={0}" + Environment.NewLine 
                 + "   RuntimeContext={1}" + Environment.NewLine

--- a/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
@@ -78,7 +78,7 @@ namespace Orleans.Runtime.Messaging
 
             if (!msg.ContainsHeader(Message.Header.TARGET_SILO))
             {
-                logger.Error(ErrorCode.Runtime_Error_100113, "Message does not have a target silo: " + msg + " -- Call stack is: " + (new System.Diagnostics.StackTrace()));
+                logger.Error(ErrorCode.Runtime_Error_100113, "Message does not have a target silo: " + msg + " -- Call stack is: " + Utils.GetStackTrace());
                 messageCenter.SendRejection(msg, Message.RejectionTypes.Unrecoverable, "Message to be sent does not have a target silo");
                 return;
             }

--- a/src/OrleansRuntime/Scheduler/WorkItemGroup.cs
+++ b/src/OrleansRuntime/Scheduler/WorkItemGroup.cs
@@ -441,7 +441,7 @@ namespace Orleans.Runtime.Scheduler
 
         private void ReportWorkGroupProblemWithBacktrace(string what, ErrorCode errorCode)
         {
-            var st = new StackTrace();
+            var st = Utils.GetStackTrace();
             var msg = string.Format("{0} {1}", what, DumpStatus());
             log.Warn(errorCode, msg + Environment.NewLine + " Called from " + st);
         }


### PR DESCRIPTION
Conditional compilation for some very minor differences between full .NET 4.5.1 and .NET Standard.
Some of these might no longer be needed when we upgrade to 4.6.*

Each fix is separated into its own commit so it's easier to review (and also track once it's merged, so please do not squash them)