### PR TITLE
Remove message headers & metadata dictionaries 

### DIFF
--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -282,7 +282,7 @@ namespace Orleans.Runtime
             if (id == null) return false;
 
             // don't set expiration for one way, system target and system grain messages.
-           return Direction != Directions.OneWay && !id.IsSystemTarget && !Constants.IsSystemGrain(id);
+            return Direction != Directions.OneWay && !id.IsSystemTarget && !Constants.IsSystemGrain(id);
         }
 
         public string DebugContext
@@ -312,14 +312,14 @@ namespace Orleans.Runtime
         // Resends are used by the sender, usualy due to en error to send or due to a transient rejection.
         public bool MayResend(IMessagingConfiguration config)
         {
-           return ResendCount < config.MaxResendCount;
+            return ResendCount < config.MaxResendCount;
         }
 
         // Forwardings are used by the receiver, usualy when it cannot process the message and forwars it to another silo to perform the processing
         // (got here due to outdated cache, silo is shutting down/overloaded, ...).
         public bool MayForward(GlobalConfiguration config)
         {
-           return ForwardCount < config.MaxForwardCount;
+            return ForwardCount < config.MaxForwardCount;
         }
 
         /// <summary>
@@ -365,7 +365,7 @@ namespace Orleans.Runtime
             {
                 if (bodyObject != null)
                 {
-                   return bodyObject;
+                    return bodyObject;
                 }
                 try
                 {
@@ -379,7 +379,7 @@ namespace Orleans.Runtime
                         bodyBytes = null;
                     }
                 }
-               return bodyObject;
+                return bodyObject;
             }
             set
             {
@@ -395,12 +395,12 @@ namespace Orleans.Runtime
         {
             if (bytes == null)
             {
-               return null;
+                return null;
             }
             try
             {
                 var stream = new BinaryTokenStreamReader(bytes);
-               return SerializationManager.Deserialize(stream);
+                return SerializationManager.Deserialize(stream);
             }
             catch (Exception ex)
             {
@@ -443,7 +443,7 @@ namespace Orleans.Runtime
             {
                 message.RequestContextData = contextData;
             }
-           return message;
+            return message;
         }
 
         // Initializes body and header but does not take ownership of byte.
@@ -509,7 +509,7 @@ namespace Orleans.Runtime
                 response.RequestContextData = contextData;
             }
 
-           return response;
+            return response;
         }
 
         public Message CreateRejectionResponse(RejectionTypes type, string info, OrleansException ex = null)
@@ -520,12 +520,12 @@ namespace Orleans.Runtime
             response.RejectionInfo = info;
             response.BodyObject = ex;
             if (logger.IsVerbose) logger.Verbose("Creating {0} rejection with info '{1}' for {2} at:" + Environment.NewLine + "{3}", type, info, this, Utils.GetStackTrace());
-           return response;
+            return response;
         }
 
         public Message CreatePromptExceptionResponse(Exception exception)
         {
-           return new Message(Category, Directions.Response)
+            return new Message(Category, Directions.Response)
             {
                 Result = ResponseTypes.Error,
                 BodyObject = Response.ExceptionResponse(exception)
@@ -539,7 +539,7 @@ namespace Orleans.Runtime
 
         private static string GetNotNullString(string s)
         {
-           return s ?? string.Empty;
+            return s ?? string.Empty;
         }
 
         /// <summary>
@@ -549,7 +549,7 @@ namespace Orleans.Runtime
         /// <returns></returns>
         public bool IsDuplicate(Message other)
         {
-           return Equals(SendingSilo, other.SendingSilo) && Equals(Id, other.Id);
+            return Equals(SendingSilo, other.SendingSilo) && Equals(Id, other.Id);
         }
 
         #region Serialization
@@ -557,7 +557,7 @@ namespace Orleans.Runtime
         public List<ArraySegment<byte>> Serialize(out int headerLength)
         {
             int dummy;
-           return Serialize_Impl(out headerLength, out dummy);
+            return Serialize_Impl(out headerLength, out dummy);
         }
 
         private List<ArraySegment<byte>> Serialize_Impl(out int headerLengthOut, out int bodyLengthOut)
@@ -600,7 +600,7 @@ namespace Orleans.Runtime
 
             headerLengthOut = headerLength;
             bodyLengthOut = bodyLength;
-           return bytes;
+            return bytes;
         }
 
 
@@ -665,7 +665,7 @@ namespace Orleans.Runtime
             AppendIfExists(HeadersContainer.Headers.TARGET_OBSERVER, sb, (m) => m.TargetObserverId);
             AppendIfExists(HeadersContainer.Headers.TARGET_SILO, sb, (m) => m.TargetSilo);
 
-           return sb.ToString();
+            return sb.ToString();
         }
         
         private void AppendIfExists(HeadersContainer.Headers header, StringBuilder sb, Func<Message, object> valueProvider)
@@ -697,7 +697,7 @@ namespace Orleans.Runtime
                         break;
                 }
             }
-           return String.Format("{0}{1}{2}{3}{4} {5}->{6} #{7}{8}{9}: {10}",
+            return String.Format("{0}{1}{2}{3}{4} {5}->{6} #{7}{8}{9}: {10}",
                 IsReadOnly ? "ReadOnly " : "", //0
                 IsAlwaysInterleave ? "IsAlwaysInterleave " : "", //1
                 IsNewPlacement ? "NewPlacement " : "", // 2
@@ -745,13 +745,13 @@ namespace Orleans.Runtime
             {
                 history.Append("    ").Append(TargetHistory);
             }
-           return history.ToString();
+            return history.ToString();
         }
 
         public bool IsSameDestination(IOutgoingMessage other)
         {
             var msg = (Message)other;
-           return msg != null && Object.Equals(TargetSilo, msg.TargetSilo);
+            return msg != null && Object.Equals(TargetSilo, msg.TargetSilo);
         }
 
         // For statistical measuring of time spent in queues.
@@ -1119,7 +1119,7 @@ namespace Orleans.Runtime
                 headers = _rejectionType == default(RejectionTypes) ? headers & ~Headers.REJECTION_TYPE : headers | Headers.REJECTION_TYPE;
                 headers = string.IsNullOrEmpty(_rejectionInfo) ? headers & ~Headers.REJECTION_INFO : headers | Headers.REJECTION_INFO;
                 headers = _requestContextData == null || _requestContextData.Count == 0 ? headers & ~Headers.REQUEST_CONTEXT : headers | Headers.REQUEST_CONTEXT;
-               return headers;
+                return headers;
             }
 
             static HeadersContainer()
@@ -1131,7 +1131,7 @@ namespace Orleans.Runtime
             [Orleans.CodeGeneration.CopierMethodAttribute]
             public static System.Object DeepCopier(System.Object original)
             {
-               return original;
+                return original;
             }
 
             [Orleans.CodeGeneration.SerializerMethodAttribute]
@@ -1348,12 +1348,12 @@ namespace Orleans.Runtime
                 if ((headers & Headers.TARGET_SILO) != Headers.NONE)
                     result.TargetSilo = stream.ReadSiloAddress();
 
-               return (HeadersContainer)result;
+                return (HeadersContainer)result;
             }
 
             private static bool ReadBool(BinaryTokenStreamReader stream)
             {
-               return stream.ReadByte() == (byte) SerializationTokenType.True;
+                return stream.ReadByte() == (byte) SerializationTokenType.True;
             }
 
             private static void WriteObj(BinaryTokenStreamWriter stream, Type type, object input)
@@ -1365,7 +1365,7 @@ namespace Orleans.Runtime
             private static object ReadObj(Type t, BinaryTokenStreamReader stream)
             {
                 var des = SerializationManager.GetDeserializer(t);
-               return des.Invoke(t, stream);
+                return des.Invoke(t, stream);
             }
 
             public static void Register()

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -117,84 +117,51 @@ namespace Orleans.Runtime
             GatewayTooBusy,
         }
 
-        public Categories Category
-        {
-            get { return GetScalarHeader<Categories>(Header.CATEGORY); }
-            set { SetHeader(Header.CATEGORY, value); }
-        }
+        public Categories Category { get; set; }
 
-        public Directions Direction
-        {
-            get { return GetScalarHeader<Directions>(Header.DIRECTION); }
-            set { SetHeader(Header.DIRECTION, value); }
-        }
+        public Directions? Direction { get; set; }
 
-        public bool IsReadOnly
-        {
-            get { return GetScalarHeader<bool>(Header.READ_ONLY); }
-            set { SetHeader(Header.READ_ONLY, value); }
-        }
+        public bool? IsReadOnly { get; set; }
 
-        public bool IsAlwaysInterleave
-        {
-            get { return GetScalarHeader<bool>(Header.ALWAYS_INTERLEAVE); }
-            set { SetHeader(Header.ALWAYS_INTERLEAVE, value); }
-        }
+        public bool? IsAlwaysInterleave { get; set; }
 
-        public bool IsUnordered
-        {
-            get { return GetScalarHeader<bool>(Header.IS_UNORDERED); }
-            set
-            {
-                if (value || ContainsHeader(Header.IS_UNORDERED))
-                    SetHeader(Header.IS_UNORDERED, value);
-            }
-        }
+        public bool? IsUnordered { get; set; } // todo
 
-        public CorrelationId Id
-        {
-            get { return GetSimpleHeader<CorrelationId>(Header.CORRELATION_ID); }
-            set { SetHeader(Header.CORRELATION_ID, value); }
-        }
+        public CorrelationId Id { get; set; }
 
-        public int ResendCount
-        {
-            get { return GetScalarHeader<int>(Header.RESEND_COUNT); }
-            set { SetHeader(Header.RESEND_COUNT, value); }
-        }
+        public int? ResendCount { get; set; }
 
-        public int ForwardCount
-        {
-            get { return GetScalarHeader<int>(Header.FORWARD_COUNT); }
-            set { SetHeader(Header.FORWARD_COUNT, value); }
-        }
+        public int? ForwardCount { get; set; }
 
+        private SiloAddress targetSilo;
         public SiloAddress TargetSilo
         {
-            get { return (SiloAddress)GetHeader(Header.TARGET_SILO); }
+            get { return targetSilo; }
             set
             {
-                SetHeader(Header.TARGET_SILO, value);
+                targetSilo = value;
                 targetAddress = null;
             }
         }
 
+        private GrainId targetGrain;
         public GrainId TargetGrain
         {
-            get { return GetSimpleHeader<GrainId>(Header.TARGET_GRAIN); }
+            get { return targetGrain; }
             set
             {
-                SetHeader(Header.TARGET_GRAIN, value);
+                targetGrain = value;
                 targetAddress = null;
             }
         }
 
+        private ActivationId targetActivation;
         public ActivationId TargetActivation
         {
-            get { return GetSimpleHeader<ActivationId>(Header.TARGET_ACTIVATION); }
+            get { return targetActivation; }
             set
             {
-                SetHeader(Header.TARGET_ACTIVATION, value);
+                targetActivation = value;
                 targetAddress = null;
             }
         }
@@ -211,42 +178,46 @@ namespace Orleans.Runtime
             }
         }
 
+        private GuidId targetObserverId;
         public GuidId TargetObserverId
         {
-            get { return GetSimpleHeader<GuidId>(Header.TARGET_OBSERVER); }
+            get { return targetObserverId; }
             set
             {
-                SetHeader(Header.TARGET_OBSERVER, value);
+                targetObserverId = value;
                 targetAddress = null;
             }
         }
 
+        private SiloAddress sendingSilo;
         public SiloAddress SendingSilo
         {
-            get { return (SiloAddress)GetHeader(Header.SENDING_SILO); }
+            get { return sendingSilo; }
             set
             {
-                SetHeader(Header.SENDING_SILO, value);
+                sendingSilo = value;
                 sendingAddress = null;
             }
         }
 
+        private GrainId sendingGrain;
         public GrainId SendingGrain
         {
-            get { return GetSimpleHeader<GrainId>(Header.SENDING_GRAIN); }
+            get { return sendingGrain; }
             set
             {
-                SetHeader(Header.SENDING_GRAIN, value);
+                sendingGrain = value;
                 sendingAddress = null;
             }
         }
 
+        private ActivationId sendingActivation;
         public ActivationId SendingActivation
         {
-            get { return GetSimpleHeader<ActivationId>(Header.SENDING_ACTIVATION); }
+            get { return sendingActivation; }
             set
             {
-                SetHeader(Header.SENDING_ACTIVATION, value);
+                sendingActivation = value;
                 sendingAddress = null;
             }
         }
@@ -263,32 +234,22 @@ namespace Orleans.Runtime
             }
         }
 
+        private bool isNewPlacement;
         public bool IsNewPlacement
         {
-            get { return GetScalarHeader<bool>(Header.IS_NEW_PLACEMENT); }
+            get { return isNewPlacement; }
             set
             {
-                if (value || ContainsHeader(Header.IS_NEW_PLACEMENT))
-                    SetHeader(Header.IS_NEW_PLACEMENT, value);
+                if (value || isNewPlacement)
+                    isNewPlacement = value;
             }
         }
 
-        public ResponseTypes Result
-        {
-            get { return GetScalarHeader<ResponseTypes>(Header.RESULT); }
-            set { SetHeader(Header.RESULT, value); }
-        }
+        public ResponseTypes Result { get; set; }
 
-        public DateTime Expiration
-        {
-            get { return GetScalarHeader<DateTime>(Header.EXPIRATION); }
-            set { SetHeader(Header.EXPIRATION, value); }
-        }
+        public DateTime? Expiration { get; set; }
 
-        public bool IsExpired
-        {
-            get { return (ContainsHeader(Header.EXPIRATION)) && DateTime.UtcNow > Expiration; }
-        }
+        public bool IsExpired => DateTime.UtcNow > Expiration;
 
         public bool IsExpirableMessage(IMessagingConfiguration config)
         {
@@ -301,31 +262,27 @@ namespace Orleans.Runtime
             return Direction != Directions.OneWay && !id.IsSystemTarget && !Constants.IsSystemGrain(id);
         }
         
-        public string DebugContext
-        {
-            get { return GetStringHeader(Header.DEBUG_CONTEXT); }
-            set { SetHeader(Header.DEBUG_CONTEXT, value); }
-        }
+        public string DebugContext { get; set; }
 
-        public IEnumerable<ActivationAddress> CacheInvalidationHeader
-        {
-            get
-            {
-                object obj = GetHeader(Header.CACHE_INVALIDATION_HEADER);
-                return obj == null ? null : ((IEnumerable)obj).Cast<ActivationAddress>();
-            }
-        }
+        public IEnumerable<ActivationAddress> CacheInvalidationHeader { get; set; }
+        //{
+        //    get
+        //    { //todo
+        //        object obj =  GetHeader(Header.CACHE_INVALIDATION_HEADER);
+        //        return obj == null ? null : ((IEnumerable)obj).Cast<ActivationAddress>();
+        //    }
+        //}
 
         internal void AddToCacheInvalidationHeader(ActivationAddress address)
         {
             var list = new List<ActivationAddress>();
-            if (ContainsHeader(Header.CACHE_INVALIDATION_HEADER))
+            if (CacheInvalidationHeader != null)
             {
-                var prevList = ((IEnumerable)GetHeader(Header.CACHE_INVALIDATION_HEADER)).Cast<ActivationAddress>();
-                list.AddRange(prevList);
+                list.AddRange(CacheInvalidationHeader);
             }
+
             list.Add(address);
-            SetHeader(Header.CACHE_INVALIDATION_HEADER, list);
+            CacheInvalidationHeader = list;
         }
 
         // Resends are used by the sender, usualy due to en error to send or due to a transient rejection.
@@ -345,38 +302,28 @@ namespace Orleans.Runtime
         /// Set by sender's placement logic when NewPlacementRequested is true
         /// so that receiver knows desired grain type
         /// </summary>
-        public string NewGrainType
-        {
-            get { return GetStringHeader(Header.NEW_GRAIN_TYPE); }
-            set { SetHeader(Header.NEW_GRAIN_TYPE, value); }
-        }
+        public string NewGrainType { get; set; }
 
+        private string genericGrainType;
         /// <summary>
         /// Set by caller's grain reference 
         /// </summary>
         public string GenericGrainType
         {
-            get { return GetStringHeader(Header.GENERIC_GRAIN_TYPE); }
-            set { SetHeader(Header.GENERIC_GRAIN_TYPE, value); }
+            get { return GetNotNullString(genericGrainType); }
+            set { genericGrainType = value; }
         }
 
-        public RejectionTypes RejectionType
-        {
-            get { return GetScalarHeader<RejectionTypes>(Header.REJECTION_TYPE); }
-            set { SetHeader(Header.REJECTION_TYPE, value); }
-        }
+        public RejectionTypes RejectionType { get; set; }
 
+        private string rejectionInfo;
         public string RejectionInfo
         {
-            get { return GetStringHeader(Header.REJECTION_INFO); }
-            set { SetHeader(Header.REJECTION_INFO, value); }
+            get { return GetNotNullString(rejectionInfo); }
+            set { rejectionInfo = value; }
         }
 
-        public Dictionary<string, object> RequestContextData
-        {
-            get { return GetScalarHeader<Dictionary<string, object>>(Header.REQUEST_CONTEXT); }
-            set { SetHeader(Header.REQUEST_CONTEXT, value); }
-        }
+        public Dictionary<string, object> RequestContextData { get; set; }
 
         public object BodyObject
         {
@@ -433,8 +380,8 @@ namespace Orleans.Runtime
             // average headers items count is 14 items, and while the Header enum contains 18 entries
             // the closest prime number is 17; assuming that possibility of all 18 headers being at the same time is low enough to
             // choose 17 in order to avoid allocations of two additional items on each call, and allocate 37 instead of 19 in rare cases
-            headers = new Dictionary<Header, object>(17);
-            metadata = new Dictionary<string, object>();
+            //headers = new Dictionary<Header, object>(17);
+            //metadata = new Dictionary<string, object>();
             bodyObject = null;
             bodyBytes = null;
             headerBytes = null;
@@ -498,40 +445,38 @@ namespace Orleans.Runtime
                 TargetSilo = this.SendingSilo
             };
 
