### PR TITLE
Remove UseStandardSerializer option

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyProcessor.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyProcessor.cs
@@ -123,7 +123,6 @@ namespace Orleans.Runtime
             }
 
             // Process each type in the assembly.
-            var shouldProcessSerialization = SerializationManager.ShouldFindSerializationInfo(assembly);
             var assemblyTypes = TypeUtils.GetDefinedTypes(assembly, Logger).ToArray();
 
             // Process each type in the assembly.
@@ -137,10 +136,8 @@ namespace Orleans.Runtime
                     {
                         Logger.Verbose3("Processing type {0}", typeName);
                     }
-                    if (shouldProcessSerialization)
-                    {
-                        SerializationManager.FindSerializationInfo(type);
-                    }
+
+                    SerializationManager.FindSerializationInfo(type);
     
                     GrainFactory.FindSupportClasses(type);
                 }

--- a/src/Orleans/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans/Configuration/MessagingConfiguration.cs
@@ -61,13 +61,6 @@ namespace Orleans.Runtime.Configuration
         ///  This is the period of time a gateway will wait before dropping a disconnected client.
         /// </summary>
         TimeSpan ClientDropTimeout { get; set; }
-        /// <summary>
-        /// The UseStandardSerializer attribute, if provided and set to "true", forces the use of the standard .NET serializer instead
-        /// of the custom Orleans serializer.
-        /// This parameter is intended for use only for testing and troubleshooting.
-        /// In production, the custom Orleans serializer should always be used because it performs significantly better.
-        /// </summary>
-        bool UseStandardSerializer { get; set; }
 
         /// <summary>
         /// The size of a buffer in the messaging buffer pool.
@@ -113,7 +106,6 @@ namespace Orleans.Runtime.Configuration
         public int GatewaySenderQueues { get; set; }
         public int ClientSenderBuckets { get; set; }
         public TimeSpan ClientDropTimeout { get; set; }
-        public bool UseStandardSerializer { get; set; }
         public bool UseJsonFallbackSerializer { get; set; }
 
         public int BufferPoolBufferSize { get; set; }
@@ -137,7 +129,6 @@ namespace Orleans.Runtime.Configuration
         private static readonly TimeSpan DEFAULT_MAX_SOCKET_AGE = TimeSpan.MaxValue;
         internal const int DEFAULT_MAX_FORWARD_COUNT = 2;
         private const bool DEFAULT_RESEND_ON_TIMEOUT = false;
-        private const bool DEFAULT_USE_STANDARD_SERIALIZER = false;
         private static readonly int DEFAULT_SILO_SENDER_QUEUES = Environment.ProcessorCount;
         private static readonly int DEFAULT_GATEWAY_SENDER_QUEUES = Environment.ProcessorCount;
         private static readonly int DEFAULT_CLIENT_SENDER_BUCKETS = (int)Math.Pow(2, 13);
@@ -166,7 +157,6 @@ namespace Orleans.Runtime.Configuration
             GatewaySenderQueues = DEFAULT_GATEWAY_SENDER_QUEUES;
             ClientSenderBuckets = DEFAULT_CLIENT_SENDER_BUCKETS;
             ClientDropTimeout = Constants.DEFAULT_CLIENT_DROP_TIMEOUT;
-            UseStandardSerializer = DEFAULT_USE_STANDARD_SERIALIZER;
 
             BufferPoolBufferSize = DEFAULT_BUFFER_POOL_BUFFER_SIZE;
             BufferPoolMaxSize = DEFAULT_BUFFER_POOL_MAX_SIZE;
@@ -209,8 +199,6 @@ namespace Orleans.Runtime.Configuration
             {
                 sb.AppendFormat("       Client Sender Buckets: {0}", ClientSenderBuckets).AppendLine();
             }
