### PR TITLE
CodeGen: Emit & load debug symbols if built in Debug mode.

### DIFF
--- a/src/Orleans/CodeGeneration/CodeGeneratorManager.cs
+++ b/src/Orleans/CodeGeneration/CodeGeneratorManager.cs
@@ -17,16 +17,6 @@ namespace Orleans.CodeGeneration
         private const string CodeGenAssemblyName = "OrleansCodeGenerator";
 
         /// <summary>
-        /// The runtime code generator.
-        /// </summary>
-        private static IRuntimeCodeGenerator CodeGeneratorInstance;
-
-        /// <summary>
-        /// The code generator cache.
-        /// </summary>
-        private static ICodeGeneratorCache CodeGeneratorCacheInstance;
-
-        /// <summary>
         /// The log.
         /// </summary>
         private static readonly Logger Log = LogManager.GetLogger("CodeGenerator");
@@ -34,16 +24,26 @@ namespace Orleans.CodeGeneration
         /// <summary>
         /// Empty generated assemblies.
         /// </summary>
-        private static readonly ReadOnlyDictionary<string, byte[]> EmptyGeneratedAssemblies =
-            new ReadOnlyDictionary<string, byte[]>(new Dictionary<string, byte[]>());
+        private static readonly ReadOnlyDictionary<string, GeneratedAssembly> EmptyGeneratedAssemblies =
+            new ReadOnlyDictionary<string, GeneratedAssembly>(new Dictionary<string, GeneratedAssembly>());
+
+        /// <summary>
+        /// The runtime code generator.
+        /// </summary>
+        private static IRuntimeCodeGenerator codeGeneratorInstance;
+
+        /// <summary>
+        /// The code generator cache.
+        /// </summary>
+        private static ICodeGeneratorCache codeGeneratorCacheInstance;
 
         /// <summary>
         /// Loads the code generator on demand
         /// </summary>
         public static void Initialize()
         {
-            CodeGeneratorInstance = LoadCodeGenerator();
-            CodeGeneratorCacheInstance = CodeGeneratorInstance as ICodeGeneratorCache;
+            codeGeneratorInstance = LoadCodeGenerator();
+            codeGeneratorCacheInstance = codeGeneratorInstance as ICodeGeneratorCache;
         }
 
         /// <summary>
@@ -54,9 +54,9 @@ namespace Orleans.CodeGeneration
         /// </param>
         public static void GenerateAndCacheCodeForAssembly(Assembly input)
         {
-            if (CodeGeneratorInstance != null)
+            if (codeGeneratorInstance != null)
             {
-                CodeGeneratorInstance.GenerateAndLoadForAssembly(input);
+                codeGeneratorInstance.GenerateAndLoadForAssembly(input);
             }
         }
 
@@ -65,9 +65,9 @@ namespace Orleans.CodeGeneration
         /// </summary>
         public static void GenerateAndCacheCodeForAllAssemblies()
         {
-            if (CodeGeneratorInstance != null)
+            if (codeGeneratorInstance != null)
             {
-                CodeGeneratorInstance.GenerateAndLoadForAssemblies(AppDomain.CurrentDomain.GetAssemblies());
+                codeGeneratorInstance.GenerateAndLoadForAssemblies(AppDomain.CurrentDomain.GetAssemblies());
             }
         }
 
@@ -75,11 +75,11 @@ namespace Orleans.CodeGeneration
         /// Returns the collection of generated assemblies as pairs of target assembly name to raw assembly bytes.
         /// </summary>
         /// <returns>The collection of generated assemblies.</returns>
