### PR TITLE
[WIP] Dependency Injection

### DIFF
--- a/src/Orleans/Core/GrainClient.cs
+++ b/src/Orleans/Core/GrainClient.cs
@@ -241,6 +241,7 @@ namespace Orleans
                         // this is probably overkill, but this ensures isFullyInitialized false
                         // before we make a call that makes RuntimeClient.Current not null
                         isFullyInitialized = false;
+                        //TODO: should get GrainFactory trhough Dependency Injection system
                         grainFactory = new GrainFactory();
 
                         if (runtimeClient == null)

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -14,7 +14,7 @@ namespace Orleans
     /// <summary>
     /// Factory for accessing grains.
     /// </summary>
-    public class GrainFactory : IGrainFactory
+    internal class GrainFactory : IGrainFactory
     {
         /// <summary>
         /// The cached <see cref="MethodInfo"/> for <see cref="GrainReference.CastInternal"/>.

--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -16,6 +16,7 @@ namespace Orleans.Providers
         private readonly AsyncLock lockable;
         private InvokeInterceptor invokeInterceptor;
 
+        //TODO change this to ClientProviderRuntime(IServceProvider svcProvider) since GrainFactory is injectable now
         public ClientProviderRuntime(IGrainFactory grainFactory, IServiceProvider serviceProvider) 
         {
             caoTable = new Dictionary<Type, Tuple<IGrainExtension, IAddressable>>();

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -152,7 +152,7 @@ namespace Orleans
                 // Ensure SerializationManager static constructor is called before AssemblyLoad event is invoked
                 SerializationManager.GetDeserializer(typeof(String));
 
-                clientProviderRuntime = new ClientProviderRuntime(grainFactory, null);
+                clientProviderRuntime = new ClientProviderRuntime(null, OrleansInternalServices.DefaultServiceProvider());
                 statisticsProviderManager = new StatisticsProviderManager("Statistics", clientProviderRuntime);
                 var statsProviderName = statisticsProviderManager.LoadProvider(config.ProviderConfigurations)
                     .WaitForResultWithThrow(initTimeout);

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -50,24 +50,6 @@ namespace Orleans.Providers.Streams.Common
 
         public bool IsRewindable { get { return queueAdapter.IsRewindable; } }
 
-        // this is a workaround until we address "Dependency Injection: register IGrainFactory #988"
-        private class GrainFactoryServiceProvider : IServiceProvider
-        {
-            private IStreamProviderRuntime providerRuntime;
-            public GrainFactoryServiceProvider(IStreamProviderRuntime providerRuntime)
-            {
-                this.providerRuntime = providerRuntime;
-            }
-            public object GetService(Type serviceType)
-            {
-                if (serviceType == typeof (GrainFactory))
-                {
-                    return providerRuntime.GrainFactory;
-                }
-                return providerRuntime == null ? null:providerRuntime.ServiceProvider.GetService(serviceType);
-            }
-        }
-
         public async Task Init(string name, IProviderRuntime providerUtilitiesManager, IProviderConfiguration config)
         {
             if(!stateManager.PresetState(ProviderState.Initialized)) return;
@@ -81,7 +63,7 @@ namespace Orleans.Providers.Streams.Common
             adapterFactory = new TAdapterFactory();
             // Temporary change, but we need GrainFactory inside ServiceProvider for now, 
             // so will change it back as soon as we have an action item to add GrainFactory to ServiceProvider.
-            adapterFactory.Init(config, Name, logger, new GrainFactoryServiceProvider(providerRuntime));
+            adapterFactory.Init(config, Name, logger, providerRuntime.ServiceProvider);
             queueAdapter = await adapterFactory.CreateAdapter();
             myConfig = new PersistentStreamProviderConfig(config);
             string startup;

--- a/src/OrleansAzureUtils/Hosting/AzureSilo.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureSilo.cs
@@ -42,6 +42,7 @@ namespace Orleans.Runtime.Host
         public string ProxyEndpointConfigurationKeyName { get; set; }
         
         private SiloHost host;
+        private IServiceProvider serviceProvider;
         private OrleansSiloInstanceManager siloInstanceManager;
         private SiloInstanceTableEntry myEntry;
         private readonly Logger logger;
@@ -50,12 +51,12 @@ namespace Orleans.Runtime.Host
         /// <summary>
         /// Constructor
         /// </summary>
-        public AzureSilo()
-            : this(new ServiceRuntimeWrapper())
+        public AzureSilo(IServiceProvider svcProvider)
+            : this(new ServiceRuntimeWrapper(), svcProvider)
         {
         }
 
-        internal AzureSilo(IServiceRuntimeWrapper serviceRuntimeWrapper)
+        internal AzureSilo(IServiceRuntimeWrapper serviceRuntimeWrapper, IServiceProvider svcProvider)
         {
             this.serviceRuntimeWrapper = serviceRuntimeWrapper;
             DataConnectionConfigurationSettingName = AzureConstants.DataConnectionConfigurationSettingName;
@@ -66,6 +67,7 @@ namespace Orleans.Runtime.Host
             MaxRetries = AzureConstants.MAX_RETRIES;  // 120 x 5s = Total: 10 minutes
 
             logger = LogManager.GetLogger("OrleansAzureSilo", LoggerType.Runtime);
+            serviceProvider = svcProvider;
         }
 
         public async Task<bool> ValidateConfiguration(ClusterConfiguration config)
@@ -162,7 +164,7 @@ namespace Orleans.Runtime.Host
             }
             else
             {
-                host = new SiloHost(instanceName, config); // Use supplied config data + Initializes logger configurations
+                host = new SiloHost(instanceName, config, serviceProvider); // Use supplied config data + Initializes logger configurations
             }
 
             IPEndPoint myEndpoint = serviceRuntimeWrapper.GetIPEndpoint(SiloEndpointConfigurationKeyName);

--- a/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
@@ -38,7 +38,7 @@ namespace Orleans.Providers.Streams.Memory
             this.providerName = providerName;
             this.queueGrains = new ConcurrentDictionary<QueueId, IMemoryStreamQueueGrain>();
             this.adapterConfig = new MemoryAdapterConfig(providerName);
-            grainFactory = (GrainFactory)serviceProvider.GetService(typeof(GrainFactory));
+            grainFactory = (IGrainFactory)serviceProvider.GetService(typeof(IGrainFactory));
             adapterConfig.PopulateFromProviderConfig(providerConfig);
             this.streamQueueMapper = new HashRingBasedStreamQueueMapper(adapterConfig.TotalQueueCount, adapterConfig.StreamProviderName);
 

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -60,6 +60,8 @@
     <Compile Include="Catalog\GrainCreator.cs" />
     <Compile Include="Counters\PerfCounterConfigData.cs" />
     <Compile Include="Startup\ConfigureServicesBuilder.cs" />
+    <Compile Include="Startup\IStartup.cs" />
+    <Compile Include="Startup\OrleansInternalServicesExtentions.cs" />
     <Compile Include="Startup\StartupBuilder.cs" />
     <Compile Include="MultiClusterNetwork\MultiClusterData.cs" />
     <Compile Include="MultiClusterNetwork\MultiClusterOracle.cs" />

--- a/src/OrleansRuntime/Silo/SiloHost.cs
+++ b/src/OrleansRuntime/Silo/SiloHost.cs
@@ -75,6 +75,7 @@ namespace Orleans.Runtime.Host
         private EventWaitHandle startupEvent;
         private EventWaitHandle shutdownEvent;
         private bool disposed;
+        private IServiceProvider services;
 
         /// <summary>
         /// Constructor
@@ -90,21 +91,28 @@ namespace Orleans.Runtime.Host
         /// <summary> Constructor </summary>
         /// <param name="siloName">Name of this silo.</param>
         /// <param name="config">Silo config that will be used to initialize this silo.</param>
-        public SiloHost(string siloName, ClusterConfiguration config) : this(siloName)
+        public SiloHost(string siloName, ClusterConfiguration config, IServiceProvider svc) : this(siloName)
         {
             SetSiloConfig(config);
+            services = svc;
         }
 
         /// <summary> Constructor </summary>
         /// <param name="siloName">Name of this silo.</param>
         /// <param name="configFile">Silo config file that will be used to initialize this silo.</param>
-        public SiloHost(string siloName, FileInfo configFile)
+        public SiloHost(string siloName, FileInfo configFile, IServiceProvider svc)
             : this(siloName)
         {
             ConfigFileName = configFile.FullName;
             var config = new ClusterConfiguration();
             config.LoadFromFile(ConfigFileName);
             SetSiloConfig(config);
+            services = svc;
+        }
+
+        public void SetServiceProvier(IServiceProvider svc)
+        {
+            this.services = svc;
         }
 
         /// <summary>
@@ -119,7 +127,7 @@ namespace Orleans.Runtime.Host
             try
             {
                 if (!ConfigLoaded) LoadOrleansConfig();
-                orleans = new Silo(Name, Type, Config);
+                orleans = new Silo(Name, Type, Config, services);
                 logger.Info(ErrorCode.Runtime_Error_100288, "Successfully initialized Orleans silo '{0}' as a {1} node.", orleans.Name, orleans.Type);
             }
             catch (Exception exc)

--- a/src/OrleansRuntime/Startup/IStartup.cs
+++ b/src/OrleansRuntime/Startup/IStartup.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.MembershipService;
+using Orleans.Runtime.ReminderService;
+
+namespace Orleans.Runtime.Startup
+{
+    public interface IStartup
+    {
+        IServiceProvider ConfigureServices(IServiceCollection services);
+    }
+}

--- a/src/OrleansRuntime/Startup/OrleansInternalServices.cs
+++ b/src/OrleansRuntime/Startup/OrleansInternalServices.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.MembershipService;
+using Orleans.Runtime.ReminderService;
+
+namespace Orleans.Runtime.Startup
+{
+    // <summary>
+    // extension methods to register services required internal Orleans methods
+    // </summary>
+    public static class OrleansInternalServices
+    {
+
+        // extension methods to register internal orleans required services
+        public static void RegisterSystemTypes(IServiceCollection serviceCollection)
+        {
+            // Register the system classes and grains in this method.
+            // Note: this method will probably have to be moved out into the Silo class to include internal runtime types.
+            IGrainFactory grainFactory = new GrainFactory();
+            serviceCollection.AddSingleton((GrainFactory)grainFactory);
+            //application grain getService by interface type which is public to them, while concret types are internal
+            serviceCollection.AddSingleton<IGrainFactory>(grainFactory);
+            serviceCollection.AddTransient<IMembershipTable, GrainBasedMembershipTable>();
+            serviceCollection.AddTransient<IReminderTable, GrainBasedReminderTable>();
+        }
+
+        //default service provider where only contains internal services, mostly used in tests
+        public static IServiceProvider DefaultServiceProvider()
+        {
+            return ServiceProvider;
+        }
+
+
+        private static IServiceProvider BuildDefaultServiceProvider()
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+            RegisterSystemTypes(serviceCollection);
+            return serviceCollection.BuildServiceProvider();
+        }
+
+        private static readonly IServiceProvider ServiceProvider = BuildDefaultServiceProvider();
+
+
+        //use this method for third party DI containers
+        public static IServiceProvider ConfigureStartup(string startupTypeName)
+        {
+            bool usingCustomServiceProvider = false;
+            IServiceCollection serviceCollection = new ServiceCollection();
+            ConfigureServicesBuilder servicesMethod = null;
+            Type startupType = null;
+
+            if (!String.IsNullOrWhiteSpace(startupTypeName))
+            {
+                startupType = Type.GetType(startupTypeName);
+                if (startupType == null)
+                {
+                    throw new InvalidOperationException($"Can not locate the type specified in the configuration file: '{startupTypeName}'.");
+                }
+
+                servicesMethod = FindConfigureServicesDelegate(startupType);
+                if (servicesMethod != null && !servicesMethod.MethodInfo.IsStatic)
+                {
+                    usingCustomServiceProvider = true;
+                }
+            }
+
+            RegisterSystemTypes(serviceCollection);
+
+            if (usingCustomServiceProvider)
+            {
+                var instance = Activator.CreateInstance(startupType);
+                return servicesMethod.Build(instance, serviceCollection);
+            }
+
+            return serviceCollection.BuildServiceProvider();
+        }
+
+        private static ConfigureServicesBuilder FindConfigureServicesDelegate(Type startupType)
+        {
+            var servicesMethod = FindMethod(startupType, "ConfigureServices", typeof(IServiceProvider), false);
+
+            return servicesMethod == null ? null : new ConfigureServicesBuilder(servicesMethod);
+        }
+
+        private static MethodInfo FindMethod(Type startupType, string methodName, Type returnType = null,
+            bool required = true)
+        {
+            var methods = startupType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+            var selectedMethods = methods.Where(method => method.Name.Equals(methodName)).ToList();
+
+            if (selectedMethods.Count > 1)
+            {
+                throw new InvalidOperationException($"Having multiple overloads of method '{methodName}' is not supported.");
+            }
+
+            var methodInfo = selectedMethods.FirstOrDefault();
+
+            if (methodInfo == null)
+            {
+                if (required)
+                {
+                    throw new InvalidOperationException($"A method named '{methodName}' in the type '{startupType.FullName}' could not be found.");
+                }
+
+                return null;
+            }
+
+            if (returnType != null && methodInfo.ReturnType != returnType)
+            {
+                if (required)
+                {
+                    throw new InvalidOperationException($"The '{methodInfo.Name}' method in the type '{startupType.FullName}' must have a return type of '{returnType.Name}'.");
+                }
+
+                return null;
+            }
+
+            return methodInfo;
+        }
+    }
+}

--- a/test/Tester/CancellationTests/GrainCancellationTokenTests.cs
+++ b/test/Tester/CancellationTests/GrainCancellationTokenTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using Tester;
 using UnitTests.GrainInterfaces;
@@ -16,7 +17,7 @@ namespace UnitTests.CancellationTests
         {
             protected override TestCluster CreateTestCluster()
             {
-                return new TestCluster(new TestClusterOptions(2));
+                return new TestCluster(new TestClusterOptions(2), OrleansInternalServices.DefaultServiceProvider());
             }
         }
 

--- a/test/Tester/DefaultClusterFixture.cs
+++ b/test/Tester/DefaultClusterFixture.cs
@@ -1,4 +1,5 @@
 ﻿using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 
 namespace Tester
@@ -10,7 +11,7 @@ namespace Tester
             var options = new TestClusterOptions();
             options.ClusterConfiguration.AddMemoryStorageProvider("Default");
             options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore");
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
     }
 }

