### PR TITLE
Remove MarshalByRefObject where it is not needed

### DIFF
--- a/src/Orleans/Runtime/AsynchAgent.cs
+++ b/src/Orleans/Runtime/AsynchAgent.cs
@@ -3,7 +3,7 @@ using System.Threading;
 
 namespace Orleans.Runtime
 {
-    internal abstract class AsynchAgent : MarshalByRefObject, IDisposable
+    internal abstract class AsynchAgent : IDisposable
     {
         public enum FaultBehavior
         {

--- a/src/Orleans/Statistics/ClientTableStatistics.cs
+++ b/src/Orleans/Statistics/ClientTableStatistics.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Orleans.Runtime
 {
-    internal class ClientTableStatistics : MarshalByRefObject, IClientPerformanceMetrics
+    internal class ClientTableStatistics : IClientPerformanceMetrics
     {
         private readonly IMessageCenter mc;
         private readonly IClientMetricsDataPublisher metricsDataPublisher;


### PR DESCRIPTION
(and not supported in .NET Standard)