### PR TITLE
Run Tester and TesterInternal assemblies in parallel

### DIFF
--- a/src/Test.cmd
+++ b/src/Test.cmd
@@ -20,7 +20,7 @@ if []==[%TEST_FILTERS%] set TEST_FILTERS=-trait "Category=BVT" -trait "Category=
 @echo on
 call "%CMDHOME%\SetupTestScript.cmd" "%OutDir%"
 
-packages\xunit.runner.console.2.1.0\tools\xunit.console %TESTS% %TEST_FILTERS% -xml "%OutDir%/xUnit-Results.xml" -parallel none -noshadow
+packages\xunit.runner.console.2.1.0\tools\xunit.console %TESTS% %TEST_FILTERS% -xml "%OutDir%/xUnit-Results.xml" -parallel assemblies -noshadow -verbose
 set testresult=%errorlevel%
 popd
 endlocal&set testresult=%testresult%


### PR DESCRIPTION
This is now possible since we use TestCluster which assigns random listening ports to the silos, and because each assembly runs in a different AppDomain.
Added -verbose switch to xUnit console runner, so we can see which test is running and can troubleshoot in an easier way when there are issues or the run halts