-            if (this.ContainsHeader(Header.SENDING_GRAIN))
+            if (SendingGrain != null)
             {
-                response.SetHeader(Header.TARGET_GRAIN, this.GetHeader(Header.SENDING_GRAIN));
-                if (this.ContainsHeader(Header.SENDING_ACTIVATION))
+                response.TargetGrain = SendingGrain;
+                if (SendingActivation != null)
                 {
-                    response.SetHeader(Header.TARGET_ACTIVATION, this.GetHeader(Header.SENDING_ACTIVATION));
+                    response.TargetActivation = SendingActivation;
                 }
             }
 
             response.SendingSilo = this.TargetSilo;
-            if (this.ContainsHeader(Header.TARGET_GRAIN))
+            if (TargetGrain != null)
             {
-                response.SetHeader(Header.SENDING_GRAIN, this.GetHeader(Header.TARGET_GRAIN));
-                if (this.ContainsHeader(Header.TARGET_ACTIVATION))
+                response.SendingGrain = TargetGrain;
+                if (TargetActivation != null)
                 {
-                    response.SetHeader(Header.SENDING_ACTIVATION, this.GetHeader(Header.TARGET_ACTIVATION));
+                    response.SendingActivation = TargetActivation;
                 }
                 else if (this.TargetGrain.IsSystemTarget)
                 {
-                    response.SetHeader(Header.SENDING_ACTIVATION, ActivationId.GetSystemActivation(TargetGrain, TargetSilo));
+                    response.SendingActivation = ActivationId.GetSystemActivation(TargetGrain, TargetSilo);
                 }
             }
 
-            if (this.ContainsHeader(Header.DEBUG_CONTEXT))
+            if (DebugContext != null)
             {
-                response.SetHeader(Header.DEBUG_CONTEXT, this.GetHeader(Header.DEBUG_CONTEXT));
+                response.DebugContext = DebugContext;
             }
-            if (this.ContainsHeader(Header.CACHE_INVALIDATION_HEADER))
+
+            response.CacheInvalidationHeader = CacheInvalidationHeader;
+            if (Expiration.HasValue)
             {
-                response.SetHeader(Header.CACHE_INVALIDATION_HEADER, this.GetHeader(Header.CACHE_INVALIDATION_HEADER));
-            }
-            if (this.ContainsHeader(Header.EXPIRATION))
-            {
-                response.SetHeader(Header.EXPIRATION, this.GetHeader(Header.EXPIRATION));
+                response.Expiration = Expiration;
             }
 
             var contextData = RequestContext.Export();
@@ -539,6 +484,7 @@ namespace Orleans.Runtime
             {
                 response.RequestContextData = contextData;
             }
+
             return response;
         }
 
@@ -562,11 +508,6 @@ namespace Orleans.Runtime
             };
         }
 
-        public bool ContainsHeader(Header tag)
-        {
-            return headers.ContainsKey(tag);
-        }
-
         public void RemoveHeader(Header tag)
         {
             lock (headers)
@@ -574,14 +515,6 @@ namespace Orleans.Runtime
                 headers.Remove(tag);
                 if (tag == Header.TARGET_ACTIVATION || tag == Header.TARGET_GRAIN | tag == Header.TARGET_SILO)
                     targetAddress = null;
-            }
-        }
-
-        public void SetHeader(Header tag, object value)
-        {
-            lock (headers)
-            {
-                headers[tag] = value;
             }
         }
 
@@ -603,6 +536,11 @@ namespace Orleans.Runtime
 
             var s = val as string;
             return s ?? String.Empty;
+        }
+
+        private string GetNotNullString(string s)
+        {
+            return s ?? string.Empty;
         }
 
         public T GetScalarHeader<T>(Header tag)
@@ -787,8 +725,8 @@ namespace Orleans.Runtime
                 }
             }
             return String.Format("{0}{1}{2}{3}{4} {5}->{6} #{7}{8}{9}: {10}",
-                IsReadOnly ? "ReadOnly " : "", //0
-                IsAlwaysInterleave ? "IsAlwaysInterleave " : "", //1
+                IsReadOnly == true ? "ReadOnly " : "", //0
+                IsAlwaysInterleave == true ? "IsAlwaysInterleave " : "", //1
                 IsNewPlacement ? "NewPlacement " : "", // 2
                 response,  //3
                 Direction, //4
@@ -803,7 +741,7 @@ namespace Orleans.Runtime
         internal void SetTargetPlacement(PlacementResult value)
         {
             if ((value.IsNewPlacement ||
-                     (ContainsHeader(Header.TARGET_ACTIVATION) &&
+                     (TargetActivation != null &&
                      !TargetActivation.Equals(value.Activation))))
             {
                 RemoveHeader(Header.PRIOR_MESSAGE_ID);
@@ -824,15 +762,15 @@ namespace Orleans.Runtime
         {
             var history = new StringBuilder();
             history.Append("<");
-            if (ContainsHeader(Header.TARGET_SILO))
+            if (TargetSilo != null)
             {
                 history.Append(TargetSilo).Append(":");
             }
-            if (ContainsHeader(Header.TARGET_GRAIN))
+            if (TargetGrain != null)
             {
                 history.Append(TargetGrain).Append(":");
             }
-            if (ContainsHeader(Header.TARGET_ACTIVATION))
+            if (TargetActivation != null)
             {
                 history.Append(TargetActivation);
             }

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -1180,27 +1180,27 @@ namespace Orleans.Runtime
 
                 if ((headers & Header.SENDING_ACTIVATION) != Header.NONE)
                 {
-                    WriteObj(stream, typeof(ActivationId), input.@SendingActivation);
+                    stream.Write(input.@SendingActivation);
                 }
 
                 if ((headers & Header.SENDING_GRAIN) != Header.NONE)
                 {
-                    WriteObj(stream, typeof(GrainId), input.@SendingGrain);
+                    stream.Write(input.@SendingGrain);
                 }
 
                 if ((headers & Header.SENDING_SILO) != Header.NONE)
                 {
-                    WriteObj(stream, typeof(SiloAddress), input.@SendingSilo);
+                    stream.Write(input.@SendingSilo);
                 }
 
                 if ((headers & Header.TARGET_ACTIVATION) != Header.NONE)
                 {
-                    WriteObj(stream, typeof(ActivationId), input.@TargetActivation);
+                    stream.Write(input.@TargetActivation);
                 }
 
                 if ((headers & Header.TARGET_GRAIN) != Header.NONE)
                 {
-                    WriteObj(stream, typeof(GrainId), input.@TargetGrain);
+                    stream.Write(input.@TargetGrain);
                 }
 
                 if ((headers & Header.TARGET_OBSERVER) != Header.NONE)
@@ -1210,7 +1210,7 @@ namespace Orleans.Runtime
 
                 if ((headers & Header.TARGET_SILO) != Header.NONE)
                 {
-                    WriteObj(stream, typeof(SiloAddress), input.@TargetSilo);
+                    stream.Write(input.@TargetSilo);
                 }
             }
 
@@ -1292,25 +1292,25 @@ namespace Orleans.Runtime
                     result.@Result = (global::Orleans.Runtime.Message.ResponseTypes)stream.ReadByte();
 
                 if ((headers & Header.SENDING_ACTIVATION) != Header.NONE)
-                    result.@SendingActivation = (global::Orleans.Runtime.ActivationId)ReadObj(typeof(global::Orleans.Runtime.ActivationId), stream);
+                    result.@SendingActivation = stream.ReadActivationId();
 
                 if ((headers & Header.SENDING_GRAIN) != Header.NONE)
-                    result.@SendingGrain = (global::Orleans.Runtime.GrainId)ReadObj(typeof(global::Orleans.Runtime.GrainId), stream);
+                    result.@SendingGrain = stream.ReadGrainId();
 
                 if ((headers & Header.SENDING_SILO) != Header.NONE)
-                    result.@SendingSilo = (global::Orleans.Runtime.SiloAddress)ReadObj(typeof(global::Orleans.Runtime.SiloAddress), stream);
+                    result.@SendingSilo = stream.ReadSiloAddress();
 
-                if ((headers & Header.TARGET_ACTIVATION) != Header.NONE)
-                    result.@TargetActivation = (global::Orleans.Runtime.ActivationId)ReadObj(typeof(global::Orleans.Runtime.ActivationId), stream);
+                if ((headers & Header.TARGET_ACTIVATION) != Header.NONE) 
+                    result.@TargetActivation = stream.ReadActivationId();
 
                 if ((headers & Header.TARGET_GRAIN) != Header.NONE)
-                    result.@TargetGrain = (global::Orleans.Runtime.GrainId)ReadObj(typeof(global::Orleans.Runtime.GrainId), stream);
+                    result.@TargetGrain = stream.ReadGrainId();
 
                 if ((headers & Header.TARGET_OBSERVER) != Header.NONE)
                     result.@TargetObserverId = (global::Orleans.Runtime.GuidId)ReadObj(typeof(global::Orleans.Runtime.GuidId), stream);
 
                 if ((headers & Header.TARGET_SILO) != Header.NONE)
-                    result.@TargetSilo = (global::Orleans.Runtime.SiloAddress)ReadObj(typeof(global::Orleans.Runtime.SiloAddress), stream);
+                    result.@TargetSilo = stream.ReadSiloAddress();
 
                 return (HeadersContainer)result;
             }

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -792,8 +792,6 @@ namespace Orleans.Runtime
         [Serializable]
         public class HeadersContainer
         {
-            // NOTE:  These are encoded on the wire as bytes for efficiency.  They are only integer enums to avoid boxing
-            // This means we can't have over byte.MaxValue of them.
             [Flags]
             public enum Header
             {

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -888,6 +888,87 @@ namespace Orleans.Runtime
             public string RejectionInfo { get; set; }
 
             public Dictionary<string, object> RequestContextData { get; set; }
+
+            static HeadersContainer()
+            {
+                Register();
+            }
+
+
+            [global::Orleans.CodeGeneration.CopierMethodAttribute]
+            public static global::System.Object DeepCopier(global::System.Object original)
+            {
+                return original;
+            }
+
+            [global::Orleans.CodeGeneration.SerializerMethodAttribute]
+            public static void Serializer(global::System.Object untypedInput, global::Orleans.Serialization.BinaryTokenStreamWriter stream, global::System.Type expected)
+            {
+                HeadersContainer input = (HeadersContainer)untypedInput;
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@CacheInvalidationHeader, stream, typeof(global::System.Collections.Generic.IEnumerable<global::Orleans.Runtime.ActivationAddress>));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@Category, stream, typeof(global::Orleans.Runtime.Message.Categories));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@DebugContext, stream, typeof(global::System.String));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@Direction, stream, typeof(global::System.Nullable<global::Orleans.Runtime.Message.Directions>));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@Expiration, stream, typeof(global::System.Nullable<global::System.DateTime>));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@ForwardCount, stream, typeof(global::System.Int32));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@GenericGrainType, stream, typeof(global::System.String));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@Id, stream, typeof(global::Orleans.Runtime.CorrelationId));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@IsAlwaysInterleave, stream, typeof(global::System.Boolean));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@IsNewPlacement, stream, typeof(global::System.Boolean));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@IsReadOnly, stream, typeof(global::System.Boolean));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@IsUnordered, stream, typeof(global::System.Boolean));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@NewGrainType, stream, typeof(global::System.String));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@RejectionInfo, stream, typeof(global::System.String));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@RejectionType, stream, typeof(global::Orleans.Runtime.Message.RejectionTypes));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@RequestContextData, stream, typeof(global::System.Collections.Generic.Dictionary<global::System.String, global::System.Object>));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@ResendCount, stream, typeof(global::System.Int32));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@Result, stream, typeof(global::Orleans.Runtime.Message.ResponseTypes));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@SendingActivation, stream, typeof(global::Orleans.Runtime.ActivationId));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@SendingGrain, stream, typeof(global::Orleans.Runtime.GrainId));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@SendingSilo, stream, typeof(global::Orleans.Runtime.SiloAddress));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@TargetActivation, stream, typeof(global::Orleans.Runtime.ActivationId));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@TargetGrain, stream, typeof(global::Orleans.Runtime.GrainId));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@TargetObserverId, stream, typeof(global::Orleans.Runtime.GuidId));
+                global::Orleans.Serialization.SerializationManager.@SerializeInner(input.@TargetSilo, stream, typeof(global::Orleans.Runtime.SiloAddress));
+            }
+
+            [global::Orleans.CodeGeneration.DeserializerMethodAttribute]
+            public static global::System.Object Deserializer(global::System.Type expected, global::Orleans.Serialization.BinaryTokenStreamReader stream)
+            {
+                var result = new HeadersContainer();
+                global::Orleans.@Serialization.@DeserializationContext.@Current.@RecordObject(result);
+                result.@CacheInvalidationHeader = (global::System.Collections.Generic.IEnumerable<global::Orleans.Runtime.ActivationAddress>)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Collections.Generic.IEnumerable<global::Orleans.Runtime.ActivationAddress>), stream);
+                result.@Category = (global::Orleans.Runtime.Message.Categories)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.Message.Categories), stream);
+                result.@DebugContext = (global::System.String)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.String), stream);
+                result.@Direction = (global::System.Nullable<global::Orleans.Runtime.Message.Directions>)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Nullable<global::Orleans.Runtime.Message.Directions>), stream);
+                result.@Expiration = (global::System.Nullable<global::System.DateTime>)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Nullable<global::System.DateTime>), stream);
+                result.@ForwardCount = (global::System.Int32)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Int32), stream);
+                result.@GenericGrainType = (global::System.String)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.String), stream);
+                result.@Id = (global::Orleans.Runtime.CorrelationId)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.CorrelationId), stream);
+                result.@IsAlwaysInterleave = (global::System.Boolean)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Boolean), stream);
+                result.@IsNewPlacement = (global::System.Boolean)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Boolean), stream);
+                result.@IsReadOnly = (global::System.Boolean)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Boolean), stream);
+                result.@IsUnordered = (global::System.Boolean)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Boolean), stream);
+                result.@NewGrainType = (global::System.String)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.String), stream);
+                result.@RejectionInfo = (global::System.String)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.String), stream);
+                result.@RejectionType = (global::Orleans.Runtime.Message.RejectionTypes)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.Message.RejectionTypes), stream);
+                result.@RequestContextData = (global::System.Collections.Generic.Dictionary<global::System.String, global::System.Object>)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Collections.Generic.Dictionary<global::System.String, global::System.Object>), stream);
+                result.@ResendCount = (global::System.Int32)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::System.Int32), stream);
+                result.@Result = (global::Orleans.Runtime.Message.ResponseTypes)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.Message.ResponseTypes), stream);
+                result.@SendingActivation = (global::Orleans.Runtime.ActivationId)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.ActivationId), stream);
+                result.@SendingGrain = (global::Orleans.Runtime.GrainId)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.GrainId), stream);
+                result.@SendingSilo = (global::Orleans.Runtime.SiloAddress)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.SiloAddress), stream);
+                result.@TargetActivation = (global::Orleans.Runtime.ActivationId)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.ActivationId), stream);
+                result.@TargetGrain = (global::Orleans.Runtime.GrainId)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.GrainId), stream);
+                result.@TargetObserverId = (global::Orleans.Runtime.GuidId)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.GuidId), stream);
+                result.@TargetSilo = (global::Orleans.Runtime.SiloAddress)global::Orleans.Serialization.SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.SiloAddress), stream);
+                return (HeadersContainer)result;
+            }
+
+            public static void Register()
+            {
+                global::Orleans.Serialization.SerializationManager.@Register(typeof(HeadersContainer), DeepCopier, Serializer, Deserializer);
+            }
         }
     }
 }

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -109,80 +109,80 @@ namespace Orleans.Runtime
 
         public Categories Category
         {
-            get { lock (Headers) return Headers.Category; }
-            set { lock (Headers) Headers.Category = value; }
+            get { return Headers.Category; }
+            set { Headers.Category = value; }
         }
 
         public Directions Direction
         {
-            get { lock (Headers) return Headers.Direction ?? default(Directions); }
-            set { lock (Headers) Headers.Direction = value; }
+            get { return Headers.Direction ?? default(Directions); }
+            set { Headers.Direction = value; }
         }
 
         public bool HasDirection => Headers.Direction.HasValue;
 
         public bool IsReadOnly
         {
-            get { lock(Headers) return Headers.IsReadOnly; }
-            set { lock (Headers) Headers.IsReadOnly = value; }
+            get { return Headers.IsReadOnly; }
+            set { Headers.IsReadOnly = value; }
         }
 
         public bool IsAlwaysInterleave
         {
-            get { lock (Headers) return Headers.IsAlwaysInterleave; }
-            set { lock (Headers) Headers.IsAlwaysInterleave = value; }
+            get { return Headers.IsAlwaysInterleave; }
+            set { Headers.IsAlwaysInterleave = value; }
         }
 
         public bool IsUnordered
         {
-            get { lock (Headers) return Headers.IsUnordered; }
-            set { lock (Headers) Headers.IsUnordered = value; }
+            get { return Headers.IsUnordered; }
+            set { Headers.IsUnordered = value; }
         }
 
         public CorrelationId Id
         {
-            get { lock (Headers) return Headers.Id; }
-            set { lock (Headers) Headers.Id = value; }
+            get { return Headers.Id; }
+            set { Headers.Id = value; }
         }
 
         public int ResendCount
         {
-            get { lock (Headers) return Headers.ResendCount; }
-            set { lock (Headers) Headers.ResendCount = value; }
+            get { return Headers.ResendCount; }
+            set {  Headers.ResendCount = value; }
         }
 
         public int ForwardCount
         {
-            get { lock (Headers) return Headers.ForwardCount; }
-            set { lock (Headers) Headers.ForwardCount = value; }
+            get { return Headers.ForwardCount; }
+            set {  Headers.ForwardCount = value; }
         }
         
         public SiloAddress TargetSilo
         {
-            get { lock (Headers) return Headers.TargetSilo; }
+            get { return Headers.TargetSilo; }
             set
             {
-                lock (Headers) Headers.TargetSilo = value;
+                Headers.TargetSilo = value;
                 targetAddress = null;
             }
         }
         
         public GrainId TargetGrain
         {
-            get { lock (Headers) return Headers.TargetGrain; }
+            get { return Headers.TargetGrain; }
             set
             {
-                lock (Headers) Headers.TargetGrain = value;
+                Headers.TargetGrain = value;
                 targetAddress = null;
             }
         }
         
         public ActivationId TargetActivation
         {
-            get { lock (Headers) return Headers.TargetActivation; }
+            get { return Headers.TargetActivation; }
             set
             {
-                lock (Headers) Headers.TargetActivation = value;
+                Headers.TargetActivation = value;
                 targetAddress = null;
             }
         }