-            sb.AppendFormat("       Use standard (.NET) serializer: {0}", UseStandardSerializer)
-                .AppendLine(isSiloConfig ? "" : "   [NOTE: This *MUST* match the setting on the server or nothing will work!]");
             sb.AppendFormat("       Use fallback json serializer: {0}", UseJsonFallbackSerializer)
                 .AppendLine(isSiloConfig ? "" : "   [NOTE: This *MUST* match the setting on the server or nothing will work!]");
             sb.AppendFormat("       Buffer Pool Buffer Size: {0}", BufferPoolBufferSize).AppendLine();
@@ -281,12 +269,6 @@ namespace Orleans.Runtime.Configuration
                     ClientSenderBuckets = ConfigUtilities.ParseInt(child.GetAttribute("ClientSenderBuckets"),
                                                             "Invalid integer value for the ClientSenderBuckets attribute on the Messaging element");
                 }
-            }
-            if (child.HasAttribute("UseStandardSerializer"))
-            {
-                UseStandardSerializer =
-                    ConfigUtilities.ParseBool(child.GetAttribute("UseStandardSerializer"),
-                                              "invalid boolean value for the UseStandardSerializer attribute on the Messaging element");
             }
 
             if (child.HasAttribute("UseJsonFallbackSerializer"))

--- a/src/Orleans/Configuration/OrleansConfiguration.xsd
+++ b/src/Orleans/Configuration/OrleansConfiguration.xsd
@@ -300,16 +300,6 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="UseStandardSerializer" type="xs:boolean" use="optional">
-      <xs:annotation>
-        <xs:documentation>
-          The UseStandardSerializer attribute, if provided and set to "true", forces the use of the standard .NET serializer instead
-          of the custom Orleans serializer.
-          This parameter is intended for use only for testing and troubleshooting.
-          In production, the custom Orleans serializer should always be used because it performs significantly better.
-        </xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="MaxForwardCount" type="xs:int" use="optional">
       <xs:annotation>
         <xs:documentation>

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -132,7 +132,7 @@ namespace Orleans
 
             if (!LogManager.IsInitialized) LogManager.Initialize(config);
             StatisticsCollector.Initialize(config);
-            SerializationManager.Initialize(config.UseStandardSerializer, cfg.SerializationProviders, config.UseJsonFallbackSerializer);
+            SerializationManager.Initialize(cfg.SerializationProviders, config.UseJsonFallbackSerializer);
             logger = LogManager.GetLogger("OutsideRuntimeClient", LoggerType.Runtime);
             appLogger = LogManager.GetLogger("Application", LoggerType.Application);
 

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -62,16 +62,6 @@ namespace Orleans.Serialization
 
         private static readonly string[] safeFailSerializers = { "Orleans.FSharp" };
 
-        /// <summary>
-        /// Toggles whether or not to use the .NET serializer (true) or the Orleans serializer (false).
-        /// This is usually set through config.
-        /// </summary>
-        internal static bool UseStandardSerializer
-        {
-            get;
-            set;
-        }
-
 #if NETSTANDARD
         // Workaround for CoreCLR where FormatterServices.GetUninitializedObject is not public (but might change in RTM so we could remove this then).
         private static readonly Func<Type, object> getUninitializedObjectDelegate =
@@ -169,10 +159,9 @@ namespace Orleans.Serialization
             }
         }
 