-        public static IDictionary<string, byte[]> GetGeneratedAssemblies()
+        public static IDictionary<string, GeneratedAssembly> GetGeneratedAssemblies()
         {
-            if (CodeGeneratorCacheInstance != null)
+            if (codeGeneratorCacheInstance != null)
             {
-                return CodeGeneratorCacheInstance.GetGeneratedAssemblies();
+                return codeGeneratorCacheInstance.GetGeneratedAssemblies();
             }
 
             return EmptyGeneratedAssemblies;
@@ -94,11 +94,11 @@ namespace Orleans.CodeGeneration
         /// <param name="generatedAssembly">
         /// The generated assembly.
         /// </param>
-        public static void AddGeneratedAssembly(string targetAssemblyName, byte[] generatedAssembly)
+        public static void AddGeneratedAssembly(string targetAssemblyName, GeneratedAssembly generatedAssembly)
         {
-            if (CodeGeneratorCacheInstance != null)
+            if (codeGeneratorCacheInstance != null)
             {
-                CodeGeneratorCacheInstance.AddGeneratedAssembly(targetAssemblyName, generatedAssembly);
+                codeGeneratorCacheInstance.AddGeneratedAssembly(targetAssemblyName, generatedAssembly);
             }
             else
             {

--- a/src/Orleans/CodeGeneration/GeneratedAssembly.cs
+++ b/src/Orleans/CodeGeneration/GeneratedAssembly.cs
@@ -1,0 +1,35 @@
+namespace Orleans.CodeGeneration
+{
+    /// <summary>
+    /// Represents a generated assembly.
+    /// </summary>
+    public class GeneratedAssembly
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GeneratedAssembly"/> class.
+        /// </summary>
+        public GeneratedAssembly()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GeneratedAssembly"/> class.
+        /// </summary>
+        /// <param name="other">The other instance.</param>
+        public GeneratedAssembly(GeneratedAssembly other)
+        {
+            this.RawBytes = other.RawBytes;
+            this.DebugSymbolRawBytes = other.DebugSymbolRawBytes;
+        }
+
+        /// <summary>
+        /// Gets or sets a serialized representation of the assembly.
+        /// </summary>
+        public byte[] RawBytes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a serialized representation of the assembly's debug symbol stream.
+        /// </summary>
+        public byte[] DebugSymbolRawBytes { get; set; }
+    }
+} 

--- a/src/Orleans/CodeGeneration/ICodeGeneratorCache.cs
+++ b/src/Orleans/CodeGeneration/ICodeGeneratorCache.cs
@@ -16,7 +16,7 @@
         /// <param name="generatedAssembly">
         /// The generated assembly.
         /// </param>
-        void AddGeneratedAssembly(string targetAssemblyName, byte[] generatedAssembly);
+        void AddGeneratedAssembly(string targetAssemblyName, GeneratedAssembly generatedAssembly);
 
         /// <summary>
         /// Returns the collection of generated assemblies as pairs of target assembly name to raw assembly bytes.
@@ -25,6 +25,6 @@
         /// <remarks>
         /// The key of the returned dictionary is the name of the assembly which the value targets.
         /// </remarks>
-        IDictionary<string, byte[]> GetGeneratedAssemblies();
+        IDictionary<string, GeneratedAssembly> GetGeneratedAssemblies();
     }
 }

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Async\TaskUtility.cs" />
     <Compile Include="Async\UnobservedExceptionsHandlerClass.cs" />
     <Compile Include="Async\TaskExtensions.cs" />
+    <Compile Include="CodeGeneration\GeneratedAssembly.cs" />
     <Compile Include="Logging\LoggerExtensions.cs" />
     <Compile Include="Logging\LoggerImpl.cs" />
     <Compile Include="Logging\LogFormatter.cs" />

--- a/src/Orleans/Runtime/RuntimeVersion.cs
+++ b/src/Orleans/Runtime/RuntimeVersion.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime
             {
                 Assembly thisProg = typeof(RuntimeVersion).GetTypeInfo().Assembly;
                 FileVersionInfo progVersionInfo = FileVersionInfo.GetVersionInfo(thisProg.Location);
-                var isDebug = IsAssemblyDebugBuild(thisProg);
+                bool isDebug = IsAssemblyDebugBuild(thisProg);
                 string productVersion = progVersionInfo.ProductVersion + (isDebug ? " (Debug)." : " (Release)."); // progVersionInfo.IsDebug; does not work
                 return string.IsNullOrEmpty(productVersion) ? ApiVersion : productVersion;
             }
@@ -61,7 +61,7 @@ namespace Orleans.Runtime
                 return progInfo.Name;
             }
         }
-        
+
         /// <summary>
         /// Writes the Orleans program ident info to the Console, eg: 'OrleansHost v2012.5.9.51607 Build:12345 Timestamp: 20120509-185359'
         /// </summary>

--- a/src/Orleans/Runtime/RuntimeVersion.cs
+++ b/src/Orleans/Runtime/RuntimeVersion.cs
@@ -16,8 +16,7 @@ namespace Orleans.Runtime
             {
                 Assembly thisProg = typeof(RuntimeVersion).GetTypeInfo().Assembly;
                 FileVersionInfo progVersionInfo = FileVersionInfo.GetVersionInfo(thisProg.Location);
-                bool isDebug = IsAssemblyDebugBuild(thisProg);
-                string productVersion = progVersionInfo.ProductVersion + (isDebug ? " (Debug)." : " (Release)."); // progVersionInfo.IsDebug; does not work
+                string productVersion = progVersionInfo.ProductVersion + (IsDebugBuild ? " (Debug)." : " (Release)."); // progVersionInfo.IsDebug; does not work
                 return string.IsNullOrEmpty(productVersion) ? ApiVersion : productVersion;
             }
         }
