### PR TITLE
Remove UseJsonFallbackSerializer

### DIFF
--- a/src/Orleans/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans/Configuration/MessagingConfiguration.cs
@@ -106,7 +106,6 @@ namespace Orleans.Runtime.Configuration
         public int GatewaySenderQueues { get; set; }
         public int ClientSenderBuckets { get; set; }
         public TimeSpan ClientDropTimeout { get; set; }
-        public bool UseJsonFallbackSerializer { get; set; }
 
         public int BufferPoolBufferSize { get; set; }
         public int BufferPoolMaxSize { get; set; }
@@ -199,8 +198,6 @@ namespace Orleans.Runtime.Configuration
             {
                 sb.AppendFormat("       Client Sender Buckets: {0}", ClientSenderBuckets).AppendLine();
             }
-            sb.AppendFormat("       Use fallback json serializer: {0}", UseJsonFallbackSerializer)
-                .AppendLine(isSiloConfig ? "" : "   [NOTE: This *MUST* match the setting on the server or nothing will work!]");
             sb.AppendFormat("       Buffer Pool Buffer Size: {0}", BufferPoolBufferSize).AppendLine();
             sb.AppendFormat("       Buffer Pool Max Size: {0}", BufferPoolMaxSize).AppendLine();
             sb.AppendFormat("       Buffer Pool Preallocation Size: {0}", BufferPoolPreallocationSize).AppendLine();
@@ -269,13 +266,6 @@ namespace Orleans.Runtime.Configuration
                     ClientSenderBuckets = ConfigUtilities.ParseInt(child.GetAttribute("ClientSenderBuckets"),
                                                             "Invalid integer value for the ClientSenderBuckets attribute on the Messaging element");
                 }
-            }
-
-            if (child.HasAttribute("UseJsonFallbackSerializer"))
-            {
-                UseJsonFallbackSerializer =
-                    ConfigUtilities.ParseBool(child.GetAttribute("UseJsonFallbackSerializer"),
-                                              "invalid boolean value for the UseJsonFallbackSerializer attribute on the Messaging element");
             }
             
             //--

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -132,7 +132,7 @@ namespace Orleans
 
             if (!LogManager.IsInitialized) LogManager.Initialize(config);
             StatisticsCollector.Initialize(config);
-            SerializationManager.Initialize(cfg.SerializationProviders, config.UseJsonFallbackSerializer);
+            SerializationManager.Initialize(cfg.SerializationProviders);
             logger = LogManager.GetLogger("OutsideRuntimeClient", LoggerType.Runtime);
             appLogger = LogManager.GetLogger("Application", LoggerType.Application);
 

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -188,7 +188,7 @@ namespace Orleans.Runtime
             ActivationData.Init(config, nodeConfig);
             StatisticsCollector.Initialize(nodeConfig);
             
-            SerializationManager.Initialize(globalConfig.SerializationProviders, globalConfig.UseJsonFallbackSerializer);
+            SerializationManager.Initialize(globalConfig.SerializationProviders);
             initTimeout = globalConfig.MaxJoinAttemptTime;
             if (Debugger.IsAttached)
             {

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -15,7 +15,7 @@ namespace UnitTests.Serialization
     {
         public SerializationTestsJsonTypes()
         {
-            SerializationManager.InitializeForTesting(useJsonFallbackSerializer: true);
+            SerializationManager.InitializeForTesting();
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]

--- a/test/TesterInternal/OrleansRuntime/ExceptionsTests.cs
+++ b/test/TesterInternal/OrleansRuntime/ExceptionsTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests.OrleansRuntime
         public ExceptionsTests()
         {
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
-            SerializationManager.Initialize(null, false);
+            SerializationManager.Initialize(null);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
+++ b/test/TesterInternal/Serialization/BuiltInSerializerTests.cs
@@ -33,28 +33,20 @@ namespace UnitTests.Serialization
         public enum SerializerToUse
         {
             Default,
-            Fallback,
-            JsonNetFallback
         }
 
         private void InitializeSerializer(SerializerToUse serializerToUse)
         {
             List<System.Reflection.TypeInfo> serializationProviders = null;
-            bool useJsonFallbackSerializer = false;
-
             switch (serializerToUse)
             {
                 case SerializerToUse.Default:            
-                    break;
-                case SerializerToUse.Fallback:
-                case SerializerToUse.JsonNetFallback:
-                    useJsonFallbackSerializer = true;
                     break;
                 default:
                     throw new InvalidOperationException("Invalid Serializer was selected");
             }
 
-            SerializationManager.Initialize(serializationProviders, useJsonFallbackSerializer);
+            SerializationManager.Initialize(serializationProviders);
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
         }
 
@@ -66,7 +58,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_ActivationAddress(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -86,7 +77,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_EmptyList(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -101,7 +91,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_BasicDictionaries(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -121,7 +110,6 @@ namespace UnitTests.Serialization
         
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_ReadOnlyDictionary(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -171,7 +159,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_DictionaryWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -255,7 +242,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_SortedDictionaryWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -269,7 +255,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_SortedListWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -283,7 +268,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_HashSetWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -305,7 +289,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_Stack(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -329,7 +312,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_SortedSetWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -351,7 +333,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_Array(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -375,7 +356,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_ArrayOfArrays(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -441,7 +421,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_ArrayOfArrayOfArrays(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -456,7 +435,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_ReadOnlyCollection(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -481,7 +459,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_UnserializableException(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -498,7 +475,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_ObjectIdentity(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -541,7 +517,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_Unrecognized(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -569,7 +544,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_Immutable(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -596,7 +570,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_Uri_Multithreaded(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -655,7 +628,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_GrainReference(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -672,7 +644,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_GrainReference_ViaStandardSerializer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -689,7 +660,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_GrainBase(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -704,7 +674,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_GrainBase_ViaStandardSerializer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -894,7 +863,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_ValidateBuildSegmentListWithLengthLimit(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -959,7 +927,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void SerializationTests_IsOrleansShallowCopyable(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -1123,7 +1090,6 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.Default)]
-        [InlineData(SerializerToUse.Fallback)]
         public void Serialize_CircularReference(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);


### PR DESCRIPTION
Follow-on from #2193.

Json.NET is not a suitable fallback serializer. It does not handle the complex types which it needs to handle.