### PR TITLE
Make IGrainFactory injectable

### DIFF
--- a/src/OrleansRuntime/Startup/StartupBuilder.cs
+++ b/src/OrleansRuntime/Startup/StartupBuilder.cs
@@ -47,11 +47,11 @@ namespace Orleans.Runtime.Startup
 
         private static void RegisterSystemTypes(IServiceCollection serviceCollection)
         {
-            // Register the system classes and grains in this method.
-            // Note: this method will probably have to be moved out into the Silo class to include internal runtime types.
-
-            serviceCollection.AddTransient<GrainBasedMembershipTable>();
-            serviceCollection.AddTransient<GrainBasedReminderTable>();
+            // add system types
+            // Note: you can replace IGrainFactory with your own implementation, but 
+            // we don't recommend it, in the aspect of performance and usability
+            serviceCollection.AddSingleton<GrainFactory>((_sp) => new GrainFactory());
+            serviceCollection.AddSingleton<IGrainFactory>((sp) => sp.GetService<GrainFactory>());
         }
 
         private static ConfigureServicesBuilder FindConfigureServicesDelegate(Type startupType)

--- a/test/TestGrainInterfaces/ISimpleDIGrain.cs
+++ b/test/TestGrainInterfaces/ISimpleDIGrain.cs
@@ -8,4 +8,9 @@ namespace UnitTests.GrainInterfaces
         Task<long> GetTicksFromService();
         Task<string> GetStringValue();
     }
+
+    public interface IDIGrainWithInjectedServices : ISimpleDIGrain
+    {
+        Task<long> GetGrainFactoryId();
+    }
 }

--- a/test/TestGrains/SimpleDIGrain.cs
+++ b/test/TestGrains/SimpleDIGrain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Orleans;
 using UnitTests.GrainInterfaces;
@@ -6,13 +7,22 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    public class SimpleDIGrain : Grain, ISimpleDIGrain
+    public class DIGrainWithInjectedServices : Grain, IDIGrainWithInjectedServices
     {
         private readonly IInjectedService injectedService;
+        private readonly IGrainFactory injectedGrainFactory;
+        private readonly long grainFactoryId;
+        public static readonly ObjectIDGenerator ObjectIdGenerator = new ObjectIDGenerator();
 
-        public SimpleDIGrain(IInjectedService injectedService)
+        public DIGrainWithInjectedServices(IInjectedService injectedService, IGrainFactory injectedGrainFactory)
         {
             this.injectedService = injectedService;
+            this.injectedGrainFactory = injectedGrainFactory;
+            bool set;
+            // get the object Id for injected GrainFactory, 
+            // object Id will be the same if the underlying object is the same,
+            // this is one way to prove that this GrainFactory is injected from DI
+            this.grainFactoryId = ObjectIdGenerator.GetId(this.injectedGrainFactory, out set);
         }
 
         public Task<long> GetTicksFromService()
@@ -23,6 +33,11 @@ namespace UnitTests.Grains
         public Task<string> GetStringValue()
         {
             return Task.FromResult(this.injectedService.GetInstanceValue());
+        }
+
+        public Task<long> GetGrainFactoryId()
+        {
+            return Task.FromResult(this.grainFactoryId);
         }
     }
 

--- a/test/Tester/DependencyInjectionGrainTests.cs
+++ b/test/Tester/DependencyInjectionGrainTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
@@ -12,6 +13,7 @@ using Xunit;
 
 namespace UnitTests.General
 {
+    [TestCategory("DI")]
     public class DependencyInjectionGrainTests : OrleansTestingBase, IClassFixture<DependencyInjectionGrainTests.Fixture>
     {
         private class Fixture : BaseTestClusterFixture
@@ -27,20 +29,41 @@ namespace UnitTests.General
         [Fact, TestCategory("BVT"), TestCategory("Functional")]
         public async Task CanGetGrainWithInjectedDependencies()
         {
-            ISimpleDIGrain grain = GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId());
+            IDIGrainWithInjectedServices grain = GrainFactory.GetGrain<IDIGrainWithInjectedServices>(GetRandomGrainId());
             long ignored = await grain.GetTicksFromService();
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task CanGetGrainWithInjectedGrainFactory()
+        {
+            // please don't inject your implemetation of IGrainFactory to DI container in Startup Class, 
+            // since we are currently not supporting replacing IGrainFactory 
+            IDIGrainWithInjectedServices grain = GrainFactory.GetGrain<IDIGrainWithInjectedServices>(GetRandomGrainId());
+            long ignored = await grain.GetGrainFactoryId();
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional")]
         public async Task CanResolveSingletonDependencies()
         {
-            var grain1 = GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId());
-            var grain2 = GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId());
+            var grain1 = GrainFactory.GetGrain<IDIGrainWithInjectedServices>(GetRandomGrainId());
+            var grain2 = GrainFactory.GetGrain<IDIGrainWithInjectedServices>(GetRandomGrainId());
 
             // the injected service will return the same value only if it's the same instance
             Assert.Equal(
                 await grain1.GetStringValue(), 
                 await grain2.GetStringValue());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task CanResolveSingletonGrainFactory()
+        {
+            var grain1 = GrainFactory.GetGrain<IDIGrainWithInjectedServices>(GetRandomGrainId());
+            var grain2 = GrainFactory.GetGrain<IDIGrainWithInjectedServices>(GetRandomGrainId());
+
+            // the injected grain factory will return the same value only if it's the same instance,
+            Assert.Equal(
+                await grain1.GetGrainFactoryId(),
+                await grain2.GetGrainFactoryId());
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional")]
@@ -59,6 +82,8 @@ namespace UnitTests.General
         {
             services.AddSingleton<IInjectedService, InjectedService>();
 
+            // explicitly register a grain class to assert that it will NOT use the registration, 
+            // as by design this is not supported.
             services.AddTransient<ExplicitlyRegisteredSimpleDIGrain>(
                 sp => new ExplicitlyRegisteredSimpleDIGrain(
                     sp.GetRequiredService<IInjectedService>(),


### PR DESCRIPTION
Make IGrainFactory injectable. 

In the future we want to make more internal system types injectable through DI container, for application layer to use and for making orleans' DI better. This is the first step. 