-        internal static void Initialize(bool useStandardSerializer, List<TypeInfo> serializationProviders, bool useJsonFallbackSerializer)
+        internal static void Initialize(List<TypeInfo> serializationProviders, bool useJsonFallbackSerializer)
         {
             RegisterBuiltInSerializers();
-            UseStandardSerializer = useStandardSerializer;
 
 #if NETSTANDARD
             if (!useJsonFallbackSerializer)
@@ -245,7 +234,6 @@ namespace Orleans.Serialization
             deserializers = new Dictionary<RuntimeTypeHandle, Deserializer>();
             grainRefConstructorDictionary = new ConcurrentDictionary<Type, Func<GrainReference, GrainReference>>();
             logger = LogManager.GetLogger("SerializationManager", LoggerType.Runtime);
-            UseStandardSerializer = false; // Default
 
             // Built-in handlers: Tuples
             Register(typeof(Tuple<>), BuiltInTypes.DeepCopyTuple, BuiltInTypes.SerializeTuple, BuiltInTypes.DeserializeTuple);
@@ -2221,14 +2209,6 @@ namespace Orleans.Serialization
             public DeepCopier DeepCopy { get; private set; }
             public Serializer Serialize { get; private set; }
             public Deserializer Deserialize { get; private set; }
-        }
-
-        public static bool ShouldFindSerializationInfo(Assembly assembly)
-        {
-            // If we're using the .Net serializer, then don't bother with this at all
-            if (UseStandardSerializer) return false;
-            
-            return true;
         }
 
         public static JsonSerializerSettings GetDefaultJsonSerializerSettings()

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -187,7 +187,7 @@ namespace Orleans.Runtime
             ActivationData.Init(config, nodeConfig);
             StatisticsCollector.Initialize(nodeConfig);
             
