### PR TITLE
Update codegen related dependency NuGets

### DIFF
--- a/src/Orleans/project.json
+++ b/src/Orleans/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
-    "System.Collections.Immutable": "1.1.36"
+    "System.Collections.Immutable": "1.1.37"
   },
   "frameworks": {
     "net451": {}

--- a/src/OrleansCodeGenerator/project.json
+++ b/src/OrleansCodeGenerator/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "1.2.0"
+    "Microsoft.CodeAnalysis.CSharp": "1.3.2"
   },
   "frameworks": {
     "net451": {}

--- a/src/OrleansCodeGenerator/project.json
+++ b/src/OrleansCodeGenerator/project.json
@@ -1,6 +1,6 @@
-{
+﻿{
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "1.0.0"
+    "Microsoft.CodeAnalysis.CSharp": "1.2.0"
   },
   "frameworks": {
     "net451": {}

--- a/src/OrleansPSUtils/project.json
+++ b/src/OrleansPSUtils/project.json
@@ -1,8 +1,8 @@
 ﻿{
   "dependencies": {
     "Microsoft.CodeAnalysis.Analyzers": "1.1.0",
-    "Microsoft.CodeAnalysis.Common": "1.2.0",
-    "Microsoft.CodeAnalysis.CSharp": "1.2.0",
+    "Microsoft.CodeAnalysis.Common": "1.3.2",
+    "Microsoft.CodeAnalysis.CSharp": "1.3.2",
     "System.Collections.Immutable": "1.1.37",
     "System.Management.Automation.dll": "10.0.10586",
     "System.Reflection.Metadata": "1.2.0"

--- a/src/OrleansPSUtils/project.json
+++ b/src/OrleansPSUtils/project.json
@@ -1,11 +1,11 @@
-{
+﻿{
   "dependencies": {
-    "Microsoft.CodeAnalysis.Analyzers": "1.0.0",
-    "Microsoft.CodeAnalysis.Common": "1.0.0",
-    "Microsoft.CodeAnalysis.CSharp": "1.0.0",
-    "System.Collections.Immutable": "1.1.36",
+    "Microsoft.CodeAnalysis.Analyzers": "1.1.0",
+    "Microsoft.CodeAnalysis.Common": "1.2.0",
+    "Microsoft.CodeAnalysis.CSharp": "1.2.0",
+    "System.Collections.Immutable": "1.1.37",
     "System.Management.Automation.dll": "10.0.10586",
-    "System.Reflection.Metadata": "1.0.21"
+    "System.Reflection.Metadata": "1.2.0"
   },
   "frameworks": {
     "net451": {}

--- a/test/Benchmarks/OrleansBenchmarks/App.config
+++ b/test/Benchmarks/OrleansBenchmarks/App.config
@@ -3,4 +3,12 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
Updated Microsoft.CodeAnalysis.*, System.Collections.Immutable, and System.Reflection.Metadata NuGets

System.Collections.Immutable 1.1.36 -> 1.1.37
System.Reflection.Metadata 1.0.21 -> 1.2.0
Microsoft.CodeAnalysis.CSharp 1.0.0 -> 1.3.2
Microsoft.CodeAnalysis.Analyzers 1.0.0 -> 1.1.0
Microsoft.CodeAnalysis.Common 1.0.0 -> 1.3.2

This eliminates build warnings about crashing unneeded C# analyzer and updates the codegen related dependencies. IMO these dependencies are fine to upgrade even if we technically don't have to, because they are Roslyn related and can be treated somewhat differently from normal dependencies used by application code, such as Newtonsoft.Json and Azure Storage.

Added a binding redirect for Newtonsoft.Json to OrleansBenchmarks to eliminate a build warning.