### PR TITLE
Replace Expression Trees with IL

### DIFF
--- a/src/Orleans/Core/GrainCasterFactory.cs
+++ b/src/Orleans/Core/GrainCasterFactory.cs
@@ -1,0 +1,131 @@
+namespace Orleans
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Reflection.Emit;
+
+    using Orleans.Runtime;
+
+    internal static class GrainCasterFactory
+    {
+        /// <summary>
+        /// The cached <see cref="MethodInfo"/> for <see cref="GrainExtensions.AsWeaklyTypedReference"/>.
+        /// </summary>
+        private static readonly MethodInfo GrainReferenceCastHelperMethodInfo =
+            TypeUtils.Method((IAddressable i) => i.AsWeaklyTypedReference());
+
+        /// <summary>
+        /// The cached <see cref="MethodInfo"/> for <see cref="Type.IsAssignableFrom"/>.
+        /// </summary>
+        private static readonly MethodInfo IsAssignableFromMethodInfo =
+            TypeUtils.Method((Type t) => t.IsAssignableFrom(default(Type)));
+
+        /// <summary>
+        /// The cached <see cref="MethodInfo"/> for <see cref="object.GetType"/>.
+        /// </summary>
+        private static readonly MethodInfo GetTypeMethodInfo = TypeUtils.Method((object o) => o.GetType());
+
+        /// <summary>
+        /// The cached <see cref="MethodInfo"/> for <see cref="Type.GetTypeFromHandle"/>.
+        /// </summary>
+        private static readonly MethodInfo GetTypeFromHandleMethodInfo =
+            TypeUtils.Method(() => Type.GetTypeFromHandle(default(RuntimeTypeHandle)));
+
+        /// <summary>
+        /// Creates a grain reference caster delegate for the provided grain interface type and concrete grain reference type.
+        /// </summary>
+        /// <param name="interfaceType"></param>
+        /// <param name="grainReferenceType"></param>
+        /// <returns></returns>
+        public static GrainFactory.GrainReferenceCaster CreateGrainReferenceCaster(
+            Type interfaceType,
+            Type grainReferenceType)
+        {
+            // Get the grain reference constructor.
+            var constructor =
+                grainReferenceType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+                                  .Where(IsGrainReferenceCopyConstructor)
+                                  .FirstOrDefault();
+
+            if (constructor == null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot find suitable constructor on generated reference type for interface '{interfaceType}'");
+            }
+
+            var method = new DynamicMethod(
+                "caster_" + grainReferenceType.Name,
+                typeof(object),
+                new[] { typeof(IAddressable) },
+                typeof(GrainFactory).Module,
+                true);
+            var il = method.GetILGenerator();
+            var returnLabel = il.DefineLabel();
+
+            // C#: object result = grainRef;
+            il.DeclareLocal(typeof(object));
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Stloc_0);
+
+            // Get the runtime value of the target grain reference type.
+            // C#: var grainReferenceType = Type.GetTypeFromHandle(<grainReferenceType>.TypeHandle);
+            il.DeclareLocal(typeof(Type));
+            il.Emit(OpCodes.Ldtoken, grainReferenceType);
+            il.Emit(OpCodes.Call, GetTypeFromHandleMethodInfo);
+            il.Emit(OpCodes.Stloc_1);
+
+            // Get the runtime value of the target interface type.
+            // C#: var interfaceType = Type.GetTypeFromHandle(<interfaceType>.TypeHandle);
+            il.DeclareLocal(typeof(Type));
+            il.Emit(OpCodes.Ldtoken, interfaceType);
+            il.Emit(OpCodes.Call, GetTypeFromHandleMethodInfo);
+            il.Emit(OpCodes.Stloc_2);
+
+            // C#: if (grainReferenceType.IsAssignableFrom(grainRef.GetType())) return grainRef;
+            il.Emit(OpCodes.Ldloc_1);
+            il.Emit(OpCodes.Ldloc_0);
+            il.Emit(OpCodes.Call, GetTypeMethodInfo);
+            il.Emit(OpCodes.Callvirt, IsAssignableFromMethodInfo);
+            il.Emit(OpCodes.Brtrue_S, returnLabel);
+
+            // Convert the grainRef parameter to a weakly typed GrainReference.
+            // C#: result = grainRef.AsWeaklyTypedReference();
+            il.Emit(OpCodes.Ldloc_0);
+            il.Emit(OpCodes.Call, GrainReferenceCastHelperMethodInfo);
+            il.Emit(OpCodes.Stloc_0);
+
+            // If the result is assignable to the target interface type, return it.
+            // C#: if (interfaceType.IsAssignableFrom(result.GetType())) return result;
+            il.Emit(OpCodes.Ldloc_2);
+            il.Emit(OpCodes.Ldloc_0);
+            il.Emit(OpCodes.Call, GetTypeMethodInfo);
+            il.Emit(OpCodes.Callvirt, IsAssignableFromMethodInfo);
+            il.Emit(OpCodes.Brtrue_S, returnLabel);
+
+            // Otherwise, cast the input to a GrainReference and wrap it in the target type by calling the copy
+            // constructor.
+            // C#: result = new <grainReferenceType>((GrainReference)result);
+            var grainRefConstructor = TypeUtils.GetConstructorThatMatches(
+                grainReferenceType,
+                new[] { typeof(GrainReference) });
+            il.Emit(OpCodes.Ldloc_0);
+            il.Emit(OpCodes.Castclass, typeof(GrainReference));
+            il.Emit(OpCodes.Newobj, grainRefConstructor);
+            il.Emit(OpCodes.Stloc_0);
+
+            // C#: return result;
+            il.MarkLabel(returnLabel);
+            il.Emit(OpCodes.Ldloc_0);
+            il.Emit(OpCodes.Ret);
+
+            return (GrainFactory.GrainReferenceCaster)method.CreateDelegate(typeof(GrainFactory.GrainReferenceCaster));
+        }
+        
+        private static bool IsGrainReferenceCopyConstructor(ConstructorInfo constructor)
+        {
+            var parameters = constructor.GetParameters();
+            return parameters.Length == 1 && parameters[0].ParameterType == typeof(GrainReference);
+        }
+    }
+}

