### PR TITLE
Release BinaryTokenStreamWriter buffers after use in more cases.

### DIFF
--- a/src/Orleans/IDs/GrainId.cs
+++ b/src/Orleans/IDs/GrainId.cs
@@ -319,7 +319,9 @@ namespace Orleans.Runtime
         {
             var writer = new BinaryTokenStreamWriter();
             writer.Write(this);
-            return writer.ToByteArray();
+            var result = writer.ToByteArray();
+            writer.ReleaseBuffers();
+            return result;
         }
 
         internal static GrainId FromByteArray(byte[] byteArray)

--- a/src/Orleans/IDs/SiloAddress.cs
+++ b/src/Orleans/IDs/SiloAddress.cs
@@ -203,6 +203,7 @@ namespace Orleans.Runtime
             writer.Write(this);
             writer.Write(extraBit);
             byte[] bytes = writer.ToByteArray();
+            writer.ReleaseBuffers();
             return jenkinsHash.ComputeHash(bytes);
         }
 

--- a/src/Orleans/IDs/UniqueKey.cs
+++ b/src/Orleans/IDs/UniqueKey.cs
@@ -281,6 +281,7 @@ namespace Orleans.Runtime
                     var writer = new BinaryTokenStreamWriter();
                     writer.Write(this);
                     byte[] bytes = writer.ToByteArray();
+                    writer.ReleaseBuffers();
                     n = jenkinsHash.ComputeHash(bytes);
                 }
                 else

--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -112,6 +112,7 @@ namespace Orleans.Serialization
             var writer = new BinaryTokenStreamWriter();
             Serialize(source, writer, source.GetType());
             var retVal = Deserialize(source.GetType(), new BinaryTokenStreamReader(writer.ToByteArray()));
+            writer.ReleaseBuffers();
             return retVal;
         }
 

--- a/src/OrleansAzureUtils/Providers/Streams/PersistentStreams/StreamDeliveryFailureEntity.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/PersistentStreams/StreamDeliveryFailureEntity.cs
@@ -97,7 +97,9 @@ namespace Orleans.Providers.Streams.PersistentStreams
         {
             var bodyStream = new BinaryTokenStreamWriter();
             SerializationManager.Serialize(token, bodyStream);
-            return bodyStream.ToByteArray();
+            var result = bodyStream.ToByteArray();
+            bodyStream.ReleaseBuffers();
+            return result;
         }
 
         private static StreamSequenceToken TokenFromBytes(byte[] bytes)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
@@ -49,7 +49,9 @@ namespace Orleans.ServiceBus.Providers
         {
             var writeStream = new BinaryTokenStreamWriter();
             SerializationManager.Serialize(eventData.Properties.Where(kvp => !SkipProperties.Contains(kvp.Key)).ToList(), writeStream);
-            return writeStream.ToByteArray();
+            var result = writeStream.ToByteArray();
+            writeStream.ReleaseBuffers();
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
I'm not certain how useful this change is, since I haven't profiled the difference.

There are several cases where we are taking buffers from the buffer pool and not returning them. This PR eliminates several of those cases.

`BinaryTokenStreamWriter.ToByteArray()` allocates a new byte array and copies the result, whereas `ToBytes()` returns the underlying `List<ArraySegment<byte>>` directly. Hence it is safe to free the buffers after the former (assuming no further use), but not after the latter. `ToBytes()` should be called `AsBytes()` or `GetBuffers()` to reduce any confusion.

Adding an overload to `JenkinsHash.ComputeHash` which took a `List<ArraySegment<byte>>` instead of just the current `byte[]` would further help to reduce allocations.