--- a/test/Tester/DependencyInjectionGrainTests.cs
+++ b/test/Tester/DependencyInjectionGrainTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
+using Orleans.Runtime.Startup;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using Tester;
@@ -19,8 +20,8 @@ namespace UnitTests.General
             protected override TestCluster CreateTestCluster()
             {
                 var options = new TestClusterOptions(1);
-                options.ClusterConfiguration.ApplyToAllNodes(nodeConfig => nodeConfig.StartupTypeName = typeof(TestStartup).AssemblyQualifiedName);
-                return new TestCluster(options);
+                IServiceProvider serviceProvider = new TestStartup().ConfigureServices(new ServiceCollection());
+                return new TestCluster(options, serviceProvider);
             }
         }
 
@@ -53,7 +54,7 @@ namespace UnitTests.General
         }
     }
 
-    public class TestStartup
+    public class TestStartup : IStartup
     {
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
@@ -64,6 +65,7 @@ namespace UnitTests.General
                     sp.GetRequiredService<IInjectedService>(),
                     "some value"));
 
+            OrleansInternalServices.RegisterSystemTypes(services);
             return services.BuildServiceProvider();
         }
     }

--- a/test/Tester/DuplicateActivationsTests.cs
+++ b/test/Tester/DuplicateActivationsTests.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using Tester;
 using UnitTests.GrainInterfaces;