@@ -201,40 +201,40 @@ namespace Orleans.Runtime
         
         public GuidId TargetObserverId
         {
-            get { lock (Headers) return Headers.TargetObserverId; }
+            get { return Headers.TargetObserverId; }
             set
             {
-                lock (Headers) Headers.TargetObserverId = value;
+                Headers.TargetObserverId = value;
                 targetAddress = null;
             }
         }
         
         public SiloAddress SendingSilo
         {
-            get { lock (Headers) return Headers.SendingSilo; }
+            get { return Headers.SendingSilo; }
             set
             {
-                lock (Headers) Headers.SendingSilo = value;
+                Headers.SendingSilo = value;
                 sendingAddress = null;
             }
         }
         
         public GrainId SendingGrain
         {
-            get { lock (Headers) return Headers.SendingGrain; }
+            get { return Headers.SendingGrain; }
             set
             {
-                lock (Headers) Headers.SendingGrain = value;
+                Headers.SendingGrain = value;
                 sendingAddress = null;
             }
         }
         
         public ActivationId SendingActivation
         {
-            get { lock (Headers) return Headers.SendingActivation; }
+            get { return Headers.SendingActivation; }
             set
             {
-                lock (Headers) Headers.SendingActivation = value;
+                Headers.SendingActivation = value;
                 sendingAddress = null;
             }
         }
@@ -253,23 +253,23 @@ namespace Orleans.Runtime
         
         public bool IsNewPlacement
         {
-            get { lock (Headers) return Headers.IsNewPlacement; }
+            get { return Headers.IsNewPlacement; }
             set
             {
-                lock (Headers) Headers.IsNewPlacement = value;
+                 Headers.IsNewPlacement = value;
             }
         }
 
         public ResponseTypes Result
         {
-            get { lock (Headers) return Headers.Result; }
-            set { lock (Headers) Headers.Result = value; }
+            get { return Headers.Result; }
+            set {  Headers.Result = value; }
         }
 
         public DateTime? Expiration
         {
-            get { lock (Headers) return Headers.Expiration; }
-            set { lock (Headers) Headers.Expiration = value; }
+            get { return Headers.Expiration; }
+            set { Headers.Expiration = value; }
         }
 
         public bool IsExpired => Expiration.HasValue && DateTime.UtcNow > Expiration.Value;
@@ -282,19 +282,19 @@ namespace Orleans.Runtime
             if (id == null) return false;
 
             // don't set expiration for one way, system target and system grain messages.
-            return Direction != Directions.OneWay && !id.IsSystemTarget && !Constants.IsSystemGrain(id);
+           return Direction != Directions.OneWay && !id.IsSystemTarget && !Constants.IsSystemGrain(id);
         }
 
         public string DebugContext
         {
-            get { lock (Headers) return GetNotNullString(Headers.DebugContext); }
-            set { lock (Headers) Headers.DebugContext = value; }
+            get { return GetNotNullString(Headers.DebugContext); }
+            set { Headers.DebugContext = value; }
         }
 
         public List<ActivationAddress> CacheInvalidationHeader
         {
-            get { lock (Headers) return Headers.CacheInvalidationHeader; }
-            set { lock (Headers) Headers.CacheInvalidationHeader = value; }
+            get { return Headers.CacheInvalidationHeader; }
+            set { Headers.CacheInvalidationHeader = value; }
         }
 
         internal void AddToCacheInvalidationHeader(ActivationAddress address)
@@ -312,14 +312,14 @@ namespace Orleans.Runtime
         // Resends are used by the sender, usualy due to en error to send or due to a transient rejection.
         public bool MayResend(IMessagingConfiguration config)
         {
-            return ResendCount < config.MaxResendCount;
+           return ResendCount < config.MaxResendCount;
         }
 
         // Forwardings are used by the receiver, usualy when it cannot process the message and forwars it to another silo to perform the processing
         // (got here due to outdated cache, silo is shutting down/overloaded, ...).
         public bool MayForward(GlobalConfiguration config)
         {
-            return ForwardCount < config.MaxForwardCount;
+           return ForwardCount < config.MaxForwardCount;
         }
 
         /// <summary>
@@ -365,7 +365,7 @@ namespace Orleans.Runtime
             {
                 if (bodyObject != null)
                 {
-                    return bodyObject;
+                   return bodyObject;
                 }
                 try
                 {
@@ -379,7 +379,7 @@ namespace Orleans.Runtime
                         bodyBytes = null;
                     }
                 }
-                return bodyObject;
+               return bodyObject;
             }
             set
             {
@@ -395,12 +395,12 @@ namespace Orleans.Runtime
         {
             if (bytes == null)
             {
-                return null;
+               return null;
             }
             try
             {
                 var stream = new BinaryTokenStreamReader(bytes);
-                return SerializationManager.Deserialize(stream);
+               return SerializationManager.Deserialize(stream);
             }
             catch (Exception ex)
             {
@@ -443,7 +443,7 @@ namespace Orleans.Runtime
             {
                 message.RequestContextData = contextData;
             }
-            return message;
+           return message;
         }
 
         // Initializes body and header but does not take ownership of byte.
@@ -509,7 +509,7 @@ namespace Orleans.Runtime
                 response.RequestContextData = contextData;
             }
 
-            return response;
+           return response;
         }
 
         public Message CreateRejectionResponse(RejectionTypes type, string info, OrleansException ex = null)
@@ -520,12 +520,12 @@ namespace Orleans.Runtime
             response.RejectionInfo = info;
             response.BodyObject = ex;
             if (logger.IsVerbose) logger.Verbose("Creating {0} rejection with info '{1}' for {2} at:" + Environment.NewLine + "{3}", type, info, this, Utils.GetStackTrace());
-            return response;
+           return response;
         }
 
         public Message CreatePromptExceptionResponse(Exception exception)
         {
-            return new Message(Category, Directions.Response)
+           return new Message(Category, Directions.Response)
             {
                 Result = ResponseTypes.Error,
                 BodyObject = Response.ExceptionResponse(exception)
@@ -539,7 +539,7 @@ namespace Orleans.Runtime
 
         private static string GetNotNullString(string s)
         {
-            return s ?? string.Empty;
+           return s ?? string.Empty;
         }
 
         /// <summary>
@@ -549,7 +549,7 @@ namespace Orleans.Runtime
         /// <returns></returns>
         public bool IsDuplicate(Message other)
         {
-            return Equals(SendingSilo, other.SendingSilo) && Equals(Id, other.Id);
+           return Equals(SendingSilo, other.SendingSilo) && Equals(Id, other.Id);
         }
 
         #region Serialization
@@ -557,16 +557,13 @@ namespace Orleans.Runtime
         public List<ArraySegment<byte>> Serialize(out int headerLength)
         {
             int dummy;
-            return Serialize_Impl(out headerLength, out dummy);
+           return Serialize_Impl(out headerLength, out dummy);
         }
 
         private List<ArraySegment<byte>> Serialize_Impl(out int headerLengthOut, out int bodyLengthOut)
         {
             var headerStream = new BinaryTokenStreamWriter();
-            lock (Headers) // Guard against any attempts to modify message headers while we are serializing them
-            {
-                SerializationManager.SerializeMessageHeaders(Headers, headerStream);
-            }
+            SerializationManager.SerializeMessageHeaders(Headers, headerStream);
 
             if (bodyBytes == null)
             {
@@ -603,7 +600,7 @@ namespace Orleans.Runtime
 
             headerLengthOut = headerLength;
             bodyLengthOut = bodyLength;
-            return bytes;
+           return bytes;
         }
 
 
@@ -643,38 +640,38 @@ namespace Orleans.Runtime
                 sb.Append(debugContex).Append(".");
             }
 
-            AppendIfExists(HeadersContainer.Header.CACHE_INVALIDATION_HEADER, sb, (m) => m.CacheInvalidationHeader);
+            AppendIfExists(HeadersContainer.Headers.CACHE_INVALIDATION_HEADER, sb, (m) => m.CacheInvalidationHeader);
+            AppendIfExists(HeadersContainer.Headers.CATEGORY, sb, (m) => m.Category);
+            AppendIfExists(HeadersContainer.Headers.DIRECTION, sb, (m) => m.Direction);
+            AppendIfExists(HeadersContainer.Headers.EXPIRATION, sb, (m) => m.Expiration);
+            AppendIfExists(HeadersContainer.Headers.FORWARD_COUNT, sb, (m) => m.ForwardCount);
+            AppendIfExists(HeadersContainer.Headers.GENERIC_GRAIN_TYPE, sb, (m) => m.GenericGrainType);
+            AppendIfExists(HeadersContainer.Headers.CORRELATION_ID, sb, (m) => m.Id);
+            AppendIfExists(HeadersContainer.Headers.ALWAYS_INTERLEAVE, sb, (m) => m.IsAlwaysInterleave);
+            AppendIfExists(HeadersContainer.Headers.IS_NEW_PLACEMENT, sb, (m) => m.IsNewPlacement);
+            AppendIfExists(HeadersContainer.Headers.READ_ONLY, sb, (m) => m.IsReadOnly);
+            AppendIfExists(HeadersContainer.Headers.IS_UNORDERED, sb, (m) => m.IsUnordered);
+            AppendIfExists(HeadersContainer.Headers.NEW_GRAIN_TYPE, sb, (m) => m.NewGrainType);
+            AppendIfExists(HeadersContainer.Headers.REJECTION_INFO, sb, (m) => m.RejectionInfo);
+            AppendIfExists(HeadersContainer.Headers.REJECTION_TYPE, sb, (m) => m.RejectionType);
+            AppendIfExists(HeadersContainer.Headers.REQUEST_CONTEXT, sb, (m) => m.RequestContextData);
+            AppendIfExists(HeadersContainer.Headers.RESEND_COUNT, sb, (m) => m.ResendCount);
+            AppendIfExists(HeadersContainer.Headers.RESULT, sb, (m) => m.Result);
+            AppendIfExists(HeadersContainer.Headers.SENDING_ACTIVATION, sb, (m) => m.SendingActivation);
+            AppendIfExists(HeadersContainer.Headers.SENDING_GRAIN, sb, (m) => m.SendingGrain);
+            AppendIfExists(HeadersContainer.Headers.SENDING_SILO, sb, (m) => m.SendingSilo);
+            AppendIfExists(HeadersContainer.Headers.TARGET_ACTIVATION, sb, (m) => m.TargetActivation);
+            AppendIfExists(HeadersContainer.Headers.TARGET_GRAIN, sb, (m) => m.TargetGrain);
+            AppendIfExists(HeadersContainer.Headers.TARGET_OBSERVER, sb, (m) => m.TargetObserverId);
+            AppendIfExists(HeadersContainer.Headers.TARGET_SILO, sb, (m) => m.TargetSilo);
 
-            AppendIfExists(HeadersContainer.Header.CATEGORY, sb, (m) => m.Category);
-            AppendIfExists(HeadersContainer.Header.DIRECTION, sb, (m) => m.Direction);
-            AppendIfExists(HeadersContainer.Header.EXPIRATION, sb, (m) => m.Expiration);
-            AppendIfExists(HeadersContainer.Header.FORWARD_COUNT, sb, (m) => m.ForwardCount);
-            AppendIfExists(HeadersContainer.Header.GENERIC_GRAIN_TYPE, sb, (m) => m.GenericGrainType);
-            AppendIfExists(HeadersContainer.Header.CORRELATION_ID, sb, (m) => m.Id);
-            AppendIfExists(HeadersContainer.Header.ALWAYS_INTERLEAVE, sb, (m) => m.IsAlwaysInterleave);
-            AppendIfExists(HeadersContainer.Header.IS_NEW_PLACEMENT, sb, (m) => m.IsNewPlacement);
-            AppendIfExists(HeadersContainer.Header.READ_ONLY, sb, (m) => m.IsReadOnly);
-            AppendIfExists(HeadersContainer.Header.IS_UNORDERED, sb, (m) => m.IsUnordered);
-            AppendIfExists(HeadersContainer.Header.NEW_GRAIN_TYPE, sb, (m) => m.NewGrainType);
-            AppendIfExists(HeadersContainer.Header.REJECTION_INFO, sb, (m) => m.RejectionInfo);
-            AppendIfExists(HeadersContainer.Header.REJECTION_TYPE, sb, (m) => m.RejectionType);
-            AppendIfExists(HeadersContainer.Header.REQUEST_CONTEXT, sb, (m) => m.RequestContextData);
-            AppendIfExists(HeadersContainer.Header.RESEND_COUNT, sb, (m) => m.ResendCount);
-            AppendIfExists(HeadersContainer.Header.RESULT, sb, (m) => m.Result);
-            AppendIfExists(HeadersContainer.Header.SENDING_ACTIVATION, sb, (m) => m.SendingActivation);
-            AppendIfExists(HeadersContainer.Header.SENDING_GRAIN, sb, (m) => m.SendingGrain);
-            AppendIfExists(HeadersContainer.Header.SENDING_SILO, sb, (m) => m.SendingSilo);
-            AppendIfExists(HeadersContainer.Header.TARGET_ACTIVATION, sb, (m) => m.TargetActivation);
-            AppendIfExists(HeadersContainer.Header.TARGET_GRAIN, sb, (m) => m.TargetGrain);
-            AppendIfExists(HeadersContainer.Header.TARGET_OBSERVER, sb, (m) => m.TargetObserverId);
-            AppendIfExists(HeadersContainer.Header.TARGET_SILO, sb, (m) => m.TargetSilo);
-
-            return sb.ToString();
+           return sb.ToString();
         }
         
-        private void AppendIfExists(HeadersContainer.Header header, StringBuilder sb, Func<Message, object> valueProvider)
+        private void AppendIfExists(HeadersContainer.Headers header, StringBuilder sb, Func<Message, object> valueProvider)
         {
-            if ((Headers.Headers & header) != HeadersContainer.Header.NONE)
+            // used only under log3 level
+            if ((Headers.GetHeadersMask() & header) != HeadersContainer.Headers.NONE)
             {
                 sb.AppendFormat("{0}={1};", header, valueProvider(this));
                 sb.AppendLine();
@@ -700,7 +697,7 @@ namespace Orleans.Runtime
                         break;
                 }
             }
-            return String.Format("{0}{1}{2}{3}{4} {5}->{6} #{7}{8}{9}: {10}",
+           return String.Format("{0}{1}{2}{3}{4} {5}->{6} #{7}{8}{9}: {10}",
                 IsReadOnly ? "ReadOnly " : "", //0
                 IsAlwaysInterleave ? "IsAlwaysInterleave " : "", //1
                 IsNewPlacement ? "NewPlacement " : "", // 2
@@ -748,13 +745,13 @@ namespace Orleans.Runtime
             {
                 history.Append("    ").Append(TargetHistory);
             }
-            return history.ToString();
+           return history.ToString();
         }
 
         public bool IsSameDestination(IOutgoingMessage other)
         {
             var msg = (Message)other;
-            return msg != null && Object.Equals(TargetSilo, msg.TargetSilo);
+           return msg != null && Object.Equals(TargetSilo, msg.TargetSilo);
         }
 
         // For statistical measuring of time spent in queues.
@@ -793,7 +790,7 @@ namespace Orleans.Runtime
         public class HeadersContainer
         {
             [Flags]
-            public enum Header
+            public enum Headers
             {
                 NONE = 0,
                 ALWAYS_INTERLEAVE = 1 << 0,
@@ -825,8 +822,6 @@ namespace Orleans.Runtime
                 // Do not add over int.MaxValue of these.
             }
 
-            private Header headers = default(Header);
-
             private Categories _category;
             private Directions? _direction;
             private bool _isReadOnly;
@@ -853,15 +848,12 @@ namespace Orleans.Runtime
             private string _rejectionInfo;
             private Dictionary<string, object> _requestContextData;
 
-            public Header Headers => headers;
-
             public Categories Category
             {
                 get { return _category; }
                 set
                 {
                     _category = value;
-                    headers = headers | Header.CATEGORY;
                 }
             }
 
@@ -871,7 +863,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _direction = value;
-                    headers = value == null ? headers & ~Header.DIRECTION : headers | Header.DIRECTION;
                 }
             }
 
@@ -881,7 +872,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _isReadOnly = value;
-                    headers = headers | Header.READ_ONLY;
                 }
             }
 
@@ -891,7 +881,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _isAlwaysInterleave = value;
-                    headers = headers | Header.ALWAYS_INTERLEAVE;
                 }
             }
 
@@ -901,7 +890,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _isUnordered = value;
-                    headers = headers | Header.IS_UNORDERED;
                 }
             }
 
@@ -911,7 +899,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _id = value;
-                    headers = value == null ? headers & ~Header.CORRELATION_ID : headers | Header.CORRELATION_ID;
                 }
             }
 
@@ -921,7 +908,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _resendCount = value;
-                    headers = headers | Header.RESEND_COUNT;
                 }
             }
 
@@ -931,7 +917,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _forwardCount = value;
-                    headers = headers | Header.FORWARD_COUNT;
                 }
             }
 
@@ -941,7 +926,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _targetSilo = value;
-                    headers = value == null ? headers & ~Header.TARGET_SILO :  headers | Header.TARGET_SILO;
                 }
             }
 
@@ -951,7 +935,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _targetGrain = value;
-                    headers = value == null ? headers & ~Header.TARGET_GRAIN : headers | Header.TARGET_GRAIN;
                 }
             }
 
@@ -961,7 +944,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _targetActivation = value;
-                    headers = value == null ? headers & ~Header.TARGET_ACTIVATION : headers | Header.TARGET_ACTIVATION;
                 }
             }
 
@@ -971,7 +953,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _targetObserverId = value;
-                    headers = value == null ? headers & ~Header.TARGET_OBSERVER : headers | Header.TARGET_OBSERVER;
                 }
             }
 
