### PR TITLE
IL-based fallback serializer

### DIFF
--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -893,6 +893,32 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Returns the <see cref="PropertyInfo"/> for the simple member access in the provided <paramref name="expression"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The containing type of the property.
+        /// </typeparam>
+        /// <typeparam name="TResult">
+        /// The return type of the property.
+        /// </typeparam>
+        /// <param name="expression">
+        /// The expression.
+        /// </param>
+        /// <returns>
+        /// The <see cref="PropertyInfo"/> for the simple member access call in the provided <paramref name="expression"/>.
+        /// </returns>
+        public static PropertyInfo Property<T, TResult>(Expression<Func<T, TResult>> expression)
+        {
+            var property = expression.Body as MemberExpression;
+            if (property != null)
+            {
+                return property.Member as PropertyInfo;
+            }
+
+            throw new ArgumentException("Expression type unsupported.");
+        }
+
+        /// <summary>
         /// Returns the <see cref="MemberInfo"/> for the simple member access in the provided <paramref name="expression"/>.
         /// </summary>
         /// <typeparam name="T">
@@ -966,6 +992,26 @@ namespace Orleans.Runtime
         /// <param name="expression">The expression.</param>
         /// <returns>The <see cref="MethodInfo"/> for the simple method call in the provided <paramref name="expression"/>.</returns>
         public static MethodInfo Method<T>(Expression<Action<T>> expression)