@@ -20,7 +21,7 @@ namespace UnitTests.CatalogTests
                 var options = new TestClusterOptions(2);
                 options.ClusterConfiguration.Globals.ResponseTimeout = TimeSpan.FromMinutes(1);
                 options.ClusterConfiguration.ApplyToAllNodes(nodeConfig => nodeConfig.MaxActiveThreads = 1);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 

--- a/test/Tester/GenericGrainsInAzureStorageTests.cs
+++ b/test/Tester/GenericGrainsInAzureStorageTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using Tester;
 using UnitTests.GrainInterfaces;
@@ -17,7 +18,7 @@ namespace UnitTests.General
             {
                 var options = new TestClusterOptions();
                 options.ClusterConfiguration.AddAzureTableStorageProvider("AzureStore");
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 

--- a/test/Tester/InvocationInterceptTests.cs
+++ b/test/Tester/InvocationInterceptTests.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
@@ -23,7 +24,7 @@ namespace UnitTests.General
             options.ClientConfiguration.AddSimpleMessageStreamProvider("SMSProvider");
             options.ClusterConfiguration.Globals.RegisterBootstrapProvider<PreInvokeCallbackBootrstrapProvider>(
                 "PreInvokeCallbackBootrstrapProvider");
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         /// <summary>

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.SqlUtils;
 using Orleans.TestingHost;
 using Tester;
@@ -191,7 +192,7 @@ namespace UnitTests.MembershipTests
         {
             var options = new TestClusterOptions(2);
             options.ClientConfiguration.PreferedGatewayIndex = 1;
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Membership")]
@@ -239,7 +240,7 @@ namespace UnitTests.MembershipTests
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
             options.ClusterConfiguration.PrimaryNode = null;
             options.ClusterConfiguration.Globals.SeedNodes.Clear();
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
@@ -288,7 +289,7 @@ namespace UnitTests.MembershipTests
             options.ClusterConfiguration.Globals.ReminderServiceType = GlobalConfiguration.ReminderServiceProviderType.Disabled;
             options.ClusterConfiguration.PrimaryNode = null;
             options.ClusterConfiguration.Globals.SeedNodes.Clear();
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("AWS")]
@@ -335,7 +336,7 @@ namespace UnitTests.MembershipTests
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.ZooKeeper;
             options.ClusterConfiguration.PrimaryNode = null;
             options.ClusterConfiguration.Globals.SeedNodes.Clear();
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
@@ -383,7 +384,7 @@ namespace UnitTests.MembershipTests
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.SqlServer;
             options.ClusterConfiguration.PrimaryNode = null;
             options.ClusterConfiguration.Globals.SeedNodes.Clear();
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
@@ -432,7 +433,7 @@ namespace UnitTests.MembershipTests
             options.ClusterConfiguration.Globals.AdoInvariant = AdoNetInvariants.InvariantNameMySql;
             options.ClusterConfiguration.PrimaryNode = null;
             options.ClusterConfiguration.Globals.SeedNodes.Clear();
-            return new TestCluster(options);
+            return new TestCluster(options.ClusterConfiguration, OrleansInternalServices.DefaultServiceProvider());
         }
 
         [Fact, TestCategory("Membership"), TestCategory("MySql")]

