### PR TITLE
Move JSON serialization methods into OrleansJsonSerializer

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -11,12 +11,9 @@ using System.Net;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters;
 using System.Text;
-using Newtonsoft.Json;
 using Orleans.CodeGeneration;
 using Orleans.Concurrency;
-using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 
@@ -27,9 +24,6 @@ namespace Orleans.Serialization
     /// </summary>
     public static class SerializationManager
     {
-        internal const string UseFullAssemblyNamesProperty = "UseFullAssemblyNames";
-        internal const string IndentJsonProperty = "IndentJSON";
-
         /// <summary>
         /// Deep copier function.
         /// </summary>
@@ -2194,41 +2188,6 @@ namespace Orleans.Serialization
             public DeepCopier DeepCopy { get; private set; }
             public Serializer Serialize { get; private set; }
             public Deserializer Deserialize { get; private set; }
-        }
-
-        public static JsonSerializerSettings GetDefaultJsonSerializerSettings()
-        {
-            return OrleansJsonSerializer.GetDefaultSerializerSettings();
-        }
-
-        /// <summary>
-        /// Customises the given serializer settings
-        /// using provider configuration.
-        /// Can be used by any provider, allowing the users to use a standard set of configuration attributes.
-        /// </summary>
-        /// <param name="settings"></param>
-        /// <param name="config"></param>
-        /// <returns><see cref="JsonSerializerSettings" /></returns>
-        public static JsonSerializerSettings UpdateSerializerSettings(JsonSerializerSettings settings, IProviderConfiguration config)
-        {
-            if (config.Properties.ContainsKey(UseFullAssemblyNamesProperty))
-            {
-                bool useFullAssemblyNames;
-                if (bool.TryParse(config.Properties[UseFullAssemblyNamesProperty], out useFullAssemblyNames) && useFullAssemblyNames)
-                {
-                    settings.TypeNameAssemblyFormat = FormatterAssemblyStyle.Full;
-                }
-            }
-
-            if (config.Properties.ContainsKey(IndentJsonProperty))
-            {
-                bool indentJSON;
-                if (bool.TryParse(config.Properties[IndentJsonProperty], out indentJSON) && indentJSON)
-                {
-                    settings.Formatting = Formatting.Indented;
-                }
-            }
-            return settings;
         }
     }
 }

--- a/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
+++ b/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
@@ -91,7 +91,7 @@ namespace Orleans.Storage
             if (config.Properties.ContainsKey(USE_JSON_FORMAT_PROPERTY_NAME))
                 useJsonFormat = "true".Equals(config.Properties[USE_JSON_FORMAT_PROPERTY_NAME], StringComparison.OrdinalIgnoreCase);
 
-            this.jsonSettings = SerializationManager.UpdateSerializerSettings(SerializationManager.GetDefaultJsonSerializerSettings(), config);
+            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
 
             initMsg = string.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 

--- a/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
+++ b/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
@@ -47,8 +47,8 @@ namespace Orleans.Runtime.Configuration
 
             if (useJsonFormat)
             {
-                properties.Add(SerializationManager.UseFullAssemblyNamesProperty, useFullAssemblyNames.ToString());
-                properties.Add(SerializationManager.IndentJsonProperty, indentJson.ToString());
+                properties.Add(OrleansJsonSerializer.UseFullAssemblyNamesProperty, useFullAssemblyNames.ToString());
+                properties.Add(OrleansJsonSerializer.IndentJsonProperty, indentJson.ToString());
             }
 
             config.Globals.RegisterStorageProvider<AzureTableStorage>(providerName, properties);
@@ -78,8 +78,8 @@ namespace Orleans.Runtime.Configuration
             {
                 { AzureBlobStorage.DataConnectionStringPropertyName, connectionString },
                 { AzureBlobStorage.ContainerNamePropertyName, containerName },
-                { SerializationManager.UseFullAssemblyNamesProperty, useFullAssemblyNames.ToString() },
-                { SerializationManager.IndentJsonProperty, indentJson.ToString() },
+                { OrleansJsonSerializer.UseFullAssemblyNamesProperty, useFullAssemblyNames.ToString() },
+                { OrleansJsonSerializer.IndentJsonProperty, indentJson.ToString() },
             };
 
             config.Globals.RegisterStorageProvider<AzureBlobStorage>(providerName, properties);