+        {
+            var methodCall = expression.Body as MethodCallExpression;
+            if (methodCall != null)
+            {
+                return methodCall.Method;
+            }
+
+            throw new ArgumentException("Expression type unsupported.");
+        }
+
+        /// <summary>
+        /// Returns the <see cref="MethodInfo"/> for the simple method call in the provided <paramref name="expression"/>.
+        /// </summary>
+        /// <param name="expression">
+        /// The expression.
+        /// </param>
+        /// <returns>
+        /// The <see cref="MethodInfo"/> for the simple method call in the provided <paramref name="expression"/>.
+        /// </returns>
+        public static MethodInfo Method(Expression<Action> expression)
         {
             var methodCall = expression.Body as MethodCallExpression;
             if (methodCall != null)

--- a/src/Orleans/Configuration/OrleansConfiguration.xsd
+++ b/src/Orleans/Configuration/OrleansConfiguration.xsd
@@ -249,6 +249,22 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
+      <xs:element name="FallbackSerializationProvider" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the fallback serialization provider, which is used for objects which can not otherwise be serialized.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="type" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                The fully qualified type name of a non-abstract, non-generic class that has a default parameterless constructor and implements Orleans.Serialization.IExternalSerializer
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
     </xs:sequence>
     <xs:attribute name="ResponseTimeout" type="tns:TimeSpan" use="optional">
       <xs:annotation>

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -135,8 +135,15 @@
     <Compile Include="IDs\UniqueKey.cs" />
     <Compile Include="Core\IGrainFactory.cs" />
     <Compile Include="Runtime\IGrainRuntime.cs" />
+    <Compile Include="Serialization\IlBasedFallbackSerializer.cs" />
+    <Compile Include="Serialization\IlCodeGenerationException.cs" />
+    <Compile Include="Serialization\IlBasedSerializers.cs" />
+    <Compile Include="Serialization\IlBasedSerializerGenerator.cs" />
+    <Compile Include="Serialization\IlBasedSerializerTypeChecker.cs" />
+    <Compile Include="Serialization\IlDelegateBuilder.cs" />
     <Compile Include="Serialization\OrleansJsonSerializer.cs" />
     <Compile Include="Serialization\BinaryFormatterSerializer.cs" />
+    <Compile Include="Serialization\ReflectedSerializationMethodInfo.cs" />
     <Compile Include="Streams\Core\StreamIdentity.cs" />
     <Compile Include="Streams\Internal\StreamHandshakeToken.cs" />
     <Compile Include="Streams\PersistentStreams\IDeploymentConfiguration.cs" />

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -132,7 +132,7 @@ namespace Orleans
 
             if (!LogManager.IsInitialized) LogManager.Initialize(config);
             StatisticsCollector.Initialize(config);
-            SerializationManager.Initialize(cfg.SerializationProviders);
+            SerializationManager.Initialize(cfg.SerializationProviders, cfg.FallbackSerializationProvider);
             logger = LogManager.GetLogger("OutsideRuntimeClient", LoggerType.Runtime);
             appLogger = LogManager.GetLogger("Application", LoggerType.Application);
 

--- a/src/Orleans/Serialization/ILBasedFallbackSerializer.cs
+++ b/src/Orleans/Serialization/ILBasedFallbackSerializer.cs
@@ -1,0 +1,107 @@
+﻿namespace Orleans.Serialization
+{
+    using System;
+    using System.Reflection;
+
+    using Orleans.Runtime;
+    
+    /// <summary>
+    /// Fallback serializer to be used when other serializers are unavailable.
+    /// </summary>
+    public class IlBasedFallbackSerializer : IExternalSerializer
+    {
+        private readonly IlBasedSerializers serializers;
+        
+        public IlBasedFallbackSerializer()
+        {
+            this.serializers = new IlBasedSerializers();
+        }
+
+        /// <summary>
+        /// Initializes the external serializer. Called once when the serialization manager creates 
+        /// an instance of this type
+        /// </summary>
+        public void Initialize(Logger logger)
+        {
+        }
+
+        /// <summary>
+        /// Informs the serialization manager whether this serializer supports the type for serialization.
+        /// </summary>
+        /// <param name="t">The type of the item to be serialized</param>
+        /// <returns>A value indicating whether the item can be serialized.</returns>
+        public bool IsSupportedType(Type t) => IlBasedSerializerTypeChecker.IsSupportedType(t.GetTypeInfo());
+
+        /// <summary>
+        /// Tries to create a copy of source.
+        /// </summary>
+        /// <param name="source">The item to create a copy of</param>
+        /// <returns>The copy</returns>
+        public object DeepCopy(object source)
+        {
+            if (source == null) return null;
+            return this.serializers.Get(source.GetType()).DeepCopy(source);
+        }
+
+        /// <summary>
+        /// Tries to serialize an item.
+        /// </summary>
+        /// <param name="item">The instance of the object being serialized</param>
+        /// <param name="writer">The writer used for serialization</param>
+        /// <param name="expectedType">The type that the deserializer will expect</param>
+        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        {
+            if (item == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            var actualType = item.GetType();
+            this.WriteType(actualType, expectedType, writer);
+            this.serializers.Get(actualType).Serialize(item, writer, expectedType);
+        }
+
+        /// <summary>
+        /// Tries to deserialize an item.
+        /// </summary>
+        /// <param name="reader">The reader used for binary deserialization</param>
+        /// <param name="expectedType">The type that should be deserialzied</param>
+        /// <returns>The deserialized object</returns>
+        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        {
+            var token = reader.ReadToken();
+            if (token == SerializationTokenType.Null) return null;
+            var actualType = this.ReadType(token, reader, expectedType);
+            var methods = this.serializers.Get(actualType);
+            var deserializer = methods.Deserialize;
+            return deserializer(expectedType, reader);
+        }
+        
+        private void WriteType(Type actualType, Type expectedType, BinaryTokenStreamWriter writer)
+        {
+            if (actualType == expectedType)
+            {
+                writer.Write((byte)SerializationTokenType.ExpectedType);
+            }
+            else
+            {
+                writer.Write((byte)SerializationTokenType.NamedType);
+                writer.Write(actualType.AssemblyQualifiedName);
+            }
+        }
+
+        private Type ReadType(SerializationTokenType token, BinaryTokenStreamReader reader, Type expectedType)
+        {
+            switch (token)
+            {
+                case SerializationTokenType.ExpectedType:
+                    return expectedType;
+                case SerializationTokenType.NamedType:
+                    return Type.GetType(reader.ReadString(), throwOnError: true);
+                default:
+                    throw new NotSupportedException($"{nameof(SerializationTokenType)} of {token} is not supported.");
+            }
+        }
+    }
+}

--- a/src/Orleans/Serialization/IlBasedSerializerGenerator.cs
+++ b/src/Orleans/Serialization/IlBasedSerializerGenerator.cs
@@ -1,0 +1,219 @@
+namespace Orleans.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    using Orleans.Runtime;
+
+    internal class IlBasedSerializerGenerator
+    {
+        private readonly ReflectedSerializationMethodInfo methods = new ReflectedSerializationMethodInfo();
+
+        private readonly SerializationManager.DeepCopier immutableTypeCopier = obj => obj;
+
+        /// <summary>
+        /// Generates a serializer for the specified type.
+        /// </summary>
+        /// <param name="type">The type to generate the serializer for.</param>
+        /// <param name="serializationFieldsFilter">
+        /// The predicate used in addition to the default logic to select which fields are included in serialization and deserialization.
+        /// </param>
+        /// <param name="copyFieldsFilter">
+        /// The predicate used in addition to the default logic to select which fields are included in copying.
+        /// </param>
+        /// <returns>The generated serializer.</returns>
+        public SerializationManager.SerializerMethods GenerateSerializer(
+            Type type,
+            Func<FieldInfo, bool> serializationFieldsFilter = null,
+            Func<FieldInfo, bool> copyFieldsFilter = null)
+        {
+            try
+            {
+                var serializationFields = this.GetFields(type, serializationFieldsFilter);
+                List<FieldInfo> copyFields;
+                if (copyFieldsFilter == serializationFieldsFilter)
+                {
+                    copyFields = serializationFields;
+                }
+                else
+                {
+                    copyFields = this.GetFields(type, copyFieldsFilter);
+                }
+
+                SerializationManager.DeepCopier copier;
+                if (type.IsOrleansShallowCopyable()) copier = this.immutableTypeCopier;
+                else copier = this.EmitCopier(type, copyFields).Build();
+
+                var serializer = this.EmitSerializer(type, serializationFields);
+                var deserializer = this.EmitDeserializer(type, serializationFields);
+                return new SerializationManager.SerializerMethods(copier, serializer.Build(), deserializer.Build());
+            }
+            catch (Exception exception)
+            {
+                throw new IlCodeGenerationException($"Serializer generation failed for type {type}", exception);
+            }
+        }
+
+        private IlDelegateBuilder<SerializationManager.DeepCopier> EmitCopier(Type type, List<FieldInfo> fields)
+        {
+            var builder = new IlDelegateBuilder<SerializationManager.DeepCopier>(
+                type.Name + "DeepCopier",
+                this.methods,
+                this.methods.DeepCopierDelegate);
+
+            // Declare local variables.
+            var result = builder.DeclareLocal(type);
+            var typedInput = builder.DeclareLocal(type);
+
+            // Set the typed input variable from the method parameter.
+            builder.LoadArgument(0);
+            builder.CastOrUnbox(type);
+            builder.StoreLocal(typedInput);
+
+            // Construct the result.
+            builder.CreateInstance(type, result);
+
+            // Record the object.
+            builder.Call(this.methods.GetCurrentSerializationContext);
+            builder.LoadArgument(0); // Load 'original' parameter.
+            builder.LoadLocal(result); // Load 'result' local.
+            builder.BoxIfValueType(type);
+            builder.Call(this.methods.RecordObjectWhileCopying);
+
+            // Copy each field.
+            foreach (var field in fields)
+            {
+                // Load the field.
+                builder.LoadLocalAsReference(type, result);
+                builder.LoadLocal(typedInput);
+                builder.LoadField(field);
+
+                // Deep-copy the field if needed, otherwise just leave it as-is.
+                if (!field.FieldType.IsOrleansShallowCopyable())
+                {
+                    builder.BoxIfValueType(field.FieldType);
+                    builder.Call(this.methods.DeepCopyInner);
+                    builder.CastOrUnbox(field.FieldType);
+                }
+
+                // Store the copy of the field on the result.
+                builder.StoreField(field);
+            }
+
+            builder.LoadLocal(result);
+            builder.BoxIfValueType(type);
+            builder.Return();
+            return builder;
+        }
+
+        private IlDelegateBuilder<SerializationManager.Serializer> EmitSerializer(Type type, List<FieldInfo> fields)
+        {
+            var builder = new IlDelegateBuilder<SerializationManager.Serializer>(
+                type.Name + "Serializer",
+                this.methods,
+                this.methods.SerializerDelegate);
+
+            // Declare local variables.
+            var typedInput = builder.DeclareLocal(type);
+
+            // Set the typed input variable from the method parameter.
+            builder.LoadArgument(0);
+            builder.CastOrUnbox(type);
+            builder.StoreLocal(typedInput);
+
+            // Serialize each field
+            foreach (var field in fields)
+            {
+                // Load the field.
+                builder.LoadLocal(typedInput);
+                builder.LoadField(field);
+                builder.BoxIfValueType(field.FieldType);
+
+                // Serialize the field.
+                builder.LoadArgument(1);
+                builder.LoadType(field.FieldType);
+                builder.Call(this.methods.SerializeInner);
+            }
+
+            builder.Return();
+            return builder;
+        }
+
+        private IlDelegateBuilder<SerializationManager.Deserializer> EmitDeserializer(Type type, List<FieldInfo> fields)
+        {
+            var builder = new IlDelegateBuilder<SerializationManager.Deserializer>(
+                type.Name + "Deserializer",
+                this.methods,
+                this.methods.DeserializerDelegate);
+
+            // Declare local variables.
+            var result = builder.DeclareLocal(type);
+
+            // Construct the result.
+            builder.CreateInstance(type, result);
+
+            // Record the object.
+            builder.Call(this.methods.GetCurrentDeserializationContext);
+            builder.LoadLocal(result);
+            builder.BoxIfValueType(type);
+            builder.Call(this.methods.RecordObjectWhileDeserializing);
+
+            // Deserialize each field.
+            foreach (var field in fields)
+            {
+                // Deserialize the field.
+                builder.LoadLocalAsReference(type, result);
+                builder.LoadType(field.FieldType);
+                builder.LoadArgument(1);
+                builder.Call(this.methods.DeserializeInner);
+
+                // Store the value on the result.
+                builder.CastOrUnbox(field.FieldType);
+                builder.StoreField(field);
+            }
+
+            builder.LoadLocal(result);
+            builder.BoxIfValueType(type);
+            builder.Return();
+            return builder;
+        }
+
+        /// <summary>
+        /// Returns a sorted list of the fields of the provided type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="fieldFilter">The predicate used in addition to the default logic to select which fields are included.</param>
+        /// <returns>A sorted list of the fields of the provided type.</returns>
+        private List<FieldInfo> GetFields(Type type, Func<FieldInfo, bool> fieldFilter = null)
+        {
+            var result = type.GetAllFields().Where(
+                field =>
+#if !NETSTANDARD
+                !field.IsNotSerialized &&
+#endif
+                !field.IsStatic && IlBasedSerializerTypeChecker.IsSupportedFieldType(field.FieldType.GetTypeInfo())
+                && (fieldFilter == null || fieldFilter(field))).ToList();
+            result.Sort(FieldInfoComparer.Instance);
+            return result;
+        }
+
+        /// <summary>
+        /// A comparer for <see cref="FieldInfo"/> which compares by name.
+        /// </summary>
+        private class FieldInfoComparer : IComparer<FieldInfo>
+        {
+            /// <summary>
+            /// Gets the singleton instance of this class.
+            /// </summary>
+            public static FieldInfoComparer Instance { get; } = new FieldInfoComparer();
+
+            public int Compare(FieldInfo x, FieldInfo y)
+            {
+                return string.Compare(x.Name, y.Name, StringComparison.Ordinal);
+            }
+        }
+
+    }
+}

--- a/src/Orleans/Serialization/IlBasedSerializerTypeChecker.cs
+++ b/src/Orleans/Serialization/IlBasedSerializerTypeChecker.cs
@@ -1,0 +1,39 @@
+namespace Orleans.Serialization
+{
+    using System;
+    using System.Reflection;
+
+    internal static class IlBasedSerializerTypeChecker
+    {
+        private static readonly RuntimeTypeHandle[] UnsupportedTypeHandles =
+        {
+            typeof(IntPtr).TypeHandle,
+            typeof(UIntPtr).TypeHandle,
+        };
+
+        private static readonly TypeInfo[] UnsupportedBaseTypes = { typeof(Delegate).GetTypeInfo() };
+
+        public static bool IsSupportedType(TypeInfo t)
+        {
+            return !t.IsAbstract && !t.IsInterface && !t.IsArray && IsSupportedFieldType(t);
+        }
+
+        public static bool IsSupportedFieldType(TypeInfo t)
+        {
+            if (t.IsPointer || t.IsByRef) return false;
+
+            var handle = t.AsType().TypeHandle;
+            for (var i = 0; i < UnsupportedTypeHandles.Length; i++)
+            {
+                if (handle.Equals(UnsupportedTypeHandles[i])) return false;
+            }
+
+            for (var i = 0; i < UnsupportedBaseTypes.Length; i++)
+            {
+                if (UnsupportedBaseTypes[i].IsAssignableFrom(t)) return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Orleans/Serialization/IlBasedSerializers.cs
+++ b/src/Orleans/Serialization/IlBasedSerializers.cs
@@ -1,0 +1,113 @@
+﻿namespace Orleans.Serialization
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq;
+    using System.Reflection;
+
+    using GeneratedSerializer = SerializationManager.SerializerMethods;
+
+    public class IlBasedSerializers
+    {
+        /// <summary>
+        /// The collection of generated serializers.
+        /// </summary>
+        private readonly ConcurrentDictionary<Type, GeneratedSerializer> serializers = new ConcurrentDictionary<Type, GeneratedSerializer>();
+
+        /// <summary>
+        /// The serializer generator.
+        /// </summary>
+        private readonly IlBasedSerializerGenerator generator = new IlBasedSerializerGenerator();
+
+        /// <summary>
+        /// The serializer used when a concrete type is not known.
+        /// </summary>
+        private readonly GeneratedSerializer genericSerializer;
+
+        /// <summary>
+        /// The serializer used for implementations of <see cref="Type"/>.
+        /// </summary>
+        private readonly GeneratedSerializer typeSerializer;
+
+        public IlBasedSerializers()
+        {
+            // Configure the serializer to be used when a concrete type is not known.
+            // The serializer will generate and register serializers for concrete types
+            // as they are discovered.
+            this.genericSerializer = new GeneratedSerializer(
+                original =>
+                {
+                    if (original == null)
+                    {
+                        return null;
+                    }
+
+                    return this.GetAndRegister(original.GetType()).DeepCopy(original);
+                },
+                (original, writer, expected) =>
+                {
+                    if (original == null)
+                    {
+                        writer.WriteNull();
+                        return;
+                    }
+
+                    this.GetAndRegister(original.GetType()).Serialize(original, writer, expected);
+                },
+                (expected, reader) => this.GetAndRegister(expected).Deserialize(expected, reader));
+
+            this.typeSerializer = new GeneratedSerializer(
+                original => original,
+                (original, writer, expected) => { writer.Write(((Type)original).AssemblyQualifiedName); },
+                (expected, reader) => Type.GetType(reader.ReadString(), throwOnError: true));
+        }
+
+        /// <summary>
+        /// Gets a serializer for the provided type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>The serializer for the provided type.</returns>
+        public GeneratedSerializer Get(Type type)
+        {
+            if (type.GetTypeInfo().IsGenericTypeDefinition) return this.genericSerializer;
+            return this.serializers.GetOrAdd(type, this.GenerateSerializer);
+        }
+
+        /// <summary>
+        /// Gets a serializer for the provided type, registers it, and returns it.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>The serializer for the provided type.</returns>
+        private GeneratedSerializer GetAndRegister(Type type)
+        {
+            var methods = this.Get(type);
+            SerializationManager.Register(type, methods.DeepCopy, methods.Serialize, methods.Deserialize, forceOverride: true);
+            return methods;
+        }
+
+        private GeneratedSerializer GenerateSerializer(Type type)
+        {
+            if (typeof(Type).IsAssignableFrom(type))
+            {
+                return this.typeSerializer;
+            }
+
+            Func<FieldInfo, bool> fieldFilter = null;
+            if (typeof(Exception).IsAssignableFrom(type))
+            {
+                fieldFilter = this.ExceptionFieldFilter;
+            }
+
+            return this.generator.GenerateSerializer(type, fieldFilter);
+        }
+        
+        private bool ExceptionFieldFilter(FieldInfo arg)
+        {
+            // Any field defined below Exception is acceptable.
+            if (arg.DeclaringType != typeof(Exception)) return true;
+
+            // Certain fields from the Exception base class are acceptable.
+            return arg.FieldType == typeof(string) || arg.FieldType == typeof(Exception);
+        }
+    }
+}

--- a/src/Orleans/Serialization/IlCodeGenerationException.cs
+++ b/src/Orleans/Serialization/IlCodeGenerationException.cs
@@ -1,0 +1,25 @@
+namespace Orleans.Serialization
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    using Orleans.Runtime;
+
+    [Serializable]
+    public class IlCodeGenerationException : OrleansException
+    {
+        public IlCodeGenerationException()
+        {
+        }
+
+        public IlCodeGenerationException(string message)
+            : base(message)
+        {
+        }
+
+        public IlCodeGenerationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Orleans/Serialization/IlDelegateBuilder.cs
+++ b/src/Orleans/Serialization/IlDelegateBuilder.cs
@@ -1,0 +1,242 @@
+namespace Orleans.Serialization
+{
+    using System;
+    using System.Reflection;
+    using System.Reflection.Emit;
+
+    internal class IlDelegateBuilder<TDelegate>
+        where TDelegate : class
+    {
+        private readonly DynamicMethod dynamicMethod;
+
+        private readonly ILGenerator il;
+
+        private readonly ReflectedSerializationMethodInfo methods;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="IlDelegateBuilder{TDelegate}"/> class.
+        /// </summary>
+        /// <param name="name">The name of the new delegate.</param>
+        /// <param name="methods">The reflected methods used during delegate creation.</param>
+        /// <param name="methodInfo">
+        /// The method info for <typeparamref name="TDelegate"/> delegates, used for determining parameter types.
+        /// </param>
+        public IlDelegateBuilder(string name, ReflectedSerializationMethodInfo methods, MethodInfo methodInfo)
+        {
+            this.methods = methods;
+            var returnType = methodInfo.ReturnType;
+            var parameterTypes = GetParameterTypes(methodInfo);
+            this.dynamicMethod = new DynamicMethod(name, returnType, parameterTypes, typeof(IlDelegateBuilder<>).GetTypeInfo().Module, true);
+            this.il = this.dynamicMethod.GetILGenerator();
+        }
+
+        /// <summary>
+        /// Declares a local variable with the specified type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>The newly declared local.</returns>
+        public Local DeclareLocal(Type type) => new IlGeneratorLocal(this.il.DeclareLocal(type));
+
+        /// <summary>
+        /// Loads the argument at the given index onto the stack.
+        /// </summary>
+        /// <param name="index">
+        /// The index of the argument to load.
+        /// </param>
+        public void LoadArgument(ushort index) => this.il.Emit(OpCodes.Ldarg, index);
+
+        /// <summary>
+        /// Pops the stack and stores it in the specified local.
+        /// </summary>
+        /// <param name="local">The local variable to store into.</param>
+        public void StoreLocal(Local local) => this.il.Emit(OpCodes.Stloc, (IlGeneratorLocal)local);
+
+        /// <summary>
+        /// Pushes the specified local onto the stack.
+        /// </summary>
+        /// <param name="local">The local variable to load from.</param>
+        public void LoadLocal(Local local) => this.il.Emit(OpCodes.Ldloc, (IlGeneratorLocal)local);
+
+        /// <summary>
+        /// Loads the specified field onto the stack from the referenced popped from the stack.
+        /// </summary>
+        /// <param name="field">The field.</param>
+        public void LoadField(FieldInfo field) => this.il.Emit(OpCodes.Ldfld, field);
+
+        /// <summary>
+        /// Boxes the value on the top of the stack.
+        /// </summary>
+        /// <param name="type">The value type.</param>
+        public void Box(Type type) => this.il.Emit(OpCodes.Box, type);
+
+        /// <summary>
+        /// Loads the specified type and pushes it onto the stack.
+        /// </summary>
+        /// <param name="type">The type to load.</param>
+        public void LoadType(Type type)
+        {
+            this.il.Emit(OpCodes.Ldtoken, type);
+            this.Call(this.methods.GetTypeFromHandle);
+        }
+
+        /// <summary>
+        /// Calls the specified method.
+        /// </summary>
+        /// <param name="method">The method to call.</param>
+        public void Call(MethodInfo method) => this.il.Emit(OpCodes.Call, method);
+
+        /// <summary>
+        /// Returns from the current method.
+        /// </summary>
+        public void Return() => this.il.Emit(OpCodes.Ret);
+
+        /// <summary>
+        /// Pops the value on the top of the stack and stores it in the specified field on the object popped from the top of the stack.
+        /// </summary>
+        /// <param name="field">The field to store into.</param>
+        public void StoreField(FieldInfo field) => this.il.Emit(OpCodes.Stfld, field);
+
+        /// <summary>
+        /// Pushes the address of the specified local onto the stack.
+        /// </summary>
+        /// <param name="local">The local variable.</param>
+        public void LoadLocalAddress(Local local) => this.il.Emit(OpCodes.Ldloca, (IlGeneratorLocal)local);
+
+        /// <summary>
+        /// Unboxes the value on the top of the stack.
+        /// </summary>
+        /// <param name="type">The value type.</param>
+        public void UnboxAny(Type type) => this.il.Emit(OpCodes.Unbox_Any, type);
+
+        /// <summary>
+        /// Casts the object on the top of the stack to the specified type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        public void CastClass(Type type) => this.il.Emit(OpCodes.Castclass, type);
+
+        /// <summary>
+        /// Initializes the value type on the stack, setting all fields to their default value.
+        /// </summary>
+        /// <param name="type">The value type.</param>
+        public void InitObject(Type type) => this.il.Emit(OpCodes.Initobj, type);
+
+        /// <summary>
+        /// Constructs a new instance of the object with the specified constructor.
+        /// </summary>
+        /// <param name="constructor">The constructor to call.</param>
+        public void NewObject(ConstructorInfo constructor)
+        {
+            this.il.Emit(OpCodes.Newobj, constructor);
+        }
+
+        /// <summary>
+        /// Builds a delegate from the previously emitted instructions.
+        /// </summary>
+        /// <returns>The delegate.</returns>
+        public TDelegate Build() => this.dynamicMethod.CreateDelegate(typeof(TDelegate)) as TDelegate;
+
+        /// <summary>
+        /// Pushes the specified local variable as a reference onto the stack.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="local">The local.</param>
+        public void LoadLocalAsReference(Type type, Local local)
+        {
+            if (type.GetTypeInfo().IsValueType)
+            {
+                this.LoadLocalAddress(local);
+            }
+            else
+            {
+                this.LoadLocal(local);
+            }
+        }
+
+        /// <summary>
+        /// Boxes the value on the top of the stack if it's a value type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        public void BoxIfValueType(Type type)
+        {
+            if (type.GetTypeInfo().IsValueType)
+            {
+                this.Box(type);
+            }
+        }
+
+        /// <summary>
+        /// Casts or unboxes the value at the top of the stack into the specified type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        public void CastOrUnbox(Type type)
+        {
+            if (type.GetTypeInfo().IsValueType)
+            {
+                this.UnboxAny(type);
+            }
+            else
+            {
+                this.CastClass(type);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new instance of the specified type and stores it in the specified local.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="local">The local.</param>
+        public void CreateInstance(Type type, Local local)
+        {
+            var constructorInfo = type.GetConstructor(Type.EmptyTypes);
+            if (type.GetTypeInfo().IsValueType)
+            {
+                this.LoadLocalAddress(local);
+                this.InitObject(type);
+            }
+            else if (constructorInfo != null)
+            {
+                // Use the default constructor.
+                this.NewObject(constructorInfo);
+                this.StoreLocal(local);
+            }
+            else
+            {
+                this.LoadType(type);
+                this.Call(this.methods.GetUninitializedObject);
+                this.CastClass(type);
+                this.StoreLocal(local);
+            }
+        }
+
+        private static Type[] GetParameterTypes(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+            var result = new Type[parameters.Length];
+            for (var i = 0; i < parameters.Length; ++i)
+            {
+                result[i] = parameters[i].ParameterType;
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Represents a local variable created via a call to <see cref="DeclareLocal"/>.
+        /// </summary>
+        internal abstract class Local
+        {
+        }
+
+        private class IlGeneratorLocal : Local
+        {
+            private readonly LocalBuilder value;
+
+            public IlGeneratorLocal(LocalBuilder value)
+            {
+                this.value = value;
+            }
+
+            public static implicit operator LocalBuilder(IlGeneratorLocal local) => local.value;
+        }
+    }
+}

--- a/src/Orleans/Serialization/ReflectedSerializationMethodInfo.cs
+++ b/src/Orleans/Serialization/ReflectedSerializationMethodInfo.cs
@@ -1,0 +1,97 @@
+namespace Orleans.Serialization
+{
+    using System;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+
+    using Orleans.Runtime;
+
+    /// <summary>
+    /// Holds references to methods which are used during serialization.
+    /// </summary>
+    internal class ReflectedSerializationMethodInfo
+    {
+        /// <summary>
+        /// A reference to the <see cref="SerializationContext.Current"/> getter method.
+        /// </summary>
+        public readonly MethodInfo GetCurrentSerializationContext;
+
+        /// <summary>
+        /// A reference to the <see cref="SerializationContext.RecordObject(object, object)"/> method.
+        /// </summary>
+        public readonly MethodInfo RecordObjectWhileCopying;
+
+        /// <summary>
+        /// A reference to <see cref="SerializationManager.DeepCopyInner"/>
+        /// </summary>
+        public readonly MethodInfo DeepCopyInner;
+
+        /// <summary>
+        /// A reference to the <see cref="SerializationManager.SerializeInner(object, BinaryTokenStreamWriter, Type)"/> method.
+        /// </summary>
+        public readonly MethodInfo SerializeInner;
+
+        /// <summary>
+        /// A reference to the <see cref="SerializationManager.DeserializeInner(Type, BinaryTokenStreamReader)"/> method.
+        /// </summary>
+        public readonly MethodInfo DeserializeInner;
+
+        /// <summary>
+        /// A reference to the <see cref="DeserializationContext.RecordObject(object)"/> method.
+        /// </summary>
+        public readonly MethodInfo RecordObjectWhileDeserializing;
+
+        /// <summary>
+        /// A reference to the getter for <see cref="DeserializationContext.Current"/>.
+        /// </summary>
+        public readonly MethodInfo GetCurrentDeserializationContext;
+
+        /// <summary>
+        /// A reference to a method which returns an uninitialized object of the provided type.
+        /// </summary>
+        public readonly MethodInfo GetUninitializedObject;
+
+        /// <summary>
+        /// A reference to <see cref="Type.GetTypeFromHandle"/>.
+        /// </summary>
+        public readonly MethodInfo GetTypeFromHandle;
+
+        /// <summary>
+        /// The <see cref="MethodInfo"/> for the <see cref="SerializationManager.Serializer"/> delegate.
+        /// </summary>
+        public readonly MethodInfo SerializerDelegate;
+
+        /// <summary>
+        /// The <see cref="MethodInfo"/> for the <see cref="SerializationManager.Deserializer"/> delegate.
+        /// </summary>
+        public readonly MethodInfo DeserializerDelegate;
+
+        /// <summary>
+        /// The <see cref="MethodInfo"/> for the <see cref="SerializationManager.DeepCopier"/> delegate.
+        /// </summary>
+        public readonly MethodInfo DeepCopierDelegate;
+
+        public ReflectedSerializationMethodInfo()
+        {
+#if NETSTANDARD
+            this.GetUninitializedObject = TypeUtils.Method(() => SerializationManager.GetUninitializedObjectWithFormatterServices(typeof(int)));
+#else
+            this.GetUninitializedObject = TypeUtils.Method(() => FormatterServices.GetUninitializedObject(typeof(int)));
+#endif
+            this.GetTypeFromHandle = TypeUtils.Method(() => Type.GetTypeFromHandle(typeof(int).TypeHandle));
+            this.DeepCopyInner = TypeUtils.Method(() => SerializationManager.DeepCopyInner(typeof(int)));
+            this.SerializeInner = TypeUtils.Method(() => SerializationManager.SerializeInner(default(object), default(BinaryTokenStreamWriter), default(Type)));
+            this.DeserializeInner = TypeUtils.Method(() => SerializationManager.DeserializeInner(default(Type), default(BinaryTokenStreamReader)));
+
+            this.GetCurrentSerializationContext = TypeUtils.Property((object _) => SerializationContext.Current).GetMethod;
+            this.RecordObjectWhileCopying = TypeUtils.Method((SerializationContext ctx) => ctx.RecordObject(default(object), default(object)));
+
+            this.GetCurrentDeserializationContext = TypeUtils.Property((object _) => DeserializationContext.Current).GetMethod;
+            this.RecordObjectWhileDeserializing = TypeUtils.Method((DeserializationContext ctx) => ctx.RecordObject(default(object)));
+            this.SerializerDelegate =
+                TypeUtils.Method((SerializationManager.Serializer del) => del.Invoke(default(object), default(BinaryTokenStreamWriter), default(Type)));
+            this.DeserializerDelegate = TypeUtils.Method((SerializationManager.Deserializer del) => del.Invoke(default(Type), default(BinaryTokenStreamReader)));
+            this.DeepCopierDelegate = TypeUtils.Method((SerializationManager.DeepCopier del) => del.Invoke(default(object)));
+        }
+    }
+}

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -185,7 +185,7 @@ namespace Orleans.Runtime
             ActivationData.Init(config, nodeConfig);
             StatisticsCollector.Initialize(nodeConfig);
             
-            SerializationManager.Initialize(globalConfig.SerializationProviders);
+            SerializationManager.Initialize(globalConfig.SerializationProviders, this.globalConfig.FallbackSerializationProvider);
             initTimeout = globalConfig.MaxJoinAttemptTime;
             if (Debugger.IsAttached)
             {

--- a/test/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/test/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -122,13 +122,24 @@ namespace UnitTests.GrainInterfaces
 
         public List<ISomeInterface> Interfaces { get; set; }
 
-        public List<SomeAbstractClass> Classes { get; set; }
+        public SomeAbstractClass[] Classes { get; set; }
 
         [Obsolete("This field should not be serialized", true)]
         public int ObsoleteIntWithError { get; set; }
 
         [Obsolete("This field should be serialized")]
         public int ObsoleteInt { get; set; }
+        
+
+        #pragma warning disable 618
+        public int GetObsoleteInt() => this.ObsoleteInt;
+        public void SetObsoleteInt(int value)
+        {
+            this.ObsoleteInt = value;
+        }
+        #pragma warning restore 618
+
+        public SomeEnum Enum { get; set; }
 
         public int NonSerializedInt
         {
@@ -156,12 +167,39 @@ namespace UnitTests.GrainInterfaces
 
     public class OuterClass
     {
+        public static SomeConcreteClass GetPrivateClassInstance() => new PrivateConcreteClass(Guid.NewGuid());
+
+        public static Type GetPrivateClassType() => typeof(PrivateConcreteClass);
+
         [Serializable]
         public class SomeConcreteClass : SomeAbstractClass
         {
             public override int Int { get; set; }
 
             public string String { get; set; }
+
+            private PrivateConcreteClass secretPrivateClass;
+
+            public void ConfigureSecretPrivateClass()
+            {
+                this.secretPrivateClass = new PrivateConcreteClass(Guid.NewGuid());
+            }
+
+            public bool AreSecretBitsIdentitcal(SomeConcreteClass other)
+            {
+                return other.secretPrivateClass?.Identity == this.secretPrivateClass?.Identity;
+            }
+        }
+
+        [Serializable]
+        private class PrivateConcreteClass : SomeConcreteClass
+        {
+            public PrivateConcreteClass(Guid identity)
+            {
+                this.Identity = identity;
+            }
+
+            public readonly Guid Identity;
         }
     }
 

--- a/test/Tester/CodeGenTests/GeneratorGrainTest.cs
+++ b/test/Tester/CodeGenTests/GeneratorGrainTest.cs
@@ -40,7 +40,7 @@ namespace Tester.CodeGenTests
 
             // Test abstract class serialization.
             var input = new OuterClass.SomeConcreteClass { Int = 89, String = Guid.NewGuid().ToString() };
-            input.Classes = new List<SomeAbstractClass>
+            input.Classes = new SomeAbstractClass[]
             {
                 input,
                 new AnotherConcreteClass
@@ -49,25 +49,19 @@ namespace Tester.CodeGenTests
                     Interfaces = new List<ISomeInterface> { input }
                 }
             };
-
-            // Set fields which should not be serialized.
-#pragma warning disable 618
-            input.ObsoleteInt = 38;
-#pragma warning restore 618
-
+            input.SetObsoleteInt(38);
+            input.Enum = SomeAbstractClass.SomeEnum.SomethingElse;
             input.NonSerializedInt = 39;
 
             var output = await grain.RoundTripClass(input);
 
             Assert.Equal(input.Int, output.Int);
+            Assert.Equal(input.Enum, output.Enum);
             Assert.Equal(input.String, ((OuterClass.SomeConcreteClass)output).String);
-            Assert.Equal(input.Classes.Count, output.Classes.Count);
+            Assert.Equal(input.Classes.Length, output.Classes.Length);
             Assert.Equal(input.String, ((OuterClass.SomeConcreteClass)output.Classes[0]).String);
             Assert.Equal(input.Classes[1].Interfaces[0].Int, output.Classes[1].Interfaces[0].Int);
-
-#pragma warning disable 618
-            Assert.Equal(input.ObsoleteInt, output.ObsoleteInt);
-#pragma warning restore 618
+            Assert.Equal(input.GetObsoleteInt(), output.GetObsoleteInt());
             
             Assert.Equal(0, output.NonSerializedInt);
 
@@ -76,12 +70,10 @@ namespace Tester.CodeGenTests
             output = await grain.GetState();
             Assert.Equal(input.Int, output.Int);
             Assert.Equal(input.String, ((OuterClass.SomeConcreteClass)output).String);
-            Assert.Equal(input.Classes.Count, output.Classes.Count);
+            Assert.Equal(input.Classes.Length, output.Classes.Length);
             Assert.Equal(input.String, ((OuterClass.SomeConcreteClass)output.Classes[0]).String);
             Assert.Equal(input.Classes[1].Interfaces[0].Int, output.Classes[1].Interfaces[0].Int);
-#pragma warning disable 618
-            Assert.Equal(input.ObsoleteInt, output.ObsoleteInt);
-#pragma warning restore 618
+            Assert.Equal(input.GetObsoleteInt(), output.GetObsoleteInt());
             Assert.Equal(0, output.NonSerializedInt);
 
             // Test interface serialization.

--- a/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
+++ b/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.CodeGeneration;
 using Orleans.Concurrency;
-using Orleans.GrainDirectory;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
@@ -51,17 +50,17 @@ namespace UnitTests.Serialization
         private void InitializeSerializer(SerializerToUse serializerToUse)
         {
             List<TypeInfo> serializationProviders = null;
-            IExternalSerializer fallback = null;
+            TypeInfo fallback = null;
             switch (serializerToUse)
             {
                 case SerializerToUse.Default:
                     break;
                 case SerializerToUse.IlBasedFallbackSerializer:
-                    fallback = new IlBasedFallbackSerializer();
+                    fallback = typeof(IlBasedFallbackSerializer).GetTypeInfo();
                     break;
 #if !NETSTANDARD_TODO
                 case SerializerToUse.BinaryFormatterFallbackSerializer:
-                    fallback = new BinaryFormatterSerializer();
+                    fallback = typeof(BinaryFormatterSerializer).GetTypeInfo();
                     break;
 #endif
                 default:

--- a/test/TesterInternal/Serialization/IlBasedSerializerTests.cs
+++ b/test/TesterInternal/Serialization/IlBasedSerializerTests.cs
@@ -1,0 +1,109 @@
+namespace UnitTests.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using Orleans.Serialization;
+
+    using UnitTests.GrainInterfaces;
+
+    using Xunit;
+
+    public class IlBasedSerializerTests
+    {
+        public IlBasedSerializerTests()
+        {
+            SerializationManager.InitializeForTesting(new List<TypeInfo>
+            {
+                typeof(IlBasedFallbackSerializer).GetTypeInfo()
+            });
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IlBasedSerializerGenerator"/> supports distinct field selection for serialization
+        /// versus copy operations.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
+        public void IlBasedSerializer_AllowCopiedFieldsToDifferFromSerializedFields()
+        {
+            var input = new FieldTest
+            {
+                One = 1,
+                Two = 2,
+                Three = 3
+            };
+
+            var generator = new IlBasedSerializerGenerator();
+            var serializers = generator.GenerateSerializer(input.GetType(), f => f.Name != "One", f => f.Name != "Three");
+            var copy = (FieldTest)serializers.DeepCopy(input);
+            Assert.Equal(1, copy.One);
+            Assert.Equal(2, copy.Two);
+            Assert.Equal(0, copy.Three);
+
+            var writer = new BinaryTokenStreamWriter();
+            serializers.Serialize(input, writer, input.GetType());
+            var reader = new BinaryTokenStreamReader(writer.ToByteArray());
+            var deserialized = (FieldTest)serializers.Deserialize(input.GetType(), reader);
+
+            Assert.Equal(0, deserialized.One);
+            Assert.Equal(2, deserialized.Two);
+            Assert.Equal(3, deserialized.Three);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
+        public void IlBasedSerializer_CanSerializeComplexClassTest()
+        {
+            var input = OuterClass.GetPrivateClassInstance();
+            input.Int = 89;
+            input.String = Guid.NewGuid().ToString();
+            input.NonSerializedInt = 39;
+            input.Classes = new SomeAbstractClass[]
+            {
+                input,
+                new AnotherConcreteClass
+                {
+                    AnotherString = "hi",
+                    Interfaces = new List<ISomeInterface> { input }
+                }
+            };
+            input.Enum = SomeAbstractClass.SomeEnum.Something;
+            input.SetObsoleteInt(38);
+            
+            var output = (SomeAbstractClass)BuiltInSerializerTests.OrleansSerializationLoop(input);
+
+            Assert.Equal(input.Int, output.Int);
+            Assert.Equal(input.Enum, output.Enum);
+            Assert.Equal(input.String, ((OuterClass.SomeConcreteClass)output).String);
+            Assert.Equal(input.Classes.Length, output.Classes.Length);
+            Assert.Equal(input.String, ((OuterClass.SomeConcreteClass)output.Classes[0]).String);
+            Assert.Equal(input.Classes[1].Interfaces[0].Int, output.Classes[1].Interfaces[0].Int);
+            Assert.Equal(0, output.NonSerializedInt);
+            Assert.Equal(input.GetObsoleteInt(), output.GetObsoleteInt());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
+        public void IlBasedSerializer_CanSerializeStructTest()
+        {
+            // Test struct serialization.
+            var expectedStruct = new SomeStruct(10) { Id = Guid.NewGuid(), PublicValue = 6, ValueWithPrivateGetter = 7 };
+            expectedStruct.SetValueWithPrivateSetter(8);
+            expectedStruct.SetPrivateValue(9);
+            var actualStruct = (SomeStruct)BuiltInSerializerTests.OrleansSerializationLoop(expectedStruct);
+            Assert.Equal(expectedStruct.Id, actualStruct.Id);
+            Assert.Equal(expectedStruct.ReadonlyField, actualStruct.ReadonlyField);
+            Assert.Equal(expectedStruct.PublicValue, actualStruct.PublicValue);
+            Assert.Equal(expectedStruct.ValueWithPrivateSetter, actualStruct.ValueWithPrivateSetter);
+            Assert.Equal(expectedStruct.GetPrivateValue(), actualStruct.GetPrivateValue());
+            Assert.Equal(expectedStruct.GetValueWithPrivateGetter(), actualStruct.GetValueWithPrivateGetter());
+        }
+
+        private class FieldTest
+        {
+#pragma warning disable 169
+            public int One;
+            public int Two;
+            public int Three;
+#pragma warning restore 169
+        }
+    }
+}

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -1021,40 +1021,6 @@ namespace UnitTests.StorageTests
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Serialization")]
-        public async Task Grain_Serialize_Func()
-        {
-            Guid id = Guid.NewGuid();
-            ISerializationTestGrain grain = GrainClient.GrainFactory.GetGrain<ISerializationTestGrain>(id);
-            await grain.Test_Serialize_Func();
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Serialization")]
-        public async Task Grain_Serialize_Predicate()
-        {
-            Guid id = Guid.NewGuid();
-            ISerializationTestGrain grain = GrainClient.GrainFactory.GetGrain<ISerializationTestGrain>(id);
-            await grain.Test_Serialize_Predicate();
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Serialization")]
-        public async Task Grain_Serialize_Predicate_Class()
-        {
-            Guid id = Guid.NewGuid();
-            ISerializationTestGrain grain = GrainClient.GrainFactory.GetGrain<ISerializationTestGrain>(id);
-            await grain.Test_Serialize_Predicate_Class();
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Serialization")]
-        public async Task Grain_Serialize_Predicate_Class_Param()
-        {
-            Guid id = Guid.NewGuid();
-            ISerializationTestGrain grain = GrainClient.GrainFactory.GetGrain<ISerializationTestGrain>(id);
-
-            IMyPredicate pred = new MyPredicate(42);
-            await grain.Test_Serialize_Predicate_Class_Param(pred);
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Serialization")]
         public void Serialize_GrainState_DeepCopy()
         {
             // NOTE: This test requires Silo to be running & Client init so that grain references can be resolved before serialization.

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -63,6 +63,7 @@
     <Compile Include="OrleansRuntime\Streams\SubscriptionMarkerTests.cs" />
     <Compile Include="RemindersTest\DynamoDBRemindersTableTests.cs" />
     <Compile Include="RemindersTest\PostgreSqlRemindersTableTests.cs" />
+    <Compile Include="Serialization\IlBasedSerializerTests.cs" />
     <Compile Include="SqlStatisticsPublisherTests\PostgreSqlStatisticsPublisherTests.cs" />
     <Compile Include="StorageTests\AWSUtils\AWSTestConstants.cs" />
     <Compile Include="StorageTests\AWSUtils\Base_PersistenceGrainTests_AWSStore.cs" />

--- a/vNext/src/Orleans/Orleans.csproj
+++ b/vNext/src/Orleans/Orleans.csproj
@@ -589,6 +589,27 @@
     <Compile Include="..\..\..\src\Orleans\Serialization\TypeUtilities.cs">
       <Link>Serialization\TypeUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\src\Orleans\Serialization\IlBasedFallbackSerializer.cs">
+      <Link>Serialization\IlBasedFallbackSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\src\Orleans\Serialization\IlBasedSerializerGenerator.cs">
+      <Link>Serialization\IlBasedSerializerGenerator.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\src\Orleans\Serialization\IlBasedSerializers.cs">
+      <Link>Serialization\IlBasedSerializers.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\src\Orleans\Serialization\IlBasedSerializerTypeChecker.cs">
+      <Link>Serialization\IlBasedSerializerTypeChecker.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\src\Orleans\Serialization\IlCodeGenerationException.cs">
+      <Link>Serialization\IlCodeGenerationException.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\src\Orleans\Serialization\IlDelegateBuilder.cs">
+      <Link>Serialization\IlDelegateBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\src\Orleans\Serialization\ReflectedSerializationMethodInfo.cs">
+      <Link>Serialization\ReflectedSerializationMethodInfo.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\src\Orleans\Statistics\ApplicationRequestsStatisticsGroup.cs">
       <Link>Statistics\ApplicationRequestsStatisticsGroup.cs</Link>
     </Compile>


### PR DESCRIPTION
This is an implementation of a *fallback* serializer which is intended to replace `BinaryFormatter` as a part of the .NET Core initiative.

This serializer is very similar to the current Roslyn-based serializers except that instead of emitting C# code, it emits IL directly at runtime, allowing it to access private members and types.

The bulk of the logic is in `IlBasedSerializerGenerator`, which I hope is easy enough to follow.

IL generation is abstracted via a simple facade called `IlDelegateBuilder<TDelegate>` which is based on on .NET's `ILGenerator`.
The usage of the class is as follows:
1. Instantiate the builder with the type of delegate being built (eg, `DeepCopier`).
2. Call methods on the builder to add instructions to it.
3. Call `Build()` to create the final delegate.

Please let me know what you think.