### PR TITLE
Remove Pure attribute usage

### DIFF
--- a/src/Orleans/IDs/GrainId.cs
+++ b/src/Orleans/IDs/GrainId.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using Orleans.Core;
 using Orleans.Serialization;
@@ -115,7 +114,6 @@ namespace Orleans.Runtime
             return Key.PrimaryKeyToLong(out keyExt);
         }
 
-        [Pure]
         internal long GetPrimaryKeyLong()
         {
             return Key.PrimaryKeyToLong();


### PR DESCRIPTION
Code contracts is an additional dependency when targeting .NET Standard that we should not pull into just for this random occurrence.
There are no other usages of code contracts in the solution