--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -69,7 +69,7 @@ namespace Orleans.Storage
             try
             {
                 this.Name = name;
-                this.jsonSettings = SerializationManager.UpdateSerializerSettings(SerializationManager.GetDefaultJsonSerializerSettings(), config);
+                this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
 
                 if (!config.Properties.ContainsKey(DataConnectionStringPropertyName)) throw new BadProviderConfigException($"The {DataConnectionStringPropertyName} setting has not been configured in the cloud role. Please add a {DataConnectionStringPropertyName} setting with a valid Azure Storage connection string.");
 
@@ -91,13 +91,20 @@ namespace Orleans.Storage
 
         IEnumerable<string> FormatPropertyMessage(IProviderConfiguration config)
         {
-            foreach (var property in new string[] { ContainerNamePropertyName, "SerializeTypeNames", "PreserveReferencesHandling", "UseFullAssemblyNames", "IndentJSON" })
+            var properties = new[]
+            {
+                ContainerNamePropertyName,
+                "SerializeTypeNames",
+                "PreserveReferencesHandling",
+                OrleansJsonSerializer.UseFullAssemblyNamesProperty,
+                OrleansJsonSerializer.IndentJsonProperty
+            };
+            foreach (var property in properties)
             {
                 if (!config.Properties.ContainsKey(property)) continue;
                 yield return string.Format("{0}={1}", property, config.Properties[property]);
             }
         }
-
 
         /// <summary> Shutdown this storage provider. </summary>
         /// <see cref="IProvider.Close"/>

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -110,7 +110,7 @@ namespace Orleans.Storage
             if (config.Properties.ContainsKey(UseJsonFormatPropertyName))
                 useJsonFormat = "true".Equals(config.Properties[UseJsonFormatPropertyName], StringComparison.OrdinalIgnoreCase);
 
-            this.jsonSettings = SerializationManager.UpdateSerializerSettings(SerializationManager.GetDefaultJsonSerializerSettings(), config);
+            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 
             Log.Info((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, initMsg);

--- a/src/OrleansSQLUtils/Storage/Provider/AdoNetStorageProvider.cs
+++ b/src/OrleansSQLUtils/Storage/Provider/AdoNetStorageProvider.cs
@@ -545,7 +545,7 @@ namespace Orleans.Storage
             var deserializers = new List<IStorageDeserializer>();
             if(config.Properties.ContainsKey(UseJsonFormatPropertyName) && @true.Equals(config.Properties[UseJsonFormatPropertyName], StringComparison.OrdinalIgnoreCase))
             {
-                var jsonSettings = SerializationManager.UpdateSerializerSettings(SerializationManager.GetDefaultJsonSerializerSettings(), config);
+                var jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
                 deserializers.Add(new OrleansStorageDefaultJsonDeserializer(jsonSettings, UseJsonFormatPropertyName));
             }
 
@@ -569,7 +569,7 @@ namespace Orleans.Storage
             var serializers = new List<IStorageSerializer>();
             if(config.Properties.ContainsKey(UseJsonFormatPropertyName) && @true.Equals(config.Properties[UseJsonFormatPropertyName], StringComparison.OrdinalIgnoreCase))
             {
-                var jsonSettings = SerializationManager.UpdateSerializerSettings(SerializationManager.GetDefaultJsonSerializerSettings(), config);
+                var jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
                 serializers.Add(new OrleansStorageDefaultJsonSerializer(jsonSettings, UseJsonFormatPropertyName));
             }
 


### PR DESCRIPTION
This is a (minorly) breaking change which moves `GetDefaultJsonSerializerSettings` & `UpdateSerializerSettings` out of `SerializationManager` and into `OrleansJsonSerializer`.

It also makes `OrleansJsonSerializer` public so that external providers can reference it.
