### PR TITLE
Simplify code generation attributes to always use Type

### DIFF
--- a/src/Orleans/CodeGeneration/ActivationAttribute.cs
+++ b/src/Orleans/CodeGeneration/ActivationAttribute.cs
@@ -2,36 +2,26 @@ using System;
 
 namespace Orleans.CodeGeneration
 {
-    using Orleans.Runtime;
-
     /// <summary>
     /// For internal (run-time) use only.
     /// Base class of all the activation attributes 
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes"), AttributeUsage(System.AttributeTargets.All)]
+    [AttributeUsage(System.AttributeTargets.All)]
     public abstract class GeneratedAttribute : Attribute
     {
         /// <summary>
-        /// Gets or sets the type which this implementation applies to.
+        /// Initializes a new instance of the <see cref="GeneratedAttribute"/> class.
         /// </summary>
-        public string ForGrainType { get; protected set; }
-
-        /// <summary>
-        /// Gets or sets the type which this implementation applies to.
-        /// </summary>
-        public Type GrainType { get; protected set; }
-
-        /// <summary>
-        /// </summary>
-        /// <param name="forGrainType">type argument</param>
-        protected GeneratedAttribute(string forGrainType)
+        /// <param name="targetType">The type which this implementation applies to.</param>
+        protected GeneratedAttribute(Type targetType)
         {
-            ForGrainType = forGrainType;
+            this.TargetType = targetType;
         }
 
         /// <summary>
+        /// Gets the type which this implementation applies to.
         /// </summary>
-        protected GeneratedAttribute() { }
+        public Type TargetType { get; }
     }
 
     /// <summary>
@@ -40,19 +30,17 @@ namespace Orleans.CodeGeneration
     [AttributeUsage(System.AttributeTargets.Class)]
     public sealed class MethodInvokerAttribute : GeneratedAttribute
     {
-        /// <summary>Initializes a new instance of <see cref="MethodInvokerAttribute"/>.</summary>
-        /// <param name="forGrainType">The type which this implementation applies to.</param>
+        /// <summary>Initializes a new instance of the <see cref="MethodInvokerAttribute"/> class.</summary>
+        /// <param name="targetType">The grain implementation type</param>
         /// <param name="interfaceId">The ID assigned to the interface by Orleans</param>
-        /// <param name="grainType">The grain implementation type</param>
-        public MethodInvokerAttribute(string forGrainType, int interfaceId, Type grainType = null)
+        public MethodInvokerAttribute(Type targetType, int interfaceId)
+            : base(targetType)
         {
-            ForGrainType = forGrainType;
             InterfaceId = interfaceId;
-            GrainType = grainType;
         }
 
-        /// <summary>The ID assigned to the interface by Orleans</summary>
-        public int InterfaceId { get; private set; }
+        /// <summary>Gets the ID assigned to the interface by Orleans</summary>
+        public int InterfaceId { get; }
     }
 
     /// <summary>Identifies a concrete grain reference to an interface ID</summary>
@@ -60,20 +48,12 @@ namespace Orleans.CodeGeneration
     public sealed class GrainReferenceAttribute : GeneratedAttribute
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="GrainReferenceAttribute"/> class.
         /// </summary>
-        /// <param name="forGrainType">type argument</param>
-        public GrainReferenceAttribute(string forGrainType)
+        /// <param name="targetType">The type which this implementation applies to.</param>
+        public GrainReferenceAttribute(Type targetType)
+            : base(targetType)
         {
-            ForGrainType = forGrainType;
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <param name="forGrainType">type argument</param>
-        public GrainReferenceAttribute(Type forGrainType)
-        {
-            GrainType = forGrainType;
-            ForGrainType = forGrainType.GetParseableName();
         }
     }
 
@@ -84,12 +64,12 @@ namespace Orleans.CodeGeneration
     public sealed class SerializerAttribute : GeneratedAttribute
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="SerializerAttribute"/> class.
         /// </summary>
-        /// <param name="serializableType">The target type that these serializer methods are for.</param>
-        public SerializerAttribute(Type serializableType)
+        /// <param name="targetType">The type that this implementation can serialize.</param>
+        public SerializerAttribute(Type targetType)
+            : base(targetType)
         {
-            GrainType = serializableType;
-            ForGrainType = serializableType.GetParseableName();
         }
     }
 }

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -342,13 +342,13 @@ namespace Orleans
             var invokerAttr = typeInfo.GetCustomAttribute<MethodInvokerAttribute>(false);
             if (invokerAttr != null)
             {
-                GrainToInvokerMapping.TryAdd(invokerAttr.GrainType, type);
+                GrainToInvokerMapping.TryAdd(invokerAttr.TargetType, type);
             }
             
             var grainReferenceAttr = typeInfo.GetCustomAttribute<GrainReferenceAttribute>(false);
             if (grainReferenceAttr != null)
             {
-                GrainToReferenceMapping.TryAdd(grainReferenceAttr.GrainType, type);
+                GrainToReferenceMapping.TryAdd(grainReferenceAttr.TargetType, type);
             }
         }
 

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -749,7 +749,7 @@ namespace Orleans.Serialization
         internal static bool IsGeneratedGrainReference(MemberInfo type)
         {
             var attr = type.GetCustomAttribute<GrainReferenceAttribute>();
-            return attr != null && attr.GrainType != null;
+            return attr?.TargetType != null;
         }
 
         /// <summary>