@@ -981,7 +962,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _sendingSilo = value;
-                    headers = value == null ? headers & ~Header.SENDING_SILO : headers | Header.SENDING_SILO;
                 }
             }
 
@@ -991,7 +971,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _sendingGrain = value;
-                    headers = value == null ? headers & ~Header.SENDING_GRAIN : headers | Header.SENDING_GRAIN;
                 }
             }
 
@@ -1001,7 +980,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _sendingActivation = value;
-                    headers = value == null ? headers & ~Header.SENDING_ACTIVATION : headers | Header.SENDING_ACTIVATION;
                 }
             }
 
@@ -1011,7 +989,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _isNewPlacement = value;
-                    headers = headers | Header.IS_NEW_PLACEMENT;
                 }
             }
 
@@ -1021,7 +998,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _result = value;
-                    headers = headers | Header.RESULT;
                 }
             }
 
@@ -1031,7 +1007,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _expiration = value;
-                    headers = value == null ? headers & ~Header.EXPIRATION : headers | Header.EXPIRATION;
                 }
             }
 
@@ -1042,7 +1017,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _debugContext = value;
-                    headers = string.IsNullOrEmpty(value) ? headers & ~Header.DEBUG_CONTEXT : headers | Header.DEBUG_CONTEXT;
                 }
             }
 
@@ -1052,7 +1026,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _cacheInvalidationHeader = value;
-                    headers = value == null || value.Count == 0 ? headers & ~Header.CACHE_INVALIDATION_HEADER : headers | Header.CACHE_INVALIDATION_HEADER;
                 }
             }
 
@@ -1066,7 +1039,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _newGrainType = value;
-                    headers = string.IsNullOrEmpty(value) ? headers & ~Header.NEW_GRAIN_TYPE : headers | Header.NEW_GRAIN_TYPE;
                 }
             }
 
@@ -1079,7 +1051,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _genericGrainType = value;
-                    headers = string.IsNullOrEmpty(value) ? headers & ~Header.GENERIC_GRAIN_TYPE : headers | Header.GENERIC_GRAIN_TYPE;
                 }
             }
 
@@ -1089,7 +1060,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _rejectionType = value;
-                    headers = headers | Header.REJECTION_TYPE;
                 }
             }
 
@@ -1099,7 +1069,6 @@ namespace Orleans.Runtime
                 set
                 {
                     _rejectionInfo = value;
-                    headers = string.IsNullOrEmpty(value) ? headers & ~Header.REJECTION_INFO : headers | Header.REJECTION_INFO;
                 }
             }
 
@@ -1109,8 +1078,48 @@ namespace Orleans.Runtime
                 set
                 {
                     _requestContextData = value;
-                    headers = value  == null || value.Count == 0 ? headers & ~Header.REQUEST_CONTEXT : headers | Header.REQUEST_CONTEXT;
                 }
+            }
+
+            internal Headers GetHeadersMask()
+            {
+                Headers headers = Headers.NONE;
+                if(Category != default(Categories))
+                    headers = headers | Headers.CATEGORY;
+
+                headers = _direction == null ? headers & ~Headers.DIRECTION : headers | Headers.DIRECTION;
+                if (IsReadOnly)
+                    headers = headers | Headers.READ_ONLY;
+                if (IsAlwaysInterleave)
+                    headers = headers | Headers.ALWAYS_INTERLEAVE;
+                if(IsUnordered)
+                    headers = headers | Headers.IS_UNORDERED;
+
+                headers = _id == null ? headers & ~Headers.CORRELATION_ID : headers | Headers.CORRELATION_ID;
+
+                if (_resendCount != default(int))
+                    headers = headers | Headers.RESEND_COUNT;
+                if(_forwardCount != default (int))
+                    headers = headers | Headers.FORWARD_COUNT;
+
+                headers = _targetSilo == null ? headers & ~Headers.TARGET_SILO : headers | Headers.TARGET_SILO;
+                headers = _targetGrain == null ? headers & ~Headers.TARGET_GRAIN : headers | Headers.TARGET_GRAIN;
+                headers = _targetActivation == null ? headers & ~Headers.TARGET_ACTIVATION : headers | Headers.TARGET_ACTIVATION;
+                headers = _targetObserverId == null ? headers & ~Headers.TARGET_OBSERVER : headers | Headers.TARGET_OBSERVER;
+                headers = _sendingSilo == null ? headers & ~Headers.SENDING_SILO : headers | Headers.SENDING_SILO;
+                headers = _sendingGrain == null ? headers & ~Headers.SENDING_GRAIN : headers | Headers.SENDING_GRAIN;
+                headers = _sendingActivation == null ? headers & ~Headers.SENDING_ACTIVATION : headers | Headers.SENDING_ACTIVATION;
+                headers = _isNewPlacement == default(bool) ? headers & ~Headers.IS_NEW_PLACEMENT : headers | Headers.IS_NEW_PLACEMENT;
+                headers = _result == default(ResponseTypes)? headers & ~Headers.RESULT : headers | Headers.RESULT;
+                headers = _expiration == null ? headers & ~Headers.EXPIRATION : headers | Headers.EXPIRATION;
+                headers = string.IsNullOrEmpty(_debugContext) ? headers & ~Headers.DEBUG_CONTEXT : headers | Headers.DEBUG_CONTEXT;
+                headers = _cacheInvalidationHeader == null || _cacheInvalidationHeader.Count == 0 ? headers & ~Headers.CACHE_INVALIDATION_HEADER : headers | Headers.CACHE_INVALIDATION_HEADER;
+                headers = string.IsNullOrEmpty(_newGrainType) ? headers & ~Headers.NEW_GRAIN_TYPE : headers | Headers.NEW_GRAIN_TYPE;
+                headers = string.IsNullOrEmpty(GenericGrainType) ? headers & ~Headers.GENERIC_GRAIN_TYPE : headers | Headers.GENERIC_GRAIN_TYPE;
+                headers = _rejectionType == default(RejectionTypes) ? headers & ~Headers.REJECTION_TYPE : headers | Headers.REJECTION_TYPE;
+                headers = string.IsNullOrEmpty(_rejectionInfo) ? headers & ~Headers.REJECTION_INFO : headers | Headers.REJECTION_INFO;
+                headers = _requestContextData == null || _requestContextData.Count == 0 ? headers & ~Headers.REQUEST_CONTEXT : headers | Headers.REQUEST_CONTEXT;
+               return headers;
             }
 
             static HeadersContainer()
@@ -1119,139 +1128,139 @@ namespace Orleans.Runtime
             }
 
 
-            [global::Orleans.CodeGeneration.CopierMethodAttribute]
-            public static global::System.Object DeepCopier(global::System.Object original)
+            [Orleans.CodeGeneration.CopierMethodAttribute]
+            public static System.Object DeepCopier(System.Object original)
             {
-                return original;
+               return original;
             }
 
-            [global::Orleans.CodeGeneration.SerializerMethodAttribute]
-            public static void Serializer(global::System.Object untypedInput,  BinaryTokenStreamWriter stream, global::System.Type expected)
+            [Orleans.CodeGeneration.SerializerMethodAttribute]
+            public static void Serializer(System.Object untypedInput,  BinaryTokenStreamWriter stream, System.Type expected)
             {
                 HeadersContainer input = (HeadersContainer)untypedInput;
-                var headers = input.headers;
-                stream.Write((int)input.headers);
-                if ((headers & Header.CACHE_INVALIDATION_HEADER) != Header.NONE)
+                var headers = input.GetHeadersMask();
+                stream.Write((int)headers);
+                if ((headers & Headers.CACHE_INVALIDATION_HEADER) != Headers.NONE)
                 {
-                    var count = input.@CacheInvalidationHeader.Count;
-                    stream.Write(input.@CacheInvalidationHeader.Count);
+                    var count = input.CacheInvalidationHeader.Count;
+                    stream.Write(input.CacheInvalidationHeader.Count);
                     for (int i = 0; i < count; i++)
                     {
-                        WriteObj(stream, typeof(ActivationAddress), input.@CacheInvalidationHeader[i]);
+                        WriteObj(stream, typeof(ActivationAddress), input.CacheInvalidationHeader[i]);
                     }
                 }
 
-                if ((headers & Header.CATEGORY) != Header.NONE)
+                if ((headers & Headers.CATEGORY) != Headers.NONE)
                 {
-                    stream.Write((byte)input.@Category);
+                    stream.Write((byte)input.Category);
                 }
 
-                if ((headers & Header.DEBUG_CONTEXT) != Header.NONE)
+                if ((headers & Headers.DEBUG_CONTEXT) != Headers.NONE)
                     stream.Write(input.DebugContext);
 
-                if ((headers & Header.DIRECTION) != Header.NONE)
+                if ((headers & Headers.DIRECTION) != Headers.NONE)
                     stream.Write((byte)input.Direction.Value);
 
-                if ((headers & Header.EXPIRATION) != Header.NONE)
-                    stream.Write(input.@Expiration.Value);
+                if ((headers & Headers.EXPIRATION) != Headers.NONE)
+                    stream.Write(input.Expiration.Value);
 
-                if ((headers & Header.FORWARD_COUNT) != Header.NONE)
-                    stream.Write(input.@ForwardCount);
+                if ((headers & Headers.FORWARD_COUNT) != Headers.NONE)
+                    stream.Write(input.ForwardCount);
 
-                if ((headers & Header.GENERIC_GRAIN_TYPE) != Header.NONE)
-                    stream.Write(input.@GenericGrainType);
+                if ((headers & Headers.GENERIC_GRAIN_TYPE) != Headers.NONE)
+                    stream.Write(input.GenericGrainType);
 
-                if ((headers & Header.CORRELATION_ID) != Header.NONE)
-                    stream.Write(input.@Id);
+                if ((headers & Headers.CORRELATION_ID) != Headers.NONE)
+                    stream.Write(input.Id);
 
-                if ((headers & Header.ALWAYS_INTERLEAVE) != Header.NONE)
-                    stream.Write(input.@IsAlwaysInterleave);
+                if ((headers & Headers.ALWAYS_INTERLEAVE) != Headers.NONE)
+                    stream.Write(input.IsAlwaysInterleave);
 
-                if ((headers & Header.IS_NEW_PLACEMENT) != Header.NONE)
-                    stream.Write(input.@IsNewPlacement);
+                if ((headers & Headers.IS_NEW_PLACEMENT) != Headers.NONE)
+                    stream.Write(input.IsNewPlacement);
 
-                if ((headers & Header.READ_ONLY) != Header.NONE)
-                    stream.Write(input.@IsReadOnly);
+                if ((headers & Headers.READ_ONLY) != Headers.NONE)
+                    stream.Write(input.IsReadOnly);
 
-                if ((headers & Header.IS_UNORDERED) != Header.NONE)
-                    stream.Write(input.@IsUnordered);
+                if ((headers & Headers.IS_UNORDERED) != Headers.NONE)
+                    stream.Write(input.IsUnordered);
 
-                if ((headers & Header.NEW_GRAIN_TYPE) != Header.NONE)
-                    stream.Write(input.@NewGrainType);
+                if ((headers & Headers.NEW_GRAIN_TYPE) != Headers.NONE)
+                    stream.Write(input.NewGrainType);
 
-                if ((headers & Header.REJECTION_INFO) != Header.NONE)
-                    stream.Write(input.@RejectionInfo);
+                if ((headers & Headers.REJECTION_INFO) != Headers.NONE)
+                    stream.Write(input.RejectionInfo);
 
-                if ((headers & Header.REJECTION_TYPE) != Header.NONE)
-                    stream.Write((byte)input.@RejectionType);
+                if ((headers & Headers.REJECTION_TYPE) != Headers.NONE)
+                    stream.Write((byte)input.RejectionType);
 
-                if ((headers & Header.REQUEST_CONTEXT) != Header.NONE)
+                if ((headers & Headers.REQUEST_CONTEXT) != Headers.NONE)
                 {
-                    var requestData = input.@RequestContextData;
+                    var requestData = input.RequestContextData;
                     var count = requestData.Count;
                     stream.Write(count);
                     foreach (var d in requestData)
                     {
                         stream.Write(d.Key);
-                        SerializationManager.@SerializeInner(d.Value, stream, typeof(object));
+                        SerializationManager.SerializeInner(d.Value, stream, typeof(object));
                     }
                 }
 
-                if ((headers & Header.RESEND_COUNT) != Header.NONE)
-                    stream.Write(input.@ResendCount);
+                if ((headers & Headers.RESEND_COUNT) != Headers.NONE)
+                    stream.Write(input.ResendCount);
 
-                if ((headers & Header.RESULT) != Header.NONE)
-                    stream.Write((byte)input.@Result);
+                if ((headers & Headers.RESULT) != Headers.NONE)
+                    stream.Write((byte)input.Result);
 
-                if ((headers & Header.SENDING_ACTIVATION) != Header.NONE)
+                if ((headers & Headers.SENDING_ACTIVATION) != Headers.NONE)
                 {
-                    stream.Write(input.@SendingActivation);
+                    stream.Write(input.SendingActivation);
                 }
 
-                if ((headers & Header.SENDING_GRAIN) != Header.NONE)
+                if ((headers & Headers.SENDING_GRAIN) != Headers.NONE)
                 {
-                    stream.Write(input.@SendingGrain);
+                    stream.Write(input.SendingGrain);
                 }
 
-                if ((headers & Header.SENDING_SILO) != Header.NONE)
+                if ((headers & Headers.SENDING_SILO) != Headers.NONE)
                 {
-                    stream.Write(input.@SendingSilo);
+                    stream.Write(input.SendingSilo);
                 }
 
-                if ((headers & Header.TARGET_ACTIVATION) != Header.NONE)
+                if ((headers & Headers.TARGET_ACTIVATION) != Headers.NONE)
                 {
-                    stream.Write(input.@TargetActivation);
+                    stream.Write(input.TargetActivation);
                 }
 
-                if ((headers & Header.TARGET_GRAIN) != Header.NONE)
+                if ((headers & Headers.TARGET_GRAIN) != Headers.NONE)
                 {
-                    stream.Write(input.@TargetGrain);
+                    stream.Write(input.TargetGrain);
                 }
 
-                if ((headers & Header.TARGET_OBSERVER) != Header.NONE)
+                if ((headers & Headers.TARGET_OBSERVER) != Headers.NONE)
                 {
-                    WriteObj(stream, typeof(GuidId), input.@TargetObserverId);
+                    WriteObj(stream, typeof(GuidId), input.TargetObserverId);
                 }
 
-                if ((headers & Header.TARGET_SILO) != Header.NONE)
+                if ((headers & Headers.TARGET_SILO) != Headers.NONE)
                 {
-                    stream.Write(input.@TargetSilo);
+                    stream.Write(input.TargetSilo);
                 }
             }
 