@@ -59,6 +58,18 @@ namespace Orleans.Runtime
                 Assembly thisProg = Assembly.GetEntryAssembly() ?? typeof(RuntimeVersion).GetTypeInfo().Assembly;
                 AssemblyName progInfo = thisProg.GetName();
                 return progInfo.Name;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not this is a debug build.
+        /// </summary>
+        public static bool IsDebugBuild
+        {
+            get
+            {
+                var thisProg = Assembly.GetEntryAssembly() ?? typeof(RuntimeVersion).GetTypeInfo().Assembly;
+                return IsAssemblyDebugBuild(thisProg);
             }
         }
 

--- a/src/Orleans/Runtime/RuntimeVersion.cs
+++ b/src/Orleans/Runtime/RuntimeVersion.cs
@@ -64,14 +64,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Gets a value indicating whether or not this is a debug build.
         /// </summary>
-        public static bool IsDebugBuild
-        {
-            get
-            {
-                var thisProg = Assembly.GetEntryAssembly() ?? typeof(RuntimeVersion).GetTypeInfo().Assembly;
-                return IsAssemblyDebugBuild(thisProg);
-            }
-        }
+        public static bool IsDebugBuild => IsAssemblyDebugBuild(typeof(RuntimeVersion).GetTypeInfo().Assembly);
 
         /// <summary>
         /// Writes the Orleans program ident info to the Console, eg: 'OrleansHost v2012.5.9.51607 Build:12345 Timestamp: 20120509-185359'

--- a/src/Orleans/Runtime/RuntimeVersion.cs
+++ b/src/Orleans/Runtime/RuntimeVersion.cs
@@ -16,7 +16,8 @@ namespace Orleans.Runtime
             {
                 Assembly thisProg = typeof(RuntimeVersion).GetTypeInfo().Assembly;
                 FileVersionInfo progVersionInfo = FileVersionInfo.GetVersionInfo(thisProg.Location);
-                string productVersion = progVersionInfo.ProductVersion + (IsDebugBuild ? " (Debug)." : " (Release)."); // progVersionInfo.IsDebug; does not work
+                var isDebug = IsAssemblyDebugBuild(thisProg);
+                string productVersion = progVersionInfo.ProductVersion + (isDebug ? " (Debug)." : " (Release)."); // progVersionInfo.IsDebug; does not work
                 return string.IsNullOrEmpty(productVersion) ? ApiVersion : productVersion;
             }
         }
@@ -60,12 +61,7 @@ namespace Orleans.Runtime
                 return progInfo.Name;
             }
         }
-
-        /// <summary>
-        /// Gets a value indicating whether or not this is a debug build.
-        /// </summary>
-        public static bool IsDebugBuild => IsAssemblyDebugBuild(typeof(RuntimeVersion).GetTypeInfo().Assembly);
-
+        
         /// <summary>
         /// Writes the Orleans program ident info to the Console, eg: 'OrleansHost v2012.5.9.51607 Build:12345 Timestamp: 20120509-185359'
         /// </summary>
@@ -78,7 +74,16 @@ namespace Orleans.Runtime
 #endif
         }
 
