### PR TITLE
Orleans ServiceBus naming consistency.

### DIFF
--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -59,7 +59,7 @@
     <Compile Include="Providers\Streams\EventHub\EventHubSequenceToken.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProvider.cs" />
-    <Compile Include="Providers\Streams\EventHub\EventHubStreamProviderConfig.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubStreamProviderSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\ICheckpointerSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubQueueMapper.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubSettings.cs" />

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -20,7 +20,7 @@ namespace Orleans.ServiceBus.Providers
         protected Logger logger;
         protected IServiceProvider serviceProvider;
         protected IProviderConfiguration providerConfig;
-        protected EventHubStreamProviderConfig adapterConfig;
+        protected EventHubStreamProviderSettings adapterSettings;
         protected IEventHubSettings hubSettings;
         protected ICheckpointerSettings checkpointerSettings;
         private IEventHubQueueMapper streamQueueMapper;
@@ -31,7 +31,7 @@ namespace Orleans.ServiceBus.Providers
         /// <summary>
         /// Name of the adapter. Primarily for logging purposes
         /// </summary>
-        public string Name => adapterConfig.StreamProviderName;
+        public string Name => adapterSettings.StreamProviderName;
 
         /// <summary>
         /// Determines whether this is a rewindable stream adapter - supports subscribing from previous point in time.
