### PR TITLE
Fix bug in GrainFactoryServiceProvider

### DIFF
--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -60,7 +60,7 @@ namespace Orleans.Providers.Streams.Common
             }
             public object GetService(Type serviceType)
             {
-                var service = providerRuntime?.ServiceProvider?.GetService(serviceType);
+                var service = providerRuntime.ServiceProvider?.GetService(serviceType);
                 if (service != null)
                 {
                     return service;

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -50,7 +50,7 @@ namespace Orleans.Providers.Streams.Common
 
         public bool IsRewindable { get { return queueAdapter.IsRewindable; } }
 
-        // this is a workaround until we address "Dependency Injection: register IGrainFactory #988"
+        // this is a workaround until an IServiceProvider instance is used in the Orleans client
         private class GrainFactoryServiceProvider : IServiceProvider
         {
             private IStreamProviderRuntime providerRuntime;
@@ -60,11 +60,18 @@ namespace Orleans.Providers.Streams.Common
             }
             public object GetService(Type serviceType)
             {
-                if (serviceType == typeof (GrainFactory))
+                var service = providerRuntime?.ServiceProvider?.GetService(serviceType);
+                if (service != null)
+                {
+                    return service;
+                }
+
+                if (serviceType == typeof(IGrainFactory))
                 {
                     return providerRuntime.GrainFactory;
                 }
-                return providerRuntime == null ? null:providerRuntime.ServiceProvider.GetService(serviceType);
+
+                return null;
             }
         }
 

--- a/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
@@ -61,7 +61,7 @@ namespace Orleans.Providers.Streams.Memory
             this.providerName = providerName;
             this.queueGrains = new ConcurrentDictionary<QueueId, IMemoryStreamQueueGrain>();
             this.adapterConfig = new MemoryAdapterConfig(providerName);
-            grainFactory = (GrainFactory)serviceProvider.GetService(typeof(GrainFactory));
+            grainFactory = (GrainFactory)serviceProvider.GetService(typeof(IGrainFactory));
             adapterConfig.PopulateFromProviderConfig(providerConfig);
             this.streamQueueMapper = new HashRingBasedStreamQueueMapper(adapterConfig.TotalQueueCount, adapterConfig.StreamProviderName);
 

--- a/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryAdapterFactory.cs
@@ -61,7 +61,7 @@ namespace Orleans.Providers.Streams.Memory
             this.providerName = providerName;
             this.queueGrains = new ConcurrentDictionary<QueueId, IMemoryStreamQueueGrain>();
             this.adapterConfig = new MemoryAdapterConfig(providerName);
-            grainFactory = (GrainFactory)serviceProvider.GetService(typeof(IGrainFactory));
+            grainFactory = (IGrainFactory)serviceProvider.GetService(typeof(IGrainFactory));
             adapterConfig.PopulateFromProviderConfig(providerConfig);
             this.streamQueueMapper = new HashRingBasedStreamQueueMapper(adapterConfig.TotalQueueCount, adapterConfig.StreamProviderName);
 


### PR DESCRIPTION
Was causing some EventHub tests to fail because providerRuntime.ServiceProvider was null, and not the providerRuntime itself (which was the path being tested for null). I believe this would have meant that if someone uses the EventHubStreamProvider from the client, they would have hit this bug.

Also replaced `MemoryAdapterFactory` to depend on `IGrainFactory` instead of the `GrainFactory` concrete class and updated hack accordingly. And since IGrainFactory is now currently being injected in the silo side, rely on that first and only fall back if it is not set.