### PR TITLE
CodeGen: Avoid wrapping IGrainMethodInvoker.Invoke body in try/catch

### DIFF
--- a/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
@@ -228,23 +228,8 @@ namespace Orleans.CodeGenerator
                         grainArgument,
                         SF.LiteralExpression(SyntaxKind.NullLiteralExpression)),
                     SF.ThrowStatement(argumentNullException));
-
-            // Wrap everything in a try-catch block.
-            var faulted = (Expression<Func<Task<object>>>)(() => TaskUtility.Faulted(null));
-            const string Exception = "exception";
-            var exception = SF.Identifier(Exception);
-            var body =
-                SF.TryStatement()
-                    .AddBlockStatements(grainArgumentCheck, interfaceIdSwitch)
-                    .AddCatches(
-                        SF.CatchClause()
-                            .WithDeclaration(
-                                SF.CatchDeclaration(typeof(Exception).GetTypeSyntax()).WithIdentifier(exception))
-                            .AddBlockStatements(
-                                SF.ReturnStatement(
-                                    faulted.Invoke().AddArgumentListArguments(SF.Argument(SF.IdentifierName(Exception))))));
-
-            return methodDeclaration.AddBodyStatements(body);
+            
+            return methodDeclaration.AddBodyStatements(grainArgumentCheck, interfaceIdSwitch);
         }
 
         /// <summary>

--- a/test/TestGrainInterfaces/IExceptionGrain.cs
+++ b/test/TestGrainInterfaces/IExceptionGrain.cs
@@ -22,6 +22,8 @@ namespace UnitTests.GrainInterfaces
 
         Task ThrowsSynchronousInvalidOperationException();
 
+        Task<object> ThrowsSynchronousExceptionObjectTask();
+
         Task ThrowsMultipleExceptionsAggregatedInFaultedTask();
 
         Task ThrowsSynchronousAggregateExceptionWithMultipleInnerExceptions();

--- a/test/TestGrains/ExceptionGrain.cs
+++ b/test/TestGrains/ExceptionGrain.cs
@@ -53,6 +53,11 @@ namespace UnitTests.Grains
             throw new InvalidOperationException("Test exception");
         }
 
+        public Task<object> ThrowsSynchronousExceptionObjectTask()
+        {
+            throw new InvalidOperationException("Test exception");
+        }
+
         public Task ThrowsMultipleExceptionsAggregatedInFaultedTask()
         {
             var tcs = new TaskCompletionSource<object>();

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -129,8 +129,12 @@ namespace UnitTests.General
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => grainCallTask);
 
             Assert.Equal("Test exception", exception.Message);
-        }
 
+            var grainCallTask2 = grain.ThrowsSynchronousInvalidOperationException();
+            var exception2 = await Assert.ThrowsAsync<InvalidOperationException>(() => grainCallTask2);
+            Assert.Equal("Test exception", exception2.Message);
+        }
+        
         [Fact(Skip = "Implementation of issue #1378 is still pending"), TestCategory("BVT"), TestCategory("Functional")]
         public void ExceptionPropagationForwardsEntireAggregateException()
         {


### PR DESCRIPTION
When code generation was originally ported from CodeDOM to Roslyn, the initial goal was to keep the emitted code close to the previous generator's.

Currently, generated `IGrainMethodInvoker.Invoke` methods have a try/catch wrapping the body.

This try/catch is needless and this PR removes it.
Example old body:
```C#
global::System.Int32 interfaceId = @request.@InterfaceId;
global::System.Int32 methodId = @request.@MethodId;
global::System.Object[] arguments = @request.@Arguments;
try
{
    if (@grain == null)
        throw new global::System.ArgumentNullException("grain");
    switch (interfaceId)
    {
        case -831689659:
            switch (methodId)
            {
                case -1573596583:
                    return ((global::Orleans.IRemindable)@grain).@ReceiveReminder((global::System.String)arguments[0], (global::Orleans.Runtime.TickStatus)arguments[1]).@Box();
                default:
                    throw new global::System.NotImplementedException("interfaceId=" + -831689659 + ",methodId=" + methodId);
            }
 
        default:
            throw new global::System.NotImplementedException("interfaceId=" + interfaceId);
    }
}
catch (global::System.Exception exception)
{
    return global::Orleans.Async.TaskUtility.@Faulted(exception);
}
```

Example new body:
```C#
global::System.Int32 interfaceId = @request.@InterfaceId;
global::System.Int32 methodId = @request.@MethodId;
global::System.Object[] arguments = @request.@Arguments;
if (@grain == null)
    throw new global::System.ArgumentNullException("grain");
switch (interfaceId)
{
    case -831689659:
        switch (methodId)
        {
            case -1573596583:
                return ((global::Orleans.IRemindable)@grain).@ReceiveReminder((global::System.String)arguments[0], (global::Orleans.Runtime.TickStatus)arguments[1]).@Box();
            default:
                throw new global::System.NotImplementedException("interfaceId=" + -831689659 + ",methodId=" + methodId);
        }

    default:
        throw new global::System.NotImplementedException("interfaceId=" + interfaceId);
}
```