### PR TITLE
Do not trace to the console by default when running tests

### DIFF
--- a/test/Tester/DependencyInjectionGrainTests.cs
+++ b/test/Tester/DependencyInjectionGrainTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
@@ -21,7 +20,7 @@ namespace UnitTests.General
             protected override TestCluster CreateTestCluster()
             {
                 var options = new TestClusterOptions(1);
-                options.ClusterConfiguration.ApplyToAllNodes(nodeConfig => nodeConfig.StartupTypeName = typeof(TestStartup).AssemblyQualifiedName);
+                options.ClusterConfiguration.UseStartupType<TestStartup>();
                 return new TestCluster(options);
             }
         }

--- a/test/Tester/TestDefaultConfiguration.cs
+++ b/test/Tester/TestDefaultConfiguration.cs
@@ -33,6 +33,7 @@ namespace Tester
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
                 { nameof(ZooKeeperConnectionString), "127.0.0.1:2181" },
+                { nameof(TestClusterOptions.FallbackOptions.TraceToConsole), "false" },
             });
             builder.AddEnvironmentVariables("Orleans");
 


### PR DESCRIPTION
I believe I unintentionally changed our default to trace to console when running our tests (#2223), and since we are tracing to a log file already, this is unnecessarily increasing our log file, and I believe in some cases it might be failing the build, as errors written to the console are treated as build failures in jenkins (I think it's related to the cryptic error we recently started to see: `Failure to restore a package: Unable to resolve service for type 'System.String' while attempting to activate 'UnitTests.Grains.ExplicitlyRegisteredSimpleDIGrain`).