### PR TITLE
Ability to specify interleaving per message type

### DIFF
--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -76,6 +76,28 @@ namespace Orleans
         }
 
         /// <summary>
+        /// The MayInterleaveAttribute attribute is used to mark classes 
+        /// that want to control request interleaving via supplied method callback.
+        /// </summary>
+        /// <remarks>
+        /// The callback method name should point to a public static function declared on the same class 
+        /// and having the following signature: <c>public static bool MayInterleave(InvokeMethodRequest req)</c>
+        /// </remarks>
+        [AttributeUsage(AttributeTargets.Class)]
+        public sealed class MayInterleaveAttribute : Attribute
+        {
+            /// <summary>
+            /// The name of the callback method
+            /// </summary>
+            internal string CallbackMethodName { get; private set; }
+
+            public MayInterleaveAttribute(string callbackMethodName)
+            {
+                CallbackMethodName = callbackMethodName;
+            }
+        }
+
+        /// <summary>
         /// The Immutable attribute indicates that instances of the marked class or struct are never modified
         /// after they are created.
         /// </summary>

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -382,14 +382,14 @@ namespace Orleans.Runtime
 
 #region Grains
 
-        internal bool IsReentrantGrain(ActivationId running)
+        internal bool IsMessageInterleaves(Message message, ActivationId running)
         {
             ActivationData target;
             GrainTypeData data;
             return TryGetActivationData(running, out target) &&
                 target.GrainInstance != null &&
                 GrainTypeManager.TryGetData(TypeUtils.GetFullName(target.GrainInstanceType), out data) &&
-                data.IsReentrant;
+                data.IsMessageInterleaves(message);
         }
 
         public void GetGrainTypeInfo(int typeCode, out string grainClass, out PlacementStrategy placement, out MultiClusterRegistrationStrategy activationStrategy, string genericArguments = null)

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -382,14 +382,14 @@ namespace Orleans.Runtime
 
 #region Grains
 
-        internal bool IsMessageInterleaves(Message message, ActivationId running)
+        internal bool CanInterleave(ActivationId running, Message message)
         {
             ActivationData target;
             GrainTypeData data;
             return TryGetActivationData(running, out target) &&
                 target.GrainInstance != null &&
                 GrainTypeManager.TryGetData(TypeUtils.GetFullName(target.GrainInstanceType), out data) &&
-                data.IsMessageInterleaves(message);
+                (data.IsReentrant || data.IsMessageAllowedToInterleave(message));
         }
 
         public void GetGrainTypeInfo(int typeCode, out string grainClass, out PlacementStrategy placement, out MultiClusterRegistrationStrategy activationStrategy, string genericArguments = null)

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Orleans.CodeGeneration;
 using Orleans.GrainDirectory;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
@@ -389,7 +391,7 @@ namespace Orleans.Runtime
             return TryGetActivationData(running, out target) &&
                 target.GrainInstance != null &&
                 GrainTypeManager.TryGetData(TypeUtils.GetFullName(target.GrainInstanceType), out data) &&
