### PR TITLE
removing async from documentation example

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -74,9 +74,9 @@ The implementation is executed inside the Orleans framework:
 ``` csharp
 public class MyGrain : IMyGrain
 {
-    public async Task<string> SayHello(string name)
+    public Task<string> SayHello(string name)
     {
-        return "Hello " + name;
+        return Task.FromResult($"Hello {name}");
     }
 }
 ```


### PR DESCRIPTION
Updating home page example to match closer to the one in the github readme