### PR TITLE
Removes InconsistentStateException from parallel tests

### DIFF
--- a/test/TesterInternal/StorageTests/Relational/CommonStorageTests.cs
+++ b/test/TesterInternal/StorageTests/Relational/CommonStorageTests.cs
@@ -35,20 +35,22 @@ namespace UnitTests.StorageTests.Relational
         }
 
 
-        internal async Task PersistenceStorage_WriteReadWriteRead100StatesInParallel()
+        internal async Task PersistenceStorage_WriteReadWriteRead100StatesInParallel(string prefix = nameof(this.PersistenceStorage_WriteReadWriteRead100StatesInParallel))
         {
             //As data is written and read the ETags are as checked for correctness (they change).
             //Additionally the Store_WriteRead tests does its validation.
             var grainTypeName = GrainTypeGenerator.GetGrainType<Guid>();
             int StartOfRange = 33900;
             const int CountOfRange = 100;
+            string grainIdTemplate = $"{prefix}-" + "{0}";
             var tasks = Enumerable.Range(StartOfRange, CountOfRange).Select(async i =>
             {
                 //Since the version is NULL, storage provider tries to insert this data
                 //as new state. If there is already data with this class, the writing fails
                 //and the storage provider throws. Essentially it means either this range
                 //is ill chosen or the test failed due another problem.
-                var grainData = CommonStorageUtilities.GetTestReferenceAndState(i, null);
+                var grainId = string.Format(grainIdTemplate, i);
+                var grainData = CommonStorageUtilities.GetTestReferenceAndState(grainId, null);
 
                 var firstVersion = grainData.Item2.ETag;
                 Assert.Equal(firstVersion, null);

--- a/test/TesterInternal/StorageTests/Relational/CommonStorageUtilities.cs
+++ b/test/TesterInternal/StorageTests/Relational/CommonStorageUtilities.cs
@@ -12,6 +12,10 @@ namespace UnitTests.StorageTests.Relational
     /// </summary>
     public static class CommonStorageUtilities
     {
+        /// <summary>
+        /// Asserts certain information is present in the <see cref="Orleans.Storage.InconsistentStateException"/>.
+        /// </summary>
+        /// <param name="exceptionMessage">The exception message to assert.</param>
         public static void AssertRelationalInconsistentExceptionMessage(string exceptionMessage)
         {
             Assert.Contains("ServiceId=", exceptionMessage);
@@ -22,9 +26,27 @@ namespace UnitTests.StorageTests.Relational
         }
 
 
+        /// <summary>
+        /// Creates a new grain and a grain reference pair.
+        /// </summary>
+        /// <param name="grainId">The grain ID.</param>
+        /// <param name="version">The initial version of the state.</param>
+        /// <returns>A grain reference and a state pair.</returns>
         internal static Tuple<GrainReference, GrainState<TestState1>> GetTestReferenceAndState(long grainId, string version)
         {
-            return new Tuple<GrainReference, GrainState<TestState1>>(GrainReference.FromGrainId(GrainId.GetGrainId(UniqueKey.NewKey(grainId, UniqueKey.Category.Grain))), new GrainState<TestState1> { State = new TestState1(), ETag = version });
+            return  Tuple.Create(GrainReference.FromGrainId(GrainId.GetGrainId(UniqueKey.NewKey(grainId, UniqueKey.Category.Grain))), new GrainState<TestState1> { State = new TestState1(), ETag = version });
+        }
+
+
+        /// <summary>
+        /// Creates a new grain and a grain reference pair.
+        /// </summary>
+        /// <param name="grainId">The grain ID.</param>
+        /// <param name="version">The initial version of the state.</param>
+        /// <returns>A grain reference and a state pair.</returns>
+        internal static Tuple<GrainReference, GrainState<TestState1>> GetTestReferenceAndState(string grainId, string version)
+        {
+            return Tuple.Create(GrainReference.FromGrainId(GrainId.FromParsableString(GrainId.GetGrainId(RandomUtilities.NormalGrainTypeCode, grainId).ToParsableString())), new GrainState<TestState1> { State = new TestState1(), ETag = version });
         }
     }
 }

--- a/test/TesterInternal/StorageTests/Relational/MySqlStorageTests.cs
+++ b/test/TesterInternal/StorageTests/Relational/MySqlStorageTests.cs
@@ -52,7 +52,7 @@ namespace UnitTests.StorageTests.Relational
         [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
         internal async Task WriteRead100StatesInParallel()
         {
-            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteRead100StatesInParallel();
+            await Relational_WriteReadWriteRead100StatesInParallel();
         }
 
         [SkippableFact]

--- a/test/TesterInternal/StorageTests/Relational/RandomUtilities.cs
+++ b/test/TesterInternal/StorageTests/Relational/RandomUtilities.cs
@@ -22,8 +22,14 @@ namespace UnitTests.StorageTests.Relational
         /// "public Category IdCategory { get { return GetCategory(TypeCodeData); } }".
         /// Note that 0L would likely do also.
         /// </summary>
-        private const long NormalGrainTypeCode = 3L;
-        private const long KeyExtensionGrainTypeCode = 6L;
+        public const long NormalGrainTypeCode = 3L;
+
+        /// <summary>
+        /// This type code is consistent with Orleans.Runtime.Category.Grain = 3, used also like
+        /// "public Category IdCategory { get { return GetCategory(TypeCodeData); } }".
+        /// Note that 0L would likely do also.
+        /// </summary>
+        public const long KeyExtensionGrainTypeCode = 6L;
 
         /// <summary>
         /// A rudimentary type switch that is read-only after construction and doesn't take into account inheritance etc. This is to simply

--- a/test/TesterInternal/StorageTests/Relational/RelationalStorageTests.cs
+++ b/test/TesterInternal/StorageTests/Relational/RelationalStorageTests.cs
@@ -62,10 +62,16 @@ namespace UnitTests.StorageTests.Relational
         }
 
 
+        internal async Task Relational_WriteReadWriteRead100StatesInParallel()
+        {
+            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteRead100StatesInParallel(nameof(Relational_WriteReadWriteRead100StatesInParallel));
+        }
+
+
         internal async Task Relational_HashCollisionTests()
         {
             ((AdoNetStorageProvider)PersistenceStorageTests.Storage).HashPicker = ConstantHasher;
-            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteRead100StatesInParallel();
+            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteRead100StatesInParallel(nameof(Relational_HashCollisionTests));
         }
 
 

--- a/test/TesterInternal/StorageTests/Relational/SqlServerStorageTests.cs
+++ b/test/TesterInternal/StorageTests/Relational/SqlServerStorageTests.cs
@@ -54,9 +54,9 @@ namespace UnitTests.StorageTests.Relational
 
         [SkippableFact]
         [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
-        internal async Task WriteRead100StatesInParallel()
+        internal async Task WriteReadWriteRead100StatesInParallel()
         {
-            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteRead100StatesInParallel();
+            await Relational_WriteReadWriteRead100StatesInParallel();
         }
 
         [SkippableFact]


### PR DESCRIPTION
In ADO.NET tests when parallel test execution became possible,
it was possible for the the hash test grain IDs and types
collide with the ones used in testing 100 parallel insertions
and reads.