-        private static bool IsAssemblyDebugBuild(Assembly assembly)
+        /// <summary>
+        /// Returns a value indicating whether the provided <paramref name="assembly"/> was built in debug mode.
+        /// </summary>
+        /// <param name="assembly">
+        /// The assembly to check.
+        /// </param>
+        /// <returns>
+        /// A value indicating whether the provided assembly was built in debug mode.
+        /// </returns>
+        internal static bool IsAssemblyDebugBuild(Assembly assembly)
         {
             foreach (var debuggableAttribute in assembly.GetCustomAttributes<DebuggableAttribute>())
             {

--- a/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
+++ b/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
@@ -46,13 +46,16 @@ namespace Orleans.CodeGenerator
         /// <param name="assemblyName">
         /// The name for the generated assembly.
         /// </param>
+        /// <param name="emitDebugSymbols">
+        /// Whether or not to emit debug symbols for the generated assembly.
+        /// </param>
         /// <returns>
         /// The raw assembly.
         /// </returns>
         /// <exception cref="CodeGenerationException">
         /// An error occurred generating code.
         /// </exception>
-        public static GeneratedAssembly CompileAssembly(GeneratedSyntax generatedSyntax, string assemblyName)
+        public static GeneratedAssembly CompileAssembly(GeneratedSyntax generatedSyntax, string assemblyName, bool emitDebugSymbols)
         {
             // Add the generated code attribute.
             var code = AddGeneratedCodeAttribute(generatedSyntax);
@@ -90,7 +93,7 @@ namespace Orleans.CodeGenerator
                     .WithOptions(options);
 
             var outputStream = new MemoryStream();
-            var symbolStream = RuntimeVersion.IsDebugBuild ? new MemoryStream() : null;
+            var symbolStream = emitDebugSymbols ? new MemoryStream() : null;
             try
             {
                 var compilationResult = compilation.Emit(outputStream, symbolStream);

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -89,8 +89,14 @@ namespace Orleans.CodeGenerator
             }
 
             var timer = Stopwatch.StartNew();
+            var emitDebugSymbols = false;
             foreach (var input in inputs)
             {
+                if (!emitDebugSymbols)
+                {
+                    emitDebugSymbols |= RuntimeVersion.IsAssemblyDebugBuild(input);
+                }
+
                 RegisterGeneratedCodeTargets(input);
                 TryLoadGeneratedAssemblyFromCache(input);
             }
@@ -110,7 +116,7 @@ namespace Orleans.CodeGenerator
                 CachedAssembly generatedAssembly;
                 if (generatedSyntax.Syntax != null)
                 {
-                    generatedAssembly = CompileAndLoad(generatedSyntax);
+                    generatedAssembly = CompileAndLoad(generatedSyntax, emitDebugSymbols);
                 }
                 else
                 {
@@ -168,7 +174,8 @@ namespace Orleans.CodeGenerator
                 CachedAssembly generatedAssembly;
                 if (generated.Syntax != null)
                 {
-                    generatedAssembly = CompileAndLoad(generated);
+                    var emitDebugSymbols = RuntimeVersion.IsAssemblyDebugBuild(input);
+                    generatedAssembly = CompileAndLoad(generated, emitDebugSymbols);
                 }
                 else
                 {
@@ -259,10 +266,13 @@ namespace Orleans.CodeGenerator
         /// Compiles the provided syntax tree, and loads and returns the result.
         /// </summary>
         /// <param name="generatedSyntax">The syntax tree.</param>
+        /// <param name="emitDebugSymbols">
+        /// Whether or not to emit debug symbols for the generated assembly.
+        /// </param>
         /// <returns>The compilation output.</returns>
-        private static CachedAssembly CompileAndLoad(GeneratedSyntax generatedSyntax)
+        private static CachedAssembly CompileAndLoad(GeneratedSyntax generatedSyntax, bool emitDebugSymbols)
         {
-            var generated = CodeGeneratorCommon.CompileAssembly(generatedSyntax, "OrleansCodeGen");
+            var generated = CodeGeneratorCommon.CompileAssembly(generatedSyntax, "OrleansCodeGen", emitDebugSymbols: emitDebugSymbols);
             Assembly.Load(generated.RawBytes, generated.DebugSymbolRawBytes);
             return new CachedAssembly(generated)
             {

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -1058,13 +1058,13 @@ namespace Orleans.Runtime
                 /// </summary>
                 public GeneratedAssemblies()
                 {
-                    Assemblies = new Dictionary<string, byte[]>();
+                    Assemblies = new Dictionary<string, GeneratedAssembly>();
                 }
 
                 /// <summary>
                 /// Gets the assemblies which were produced by code generation.
                 /// </summary>
-                public Dictionary<string, byte[]> Assemblies { get; private set; }
+                public Dictionary<string, GeneratedAssembly> Assemblies { get; }
 
                 /// <summary>
                 /// Adds a new assembly to this collection.
@@ -1075,7 +1075,7 @@ namespace Orleans.Runtime
                 /// <param name="value">
                 /// The raw generated assembly.
                 /// </param>
-                public void Add(string key, byte[] value)
+                public void Add(string key, GeneratedAssembly value)
                 {
                     if (!string.IsNullOrWhiteSpace(key))
                     {
@@ -1094,7 +1094,7 @@ namespace Orleans.Runtime
                 /// </summary>
                 /// <param name="targetAssemblyName">The assembly which the cached assembly was generated for.</param>
                 /// <param name="cachedAssembly">The generated assembly.</param>
-                public void AddCachedAssembly(string targetAssemblyName, byte[] cachedAssembly)
+                public void AddCachedAssembly(string targetAssemblyName, GeneratedAssembly cachedAssembly)
                 {
                     CodeGeneratorManager.AddGeneratedAssembly(targetAssemblyName, cachedAssembly);
                 }

--- a/src/OrleansTestingHost/TestCluster.cs
+++ b/src/OrleansTestingHost/TestCluster.cs
@@ -15,6 +15,8 @@ using OrleansTelemetryConsumers.Counters;
 
 namespace Orleans.TestingHost
 {
+    using Orleans.CodeGeneration;
+
     /// <summary>
     /// A host class for local testing with Orleans using in-process silos. 
     /// Runs a Primary and optionally secondary silos in seperate app domains, and client in the main app domain.
@@ -30,7 +32,7 @@ namespace Orleans.TestingHost
         public IReadOnlyList<SiloHandle> SecondarySilos => this.additionalSilos;
 
         protected readonly List<SiloHandle> additionalSilos = new List<SiloHandle>();
-        protected readonly Dictionary<string, byte[]> additionalAssemblies = new Dictionary<string, byte[]>();
+        protected readonly Dictionary<string, GeneratedAssembly> additionalAssemblies = new Dictionary<string, GeneratedAssembly>();
 
         public ClientConfiguration ClientConfiguration { get; private set; }
 
@@ -384,7 +386,7 @@ namespace Orleans.TestingHost
                 {
                     // If we have never seen generated code for this assembly before, or generated code might be
                     // newer, store it for later silo creation.
-                    byte[] existing;
+                    GeneratedAssembly existing;
                     if (!this.additionalAssemblies.TryGetValue(assembly.Key, out existing) || assembly.Value != null)
                     {
                         this.additionalAssemblies[assembly.Key] = assembly.Value;
@@ -393,7 +395,7 @@ namespace Orleans.TestingHost
             }
         }
 
-        private Dictionary<string, byte[]> TryGetGeneratedAssemblies(SiloHandle siloHandle)
+        private Dictionary<string, GeneratedAssembly> TryGetGeneratedAssemblies(SiloHandle siloHandle)
         {
             var tryToRetrieveGeneratedAssemblies = Task.Run(() =>
             {

--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -17,6 +17,8 @@ using OrleansTelemetryConsumers.Counters;
 
 namespace Orleans.TestingHost
 {
+    using Orleans.CodeGeneration;
+
     /// <summary>
     /// Important note: <see cref="TestingSiloHost"/> will be eventually deprectated. It is recommended that you use <see cref="TestCluster"/> instead.
     /// A host class for local testing with Orleans using in-process silos.
@@ -41,7 +43,7 @@ namespace Orleans.TestingHost
         public SiloHandle Primary { get; private set; }
         public SiloHandle Secondary { get; private set; }
         protected readonly List<SiloHandle> additionalSilos = new List<SiloHandle>();
-        protected readonly Dictionary<string, byte[]> additionalAssemblies = new Dictionary<string, byte[]>();
+        protected readonly Dictionary<string, GeneratedAssembly> additionalAssemblies = new Dictionary<string, GeneratedAssembly>();
 
         protected TestingSiloOptions siloInitOptions { get; private set; }
         protected TestingClientOptions clientInitOptions { get; private set; }
@@ -460,7 +462,7 @@ namespace Orleans.TestingHost
                 {
                     // If we have never seen generated code for this assembly before, or generated code might be
                     // newer, store it for later silo creation.
-                    byte[] existing;
+                    GeneratedAssembly existing;
                     if (!this.additionalAssemblies.TryGetValue(assembly.Key, out existing) || assembly.Value != null)
                     {
                         this.additionalAssemblies[assembly.Key] = assembly.Value;
@@ -469,7 +471,7 @@ namespace Orleans.TestingHost
             }
         }
 
-        private static Dictionary<string, byte[]> TryGetGeneratedAssemblies(SiloHandle siloHandle)
+        private static Dictionary<string, GeneratedAssembly> TryGetGeneratedAssemblies(SiloHandle siloHandle)
         {
             var tryToRetrieveGeneratedAssemblies = Task.Run(() =>
             {


### PR DESCRIPTION
When using runtime code generation, currently assemblies are compiled and loaded without debug symbols.

In order to slightly improve the debugging situation, this PR causes the runtime code generator to emit debug symbols and load them alongside generated assemblies.

**Approach:** The crux of this change simply instructs Roslyn to emit debug symbols (see `compilation.Emit` calls in `CodeGeneratorCommon`) and then passes those debug symbols to `Assembly.Load`.

In order to make this work during test runs, where we are caching generated assemblies to improve performance, we need to alter `ICodeGeneratorCache` to work with symbols as well as just raw assemblies. To achieve this we change uses of `byte[]` to `GeneratedAssembly`, which holds assembly + symbols.