--- a/test/Tester/MembershipTests/SilosStopTests.cs
+++ b/test/Tester/MembershipTests/SilosStopTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Runtime;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using UnitTests.GrainInterfaces;
 using UnitTests.Tester;
@@ -20,7 +21,7 @@ namespace UnitTests.MembershipTests
 
             // use only Primary as the gateway
             options.ClientConfiguration.Gateways = options.ClientConfiguration.Gateways.Take(1).ToList();
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Liveness")]

--- a/test/Tester/StreamingTests/AQClientStreamTests.cs
+++ b/test/Tester/StreamingTests/AQClientStreamTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using Tester.TestStreamProviders;
 using UnitTests.Tester;
@@ -33,7 +34,7 @@ namespace Tester.StreamingTests
             options.ClusterConfiguration.AddAzureQueueStreamProvider(AQStreamProviderName);
             options.ClusterConfiguration.Globals.ClientDropTimeout = TimeSpan.FromSeconds(5);
             options.ClientConfiguration.AddAzureQueueStreamProvider(AQStreamProviderName);
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         public override void Dispose()

--- a/test/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/AQSubscriptionMultiplicityTests.cs
@@ -4,6 +4,7 @@ using Orleans;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using UnitTests.Tester;
 using Xunit;
@@ -22,7 +23,7 @@ namespace UnitTests.StreamingTests
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
             options.ClusterConfiguration.AddAzureQueueStreamProvider(AQStreamProviderName);
             options.ClientConfiguration.AddAzureQueueStreamProvider(AQStreamProviderName);
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         public AQSubscriptionMultiplicityTests()