-            [global::Orleans.CodeGeneration.DeserializerMethodAttribute]
-            public static global::System.Object Deserializer(global::System.Type expected,  BinaryTokenStreamReader stream)
+            [Orleans.CodeGeneration.DeserializerMethodAttribute]
+            public static System.Object Deserializer(System.Type expected,  BinaryTokenStreamReader stream)
             {
                 var result = new HeadersContainer();
-                global::Orleans.@Serialization.@DeserializationContext.@Current.@RecordObject(result);
-                var headers = (Header)stream.ReadInt();
+                Orleans.Serialization.DeserializationContext.Current.RecordObject(result);
+                var headers = (Headers)stream.ReadInt();
 
-                if ((headers & Header.CACHE_INVALIDATION_HEADER) != Header.NONE)
+                if ((headers & Headers.CACHE_INVALIDATION_HEADER) != Headers.NONE)
                 {
                     var n = stream.ReadInt();
                     if (n > 0)
                     {
-                       var list = result.@CacheInvalidationHeader = new List<ActivationAddress>(n);
+                       var list = result.CacheInvalidationHeader = new List<ActivationAddress>(n);
                         for (int i = 0; i < n; i++)
                         {
                             list.Add((ActivationAddress)ReadObj(typeof(ActivationAddress), stream));
@@ -1259,49 +1268,49 @@ namespace Orleans.Runtime
                     }
                 }
 
-                if ((headers & Header.CATEGORY) != Header.NONE)
-                    result.@Category = (Categories)stream.ReadByte();
+                if ((headers & Headers.CATEGORY) != Headers.NONE)
+                    result.Category = (Categories)stream.ReadByte();
 
-                if ((headers & Header.DEBUG_CONTEXT) != Header.NONE)
-                    result.@DebugContext = stream.ReadString();
+                if ((headers & Headers.DEBUG_CONTEXT) != Headers.NONE)
+                    result.DebugContext = stream.ReadString();
 
-                if ((headers & Header.DIRECTION) != Header.NONE)
-                    result.@Direction = (Message.Directions)stream.ReadByte();
+                if ((headers & Headers.DIRECTION) != Headers.NONE)
+                    result.Direction = (Message.Directions)stream.ReadByte();
 
-                if ((headers & Header.EXPIRATION) != Header.NONE)
-                    result.@Expiration = stream.ReadDateTime();
+                if ((headers & Headers.EXPIRATION) != Headers.NONE)
+                    result.Expiration = stream.ReadDateTime();
 
-                if ((headers & Header.FORWARD_COUNT) != Header.NONE)
-                    result.@ForwardCount = stream.ReadInt();
+                if ((headers & Headers.FORWARD_COUNT) != Headers.NONE)
+                    result.ForwardCount = stream.ReadInt();
 
-                if ((headers & Header.GENERIC_GRAIN_TYPE) != Header.NONE)
-                    result.@GenericGrainType = stream.ReadString();
+                if ((headers & Headers.GENERIC_GRAIN_TYPE) != Headers.NONE)
+                    result.GenericGrainType = stream.ReadString();
 
-                if ((headers & Header.CORRELATION_ID) != Header.NONE)
-                    result.@Id = (global::Orleans.Runtime.CorrelationId)ReadObj(typeof(global::Orleans.Runtime.CorrelationId), stream);
+                if ((headers & Headers.CORRELATION_ID) != Headers.NONE)
+                    result.Id = (Orleans.Runtime.CorrelationId)ReadObj(typeof(Orleans.Runtime.CorrelationId), stream);
 
-                if ((headers & Header.ALWAYS_INTERLEAVE) != Header.NONE)
-                    result.@IsAlwaysInterleave = ReadBool(stream);
+                if ((headers & Headers.ALWAYS_INTERLEAVE) != Headers.NONE)
+                    result.IsAlwaysInterleave = ReadBool(stream);
 
-                if ((headers & Header.IS_NEW_PLACEMENT) != Header.NONE)
-                    result.@IsNewPlacement = ReadBool(stream);
+                if ((headers & Headers.IS_NEW_PLACEMENT) != Headers.NONE)
+                    result.IsNewPlacement = ReadBool(stream);
 
-                if ((headers & Header.READ_ONLY) != Header.NONE)
-                    result.@IsReadOnly = ReadBool(stream);
+                if ((headers & Headers.READ_ONLY) != Headers.NONE)
+                    result.IsReadOnly = ReadBool(stream);
 
-                if ((headers & Header.IS_UNORDERED) != Header.NONE)
-                    result.@IsUnordered = ReadBool(stream);
+                if ((headers & Headers.IS_UNORDERED) != Headers.NONE)
+                    result.IsUnordered = ReadBool(stream);
 
-                if ((headers & Header.NEW_GRAIN_TYPE) != Header.NONE)
-                    result.@NewGrainType = stream.ReadString();
+                if ((headers & Headers.NEW_GRAIN_TYPE) != Headers.NONE)
+                    result.NewGrainType = stream.ReadString();
 
-                if ((headers & Header.REJECTION_INFO) != Header.NONE)
-                    result.@RejectionInfo = stream.ReadString();
+                if ((headers & Headers.REJECTION_INFO) != Headers.NONE)
+                    result.RejectionInfo = stream.ReadString();
 
-                if ((headers & Header.REJECTION_TYPE) != Header.NONE)
-                    result.@RejectionType = (RejectionTypes)stream.ReadByte();
+                if ((headers & Headers.REJECTION_TYPE) != Headers.NONE)
+                    result.RejectionType = (RejectionTypes)stream.ReadByte();
 
-                if ((headers & Header.REQUEST_CONTEXT) != Header.NONE)
+                if ((headers & Headers.REQUEST_CONTEXT) != Headers.NONE)
                 {
                     var c = stream.ReadInt();
                     var requestData = new Dictionary<string, object>(c);
@@ -1309,42 +1318,42 @@ namespace Orleans.Runtime
                     {
                         requestData[stream.ReadString()] = SerializationManager.DeserializeInner(null, stream);
                     }
-                    result.@RequestContextData = requestData;
+                    result.RequestContextData = requestData;
                 }
 
-                if ((headers & Header.RESEND_COUNT) != Header.NONE)
-                    result.@ResendCount = stream.ReadInt();
+                if ((headers & Headers.RESEND_COUNT) != Headers.NONE)
+                    result.ResendCount = stream.ReadInt();
 
-                if ((headers & Header.RESULT) != Header.NONE)
-                    result.@Result = (global::Orleans.Runtime.Message.ResponseTypes)stream.ReadByte();
+                if ((headers & Headers.RESULT) != Headers.NONE)
+                    result.Result = (Orleans.Runtime.Message.ResponseTypes)stream.ReadByte();
 
-                if ((headers & Header.SENDING_ACTIVATION) != Header.NONE)
-                    result.@SendingActivation = stream.ReadActivationId();
+                if ((headers & Headers.SENDING_ACTIVATION) != Headers.NONE)
+                    result.SendingActivation = stream.ReadActivationId();
 
-                if ((headers & Header.SENDING_GRAIN) != Header.NONE)
-                    result.@SendingGrain = stream.ReadGrainId();
+                if ((headers & Headers.SENDING_GRAIN) != Headers.NONE)
+                    result.SendingGrain = stream.ReadGrainId();
 
-                if ((headers & Header.SENDING_SILO) != Header.NONE)
-                    result.@SendingSilo = stream.ReadSiloAddress();
+                if ((headers & Headers.SENDING_SILO) != Headers.NONE)
+                    result.SendingSilo = stream.ReadSiloAddress();
 
-                if ((headers & Header.TARGET_ACTIVATION) != Header.NONE) 
-                    result.@TargetActivation = stream.ReadActivationId();
+                if ((headers & Headers.TARGET_ACTIVATION) != Headers.NONE) 
+                    result.TargetActivation = stream.ReadActivationId();
 
-                if ((headers & Header.TARGET_GRAIN) != Header.NONE)
-                    result.@TargetGrain = stream.ReadGrainId();
+                if ((headers & Headers.TARGET_GRAIN) != Headers.NONE)
+                    result.TargetGrain = stream.ReadGrainId();
 
-                if ((headers & Header.TARGET_OBSERVER) != Header.NONE)
-                    result.@TargetObserverId = (global::Orleans.Runtime.GuidId)ReadObj(typeof(global::Orleans.Runtime.GuidId), stream);
+                if ((headers & Headers.TARGET_OBSERVER) != Headers.NONE)
+                    result.TargetObserverId = (Orleans.Runtime.GuidId)ReadObj(typeof(Orleans.Runtime.GuidId), stream);
 
-                if ((headers & Header.TARGET_SILO) != Header.NONE)
-                    result.@TargetSilo = stream.ReadSiloAddress();
+                if ((headers & Headers.TARGET_SILO) != Headers.NONE)
+                    result.TargetSilo = stream.ReadSiloAddress();
 
-                return (HeadersContainer)result;
+               return (HeadersContainer)result;
             }
 
             private static bool ReadBool(BinaryTokenStreamReader stream)
             {
-                return stream.ReadByte() == (byte) SerializationTokenType.True;
+               return stream.ReadByte() == (byte) SerializationTokenType.True;
             }
 
             private static void WriteObj(BinaryTokenStreamWriter stream, Type type, object input)
@@ -1356,12 +1365,12 @@ namespace Orleans.Runtime
             private static object ReadObj(Type t, BinaryTokenStreamReader stream)
             {
                 var des = SerializationManager.GetDeserializer(t);
-                return des.Invoke(t, stream);
+               return des.Invoke(t, stream);
             }
 
             public static void Register()
             {
-                 SerializationManager.@Register(typeof(HeadersContainer), DeepCopier, Serializer, Deserializer);
+                 SerializationManager.Register(typeof(HeadersContainer), DeepCopier, Serializer, Deserializer);
             }
         }
     }

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -67,8 +67,6 @@ namespace Orleans.Runtime
         [NonSerialized]
         private Dictionary<string, object> metadata;
 
-        private readonly object headersLockObj = new object();
-
         /// <summary>
         /// NOTE: The contents of bodyBytes should never be modified
         /// </summary>
@@ -122,78 +120,78 @@ namespace Orleans.Runtime
 
         public Categories Category
         {
-            get { return Headers.Category; }
-            set { Headers.Category = value; }
+            get { lock (Headers) return Headers.Category; }
+            set { lock (Headers) Headers.Category = value; }
         }
 
-        public Directions? Direction
+        public Directions Direction
         {
-            get { return Headers.Direction; }
-            set { Headers.Direction = value; }
+            get { lock (Headers) return Headers.Direction; }
+            set { lock (Headers) Headers.Direction = value; }
         }
 
         public bool IsReadOnly
         {
-            get { return Headers.IsReadOnly; }
-            set { Headers.IsReadOnly = value; }
+            get { lock(Headers) return Headers.IsReadOnly; }
+            set { lock (Headers) Headers.IsReadOnly = value; }
         }
 
         public bool IsAlwaysInterleave
         {
-            get { return Headers.IsAlwaysInterleave; }
-            set { Headers.IsAlwaysInterleave = value; }
+            get { lock (Headers) return Headers.IsAlwaysInterleave; }
+            set { lock (Headers) Headers.IsAlwaysInterleave = value; }
         }
 
         public bool IsUnordered
         {
-            get { return Headers.IsUnordered; }
-            set { Headers.IsUnordered = value; }
+            get { lock (Headers) return Headers.IsUnordered; }
+            set { lock (Headers) Headers.IsUnordered = value; }
         } // todo
 
         public CorrelationId Id
         {
-            get { return Headers.Id; }
-            set { Headers.Id = value; }
+            get { lock (Headers) return Headers.Id; }
+            set { lock (Headers) Headers.Id = value; }
         }
 
         public int ResendCount
         {
-            get { return Headers.ResendCount; }
-            set { Headers.ResendCount = value; }
+            get { lock (Headers) return Headers.ResendCount; }
+            set { lock (Headers) Headers.ResendCount = value; }
         }
 
         public int ForwardCount
         {
-            get { return Headers.ForwardCount; }
-            set { Headers.ForwardCount = value; }
+            get { lock (Headers) return Headers.ForwardCount; }
+            set { lock (Headers) Headers.ForwardCount = value; }
         }
         
         public SiloAddress TargetSilo
         {
-            get { return Headers.TargetSilo; }
+            get { lock (Headers) return Headers.TargetSilo; }
             set
             {
-                Headers.TargetSilo = value;
+                lock (Headers) Headers.TargetSilo = value;
                 targetAddress = null;
             }
         }
         
         public GrainId TargetGrain
         {
-            get { return Headers.TargetGrain; }
+            get { lock (Headers) return Headers.TargetGrain; }
             set
             {
-                Headers.TargetGrain = value;
+                lock (Headers) Headers.TargetGrain = value;
                 targetAddress = null;
             }
         }
         
         public ActivationId TargetActivation
         {
-            get { return Headers.TargetActivation; }
+            get { lock (Headers) return Headers.TargetActivation; }
             set
             {
-                Headers.TargetActivation = value;
+                lock (Headers) Headers.TargetActivation = value;
                 targetAddress = null;
             }
         }
@@ -212,40 +210,40 @@ namespace Orleans.Runtime
         
         public GuidId TargetObserverId
         {
-            get { return Headers.TargetObserverId; }
+            get { lock (Headers) return Headers.TargetObserverId; }
             set
             {
-                Headers.TargetObserverId = value;
+                lock (Headers) Headers.TargetObserverId = value;
                 targetAddress = null;
             }
         }
         
         public SiloAddress SendingSilo
         {
-            get { return Headers.SendingSilo; }
+            get { lock (Headers) return Headers.SendingSilo; }
             set
             {
-                Headers.SendingSilo = value;
+                lock (Headers) Headers.SendingSilo = value;
                 sendingAddress = null;
             }
         }
         
         public GrainId SendingGrain
         {
-            get { return Headers.SendingGrain; }
+            get { lock (Headers) return Headers.SendingGrain; }
             set
             {
-                Headers.SendingGrain = value;
+                lock (Headers) Headers.SendingGrain = value;
                 sendingAddress = null;
             }
         }
         
         public ActivationId SendingActivation
         {
-            get { return Headers.SendingActivation; }
+            get { lock (Headers) return Headers.SendingActivation; }
             set
             {
-                Headers.SendingActivation = value;
+                lock (Headers) Headers.SendingActivation = value;
                 sendingAddress = null;
             }
         }
@@ -262,29 +260,28 @@ namespace Orleans.Runtime
             }
         }
         
-        public bool? IsNewPlacement
+        public bool IsNewPlacement
         {
-            get { return Headers.IsNewPlacement; }
+            get { lock (Headers) return Headers.IsNewPlacement; }
             set
             {
-               // todo: recheck if (value == true)
-                    Headers.IsNewPlacement = value;
+                lock (Headers) Headers.IsNewPlacement = value;
             }
         }
 
         public ResponseTypes Result
         {
-            get { return Headers.Result; }
-            set { Headers.Result = value; }
+            get { lock (Headers) return Headers.Result; }
+            set { lock (Headers) Headers.Result = value; }
         }
 
         public DateTime? Expiration
         {
-            get { return Headers.Expiration; }
-            set { Headers.Expiration = value; }
+            get { lock (Headers) return Headers.Expiration; }
+            set { lock (Headers) Headers.Expiration = value; }
         }
 
-        public bool IsExpired => DateTime.UtcNow > Expiration;
+        public bool IsExpired => Expiration.HasValue && DateTime.UtcNow > Expiration.Value;
 
         public bool IsExpirableMessage(IMessagingConfiguration config)
         {
@@ -299,14 +296,14 @@ namespace Orleans.Runtime
 
         public string DebugContext
         {
-            get { return Headers.DebugContext; }
-            set { Headers.DebugContext = value; }
+            get { lock (Headers) return GetNotNullString(Headers.DebugContext); }
+            set { lock (Headers) Headers.DebugContext = value; }
         }
 
         public IEnumerable<ActivationAddress> CacheInvalidationHeader
         {
-            get { return Headers.CacheInvalidationHeader; }
-            set { Headers.CacheInvalidationHeader = value; }
+            get { lock (Headers) return Headers.CacheInvalidationHeader; }
+            set { lock (Headers) Headers.CacheInvalidationHeader = value; }
         }
 
         //{
@@ -348,7 +345,7 @@ namespace Orleans.Runtime
         /// </summary>
         public string NewGrainType
         {
-            get { return Headers.NewGrainType; }
+            get { return GetNotNullString(Headers.NewGrainType); }
             set { Headers.NewGrainType = value; }
         }
         
@@ -435,7 +432,7 @@ namespace Orleans.Runtime
             // the closest prime number is 17; assuming that possibility of all 18 headers being at the same time is low enough to
             // choose 17 in order to avoid allocations of two additional items on each call, and allocate 37 instead of 19 in rare cases
             //headers = new Dictionary<Header, object>(17);
-            //metadata = new Dictionary<string, object>();
+            metadata = new Dictionary<string, object>();
             bodyObject = null;
             bodyBytes = null;
             headerBytes = null;
@@ -478,7 +475,7 @@ namespace Orleans.Runtime
             metadata = new Dictionary<string, object>();
 
             var input = new BinaryTokenStreamReader(header);
-            SerializationManager.DeserializeMessageHeaders(input, this);
+            Headers = SerializationManager.DeserializeMessageHeaders(input);
             if (deserializeBody)
             {
                 bodyObject = DeserializeBody(body);
@@ -528,10 +525,7 @@ namespace Orleans.Runtime
             }
 
             response.CacheInvalidationHeader = CacheInvalidationHeader;
-            if (Expiration.HasValue)
-            {
-                response.Expiration = Expiration;
-            }
+            response.Expiration = Expiration;
 
             var contextData = RequestContext.Export();
             if (contextData != null)
@@ -624,7 +618,8 @@ namespace Orleans.Runtime
         private List<ArraySegment<byte>> Serialize_Impl(out int headerLengthOut, out int bodyLengthOut)
         {
             var headerStream = new BinaryTokenStreamWriter();
-           //todo lock (headers) // Guard against any attempts to modify message headers while we are serializing them
+            lock (Headers)
+            //todo lock (headers) // Guard against any attempts to modify message headers while we are serializing them
             {
                 SerializationManager.SerializeMessageHeaders(Headers, headerStream);
             }
@@ -829,7 +824,7 @@ namespace Orleans.Runtime
         {
             public Categories Category { get; set; }
 
-            public Directions? Direction { get; set; }
+            public Directions Direction { get; set; }
 
             public bool IsReadOnly { get; set; }
 
@@ -857,7 +852,7 @@ namespace Orleans.Runtime
 
             public ActivationId SendingActivation { get; set; }
 
-            public bool? IsNewPlacement { get; set; }
+            public bool IsNewPlacement { get; set; }
 
             public ResponseTypes Result { get; set; }
 

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -1131,7 +1131,6 @@ namespace Orleans.Runtime
                 HeadersContainer input = (HeadersContainer)untypedInput;
                 var headers = input.headers;
                 stream.Write((int)input.headers);
-              //  SerializationManager.@SerializeInner(input.headers, stream, typeof(Header));
                 if ((headers & Header.CACHE_INVALIDATION_HEADER) != Header.NONE)
                 {
                     var count = input.@CacheInvalidationHeader.Count;

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -126,9 +126,11 @@ namespace Orleans.Runtime
 
         public Directions Direction
         {
-            get { lock (Headers) return Headers.Direction; }
+            get { lock (Headers) return Headers.Direction ?? default(Directions); }
             set { lock (Headers) Headers.Direction = value; }
         }
+
+        public bool HasDirection => Headers.Direction.HasValue;
 
         public bool IsReadOnly
         {
@@ -824,7 +826,7 @@ namespace Orleans.Runtime
         {
             public Categories Category { get; set; }
 
-            public Directions Direction { get; set; }
+            public Directions? Direction { get; set; }
 
             public bool IsReadOnly { get; set; }
 

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -291,7 +291,7 @@ namespace Orleans.Runtime
             set { lock (Headers) Headers.DebugContext = value; }
         }
 
-        public IEnumerable<ActivationAddress> CacheInvalidationHeader
+        public List<ActivationAddress> CacheInvalidationHeader
         {
             get { lock (Headers) return Headers.CacheInvalidationHeader; }
             set { lock (Headers) Headers.CacheInvalidationHeader = value; }
@@ -781,43 +781,36 @@ namespace Orleans.Runtime
             public enum Header
             {
                 NONE = 0,
-                ALWAYS_INTERLEAVE = 1,
-                CACHE_INVALIDATION_HEADER,
-                CATEGORY,
-                CORRELATION_ID,
-                DEBUG_CONTEXT,
-                DIRECTION,
-                EXPIRATION,
-                FORWARD_COUNT,
-                INTERFACE_ID,  // DEPRECATED - leave that enum value to maintain next enum numerical values
-                METHOD_ID,  // DEPRECATED - leave that enum value to maintain next enum numerical values
-                NEW_GRAIN_TYPE,
-                GENERIC_GRAIN_TYPE,
-                RESULT,
-                REJECTION_INFO,
-                REJECTION_TYPE,
-                READ_ONLY,
-                RESEND_COUNT,
-                SENDING_ACTIVATION,
-                SENDING_GRAIN,
-                SENDING_SILO,
-                IS_NEW_PLACEMENT,
+                ALWAYS_INTERLEAVE = 1 << 0,
+                CACHE_INVALIDATION_HEADER = 1 << 1,
+                CATEGORY = 1 << 2,
+                CORRELATION_ID = 1 << 3,
+                DEBUG_CONTEXT = 1 << 4,
+                DIRECTION = 1 << 5,
+                EXPIRATION = 1 << 6,
+                FORWARD_COUNT = 1 << 7,
+                NEW_GRAIN_TYPE = 1 << 8,
+                GENERIC_GRAIN_TYPE = 1 << 9,
+                RESULT = 1 << 10,
+                REJECTION_INFO = 1 << 11,
+                REJECTION_TYPE = 1 << 12,
+                READ_ONLY = 1 << 13,
+                RESEND_COUNT = 1 << 14,
+                SENDING_ACTIVATION = 1 << 15,
+                SENDING_GRAIN = 1 <<16,
+                SENDING_SILO = 1 << 17,
+                IS_NEW_PLACEMENT = 1 << 18,
 
-                TARGET_ACTIVATION,
-                TARGET_GRAIN,
-                TARGET_SILO,
-                TARGET_OBSERVER,
-                TIMESTAMPS, // DEPRECATED - leave that enum value to maintain next enum numerical values
-                IS_UNORDERED,
-
-                PRIOR_MESSAGE_ID, // Unused
-                PRIOR_MESSAGE_TIMES, // Unused
-
-                REQUEST_CONTEXT,
+                TARGET_ACTIVATION = 1 << 19,
+                TARGET_GRAIN = 1 << 20,
+                TARGET_SILO = 1 << 21,
+                TARGET_OBSERVER = 1 << 22,
+                IS_UNORDERED = 1 << 23,
+                REQUEST_CONTEXT = 1 << 24,
                 // Do not add over byte.MaxValue of these.
             }
 
-            private Header headers;
+            private Header headers = default(Header);
 
             private Categories _category;
             private Directions? _direction;
@@ -838,7 +831,7 @@ namespace Orleans.Runtime
             private ResponseTypes _result;
             private DateTime? _expiration;
             private string _debugContext;
-            private IEnumerable<ActivationAddress> _cacheInvalidationHeader;
+            private List<ActivationAddress> _cacheInvalidationHeader;
             private string _newGrainType;
             private string _genericGrainType;
             private RejectionTypes _rejectionType;
@@ -861,7 +854,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _direction = value;
-                    headers = headers | Header.DIRECTION;
+                    headers = value == null ? headers & ~Header.DIRECTION : headers | Header.DIRECTION;
                 }
             }
 
@@ -901,7 +894,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _id = value;
-                    headers = headers | Header.CORRELATION_ID;
+                    headers = value == null ? headers & ~Header.CORRELATION_ID : headers | Header.CORRELATION_ID;
                 }
             }
 
@@ -931,7 +924,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _targetSilo = value;
-                    headers = headers | Header.TARGET_SILO;
+                    headers = value == null ? headers & ~Header.TARGET_SILO :  headers | Header.TARGET_SILO;
                 }
             }
 
