### PR TITLE
Renamed InjectMoreWorkerThreads to EnableWorkerThreadInjection

### DIFF
--- a/src/Orleans/Configuration/NodeConfiguration.cs
+++ b/src/Orleans/Configuration/NodeConfiguration.cs
@@ -111,7 +111,7 @@ namespace Orleans.Runtime.Configuration
         /// </summary>
         public TimeSpan TurnWarningLengthThreshold { get; set; }
 
-        internal bool InjectMoreWorkerThreads { get; set; }
+        internal bool EnableWorkerThreadInjection { get; set; }
 
         /// <summary>
         /// The LoadShedding element specifies the gateway load shedding configuration for the node.
@@ -224,7 +224,7 @@ namespace Orleans.Runtime.Configuration
         private const int DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE = 200;
         private static readonly int DEFAULT_MIN_DOT_NET_CONNECTION_LIMIT = DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE;
         private static readonly TimeSpan DEFAULT_ACTIVATION_SCHEDULING_QUANTUM = TimeSpan.FromMilliseconds(100);
-        internal const bool INJECT_MORE_WORKER_THREADS = false;
+        internal const bool ENABLE_WORKER_THREAD_INJECTION = false;
 
         public NodeConfiguration()
         {
@@ -242,7 +242,7 @@ namespace Orleans.Runtime.Configuration
             DelayWarningThreshold = TimeSpan.FromMilliseconds(10000); // 10,000 milliseconds
             ActivationSchedulingQuantum = DEFAULT_ACTIVATION_SCHEDULING_QUANTUM;
             TurnWarningLengthThreshold = TimeSpan.FromMilliseconds(200);
-            InjectMoreWorkerThreads = INJECT_MORE_WORKER_THREADS;
+            EnableWorkerThreadInjection = ENABLE_WORKER_THREAD_INJECTION;
 
             LoadSheddingEnabled = false;
             LoadSheddingLimit = 95;
@@ -289,7 +289,7 @@ namespace Orleans.Runtime.Configuration
             DelayWarningThreshold = other.DelayWarningThreshold;
             ActivationSchedulingQuantum = other.ActivationSchedulingQuantum;
             TurnWarningLengthThreshold = other.TurnWarningLengthThreshold;
-            InjectMoreWorkerThreads = other.InjectMoreWorkerThreads;
+            EnableWorkerThreadInjection = other.EnableWorkerThreadInjection;
 
             LoadSheddingEnabled = other.LoadSheddingEnabled;
             LoadSheddingLimit = other.LoadSheddingLimit;
@@ -349,7 +349,7 @@ namespace Orleans.Runtime.Configuration
             sb.Append("      ").Append("   Delay Warning Threshold: ").Append(DelayWarningThreshold).AppendLine();
             sb.Append("      ").Append("   Activation Scheduling Quantum: ").Append(ActivationSchedulingQuantum).AppendLine();
             sb.Append("      ").Append("   Turn Warning Length Threshold: ").Append(TurnWarningLengthThreshold).AppendLine();
-            sb.Append("      ").Append("   Inject More Worker Threads: ").Append(InjectMoreWorkerThreads).AppendLine();
+            sb.Append("      ").Append("   Inject More Worker Threads: ").Append(EnableWorkerThreadInjection).AppendLine();
             sb.Append("      ").Append("   MinDotNetThreadPoolSize: ").Append(MinDotNetThreadPoolSize).AppendLine();
 #if !NETSTANDARD_TODO
             int workerThreads;

--- a/src/OrleansRuntime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/OrleansRuntime/Scheduler/OrleansTaskScheduler.cs
@@ -30,13 +30,13 @@ namespace Orleans.Runtime.Scheduler
 
         public OrleansTaskScheduler(int maxActiveThreads)
             : this(maxActiveThreads, TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(100),
-            NodeConfiguration.INJECT_MORE_WORKER_THREADS, LimitManager.GetDefaultLimit(LimitNames.LIMIT_MAX_PENDING_ITEMS))
+            NodeConfiguration.ENABLE_WORKER_THREAD_INJECTION, LimitManager.GetDefaultLimit(LimitNames.LIMIT_MAX_PENDING_ITEMS))
         {
         }
 
         public OrleansTaskScheduler(GlobalConfiguration globalConfig, NodeConfiguration config)
             : this(config.MaxActiveThreads, config.DelayWarningThreshold, config.ActivationSchedulingQuantum,
-                    config.TurnWarningLengthThreshold, config.InjectMoreWorkerThreads, config.LimitManager.GetLimit(LimitNames.LIMIT_MAX_PENDING_ITEMS))
+                    config.TurnWarningLengthThreshold, config.EnableWorkerThreadInjection, config.LimitManager.GetLimit(LimitNames.LIMIT_MAX_PENDING_ITEMS))
         {
         }
 


### PR DESCRIPTION
This is a minor follow-up for #2218.

Renamed InjectMoreWorkerThreads to EnableWorkerThreadInjection in config for better clarity.