--- a/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
+using Orleans.Runtime.Startup;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
@@ -46,7 +47,7 @@ namespace UnitTests.StreamingTests
 
                 // register stream provider
                 options.ClusterConfiguration.Globals.RegisterStreamProvider<GeneratorStreamProvider>(StreamProviderName, settings);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 

--- a/test/Tester/StreamingTests/ControllableStreamProviderTests.cs
+++ b/test/Tester/StreamingTests/ControllableStreamProviderTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Runtime;
+using Orleans.Runtime.Startup;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using Tester;
@@ -29,7 +30,7 @@ namespace UnitTests.StreamingTests
                         {PersistentStreamProviderConfig.STREAM_PUBSUB_TYPE, StreamPubSubType.ImplicitOnly.ToString()}
                     };
                 options.ClusterConfiguration.Globals.RegisterStreamProvider<ControllableTestStreamProvider>(StreamProviderName, settings);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 

--- a/test/Tester/StreamingTests/DelayedQueueRebalancingTests.cs
+++ b/test/Tester/StreamingTests/DelayedQueueRebalancingTests.cs
@@ -7,6 +7,7 @@ using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using UnitTests.Tester;
@@ -35,7 +36,7 @@ namespace UnitTests.StreamingTests
 
             options.ClusterConfiguration.AddAzureQueueStreamProvider(adapterName, persistentStreamProviderConfig: persistentStreamProviderConfig);
             options.ClientConfiguration.Gateways = options.ClientConfiguration.Gateways.Take(1).ToList();
