### PR TITLE
Move tests in Tester which uses HostedTestClusterEnsureDefaultStarted to vNext

### DIFF
--- a/vNext/src/Orleans.vNext.sln
+++ b/vNext/src/Orleans.vNext.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tester", "..\test\Tester\Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestGrains", "..\test\TestGrains\TestGrains.csproj", "{AACE28AE-F301-472A-B633-02B55434871A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestInternalGrainInterfaces", "..\test\TestInternalGrainInterface\TestInternalGrainInterfaces.csproj", "{AAE67055-F38A-45F0-AEA7-5754F4814EAA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -89,6 +91,10 @@ Global
 		{AACE28AE-F301-472A-B633-02B55434871A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AACE28AE-F301-472A-B633-02B55434871A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AACE28AE-F301-472A-B633-02B55434871A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAE67055-F38A-45F0-AEA7-5754F4814EAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAE67055-F38A-45F0-AEA7-5754F4814EAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAE67055-F38A-45F0-AEA7-5754F4814EAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAE67055-F38A-45F0-AEA7-5754F4814EAA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -105,5 +111,6 @@ Global
 		{A972213F-189B-41D4-90FE-38D513C1106A} = {224EAB7B-DBF8-4652-AC71-6C6ABBAB22AD}
 		{A9C8FFEC-4947-4F04-BA73-1F17B329A55A} = {224EAB7B-DBF8-4652-AC71-6C6ABBAB22AD}
 		{AACE28AE-F301-472A-B633-02B55434871A} = {224EAB7B-DBF8-4652-AC71-6C6ABBAB22AD}
+		{AAE67055-F38A-45F0-AEA7-5754F4814EAA} = {224EAB7B-DBF8-4652-AC71-6C6ABBAB22AD}
 	EndGlobalSection
 EndGlobal

--- a/vNext/test/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/vNext/test/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -44,26 +44,71 @@
     <Compile Include="..\..\..\test\TestGrainInterfaces\CodegenTestInterfaces.cs">
       <Link>CodegenTestInterfaces.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\GetGrainInterfaces.cs">
+      <Link>GetGrainInterfaces.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\GrainInterfaceHierarchyIGrains.cs">
+      <Link>GrainInterfaceHierarchyIGrains.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IActivateDeactivateTestGrain.cs">
+      <Link>IActivateDeactivateTestGrain.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\test\TestGrainInterfaces\IActivateDeactivateWatcherGrain.cs">
       <Link>IActivateDeactivateWatcherGrain.cs</Link>
     </Compile>
     <Compile Include="..\..\..\test\TestGrainInterfaces\ICircularStateTestGrain.cs">
       <Link>ICircularStateTestGrain.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IClusterTestGrains.cs">
+      <Link>IClusterTestGrains.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IExceptionGrain.cs">
+      <Link>IExceptionGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IExtensionTestGrain.cs">
+      <Link>IExtensionTestGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IExternalTypeGrain.cs">
+      <Link>IExternalTypeGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IInitialStateGrain.cs">
+      <Link>IInitialStateGrain.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\test\TestGrainInterfaces\IJsonEchoGrain.cs">
       <Link>IJsonEchoGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IKeyExtensionTestGrain.cs">
+      <Link>IKeyExtensionTestGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IMethodInterceptionGrain.cs">
+      <Link>IMethodInterceptionGrain.cs</Link>
     </Compile>
     <Compile Include="..\..\..\test\TestGrainInterfaces\IPersistenceTestGrains.cs">
       <Link>IPersistenceTestGrains.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IReminderTestGrain.cs">
+      <Link>IReminderTestGrain.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\test\TestGrainInterfaces\ISerializationGeneratorTests.cs">
       <Link>ISerializationGeneratorTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\ISimpleGenericGrain.cs">
+      <Link>ISimpleGenericGrain.cs</Link>
     </Compile>
     <Compile Include="..\..\..\test\TestGrainInterfaces\ISimpleObserverableGrain.cs">
       <Link>ISimpleObserverableGrain.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\ISimplePersistentGrain.cs">
+      <Link>ISimplePersistentGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\IStatelessWorkerGrain.cs">
+      <Link>IStatelessWorkerGrain.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\test\TestGrainInterfaces\IStreamLifecycleTestGrains.cs">
       <Link>IStreamLifecycleTestGrains.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrainInterfaces\ITestExtension.cs">
+      <Link>ITestExtension.cs</Link>
     </Compile>
     <Compile Include="..\..\..\test\TestGrainInterfaces\ITestGrain.cs">
       <Link>ITestGrain.cs</Link>

--- a/vNext/test/TestGrains/TestGrains.csproj
+++ b/vNext/test/TestGrains/TestGrains.csproj
@@ -47,8 +47,56 @@
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\test\TestGrains\ActivateDeactivateWatcherGrain.cs">
+      <Link>ActivateDeactivateWatcherGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\ClusterTestGrains.cs">
+      <Link>ClusterTestGrains.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\ExceptionGrain.cs">
+      <Link>ExceptionGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\ExternalTypeGrain.cs">
+      <Link>ExternalTypeGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\GenericGrains.cs">
+      <Link>GenericGrains.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\GetGrainGrains.cs">
+      <Link>GetGrainGrains.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\GrainInterfaceHierarchyGrains.cs">
+      <Link>GrainInterfaceHierarchyGrains.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\InitialStateGrain.cs">
+      <Link>InitialStateGrain.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\test\TestGrains\JsonEchoGrain.cs">
       <Link>JsonEchoGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\KeyExtensionTestGrain.cs">
+      <Link>KeyExtensionTestGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\MethodInterceptionGrain.cs">
+      <Link>MethodInterceptionGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\MultipleConstructorsSimpleGrain.cs">
+      <Link>MultipleConstructorsSimpleGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\ReminderTestGrain.cs">
+      <Link>ReminderTestGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\SimpleGenericGrain.cs">
+      <Link>SimpleGenericGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\SimpleGrain.cs">
+      <Link>SimpleGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\SimplePersistentGrain.cs">
+      <Link>SimplePersistentGrain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\TestGrains\StatelessWorkerGrain.cs">
+      <Link>StatelessWorkerGrain.cs</Link>
     </Compile>
     <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>

--- a/vNext/test/TestInternalGrainInterface/Properties/AssemblyInfo.cs
+++ b/vNext/test/TestInternalGrainInterface/Properties/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.FSharp.Core;
+using Orleans.CodeGeneration;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestInternalGrainInterfaces")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("314454e5-b572-40aa-9c3e-4ebf7d456c0b")]
+
+[assembly: InternalsVisibleTo("TestInternalGrains")]
+[assembly: InternalsVisibleTo("Tester")]

--- a/vNext/test/TestInternalGrainInterface/TestInternalGrainInterfaces.csproj
+++ b/vNext/test/TestInternalGrainInterface/TestInternalGrainInterfaces.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A682ABC1-1A51-4794-8012-DA8E59EBC72A}</ProjectGuid>
+    <ProjectGuid>{AAE67055-F38A-45F0-AEA7-5754F4814EAA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>UnitTests.Grains</RootNamespace>
-    <AssemblyName>TestInternalGrains</AssemblyName>
+    <RootNamespace>UnitTests.GrainInterfaces</RootNamespace>
+    <AssemblyName>TestInternalGrainInterfaces</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -39,43 +39,21 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\test\TestInternalGrains\ActivateDeactivateTestGrain.cs">
-      <Link>ActivateDeactivateTestGrain.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\TestInternalGrains\EchoTaskGrain.cs">
-      <Link>EchoTaskGrain.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\TestInternalGrains\ExtensionTestGrain.cs">
-      <Link>ExtensionTestGrain.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\TestInternalGrains\InterlockedFlag.cs">
-      <Link>InterlockedFlag.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\TestInternalGrains\PersistenceTestGrains.cs">
-      <Link>PersistenceTestGrains.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\TestInternalGrains\StreamLifecycleTestGrains.cs">
-      <Link>StreamLifecycleTestGrains.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\TestInternalGrains\TestExtension.cs">
-      <Link>TestExtension.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\TestInternalGrains\TestGrain.cs">
-      <Link>TestGrain.cs</Link>
-    </Compile>
-    <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs">
+    <Compile Include="..\..\..\src\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\OrleansRuntime\OrleansRuntime.csproj">
-      <Project>{aff2004c-cdf8-479c-bf27-c6bfe8ef93ea}</Project>
-      <Name>OrleansRuntime</Name>
-    </ProjectReference>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Orleans\Orleans.csproj">
       <Project>{ac1bd60c-e7d8-4452-a21c-290aec8e2e7a}</Project>
       <Name>Orleans</Name>
@@ -85,13 +63,10 @@
       <Name>TestGrainInterfaces</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="project.json" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- Begin Orleans: Without these lines the project won't build properly -->
   <PropertyGroup>
-    <OrleansProjectType>Server</OrleansProjectType>
+    <OrleansProjectType>Client</OrleansProjectType>
   </PropertyGroup>
   <!-- Set path to ClientGenerator.exe -->
   <Choose>

--- a/vNext/test/TestInternalGrainInterface/project.json
+++ b/vNext/test/TestInternalGrainInterface/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "FSharp.Core": "4.0.0.1"
+  },
+  "frameworks": {
+    "net462": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}

--- a/vNext/test/Tester/Tester.csproj
+++ b/vNext/test/Tester/Tester.csproj
@@ -86,8 +86,68 @@
     <Compile Include="..\..\..\test\Tester\CollectionFixtures.cs">
       <Link>CollectionFixtures.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\test\Tester\ConcreteStateClassTests.cs">
+      <Link>ConcreteStateClassTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\DeactivationTests.cs">
+      <Link>DeactivationTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\ExceptionPropagationTests.cs">
+      <Link>ExceptionPropagationTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\ExternalTypesTests.cs">
+      <Link>ExternalTypesTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\General\JsonGrainTests.cs">
+      <Link>General\JsonGrainTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\GenericGrainTests.cs">
+      <Link>GenericGrainTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\GeoClusterTests\SimpleGlobalSingleInstanceGrainTests.cs">
+      <Link>GeoClusterTests\SimpleGlobalSingleInstanceGrainTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\GrainActivateDeactivateTests.cs">
+      <Link>GrainActivateDeactivateTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\GrainFactoryTests.cs">
+      <Link>GrainFactoryTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\GrainInterfaceHierarchyTests.cs">
+      <Link>GrainInterfaceHierarchyTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\KeyExtensionTests.cs">
+      <Link>KeyExtensionTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\ManagementGrainTests.cs">
+      <Link>ManagementGrainTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\MemoryStorageProviderTests.cs">
+      <Link>MemoryStorageProviderTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\MethodInterceptionTests.cs">
+      <Link>MethodInterceptionTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\ObserverTests.cs">
+      <Link>ObserverTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\test\Tester\TestUtils.cs">
       <Link>TestUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\ProviderTests.cs">
+      <Link>ProviderTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\ReminderTest.cs">
+      <Link>ReminderTest.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\RequestContextTest.cs">
+      <Link>RequestContextTest.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\SimpleGrainTests.cs">
+      <Link>SimpleGrainTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\StatelessWorkerTests.cs">
+      <Link>StatelessWorkerTests.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This lives on top of #2322 . will need to wait for #2322 to be pushed and then rebase. 

Move tests in Tester which uses HostedTestClusterEnsureDefaultStarted to vNext Tester project. 

Some tests test persistence, so we will need to port over OrleansProviders project soon. 