### PR TITLE
Fix SerializationManager.GetFallbackSerializer() in .NET Standard

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1869,12 +1869,12 @@ namespace Orleans.Serialization
         private static IExternalSerializer GetFallbackSerializer()
         {
 #if NETSTANDARD
-                throw new OrleansException("Can't use binary formatter as fallback serializer while running on .Net Core");
+            throw new OrleansException("Can't use binary formatter as fallback serializer while running on .Net Core");
 #else
             var serializer = new BinaryFormatterSerializer();
-#endif
             serializer.Initialize(logger);
             return serializer;
+#endif
         }
 
 #if !NETSTANDARD_TODO


### PR DESCRIPTION
It broke due to a PR for the main solution. We are currently working on having CI build this .NET Standard solution, so that these issues are less frequent in the future, because they are very easy to miss.