### PR TITLE
Remove test dependency on OrleansManager (#2252)

### DIFF
--- a/src/OrleansManager/OrleansManager.csproj
+++ b/src/OrleansManager/OrleansManager.csproj
@@ -50,7 +50,6 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RuntimeInterfaceConstants.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orleans\Orleans.csproj">

--- a/src/OrleansManager/Program.cs
+++ b/src/OrleansManager/Program.cs
@@ -38,7 +38,7 @@ namespace OrleansManager
         {
             GrainClient.Initialize();
 
-            systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             Dictionary<string, string> options = args.Skip(1)
                 .Where(s => s.StartsWith("-"))
                 .Select(s => s.Substring(1).Split('='))

--- a/src/OrleansManager/RuntimeInterfaceConstants.cs
+++ b/src/OrleansManager/RuntimeInterfaceConstants.cs
@@ -1,7 +1,0 @@
-﻿namespace Orleans
-{
-    public class RuntimeInterfaceConstants
-    {
-        public const long SYSTEM_MANAGEMENT_ID = 1;
-    }
-}

--- a/test/TestInternalGrains/EchoTaskGrain.cs
+++ b/test/TestInternalGrains/EchoTaskGrain.cs
@@ -139,7 +139,7 @@ namespace UnitTests.Grains
             logger.Info("IEchoGrainAsync.PingOtherSilo");
             SiloAddress mySilo = Data.Address.Silo;
 
-            IManagementGrain mgmtGrain = GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain mgmtGrain = GrainFactory.GetGrain<IManagementGrain>(0);
             var silos = await mgmtGrain.GetHosts();
 
             SiloAddress siloAddress = silos.Where(pair => !pair.Key.Equals(mySilo)).Select(pair => pair.Key).First();
@@ -154,7 +154,7 @@ namespace UnitTests.Grains
             logger.Info("IEchoGrainAsync.PingClusterMemberAsync");
             SiloAddress mySilo = Data.Address.Silo;
 
-            IManagementGrain mgmtGrain = GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain mgmtGrain = GrainFactory.GetGrain<IManagementGrain>(0);
             var silos = await mgmtGrain.GetHosts();
 
             SiloAddress siloAddress = silos.Where(pair => !pair.Key.Equals(mySilo)).Select(pair => pair.Key).First();

--- a/test/TestInternalGrains/PlacementTestGrain.cs
+++ b/test/TestInternalGrains/PlacementTestGrain.cs
@@ -65,7 +65,7 @@ namespace UnitTests.Grains
         {
             // force the latched statistics to propigate throughout the cluster.
             IManagementGrain mgmtGrain =
-                grainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+                grainFactory.GetGrain<IManagementGrain>(0);
 
             var hosts = await mgmtGrain.GetHosts(true);
             var keys = hosts.Select(kvp => kvp.Key).ToArray();

--- a/test/Tester/ManagementGrainTests.cs
+++ b/test/Tester/ManagementGrainTests.cs
@@ -25,7 +25,7 @@ namespace UnitTests.Management
             : base(fixture)
         {
             this.output = output;
-            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Management")]

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -39,7 +39,7 @@ namespace UnitTests.MembershipTests
 
             SiloHandle silo3 = this.HostedCluster.StartAdditionalSilo();
 
-            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
 
             Dictionary<SiloAddress, SiloStatus> statuses = await mgmtGrain.GetHosts(false);
             foreach (var pair in statuses)

--- a/test/Tester/OrleansTestingBase.cs
+++ b/test/Tester/OrleansTestingBase.cs
@@ -39,7 +39,7 @@ namespace UnitTests.Tester
 
         protected void TestSilosStarted(int expected)
         {
-            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
 
             Dictionary<SiloAddress, SiloStatus> statuses = mgmtGrain.GetHosts(onlyActive: true).Result;
             foreach (var pair in statuses)

--- a/test/Tester/PSClientTests/PSClientTests.cs
+++ b/test/Tester/PSClientTests/PSClientTests.cs
@@ -122,7 +122,7 @@ namespace Tester
 
             var getGrainCommand = new Command("Get-Grain");
             getGrainCommand.Parameters.Add("GrainType", typeof(IManagementGrain));
-            getGrainCommand.Parameters.Add("LongKey", RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            getGrainCommand.Parameters.Add("LongKey", (long)0);
             _ps.Commands.AddCommand(getGrainCommand);
 
             var results = _ps.Invoke<IManagementGrain>();

--- a/test/Tester/TestUtils.cs
+++ b/test/Tester/TestUtils.cs
@@ -94,7 +94,7 @@ namespace Tester
         {
             int result = 0;
 
-            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             SimpleGrainStatistic[] stats = await mgmtGrain.GetSimpleGrainStatistics();
             foreach (var stat in stats)
             {

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -225,10 +225,6 @@
       <Project>{b9196cb5-d356-4228-b73f-143f2eb80c64}</Project>
       <Name>OrleansGoogleUtils</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\OrleansManager\OrleansManager.csproj">
-      <Project>{60498b15-9700-4623-bda0-365238f2c1ad}</Project>
-      <Name>OrleansManager</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\OrleansProviders\OrleansProviders.csproj">
       <Project>{0054db14-2a92-4cc0-959e-a2c51f5e65d4}</Project>
       <Name>OrleansProviders</Name>

--- a/test/TesterInternal/ActivationsLifeCycleTests/ActivationCollectorTests.cs
+++ b/test/TesterInternal/ActivationsLifeCycleTests/ActivationCollectorTests.cs
@@ -194,7 +194,7 @@ namespace UnitTests.ActivationsLifeCycleTests
 
             TimeSpan everything = TimeSpan.FromMinutes(10);
             logger.Info("ManualCollectionShouldNotCollectBusyActivations: triggering manual collection (timespan is {0} sec).",  everything.TotalSeconds);
-            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             await mgmtGrain.ForceActivationCollection(everything);
             
 

--- a/test/TesterInternal/General/ElasticPlacementTest.cs
+++ b/test/TesterInternal/General/ElasticPlacementTest.cs
@@ -299,7 +299,7 @@ namespace UnitTests.General
         {
             string fullTypeName = "UnitTests.Grains.ActivationCountBasedPlacementTestGrain";
 
-            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             SimpleGrainStatistic[] stats = await mgmtGrain.GetSimpleGrainStatistics();
 
             return this.HostedCluster.GetActiveSilos()

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -705,7 +705,7 @@ namespace UnitTests.General
             const string PropagateActivityIdConfigKey = @"/OrleansConfiguration/Defaults/Tracing/@PropagateActivityId";
             var changeConfig = new Dictionary<string, string>();
 
-            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
 
             IRequestContextTestGrain grain = GrainClient.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 

--- a/test/TesterInternal/GeoClusterTests/BasicMultiClusterTest.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicMultiClusterTest.cs
@@ -24,7 +24,7 @@ namespace Tests.GeoClusterTests
                  // use null clusterId, in this test, because we are testing non-geo clients
                 : base(name, gatewayport, null, customizer)
             {
-                systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+                systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             }
             IManagementGrain systemManagement;
 

--- a/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
+++ b/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
@@ -60,7 +60,7 @@ namespace Tests.GeoClusterTests
         {
             public ClientWrapper(string name, int gatewayport, string clusterId, Action<ClientConfiguration> customizer) : base(name, gatewayport, clusterId, customizer)
             {
-                systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+                systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             }
 
             public int CallGrain(int i)

--- a/test/TesterInternal/GeoClusterTests/MultiClusterNetworkTests.cs
+++ b/test/TesterInternal/GeoClusterTests/MultiClusterNetworkTests.cs
@@ -25,7 +25,7 @@ namespace Tests.GeoClusterTests
         {
             public ClientWrapper(string name, int gatewayport, string clusterId, Action<ClientConfiguration> customizer) : base(name, gatewayport, clusterId, customizer)
             {
-                systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+                systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             }
             IManagementGrain systemManagement;
 

--- a/test/TesterInternal/StreamingTests/DynamicStreamProviderConfigurationTests.cs
+++ b/test/TesterInternal/StreamingTests/DynamicStreamProviderConfigurationTests.cs
@@ -232,7 +232,7 @@ namespace UnitTests.StreamingTests
 
         private async Task AddProvidersAndVerify(List<string> streamProviderNames)
         {
-            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             List<string> names = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
 
             IDictionary<string, bool> hasNewProvider = new Dictionary<string, bool>();
@@ -270,7 +270,7 @@ namespace UnitTests.StreamingTests
 
         private async Task RemoveProvidersAndVerify(List<string> streamProviderNames)
         {
-            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             List<string> names = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
             int Count = names.Count;
             foreach (string name in streamProviderNames)

--- a/test/TesterInternal/StreamingTests/StreamLimitTests.cs
+++ b/test/TesterInternal/StreamingTests/StreamLimitTests.cs
@@ -57,7 +57,7 @@ namespace UnitTests.StreamingTests
         {
             this.output = output;
             StreamNamespace = StreamTestsConstants.StreamLifecycleTestsNamespace;
-            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
         }
         
         [Fact, TestCategory("Streaming"), TestCategory("Limits")]

--- a/test/TesterInternal/StreamingTests/StreamReliabilityTests.cs
+++ b/test/TesterInternal/StreamingTests/StreamReliabilityTests.cs
@@ -1003,7 +1003,7 @@ namespace UnitTests.Streaming.Reliability
 #else
             string grainType = typeof(StreamReliabilityTestGrain).FullName;
 #endif
-            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
 
             SimpleGrainStatistic[] grainStats = await mgmtGrain.GetSimpleGrainStatistics();
             output.WriteLine("Found grains " + Utils.EnumerableToString(grainStats));

--- a/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
@@ -333,7 +333,7 @@ namespace UnitTests.StreamingTests
         public static async Task<int> GetNumActivations(IEnumerable<IGrain> targets)
         {
             var grainIds = targets.Distinct().Where(t => t is GrainReference).Select(t => ((GrainReference)t).GrainId).ToArray();
-            IManagementGrain systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            IManagementGrain systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
             var tasks = grainIds.Select(g => systemManagement.GetGrainActivationCount(GrainReference.FromGrainId(g))).ToArray();
             await Task.WhenAll(tasks);
             return tasks.Sum(t => t.Result);

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -251,10 +251,6 @@
       <Project>{5c177f58-a40c-449f-8c2f-a2657f963edc}</Project>
       <Name>OrleansHost</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\OrleansManager\OrleansManager.csproj">
-      <Project>{60498b15-9700-4623-bda0-365238f2c1ad}</Project>
-      <Name>OrleansManager</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\OrleansProviders\OrleansProviders.csproj">
       <Project>{0054db14-2a92-4cc0-959e-a2c51f5e65d4}</Project>
       <Name>OrleansProviders</Name>


### PR DESCRIPTION
As per #2252, this inlines the constant id for IManagementGrain and removed test project dependencies on OrleansManager