@@ -941,7 +934,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _targetGrain = value;
-                    headers = headers | Header.TARGET_GRAIN;
+                    headers = value == null ? headers & ~Header.TARGET_GRAIN : headers | Header.TARGET_GRAIN;
                 }
             }
 
@@ -951,7 +944,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _targetActivation = value;
-                    headers = headers | Header.TARGET_ACTIVATION;
+                    headers = value == null ? headers & ~Header.TARGET_ACTIVATION : headers | Header.TARGET_ACTIVATION;
                 }
             }
 
@@ -961,7 +954,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _targetObserverId = value;
-                    headers = headers | Header.TARGET_OBSERVER;
+                    headers = value == null ? headers & ~Header.TARGET_OBSERVER : headers | Header.TARGET_OBSERVER;
                 }
             }
 
@@ -971,7 +964,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _sendingSilo = value;
-                    headers = headers | Header.SENDING_SILO;
+                    headers = value == null ? headers & ~Header.SENDING_SILO : headers | Header.SENDING_SILO;
                 }
             }
 
@@ -981,7 +974,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _sendingGrain = value;
-                    headers = headers | Header.SENDING_GRAIN;
+                    headers = value == null ? headers & ~Header.SENDING_GRAIN : headers | Header.SENDING_GRAIN;
                 }
             }
 
@@ -991,7 +984,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _sendingActivation = value;
-                    headers = headers | Header.SENDING_ACTIVATION;
+                    headers = value == null ? headers & ~Header.SENDING_ACTIVATION : headers | Header.SENDING_ACTIVATION;
                 }
             }
 
@@ -1021,7 +1014,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _expiration = value;
-                    headers = headers | Header.EXPIRATION;
+                    headers = value == null ? headers & ~Header.EXPIRATION : headers | Header.EXPIRATION;
                 }
             }
 
@@ -1032,17 +1025,17 @@ namespace Orleans.Runtime
                 set
                 {
                     _debugContext = value;
-                    headers = headers | Header.DEBUG_CONTEXT;
+                    headers = string.IsNullOrEmpty(value) ? headers & ~Header.DEBUG_CONTEXT : headers | Header.DEBUG_CONTEXT;
                 }
             }
 
-            public IEnumerable<ActivationAddress> CacheInvalidationHeader
+            public List<ActivationAddress> CacheInvalidationHeader
             {
                 get { return _cacheInvalidationHeader; }
                 set
                 {
                     _cacheInvalidationHeader = value;
-                    headers = headers | Header.CACHE_INVALIDATION_HEADER;
+                    headers = value == null || value.Count == 0 ? headers & ~Header.CACHE_INVALIDATION_HEADER : headers | Header.CACHE_INVALIDATION_HEADER;
                 }
             }
 
@@ -1056,7 +1049,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _newGrainType = value;
-                    headers = headers | Header.NEW_GRAIN_TYPE;
+                    headers = string.IsNullOrEmpty(value) ? headers & ~Header.NEW_GRAIN_TYPE : headers | Header.NEW_GRAIN_TYPE;
                 }
             }
 
@@ -1069,7 +1062,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _genericGrainType = value;
-                    headers = headers | Header.GENERIC_GRAIN_TYPE;
+                    headers = string.IsNullOrEmpty(value) ? headers & ~Header.GENERIC_GRAIN_TYPE : headers | Header.GENERIC_GRAIN_TYPE;
                 }
             }
 
@@ -1089,7 +1082,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _rejectionInfo = value;
-                    headers = headers | Header.REJECTION_INFO;
+                    headers = string.IsNullOrEmpty(value) ? headers & ~Header.REJECTION_INFO : headers | Header.REJECTION_INFO;
                 }
             }
 
@@ -1099,7 +1092,7 @@ namespace Orleans.Runtime
                 set
                 {
                     _requestContextData = value;
-                    headers = headers | Header.REQUEST_CONTEXT;
+                    headers = value  == null || value.Count == 0 ? headers & ~Header.REQUEST_CONTEXT : headers | Header.REQUEST_CONTEXT;
                 }
             }
 
@@ -1120,81 +1113,111 @@ namespace Orleans.Runtime
             {
                 HeadersContainer input = (HeadersContainer)untypedInput;
                 var headers = input.headers;
-                SerializationManager.@SerializeInner(input.headers, stream, typeof(Header));
+                stream.Write((int)input.headers);
+              //  SerializationManager.@SerializeInner(input.headers, stream, typeof(Header));
                 if ((headers & Header.CACHE_INVALIDATION_HEADER) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@CacheInvalidationHeader, stream, typeof(global::System.Collections.Generic.IEnumerable<global::Orleans.Runtime.ActivationAddress>));
+                {
+                    var count = input.@CacheInvalidationHeader.Count;
+                    stream.Write(input.@CacheInvalidationHeader.Count);
+                    for (int i = 0; i < count; i++)
+                    {
+                        WriteObj(stream, typeof(ActivationAddress), input.@CacheInvalidationHeader[i]);
+                    }
+                }
 
                 if ((headers & Header.CATEGORY) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@Category, stream, typeof(global::Orleans.Runtime.Message.Categories));
+                {
+                    stream.Write((byte)input.@Category);
+                }
 
                 if ((headers & Header.DEBUG_CONTEXT) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@DebugContext, stream, typeof(global::System.String));
+                    stream.Write(input.DebugContext);
 
                 if ((headers & Header.DIRECTION) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@Direction, stream, typeof(global::System.Nullable<global::Orleans.Runtime.Message.Directions>));
+                    stream.Write((byte)input.Direction.Value); // todo
 
                 if ((headers & Header.EXPIRATION) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@Expiration, stream, typeof(global::System.Nullable<global::System.DateTime>));
+                    stream.Write(input.@Expiration.Value);
 
                 if ((headers & Header.FORWARD_COUNT) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@ForwardCount, stream, typeof(global::System.Int32));
+                    stream.Write(input.@ForwardCount);
 
                 if ((headers & Header.GENERIC_GRAIN_TYPE) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@GenericGrainType, stream, typeof(global::System.String));
+                    stream.Write(input.@GenericGrainType);
 
                 if ((headers & Header.CORRELATION_ID) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@Id, stream, typeof(global::Orleans.Runtime.CorrelationId));
+                    stream.Write(input.@Id);
 
                 if ((headers & Header.ALWAYS_INTERLEAVE) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@IsAlwaysInterleave, stream, typeof(global::System.Boolean));
+                    stream.Write(input.@IsAlwaysInterleave);
 
                 if ((headers & Header.IS_NEW_PLACEMENT) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@IsNewPlacement, stream, typeof(global::System.Boolean));
+                    stream.Write(input.@IsNewPlacement);
 
                 if ((headers & Header.READ_ONLY) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@IsReadOnly, stream, typeof(global::System.Boolean));
+                    stream.Write(input.@IsReadOnly);
 
                 if ((headers & Header.IS_UNORDERED) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@IsUnordered, stream, typeof(global::System.Boolean));
+                    stream.Write(input.@IsUnordered);
 
                 if ((headers & Header.NEW_GRAIN_TYPE) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@NewGrainType, stream, typeof(global::System.String));
+                    stream.Write(input.@NewGrainType);
 
                 if ((headers & Header.REJECTION_INFO) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@RejectionInfo, stream, typeof(global::System.String));
+                    stream.Write(input.@RejectionInfo);
 
                 if ((headers & Header.REJECTION_TYPE) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@RejectionType, stream, typeof(global::Orleans.Runtime.Message.RejectionTypes));
+                    stream.Write((byte)input.@RejectionType);
 
-                if ((headers & Header.REQUEST_CONTEXT) != Header.NONE)
+                if ((headers & Header.REQUEST_CONTEXT) != Header.NONE) // todo
                     SerializationManager.@SerializeInner(input.@RequestContextData, stream, typeof(global::System.Collections.Generic.Dictionary<global::System.String, global::System.Object>));
 
                 if ((headers & Header.RESEND_COUNT) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@ResendCount, stream, typeof(global::System.Int32));
+                    stream.Write(input.@ResendCount);
 
                 if ((headers & Header.RESULT) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@Result, stream, typeof(global::Orleans.Runtime.Message.ResponseTypes));
+                    stream.Write((byte)input.@Result);
 
                 if ((headers & Header.SENDING_ACTIVATION) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@SendingActivation, stream, typeof(global::Orleans.Runtime.ActivationId));
+                {
+                    WriteObj(stream, typeof(ActivationId), input.@SendingActivation);
+                }
 
                 if ((headers & Header.SENDING_GRAIN) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@SendingGrain, stream, typeof(global::Orleans.Runtime.GrainId));
+                {
+                    WriteObj(stream, typeof(GrainId), input.@SendingGrain);
+                }
 
                 if ((headers & Header.SENDING_SILO) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@SendingSilo, stream, typeof(global::Orleans.Runtime.SiloAddress));
+                {
+                    WriteObj(stream, typeof(SiloAddress), input.@SendingSilo);
+                }
 
                 if ((headers & Header.TARGET_ACTIVATION) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@TargetActivation, stream, typeof(global::Orleans.Runtime.ActivationId));
+                {
+                    WriteObj(stream, typeof(ActivationId), input.@TargetActivation);
+                }
 
                 if ((headers & Header.TARGET_GRAIN) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@TargetGrain, stream, typeof(global::Orleans.Runtime.GrainId));
+                {
+                    WriteObj(stream, typeof(GrainId), input.@TargetGrain);
+                }
 
                 if ((headers & Header.TARGET_OBSERVER) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@TargetObserverId, stream, typeof(global::Orleans.Runtime.GuidId));
+                {
+                    WriteObj(stream, typeof(GuidId), input.@TargetObserverId);
+                }
 
                 if ((headers & Header.TARGET_SILO) != Header.NONE)
-                    SerializationManager.@SerializeInner(input.@TargetSilo, stream, typeof(global::Orleans.Runtime.SiloAddress));
+                {
+                    WriteObj(stream, typeof(SiloAddress), input.@TargetSilo);
+                }
+            }
+
+            private static void WriteObj(BinaryTokenStreamWriter stream, Type type, object input)
+            {
+                var ser = SerializationManager.GetSerializer(type);
+                ser.Invoke(input, stream, type);
             }
 
             [global::Orleans.CodeGeneration.DeserializerMethodAttribute]
@@ -1202,84 +1225,105 @@ namespace Orleans.Runtime
             {
                 var result = new HeadersContainer();
                 global::Orleans.@Serialization.@DeserializationContext.@Current.@RecordObject(result);
-                var headers = (Header)SerializationManager.@DeserializeInner(typeof(Header), stream);
+                var headers = (Header)stream.ReadInt();
 
                 if ((headers & Header.CACHE_INVALIDATION_HEADER) != Header.NONE)
-                    result.@CacheInvalidationHeader = (global::System.Collections.Generic.IEnumerable<global::Orleans.Runtime.ActivationAddress>) SerializationManager.@DeserializeInner(typeof(global::System.Collections.Generic.IEnumerable<global::Orleans.Runtime.ActivationAddress>), stream);
+                {
+                    var n = stream.ReadInt();
+                    if (n > 0)
+                    {
+                       var list = result.@CacheInvalidationHeader = new List<ActivationAddress>(n);
+                        for (int i = 0; i < n; i++)
+                        {
+                            list.Add((ActivationAddress)ReadObj(typeof(ActivationAddress), stream));
+                        }
+                    }
+                }
 
                 if ((headers & Header.CATEGORY) != Header.NONE)
-                    result.@Category = (global::Orleans.Runtime.Message.Categories) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.Message.Categories), stream);
+                    result.@Category = (Categories)stream.ReadByte();
 
                 if ((headers & Header.DEBUG_CONTEXT) != Header.NONE)
-                    result.@DebugContext = (global::System.String) SerializationManager.@DeserializeInner(typeof(global::System.String), stream);
+                    result.@DebugContext = stream.ReadString();
 
                 if ((headers & Header.DIRECTION) != Header.NONE)
-                    result.@Direction = (global::System.Nullable<global::Orleans.Runtime.Message.Directions>) SerializationManager.@DeserializeInner(typeof(global::System.Nullable<global::Orleans.Runtime.Message.Directions>), stream);
+                    result.@Direction = (Message.Directions)stream.ReadByte();
 
                 if ((headers & Header.EXPIRATION) != Header.NONE)
-                    result.@Expiration = (global::System.Nullable<global::System.DateTime>) SerializationManager.@DeserializeInner(typeof(global::System.Nullable<global::System.DateTime>), stream);
+                    result.@Expiration = stream.ReadDateTime();
 
                 if ((headers & Header.FORWARD_COUNT) != Header.NONE)
-                    result.@ForwardCount = (global::System.Int32) SerializationManager.@DeserializeInner(typeof(global::System.Int32), stream);
+                    result.@ForwardCount = stream.ReadInt();
 
                 if ((headers & Header.GENERIC_GRAIN_TYPE) != Header.NONE)
-                    result.@GenericGrainType = (global::System.String) SerializationManager.@DeserializeInner(typeof(global::System.String), stream);
+                    result.@GenericGrainType = stream.ReadString();
 
                 if ((headers & Header.CORRELATION_ID) != Header.NONE)
-                    result.@Id = (global::Orleans.Runtime.CorrelationId) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.CorrelationId), stream);
+                    result.@Id = (global::Orleans.Runtime.CorrelationId)ReadObj(typeof(global::Orleans.Runtime.CorrelationId), stream);
 
                 if ((headers & Header.ALWAYS_INTERLEAVE) != Header.NONE)
-                    result.@IsAlwaysInterleave = (global::System.Boolean) SerializationManager.@DeserializeInner(typeof(global::System.Boolean), stream);
+                    result.@IsAlwaysInterleave = ReadBool(stream);
 
                 if ((headers & Header.IS_NEW_PLACEMENT) != Header.NONE)
-                    result.@IsNewPlacement = (global::System.Boolean) SerializationManager.@DeserializeInner(typeof(global::System.Boolean), stream);
+                    result.@IsNewPlacement = ReadBool(stream);
 
                 if ((headers & Header.READ_ONLY) != Header.NONE)
-                    result.@IsReadOnly = (global::System.Boolean) SerializationManager.@DeserializeInner(typeof(global::System.Boolean), stream);
+                    result.@IsReadOnly = ReadBool(stream);
 
                 if ((headers & Header.IS_UNORDERED) != Header.NONE)
-                    result.@IsUnordered = (global::System.Boolean) SerializationManager.@DeserializeInner(typeof(global::System.Boolean), stream);
+                    result.@IsUnordered = ReadBool(stream);
 
                 if ((headers & Header.NEW_GRAIN_TYPE) != Header.NONE)
-                    result.@NewGrainType = (global::System.String) SerializationManager.@DeserializeInner(typeof(global::System.String), stream);
+                    result.@NewGrainType = stream.ReadString();
 
                 if ((headers & Header.REJECTION_INFO) != Header.NONE)
-                    result.@RejectionInfo = (global::System.String) SerializationManager.@DeserializeInner(typeof(global::System.String), stream);
+                    result.@RejectionInfo = stream.ReadString();
 
                 if ((headers & Header.REJECTION_TYPE) != Header.NONE)
-                    result.@RejectionType = (global::Orleans.Runtime.Message.RejectionTypes) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.Message.RejectionTypes), stream);
+                    result.@RejectionType = (RejectionTypes)stream.ReadByte();
 
                 if ((headers & Header.REQUEST_CONTEXT) != Header.NONE)
