### PR TITLE
Remove CancellationTokenCallbacksThrow_ExceptionShouldBePropagated test from BVT/Functional sets

### DIFF
--- a/test/Tester/CancellationTests/GrainCancellationTokenTests.cs
+++ b/test/Tester/CancellationTests/GrainCancellationTokenTests.cs
@@ -99,7 +99,7 @@ namespace UnitTests.CancellationTests
             Assert.Equal(true, result);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Cancellation")]
+        [Fact, TestCategory("Cancellation")]
         public async Task CancellationTokenCallbacksThrow_ExceptionShouldBePropagated()
         {
             var grain = GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());


### PR DESCRIPTION
Remove CancellationTokenCallbacksThrow_ExceptionShouldBePropagated test from BVT/Functional sets, as it's failing intermittently on a regular basis.

/cc @dVakulen.