### PR TITLE
CodeGen: fix generated DeepCopy method to call RecordObject earlier

### DIFF
--- a/src/Orleans/Serialization/SerializationContext.cs
+++ b/src/Orleans/Serialization/SerializationContext.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 
 namespace Orleans.Serialization
 {
+    using System.Runtime.CompilerServices;
+
     /// <summary>
     /// Maintains context information for current thread during serialization operations.
     /// </summary>
@@ -60,7 +62,7 @@ namespace Orleans.Serialization
 
             public override int GetHashCode(object obj)
             {
-                return obj == null ? 0 : obj.GetHashCode();
+                return obj == null ? 0 : RuntimeHelpers.GetHashCode(obj);
             }
         }
 

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -283,12 +283,6 @@ namespace Orleans.CodeGenerator
                                 SF.VariableDeclarator("result")
                                     .WithInitializer(SF.EqualsValueClause(GetObjectCreationExpressionSyntax(type))))));
 
-                // Copy all members from the input to the result.
-                foreach (var field in fields)
-                {
-                    body.Add(SF.ExpressionStatement(field.GetSetter(resultVariable, field.GetGetter(inputVariable))));
-                }
-
                 // Record this serialization.
                 Expression<Action> recordObject =
                     () => SerializationContext.Current.RecordObject(default(object), default(object));
@@ -303,6 +297,12 @@ namespace Orleans.CodeGenerator
                     SF.ExpressionStatement(
                         recordObject.Invoke(currentSerializationContext)
                             .AddArgumentListArguments(SF.Argument(originalVariable), SF.Argument(resultVariable))));
+
+                // Copy all members from the input to the result.
+                foreach (var field in fields)
+                {
+                    body.Add(SF.ExpressionStatement(field.GetSetter(resultVariable, field.GetGetter(inputVariable))));
+                }
 
                 body.Add(SF.ReturnStatement(resultVariable));
             }

--- a/test/TestGrainInterfaces/ICircularStateTestGrain.cs
+++ b/test/TestGrainInterfaces/ICircularStateTestGrain.cs
@@ -21,6 +21,7 @@ namespace TestGrainInterfaces
     {
         public CircularTest2 CircularTest2 { get; set; }
     }
+
     [Serializable]
     public class CircularTest2
     {

--- a/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
+++ b/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
@@ -21,6 +21,8 @@ using Xunit.Abstractions;
 
 namespace UnitTests.Serialization
 {
+    using TestGrainInterfaces;
+
     /// <summary>
     /// Test the built-in serializers
     /// </summary>
@@ -1151,21 +1153,6 @@ namespace UnitTests.Serialization
             deserialized = (CircularTest1)OrleansSerializationLoop(c1, true);
             Assert.Equal(c1.CircularTest2.CircularTest1List.Count, deserialized.CircularTest2.CircularTest1List.Count);
             Assert.Equal(deserialized, deserialized.CircularTest2.CircularTest1List[0]);
-        }
-
-        [Serializable]
-        public class CircularTest1
-        {
-            public CircularTest2 CircularTest2 { get; set; }
-        }
-        [Serializable]
-        public class CircularTest2
-        {
-            public CircularTest2()
-            {
-                CircularTest1List = new List<CircularTest1>();                   
-            }
-            public List<CircularTest1> CircularTest1List { get; set; }
         }
     }
 }


### PR DESCRIPTION
Currently generated `DeepCopy` method incorrectly calls `RecordObject` after copying fields instead of before. This results in circular references involving being incorrectly serialized, resulting in a loss of referential equality.

The fix is to simply emit the call to `RecordObject` before the field-copying calls.

This was not failing in our test suite (`Serialize_CircularReference`) because the assembly holding the recursively defined type has the `[SkipCodeGeneration]` attribute, so a serializer was not being generated and so the fallback serializer was being used. 