-                    result.@RequestContextData = (global::System.Collections.Generic.Dictionary<global::System.String, global::System.Object>) SerializationManager.@DeserializeInner(typeof(global::System.Collections.Generic.Dictionary<global::System.String, global::System.Object>), stream);
+                    result.@RequestContextData = (global::System.Collections.Generic.Dictionary<global::System.String, global::System.Object>)SerializationManager.@DeserializeInner(typeof(global::System.Collections.Generic.Dictionary<global::System.String, global::System.Object>), stream);
 
                 if ((headers & Header.RESEND_COUNT) != Header.NONE)
-                    result.@ResendCount = (global::System.Int32) SerializationManager.@DeserializeInner(typeof(global::System.Int32), stream);
+                    result.@ResendCount = stream.ReadInt();
 
                 if ((headers & Header.RESULT) != Header.NONE)
-                    result.@Result = (global::Orleans.Runtime.Message.ResponseTypes) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.Message.ResponseTypes), stream);
+                    result.@Result = (global::Orleans.Runtime.Message.ResponseTypes)stream.ReadByte();
 
                 if ((headers & Header.SENDING_ACTIVATION) != Header.NONE)
-                    result.@SendingActivation = (global::Orleans.Runtime.ActivationId) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.ActivationId), stream);
+                    result.@SendingActivation = (global::Orleans.Runtime.ActivationId)ReadObj(typeof(global::Orleans.Runtime.ActivationId), stream);
 
                 if ((headers & Header.SENDING_GRAIN) != Header.NONE)
-                    result.@SendingGrain = (global::Orleans.Runtime.GrainId) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.GrainId), stream);
+                    result.@SendingGrain = (global::Orleans.Runtime.GrainId)ReadObj(typeof(global::Orleans.Runtime.GrainId), stream);
 
                 if ((headers & Header.SENDING_SILO) != Header.NONE)
-                    result.@SendingSilo = (global::Orleans.Runtime.SiloAddress) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.SiloAddress), stream);
+                    result.@SendingSilo = (global::Orleans.Runtime.SiloAddress)ReadObj(typeof(global::Orleans.Runtime.SiloAddress), stream);
 
                 if ((headers & Header.TARGET_ACTIVATION) != Header.NONE)
-                    result.@TargetActivation = (global::Orleans.Runtime.ActivationId) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.ActivationId), stream);
+                    result.@TargetActivation = (global::Orleans.Runtime.ActivationId)ReadObj(typeof(global::Orleans.Runtime.ActivationId), stream);
 
                 if ((headers & Header.TARGET_GRAIN) != Header.NONE)
-                    result.@TargetGrain = (global::Orleans.Runtime.GrainId) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.GrainId), stream);
+                    result.@TargetGrain = (global::Orleans.Runtime.GrainId)ReadObj(typeof(global::Orleans.Runtime.GrainId), stream);
 
                 if ((headers & Header.TARGET_OBSERVER) != Header.NONE)
-                    result.@TargetObserverId = (global::Orleans.Runtime.GuidId) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.GuidId), stream);
+                    result.@TargetObserverId = (global::Orleans.Runtime.GuidId)ReadObj(typeof(global::Orleans.Runtime.GuidId), stream);
 
                 if ((headers & Header.TARGET_SILO) != Header.NONE)
-                    result.@TargetSilo = (global::Orleans.Runtime.SiloAddress) SerializationManager.@DeserializeInner(typeof(global::Orleans.Runtime.SiloAddress), stream);
+                    result.@TargetSilo = (global::Orleans.Runtime.SiloAddress)ReadObj(typeof(global::Orleans.Runtime.SiloAddress), stream);
 
                 return (HeadersContainer)result;
+            }
+
+            private static bool ReadBool(BinaryTokenStreamReader stream)
+            {
+                return stream.ReadByte() == (byte) SerializationTokenType.True;
+            }
+
+            private static object ReadObj(Type t, BinaryTokenStreamReader stream)
+            {
+                var des = SerializationManager.GetDeserializer(t);
+                return des.Invoke(t, stream);
             }
 
             public static void Register()

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -167,7 +167,7 @@ namespace Orleans.Messaging
                 }
             }
             // For untargeted messages to system targets, and for unordered messages, pick a next connection in round robin fashion.
-            else if (msg.TargetGrain.IsSystemTarget || msg.IsUnordered)
+            else if (msg.TargetGrain.IsSystemTarget || msg.IsUnordered == true)
             {
                 // Get the cached list of live gateways.
                 // Pick a next gateway name in a round robin fashion.

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -167,7 +167,7 @@ namespace Orleans.Messaging
                 }
             }
             // For untargeted messages to system targets, and for unordered messages, pick a next connection in round robin fashion.
-            else if (msg.TargetGrain.IsSystemTarget || msg.IsUnordered == true)
+            else if (msg.TargetGrain.IsSystemTarget || msg.IsUnordered)
             {
                 // Get the cached list of live gateways.
                 // Pick a next gateway name in a round robin fashion.

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -638,7 +638,7 @@ namespace Orleans
             if (logger.IsVerbose) logger.Verbose("Resend {0}", message);
 
             message.ResendCount = message.ResendCount + 1;
-            message.SetMetadata(Message.Metadata.TARGET_HISTORY, message.GetTargetHistory());
+            message.TargetHistory = message.GetTargetHistory();
             
             if (!message.TargetGrain.IsSystemTarget)
             {

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -642,9 +642,11 @@ namespace Orleans
             
             if (!message.TargetGrain.IsSystemTarget)
             {
-                message.RemoveHeader(Message.Header.TARGET_ACTIVATION);
-                message.RemoveHeader(Message.Header.TARGET_SILO);
+                message.TargetActivation = null;
+                message.TargetSilo = null;
+                message.ClearTargetAddress();
             }
+
             transport.SendMessage(message);
             return true;
         }

--- a/src/Orleans/Serialization/BinaryTokenStreamReader.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamReader.cs
@@ -270,6 +270,12 @@ namespace Orleans.Serialization
             return new decimal(raw);
         }
 
+        public DateTime ReadDateTime()
+        {
+            var n = ReadLong();
+            return n == 0 ? default(DateTime) : DateTime.FromBinary(n);
+        }
+
         /// <summary> Read an <c>string</c> value from the stream. </summary>
         /// <returns>Data from current position in stream, converted to the appropriate output type.</returns>
         public string ReadString()

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1760,7 +1760,7 @@ namespace Orleans.Serialization
 
 #region Special case code for message headers
 
-        internal static void SerializeMessageHeaders(Dictionary<Message.Header, object> headers, BinaryTokenStreamWriter stream)
+        internal static void SerializeMessageHeaders(Message.HeadersContainer headers, BinaryTokenStreamWriter stream)
         {
             Stopwatch timer = null;
             if (StatisticsCollector.CollectSerializationStats)
@@ -1768,80 +1768,24 @@ namespace Orleans.Serialization
                 timer = new Stopwatch();
                 timer.Start();
             }
-            SerializeMessageHeaderDictHelper(headers, stream);
+
+            //var ser = GetSerializer(typeof(Message.HeadersContainer));
+            //ser(headers, stream, typeof(Message.HeadersContainer));
+            new OrleansJsonSerializer().Serialize(headers, stream, typeof(Message.HeadersContainer)) ;
+            //if (ser != null)
+            {
+                // ????? stream.WriteTypeHeader(t);
+            }
 
             if (timer != null)
             {
                 timer.Stop();
                 HeaderSers.Increment();
-                HeaderSersNumHeaders.IncrementBy(headers.Count);
                 HeaderSerTime.IncrementBy(timer.ElapsedTicks);
             }
         }
 
-        private static void SerializeMessageHeaderDictHelper(Dictionary<Message.Header, object> headers, BinaryTokenStreamWriter stream)
-        {
-            stream.Write(SerializationTokenType.StringObjDict);
-            stream.Write(headers.Count);
-            foreach (var header in headers)
-            {
-                stream.Write((byte)header.Key);
-                SerializeMessageHeaderValueHelper(header.Value, stream);
-            }
-        }
-
-        private static void SerializeMessageHeaderListHelper(List<object> list, BinaryTokenStreamWriter stream)
-        {
-            stream.Write(SerializationTokenType.ObjList);
-            stream.Write(list.Count);
-            foreach (var item in list)
-                SerializeMessageHeaderValueHelper(item, stream);
-        }
-
-        private static void SerializeMessageHeaderValueHelper(object value, BinaryTokenStreamWriter stream)
-        {
-            if (value == null)
-            {
-                stream.WriteNull();
-                return;
-            }
-
-            if (value is Enum)
-            {
-                // Within message headers, enums get serialized as integers, and get re-cast in the code
-                stream.Write(SerializationTokenType.Int);
-                stream.Write(Convert.ToInt32(value));
-                return;
-            }
-
-            if (stream.TryWriteSimpleObject(value))
-                return;
-
-            if (value is Dictionary<Message.Header, object>)
-            {
-                SerializeMessageHeaderDictHelper((Dictionary<Message.Header, object>)value, stream);
-                return;
-            }
-
-            if (value is List<object>)
-            {
-                SerializeMessageHeaderListHelper((List<object>)value, stream);
-                return;
-            }
-
-            var t = value.GetType();
-            var ser = GetSerializer(t);
-            if (ser != null)
-            {
-                stream.WriteTypeHeader(t);
-                ser(value, stream, null);
-                return;
-            }
-
-            throw new ArgumentException("Invalid message header passed to SerializeMessageHeaders; type is " + value.GetType().Name, "value");
-        }
-
-        internal static Dictionary<Message.Header, object> DeserializeMessageHeaders(BinaryTokenStreamReader stream)
+        internal static void DeserializeMessageHeaders(BinaryTokenStreamReader stream, Message message)
         {
             Stopwatch timer = null;
             if (StatisticsCollector.CollectSerializationStats)
@@ -1849,81 +1793,42 @@ namespace Orleans.Serialization
                 timer = new Stopwatch();
                 timer.Start();
             }
-            var token = stream.ReadToken();
-            if (token != SerializationTokenType.StringObjDict)
-            {
-                if (token == SerializationTokenType.SpecifiedType)
-                {
-                    Type t = null;
-                    try
-                    {
-                        t = stream.ReadSpecifiedTypeHeader();
-                    }
-                    catch (Exception) { }
+         //   var token = stream.ReadToken();
+            //if (token != SerializationTokenType.StringObjDict)
+            //{
+            //    if (token == SerializationTokenType.SpecifiedType)
+            //    {
+            //        Type t = null;
+            //        try
+            //        {
+            //            t = stream.ReadSpecifiedTypeHeader();
+            //        }
+            //        catch (Exception) { }
 
-                    if(t != null)
-                        throw new SerializationException(String.Format("Introductory token for message headers is incorrect: token = {0}, SpecifiedTypeHeader = {1} ", token, t));
-                }
-                throw new SerializationException(String.Format("Introductory token for message headers is incorrect: {0}", token));
-            }
-            var result = DeserializeMessageHeaderDictHelper(stream);
+            //        if(t != null)
+            //            throw new SerializationException(String.Format("Introductory token for message headers is incorrect: token = {0}, SpecifiedTypeHeader = {1} ", token, t));
+            //    }
+            //    throw new SerializationException(String.Format("Introductory token for message headers is incorrect: {0}", token));
+            //}
+
+
+            //   var result = DeserializeMessageHeaderDictHelper(stream);
+
+            //var tq = stream.ReadSpecifiedTypeHeader();
+
+
+            // var des = GetDeserializer(typeof(Message.HeadersContainer));
+            message.Headers =(Message.HeadersContainer) (new OrleansJsonSerializer().Deserialize(typeof(Message.HeadersContainer), stream));
+           // message.Headers = (Message.HeadersContainer)des(typeof(Message.HeadersContainer), stream);
 
             if (timer != null)
             {
                 timer.Stop();
                 HeaderDesers.Increment();
-                HeaderDesersNumHeaders.IncrementBy(result.Count);
                 HeaderDeserTime.IncrementBy(timer.ElapsedTicks);
             }
-            return result;
         }
-
-        private static Dictionary<Message.Header, object> DeserializeMessageHeaderDictHelper(BinaryTokenStreamReader stream)
-        {
-            var count = stream.ReadInt();
-            var result = new Dictionary<Message.Header, object>(count);
-            for (var i = 0; i < count; i++)
-            {
-                var key = stream.ReadByte();
-                result.Add((Message.Header)key, DeserializeMessageHeaderHelper(stream));
-            }
-            return result;
-        }
-
-        private static List<object> DeserializeMessageHeaderListHelper(BinaryTokenStreamReader stream)
-        {
-            var count = stream.ReadInt();
-            var result = new List<object>(count);
-            for (var i = 0; i < count; i++)
-                result.Add(DeserializeMessageHeaderHelper(stream));
-
-            return result;
-        }
-
-
-        private static object DeserializeMessageHeaderHelper(BinaryTokenStreamReader stream)
-        {
-            object result;
-            SerializationTokenType token;
-            if (stream.TryReadSimpleType(out result, out token))
-                return result;
-
-            if (token == SerializationTokenType.ObjList)
-                return DeserializeMessageHeaderListHelper(stream);
-
-            if (token == SerializationTokenType.StringObjDict)
-                return DeserializeMessageHeaderDictHelper(stream);
-
-            if (token == SerializationTokenType.SpecifiedType)
-            {
-                var t = stream.ReadSpecifiedTypeHeader();
-                var des = GetDeserializer(t);
-                if (des != null)
-                    return des(t, stream);
-            }
-            throw new SerializationException(String.Format("Unexpected token {0} parsing message headers", token));
-        }
-
+        
         private static bool TryLookupExternalSerializer(Type t, out IExternalSerializer serializer)
         {
             // essentially a no-op if there are no external serializers registered

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1785,7 +1785,7 @@ namespace Orleans.Serialization
             }
         }
 
-        internal static void DeserializeMessageHeaders(BinaryTokenStreamReader stream, Message message)
+        internal static Message.HeadersContainer DeserializeMessageHeaders(BinaryTokenStreamReader stream)
         {
             Stopwatch timer = null;
             if (StatisticsCollector.CollectSerializationStats)
@@ -1818,7 +1818,7 @@ namespace Orleans.Serialization
 
 
             // var des = GetDeserializer(typeof(Message.HeadersContainer));
-            message.Headers =(Message.HeadersContainer) (new OrleansJsonSerializer().Deserialize(typeof(Message.HeadersContainer), stream));
+           var headers =(Message.HeadersContainer) (new OrleansJsonSerializer().Deserialize(typeof(Message.HeadersContainer), stream));
            // message.Headers = (Message.HeadersContainer)des(typeof(Message.HeadersContainer), stream);
 
             if (timer != null)
@@ -1827,6 +1827,7 @@ namespace Orleans.Serialization
                 HeaderDesers.Increment();
                 HeaderDeserTime.IncrementBy(timer.ElapsedTicks);
             }
+            return headers;
         }
         
         private static bool TryLookupExternalSerializer(Type t, out IExternalSerializer serializer)

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1769,13 +1769,8 @@ namespace Orleans.Serialization
                 timer.Start();
             }
 
-            //var ser = GetSerializer(typeof(Message.HeadersContainer));
-            //ser(headers, stream, typeof(Message.HeadersContainer));
-            new OrleansJsonSerializer().Serialize(headers, stream, typeof(Message.HeadersContainer)) ;
-            //if (ser != null)
-            {
-                // ????? stream.WriteTypeHeader(t);
-            }
+            var ser = GetSerializer(typeof(Message.HeadersContainer));
+            ser(headers, stream, typeof(Message.HeadersContainer));
 
             if (timer != null)
             {
@@ -1793,33 +1788,9 @@ namespace Orleans.Serialization
                 timer = new Stopwatch();
                 timer.Start();
             }
-         //   var token = stream.ReadToken();
-            //if (token != SerializationTokenType.StringObjDict)
-            //{
-            //    if (token == SerializationTokenType.SpecifiedType)
-            //    {
-            //        Type t = null;
-            //        try
-            //        {
-            //            t = stream.ReadSpecifiedTypeHeader();
-            //        }
-            //        catch (Exception) { }
 
-            //        if(t != null)
-            //            throw new SerializationException(String.Format("Introductory token for message headers is incorrect: token = {0}, SpecifiedTypeHeader = {1} ", token, t));
-            //    }
-            //    throw new SerializationException(String.Format("Introductory token for message headers is incorrect: {0}", token));
-            //}
-
-
-            //   var result = DeserializeMessageHeaderDictHelper(stream);
-
-            //var tq = stream.ReadSpecifiedTypeHeader();
-
-
-            // var des = GetDeserializer(typeof(Message.HeadersContainer));
-           var headers =(Message.HeadersContainer) (new OrleansJsonSerializer().Deserialize(typeof(Message.HeadersContainer), stream));
-           // message.Headers = (Message.HeadersContainer)des(typeof(Message.HeadersContainer), stream);
+             var des = GetDeserializer(typeof(Message.HeadersContainer));
+             var headers = (Message.HeadersContainer)des(typeof(Message.HeadersContainer), stream);
 
             if (timer != null)
             {
@@ -1827,6 +1798,7 @@ namespace Orleans.Serialization
                 HeaderDesers.Increment();
                 HeaderDeserTime.IncrementBy(timer.ElapsedTicks);
             }
+
             return headers;
         }
         

--- a/src/Orleans/Statistics/MessagingStatisticsGroup.cs
+++ b/src/Orleans/Statistics/MessagingStatisticsGroup.cs
@@ -149,14 +149,14 @@ namespace Orleans.Runtime
             perSiloPingReplyMissedCounters = new ConcurrentDictionary<string, CounterStatistic>();
         }
 
-        internal static void OnMessageSend(SiloAddress targetSilo, Message.Directions? direction, int numTotalBytes, int headerBytes, SocketDirection socketDirection)
+        internal static void OnMessageSend(SiloAddress targetSilo, Message.Directions direction, int numTotalBytes, int headerBytes, SocketDirection socketDirection)
         {
             if (numTotalBytes < 0)
                 throw new ArgumentException(String.Format("OnMessageSend(numTotalBytes={0})", numTotalBytes), "numTotalBytes");
             OnMessageSend_Impl(targetSilo, direction, numTotalBytes, headerBytes, 1);
         }
 