-                (data.IsReentrant || data.IsMessageAllowedToInterleave(message));
+                (data.IsReentrant || data.MayInterleave((InvokeMethodRequest)message.BodyObject));
         }
 
         public void GetGrainTypeInfo(int typeCode, out string grainClass, out PlacementStrategy placement, out MultiClusterRegistrationStrategy activationStrategy, string genericArguments = null)

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -314,7 +314,7 @@ namespace Orleans.Runtime
         public bool CanInterleave(ActivationData targetActivation, Message incoming)
         {
             bool canInterleave = 
-                   catalog.IsReentrantGrain(targetActivation.ActivationId)
+                   catalog.IsMessageInterleaves(incoming, targetActivation.ActivationId)
                 || incoming.IsAlwaysInterleave
                 || targetActivation.Running == null
                 || (targetActivation.Running.IsReadOnly && incoming.IsReadOnly);
@@ -341,7 +341,7 @@ namespace Orleans.Runtime
             foreach (object invocationObj in prevChain)
             {
                 var prevId = ((RequestInvocationHistory)invocationObj).ActivationId;
-                if (!prevId.Equals(nextActivationId) || catalog.IsReentrantGrain(nextActivationId)) continue;
+                if (!prevId.Equals(nextActivationId) || catalog.IsMessageInterleaves(message, nextActivationId)) continue;
 
                 var newChain = new List<RequestInvocationHistory>();
                 newChain.AddRange(prevChain.Cast<RequestInvocationHistory>());

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -314,7 +314,7 @@ namespace Orleans.Runtime
         public bool CanInterleave(ActivationData targetActivation, Message incoming)
         {
             bool canInterleave = 
-                   catalog.IsMessageInterleaves(incoming, targetActivation.ActivationId)
+                   catalog.CanInterleave(targetActivation.ActivationId, incoming)
                 || incoming.IsAlwaysInterleave
                 || targetActivation.Running == null
                 || (targetActivation.Running.IsReadOnly && incoming.IsReadOnly);
@@ -341,7 +341,7 @@ namespace Orleans.Runtime
             foreach (object invocationObj in prevChain)
             {
                 var prevId = ((RequestInvocationHistory)invocationObj).ActivationId;
-                if (!prevId.Equals(nextActivationId) || catalog.IsMessageInterleaves(message, nextActivationId)) continue;
+                if (!prevId.Equals(nextActivationId) || catalog.CanInterleave(nextActivationId, message)) continue;
 
                 var newChain = new List<RequestInvocationHistory>();
                 newChain.AddRange(prevChain.Cast<RequestInvocationHistory>());

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
@@ -138,9 +138,9 @@ namespace Orleans.Runtime
             IsMessageInterleavesPredicate = predicate;
         }
 
-        public bool IsMessageInterleaves(Message message)
+        public bool IsMessageAllowedToInterleave(Message message)
         {
-            return IsReentrant || IsMessageInterleavesPredicate(message.BodyObject.GetType());
+            return IsMessageInterleavesPredicate(message.BodyObject.GetType());
         }
     }
 }

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
@@ -142,8 +142,10 @@ namespace Orleans.Runtime
 
         public bool IsMessageAllowedToInterleave(Message message)
         {
-            var request = message.BodyObject as InvokeMethodRequest;
-            return request != null && IsMessageAllowedToInterleavePredicate(request);
+            if (message.Direction != Message.Directions.Request)
+                return IsReentrant;
+
+            return IsMessageAllowedToInterleavePredicate((InvokeMethodRequest)message.BodyObject);
         }
     }
 }

--- a/test/TestExtensions/HostedTestClusterBase.cs
+++ b/test/TestExtensions/HostedTestClusterBase.cs
@@ -13,7 +13,7 @@ namespace TestExtensions
     {
         protected TestCluster HostedCluster { get; private set; }
 
-        public HostedTestClusterEnsureDefaultStarted(DefaultClusterFixture fixture)
+        public HostedTestClusterEnsureDefaultStarted(BaseTestClusterFixture fixture)
         {
             this.HostedCluster = fixture.HostedCluster;
         }

--- a/test/TestExtensions/HostedTestClusterBase.cs
+++ b/test/TestExtensions/HostedTestClusterBase.cs
@@ -13,7 +13,7 @@ namespace TestExtensions
     {
         protected TestCluster HostedCluster { get; private set; }
 
-        public HostedTestClusterEnsureDefaultStarted(BaseTestClusterFixture fixture)
+        public HostedTestClusterEnsureDefaultStarted(DefaultClusterFixture fixture)
         {
             this.HostedCluster = fixture.HostedCluster;
         }

--- a/test/TestGrainInterfaces/IReentrancyGrain.cs
+++ b/test/TestGrainInterfaces/IReentrancyGrain.cs
@@ -23,6 +23,19 @@ namespace UnitTests.GrainInterfaces
         Task SetSelf(INonReentrantGrain self);
     }
 
+    public interface INonReentrantGrainWithMessageInterleavePredicate : IGrainWithIntegerKey
+    {
+        Task<string> One(string arg); // this interleaves only when arg == "reentrant"
+
+        Task<string> Two();
+
+        Task<string> TwoReentrant();
+
+        Task Exceptional();
+
+        Task SetSelf(INonReentrantGrainWithMessageInterleavePredicate self);
+    }
+
     [Unordered]
     public interface IUnorderedNonReentrantGrain : IGrainWithIntegerKey
     {

--- a/test/TestGrainInterfaces/IReentrancyGrain.cs
+++ b/test/TestGrainInterfaces/IReentrancyGrain.cs
@@ -28,10 +28,12 @@ namespace UnitTests.GrainInterfaces
         Task<string> One(string arg); // this interleaves only when arg == "reentrant"
 
         Task<string> Two();
-
         Task<string> TwoReentrant();
 
         Task Exceptional();
+
+        Task SubscribeToStream();
+        Task PushToStream(string item);
 
         Task SetSelf(INonReentrantGrainWithMessageInterleavePredicate self);
     }

--- a/test/TestGrainInterfaces/IReentrancyGrain.cs
+++ b/test/TestGrainInterfaces/IReentrancyGrain.cs
@@ -23,7 +23,7 @@ namespace UnitTests.GrainInterfaces
         Task SetSelf(INonReentrantGrain self);
     }
 
