### PR TITLE
Add TestGrainInterfaces project to .NET Standard solution

### DIFF
--- a/vNext/src/Orleans.vNext.sln
+++ b/vNext/src/Orleans.vNext.sln
@@ -31,6 +31,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{5478B4
 		..\.nuget\packages.config = ..\.nuget\packages.config
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestGrainInterfaces", "..\test\TestGrainInterfaces\TestGrainInterfaces.csproj", "{A972213F-189B-41D4-90FE-38D513C1106A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{AFD242B4-EDA9-42CD-BA39-E410B98ADD2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AFD242B4-EDA9-42CD-BA39-E410B98ADD2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AFD242B4-EDA9-42CD-BA39-E410B98ADD2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A972213F-189B-41D4-90FE-38D513C1106A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A972213F-189B-41D4-90FE-38D513C1106A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A972213F-189B-41D4-90FE-38D513C1106A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A972213F-189B-41D4-90FE-38D513C1106A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -77,5 +83,6 @@ Global
 		{40EE3B00-D381-485F-9C69-FF706837DEED} = {22C57246-E750-4254-80D2-9BEF9C241189}
 		{621FF7D4-93D7-4C1D-A0AD-229DB1ADC7B4} = {224EAB7B-DBF8-4652-AC71-6C6ABBAB22AD}
 		{AFD242B4-EDA9-42CD-BA39-E410B98ADD2A} = {224EAB7B-DBF8-4652-AC71-6C6ABBAB22AD}
+		{A972213F-189B-41D4-90FE-38D513C1106A} = {224EAB7B-DBF8-4652-AC71-6C6ABBAB22AD}
 	EndGlobalSection
 EndGlobal

--- a/vNext/test/NonSiloTests/Orleans.NonSiloTests.csproj
+++ b/vNext/test/NonSiloTests/Orleans.NonSiloTests.csproj
@@ -52,6 +52,10 @@
       <Project>{afd242b4-eda9-42cd-ba39-e410b98add2a}</Project>
       <Name>TestExtensions</Name>
     </ProjectReference>
+    <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj">
+      <Project>{a972213f-189b-41d4-90fe-38d513c1106a}</Project>
+      <Name>TestGrainInterfaces</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/vNext/test/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/vNext/test/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -1,0 +1,175 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform>AnyCPU</Platform>
+    <ProductVersion>10.0.20506</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{3972213F-189B-41D4-90FE-38D513C1106D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
+    <AssemblyName>TestGrainInterfaces</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <WarningsAsErrors>4014</WarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <WarningsAsErrors>4014</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="GetGrainInterfaces.cs" />
+    <Compile Include="IActivateDeactivateTestGrain.cs" />
+    <Compile Include="IChainedGrain.cs" />
+    <Compile Include="ICircularStateTestGrain.cs" />
+    <Compile Include="IActivateDeactivateWatcherGrain.cs" />
+    <Compile Include="ICatalogTestGrain.cs" />
+    <Compile Include="IClientAddressableTestConsumer.cs" />
+    <Compile Include="IClusterTestGrains.cs" />
+    <Compile Include="ICollectionTestGrain.cs" />
+    <Compile Include="IConcurrentGrain.cs" />
+    <Compile Include="IConsumerEventCountingGrain.cs" />
+    <Compile Include="IDeadlockGrain.cs" />
+    <Compile Include="IEchoTaskGrain.cs" />
+    <Compile Include="IErrorGrain.cs" />
+    <Compile Include="IExceptionGrain.cs" />
+    <Compile Include="IExtensionTestGrain.cs" />
+    <Compile Include="IExternalTypeGrain.cs" />
+    <Compile Include="IFaultableConsumerGrain.cs" />
+    <Compile Include="IFSharpParametersGrain.cs" />
+    <Compile Include="IGeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs" />
+    <Compile Include="IGeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs" />
+    <Compile Include="IGeneratorTestDerivedDerivedGrain.cs" />
+    <Compile Include="IGeneratorTestDerivedGrain1.cs" />
+    <Compile Include="IGeneratorTestDerivedGrain2.cs" />
+    <Compile Include="IGeneratorTestGrain.cs" />
+    <Compile Include="IMethodInterceptionGrain.cs" />
+    <Compile Include="IJournaledPersonGrain.cs" />
+    <Compile Include="IGeneratedEventCollectorGrain.cs" />
+    <Compile Include="IGeneratedEventReporterGrain.cs" />
+    <Compile Include="IGenericInterfaces.cs" />
+    <Compile Include="IInitialStateGrain.cs" />
+    <Compile Include="IKeyExtensionTestGrain.cs" />
+    <Compile Include="IMultifacetReader.cs" />
+    <Compile Include="IMultifacetWriter.cs" />
+    <Compile Include="IJsonEchoGrain.cs" />
+    <Compile Include="IMultipleImplicitSubscriptionGrain.cs" />
+    <Compile Include="IMultipleSubscriptionConsumerGrain.cs" />
+    <Compile Include="GrainInterfaceHierarchyIGrains.cs" />
+    <Compile Include="IPersistenceTestGrains.cs" />
+    <Compile Include="IPlacementTestGrain.cs" />
+    <Compile Include="IPolymorphicTestGrain.cs" />
+    <Compile Include="IProducerEventCountingGrain.cs" />
+    <Compile Include="IPromiseForwardGrain.cs" />
+    <Compile Include="IProxyGrain.cs" />
+    <Compile Include="IReentrancyGrain.cs" />
+    <Compile Include="IReentrantStressTestGrain.cs" />
+    <Compile Include="IReminderTestGrain.cs" />
+    <Compile Include="IReminderTestGrain2.cs" />
+    <Compile Include="IRequestContextTestGrain.cs" />
+    <Compile Include="ISampleStreamingGrain.cs" />
+    <Compile Include="ISerializationGeneratorTests.cs" />
+    <Compile Include="ISimpleDIGrain.cs" />
+    <Compile Include="ISimpleGenericGrain.cs" />
+    <Compile Include="CodegenTestInterfaces.cs" />
+    <Compile Include="ISimpleGrainWithAsyncMethods.cs" />
+    <Compile Include="IStatelessWorkerGrain.cs" />
+    <Compile Include="ISimpleObserverableGrain.cs" />
+    <Compile Include="IObserverGrain.cs" />
+    <Compile Include="ISimpleGrain.cs" />
+    <Compile Include="ISimplePersistentGrain.cs" />
+    <Compile Include="ILivenessTestGrain.cs" />
+    <Compile Include="IStreamingGrain.cs" />
+    <Compile Include="IStreamingImmutabilityTestGrain.cs" />
+    <Compile Include="IStreamInterceptionGrain.cs" />
+    <Compile Include="IStreamLifecycleTestGrains.cs" />
+    <Compile Include="IStreamLifecycleTestInternalGrains.cs" />
+    <Compile Include="IStreamReliabilityTestGrains.cs" />
+    <Compile Include="ITestExtension.cs" />
+    <Compile Include="ITestGrain.cs" />
+    <Compile Include="IStreaming_ProducerGrain.cs" />
+    <Compile Include="ITimerGrain.cs" />
+    <Compile Include="IValueTypeTestGrain.cs" />
+    <Compile Include="IConsiderForCodeGenerationGrain.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\orleans.codegen.cs" />
+    <Compile Include="SerializerExclusions.cs" />
+    <Compile Include="SQLAdapter\ICustomerGrain.cs" />
+    <Compile Include="SQLAdapter\IDeviceGrain.cs" />
+    <Compile Include="UnitTestGrainInterfaces.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OrleansRuntime\OrleansRuntime.csproj">
+      <Project>{6ff2004c-cdf8-479c-bf27-c6bfe8ef93e0}</Project>
+      <Name>OrleansRuntime</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Orleans\Orleans.csproj">
+      <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
+      <Name>Orleans</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestFSharpInterfaces\TestFSharpInterfaces.fsproj">
+      <Project>{2375d7d5-9b30-493f-9c2e-a6b2811a3c5a}</Project>
+      <Name>TestFSharpInterfaces</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestInterfaces\TestInterfaces.csproj">
+      <Project>{aeff3b6c-7986-4bf9-85f5-2571decf8959}</Project>
+      <Name>TestInterfaces</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- Begin Orleans: Without these lines the project won't build properly -->
+  <PropertyGroup>
+    <OrleansProjectType>Client</OrleansProjectType>
+  </PropertyGroup>
+  <!-- Set path to ClientGenerator.exe -->
+  <Choose>
+    <When Condition="'$(builduri)' != ''">
+      <PropertyGroup>
+        <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\..\src\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(ProjectDir)..\..\src\Orleans.SDK.targets" />
+  <!--End Orleans -->
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target> 
+  -->
+</Project>

--- a/vNext/test/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/vNext/test/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -5,12 +5,12 @@
     <Platform>AnyCPU</Platform>
     <ProductVersion>10.0.20506</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{3972213F-189B-41D4-90FE-38D513C1106D}</ProjectGuid>
+    <ProjectGuid>{a972213F-189B-41D4-90FE-38D513C1106a}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
     <AssemblyName>TestGrainInterfaces</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -44,105 +44,18 @@
     <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="GetGrainInterfaces.cs" />
-    <Compile Include="IActivateDeactivateTestGrain.cs" />
-    <Compile Include="IChainedGrain.cs" />
-    <Compile Include="ICircularStateTestGrain.cs" />
-    <Compile Include="IActivateDeactivateWatcherGrain.cs" />
-    <Compile Include="ICatalogTestGrain.cs" />
-    <Compile Include="IClientAddressableTestConsumer.cs" />
-    <Compile Include="IClusterTestGrains.cs" />
-    <Compile Include="ICollectionTestGrain.cs" />
-    <Compile Include="IConcurrentGrain.cs" />
-    <Compile Include="IConsumerEventCountingGrain.cs" />
-    <Compile Include="IDeadlockGrain.cs" />
-    <Compile Include="IEchoTaskGrain.cs" />
-    <Compile Include="IErrorGrain.cs" />
-    <Compile Include="IExceptionGrain.cs" />
-    <Compile Include="IExtensionTestGrain.cs" />
-    <Compile Include="IExternalTypeGrain.cs" />
-    <Compile Include="IFaultableConsumerGrain.cs" />
-    <Compile Include="IFSharpParametersGrain.cs" />
-    <Compile Include="IGeneratorTestDerivedFromCSharpInterfaceInExternalAssemblyGrain.cs" />
-    <Compile Include="IGeneratorTestDerivedFromFSharpInterfaceInExternalAssemblyGrain.cs" />
-    <Compile Include="IGeneratorTestDerivedDerivedGrain.cs" />
-    <Compile Include="IGeneratorTestDerivedGrain1.cs" />
-    <Compile Include="IGeneratorTestDerivedGrain2.cs" />
-    <Compile Include="IGeneratorTestGrain.cs" />
-    <Compile Include="IMethodInterceptionGrain.cs" />
-    <Compile Include="IJournaledPersonGrain.cs" />
-    <Compile Include="IGeneratedEventCollectorGrain.cs" />
-    <Compile Include="IGeneratedEventReporterGrain.cs" />
-    <Compile Include="IGenericInterfaces.cs" />
-    <Compile Include="IInitialStateGrain.cs" />
-    <Compile Include="IKeyExtensionTestGrain.cs" />
-    <Compile Include="IMultifacetReader.cs" />
-    <Compile Include="IMultifacetWriter.cs" />
-    <Compile Include="IJsonEchoGrain.cs" />
-    <Compile Include="IMultipleImplicitSubscriptionGrain.cs" />
-    <Compile Include="IMultipleSubscriptionConsumerGrain.cs" />
-    <Compile Include="GrainInterfaceHierarchyIGrains.cs" />
-    <Compile Include="IPersistenceTestGrains.cs" />
-    <Compile Include="IPlacementTestGrain.cs" />
-    <Compile Include="IPolymorphicTestGrain.cs" />
-    <Compile Include="IProducerEventCountingGrain.cs" />
-    <Compile Include="IPromiseForwardGrain.cs" />
-    <Compile Include="IProxyGrain.cs" />
-    <Compile Include="IReentrancyGrain.cs" />
-    <Compile Include="IReentrantStressTestGrain.cs" />
-    <Compile Include="IReminderTestGrain.cs" />
-    <Compile Include="IReminderTestGrain2.cs" />
-    <Compile Include="IRequestContextTestGrain.cs" />
-    <Compile Include="ISampleStreamingGrain.cs" />
-    <Compile Include="ISerializationGeneratorTests.cs" />
-    <Compile Include="ISimpleDIGrain.cs" />
-    <Compile Include="ISimpleGenericGrain.cs" />
-    <Compile Include="CodegenTestInterfaces.cs" />
-    <Compile Include="ISimpleGrainWithAsyncMethods.cs" />
-    <Compile Include="IStatelessWorkerGrain.cs" />
-    <Compile Include="ISimpleObserverableGrain.cs" />
-    <Compile Include="IObserverGrain.cs" />
-    <Compile Include="ISimpleGrain.cs" />
-    <Compile Include="ISimplePersistentGrain.cs" />
-    <Compile Include="ILivenessTestGrain.cs" />
-    <Compile Include="IStreamingGrain.cs" />
-    <Compile Include="IStreamingImmutabilityTestGrain.cs" />
-    <Compile Include="IStreamInterceptionGrain.cs" />
-    <Compile Include="IStreamLifecycleTestGrains.cs" />
-    <Compile Include="IStreamLifecycleTestInternalGrains.cs" />
-    <Compile Include="IStreamReliabilityTestGrains.cs" />
-    <Compile Include="ITestExtension.cs" />
-    <Compile Include="ITestGrain.cs" />
-    <Compile Include="IStreaming_ProducerGrain.cs" />
-    <Compile Include="ITimerGrain.cs" />
-    <Compile Include="IValueTypeTestGrain.cs" />
-    <Compile Include="IConsiderForCodeGenerationGrain.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\orleans.codegen.cs" />
-    <Compile Include="SerializerExclusions.cs" />
-    <Compile Include="SQLAdapter\ICustomerGrain.cs" />
-    <Compile Include="SQLAdapter\IDeviceGrain.cs" />
-    <Compile Include="UnitTestGrainInterfaces.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrleansRuntime\OrleansRuntime.csproj">
-      <Project>{6ff2004c-cdf8-479c-bf27-c6bfe8ef93e0}</Project>
+      <Project>{aff2004c-cdf8-479c-bf27-c6bfe8ef93ea}</Project>
       <Name>OrleansRuntime</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Orleans\Orleans.csproj">
-      <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
+      <Project>{ac1bd60c-e7d8-4452-a21c-290aec8e2e7a}</Project>
       <Name>Orleans</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\TestFSharpInterfaces\TestFSharpInterfaces.fsproj">
-      <Project>{2375d7d5-9b30-493f-9c2e-a6b2811a3c5a}</Project>
-      <Name>TestFSharpInterfaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\TestInterfaces\TestInterfaces.csproj">
-      <Project>{aeff3b6c-7986-4bf9-85f5-2571decf8959}</Project>
-      <Name>TestInterfaces</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/vNext/test/TestGrainInterfaces/project.json
+++ b/vNext/test/TestGrainInterfaces/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "FSharp.Core": "4.0.0.1"
+  },
+  "frameworks": {
+    "net451": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}

--- a/vNext/test/TestGrainInterfaces/project.json
+++ b/vNext/test/TestGrainInterfaces/project.json
@@ -3,7 +3,7 @@
     "FSharp.Core": "4.0.0.1"
   },
   "frameworks": {
-    "net451": {}
+    "net462": {}
   },
   "runtimes": {
     "win-anycpu": {},


### PR DESCRIPTION
Kept separate commits to show exactly how I am migrating 1 project at a time from the main solution (at request by @xiazen). Can be squashed into 1 commit