### PR TITLE
Optimize the scheduler, remove redundant semaphore and interlocked exchange.

### DIFF
--- a/src/OrleansRuntime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/OrleansRuntime/Scheduler/OrleansTaskScheduler.cs
@@ -355,24 +355,6 @@ namespace Orleans.Runtime.Scheduler
             return Pool.DoHealthCheck();
         }
 
-        /// <summary>
-        /// Action to be invoked when there is no more work for this scheduler
-        /// </summary>
-        internal Action OnIdle { get; set; }
-
-        /// <summary>
-        /// Invoked by WorkerPool when all threads go idle
-        /// </summary>
-        internal void OnAllWorkerThreadsIdle()
-        {
-            if (OnIdle == null || RunQueueLength != 0) return;
-
-#if DEBUG
-            if (logger.IsVerbose2) logger.Verbose2("OnIdle");
-#endif
-            OnIdle();
-        }
-
         internal void PrintStatistics()
         {
             if (!logger.IsInfo) return;

--- a/src/OrleansRuntime/Scheduler/WorkerPoolThread.cs
+++ b/src/OrleansRuntime/Scheduler/WorkerPoolThread.cs
@@ -9,7 +9,7 @@ namespace Orleans.Runtime.Scheduler
 {
     internal class WorkerPoolThread : AsynchAgent
     {
-        private const int MAX_THREAD_COUNT_TO_REPLACE = 500;
+        internal const int MAX_THREAD_COUNT_TO_REPLACE = 500;
         private const int MAX_CPU_USAGE_TO_REPLACE = 50;
 
         private readonly WorkerPool pool;
@@ -327,7 +327,7 @@ namespace Orleans.Runtime.Scheduler
             // exit when it's done with the turn.
             // Note that we only do this if the current load is reasonably low and the current thread
             // count is reasonably small.
-            if (!pool.InjectMoreWorkerThreads || pool.BusyWorkerCount >= MAX_THREAD_COUNT_TO_REPLACE ||
+            if (!pool.ShouldInjectWorkerThread ||
                 (Silo.CurrentSilo == null || !(Silo.CurrentSilo.Metrics.CpuUsage < MAX_CPU_USAGE_TO_REPLACE))) return;
 
             if (Cts.IsCancellationRequested) return;


### PR DESCRIPTION
It would be interesting to know if this saves any perf.

We maintain this semaphore and counter only for the case that we inject more threads dynamically. We don't actually do that any more, for years (its a separate discussion why). Did not want to fully remove the thread injection, but sure no need to pay the semaphore and interlocked exchange price, on a very hot path.

It is one of those things that is hard to predict how perf. will be impacted. I won't be surprised if it does not help at all (semaphore was never blocking, it always had enough room), or saves a ton (since it still inc/dec the semaphore on every task)!
