### PR TITLE
.NET Standard support non-serialized fields via NonSerializedAttribute

### DIFF
--- a/src/Orleans/Serialization/IlBasedSerializerGenerator.cs
+++ b/src/Orleans/Serialization/IlBasedSerializerGenerator.cs
@@ -190,10 +190,8 @@ namespace Orleans.Serialization
         {
             var result = type.GetAllFields().Where(
                 field =>
-#if !NETSTANDARD
-                !field.IsNotSerialized &&
-#endif
-                !field.IsStatic && IlBasedSerializerTypeChecker.IsSupportedFieldType(field.FieldType.GetTypeInfo())
+                field.GetCustomAttribute<NonSerializedAttribute>() == null
+                && !field.IsStatic && IlBasedSerializerTypeChecker.IsSupportedFieldType(field.FieldType.GetTypeInfo())
                 && (fieldFilter == null || fieldFilter(field))).ToList();
             result.Sort(FieldInfoComparer.Instance);
             return result;

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -200,7 +200,7 @@ namespace Orleans.Serialization
             lock (registerBuiltInSerializerLockObj)
             {
                 if (IsBuiltInSerializersRegistered)
-        {
+                {
                     return;
                 }
 

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -107,7 +107,7 @@ namespace Orleans.CodeGenerator
             // This check is here and not within TypeUtilities.IsTypeIsInaccessibleForSerialization() to prevent potential infinite recursions 
             var skipSerialzerGeneration = t.GetAllFields()
                 .Any(
-                    field => !field.IsNotSerialized &&
+                    field => field.GetCustomAttribute<NonSerializedAttribute>() == null &&
                         TypeUtilities.IsTypeIsInaccessibleForSerialization(
                             field.FieldType,
                             module,

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -554,7 +554,7 @@ namespace Orleans.CodeGenerator
         {
             var result =
                 type.GetAllFields()
-                    .Where(field => !field.IsNotSerialized)
+                    .Where(field => field.GetCustomAttribute<NonSerializedAttribute>() == null)
                     .Select((info, i) => new FieldInfoMember { FieldInfo = info, FieldNumber = i })
                     .ToList();
             result.Sort(FieldInfoMember.Comparer.Instance);


### PR DESCRIPTION
Fields in .NET Standard do not have a `FieldInfo.IsNotSerialized` property but the corresponding `[NonSerialized]` attribute is supported, so currently we are serializing fields which are marked as `[NonSerialized]`.

This PR fixes that.

An upcoming PR adds additional testing for non-serialized fields, such coverage exists today, but only for `IlBasedFallbackSerializer`. The new PR is blocked by #2253 & #2261.