@@ -761,7 +761,7 @@ namespace Orleans.Serialization
         private static void RegisterGrainReferenceSerializers(Type type)
         {
             var attr = type.GetTypeInfo().GetCustomAttribute<GrainReferenceAttribute>();
-            if (attr == null || attr.GrainType == null)
+            if (attr?.TargetType != null)
             {
                 return;
             }

--- a/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
@@ -56,9 +56,8 @@ namespace Orleans.CodeGenerator
                 CodeGeneratorCommon.GetGeneratedCodeAttributeSyntax(),
                 SF.Attribute(typeof(MethodInvokerAttribute).GetNameSyntax())
                     .AddArgumentListArguments(
-                        SF.AttributeArgument(grainType.GetParseableName().GetLiteralExpression()),
-                        SF.AttributeArgument(interfaceIdArgument),
-                        SF.AttributeArgument(grainTypeArgument)),
+                        SF.AttributeArgument(grainTypeArgument),
+                        SF.AttributeArgument(interfaceIdArgument)),
 #if !NETSTANDARD
                 SF.Attribute(typeof(ExcludeFromCodeCoverageAttribute).GetNameSyntax())
 #endif

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -530,13 +530,9 @@ namespace Orleans.CodeGenerator
             var results = new HashSet<Type>();
             foreach (var attribute in attributes)
             {
-                if (attribute.GrainType != null)
+                if (attribute.TargetType != null)
                 {
-                    results.Add(attribute.GrainType);
-                }
-                else if (!string.IsNullOrWhiteSpace(attribute.ForGrainType))
-                {
-                    results.Add(Type.GetType(attribute.ForGrainType));
+                    results.Add(attribute.TargetType);
                 }
             }
 

--- a/test/TesterInternal/General/InternalSerializationTests.cs
+++ b/test/TesterInternal/General/InternalSerializationTests.cs
@@ -117,7 +117,7 @@ namespace UnitTests.Serialization
                 _ =>
                 {
                     var attr = _.GetCustomAttribute<GrainReferenceAttribute>();
-                    return attr != null && attr.GrainType == grainType;
+                    return attr != null && attr.TargetType == grainType;
                 }).AsType();
 
             if (typeInfo.IsConstructedGenericType)


### PR DESCRIPTION
Currently code generation attributes such as `[MethodInvoker]` and `[GrainReference]` can be instantiated using either the name of the `IGrain` type which they were generated for, or the `Type` itself.

This removes the string property, which is unnecessary.
Before:
```c#
[MethodInvoker("global::Orleans.IMembershipTableGrain", -1256503757, typeof (global::Orleans.IMembershipTableGrain))]
```
After:
```C#
[MethodInvoker(typeof(IMembershipTableGrain), -1256503757)]
```

Renames `GrainType` to `TargetType`, since the property is used for both generated serializers and grain interfaces.

Removes the unnecessary code analysis suppression, since [CA1813:AvoidUnsealedAttributes](https://msdn.microsoft.com/en-us/library/ms182267.aspx) does not apply to abstract classes.

Edit: this simplifies the logic used when loading support classes, so that it is more obviously correct. Previously the code (inconsistently) checked for both the `GrainType` & `ForGrainType` properties.