### PR TITLE
Serialize Type & RuntimeType using AssemblyQualifiedName

### DIFF
--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -1637,12 +1637,12 @@ namespace Orleans.Serialization
 
         internal static void SerializeType(object obj, BinaryTokenStreamWriter stream, Type expected)
         {
-            stream.Write(((Type)obj).OrleansTypeName());
+            stream.Write(((Type)obj).AssemblyQualifiedName);
         }
 
         internal static object DeserializeType(Type expected, BinaryTokenStreamReader stream)
         {
-            return SerializationManager.ResolveTypeName(stream.ReadString());
+            return Type.GetType(stream.ReadString(), throwOnError: true);
         }
 
         internal static object CopyType(object obj)

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -292,6 +292,9 @@ namespace Orleans.Serialization
             Register(typeof(TimeSpan), BuiltInTypes.CopyTimeSpan, BuiltInTypes.SerializeTimeSpan, BuiltInTypes.DeserializeTimeSpan);
             Register(typeof(DateTimeOffset), BuiltInTypes.CopyDateTimeOffset, BuiltInTypes.SerializeDateTimeOffset, BuiltInTypes.DeserializeDateTimeOffset);
             Register(typeof(Type), BuiltInTypes.CopyType, BuiltInTypes.SerializeType, BuiltInTypes.DeserializeType);
+            // ReSharper disable once PossibleMistakenCallToGetType.2
+            // Register a serializer for RuntimeType
+            Register(typeof(Type).GetType(), BuiltInTypes.CopyType, BuiltInTypes.SerializeType, BuiltInTypes.DeserializeType);
             Register(typeof(Guid), BuiltInTypes.CopyGuid, BuiltInTypes.SerializeGuid, BuiltInTypes.DeserializeGuid);
             Register(typeof(IPAddress), BuiltInTypes.CopyIPAddress, BuiltInTypes.SerializeIPAddress, BuiltInTypes.DeserializeIPAddress);
             Register(typeof(IPEndPoint), BuiltInTypes.CopyIPEndPoint, BuiltInTypes.SerializeIPEndPoint, BuiltInTypes.DeserializeIPEndPoint);

--- a/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
+++ b/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
@@ -68,6 +68,17 @@ namespace UnitTests.Serialization
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
         [InlineData(SerializerToUse.Fallback)]
+        public void Serialize_Type(SerializerToUse serializerToUse)
+        {
+            InitializeSerializer(serializerToUse);
+            var expected = new List<string>().GetType();
+            var actual = (Type)OrleansSerializationLoop(typeof(List<string>));
+            Assert.Equal(expected.TypeHandle, actual.TypeHandle);
+        }
+
+        [Theory, TestCategory("Functional"), TestCategory("Serialization")]
+        [InlineData(SerializerToUse.Default)]
+        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_ActivationAddress(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);


### PR DESCRIPTION
This is a fix + test case for #2156.

It is a work-in-progress & is not expected to be committed as-is, since the presence of version & key info in assembly names is not ideal for most users.