--- a/src/Orleans/Core/GrainExtensions.cs
+++ b/src/Orleans/Core/GrainExtensions.cs
@@ -11,27 +11,29 @@ namespace Orleans
     {
         private const string WRONG_GRAIN_ERROR_MSG = "Passing a half baked grain as an argument. It is possible that you instantiated a grain class explicitely, as a regular object and not via Orleans runtime or via proper test mocking";
 
-        private static GrainReference AsWeaklyTypedReference(this IAddressable grain)
+        internal static GrainReference AsWeaklyTypedReference(this IAddressable grain)
         {
-            var reference = grain as GrainReference;
             // When called against an instance of a grain reference class, do nothing
+            var reference = grain as GrainReference;
             if (reference != null) return reference;
 
             var grainBase = grain as Grain;
             if (grainBase != null)
             {
-                if (grainBase.Data == null || grainBase.Data.GrainReference == null)
+                if (grainBase.Data?.GrainReference == null)
                 {
-                    throw new ArgumentException(WRONG_GRAIN_ERROR_MSG, "grain");
+                    throw new ArgumentException(WRONG_GRAIN_ERROR_MSG, nameof(grain));
                 }
+
                 return grainBase.Data.GrainReference;
             }
 
             var systemTarget = grain as ISystemTargetBase;
-            if (systemTarget != null)
-                return GrainReference.FromGrainId(systemTarget.GrainId, null, systemTarget.Silo);
+            if (systemTarget != null) return GrainReference.FromGrainId(systemTarget.GrainId, null, systemTarget.Silo);
 
-            throw new ArgumentException(String.Format("AsWeaklyTypedReference has been called on an unexpected type: {0}.", grain.GetType().FullName), "grain");
+            throw new ArgumentException(
+                $"AsWeaklyTypedReference has been called on an unexpected type: {grain.GetType().FullName}.",
+                nameof(grain));
         }
 
         /// <summary>

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
 using Orleans.Runtime;
-using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
 
 namespace Orleans
 {
@@ -16,12 +13,6 @@ namespace Orleans
     /// </summary>
     public class GrainFactory : IGrainFactory
     {
-        /// <summary>
-        /// The cached <see cref="MethodInfo"/> for <see cref="GrainReference.CastInternal"/>.
-        /// </summary>
-        private static readonly MethodInfo GrainReferenceCastInternalMethodInfo =
-            TypeUtils.Method(() => GrainReference.CastInternal(default(Type), null, default(IAddressable), 0));
-
         /// <summary>
         /// The mapping between grain types and the corresponding type for the <see cref="IGrainMethodInvoker"/> implementation.
         /// </summary>
@@ -57,7 +48,7 @@ namespace Orleans
         /// </summary>
         /// <param name="existingReference">The existing <see cref="IAddressable"/> reference.</param>
         /// <returns>The concrete <see cref="GrainReference"/> implementation.</returns>
-        private delegate object GrainReferenceCaster(IAddressable existingReference);
+        internal delegate object GrainReferenceCaster(IAddressable existingReference);
 
         /// <summary>
         /// Gets a reference to a grain.
@@ -272,12 +263,18 @@ namespace Orleans
                                            ? typeInfo.GetGenericTypeDefinition()
                                            : interfaceType;
 
+            if (!typeof(IAddressable).IsAssignableFrom(interfaceType))
+            {
+                throw new InvalidCastException(
+                    $"Target interface must be derived from Orleans.IAddressable - cannot handle {interfaceType}");
+            }
+
             // Try to find the correct GrainReference type for this interface.
             Type grainReferenceType;
             if (!GrainToReferenceMapping.TryGetValue(genericInterfaceType, out grainReferenceType))
             {
                 throw new InvalidOperationException(
-                    string.Format("Cannot find generated GrainReference class for interface '{0}'", interfaceType));
+                    $"Cannot find generated GrainReference class for interface '{interfaceType}'");
             }
 
             if (interfaceType.IsConstructedGenericType)
@@ -285,44 +282,16 @@ namespace Orleans
                 grainReferenceType = grainReferenceType.MakeGenericType(typeInfo.GenericTypeArguments);
             }
 
-            // Get the grain reference constructor.
-            var constructor =
-                grainReferenceType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
-                    .Where(
-                        _ =>
-                        {
-                            var parameters = _.GetParameters();
-                            return parameters.Length == 1 && parameters[0].ParameterType == typeof(GrainReference);
-                        }).FirstOrDefault();
-
-            if (constructor == null)
+            if (!typeof(IAddressable).IsAssignableFrom(grainReferenceType))
             {
-                throw new InvalidOperationException(
-                    string.Format(
-                        "Cannot find suitable constructor on generated reference type for interface '{0}'",
-                        interfaceType));
+                // This represents an internal programming error.
+                throw new InvalidCastException(
+                    $"Target reference type must be derived from Orleans.IAddressable - cannot handle {grainReferenceType}");
             }
 
-            // Construct an expression to construct a new instance of this grain reference when given another grain
-            // reference.
-            var createLambdaParameter = Expression.Parameter(typeof(GrainReference), "gr");
-            var createLambda =
-                Expression.Lambda<Func<GrainReference, IAddressable>>(
-                    Expression.New(constructor, createLambdaParameter),
-                    createLambdaParameter);
-            var grainRefParameter = Expression.Parameter(typeof(IAddressable), "grainRef");
-            var body =
-                Expression.Call(
-                    GrainReferenceCastInternalMethodInfo,
-                    Expression.Constant(interfaceType),
-                    createLambda,
-                    grainRefParameter,
-                    Expression.Constant(GrainInterfaceUtils.GetGrainInterfaceId(interfaceType)));
-
-            // Compile and return the reference casting lambda.
-            var lambda = Expression.Lambda<GrainReferenceCaster>(body, grainRefParameter);
-            return lambda.Compile();
+            return GrainCasterFactory.CreateGrainReferenceCaster(interfaceType, grainReferenceType);
         }