@@ -73,29 +73,29 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="svcProvider"></param>
         public virtual void Init(IProviderConfiguration providerCfg, string providerName, Logger log, IServiceProvider svcProvider)
         {
-            if (providerCfg == null) throw new ArgumentNullException("providerCfg");
-            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException("providerName");
-            if (log == null) throw new ArgumentNullException("log");
+            if (providerCfg == null) throw new ArgumentNullException(nameof(providerCfg));
+            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
+            if (log == null) throw new ArgumentNullException(nameof(log));
 
             providerConfig = providerCfg;
             serviceProvider = svcProvider;
             receivers = new ConcurrentDictionary<QueueId, EventHubAdapterReceiver>();
 
-            adapterConfig = new EventHubStreamProviderConfig(providerName);
-            adapterConfig.PopulateFromProviderConfig(providerConfig);
-            hubSettings = adapterConfig.GetEventHubSettings(providerConfig, serviceProvider);
+            adapterSettings = new EventHubStreamProviderSettings(providerName);
+            adapterSettings.PopulateFromProviderConfig(providerConfig);
+            hubSettings = adapterSettings.GetEventHubSettings(providerConfig, serviceProvider);
             client = EventHubClient.CreateFromConnectionString(hubSettings.ConnectionString, hubSettings.Path);
 
             if (CheckpointerFactory == null)
             {
-                checkpointerSettings = adapterConfig.GetCheckpointerSettings(providerConfig, serviceProvider);
-                CheckpointerFactory = partition => EventHubCheckpointer.Create(checkpointerSettings, adapterConfig.StreamProviderName, partition);
+                checkpointerSettings = adapterSettings.GetCheckpointerSettings(providerConfig, serviceProvider);
+                CheckpointerFactory = partition => EventHubCheckpointer.Create(checkpointerSettings, adapterSettings.StreamProviderName, partition);
             }
 
             if (CacheFactory == null)
             {
-                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
-                var timePurge = new TimePurgePredicate(adapterConfig.DataMinTimeInCache, adapterConfig.DataMaxAgeInCache);
+                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterSettings.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
+                var timePurge = new TimePurgePredicate(adapterSettings.DataMinTimeInCache, adapterSettings.DataMaxAgeInCache);
                 CacheFactory = (partition,checkpointer,cacheLogger) => new EventHubQueueCache(checkpointer, bufferPool, timePurge, cacheLogger);
             }
 
@@ -107,7 +107,7 @@ namespace Orleans.ServiceBus.Providers
 
             if (QueueMapperFactory == null)
             {
-                QueueMapperFactory = partitions => new EventHubQueueMapper(partitionIds, adapterConfig.StreamProviderName);
+                QueueMapperFactory = partitions => new EventHubQueueMapper(partitionIds, adapterSettings.StreamProviderName);
             }
 
             logger = log.GetLogger($"EventHub.{hubSettings.Path}");
@@ -203,7 +203,7 @@ namespace Orleans.ServiceBus.Providers
 
         private EventHubAdapterReceiver MakeReceiver(QueueId queueId)
         {
-            var config = new EventHubPartitionConfig
+            var config = new EventHubPartitionSettings
             {
                 Hub = hubSettings,
                 Partition = streamQueueMapper.QueueToPartition(queueId),

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -12,19 +12,18 @@ using Orleans.Streams;
 
 namespace Orleans.ServiceBus.Providers
 {
-    internal class EventHubPartitionConfig
+    internal class EventHubPartitionSettings
     {
         public IEventHubSettings Hub { get; set; }
         public string Partition { get; set; }
     }
-
-
+    
     internal class EventHubAdapterReceiver : IQueueAdapterReceiver, IQueueCache
     {
         public const int MaxMessagesPerRead = 1000;
         private static readonly TimeSpan ReceiveTimeout = TimeSpan.FromSeconds(5);
 
-        private readonly EventHubPartitionConfig config;
+        private readonly EventHubPartitionSettings settings;
         private readonly Func<string, IStreamQueueCheckpointer<string>, Logger, IEventHubQueueCache> cacheFactory;
         private readonly Func<string, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory;
         private readonly Logger baseLogger;
@@ -52,7 +51,7 @@ namespace Orleans.ServiceBus.Providers
 
         public int GetMaxAddCount() { return flowController.GetMaxAddCount(); }
 
-        public EventHubAdapterReceiver(EventHubPartitionConfig partitionConfig,
+        public EventHubAdapterReceiver(EventHubPartitionSettings partitionSettings,
             Func<string, IStreamQueueCheckpointer<string>, Logger,IEventHubQueueCache> cacheFactory,
             Func<string, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory,
             Logger logger)
@@ -61,21 +60,21 @@ namespace Orleans.ServiceBus.Providers
             this.checkpointerFactory = checkpointerFactory;
             baseLogger = logger;
             this.logger = logger.GetSubLogger("-receiver");
-            config = partitionConfig;
+            settings = partitionSettings;
 
-            hubReceiveTimeMetric = $"Orleans.ServiceBus.EventHub.ReceiveTime_{config.Hub.Path}";
-            partitionReceiveTimeMetric = $"Orleans.ServiceBus.EventHub.ReceiveTime_{config.Hub.Path}-{config.Partition}";
-            hubReadFailure = $"Orleans.ServiceBus.EventHub.ReadFailure_{config.Hub.Path}";
-            partitionReadFailure = $"Orleans.ServiceBus.EventHub.ReadFailure_{config.Hub.Path}-{config.Partition}";
-            hubMessagesRecieved = $"Orleans.ServiceBus.EventHub.MessagesReceived_{config.Hub.Path}";
-            partitionMessagesReceived = $"Orleans.ServiceBus.EventHub.MessagesReceived_{config.Hub.Path}-{config.Partition}";
-            hubAgeOfMessagesBeingProcessed = $"Orleans.ServiceBus.EventHub.AgeOfMessagesBeingProcessed_{config.Hub.Path}";
-            partitionAgeOfMessagesBeingProcessed = $"Orleans.ServiceBus.EventHub.AgeOfMessagesBeingProcessed_{config.Hub.Path}-{config.Partition}";
+            hubReceiveTimeMetric = $"Orleans.ServiceBus.EventHub.ReceiveTime_{settings.Hub.Path}";
+            partitionReceiveTimeMetric = $"Orleans.ServiceBus.EventHub.ReceiveTime_{settings.Hub.Path}-{settings.Partition}";
+            hubReadFailure = $"Orleans.ServiceBus.EventHub.ReadFailure_{settings.Hub.Path}";
+            partitionReadFailure = $"Orleans.ServiceBus.EventHub.ReadFailure_{settings.Hub.Path}-{settings.Partition}";
+            hubMessagesRecieved = $"Orleans.ServiceBus.EventHub.MessagesReceived_{settings.Hub.Path}";
+            partitionMessagesReceived = $"Orleans.ServiceBus.EventHub.MessagesReceived_{settings.Hub.Path}-{settings.Partition}";
+            hubAgeOfMessagesBeingProcessed = $"Orleans.ServiceBus.EventHub.AgeOfMessagesBeingProcessed_{settings.Hub.Path}";
+            partitionAgeOfMessagesBeingProcessed = $"Orleans.ServiceBus.EventHub.AgeOfMessagesBeingProcessed_{settings.Hub.Path}-{settings.Partition}";
         }
 
         public Task Initialize(TimeSpan timeout)
         {
-            logger.Info("Initializing EventHub partition {0}-{1}.", config.Hub.Path, config.Partition);
+            logger.Info("Initializing EventHub partition {0}-{1}.", settings.Hub.Path, settings.Partition);
             // if receiver was already running, do nothing
             return ReceiverRunning == Interlocked.Exchange(ref recieverState, ReceiverRunning) ? TaskDone.Done : Initialize();
         }
@@ -87,11 +86,11 @@ namespace Orleans.ServiceBus.Providers
         /// <returns></returns>
         private async Task Initialize()
         {
-            checkpointer = await checkpointerFactory(config.Partition);
-            cache = cacheFactory(config.Partition, checkpointer, baseLogger);
+            checkpointer = await checkpointerFactory(settings.Partition);
+            cache = cacheFactory(settings.Partition, checkpointer, baseLogger);
             flowController = new AggregatedQueueFlowController(MaxMessagesPerRead) { cache };
             string offset = await checkpointer.Load();
-            receiver = await CreateReceiver(config, offset, logger);
+            receiver = await CreateReceiver(settings, offset, logger);
         }
 
         public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
@@ -104,7 +103,7 @@ namespace Orleans.ServiceBus.Providers
             // if receiver initialization failed, retry
             if (receiver == null)
             {
-                logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead, "Retrying initialization of EventHub partition {0}-{1}.", config.Hub.Path, config.Partition);
+                logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead, "Retrying initialization of EventHub partition {0}-{1}.", settings.Hub.Path, settings.Partition);
                 await Initialize();
                 if (receiver==null)
                 {
@@ -129,8 +128,8 @@ namespace Orleans.ServiceBus.Providers
             {
                 logger.TrackMetric(hubReadFailure, 1);
                 logger.TrackMetric(partitionReadFailure, 1);
-                logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead, "Failed to read from EventHub partition {0}-{1}. : Exception: {2}.", config.Hub.Path,
-                    config.Partition, ex);
+                logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead, "Failed to read from EventHub partition {0}-{1}. : Exception: {2}.", settings.Hub.Path,
+                    settings.Partition, ex);
                 throw;
             }
 
@@ -197,7 +196,7 @@ namespace Orleans.ServiceBus.Providers
                 return TaskDone.Done;
             }
 
-            logger.Info("Stopping reading from EventHub partition {0}-{1}", config.Hub.Path, config.Partition);
+            logger.Info("Stopping reading from EventHub partition {0}-{1}", settings.Hub.Path, settings.Partition);
 
             // clear cache and receiver
             IEventHubQueueCache localCache = Interlocked.Exchange(ref cache, null);
@@ -214,30 +213,30 @@ namespace Orleans.ServiceBus.Providers
             return closeTask;
         }
 
-        private static async Task<EventHubReceiver> CreateReceiver(EventHubPartitionConfig partitionConfig, string offset, Logger logger)
+        private static async Task<EventHubReceiver> CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, Logger logger)
         {
             bool offsetInclusive = true;
-            EventHubClient client = EventHubClient.CreateFromConnectionString(partitionConfig.Hub.ConnectionString, partitionConfig.Hub.Path);
-            EventHubConsumerGroup consumerGroup = client.GetConsumerGroup(partitionConfig.Hub.ConsumerGroup);
-            if (partitionConfig.Hub.PrefetchCount.HasValue)
+            EventHubClient client = EventHubClient.CreateFromConnectionString(partitionSettings.Hub.ConnectionString, partitionSettings.Hub.Path);
+            EventHubConsumerGroup consumerGroup = client.GetConsumerGroup(partitionSettings.Hub.ConsumerGroup);
+            if (partitionSettings.Hub.PrefetchCount.HasValue)
             {
-                consumerGroup.PrefetchCount = partitionConfig.Hub.PrefetchCount.Value;
+                consumerGroup.PrefetchCount = partitionSettings.Hub.PrefetchCount.Value;
             }
             // if we have a starting offset or if we're not configured to start reading from utc now, read from offset
-            if (!partitionConfig.Hub.StartFromNow || offset != EventHubConsumerGroup.StartOfStream)
+            if (!partitionSettings.Hub.StartFromNow || offset != EventHubConsumerGroup.StartOfStream)
             {
-                logger.Info("Starting to read from EventHub partition {0}-{1} at offset {2}", partitionConfig.Hub.Path, partitionConfig.Partition, offset);
+                logger.Info("Starting to read from EventHub partition {0}-{1} at offset {2}", partitionSettings.Hub.Path, partitionSettings.Partition, offset);
             }
             else
             {
                 // to start reading from most recent data, we get the latest offset from the partition.
                 PartitionRuntimeInformation patitionInfo =
-                    await client.GetPartitionRuntimeInformationAsync(partitionConfig.Partition);
+                    await client.GetPartitionRuntimeInformationAsync(partitionSettings.Partition);
                 offset = patitionInfo.LastEnqueuedOffset;
                 offsetInclusive = false;
-                logger.Info("Starting to read latest messages from EventHub partition {0}-{1} at offset {2}", partitionConfig.Hub.Path, partitionConfig.Partition, offset);
+                logger.Info("Starting to read latest messages from EventHub partition {0}-{1} at offset {2}", partitionSettings.Hub.Path, partitionSettings.Partition, offset);
             }
-            return await consumerGroup.CreateReceiverAsync(partitionConfig.Partition, offset, offsetInclusive);
+            return await consumerGroup.CreateReceiverAsync(partitionSettings.Partition, offset, offsetInclusive);
         }
 
         private class StreamActivityNotificationBatch : IBatchContainer

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -19,8 +19,18 @@ namespace Orleans.ServiceBus.Providers
         private Task inProgressSave;
         private DateTime? throttleSavesUntilUtc;
 
