### PR TITLE
ClientInvokeCallback tests should always reset ClientInvokeCallback

### DIFF
--- a/src/Orleans/Core/GrainClient.cs
+++ b/src/Orleans/Core/GrainClient.cs
@@ -312,6 +312,7 @@ namespace Orleans
             }
             outsideRuntimeClient = null;
             grainFactory = null;
+            ClientInvokeCallback = null;
         }
 
         /// <summary>

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -422,6 +422,7 @@ namespace UnitTests.General
         public void Dispose()
         {
             Trace.CorrelationManager.ActivityId = Guid.Empty;
+            GrainClient.ClientInvokeCallback = null;
             RequestContext.Clear();
         }
 


### PR DESCRIPTION
We are seeing failures related to this in functional test runs recently.
One of the test cases is not resetting ClientInvokeCallback.

This PR wraps each of those tests in try/finally blocks to reset `GrainClient.ClientInvokeCallback` and also resets it in the classes `Dispose()` method.