-    public interface INonReentrantGrainWithMessageInterleavePredicate : IGrainWithIntegerKey
+    public interface IMayInterleavePredicateGrain : IGrainWithIntegerKey
     {
         Task<string> One(string arg); // this interleaves only when arg == "reentrant"
 
@@ -35,7 +35,7 @@ namespace UnitTests.GrainInterfaces
         Task SubscribeToStream();
         Task PushToStream(string item);
 
-        Task SetSelf(INonReentrantGrainWithMessageInterleavePredicate self);
+        Task SetSelf(IMayInterleavePredicateGrain self);
     }
 
     [Unordered]

--- a/test/TestGrains/ReentrantGrain.cs
+++ b/test/TestGrains/ReentrantGrain.cs
@@ -68,6 +68,39 @@ namespace UnitTests.Grains
         }
     }
 
+    public class NonReentrantGrainWithMessageInterleavePredicate : Grain, INonReentrantGrainWithMessageInterleavePredicate
+    {
+        private INonReentrantGrainWithMessageInterleavePredicate Self { get; set; }
+
+        // this interleaves only when arg == "reentrant" 
+        // and test predicate will throw when arg = "err"
+        public Task<string> One(string arg)
+        {
+            return Task.FromResult("one");
+        }
+
+        public async Task<string> Two()
+        {
+            return await Self.One("") + " two";
+        }
+
+        public async Task<string> TwoReentrant()
+        {
+            return await Self.One("reentrant") + " two";
+        }
+
+        public Task Exceptional()
+        {
+            return Self.One("err");
+        }
+
+        public Task SetSelf(INonReentrantGrainWithMessageInterleavePredicate self)
+        {
+            Self = self;
+            return TaskDone.Done;
+        }
+    }
+
     public class UnorderedNonRentrantGrain : Grain, IUnorderedNonReentrantGrain
     {
         private IUnorderedNonReentrantGrain Self { get; set; }

--- a/test/TestGrains/ReentrantGrain.cs
+++ b/test/TestGrains/ReentrantGrain.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Concurrency;
 using Orleans.Runtime;
+using Orleans.Streams;
+
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
@@ -93,6 +95,26 @@ namespace UnitTests.Grains
         {
             return Self.One("err");
         }
+
+        public async Task SubscribeToStream()
+        {
+            var stream = GetStream();
+
+            await stream.SubscribeAsync((item, _) =>
+            {
+                var logger = GetLogger();
+                logger.Info("Received stream item:" + item);
+                return TaskDone.Done;
+            });
+        }
+
+        public Task PushToStream(string item)
+        {
+            return GetStream().OnNextAsync(item);
+        }
+
+        IAsyncStream<string> GetStream() => 
+            GetStreamProvider("sms").GetStream<string>(Guid.Empty, "test-stream-interleave");
 
         public Task SetSelf(INonReentrantGrainWithMessageInterleavePredicate self)
         {

--- a/test/TestGrains/ReentrantGrain.cs
+++ b/test/TestGrains/ReentrantGrain.cs
@@ -71,7 +71,7 @@ namespace UnitTests.Grains
         }
     }
 
