### PR TITLE
Recover types from ReflectionTypeLoadException

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyLoaderReflectionCriterion.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoaderReflectionCriterion.cs
@@ -39,10 +39,10 @@ namespace Orleans.Runtime
             return NewCriterion(
                     (Assembly assembly, out IEnumerable<string> assemblyComplaints) =>
                     {
-                        Type[] types;
+                        TypeInfo[] types;
                         try
                         {
-                            types = assembly.DefinedTypes.ToArray();
+                            types = TypeUtils.GetDefinedTypes(assembly, null).ToArray();
                         }
                         catch (ReflectionTypeLoadException e)
                         {

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -561,7 +561,7 @@ namespace Orleans.Runtime
             }
             catch (Exception exception)
             {
-                if (logger.IsWarning)
+                if (logger!= null && logger.IsWarning)
                 {
                     var message =
                         string.Format(
@@ -569,6 +569,13 @@ namespace Orleans.Runtime
                             assembly.FullName,
                             exception);
                     logger.Warn(ErrorCode.Loader_TypeLoadError_5, message, exception);
+                }
+                
+                var typeLoadException = exception as ReflectionTypeLoadException;
+                if (typeLoadException != null)
+                {
+                    return typeLoadException.Types?.Where(type => type != null).Select(type => type.GetTypeInfo()) ??
+                           Enumerable.Empty<TypeInfo>();
                 }
 
                 return Enumerable.Empty<TypeInfo>();

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -561,13 +561,9 @@ namespace Orleans.Runtime
             }
             catch (Exception exception)
             {
-                if (logger!= null && logger.IsWarning)
+                if (logger != null && logger.IsWarning)
                 {
-                    var message =
-                        string.Format(
-                            "AssemblyLoader encountered an exception loading types from assembly '{0}': {1}",
-                            assembly.FullName,
-                            exception);
+                    var message = $"AssemblyLoader encountered an exception loading types from assembly '{assembly.FullName}': {exception}";
                     logger.Warn(ErrorCode.Loader_TypeLoadError_5, message, exception);
                 }
                 

--- a/src/Orleans/Providers/ProviderTypeLoader.cs
+++ b/src/Orleans/Providers/ProviderTypeLoader.cs
@@ -73,7 +73,7 @@ namespace Orleans.Providers
 
             try
             {
-                foreach (var type in assembly.DefinedTypes)
+                foreach (var type in TypeUtils.GetDefinedTypes(assembly, logger))
                 {
                     ProcessType(type);
                 }
@@ -94,7 +94,7 @@ namespace Orleans.Providers
                 // We assume that it's better to fetch and iterate through the list of types once,
                 // and the list of TypeManagers many times, rather than the other way around.
                 // Certainly it can't be *less* efficient to do it this way.
-                foreach (var type in args.LoadedAssembly.DefinedTypes)
+                foreach (var type in TypeUtils.GetDefinedTypes(args.LoadedAssembly, logger))
                 {
                     foreach (var mgr in managers)
                     {

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -326,7 +326,7 @@ namespace Orleans.CodeGenerator
                 KnownAssemblyAttribute knownAssemblyAttribute;
                 var considerAllTypesForSerialization = knownAssemblyAttributes.TryGetValue(assembly, out knownAssemblyAttribute)
                                           && knownAssemblyAttribute.TreatTypesAsSerializable;
-                foreach (var type in assembly.DefinedTypes)
+                foreach (var type in TypeUtils.GetDefinedTypes(assembly, Logger))
                 {
                     var considerForSerialization = considerAllTypesForSerialization || type.GetTypeInfo().IsSerializable;
                     ConsiderType(type, runtime, targetAssembly, includedTypes, considerForSerialization);
@@ -503,8 +503,8 @@ namespace Orleans.CodeGenerator
             // Get assemblies which contain generated code.
             var all =
                 AppDomain.CurrentDomain.GetAssemblies()
-                    .Where(_ => _.GetCustomAttribute<GeneratedCodeAttribute>() != null)
-                    .SelectMany(_ => _.DefinedTypes);
+                    .Where(assemblies => assemblies.GetCustomAttribute<GeneratedCodeAttribute>() != null)
+                    .SelectMany(assembly => TypeUtils.GetDefinedTypes(assembly, Logger));
 
             // Get all generated types in each assembly.
             var attributes = all.SelectMany(_ => _.GetCustomAttributes<GeneratedAttribute>());


### PR DESCRIPTION
There are several places where we enumerate all types in an assembly.
When a type cannot be initialized for some reason, a `ReflectionTypeLoadException` is thrown. Types can fail to initialize for a variety of reasons including failure to load referenced types or static constructor exceptions.
Currently we bail out at that point and do not process any types for that assembly.
`ReflectionTypeLoadException` has a `Types` property which contains an array of the types which were successfully loaded.

This change salvages those types which were successfully loaded.