-            var host = new TestCluster(options);
+            var host = new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             host.Deploy(new[] { Silo.PrimarySiloName, "Secondary_1" });
             return host;
         }

--- a/test/Tester/StreamingTests/EHClientStreamTests.cs
+++ b/test/Tester/StreamingTests/EHClientStreamTests.cs
@@ -6,6 +6,7 @@ using Microsoft.WindowsAzure.Storage.Table;
 using Orleans.AzureUtils;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.ServiceBus.Providers;
 using Orleans.TestingHost;
 using Tester.TestStreamProviders;
@@ -50,7 +51,7 @@ namespace Tester.StreamingTests
             var options = new TestClusterOptions(2);
             AdjustConfig(options.ClusterConfiguration);
             AdjustConfig(options.ClientConfiguration);
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         public override void Dispose()

--- a/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -9,6 +9,7 @@ using Orleans.AzureUtils;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
 using Orleans.TestingHost;
@@ -51,7 +52,7 @@ namespace UnitTests.StreamingTests
                 options.ClusterConfiguration.AddMemoryStorageProvider("Default");
                 options.ClusterConfiguration.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
                 options.ClientConfiguration.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
 
             public override void Dispose()

--- a/test/Tester/StreamingTests/EHStreamPerPartitionTests.cs
+++ b/test/Tester/StreamingTests/EHStreamPerPartitionTests.cs
@@ -8,6 +8,7 @@ using Orleans;
 using Orleans.AzureUtils;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
 using Orleans.TestingHost;