+
         #endregion
 
         #region SystemTargets

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Async\UnobservedExceptionsHandlerClass.cs" />
     <Compile Include="Async\TaskExtensions.cs" />
     <Compile Include="CodeGeneration\GeneratedAssembly.cs" />
+    <Compile Include="Core\GrainCasterFactory.cs" />
     <Compile Include="Logging\LoggerExtensions.cs" />
     <Compile Include="Logging\LoggerImpl.cs" />
     <Compile Include="Logging\LogFormatter.cs" />

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -433,56 +433,9 @@ namespace Orleans.Runtime
 
             return RuntimeClient.Current.GrainTypeResolver != null && RuntimeClient.Current.GrainTypeResolver.IsUnordered(GrainId.GetTypeCode());
         }
-        
+
         #endregion
-
-        /// <summary>
-        /// Internal implementation of Cast operation for grain references
-        /// Called from generated code.
-        /// </summary>
-        /// <param name="targetReferenceType">Type that this grain reference should be cast to</param>
-        /// <param name="grainRefCreatorFunc">Delegate function to create grain references of the target type</param>
-        /// <param name="grainRef">Grain reference to cast from</param>
-        /// <param name="interfaceId">Interface id value for the target cast type</param>
-        /// <returns>GrainReference that is usable as the target type</returns>
-        /// <exception cref="System.InvalidCastException">if the grain cannot be cast to the target type</exception>
-        protected internal static IAddressable CastInternal(
-            Type targetReferenceType,
-            Func<GrainReference, IAddressable> grainRefCreatorFunc,
-            IAddressable grainRef,
-            int interfaceId)
-        {
-            if (grainRef == null) throw new ArgumentNullException("grainRef");
-
-            Type sourceType = grainRef.GetType();
-
-            if (!typeof(IAddressable).IsAssignableFrom(targetReferenceType))
-            {
-                throw new InvalidCastException(String.Format("Target type must be derived from Orleans.IAddressable - cannot handle {0}", targetReferenceType));
-            }
-            else if (typeof(Grain).IsAssignableFrom(sourceType))
-            {
-                Grain grainClassRef = (Grain)grainRef;
-                GrainReference g = FromGrainId(grainClassRef.Data.Identity);
-                grainRef = g;
-            }
-            else if (!typeof(GrainReference).IsAssignableFrom(sourceType))
-            {
-                throw new InvalidCastException(String.Format("Grain reference object must an Orleans.GrainReference - cannot handle {0}", sourceType));
-            }
-
-            if (targetReferenceType.IsAssignableFrom(sourceType))
-            {
-                // Already compatible - no conversion or wrapping necessary
-                return grainRef;
-            }
-
-            // We have an untyped grain reference that may resolve eventually successfully -- need to enclose in an apprroately typed wrapper class
-            var grainReference = (GrainReference) grainRef;
-            var grainWrapper = (GrainReference) grainRefCreatorFunc(grainReference);
-            return grainWrapper;
-        }
-
+        
         private static String GetDebugContext(string interfaceName, string methodName, object[] arguments)
         {
             // String concatenation is approx 35% faster than string.Format here

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -812,7 +812,7 @@ namespace Orleans.Serialization
                 ".ctor_" + type.Name,
                 typeof(GrainReference),
                 new[] { typeof(GrainReference) },
-                typeof(SerializationManager).Module,
+                typeof(SerializationManager).GetTypeInfo().Module,
                 true);
             var il = method.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -6,7 +6,6 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Net;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -806,18 +805,22 @@ namespace Orleans.Serialization
                 }
 
                 type = type.MakeGenericType(genericArgs);
