### PR TITLE
Remove Nuget transitive dependencies on dependent projects

### DIFF
--- a/src/OrleansAWSUtils/project.json
+++ b/src/OrleansAWSUtils/project.json
@@ -1,8 +1,7 @@
 ﻿{
   "dependencies": {
     "AWSSDK.DynamoDBv2": "3.1.5.2",
-    "AWSSDK.SQS": "3.1.0.9",
-    "Newtonsoft.Json": "7.0.1"
+    "AWSSDK.SQS": "3.1.0.9"
   },
   "frameworks": {
     "net451": {}

--- a/src/OrleansAzureUtils/project.json
+++ b/src/OrleansAzureUtils/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "Newtonsoft.Json": "7.0.1",
     "WindowsAzure.Storage": "7.0.0"
   },
   "frameworks": {

--- a/src/OrleansBondUtils/project.json
+++ b/src/OrleansBondUtils/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "Bond.Runtime.CSharp": "3.0.7",
-    "Newtonsoft.Json": "7.0.1"
+    "Bond.Runtime.CSharp": "3.0.7"
   },
   "frameworks": {
     "net451": {}

--- a/src/OrleansConsulUtils/project.json
+++ b/src/OrleansConsulUtils/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "Consul": "0.6.4.1",
-    "Newtonsoft.Json": "7.0.1"
+    "Consul": "0.6.4.1"
   },
   "frameworks": {
     "net451": {}

--- a/src/OrleansPSUtils/project.json
+++ b/src/OrleansPSUtils/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "Microsoft.CodeAnalysis.Analyzers": "1.0.0",
-    "Newtonsoft.Json": "7.0.1",
     "Microsoft.CodeAnalysis.Common": "1.0.0",
     "Microsoft.CodeAnalysis.CSharp": "1.0.0",
     "System.Collections.Immutable": "1.1.36",

--- a/src/OrleansSQLUtils/project.json
+++ b/src/OrleansSQLUtils/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {
     "net451": {}

--- a/src/OrleansServiceBus/project.json
+++ b/src/OrleansServiceBus/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "dependencies": {
     "Microsoft.WindowsAzure.ConfigurationManager": "3.1.0",
-    "Newtonsoft.Json": "7.0.1",
     "WindowsAzure.ServiceBus": "3.3.2",
     "WindowsAzure.Storage": "7.0.0"
   },

--- a/src/OrleansTestingHost/project.json
+++ b/src/OrleansTestingHost/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {
     "net451": {}

--- a/src/OrleansZooKeeperUtils/project.json
+++ b/src/OrleansZooKeeperUtils/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "Newtonsoft.Json": "7.0.1",
     "ZooKeeperNetEx": "3.4.8.5"
   },
   "frameworks": {

--- a/test/TestGrainInterfaces/project.json
+++ b/test/TestGrainInterfaces/project.json
@@ -1,13 +1,12 @@
 {
   "dependencies": {
-"FSharp.Core": "4.0.0.1",
-"Newtonsoft.Json": "7.0.1"
+    "FSharp.Core": "4.0.0.1"
   },
   "frameworks": {
     "net451": {}
   },
-    "runtimes":  {
-        "win-anycpu": {},
-        "win": {}
-    }
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
 }

--- a/test/TestGrains/project.json
+++ b/test/TestGrains/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {
     "net451": {}

--- a/test/TestInternalGrains/project.json
+++ b/test/TestInternalGrains/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "Newtonsoft.Json": "7.0.1",
     "xunit.assert": "2.1.0"
   },
   "frameworks": {

--- a/test/Tester/project.json
+++ b/test/Tester/project.json
@@ -5,7 +5,6 @@
     "FSharp.Core": "4.0.0.1",
     "Google.Protobuf": "3.0.0",
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
-    "Newtonsoft.Json": "7.0.1",
     "System.Management.Automation.dll": "10.0.10586",
     "WindowsAzure.ServiceBus": "3.3.2",
     "WindowsAzure.Storage": "7.0.0",

--- a/test/Tester/project.json
+++ b/test/Tester/project.json
@@ -1,13 +1,6 @@
 ﻿{
   "dependencies": {
-    "Bond.Runtime.CSharp": "3.0.7",
     "FluentAssertions": "4.0.0",
-    "FSharp.Core": "4.0.0.1",
-    "Google.Protobuf": "3.0.0",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0",
-    "System.Management.Automation.dll": "10.0.10586",
-    "WindowsAzure.ServiceBus": "3.3.2",
-    "WindowsAzure.Storage": "7.0.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"

--- a/test/TesterInternal/project.json
+++ b/test/TesterInternal/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "FSharp.Core": "4.0.0.1",
-    "Newtonsoft.Json": "7.0.1",
     "WindowsAzure.Storage": "7.0.0",
     "AWSSDK.DynamoDBv2": "3.1.5.2",
     "xunit": "2.1.0",

--- a/test/TesterInternal/project.json
+++ b/test/TesterInternal/project.json
@@ -1,8 +1,5 @@
 {
   "dependencies": {
-    "FSharp.Core": "4.0.0.1",
-    "WindowsAzure.Storage": "7.0.0",
-    "AWSSDK.DynamoDBv2": "3.1.5.2",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"


### PR DESCRIPTION
Cleaned up the nuget dependencies from the project.json files where the dependent project does not care which nuget package version dependency to use, it just cares to transitively get the dependency.
for instance, no project really cares which version of NewtsonSoft.Json is set up, as long as they reference the same one as Orleans.dll
In the case of Tester and TesterInternal, they do not care about which version of almost all packages they use, as long as they match the same ones that the projects under test are using.

This is in preparation of the CoreCLR work, to avoid merge conflicts all over the place when we change a dependency here or there.