@@ -47,7 +48,7 @@ namespace UnitTests.StreamingTests
                 options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
                 options.ClusterConfiguration.Globals.RegisterStreamProvider<StreamPerPartitionEventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
                 options.ClientConfiguration.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName, BuildProviderSettings());
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
 
             public override void Dispose()

--- a/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
+++ b/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
@@ -9,6 +9,7 @@ using Orleans.Providers.Streams.Common;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
 using Orleans.TestingHost;
@@ -45,7 +46,7 @@ namespace UnitTests.StreamingTests
             var options = new TestClusterOptions(2);
             AdjustConfig(options.ClusterConfiguration);
             AdjustConfig(options.ClientConfiguration);
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]

--- a/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
@@ -7,6 +7,7 @@ using Orleans;
 using Orleans.AzureUtils;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.ServiceBus.Providers;
 using Orleans.Storage;
 using Orleans.Streams;
@@ -44,7 +45,7 @@ namespace UnitTests.StreamingTests
             {
                 var options = new TestClusterOptions(2);
                 AdjustClusterConfiguration(options.ClusterConfiguration);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
 
             public override void Dispose()

--- a/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -5,6 +5,7 @@ using Orleans;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using Tester;
@@ -45,7 +46,7 @@ namespace UnitTests.StreamingTests
                 // register stream provider
                 options.ClusterConfiguration.Globals.RegisterStreamProvider<GeneratorStreamProvider>(StreamProviderName, settings);
 
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 

--- a/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
@@ -6,6 +6,7 @@ using Orleans.Providers.Streams.Generator;
 using Orleans.Providers.Streams.Memory;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using TestGrains;
 using UnitTests.Tester;
@@ -35,7 +36,7 @@ namespace Tester.StreamingTests
                 var options = new TestClusterOptions(1);
                 AdjustConfig(options.ClusterConfiguration);
                 AdjustConfig(options.ClientConfiguration);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
 
             private static void AdjustConfig(ClusterConfiguration config)

--- a/test/Tester/StreamingTests/PullingAgentManagementTests.cs
+++ b/test/Tester/StreamingTests/PullingAgentManagementTests.cs
@@ -6,6 +6,7 @@ using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using Tester;
 using UnitTests.Tester;
@@ -28,7 +29,7 @@ namespace UnitTests.StreamingTests
                 // options.ClientConfiguration.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME, false);
 
                 options.ClusterConfiguration.AddAzureQueueStreamProvider(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 

--- a/test/Tester/StreamingTests/SMSClientStreamTests.cs
+++ b/test/Tester/StreamingTests/SMSClientStreamTests.cs
@@ -3,6 +3,8 @@ using System;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
+using Orleans.Storage;
 using Orleans.TestingHost;
 using UnitTests.StreamingTests;
 using UnitTests.Tester;
@@ -32,7 +34,7 @@ namespace Tester.StreamingTests
             options.ClusterConfiguration.Globals.ClientDropTimeout = TimeSpan.FromSeconds(5);
 
             options.ClientConfiguration.AddSimpleMessageStreamProvider(SMSStreamProviderName);
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]

--- a/test/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/test/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -32,7 +32,7 @@ namespace UnitTests.StreamingTests
             options.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
             options.ClientConfiguration.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
 
-            return new TestCluster(options);
+            return new TestCluster(options, null);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]

--- a/test/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using Tester;
 using UnitTests.Tester;
@@ -24,7 +25,7 @@ namespace UnitTests.StreamingTests
 
                 options.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamProvider);
                 options.ClientConfiguration.AddSimpleMessageStreamProvider(StreamProvider);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 

--- a/test/Tester/StreamingTests/SQSClientStreamTests.cs
+++ b/test/Tester/StreamingTests/SQSClientStreamTests.cs
@@ -6,6 +6,7 @@ using OrleansAWSUtils.Streams;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Orleans.Runtime.Startup;
 using Tester.StreamingTests;
 using UnitTests.Tester;
 using Xunit;
