### PR TITLE
Initialize SerializationManager in IlBasedSerializerTests

### DIFF
--- a/test/NonSiloTests/SerializationTests/IlBasedSerializerTests.cs
+++ b/test/NonSiloTests/SerializationTests/IlBasedSerializerTests.cs
@@ -9,6 +9,11 @@ namespace UnitTests.Serialization
     [TestCategory("BVT"), TestCategory("Serialization")]
     public class IlBasedSerializerTests
     {
+        public IlBasedSerializerTests()
+        {
+            SerializationManager.InitializeForTesting();
+        }
+
         /// <summary>
         /// Tests that <see cref="IlBasedSerializerGenerator"/> supports distinct field selection for serialization
         /// versus copy operations.


### PR DESCRIPTION
In #2277 I removed the call to initialize SerializationManager, which resulted in the test only passing if another test had already initialized SerializationManager.

This change adds the call back.