-                typeInfo = type.GetTypeInfo();
             }
 
             var constructor = TypeUtils.GetConstructorThatMatches(type, new[] { typeof(GrainReference) });
-
-            var ctorParam = Expression.Parameter(typeof(GrainReference), "grainRef");
-            var lambda = Expression.Lambda(
-                typeof(Func<,>).MakeGenericType(typeof(GrainReference), type),
-                Expression.New(constructor, ctorParam),
-                true,
-                ctorParam);
-            return (Func<GrainReference, GrainReference>)lambda.Compile();
+            var method = new DynamicMethod(
+                ".ctor_" + type.Name,
+                typeof(GrainReference),
+                new[] { typeof(GrainReference) },
+                typeof(SerializationManager).Module,
+                true);
+            var il = method.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Newobj, constructor);
+            il.Emit(OpCodes.Ret);
+            return
+                (Func<GrainReference, GrainReference>)
+                method.CreateDelegate(typeof(Func<GrainReference, GrainReference>));
         }
 
 

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -2,9 +2,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading.Tasks;


### PR DESCRIPTION
Three commits with the same purpose: replacing usage of [LINQ Expression Tree](https://msdn.microsoft.com/en-us/library/mt654263.aspx) compilation with IL, since [this blog post about .NET Standard](https://blogs.msdn.microsoft.com/dotnet/2016/09/26/introducing-net-standard/) indicates that Expression.Compile will be interpreted (rather than compiled to IL) in upcoming versions of the platform:
> In some cases we’ll emulate their behavior (e.g. interpreting expression trees instead of compiling them) while in other cases we’ll throw (e.g. when compiling regexes).

The mixed use of LINQ Expressions & IL has also been bugging me for a while.

As a part of this work, this change removes `GrainFactory.CastInternal` and instead calls `GrainExtensions.AsReference<T>` as needed. I removed that method because calling it from IL was complicated because one of the parameters was a `Func<IAddressable, GrainReference>`, which is difficult to call from IL (requires generating a type with static fields/methods & passing function pointer to ctor for `Func<..>`) & it wasn't strictly necessary. The result is simpler, in my opinion.

Let me know what you think.