@@ -46,7 +47,7 @@ namespace Tester
             options.ClusterConfiguration.Globals.DataConnectionString = StorageConnectionString;
             options.ClusterConfiguration.Globals.RegisterStreamProvider<SQSStreamProvider>(SQSStreamProviderName, streamConnectionString);
             options.ClientConfiguration.RegisterStreamProvider<SQSStreamProvider>(SQSStreamProviderName, streamConnectionString);
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         public override void Dispose()

--- a/test/Tester/StreamingTests/SQSSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/SQSSubscriptionMultiplicityTests.cs
@@ -7,6 +7,7 @@ using OrleansAWSUtils.Streams;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Orleans.Runtime.Startup;
 using UnitTests.StreamingTests;
 using UnitTests.Tester;
 using Xunit;
@@ -37,7 +38,7 @@ namespace Tester
             options.ClusterConfiguration.Globals.DataConnectionString = StreamConnectionString;
             options.ClusterConfiguration.Globals.RegisterStreamProvider<SQSStreamProvider>(SQSStreamProviderName, streamConnectionString);
             options.ClientConfiguration.RegisterStreamProvider<SQSStreamProvider>(SQSStreamProviderName, streamConnectionString);
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         public SQSSubscriptionMultiplicityTests()

--- a/test/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/test/Tester/StreamingTests/SampleStreamingTests.cs
@@ -4,6 +4,7 @@ using Orleans;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
 using Tester;
@@ -26,7 +27,7 @@ namespace UnitTests.StreamingTests
 
                 options.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamProvider, false);
                 options.ClientConfiguration.AddSimpleMessageStreamProvider(StreamProvider, false);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 
@@ -92,7 +93,7 @@ namespace UnitTests.StreamingTests
 
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
             options.ClusterConfiguration.AddAzureQueueStreamProvider(StreamProvider);
-            return new TestCluster(options);
+            return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
         }
 
         public override void Dispose()

--- a/test/Tester/StreamingTests/StreamFilteringTests.cs
+++ b/test/Tester/StreamingTests/StreamFilteringTests.cs
@@ -7,6 +7,7 @@ using Orleans;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Startup;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
 using UnitTests.GrainInterfaces;
@@ -242,7 +243,7 @@ namespace Tester.StreamingTests
 
                 options.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamProvider, false);
                 options.ClientConfiguration.AddSimpleMessageStreamProvider(StreamProvider, false);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 
@@ -297,7 +298,7 @@ namespace Tester.StreamingTests
                 options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
 
                 options.ClusterConfiguration.AddAzureQueueStreamProvider(StreamProvider);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
 
             public override void Dispose()

--- a/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
+using Orleans.Runtime.Startup;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
@@ -53,7 +54,7 @@ namespace UnitTests.StreamingTests
 
                 // register stream provider
                 options.ClusterConfiguration.Globals.RegisterStreamProvider<GeneratorStreamProvider>(StreamProviderName, settings);
-                return new TestCluster(options);
+                return new TestCluster(options, OrleansInternalServices.DefaultServiceProvider());
             }
         }
 


### PR DESCRIPTION
- Make orleans service provider available to application layer grain (#934)
- Make GrainFactory injectable ()  #988 

TODO:
1. find real dependency of each class which requires DI, inject the real dependency instead of the whole ServiceProvider
2. look at how ASP.NET handle third party DI container, maybe borrow some of their pattern over. Right now we are using the original method
3.  update external providers to be use DI system, I briefly tried in PersistentStreamProvider this time. 
4. if we are going this way, we will change public class, such as Silo.cs, AzureSilo.cs, which introduce backwards compatibility problem. 
5. if we are going this direction, a lot of files will need to change, mostly tests and external provider classes and its related classes, especially those manager class which is in charge of instantiating the external provider classes . 

This PR is not complete, post this to the community as a possible direction we want to go in fixing DI. 
