### PR TITLE
Serialization fixes

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -761,7 +761,7 @@ namespace Orleans.Serialization
         private static void RegisterGrainReferenceSerializers(Type type)
         {
             var attr = type.GetTypeInfo().GetCustomAttribute<GrainReferenceAttribute>();
-            if (attr?.TargetType != null)
+            if (attr?.TargetType == null)
             {
                 return;
             }

--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -285,9 +285,16 @@ namespace Orleans.Serialization
             }
 
             // Check InternalsVisibleTo attributes on the from-assembly, pointing to the to-assembly.
-            var serializationAssemblyName = toAssembly.GetName().FullName;
+            var fullName = toAssembly.GetName().FullName;
+            var shortName = toAssembly.GetName().Name;
             var internalsVisibleTo = fromAssembly.GetCustomAttributes<InternalsVisibleToAttribute>();
-            return internalsVisibleTo.Any(_ => _.AssemblyName == serializationAssemblyName);
+            foreach (var attr in internalsVisibleTo)
+            {
+                if (string.Equals(attr.AssemblyName, fullName, StringComparison.InvariantCulture)) return true;
+                if (string.Equals(attr.AssemblyName, shortName, StringComparison.InvariantCulture)) return true;
+            }
+
+            return false;
         }
 
         private static bool IsSpecialClass(Type type)

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -105,13 +105,8 @@ namespace Orleans.CodeGenerator
             if (TypeUtils.HasAllSerializationMethods(t)) return false;
 
             // This check is here and not within TypeUtilities.IsTypeIsInaccessibleForSerialization() to prevent potential infinite recursions 
-            var skipSerialzerGeneration = t.GetAllFields()
-                .Any(
-                    field => field.GetCustomAttribute<NonSerializedAttribute>() == null &&
-                        TypeUtilities.IsTypeIsInaccessibleForSerialization(
-                            field.FieldType,
-                            module,
-                            targetAssembly));
+            var skipSerialzerGeneration =
+                t.GetAllFields().Any(field => IsFieldInaccessibleForSerialization(module, targetAssembly, field));
             if (skipSerialzerGeneration)
             {
                 return false;
@@ -119,6 +114,13 @@ namespace Orleans.CodeGenerator
 
             typesToProcess.Add(t);
             return true;
+        }
+
+        private static bool IsFieldInaccessibleForSerialization(Module module, Assembly targetAssembly, FieldInfo field)
+        {
+            return field.GetCustomAttribute<NonSerializedAttribute>() == null
+                   && !SerializationManager.HasSerializer(field.FieldType)
+                   && TypeUtilities.IsTypeIsInaccessibleForSerialization(field.FieldType, module, targetAssembly);
         }
 
         internal bool GetNextTypeToProcess(out Type next)

--- a/test/NonSiloTests/SerializationTests/BuiltInSerializerTests.cs
+++ b/test/NonSiloTests/SerializationTests/BuiltInSerializerTests.cs
@@ -22,6 +22,9 @@ namespace UnitTests.Serialization
 {
     using System.Reflection;
 
+    using Orleans.GrainDirectory;
+    using Orleans.Runtime.GrainDirectory;
+
     using TestGrainInterfaces;
 
     /// <summary>
@@ -75,6 +78,24 @@ namespace UnitTests.Serialization
         {
             this.output = output;
             LogManager.Initialize(new NodeConfiguration());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("CodeGen")]
+        public void InternalSerializableTypesHaveSerializers()
+        {
+            InitializeSerializer(SerializerToUse.Default);
+            Assert.True(
+                SerializationManager.HasSerializer(typeof(AddressesAndTag)),
+                $"Should be able to serialize internal type {nameof(AddressesAndTag)}.");
+            Assert.True(
+                SerializationManager.HasSerializer(typeof(ActivationInfo)),
+                $"Should be able to serialize internal type {nameof(ActivationInfo)}.");
+            var grainReferenceType = typeof(IGrain).Assembly.GetType(
+                "Orleans.OrleansCodeGenRemindableReference",
+                throwOnError: true);
+            Assert.True(
+                SerializationManager.HasSerializer(grainReferenceType),
+                $"Should be able to serialize grain reference type {grainReferenceType}.");
         }
 
         [Theory, TestCategory("BVT"), TestCategory("Serialization")]


### PR DESCRIPTION
Fixes for 3 serialization issues:

1. A recent change (by myself) resulted in generated `GrainReference` classes being passed through the fallback serializer.
2. Due to an inadequacy in `TypeUtilities.AreInternalsVisibleTo`, serializers were not being generated for types referencing internals from another assembly. For example, `ActivationInfo` in `OrleansRuntime` would not have a serializer generated because it has a field whose type is internal to `Orleans`. The change adds support for `[assembly: InternalsVisibleTo("xxx")]` where "xxx" is the short name of an assembly (eg, `"OrleansRuntime"`, rather than only supporting fully qualified assembly names.
3. The check to determine if a type is accessible for serialization involves recursively checking all serialized fields in that type. The check was deficient because it did not support fields which had predefined serializers (eg, `List<SomeAccessibleType>`).

I've added a test for types which were not having serializers generated.

Note: the commits are independent except for the last one containing the new test case.