### PR TITLE
Fix synchronization bug in Orleans/Async/BatchWorker 

### DIFF
--- a/src/Orleans/Async/BatchWorker.cs
+++ b/src/Orleans/Async/BatchWorker.cs
@@ -60,7 +60,7 @@ namespace Orleans
         private void CheckForMoreWork()
         {
             TaskCompletionSource<Task> signal = null;
-            Task task_to_signal = null; ;
+            Task taskToSignal = null;
 
             lock (this)
             {
@@ -77,7 +77,7 @@ namespace Orleans
                     Start();
 
                     // the current cycle is what we need to signal
-                    task_to_signal = currentWorkCycle;
+                    taskToSignal = currentWorkCycle;
                 }
                 else
                 {
@@ -86,8 +86,7 @@ namespace Orleans
             }
 
             // to be safe, must do the signalling out here so it is not under the lock
-            if (signal != null)
-                signal.SetResult(task_to_signal);
+            signal?.SetResult(taskToSignal);
         }
 
         /// <summary>


### PR DESCRIPTION
A rare race on the currentWorkCycle field can cause NullPointerException.

The reason is that the delegate does not properly capture the current value of currentWorkCycle under the lock, but the delegate executes after the lock is released, at which point the value of currentWorkCycle may have changed already. 

The fix is to manually capture the current value. This is more efficient anyway. Not sure why I ever used a delegate in the first place.