-        public bool CheckpointExists { get { return entity != null && entity.Offset != EventHubConsumerGroup.StartOfStream; } }
+        /// <summary>
+        /// Indicates if a checkpoint exists
+        /// </summary>
+        public bool CheckpointExists => entity != null && entity.Offset != EventHubConsumerGroup.StartOfStream;
 
+        /// <summary>
+        /// Factory function that creates and initializes the checkpointer
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <param name="streamProviderName"></param>
+        /// <param name="partition"></param>
+        /// <returns></returns>
         public static async Task<IStreamQueueCheckpointer<string>> Create(ICheckpointerSettings settings, string streamProviderName, string partition)
         {
             var checkpointer = new EventHubCheckpointer(settings, streamProviderName, partition);
@@ -32,15 +42,15 @@ namespace Orleans.ServiceBus.Providers
         {
             if (settings == null)
             {
-                throw new ArgumentNullException("settings");
+                throw new ArgumentNullException(nameof(settings));
             }
             if (string.IsNullOrWhiteSpace(streamProviderName))
             {
-                throw new ArgumentNullException("streamProviderName");
+                throw new ArgumentNullException(nameof(streamProviderName));
             }
             if (string.IsNullOrWhiteSpace(partition))
             {
-                throw new ArgumentNullException("partition");
+                throw new ArgumentNullException(nameof(partition));
             }
             persistInterval = settings.PersistInterval;
             dataManager = new AzureTableDataManager<EventHubPartitionCheckpointEntity>(settings.TableName, settings.DataConnectionString);
@@ -52,6 +62,10 @@ namespace Orleans.ServiceBus.Providers
             return dataManager.InitTableAsync();
         }
 
+        /// <summary>
+        /// Loads a checkpoint
+        /// </summary>
+        /// <returns></returns>
         public async Task<string> Load()
         {
             Tuple<EventHubPartitionCheckpointEntity, string> results =
@@ -63,6 +77,11 @@ namespace Orleans.ServiceBus.Providers
             return entity.Offset;
         }
 
+        /// <summary>
+        /// Updates the checkpoint.  This is a best effort.  It does not always update the checkpoint.
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <param name="utcNow"></param>
         public void Update(string offset, DateTime utcNow)
         {
             // if offset has not changed, do nothing

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -256,7 +256,7 @@ namespace Orleans.ServiceBus.Providers
                 {
                     string errmsg = String.Format(CultureInfo.InvariantCulture,
                         "Message size is to big. MessageSize: {0}", size);
-                    throw new ArgumentOutOfRangeException("size", errmsg);
+                    throw new ArgumentOutOfRangeException(nameof(size), errmsg);
                 }
             }
             return segment;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
@@ -1,5 +1,4 @@
 ﻿
-using System;
 using Microsoft.ServiceBus.Messaging;
 using Microsoft.WindowsAzure.Storage.Table;
 using Orleans.AzureUtils;
@@ -26,13 +25,13 @@ namespace Orleans.ServiceBus.Providers
 
         public static string MakePartitionKey(string streamProviderName, string checkpointNamespace)
         {
-            string key = String.Format("EventHubCheckpoints_{0}_{1}", streamProviderName, checkpointNamespace);
+            string key = $"EventHubCheckpoints_{streamProviderName}_{checkpointNamespace}";
             return AzureStorageUtils.SanitizeTableProperty(key);
         }
 
         public static string MakeRowKey(string partition)
         {
-            string key = String.Format("partition_{0}", partition);
+            string key = $"partition_{partition}";
             return AzureStorageUtils.SanitizeTableProperty(key);
         }
     }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueMapper.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueMapper.cs