-    [MayInterleave("MayInterleave")]
+    [MayInterleave(nameof(MayInterleave))]
     public class MayInterleavePredicateGrain : Grain, IMayInterleavePredicateGrain
     {
         public static bool MayInterleave(InvokeMethodRequest req)

--- a/test/TesterInternal/ReentrancyTests.cs
+++ b/test/TesterInternal/ReentrancyTests.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Concurrency;
 using Orleans.Providers;
+using Orleans.Providers.Streams.SimpleMessageStream;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
@@ -27,8 +29,10 @@ namespace UnitTests
             {
                 var options = new TestClusterOptions();
                 options.ClusterConfiguration.Globals.RegisterBootstrapProvider<MessageInterleavesPredicateBootstrapProvider>("message_interleaves_predicate_bootstrap");
+                options.ClusterConfiguration.Globals.RegisterStreamProvider<SimpleMessageStreamProvider>("sms");
                 options.ClusterConfiguration.AddMemoryStorageProvider("Default");
                 options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore");
+                options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
                 return new TestCluster(options);
             }
         }
@@ -116,11 +120,11 @@ namespace UnitTests
             }
             if (this.HostedCluster.ClusterConfiguration.Globals.PerformDeadlockDetection)
             {
-                Assert.True(deadlock, "Non-reentrant grain should deadlock");
+                Assert.True(deadlock, "Non-reentrant grain should deadlock when CanInterleave predicate returns false");
             }
             else
             {
-                Assert.True(timeout, "Non-reentrant grain should timeout");
+                Assert.True(timeout, "Non-reentrant grain should timeout when CanInterleave predicate returns false");
             }
             logger.Info("Reentrancy NonReentrantGrain_WithMessageInterleavesPredicate_WhenPredicateReturnsFalse Test finished OK.");
         }
