### PR TITLE
Replace "Microsoft Research" with "Microsoft" in the nuspecs

### DIFF
--- a/src/Chocolatey/orleans.nuspec
+++ b/src/Chocolatey/orleans.nuspec
@@ -12,7 +12,7 @@
     </description>
     <projectUrl>https://github.com/dotnet/orleans</projectUrl>
     <tags>Orleans Silo Deployment Cloud-Computing Actor-Model Actors Virtual-Actors Distributed-Systems C# .NET</tags>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <copyright>Copyright (C) 2015 Microsoft Research</copyright>
     <licenseUrl>https://github.com/dotnet/orleans/blob/master/LICENSE</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.Client.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Client.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.Client</id>
     <version>$version$</version>
     <title>Microsoft Orleans Client Libraries</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.Core.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Core.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.Core</id>
     <version>$version$</version>
     <title>Microsoft Orleans Core Library</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
+++ b/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.CounterControl</id>
     <version>$version$</version>
     <title>Microsoft Orleans Performance Counter Tool</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.EventSourcing.nuspec
+++ b/src/NuGet/Microsoft.Orleans.EventSourcing.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.EventSourcing</id>
     <version>$version$</version>
     <title>Microsoft Orleans Event-Sourcing</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansAWSUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansAWSUtils.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansAWSUtils</id>
     <version>$version$</version>
     <title>Microsoft Orleans AWS Utilities</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansAzureUtils</id>
     <version>$version$</version>
     <title>Microsoft Orleans Azure Utilities</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.Build.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.Build.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansCodeGenerator.Build</id>
     <version>$version$</version>
     <title>Microsoft Orleans Build-time Code Generation</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansCodeGenerator</id>
     <version>$version$</version>
     <title>Microsoft Orleans Code Generation</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansHost</id>
     <version>$version$</version>
     <title>Microsoft Orleans Silo Host</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansManager</id>
     <version>$version$</version>
     <title>Microsoft Orleans Management Tool</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansProviders</id>
     <version>$version$</version>
     <title>Microsoft Orleans Providers</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansRuntime</id>
     <version>$version$</version>
     <title>Microsoft Orleans Runtime</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansServiceBus</id>
     <version>$version$</version>
     <title>Microsoft Orleans ServiceBus Utilities</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansSqlUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansSqlUtils.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansSqlUtils</id>
     <version>$version$</version>
     <title>Microsoft Orleans Sql Utilities</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansTelemetryConsumers.AI.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansTelemetryConsumers.AI.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansTelemetryConsumers.AI</id>
     <version>$version$</version>
     <title>Microsoft Orleans Telemetry Consumer - Azure Application Insights</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansTelemetryConsumers.Counters.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansTelemetryConsumers.Counters.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansTelemetryConsumers.Counters</id>
     <version>$version$</version>
     <title>Microsoft Orleans Telemetry Consumer - Performance Counters</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansTelemetryConsumers.NewRelic.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansTelemetryConsumers.NewRelic.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansTelemetryConsumers.NewRelic</id>
     <version>$version$</version>
     <title>Microsoft Orleans Telemetry Consumer - NewRelic</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.OrleansZooKeeperUtils</id>
     <version>$version$</version>
     <title>Microsoft Orleans ZooKeeper Utilities</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.Serialization.Bond.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Serialization.Bond.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.Serialization.Bond</id>
     <version>$version$</version>
     <title>Microsoft Orleans Bond Serializer</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.Server.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Server.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.Server</id>
     <version>$version$</version>
     <title>Microsoft Orleans Server Libraries</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.ServiceFabric.nuspec
+++ b/src/NuGet/Microsoft.Orleans.ServiceFabric.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.ServiceFabric</id>
     <version>$version$</version>
     <title>Microsoft Orleans Service Fabric Support</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.Templates.Grains.nuspec-NoSymbols
+++ b/src/NuGet/Microsoft.Orleans.Templates.Grains.nuspec-NoSymbols
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.Templates.Grains</id>
     <version>$version$</version>
     <title>Microsoft Orleans VS Templates for Grain Classes</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.Templates.Interfaces.nuspec-NoSymbols
+++ b/src/NuGet/Microsoft.Orleans.Templates.Interfaces.nuspec-NoSymbols
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.Templates.Interfaces</id>
     <version>$version$</version>
     <title>Microsoft Orleans VS Templates for Grain Interfaces</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>

--- a/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Orleans.TestingHost</id>
     <version>$version$</version>
     <title>Microsoft Orleans Testing Host Library</title>
-    <authors>Microsoft Research</authors>
+    <authors>Microsoft</authors>
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>


### PR DESCRIPTION
Since the project moved out of MSR awhile ago.
Need to cherry-pick this to 1.3.0 final.