@@ -7,17 +7,25 @@ using Orleans.Streams;
 
 namespace Orleans.ServiceBus.Providers
 {
+    /// <summary>
+    /// Queue mapper that tracks which EventHub partition was mapped to which queueId
+    /// </summary>
     public class EventHubQueueMapper : HashRingBasedStreamQueueMapper, IEventHubQueueMapper
     {
         private readonly Dictionary<QueueId, string> partitionDictionary = new Dictionary<QueueId, string>();
 
+        /// <summary>
+        /// Queue mapper that tracks which EventHub partition was mapped to which queueId
+        /// </summary>
+        /// <param name="partitionIds">List of EventHubPartitions</param>
+        /// <param name="queueNamePrefix">Prefix for queueIds.  Must be unique per stream provider</param>
         public EventHubQueueMapper(string[] partitionIds, string queueNamePrefix)
             : base(partitionIds.Length, queueNamePrefix)
         {
             QueueId[] queues = GetAllQueues().ToArray();
             if (queues.Length != partitionIds.Length)
             {
-                throw new ArgumentOutOfRangeException("partitionIds", "partitons and Queues do not line up");
+                throw new ArgumentOutOfRangeException(nameof(partitionIds), "partitons and Queues do not line up");
             }
             for (int i = 0; i < queues.Length; i++)
             {
@@ -25,11 +33,16 @@ namespace Orleans.ServiceBus.Providers
             }
         }
 
+        /// <summary>
+        /// Gets the EventHub partition by QueueId
+        /// </summary>
+        /// <param name="queue"></param>
+        /// <returns></returns>
         public string QueueToPartition(QueueId queue)
         {
             if (queue == null)
             {
-                throw new ArgumentNullException("queue");
+                throw new ArgumentNullException(nameof(queue));
             }
 
             string partitionId;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -5,9 +5,19 @@ using Orleans.Providers.Streams.Common;
 
 namespace Orleans.ServiceBus.Providers
 {
+    /// <summary>
+    /// Location of a message within an EventHub partition
+    /// </summary>
     public interface IEventHubPartitionLocation
     {
+        /// <summary>
+        /// Offset of the message within an EventHub partition
+        /// </summary>
         string EventHubOffset { get; }
+
+        /// <summary>
+        /// EventHub sequence id of the message
+        /// </summary>
         long SequenceNumber { get; }
     }
 
@@ -23,14 +33,26 @@ namespace Orleans.ServiceBus.Providers
     [Serializable]
     public class EventHubSequenceToken : EventSequenceToken, IEventHubPartitionLocation
     {
-        public string EventHubOffset { get; private set; }
+        /// <summary>
+        /// Offset of the message within an EventHub partition
+        /// </summary>
+        public string EventHubOffset { get; }
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="eventHubOffset">EventHub offset within the partition from which this message came.</param>
+        /// <param name="sequenceNumber">EventHub sequenceNumber for this message.</param>
+        /// <param name="eventIndex">Index into a batch of events, if multiple events were delivered within a single EventHub message.</param>
         public EventHubSequenceToken(string eventHubOffset, long sequenceNumber, int eventIndex)
             : base(sequenceNumber, eventIndex)
         {
             EventHubOffset = eventHubOffset;
         }
 
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
             return string.Format(CultureInfo.InvariantCulture, "EventHubSequenceToken(EventHubOffset: {0}, SequenceNumber: {1}, EventIndex: {2})", EventHubOffset, SequenceNumber, EventIndex);

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSettings.cs
@@ -6,6 +6,9 @@ using Orleans.Providers;
 
 namespace Orleans.ServiceBus.Providers
 {
+    /// <summary>
+    /// EventHub settings for a specific hub
+    /// </summary>
     [Serializable]
     public class EventHubSettings : IEventHubSettings
     {
@@ -17,21 +20,32 @@ namespace Orleans.ServiceBus.Providers
         private const string StartFromNowName = "StartFromNow";
         private const bool StartFromNowDefault = true;
 
+        /// <summary>
+        /// Default constructor
+        /// </summary>
         public EventHubSettings(){}
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="connectionString">EventHub connection string.</param>
+        /// <param name="consumerGroup">EventHub consumer group.</param>
+        /// <param name="path">Hub path.</param>
+        /// <param name="startFromNow">In cases where no checkpoint is found, this indicates if service should read from the most recent data, or from the begining of a partition.</param>
+        /// <param name="prefetchCount">optional parameter that configures the receiver prefetch count.</param>
         public EventHubSettings(string connectionString, string consumerGroup, string path, bool startFromNow = StartFromNowDefault, int? prefetchCount = null)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException("connectionString");
+                throw new ArgumentNullException(nameof(connectionString));
             }
             if (string.IsNullOrWhiteSpace(consumerGroup))
             {
-                throw new ArgumentNullException("consumerGroup");
+                throw new ArgumentNullException(nameof(consumerGroup));
             }
             if (string.IsNullOrWhiteSpace(path))
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
             ConnectionString = connectionString;
             ConsumerGroup = consumerGroup;
@@ -40,10 +54,25 @@ namespace Orleans.ServiceBus.Providers
             StartFromNow = startFromNow;
         }
 
+        /// <summary>
+        /// EventHub connection string.
+        /// </summary>
         public string ConnectionString { get; private set; }
+        /// <summary>
+        /// EventHub consumer group.
+        /// </summary>
         public string ConsumerGroup { get; private set; }
+        /// <summary>
+        /// Hub path.
+        /// </summary>
         public string Path { get; private set; }
+        /// <summary>
+        /// Optional parameter that configures the receiver prefetch count.
+        /// </summary>
         public int? PrefetchCount { get; private set; }
+        /// <summary>
+        /// In cases where no checkpoint is found, this indicates if service should read from the most recent data, or from the begining of a partition.
+        /// </summary>
         public bool StartFromNow { get; private set; }
 
         /// <summary>
@@ -71,17 +100,17 @@ namespace Orleans.ServiceBus.Providers
             ConnectionString = providerConfiguration.GetProperty(ConnectionStringName, null);
             if (string.IsNullOrWhiteSpace(ConnectionString))
             {
-                throw new ArgumentOutOfRangeException("providerConfiguration", ConnectionStringName + " not set.");
+                throw new ArgumentOutOfRangeException(nameof(providerConfiguration), ConnectionStringName + " not set.");
             }
             ConsumerGroup = providerConfiguration.GetProperty(ConsumerGroupName, null);
             if (string.IsNullOrWhiteSpace(ConsumerGroup))
             {
-                throw new ArgumentOutOfRangeException("providerConfiguration", ConsumerGroupName + " not set.");
+                throw new ArgumentOutOfRangeException(nameof(providerConfiguration), ConsumerGroupName + " not set.");
             }
             Path = providerConfiguration.GetProperty(PathName, null);
             if (string.IsNullOrWhiteSpace(Path))
             {
-                throw new ArgumentOutOfRangeException("providerConfiguration", PathName + " not set.");
+                throw new ArgumentOutOfRangeException(nameof(providerConfiguration), PathName + " not set.");
             }
             PrefetchCount = providerConfiguration.GetIntProperty(PrefetchCountName, InvalidPrefetchCount);
             if (PrefetchCount == InvalidPrefetchCount)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderSettings.cs
@@ -7,9 +7,9 @@ using Orleans.Providers;
 namespace Orleans.ServiceBus.Providers
 {
     /// <summary>
-    /// Configuration class for EventHubStreamProvider.
+    /// Settings class for EventHubStreamProvider.
     /// </summary>
-    public class EventHubStreamProviderConfig
+    public class EventHubStreamProviderSettings
     {
         /// <summary>
         /// Stream provider name.  This setting is required.
@@ -83,7 +83,7 @@ namespace Orleans.ServiceBus.Providers
         /// Constructor.  Requires provider name.
         /// </summary>
         /// <param name="streamProviderName"></param>
-        public EventHubStreamProviderConfig(string streamProviderName)
+        public EventHubStreamProviderSettings(string streamProviderName)
         {
             StreamProviderName = streamProviderName;
         }
@@ -122,7 +122,7 @@ namespace Orleans.ServiceBus.Providers
             CheckpointerSettingsType = providerConfiguration.GetTypeProperty(CheckpointerSettingsTypeName, null);
             if (string.IsNullOrWhiteSpace(StreamProviderName))
             {
-                throw new ArgumentOutOfRangeException("providerConfiguration", "StreamProviderName not set.");
+                throw new ArgumentOutOfRangeException(nameof(providerConfiguration), "StreamProviderName not set.");
             }
             CacheSizeMb = providerConfiguration.GetIntProperty(CacheSizeMbName, DefaultCacheSizeMb);
             DataMinTimeInCache = providerConfiguration.GetTimeSpanProperty(DataMinTimeInCacheName, DefaultDataMinTimeInCache);

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/ICheckpointerSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/ICheckpointerSettings.cs
@@ -5,6 +5,9 @@ using Orleans.Providers;
 
 namespace Orleans.ServiceBus.Providers
 {
+    /// <summary>
+    /// Setting interface for checkpointer
+    /// </summary>
     public interface ICheckpointerSettings
     {
         /// <summary>
@@ -28,6 +31,9 @@ namespace Orleans.ServiceBus.Providers
         string CheckpointNamespace { get; }
     }
 
+    /// <summary>
+    /// EventHub checkpointer.
+    /// </summary>
     public class EventHubCheckpointerSettings : ICheckpointerSettings
     {
         private const string DataConnectionStringName = "CheckpointerDataConnectionString";
@@ -36,31 +42,53 @@ namespace Orleans.ServiceBus.Providers
         private const string CheckpointNamespaceName = "CheckpointNamespace";
         private static readonly TimeSpan DefaultPersistInterval = TimeSpan.FromMinutes(1);
 
+        /// <summary>
+        /// Default constructor/
+        /// </summary>
         public EventHubCheckpointerSettings(){}
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="dataConnectionString">Azure table storage connections string.</param>
+        /// <param name="table">table name.</param>
+        /// <param name="checkpointNamespace">checkpointer namespace.</param>
+        /// <param name="persistInterval">checkpoint interval.</param>
         public EventHubCheckpointerSettings(string dataConnectionString, string table, string checkpointNamespace, TimeSpan? persistInterval = null)
         {
             if (string.IsNullOrWhiteSpace(dataConnectionString))
             {
-                throw new ArgumentNullException("dataConnectionString");
+                throw new ArgumentNullException(nameof(dataConnectionString));
             }
             if (string.IsNullOrWhiteSpace(table))
             {
-                throw new ArgumentNullException("table");
+                throw new ArgumentNullException(nameof(table));
             }
             if (string.IsNullOrWhiteSpace(checkpointNamespace))
             {
-                throw new ArgumentNullException("checkpointNamespace");
+                throw new ArgumentNullException(nameof(checkpointNamespace));
             }
             DataConnectionString = dataConnectionString;
             TableName = table;
             CheckpointNamespace = checkpointNamespace;
-            PersistInterval = persistInterval.HasValue ? persistInterval.Value : DefaultPersistInterval;
+            PersistInterval = persistInterval ?? DefaultPersistInterval;
         }
 
+        /// <summary>
+        /// Azure table storage connections string.
+        /// </summary>
         public string DataConnectionString { get; private set; }
+        /// <summary>
+        /// Azure table name.
+        /// </summary>
         public string TableName { get; private set; }
+        /// <summary>
+        /// Intervale to write checkpoints.  Prevents spamming storage.
+        /// </summary>
         public TimeSpan PersistInterval { get; private set; }
+        /// <summary>
+        /// Unique namespace for checkpoint data.  Is similar to consumer group.
+        /// </summary>
         public string CheckpointNamespace { get; private set; }
 
         /// <summary>
@@ -84,18 +112,18 @@ namespace Orleans.ServiceBus.Providers
             DataConnectionString = providerConfiguration.GetProperty(DataConnectionStringName, null);
             if (string.IsNullOrWhiteSpace(DataConnectionString))
             {
-                throw new ArgumentOutOfRangeException("providerConfiguration", DataConnectionStringName + " not set.");
+                throw new ArgumentOutOfRangeException(nameof(providerConfiguration), DataConnectionStringName + " not set.");
             }
             TableName = providerConfiguration.GetProperty(TableNameName, null);
             if (string.IsNullOrWhiteSpace(TableName))
             {
-                throw new ArgumentOutOfRangeException("providerConfiguration", TableNameName + " not set.");
+                throw new ArgumentOutOfRangeException(nameof(providerConfiguration), TableNameName + " not set.");
             }
             PersistInterval = providerConfiguration.GetTimeSpanProperty(PersistIntervalName, DefaultPersistInterval);
             CheckpointNamespace = providerConfiguration.GetProperty(CheckpointNamespaceName, null);
             if (string.IsNullOrWhiteSpace(CheckpointNamespace))
             {
-                throw new ArgumentOutOfRangeException("providerConfiguration", CheckpointNamespaceName + " not set.");
+                throw new ArgumentOutOfRangeException(nameof(providerConfiguration), CheckpointNamespaceName + " not set.");
             }
         }
     }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueMapper.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueMapper.cs
@@ -1,4 +1,5 @@
-﻿using Orleans.Streams;
+﻿
+using Orleans.Streams;
 
 namespace Orleans.ServiceBus.Providers
 {
@@ -7,6 +8,11 @@ namespace Orleans.ServiceBus.Providers
     /// </summary>
     public interface IEventHubQueueMapper : IStreamQueueMapper
     {
+        /// <summary>
+        /// Gets the EventHub partition by QueueId
+        /// </summary>
+        /// <param name="queue"></param>
+        /// <returns></returns>
         string QueueToPartition(QueueId queue);
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubSettings.cs
@@ -1,12 +1,26 @@
 ﻿
-
 namespace Orleans.ServiceBus.Providers
 {
+    /// <summary>
+    /// EventHub settings inteface for a specific hub.
+    /// </summary>
     public interface IEventHubSettings
     {
+        /// <summary>
+        /// EventHub connection string.
+        /// </summary>
         string ConnectionString { get; }
+        /// <summary>
+        /// EventHub consumer group.
+        /// </summary>
         string ConsumerGroup { get; }
+        /// <summary>
+        /// Hub Path.
+        /// </summary>
         string Path { get; }
+        /// <summary>
+        /// Optional parameter which configures the EventHub reciever's prefetch count.
+        /// </summary>
         int? PrefetchCount { get; }
 
         /// <summary>

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/SegmentBuilder.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/SegmentBuilder.cs
@@ -42,11 +42,11 @@ namespace Orleans.ServiceBus.Providers
         {
             if (segment.Array == null)
             {
-                throw new ArgumentNullException("segment");
+                throw new ArgumentNullException(nameof(segment));
             }
             if (bytes == null)
             {
-                throw new ArgumentNullException("bytes");
+                throw new ArgumentNullException(nameof(bytes));
             }
 
             Array.Copy(BitConverter.GetBytes(bytes.Length), 0, segment.Array, segment.Offset + writerOffset, sizeof(int));
@@ -68,7 +68,7 @@ namespace Orleans.ServiceBus.Providers
         {
             if (segment.Array == null)
             {
-                throw new ArgumentNullException("segment");
+                throw new ArgumentNullException(nameof(segment));
             }
             if (str == null)
             {
@@ -96,7 +96,7 @@ namespace Orleans.ServiceBus.Providers
         {
             if (segment.Array == null)
             {
-                throw new ArgumentNullException("segment");
+                throw new ArgumentNullException(nameof(segment));
             }
             int size = BitConverter.ToInt32(segment.Array, segment.Offset + readerOffset);
             readerOffset += sizeof(int);
@@ -113,7 +113,7 @@ namespace Orleans.ServiceBus.Providers
         {
             if (segment.Array == null)
             {
-                throw new ArgumentNullException("segment");
+                throw new ArgumentNullException(nameof(segment));
             }
             int size = BitConverter.ToInt32(segment.Array, segment.Offset + readerOffset);
             readerOffset += sizeof(int);

--- a/test/Tester/StreamingTests/EHClientStreamTests.cs
+++ b/test/Tester/StreamingTests/EHClientStreamTests.cs
@@ -28,8 +28,8 @@ namespace Tester.StreamingTests
         private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
                 EHConsumerGroup, EHPath);
 
-        private static readonly EventHubStreamProviderConfig ProviderConfig =
-            new EventHubStreamProviderConfig(StreamProviderName) { CacheSizeMb = 3 };
+        private static readonly EventHubStreamProviderSettings ProviderSettings =
+            new EventHubStreamProviderSettings(StreamProviderName) { CacheSizeMb = 3 };
 
         private static readonly EventHubCheckpointerSettings CheckpointerSettings =
             new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable,
@@ -94,7 +94,7 @@ namespace Tester.StreamingTests
         {
             var settings = new Dictionary<string, string>();
             // get initial settings from configs
-            ProviderConfig.WriteProperties(settings);
+            ProviderSettings.WriteProperties(settings);
             EventHubConfig.WriteProperties(settings);
             CheckpointerSettings.WriteProperties(settings);
             return settings;

--- a/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -32,8 +32,8 @@ namespace UnitTests.StreamingTests
         private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
                 EHConsumerGroup, EHPath);
 
-        private static readonly EventHubStreamProviderConfig ProviderConfig =
-            new EventHubStreamProviderConfig(StreamProviderName);
+        private static readonly EventHubStreamProviderSettings ProviderSettings =
+            new EventHubStreamProviderSettings(StreamProviderName);
 
         private static readonly EventHubCheckpointerSettings CheckpointerSettings =
             new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
@@ -67,7 +67,7 @@ namespace UnitTests.StreamingTests
                 var settings = new Dictionary<string, string>();
 
                 // get initial settings from configs
-                ProviderConfig.WriteProperties(settings);
+                ProviderSettings.WriteProperties(settings);
                 EventHubConfig.WriteProperties(settings);
                 CheckpointerSettings.WriteProperties(settings);
 

--- a/test/Tester/StreamingTests/EHStreamPerPartitionTests.cs
+++ b/test/Tester/StreamingTests/EHStreamPerPartitionTests.cs
@@ -31,8 +31,8 @@ namespace UnitTests.StreamingTests
         private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
                 EHConsumerGroup, EHPath);
 
-        private static readonly EventHubStreamProviderConfig ProviderConfig =
-            new EventHubStreamProviderConfig(StreamProviderName);
+        private static readonly EventHubStreamProviderSettings ProviderSettings =
+            new EventHubStreamProviderSettings(StreamProviderName);
 
         private static readonly EventHubCheckpointerSettings CheckpointerSettings =
             new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
@@ -63,7 +63,7 @@ namespace UnitTests.StreamingTests
                 var settings = new Dictionary<string, string>();
 
                 // get initial settings from configs
-                ProviderConfig.WriteProperties(settings);
+                ProviderSettings.WriteProperties(settings);
                 EventHubConfig.WriteProperties(settings);
                 CheckpointerSettings.WriteProperties(settings);
 

--- a/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
+++ b/test/Tester/StreamingTests/EHStreamProviderCheckpointTests.cs
@@ -33,8 +33,8 @@ namespace UnitTests.StreamingTests
         private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
             EHConsumerGroup, EHPath);
 
-        private static readonly EventHubStreamProviderConfig ProviderConfig =
-            new EventHubStreamProviderConfig(StreamProviderName) { CacheSizeMb = 3 };
+        private static readonly EventHubStreamProviderSettings ProviderSettings =
+            new EventHubStreamProviderSettings(StreamProviderName) { CacheSizeMb = 3 };
 
         private static readonly EventHubCheckpointerSettings CheckpointerSettings =
             new EventHubCheckpointerSettings(StorageTestConstants.DataConnectionString, EHCheckpointTable, CheckpointNamespace,
@@ -180,7 +180,7 @@ namespace UnitTests.StreamingTests
             var settings = new Dictionary<string, string>();
 
             // get initial settings from configs
-            ProviderConfig.WriteProperties(settings);
+            ProviderSettings.WriteProperties(settings);
             EventHubConfig.WriteProperties(settings);
             CheckpointerSettings.WriteProperties(settings);
 

--- a/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/EHSubscriptionMultiplicityTests.cs
@@ -26,8 +26,8 @@ namespace UnitTests.StreamingTests
         private const string EHCheckpointTable = "ehcheckpoint";
         private static readonly string CheckpointNamespace = Guid.NewGuid().ToString();
 
-        public static readonly EventHubStreamProviderConfig ProviderConfig =
-            new EventHubStreamProviderConfig(StreamProviderName);
+        public static readonly EventHubStreamProviderSettings ProviderSettings =
+            new EventHubStreamProviderSettings(StreamProviderName);
 
         private static readonly EventHubSettings EventHubConfig = new EventHubSettings(StorageTestConstants.EventHubConnectionString,
             EHConsumerGroup, EHPath);
@@ -59,7 +59,7 @@ namespace UnitTests.StreamingTests
             {
                 var settings = new Dictionary<string, string>();
                 // get initial settings from configs
-                ProviderConfig.WriteProperties(settings);
+                ProviderSettings.WriteProperties(settings);
                 EventHubConfig.WriteProperties(settings);
                 CheckpointerSettings.WriteProperties(settings);
 

--- a/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
@@ -24,9 +24,9 @@ namespace Tester.TestStreamProviders.EventHub
             {
                 if (timePurgePredicate != null)
                 {
-                    timePurgePredicate = new TimePurgePredicate(adapterConfig.DataMinTimeInCache, adapterConfig.DataMaxAgeInCache);
+                    timePurgePredicate = new TimePurgePredicate(adapterSettings.DataMinTimeInCache, adapterSettings.DataMaxAgeInCache);
                 }
-                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterConfig.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
+                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterSettings.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
                 var dataAdapter = new CachedDataAdapter(partition, bufferPool, timePurgePredicate);
                 return new EventHubQueueCache(checkpointer, dataAdapter, log);
             }


### PR DESCRIPTION
Inconsistently named things "Settings" or "Config".  Now we consistently use "Settings"
Inconsistently used nameof vs. hard coded names in parameter validation.  Now we always use nameof.
Added more xml comments along the way.