### PR TITLE
Reset client gateway reciever buffer on socket reset.

### DIFF
--- a/src/Orleans/Messaging/GatewayClientReceiver.cs
+++ b/src/Orleans/Messaging/GatewayClientReceiver.cs
@@ -13,6 +13,7 @@ namespace Orleans.Messaging
     {
         private readonly GatewayConnection gatewayConnection;
         private readonly IncomingMessageBuffer buffer;
+        private Socket socket;
 
         internal GatewayClientReceiver(GatewayConnection gateway)
             : base(gateway.Address.ToString())
@@ -67,17 +68,20 @@ namespace Orleans.Messaging
 
         private int FillBuffer(List<ArraySegment<byte>> bufferSegments)
         {
-            Socket socketCapture = null;
             try
             {
                 if (gatewayConnection.Socket == null || !gatewayConnection.Socket.Connected)
                 {
                     gatewayConnection.Connect();
                 }
-                socketCapture = gatewayConnection.Socket;
-                if (socketCapture != null && socketCapture.Connected)
+                if(!Equals(socket, gatewayConnection.Socket))
                 {
-                    var bytesRead = socketCapture.Receive(bufferSegments);
+                    buffer.Reset();
+                    socket = gatewayConnection.Socket;
+                }
+                if (socket != null && socket.Connected)
+                {
+                    var bytesRead = socket.Receive(bufferSegments);
                     if (bytesRead == 0)
                     {
                         throw new EndOfStreamException("Socket closed");
@@ -92,7 +96,8 @@ namespace Orleans.Messaging
                 if (Cts.IsCancellationRequested) return 0;
 
                 Log.Warn(ErrorCode.Runtime_Error_100158, String.Format("Exception receiving from gateway {0}: {1}", gatewayConnection.Address, ex.Message));
-                gatewayConnection.MarkAsDisconnected(socketCapture);
+                gatewayConnection.MarkAsDisconnected(socket);
+                socket = null;
                 return 0;
             }
             return 0;


### PR DESCRIPTION
Networking receiver buffer must be reset on socket error or reset.  Since this can happen on a send rather than a receive, it is now possible for the socket to be reset by the send without the receive buffer being cleared, which can lead to buffer corruption.
This change resets the receive buffer whenever the socket changes.