### PR TITLE
Use the ISerializable subset available in .NET Standard

### DIFF
--- a/src/Orleans/Core/Exceptions.cs
+++ b/src/Orleans/Core/Exceptions.cs
@@ -22,11 +22,12 @@ namespace Orleans.Runtime
         public OrleansException(string message) : base(message) { }
 
         public OrleansException(string message, Exception innerException) : base(message, innerException) { }
-
+#if !NETSTANDARD
         protected OrleansException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
+#endif
     }
 
     /// <summary>
@@ -47,10 +48,12 @@ namespace Orleans.Runtime
 
         public GatewayTooBusyException(string message, Exception innerException) : base(message, innerException) { }
 
+#if !NETSTANDARD
         protected GatewayTooBusyException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
+#endif
     }
 
     /// <summary>
@@ -75,10 +78,12 @@ namespace Orleans.Runtime
         public LimitExceededException(string limitName, int current, int threshold, object extraInfo) 
             : base(string.Format("Limit exceeded {0} Current={1} Threshold={2} {3}", limitName, current, threshold, extraInfo)) { }
 
+#if !NETSTANDARD
         protected LimitExceededException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
+#endif
     }
 
     /// <summary>
@@ -113,6 +118,7 @@ namespace Orleans.Runtime
             CallChain = callChain.Select(req => new Tuple<GrainId, string>(req.GrainId, req.DebugContext)).ToList();
         }
 
+#if !NETSTANDARD
         protected DeadlockException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -131,6 +137,7 @@ namespace Orleans.Runtime
 
             base.GetObjectData(info, context);
         }
+#endif
     }
 
     /// <summary>
@@ -143,9 +150,11 @@ namespace Orleans.Runtime
         public GrainExtensionNotInstalledException(string msg) : base(msg) { }
         public GrainExtensionNotInstalledException(string message, Exception innerException) : base(message, innerException) { }
 
+#if !NETSTANDARD
         protected GrainExtensionNotInstalledException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
+#endif
     }
 
     /// <summary>
@@ -158,9 +167,11 @@ namespace Orleans.Runtime
         public SiloUnavailableException(string msg) : base(msg) { }
         public SiloUnavailableException(string message, Exception innerException) : base(message, innerException) { }
 
+#if !NETSTANDARD
         protected SiloUnavailableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
+#endif
     }
 
     /// <summary>
@@ -173,9 +184,11 @@ namespace Orleans.Runtime
         public InvalidSchedulingContextException(string msg) : base(msg) { }
         public InvalidSchedulingContextException(string message, Exception innerException) : base(message, innerException) { }
 
+#if !NETSTANDARD
         protected InvalidSchedulingContextException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
+#endif
     }
 
     /// <summary>
@@ -188,9 +201,11 @@ namespace Orleans.Runtime
         internal ClientNotAvailableException(string msg) : base(msg) { }
         internal ClientNotAvailableException(string message, Exception innerException) : base(message, innerException) { }
 
+#if !NETSTANDARD
         protected ClientNotAvailableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
+#endif
     }
 }
 

--- a/src/Orleans/Providers/IOrleansProvider.cs
+++ b/src/Orleans/Providers/IOrleansProvider.cs
@@ -176,8 +176,10 @@ namespace Orleans.Providers
         public ProviderInitializationException(string msg, Exception exc)
             : base(msg, exc)
         { }
+#if !NETSTANDARD
         protected ProviderInitializationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
+#endif
     }
 }

--- a/src/Orleans/Providers/IStorageProvider.cs
+++ b/src/Orleans/Providers/IStorageProvider.cs
@@ -69,9 +69,11 @@ namespace Orleans.Storage
         public BadProviderConfigException(string msg, Exception exc)
             : base(msg, exc)
         { }
+#if !NETSTANDARD
         protected BadProviderConfigException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
+#endif
     }
 
     /// <summary>
@@ -94,9 +96,11 @@ namespace Orleans.Storage
         public InconsistentStateException(string msg, Exception exc)
             : base(msg, exc)
         { }
+#if !NETSTANDARD
         protected InconsistentStateException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {}
+#endif
 
         public InconsistentStateException(
           string errorMsg,

--- a/src/Orleans/Providers/ProviderStateManager.cs
+++ b/src/Orleans/Providers/ProviderStateManager.cs
@@ -83,10 +83,12 @@ namespace Orleans.Providers
 
         public ProviderStateException(string message, Exception innerException) : base(message, innerException) { }
 
+#if !NETSTANDARD
         protected ProviderStateException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
+#endif
     }
 
 }

--- a/src/Orleans/Streams/PersistentStreams/StreamEventDeliveryFailureException.cs
+++ b/src/Orleans/Streams/PersistentStreams/StreamEventDeliveryFailureException.cs
@@ -18,6 +18,8 @@ namespace Orleans.Streams
         internal StreamEventDeliveryFailureException(StreamId streamId)
             : base(string.Format(ErrorStringFormat, streamId.ProviderName, streamId)) { }
         public StreamEventDeliveryFailureException(string message, Exception innerException) : base(message, innerException) { }
+#if !NETSTANDARD
         public StreamEventDeliveryFailureException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
     }
 }

--- a/src/Orleans/Streams/Providers/IStreamProviderImpl.cs
+++ b/src/Orleans/Streams/Providers/IStreamProviderImpl.cs
@@ -25,8 +25,10 @@ namespace Orleans.Streams
         public ProviderStartException(string msg, Exception exc)
             : base(msg, exc)
         { }
+#if !NETSTANDARD
         protected ProviderStartException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
