### PR TITLE
Updates the Nuget icons to the new one

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansConsulUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansConsulUtils.nuspec
@@ -8,7 +8,7 @@
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
-    <iconUrl>https://raw.githubusercontent.com/jthelin/jthelin.github.io/master/images/Orleans-nuget.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
     <summary>
       Consul Utilities Library of Microsoft Orleans - OrleansConsulUtils.dll
     </summary>

--- a/src/NuGet/Microsoft.Orleans.OrleansSqlUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansSqlUtils.nuspec
@@ -8,7 +8,7 @@
     <owners>Microsoft,Orleans</owners>
     <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
     <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
-    <iconUrl>https://raw.githubusercontent.com/jthelin/jthelin.github.io/master/images/Orleans-nuget.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
     <summary>
       Sql Utilities Library of Microsoft Orleans - OrleansSqlUtils.dll
     </summary>


### PR DESCRIPTION
It looks like two package icons are not updated to
the new one. Also, one image in OrleansContrib,
Microsoft.Orleans.ServiceFabric.Client, still
uses the old one.

See at https://www.nuget.org/packages?q=microsoft.orleans.*.