### PR TITLE
Mark GeneratedAssembly/CachedAssembly serializable

### DIFF
--- a/src/Orleans/CodeGeneration/GeneratedAssembly.cs
+++ b/src/Orleans/CodeGeneration/GeneratedAssembly.cs
@@ -3,6 +3,7 @@ namespace Orleans.CodeGeneration
     /// <summary>
     /// Represents a generated assembly.
     /// </summary>
+    [System.Serializable]
     public class GeneratedAssembly
     {
         /// <summary>

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -565,6 +565,7 @@ namespace Orleans.CodeGenerator
             }
         }
 
+        [Serializable]
         private class CachedAssembly : GeneratedAssembly
         {
             public CachedAssembly()


### PR DESCRIPTION
I've seen exceptions thrown because of this. They are transmitted across AppDomain boundaries.