-            SerializationManager.Initialize(globalConfig.UseStandardSerializer, globalConfig.SerializationProviders, globalConfig.UseJsonFallbackSerializer);
+            SerializationManager.Initialize(globalConfig.SerializationProviders, globalConfig.UseJsonFallbackSerializer);
             initTimeout = globalConfig.MaxJoinAttemptTime;
             if (Debugger.IsAttached)
             {

--- a/test/TesterInternal/OrleansRuntime/ExceptionsTests.cs
+++ b/test/TesterInternal/OrleansRuntime/ExceptionsTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests.OrleansRuntime
         public ExceptionsTests()
         {
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
-            SerializationManager.Initialize(false, null, false);
+            SerializationManager.Initialize(null, false);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
+++ b/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
@@ -39,7 +39,6 @@ namespace UnitTests.Serialization
 
         private void InitializeSerializer(SerializerToUse serializerToUse)
         {
-            bool useStandardSerializer = false;
             List<System.Reflection.TypeInfo> serializationProviders = null;
             bool useJsonFallbackSerializer = false;
 
@@ -55,7 +54,7 @@ namespace UnitTests.Serialization
                     throw new InvalidOperationException("Invalid Serializer was selected");
             }
 
-            SerializationManager.Initialize(useStandardSerializer, serializationProviders, useJsonFallbackSerializer);
+            SerializationManager.Initialize(serializationProviders, useJsonFallbackSerializer);
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
         }
 
@@ -71,7 +70,6 @@ namespace UnitTests.Serialization
         public void Serialize_ActivationAddress(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            //SerializationManager.UseStandardSerializer = false;
             var grain = GrainId.NewId();
             var addr = ActivationAddress.GetAddress(null, grain, null);
             object deserialized = OrleansSerializationLoop(addr, false);
@@ -92,7 +90,6 @@ namespace UnitTests.Serialization
         public void Serialize_EmptyList(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
             var list = new List<int>();
             var deserialized = OrleansSerializationLoop(list, false);
             Assert.IsAssignableFrom<List<int>>(deserialized);  //Empty list of integers copied as wrong type"
@@ -108,7 +105,6 @@ namespace UnitTests.Serialization
         public void Serialize_BasicDictionaries(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             Dictionary<string, string> source1 = new Dictionary<string, string>();
             source1["Hello"] = "Yes";
@@ -129,7 +125,6 @@ namespace UnitTests.Serialization
         public void Serialize_ReadOnlyDictionary(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             Dictionary<string, string> source1 = new Dictionary<string, string>();
             source1["Hello"] = "Yes";
@@ -180,7 +175,6 @@ namespace UnitTests.Serialization
         public void Serialize_DictionaryWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             Dictionary<string, string> source1 = new Dictionary<string, string>(new CaseInsensitiveStringEquality());
             source1["Hello"] = "Yes";
@@ -238,8 +232,6 @@ namespace UnitTests.Serialization
         /*[Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public void Serialize_Enums()
         {
-            SerializationManager.UseStandardSerializer = false;
-
             var result = OrleansSerializationLoop(IntEnum.Value2);
             Assert.IsAssignableFrom<>(result, typeof(IntEnum), "Serialization round-trip resulted in incorrect type, " + result.GetType().Name + ", for int enum");
             Assert.Equal(IntEnum.Value2, (IntEnum)result, "Serialization round-trip resulted in incorrect value for int enum");
@@ -267,7 +259,6 @@ namespace UnitTests.Serialization
         public void Serialize_SortedDictionaryWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             var source1 = new SortedDictionary<string, string>(new CaseInsensitiveStringComparer());
             source1["Hello"] = "Yes";
@@ -282,7 +273,6 @@ namespace UnitTests.Serialization
         public void Serialize_SortedListWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             var source1 = new SortedList<string, string>(new CaseInsensitiveStringComparer());
             source1["Hello"] = "Yes";
@@ -297,7 +287,6 @@ namespace UnitTests.Serialization
         public void Serialize_HashSetWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             var source1 = new HashSet<string>(new CaseInsensitiveStringEquality());
             source1.Add("one");
@@ -320,7 +309,6 @@ namespace UnitTests.Serialization
         public void Serialize_Stack(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             var source1 = new Stack<string>();
             source1.Push("one");
@@ -345,7 +333,6 @@ namespace UnitTests.Serialization
         public void Serialize_SortedSetWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             var source1 = new SortedSet<string>(new CaseInsensitiveStringComparer());
             source1.Add("one");
@@ -368,7 +355,6 @@ namespace UnitTests.Serialization
         public void Serialize_Array(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             var source1 = new int[] { 1, 3, 5 };
             object deserialized = OrleansSerializationLoop(source1);
@@ -393,7 +379,6 @@ namespace UnitTests.Serialization
         public void Serialize_ArrayOfArrays(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             var source1 = new[] { new[] { 1, 3, 5 }, new[] { 10, 20, 30 }, new[] { 17, 13, 11, 7, 5, 3, 2 } };
             object deserialized = OrleansSerializationLoop(source1);
@@ -460,7 +445,6 @@ namespace UnitTests.Serialization
         public void Serialize_ArrayOfArrayOfArrays(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             var source1 = new[] {new[] {1, 3, 5}, new[] {10, 20, 30}, new[] {17, 13, 11, 7, 5, 3, 2}};
             var source2 = new[] { new[] { 1, 3 }, new[] { 10, 20 }, new[] { 17, 13, 11, 7, 5 } };
@@ -476,7 +460,6 @@ namespace UnitTests.Serialization
         public void Serialize_ReadOnlyCollection(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             var source1 = new List<string> { "Yes", "No" };
             var collection = new ReadOnlyCollection<string>(source1);
@@ -502,7 +485,6 @@ namespace UnitTests.Serialization
         public void Serialize_UnserializableException(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
-            SerializationManager.UseStandardSerializer = false;
 
             const string message = "This is a test message";
             // throw the exception so that stack trace is populated
@@ -635,8 +617,6 @@ namespace UnitTests.Serialization
         ////[Fact, TestCategory("Functional"), TestCategory("Serialization")]
         //public void Serialize_RequestInvocationHistory()
         //{
-        //    //SerializationManager.UseStandardSerializer = false;
-
         //    //Message inMsg = new Message();
         //    //inMsg.TargetGrain = GrainId.NewId();
         //    //inMsg.TargetActivation = ActivationId.NewId();


### PR DESCRIPTION
Removes `UseStandardSerializer` option, which is designed to allow users to use BinaryFormatter instead of Orleans' serializer. BinaryFormatter is not available on .NET Core and users can use BinaryFormatter by providing an `IExternalSerializer` implementation.

Once this is merged, I'll propose a similar PR to remove the JSON fallback serialization option.