+#endif
     }
 }

--- a/src/Orleans/Streams/PubSub/FaultedSubscriptionException.cs
+++ b/src/Orleans/Streams/PubSub/FaultedSubscriptionException.cs
@@ -19,6 +19,8 @@ namespace Orleans.Streams
         internal FaultedSubscriptionException(GuidId subscriptionId, StreamId streamId)
             : base(string.Format(ErrorStringFormat, subscriptionId.Guid, streamId)) { }
         public FaultedSubscriptionException(string message, Exception innerException) : base(message, innerException) { }
+#if !NETSTANDARD
         public FaultedSubscriptionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
     }
 }

--- a/src/Orleans/Streams/QueueAdapters/DataNotAvailableException.cs
+++ b/src/Orleans/Streams/QueueAdapters/DataNotAvailableException.cs
@@ -14,9 +14,11 @@ namespace Orleans.Streams
         public DataNotAvailableException(string message) : base(message) { }
         public DataNotAvailableException(string message, Exception inner) : base(message, inner) { }
 
+#if !NETSTANDARD
         public DataNotAvailableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/Orleans/Streams/QueueAdapters/QueueCacheMissException.cs
+++ b/src/Orleans/Streams/QueueAdapters/QueueCacheMissException.cs
@@ -33,6 +33,7 @@ namespace Orleans.Streams
             High = high;
         }
 
+#if !NETSTANDARD
         public QueueCacheMissException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -48,5 +49,6 @@ namespace Orleans.Streams
             info.AddValue("High", High);
             base.GetObjectData(info, context);
         }
+#endif
     }
 }

--- a/src/Orleans/Timers/IRemindable.cs
+++ b/src/Orleans/Timers/IRemindable.cs
@@ -82,10 +82,12 @@ namespace Orleans
         {
             public ReminderException(string msg) : base(msg) { }
 
+#if !NETSTANDARD
             public ReminderException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {
             }
+#endif
         }
 
         #endregion

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -46,6 +46,7 @@ namespace Orleans.Runtime
                 PrimaryDirectoryForGrain = primaryDirectoryForGrain;
             }
 
+#if !NETSTANDARD
             // Implementation of exception serialization with custom properties according to:
             // http://stackoverflow.com/questions/94488/what-is-the-correct-way-to-make-a-custom-net-exception-serializable
             protected DuplicateActivationException(SerializationInfo info, StreamingContext context)
@@ -68,6 +69,7 @@ namespace Orleans.Runtime
                 // MUST call through to the base class to let it save its own state
                 base.GetObjectData(info, context);
             }
+#endif
         }
 
         [Serializable]
@@ -89,6 +91,7 @@ namespace Orleans.Runtime
                 IsStatelessWorker = isStatelessWorker;
             }
 
+#if !NETSTANDARD
             protected NonExistentActivationException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {
@@ -109,6 +112,7 @@ namespace Orleans.Runtime
                 // MUST call through to the base class to let it save its own state
                 base.GetObjectData(info, context);
             }
+#endif
         }
 
 
@@ -323,7 +327,7 @@ namespace Orleans.Runtime
             return report;
         }
 
-        #region MessageTargets
+#region MessageTargets
 
         /// <summary>
         /// Register a new object to which messages can be delivered with the local lookup table and scheduler.
@@ -374,9 +378,9 @@ namespace Orleans.Runtime
             return numActsBefore;
         }
 
-        #endregion
+#endregion
 
-        #region Grains
+#region Grains
 
         internal bool IsReentrantGrain(ActivationId running)
         {
@@ -393,9 +397,9 @@ namespace Orleans.Runtime
             GrainTypeManager.GetTypeInfo(typeCode, out grainClass, out placement, out activationStrategy, genericArguments);
         }
 
-        #endregion
+#endregion
 
-        #region Activations
+#region Activations
 
         public int ActivationCount { get { return activations.Count; } }
 
@@ -1198,8 +1202,8 @@ namespace Orleans.Runtime
             // We currently don't have any other case for multiple activations except for StatelessWorker. 
         }
 
-        #endregion
-        #region Activations - private
+#endregion
+#region Activations - private
 
         /// <summary>
         /// Invoke the activate method on a newly created activation
@@ -1217,8 +1221,8 @@ namespace Orleans.Runtime
             return scheduler.QueueTask(() => CallGrainActivate(activation, requestContextData), new SchedulingContext(activation)); // Target grain's scheduler context);
             // ActivationData will transition out of ActivationState.Activating via Dispatcher.OnActivationCompletedRequest
         }
-        #endregion
-        #region IPlacementContext
+#endregion
+#region IPlacementContext
 
         public Logger Logger => logger;
 
@@ -1256,8 +1260,8 @@ namespace Orleans.Runtime
             }
         }
 
-        #endregion
-        #region Implementation of ICatalog
+#endregion
+#region Implementation of ICatalog
 
         public Task CreateSystemGrain(GrainId grainId, string grainType)
         {
@@ -1286,9 +1290,9 @@ namespace Orleans.Runtime
             return datas;
         }
 
-        #endregion
+#endregion
 
-        #region Implementation of ISiloStatusListener
+#region Implementation of ISiloStatusListener
 
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
         {
@@ -1347,6 +1351,6 @@ namespace Orleans.Runtime
             }
         }
 
-        #endregion
+#endregion
     }
 }


### PR DESCRIPTION
Support is in preview via the System.Runtime.Serialization.Formatters package, but system types such as exceptions do not implement ISerializable nor have the constructors for serialization.