### PR TITLE
Make basic silo tests run with .NET Standard version of Orleans

### DIFF
--- a/src/OrleansTestingHost/AppDomainSiloHandle.cs
+++ b/src/OrleansTestingHost/AppDomainSiloHandle.cs
@@ -81,7 +81,9 @@ namespace Orleans.TestingHost
                 Type = type,
                 AppDomain = appDomain,
                 additionalAssemblies = additionalAssemblies,
+#if !NETSTANDARD_TODO
                 TestHook = siloHost.TestHook,
+#endif
             };
 
             retValue.ImportGeneratedAssemblies();

--- a/vNext/test/Tester/App.config
+++ b/vNext/test/Tester/App.config
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <ThrowUnobservedTaskExceptions enabled="false" />
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="false" />
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.ComponentModel.TypeConverter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/vNext/test/Tester/Tester.csproj
+++ b/vNext/test/Tester/Tester.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
@@ -72,6 +73,10 @@
     <ProjectReference Include="..\TestGrains\TestGrains.csproj">
       <Project>{aace28ae-f301-472a-b633-02b55434871a}</Project>
       <Name>TestGrains</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestInternalGrains\TestInternalGrains.csproj">
+      <Project>{a682abc1-1a51-4794-8012-da8e59ebc72a}</Project>
+      <Name>TestInternalGrains</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/vNext/test/Tester/project.json
+++ b/vNext/test/Tester/project.json
@@ -6,7 +6,31 @@
     "Newtonsoft.Json": "9.0.1",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "Xunit.SkippableFact": "1.2.14",
+
+
+
+
+    "System.Collections.Immutable": "1.2.0",
+    "System.Security.Cryptography.Algorithms": "4.2.0",
+    "System.Xml.XmlDocument": "4.0.1",
+    "System.Xml.XPath.XmlDocument": "4.0.1",
+    "System.ComponentModel.TypeConverter": "4.1.0",
+    "System.Linq.Expressions": "4.1.0",
+    "System.Diagnostics.Process": "4.1.0",
+    "System.Threading.Thread": "4.0.0",
+    "System.Diagnostics.TraceSource": "4.0.0",
+    "System.Reflection.TypeExtensions": "4.1.0",
+    "System.Net.NameResolution": "4.0.0",
+    "System.Net.NetworkInformation": "4.1.0",
+    "System.Runtime.Serialization.Formatters": "4.0.0-rc3-24212-01",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
+    "System.Reflection.Emit.Lightweight": "4.0.1",
+    "System.Diagnostics.FileVersionInfo": "4.0.0",
+    "System.Threading.ThreadPool": "4.0.10",
+
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
+    "System.Runtime": "4.1.0"
   },
   "frameworks": {
     "net462": {}


### PR DESCRIPTION
AppDomain shim loads all assemblies in local folder.
Added all references from Orleans and OrleansRuntime into Tester since because of the csproj hack, it looks like the nuget dependencies are not transitively passed on to Tester