### PR TITLE
Fix support for serializing SByte[]

### DIFF
--- a/src/Orleans/Serialization/BinaryTokenStreamReader.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamReader.cs
@@ -877,6 +877,8 @@ namespace Orleans.Serialization
                     return typeof(char[]);
                 case SerializationTokenType.BoolArray:
                     return typeof(bool[]);
+                case SerializationTokenType.SByteArray:
+                    return typeof(sbyte[]);
                 case SerializationTokenType.NamedType:
                     var typeName = ReadString();
                     try

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -124,6 +124,7 @@ namespace Orleans.Serialization
         private static readonly RuntimeTypeHandle charTypeHandle = typeof(char).TypeHandle;
         private static readonly RuntimeTypeHandle boolTypeHandle = typeof(bool).TypeHandle;
         private static readonly RuntimeTypeHandle objectTypeHandle = typeof(object).TypeHandle;
+        private static readonly RuntimeTypeHandle byteArrayTypeHandle = typeof(byte[]).TypeHandle;
 
         internal static CounterStatistic Copies;
         internal static CounterStatistic Serializations;
@@ -999,7 +1000,7 @@ namespace Orleans.Serialization
                     return originalArray;
                 }
                 // A common special case
-                if ((original is byte[]) && (originalArray.Rank == 1))
+                if (t.TypeHandle.Equals(byteArrayTypeHandle) && (originalArray.Rank == 1))
                 {
                     var source = (byte[])original;
                     if (source.Length > LARGE_OBJECT_LIMIT)
@@ -1264,6 +1265,14 @@ namespace Orleans.Serialization
                     stream.Write(SerializationTokenType.ByteArray);
                     stream.Write(array.Length);
                     stream.Write((byte[])array);
+                    return;
+                }
+                if (et.TypeHandle.Equals(sbyteTypeHandle))
+                {
+                    stream.Write(SerializationTokenType.SpecifiedType);
+                    stream.Write(SerializationTokenType.SByteArray);
+                    stream.Write(array.Length);
+                    stream.Write((sbyte[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(boolTypeHandle))

--- a/src/Orleans/Serialization/SerializationTokenType.cs
+++ b/src/Orleans/Serialization/SerializationTokenType.cs
@@ -81,6 +81,7 @@ namespace Orleans.Serialization
         FloatArray = 248,   // Single-dimension only; followed by the count of elements, then the elements
         DoubleArray = 249,  // Single-dimension only; followed by the count of elements, then the elements
         BoolArray = 250,    // Single-dimension only; followed by the count of elements, then the elements
+        SByteArray = 251,    // Single-dimension only; followed by the count of elements, then the elements
 
         // Last but not least...
         Error = 255,

--- a/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
+++ b/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
@@ -377,6 +377,14 @@ namespace UnitTests.Serialization
             var source2 = new string[] { "hello", "goodbye", "yes", "no", "", "I don't know" };
             deserialized = OrleansSerializationLoop(source2);
             ValidateArray<string>(source2, deserialized, "string");
+
+            var source3 = new sbyte[] { 1, 3, 5 };
+            deserialized = OrleansSerializationLoop(source3);
+            ValidateArray<sbyte>(source3, deserialized, "sbyte");
+
+            var source4 = new byte[] { 1, 3, 5 };
+            deserialized = OrleansSerializationLoop(source4);
+            ValidateArray<byte>(source4, deserialized, "byte");
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]


### PR DESCRIPTION
Currently we have optimizations for serializing certain types, including various array types.

Serialization is broken for `SByte[]`  because it is serialized without optimization, but erroneously deserialized with an optimization for `byte[]`. Since the optimized serialization occupies half the space, this results in incorrect deserialization.

This PR fixes that and expands test coverage to include this case.