### PR TITLE
Centralize platform info logging

### DIFF
--- a/src/Orleans/Configuration/ConfigUtilities.cs
+++ b/src/Orleans/Configuration/ConfigUtilities.cs
@@ -619,7 +619,8 @@ namespace Orleans.Runtime.Configuration
         public static string RuntimeVersionInfo()
         {
             var sb = new StringBuilder();
-#if !NETSTANDARD
+            sb.Append("   Orleans version: ").AppendLine(RuntimeVersion.Current);
+#if !NETSTANDARD_TODO
 			// TODO: could use Microsoft.Extensions.PlatformAbstractions package to get this info
             sb.Append("   .NET version: ").AppendLine(Environment.Version.ToString());
             sb.Append("   Is .NET 4.5=").AppendLine(IsNet45OrNewer().ToString());

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -211,8 +211,8 @@ namespace Orleans.Runtime
 
             logger.Info(ErrorCode.SiloInitializing, "-------------- Initializing {0} silo on host {1} MachineName {2} at {3}, gen {4} --------------",
                 siloType, nodeConfig.DNSHostName, Environment.MachineName, here, generation);
-            logger.Info(ErrorCode.SiloInitConfig, "Starting silo {0} with runtime Version='{1}' .NET version='{2}' Is .NET 4.5={3} OS version='{4}' Config= " + Environment.NewLine + "{5}",
-                name, RuntimeVersion.Current, Environment.Version, ConfigUtilities.IsNet45OrNewer(), Environment.OSVersion, config.ToString(name));
+            logger.Info(ErrorCode.SiloInitConfig, "Starting silo {0} with the following configuration= " + Environment.NewLine + "{1}",
+                name, config.ToString(name));
 
             if (keyStore != null)
             {


### PR DESCRIPTION
There was duplicate info being logged already, and it was also spread out in multiple files. This way it's in a single location that can be fixed in 1 go for .NET Standard