-        internal static void OnMessageBatchSend(SiloAddress targetSilo, Message.Directions? direction, int numTotalBytes, int headerBytes, SocketDirection socketDirection, int numMsgsInBatch)
+        internal static void OnMessageBatchSend(SiloAddress targetSilo, Message.Directions direction, int numTotalBytes, int headerBytes, SocketDirection socketDirection, int numMsgsInBatch)
         {
             if (numTotalBytes < 0)
                 throw new ArgumentException(String.Format("OnMessageBatchSend(numTotalBytes={0})", numTotalBytes), "numTotalBytes");
@@ -164,13 +164,10 @@ namespace Orleans.Runtime
             perSocketDirectionStatsSend[(int)socketDirection].OnMessage(numMsgsInBatch, numTotalBytes);
         }
 
-        private static void OnMessageSend_Impl(SiloAddress targetSilo, Message.Directions? direction, int numTotalBytes, int headerBytes, int numMsgsInBatch)
+        private static void OnMessageSend_Impl(SiloAddress targetSilo, Message.Directions direction, int numTotalBytes, int headerBytes, int numMsgsInBatch)
         {
             MessagesSentTotal.IncrementBy(numMsgsInBatch);
-            if (direction.HasValue)
-            {
-                MessagesSentPerDirection[(int) direction.Value].IncrementBy(numMsgsInBatch);
-            }
+            MessagesSentPerDirection[(int)direction].IncrementBy(numMsgsInBatch);
 
             TotalBytesSent.IncrementBy(numTotalBytes);
             HeaderBytesSent.IncrementBy(headerBytes);

--- a/src/Orleans/Statistics/MessagingStatisticsGroup.cs
+++ b/src/Orleans/Statistics/MessagingStatisticsGroup.cs
@@ -250,7 +250,7 @@ namespace Orleans.Runtime
 
         internal static void OnFailedSentMessage(Message msg)
         {
-            if (msg == null || msg.Direction == null) return;
+            if (msg == null || !msg.HasDirection) return;
             int direction = (int)msg.Direction;
             if (FailedSentMessages[direction] == null)
             {
@@ -262,7 +262,7 @@ namespace Orleans.Runtime
 
         internal static void OnDroppedSentMessage(Message msg)
         {
-            if (msg?.Direction == null) return;
+            if (msg == null || !msg.HasDirection) return;
             int direction = (int)msg.Direction;
             if (DroppedSentMessages[direction] == null)
             {
@@ -274,7 +274,7 @@ namespace Orleans.Runtime
 
         internal static void OnRejectedMessage(Message msg)
         {
-            if (msg?.Direction == null) return;
+            if (msg == null || !msg.HasDirection) return;
             int direction = (int)msg.Direction;
             if (RejectedMessages[direction] == null)
             {

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -83,7 +83,7 @@ namespace Orleans.Runtime
                 Task ignore;
                 ActivationData target = catalog.GetOrCreateActivation(
                     message.TargetAddress, 
-                    message.IsNewPlacement, 
+                    message.IsNewPlacement == true,
                     message.NewGrainType,
                     String.IsNullOrEmpty(message.GenericGrainType) ? null : message.GenericGrainType, 
                     message.RequestContextData,

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -83,7 +83,7 @@ namespace Orleans.Runtime
                 Task ignore;
                 ActivationData target = catalog.GetOrCreateActivation(
                     message.TargetAddress, 
-                    message.IsNewPlacement == true,
+                    message.IsNewPlacement,
                     message.NewGrainType,
                     String.IsNullOrEmpty(message.GenericGrainType) ? null : message.GenericGrainType, 
                     message.RequestContextData,
@@ -310,9 +310,9 @@ namespace Orleans.Runtime
         {
             bool canInterleave = 
                    catalog.IsReentrantGrain(targetActivation.ActivationId)
-                || incoming.IsAlwaysInterleave == true
+                || incoming.IsAlwaysInterleave
                 || targetActivation.Running == null
-                || (targetActivation.Running.IsReadOnly == true && incoming.IsReadOnly == true);
+                || (targetActivation.Running.IsReadOnly && incoming.IsReadOnly);
 
             return canInterleave;
         }

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -310,9 +310,9 @@ namespace Orleans.Runtime
         {
             bool canInterleave = 
                    catalog.IsReentrantGrain(targetActivation.ActivationId)
-                || incoming.IsAlwaysInterleave
+                || incoming.IsAlwaysInterleave == true
                 || targetActivation.Running == null
-                || (targetActivation.Running.IsReadOnly && incoming.IsReadOnly);
+                || (targetActivation.Running.IsReadOnly == true && incoming.IsReadOnly == true);
 
             return canInterleave;
         }

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -243,7 +243,7 @@ namespace Orleans.Runtime
         private void ResendMessageImpl(Message message, ActivationAddress forwardingAddress = null)
         {
             if (logger.IsVerbose) logger.Verbose("Resend {0}", message);
-            message.SetMetadata(Message.Metadata.TARGET_HISTORY, message.GetTargetHistory());
+            message.TargetHistory = message.GetTargetHistory();
 
             if (message.TargetGrain.IsSystemTarget)
             {

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -252,13 +252,14 @@ namespace Orleans.Runtime
             else if (forwardingAddress != null)
             {
                 message.TargetAddress = forwardingAddress;
-                message.RemoveHeader(Message.Header.IS_NEW_PLACEMENT);
+                message.IsNewPlacement = null;
                 dispatcher.Transport.SendMessage(message);
             }
             else
             {
-                message.RemoveHeader(Message.Header.TARGET_ACTIVATION);
-                message.RemoveHeader(Message.Header.TARGET_SILO);
+                message.TargetActivation = null;
+                message.TargetSilo = null;
+                message.ClearTargetAddress();
                 dispatcher.SendMessage(message);
             }
         }

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -277,7 +277,7 @@ namespace Orleans.Runtime
         {
             try
             {
-                if (message.ContainsHeader(Message.Header.CACHE_INVALIDATION_HEADER))
+                if (message.CacheInvalidationHeader != null)
                 {
                     foreach (ActivationAddress address in message.CacheInvalidationHeader)
                     {
@@ -534,7 +534,7 @@ namespace Orleans.Runtime
                     case Message.RejectionTypes.Unrecoverable:
                     // fall through & reroute
                     case Message.RejectionTypes.Transient:
-                        if (!message.ContainsHeader(Message.Header.CACHE_INVALIDATION_HEADER))
+                        if (message.CacheInvalidationHeader == null)
                         {
                             // Remove from local directory cache. Note that SendingGrain is the original target, since message is the rejection response.
                             // If CacheMgmtHeader is present, we already did this. Otherwise, we left this code for backward compatability. 

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -252,7 +252,7 @@ namespace Orleans.Runtime
             else if (forwardingAddress != null)
             {
                 message.TargetAddress = forwardingAddress;
-                message.IsNewPlacement = null;
+                message.IsNewPlacement = false;
                 dispatcher.Transport.SendMessage(message);
             }
             else

--- a/src/OrleansRuntime/Messaging/GatewayAcceptor.cs
+++ b/src/OrleansRuntime/Messaging/GatewayAcceptor.cs
@@ -69,8 +69,9 @@ namespace Orleans.Runtime.Messaging
             if (targetAddress == null)
             {
                 // reroute via Dispatcher
-                msg.RemoveHeader(Message.Header.TARGET_SILO);
-                msg.RemoveHeader(Message.Header.TARGET_ACTIVATION);
+                msg.TargetSilo = null;
+                msg.TargetActivation = null;
+                msg.ClearTargetAddress();
 
                 if (msg.TargetGrain.IsSystemTarget)
                 {

--- a/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
@@ -65,9 +65,9 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-            if (!msg.ContainsMetadata(QUEUED_TIME_METADATA))
+            if (!msg.QueuedTime.HasValue)
             {
-                msg.SetMetadata(QUEUED_TIME_METADATA, DateTime.UtcNow);
+                msg.QueuedTime = DateTime.UtcNow;
             }
 
             // First check to see if it's really destined for a proxied client, instead of a local grain.

--- a/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
@@ -76,7 +76,7 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-            if (!msg.ContainsHeader(Message.Header.TARGET_SILO))
+            if (msg.TargetSilo == null)
             {
                 logger.Error(ErrorCode.Runtime_Error_100113, "Message does not have a target silo: " + msg + " -- Call stack is: " + Utils.GetStackTrace());
                 messageCenter.SendRejection(msg, Message.RejectionTypes.Unrecoverable, "Message to be sent does not have a target silo");

--- a/src/OrleansRuntime/Messaging/SiloMessageSender.cs
+++ b/src/OrleansRuntime/Messaging/SiloMessageSender.cs
@@ -145,7 +145,7 @@ namespace Orleans.Runtime.Messaging
             else
             {
                 msg.ReleaseBodyAndHeaderBuffers();
-                if (Log.IsVerbose3) Log.Verbose3("Sending queue delay time for: {0} is {1}", msg, DateTime.UtcNow.Subtract((DateTime)msg.GetMetadata(OutboundMessageQueue.QUEUED_TIME_METADATA)));
+                if (Log.IsVerbose3) Log.Verbose3("Sending queue delay time for: {0} is {1}", msg, DateTime.UtcNow.Subtract(msg.QueuedTime ?? DateTime.UtcNow));
             }
         }
 
@@ -170,16 +170,16 @@ namespace Orleans.Runtime.Messaging
             if (msg == null) return;
 
             int maxRetries = DEFAULT_MAX_RETRIES;
-            if (msg.ContainsMetadata(Message.Metadata.MAX_RETRIES))
-                maxRetries = (int)msg.GetMetadata(Message.Metadata.MAX_RETRIES);
+            if (msg.MaxRetries.HasValue)
+                maxRetries = msg.MaxRetries.Value;
             
             int retryCount = 0;
-            if (msg.ContainsMetadata(RETRY_COUNT_TAG))
-                retryCount = (int)msg.GetMetadata(RETRY_COUNT_TAG);
+            if (msg.RetryCount.HasValue)
+                retryCount = msg.RetryCount.Value;
             
             if (retryCount < maxRetries)
             {
-                msg.SetMetadata(RETRY_COUNT_TAG, retryCount + 1);
+                msg.RetryCount = retryCount + 1;
                 messageCenter.OutboundQueue.SendMessage(msg);
             }
             else

--- a/src/OrleansRuntime/Messaging/SiloMessageSender.cs
+++ b/src/OrleansRuntime/Messaging/SiloMessageSender.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.Messaging
             }
 
             // Fill in the outbound message with our silo address, if it's not already set
-            if (!msg.ContainsHeader(Message.Header.SENDING_SILO))
+            if (msg.SendingSilo == null)
                 msg.SendingSilo = messageCenter.MyAddress;
             
 

--- a/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
+++ b/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
@@ -81,10 +81,10 @@ namespace UnitTests.SerializerTests
 
             //byte[] serialized = resp.FormatForSending();
             //Message resp1 = new Message(serialized, serialized.Length);
-            Assert.Equal<Message.Categories>(resp.Category, resp1.Category); //Category is incorrect"
-            Assert.Equal<Message.Directions?>(resp.Direction, resp1.Direction); //Direction is incorrect
-            Assert.Equal<CorrelationId>(resp.Id, resp1.Id); //Correlation ID is incorrect
-            Assert.Equal<bool>((bool)resp.IsAlwaysInterleave, (bool)resp1.IsAlwaysInterleave); //Foo Boolean is incorrect
+            Assert.Equal(resp.Category, resp1.Category); //Category is incorrect"
+            Assert.Equal(resp.Direction, resp1.Direction); //Direction is incorrect
+            Assert.Equal(resp.Id, resp1.Id); //Correlation ID is incorrect
+            Assert.Equal(resp.IsAlwaysInterleave, resp1.IsAlwaysInterleave); //Foo Boolean is incorrect
             Assert.Equal(resp.CacheInvalidationHeader, resp1.CacheInvalidationHeader); //Bar string is incorrect
             Assert.True(resp.TargetSilo.Equals(resp1.TargetSilo));
             Assert.True(resp.TargetGrain.Equals(resp1.TargetGrain));

--- a/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
+++ b/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
@@ -88,7 +88,9 @@ namespace UnitTests.SerializerTests
             Assert.Equal<CorrelationId>(resp.Id, resp1.Id); //Correlation ID is incorrect
             Assert.Equal<bool>((bool)resp.IsAlwaysInterleave, (bool)resp1.IsAlwaysInterleave); //Foo Boolean is incorrect
             Assert.Equal(resp.CacheInvalidationHeader, resp1.CacheInvalidationHeader); //Bar string is incorrect
-            Assert.True(resp.TargetSilo.Equals(resp1.TargetSilo)); //TargetSilo is incorrect
+            Assert.True(resp.TargetSilo.Equals(resp1.TargetSilo));
+            Assert.True(resp.TargetGrain.Equals(resp1.TargetGrain));
+            Assert.True(resp.SendingGrain.Equals(resp1.SendingGrain));
             Assert.True(resp.SendingSilo.Equals(resp1.SendingSilo)); //SendingSilo is incorrect
             List<object> responseList = Assert.IsAssignableFrom<List<object>>(resp1.BodyObject);
             Assert.Equal<int>(numItems, responseList.Count); //Body list has wrong number of entries

--- a/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
+++ b/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
@@ -41,8 +41,8 @@ namespace UnitTests.SerializerTests
             resp.TargetSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 300), 0);
             resp.SendingGrain = GrainId.NewId();
             resp.TargetGrain = GrainId.NewId();
-            resp.SetHeader(Message.Header.ALWAYS_INTERLEAVE, true);
-            resp.SetHeader(Message.Header.CACHE_INVALIDATION_HEADER, "TestBar");
+            resp.IsAlwaysInterleave = true;
+          // wtf  resp.CacheInvalidationHeader = "TestBar";
             //resp.SetStringBody("This is test data");
 
             List<object> requestBody = new List<object>();
@@ -84,7 +84,7 @@ namespace UnitTests.SerializerTests
             //byte[] serialized = resp.FormatForSending();
             //Message resp1 = new Message(serialized, serialized.Length);
             Assert.Equal<Message.Categories>(resp.Category, resp1.Category); //Category is incorrect"
-            Assert.Equal<Message.Directions>(resp.Direction, resp1.Direction); //Direction is incorrect
+            Assert.Equal<Message.Directions?>(resp.Direction, resp1.Direction); //Direction is incorrect
             Assert.Equal<CorrelationId>(resp.Id, resp1.Id); //Correlation ID is incorrect
             Assert.Equal<bool>((bool)resp.GetHeader(Message.Header.ALWAYS_INTERLEAVE), (bool)resp1.GetHeader(Message.Header.ALWAYS_INTERLEAVE)); //Foo Boolean is incorrect
             Assert.Equal<string>((string)resp.GetHeader(Message.Header.CACHE_INVALIDATION_HEADER), (string)resp1.GetHeader(Message.Header.CACHE_INVALIDATION_HEADER)); //Bar string is incorrect

--- a/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
+++ b/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
@@ -42,8 +42,6 @@ namespace UnitTests.SerializerTests
             resp.SendingGrain = GrainId.NewId();
             resp.TargetGrain = GrainId.NewId();
             resp.IsAlwaysInterleave = true;
-          // wtf  resp.CacheInvalidationHeader = "TestBar";
-            //resp.SetStringBody("This is test data");
 
             List<object> requestBody = new List<object>();
             for (int k = 0; k < numItems; k++)

--- a/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
+++ b/test/TesterInternal/SerializerTests/MessageSerializerTests.cs
@@ -86,8 +86,8 @@ namespace UnitTests.SerializerTests
             Assert.Equal<Message.Categories>(resp.Category, resp1.Category); //Category is incorrect"
             Assert.Equal<Message.Directions?>(resp.Direction, resp1.Direction); //Direction is incorrect
             Assert.Equal<CorrelationId>(resp.Id, resp1.Id); //Correlation ID is incorrect
-            Assert.Equal<bool>((bool)resp.GetHeader(Message.Header.ALWAYS_INTERLEAVE), (bool)resp1.GetHeader(Message.Header.ALWAYS_INTERLEAVE)); //Foo Boolean is incorrect
-            Assert.Equal<string>((string)resp.GetHeader(Message.Header.CACHE_INVALIDATION_HEADER), (string)resp1.GetHeader(Message.Header.CACHE_INVALIDATION_HEADER)); //Bar string is incorrect
+            Assert.Equal<bool>((bool)resp.IsAlwaysInterleave, (bool)resp1.IsAlwaysInterleave); //Foo Boolean is incorrect
+            Assert.Equal(resp.CacheInvalidationHeader, resp1.CacheInvalidationHeader); //Bar string is incorrect
             Assert.True(resp.TargetSilo.Equals(resp1.TargetSilo)); //TargetSilo is incorrect
             Assert.True(resp.SendingSilo.Equals(resp1.SendingSilo)); //SendingSilo is incorrect
             List<object> responseList = Assert.IsAssignableFrom<List<object>>(resp1.BodyObject);


### PR DESCRIPTION
Instantiation of the two dictionaries per message is by far the top contributor to the memory pressure in many workloads: 

![timeline64_2016-09-07_20-06-07](https://cloud.githubusercontent.com/assets/5787619/18321487/d48d797c-7536-11e6-8ba8-e00dcf88637b.png)

Plus as it one of the hottest code path in Orleans - usage of the dictionary consumes some chunk of CPU: 

![timeline64_2016-09-07_20-11-17](https://cloud.githubusercontent.com/assets/5787619/18321659/975345b8-7537-11e6-82de-3198edbb640d.png)

![timeline64_2016-09-07_20-14-06](https://cloud.githubusercontent.com/assets/5787619/18321670/a42771e2-7537-11e6-85a8-a9e1b82fedbf.png)

After removal: memory footprint reduced by 4x, serialization time improved by ~10%, average serialized size reduced by ~11% (which can be 11% of whole serialized message in case of message with small payload). 

Adding of the new header will require bigger effort from now, but I think that it's justified.
