### PR TITLE
Remove WorkingStorageDirectory property

### DIFF
--- a/src/Orleans/Configuration/NodeConfiguration.cs
+++ b/src/Orleans/Configuration/NodeConfiguration.cs
@@ -197,15 +197,6 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public StatisticsLevel StatisticsCollectionLevel { get; set; }
 
-        private string workingStoreDir;
-        /// <summary>
-        /// </summary>
-        internal string WorkingStorageDirectory
-        {
-            get { return workingStoreDir ?? (workingStoreDir = GetDefaultWorkingStoreDirectory()); }
-            set { workingStoreDir = value; }
-        }
-
         /// <summary>
         /// </summary>
         public int MinDotNetThreadPoolSize { get; set; }
@@ -498,13 +489,6 @@ namespace Orleans.Runtime.Configuration
 
                 }
             }
-        }
-
-        private string GetDefaultWorkingStoreDirectory()
-        {
-            string workingStoreLocation = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
-            string cacheDirBase = Path.Combine(workingStoreLocation, "OrleansData");
-            return cacheDirBase;
         }
     }
 }


### PR DESCRIPTION
This was dead code and also causing issues in .NET Standard, since `Environment.SpecialFolder.LocalApplicationData` is not available