### PR TITLE
Adds native JSON support to MySQL

### DIFF
--- a/src/OrleansSQLUtils/CreateOrleansTables_MySql.sql
+++ b/src/OrleansSQLUtils/CreateOrleansTables_MySql.sql
@@ -226,6 +226,12 @@ CREATE TABLE Storage
 ) ROW_FORMAT = COMPRESSED KEY_BLOCK_SIZE = 16;
 ALTER TABLE Storage ADD INDEX IX_Storage (GrainIdHash, GrainTypeHash);
 
+-- The following alters the column to JSON format if MySQL is at least of version 5.7.8.
+-- See more at https://dev.mysql.com/doc/refman/5.7/en/json.html for JSON and
+-- http://dev.mysql.com/doc/refman/5.7/en/comments.html for the syntax.
+/*!50708 ALTER TABLE Storage MODIFY COLUMN PayloadJson JSON */;
+
+
 INSERT INTO OrleansQuery(QueryKey, QueryText)
 VALUES
 (


### PR DESCRIPTION
Adds native JSON support to MySQL

MySQL 5.7.8 added a native JSON type, release notes
https://dev.mysql.com/doc/refman/5.7/en/json.html.

As we currently support only the latest version, this
could be included without regard to older versions. A small
problem is the official packet was released already and the
type there is plain text.

This alter to the table is backwards compatible, but for very
large tables can be time consuming.