@@ -132,13 +136,83 @@ namespace UnitTests
             grain.SetSelf(grain).Wait();
             try
             {
-                Assert.True(grain.TwoReentrant().Wait(2000), "Grain should reenter");
+                Assert.True(grain.TwoReentrant().Wait(2000), "Grain should reenter when CanInterleave predicate returns true");
             }
             catch (Exception ex)
             {
                 Assert.True(false, string.Format("Unexpected exception {0}: {1}", ex.Message, ex.StackTrace));
             }
             logger.Info("Reentrancy NonReentrantGrain_WithMessageInterleavesPredicate_WhenPredicateReturnsTrue Test finished OK.");
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
+        public void NonReentrantGrain_WithMessageInterleavesPredicate_StreamItemDelivery_WhenPredicateReturnsFalse()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<INonReentrantGrainWithMessageInterleavePredicate>(GetRandomGrainId());
+            grain.SubscribeToStream().Wait();
+            bool timeout = false;
+            bool deadlock = false;
+            try
+            {
+                timeout = !grain.PushToStream("foo").Wait(2000);
+            }
+            catch (Exception exc)
+            {
+                Exception baseExc = exc.GetBaseException();
+                if (baseExc.GetType().Equals(typeof(DeadlockException)))
+                {
+                    deadlock = true;
+                }
+                else
+                {
+                    Assert.True(false, string.Format("Unexpected exception {0}: {1}", exc.Message, exc.StackTrace));
+                }
+            }
+            if (this.HostedCluster.ClusterConfiguration.Globals.PerformDeadlockDetection)
+            {
+                Assert.True(deadlock, "Non-reentrant grain should deadlock on stream item delivery to itself when CanInterleave predicate returns false");
+            }
+            else
+            {
+                Assert.True(timeout, "Non-reentrant grain should timeout on stream item delivery to itself when CanInterleave predicate returns false");
+            }
+            logger.Info("Reentrancy NonReentrantGrain_WithMessageInterleavesPredicate_StreamItemDelivery_WhenPredicateReturnsFalse Test finished OK.");
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
+        public void NonReentrantGrain_WithMessageInterleavesPredicate_StreamItemDelivery_WhenPredicateReturnsTrue()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<INonReentrantGrainWithMessageInterleavePredicate>(GetRandomGrainId());
+            grain.SubscribeToStream().Wait();
+            try
+            {
+                grain.PushToStream("reentrant").Wait(2000);
+            }
+            catch (Exception ex)
+            {
+                Assert.True(false, string.Format("Unexpected exception {0}: {1}", ex.Message, ex.StackTrace));
+            }
+            logger.Info("Reentrancy NonReentrantGrain_WithMessageInterleavesPredicate_StreamItemDelivery_WhenPredicateReturnsTrue Test finished OK.");
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
+        public void NonReentrantGrain_WithMessageInterleavesPredicate_WhenPredicateThrows()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<INonReentrantGrainWithMessageInterleavePredicate>(GetRandomGrainId());
+            grain.SetSelf(grain).Wait();
+            try
+            {
+                grain.Exceptional().Wait(2000);
+            }
+            catch (Exception ex)
+            {
+                Assert.IsType<OrleansException>(ex.GetBaseException());
+                Assert.NotNull(ex.GetBaseException().InnerException);
+                Assert.IsType<ApplicationException>(ex.GetBaseException().InnerException);
+                Assert.True(ex.GetBaseException().InnerException?.Message == "boom", 
+                    "Should fail with Orleans runtime exception having all of neccessary details");
+            }
+            logger.Info("Reentrancy NonReentrantGrain_WithMessageInterleavesPredicate_WhenPredicateThrows Test finished OK.");
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
@@ -426,12 +500,33 @@ namespace UnitTests
             GrainTypeManager.Instance.TryGetData(typeof(NonReentrantGrainWithMessageInterleavePredicate).FullName, out grainType);
             grainType.SetMessageAllowedToInterleavePredicate(req =>
             {
-                if (req.Arguments.Length != 1)
+                // not interested
+                if (req.Arguments.Length == 0)
                     return false;
 
-                var arg = (string)req.Arguments[0];
+                string arg = null;
+
+                // assume single argument message
+                if (req.Arguments.Length == 1)
+                    arg = (string)UnwrapImmutable(req.Arguments[0]);
+
+                // assume stream message
+                if (req.Arguments.Length == 2)
+                    arg = (string) UnwrapImmutable(req.Arguments[1]);
+                
+                if (arg == "err")
+                    throw new ApplicationException("boom");
+
                 return arg == "reentrant";
             });
+        }
+
+        static object UnwrapImmutable(object item)
+        {
+            // how to unwrap Immutable<T>? Can we make Immutable<T> to implement IImmutable to support such cases?
+            return item is Immutable<object>
+                       ? ((Immutable<object>) item).Value
+                       : item;
         }
 
         public Task Close() => TaskDone.Done;


### PR DESCRIPTION
Hi guys!

As you know Orleankka provides a functional message-based style API for Orleans and all grains have a uniform interface like: 

```cs
interface IActor
{
    Task<object> Receive(object msg);
}
```

To support some advanced scenarios like ability to specify message interleaving in a more granular way (per-message type) which is incredibly valuable feature we extended this interface with additional method:

```cs
interface IActor
{
    Task<object> Receive(object msg);
    [AlwaysInterleave] Task<object> ReceiveReentrant(object msg);
}
```
So when sending a message via actor reference we were selecting one method ot the other depending on the configuration for this message/actor type.

I'm preparing next big and updated release (1.0, ya finally!) and most anticipated feature is to be able to send messages from clients without need to reference server-side libraries (containing actor definitions). Basically, proper client-server separation.

Unfortunately, current implementation of per-message reentrancy requires to have that information on client (so that we can choose either `Receive` or `ReceiveReentrant`). Which is a leak of server-side knowledge and is very illogical.

I haven't found any other way then to extend implementation upstream. It's just a rough sketch not a final code, something to discuss further. I will highly appreciate you help on this issue. Please advice, mesage reentrancy is very important (and used) feature in Orleankka and now this stops me from releasing 1.0 😞 