### PR TITLE
Modified stream types to not use fallback serializer and allow external

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The idea is to track end-user facing changes as they occur.*
 - Invoker codegen: methods returning Task<object> do not need Box() calls #2221
 - CodeGen: Avoid wrapping IGrainMethodInvoker.Invoke body in try/catch #2220
 - Several major performance improvements
+- Add streaming support for types that are serialized using IExternalSerializers
 
 ### [v1.3.0]
 - Bug fixes:

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1836,7 +1836,7 @@ namespace Orleans.Serialization
 
 #region Fallback serializer and deserializer
 
-        private static void FallbackSerializer(object raw, BinaryTokenStreamWriter stream, Type t)
+        internal static void FallbackSerializer(object raw, BinaryTokenStreamWriter stream, Type t)
         {
             Stopwatch timer = null;
             if (StatisticsCollector.CollectSerializationStats)

--- a/src/OrleansAWSUtils/Streams/SQSBatchContainer.cs
+++ b/src/OrleansAWSUtils/Streams/SQSBatchContainer.cs
@@ -90,7 +90,7 @@ namespace OrleansAWSUtils.Streams
             var json = JObject.Parse(msg.Body);
             var sqsBatch = SerializationManager.DeserializeFromByteArray<SQSBatchContainer>(json["payload"].ToObject<byte[]>());
             sqsBatch.Message = msg;
-            sqsBatch.sequenceToken = new EventSequenceToken(sequenceId);
+            sqsBatch.sequenceToken = new EventSequenceTokenV2(sequenceId);
             return sqsBatch;
         }
 

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -57,6 +57,7 @@
     <Compile Include="MultiClusterNetwork\GossipTableInstanceManager.cs" />
     <Compile Include="Providers\AzureConfigurationExtensions.cs" />
     <Compile Include="Providers\Storage\AzureBlobStorage.cs" />
+    <Compile Include="Providers\Streams\AzureQueue\AzureQueueBatchContainerV2.cs" />
     <Compile Include="Providers\Streams\PersistentStreams\AzureTableStorageStreamFailureHandler.cs" />
     <Compile Include="Providers\Streams\PersistentStreams\StreamDeliveryFailureEntity.cs" />
     <Compile Include="Storage\AzureBasedMembershipTable.cs" />

--- a/src/OrleansAzureUtils/Properties/AssemblyInfo.cs
+++ b/src/OrleansAzureUtils/Properties/AssemblyInfo.cs
@@ -21,4 +21,5 @@ using Orleans.CodeGeneration;
 [assembly: InternalsVisibleTo("UnitTests")]
 [assembly: InternalsVisibleTo("TesterInternal")]
 [assembly: InternalsVisibleTo("UnitTestGrains")]
+[assembly: InternalsVisibleTo("Orleans.NonSiloTests")]
 [assembly: SkipCodeGeneration]

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainer.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainer.cs
@@ -4,9 +4,9 @@ using System.Linq;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Newtonsoft.Json;
 using Orleans.Providers.Streams.Common;
-using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Streams;
+using RuntimeRequestContext = Orleans.Runtime.RequestContext;
 
 namespace Orleans.Providers.Streams.AzureQueue
 {
@@ -14,22 +14,24 @@ namespace Orleans.Providers.Streams.AzureQueue
     internal class AzureQueueBatchContainer : IBatchContainer
     {
         [JsonProperty]
-        private EventSequenceToken sequenceToken;
+        protected EventSequenceToken sequenceToken;
 
         [JsonProperty]
-        private readonly List<object> events;
+        protected List<object> events;
 
         [JsonProperty]
-        private readonly Dictionary<string, object> requestContext;
+        protected Dictionary<string, object> requestContext;
 
         [NonSerialized]
         // Need to store reference to the original AQ CloudQueueMessage to be able to delete it later on.
         // Don't need to serialize it, since we are never interested in sending it to stream consumers.
         internal CloudQueueMessage CloudQueueMessage;
 
-        public Guid StreamGuid { get; private set; }
+        public Guid StreamGuid { get; protected set; }
 
-        public String StreamNamespace { get; private set; }
+        public String StreamNamespace { get; protected set; }
+
+        internal Dictionary<string, object> RequestContext => this.requestContext;
 
         public StreamSequenceToken SequenceToken
         {
@@ -37,7 +39,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         }
 
         [JsonConstructor]
-        private AzureQueueBatchContainer(
+        internal AzureQueueBatchContainer(
             Guid streamGuid, 
             String streamNamespace,
             List<object> events,
@@ -48,7 +50,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             this.sequenceToken = sequenceToken;
         }
 
-        private AzureQueueBatchContainer(Guid streamGuid, String streamNamespace, List<object> events, Dictionary<string, object> requestContext)
+        protected AzureQueueBatchContainer(Guid streamGuid, String streamNamespace, List<object> events, Dictionary<string, object> requestContext)
         {
             if (events == null) throw new ArgumentNullException("events", "Message contains no events");
             
@@ -56,6 +58,10 @@ namespace Orleans.Providers.Streams.AzureQueue
             StreamNamespace = streamNamespace;
             this.events = events;
             this.requestContext = requestContext;
+        }
+
+        protected AzureQueueBatchContainer()
+        {
         }
 
         public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
@@ -73,9 +79,14 @@ namespace Orleans.Providers.Streams.AzureQueue
             return false; // Consumer is not interested in any of these events, so don't send.
         }
 
+        internal void SetSequenceToken(EventSequenceToken token)
+        {
+            this.sequenceToken = token;
+        }
+
         internal static CloudQueueMessage ToCloudQueueMessage<T>(Guid streamGuid, String streamNamespace, IEnumerable<T> events, Dictionary<string, object> requestContext)
         {
-            var azureQueueBatchMessage = new AzureQueueBatchContainer(streamGuid, streamNamespace, events.Cast<object>().ToList(), requestContext);
+            var azureQueueBatchMessage = new AzureQueueBatchContainerV2(streamGuid, streamNamespace, events.Cast<object>().ToList(), requestContext);
             var rawBytes = SerializationManager.SerializeToByteArray(azureQueueBatchMessage);
             return new CloudQueueMessage(rawBytes);
         }
@@ -92,7 +103,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         {
             if (requestContext != null)
             {
-                RequestContext.Import(requestContext);
+                RuntimeRequestContext.Import(requestContext);
                 return true;
             }
             return false;

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Orleans.CodeGeneration;
+using Orleans.Providers.Streams.Common;
+using Orleans.Serialization;
+
+namespace Orleans.Providers.Streams.AzureQueue
+{
+    [RegisterSerializer]
+    internal class AzureQueueBatchContainerV2 : AzureQueueBatchContainer
+    {
+        [JsonConstructor]
+        internal AzureQueueBatchContainerV2(
+            Guid streamGuid, 
+            string streamNamespace,
+            List<object> events,
+            Dictionary<string, object> requestContext, 
+            EventSequenceTokenV2 sequenceToken)
+            : base(streamGuid, streamNamespace, events, requestContext, sequenceToken)
+        {
+        }
+
+        internal AzureQueueBatchContainerV2(
+            Guid streamGuid,
+            string streamNamespace,
+            List<object> events,
+            Dictionary<string, object> requestContext)
+            : base(streamGuid, streamNamespace, events, requestContext)
+        {
+        }
+
+        private AzureQueueBatchContainerV2() : base()
+        {
+        }
+
+        /// <summary>
+        /// Creates a deep copy of an object
+        /// </summary>
+        /// <param name="original">The object to create a copy of</param>
+        /// <returns>The copy.</returns>
+        public static object DeepCopy(object original)
+        {
+            var source = original as AzureQueueBatchContainerV2;
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(original));
+            }
+
+            var copy = new AzureQueueBatchContainerV2();
+            SerializationContext.Current.RecordObject(original, copy);
+            var token = source.sequenceToken == null ? null : new EventSequenceTokenV2(source.sequenceToken.SequenceNumber, source.sequenceToken.EventIndex);
+            var events = source.events?.Select(SerializationManager.DeepCopyInner).ToList();
+            var context = source.requestContext?.ToDictionary(kv => kv.Key, kv => SerializationManager.DeepCopyInner(kv.Value));
+            copy.SetValues(source.StreamGuid, source.StreamNamespace, events, context, token);
+            return copy;
+        }
+
+        /// <summary>
+        /// Serializes the container to the binary stream.
+        /// </summary>
+        /// <param name="untypedInput">The object to serialize</param>
+        /// <param name="writer">The stream to write to</param>
+        /// <param name="expected">The expected type</param>
+        public static void Serialize(object untypedInput, BinaryTokenStreamWriter writer, Type expected)
+        {
+            var typed = untypedInput as AzureQueueBatchContainerV2;
+            if (typed == null)
+            {
+                throw new SerializationException();
+            }
+
+            writer.Write(typed.StreamGuid);
+            writer.Write(typed.StreamNamespace);
+            WriteOrSerializeInner(typed.sequenceToken, writer);
+            WriteOrSerializeInner(typed.events, writer);
+            WriteOrSerializeInner(typed.requestContext, writer);
+        }
+
+        /// <summary>
+        /// Deserializes the container from the data stream.
+        /// </summary>
+        /// <param name="expected">The expected type</param>
+        /// <param name="reader">The stream reader</param>
+        /// <returns>The deserialized value</returns>
+        public static object Deserialize(Type expected, BinaryTokenStreamReader reader)
+        {
+            var deserialized = new AzureQueueBatchContainerV2();
+            DeserializationContext.Current.RecordObject(deserialized);
+            var guid = reader.ReadGuid();
+            var ns = reader.ReadString();
+            var eventToken = SerializationManager.DeserializeInner<EventSequenceTokenV2>(reader);
+            var events = SerializationManager.DeserializeInner<List<object>>(reader);
+            var context = SerializationManager.DeserializeInner<Dictionary<string, object>>(reader);
+            deserialized.SetValues(guid, ns, events, context, eventToken);
+            return deserialized;
+        }
+
+        /// <summary>
+        /// Register the serializer methods.
+        /// </summary>
+        public static void Register()
+        {
+            SerializationManager.Register(typeof(AzureQueueBatchContainerV2), DeepCopy, Serialize, Deserialize);
+        }
+
+        private static void WriteOrSerializeInner<T>(T val, BinaryTokenStreamWriter writer) where T : class
+        {
+            if (val == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                SerializationManager.SerializeInner(val, writer, val.GetType());
+            }
+        }
+
+        private void SetValues(Guid streamGuid, string streamNamespace, List<object> events, Dictionary<string, object> requestContext, EventSequenceTokenV2 sequenceToken)
+        {
+            this.StreamGuid = streamGuid;
+            this.StreamNamespace = streamNamespace;
+            this.events = events;
+            this.requestContext = requestContext;
+            this.sequenceToken = sequenceToken;
+        }
+    }
+}

--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BuiltInProvidersConfigurationExtensions.cs" />
+    <Compile Include="Streams\Common\EventSequenceTokenV2.cs" />
     <Compile Include="Streams\Memory\IMemoryStreamQueueGrain.cs" />
     <Compile Include="Streams\Memory\MemoryAdapterConfig.cs" />
     <Compile Include="Streams\Memory\MemoryAdapterFactory.cs" />

--- a/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Orleans.CodeGeneration;
+using Orleans.Serialization;
+
+namespace Orleans.Providers.Streams.Common
+{
+    /// <summary>
+    /// Stream sequcen token that tracks sequence nubmer and event index
+    /// </summary>
+    [RegisterSerializer]
+    public class EventSequenceTokenV2 : EventSequenceToken
+    {
+        /// <summary>
+        /// Sequence token constructor
+        /// </summary>
+        /// <param name="seqNumber"></param>
+        public EventSequenceTokenV2(long seqNumber) : base(seqNumber)
+        {
+        }
+
+        /// <summary>
+        /// Sequence token constructor
+        /// </summary>
+        /// <param name="seqNumber"></param>
+        /// <param name="eventInd"></param>
+        public EventSequenceTokenV2(long seqNumber, int eventInd) : base(seqNumber, eventInd)
+        {
+        }
+
+        /// <summary>
+        /// Register the serializers
+        /// </summary>
+        public static void Register()
+        {
+            SerializationManager.Register(typeof(EventSequenceTokenV2), DeepCopy, Serialize, Deserialize);
+        }
+
+        /// <summary>
+        /// Create a deep copy of the token.
+        /// </summary>
+        /// <param name="original">The token to copy</param>
+        /// <returns>A copy</returns>
+        public static object DeepCopy(object original)
+        {
+            var source = original as EventSequenceTokenV2;
+            if (source == null)
+            {
+                return null;
+            }
+
+            var copy = new EventSequenceTokenV2(source.SequenceNumber, source.EventIndex);
+            SerializationContext.Current.RecordObject(original, copy);
+            return copy;
+        }
+
+        /// <summary>
+        /// Serialize the event sequence token.
+        /// </summary>
+        /// <param name="untypedInput">The object to serialize.</param>
+        /// <param name="writer">The writer to write the binary stream to.</param>
+        /// <param name="expected">The expected type.</param>
+        public static void Serialize(object untypedInput, BinaryTokenStreamWriter writer, Type expected)
+        {
+            var typed = untypedInput as EventSequenceTokenV2;
+            if (typed == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.Write(typed.SequenceNumber);
+            writer.Write(typed.EventIndex);
+        }
+
+        /// <summary>
+        /// Deserializes an event sequence token
+        /// </summary>
+        /// <param name="expected">The expected type.</param>
+        /// <param name="reader">The binary stream to read from.</param>
+        /// <returns></returns>
+        public static object Deserialize(Type expected, BinaryTokenStreamReader reader)
+        {
+            var result = new EventSequenceTokenV2(reader.ReadLong(), reader.ReadInt());
+            DeserializationContext.Current.RecordObject(result);
+            return result;
+        }
+    }
+}

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -115,12 +115,12 @@ namespace Orleans.Providers.Streams.Generator
                 var stream = new BinaryTokenStreamReader(cachedMessage.Payload);
                 object payloadObject = SerializationManager.Deserialize(stream);
                 return new GeneratedBatchContainer(cachedMessage.StreamGuid, cachedMessage.StreamNamespace,
-                    payloadObject, new EventSequenceToken(cachedMessage.SequenceNumber));
+                    payloadObject, new EventSequenceTokenV2(cachedMessage.SequenceNumber));
             }
 
             public StreamSequenceToken GetSequenceToken(ref CachedMessage cachedMessage)
             {
-                return new EventSequenceToken(cachedMessage.SequenceNumber);
+                return new EventSequenceTokenV2(cachedMessage.SequenceNumber);
             }
 
             public StreamPosition GetStreamPosition(GeneratedBatchContainer queueMessage)

--- a/src/OrleansProviders/Streams/Generator/Generators/SimpleGenerator.cs
+++ b/src/OrleansProviders/Streams/Generator/Generators/SimpleGenerator.cs
@@ -57,7 +57,7 @@ namespace Orleans.Providers.Streams.Generator
                         ? GeneratedEvent.GeneratedEventType.Fill
                         : GeneratedEvent.GeneratedEventType.Report,
             };
-            return new GeneratedBatchContainer(streamGuid, config.StreamNamespace, evt, new EventSequenceToken(sequenceId));
+            return new GeneratedBatchContainer(streamGuid, config.StreamNamespace, evt, new EventSequenceTokenV2(sequenceId));
         }
     }
 }

--- a/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
@@ -113,7 +113,7 @@ namespace Orleans.Providers
             public StreamPosition GetStreamPosition(MemoryMessageData queueMessage)
             {
                 return new StreamPosition(new StreamIdentity(queueMessage.StreamGuid, queueMessage.StreamNamespace),
-                    new EventSequenceToken(queueMessage.SequenceNumber));
+                    new EventSequenceTokenV2(queueMessage.SequenceNumber));
             }
 
             public bool ShouldPurge(ref MemoryMessageData cachedMessage, ref MemoryMessageData newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc)

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -406,7 +406,7 @@ namespace Orleans.Streams
                     return false;
                 }
 
-                // Retrive one multiBatch from the queue. Every multiBatch has an IEnumerable of IBatchContainers, each IBatchContainer may have multiple events.
+                // Retrieve one multiBatch from the queue. Every multiBatch has an IEnumerable of IBatchContainers, each IBatchContainer may have multiple events.
                 IList<IBatchContainer> multiBatch = await rcvr.GetQueueMessagesAsync(maxCacheAddCount);
 
                 if (multiBatch == null || multiBatch.Count == 0) return false; // queue is empty. Exit the loop. Will attempt again in the next timer callback.

--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Providers\Streams\EventHub\EventHubQueueCache.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubQueueMapper.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSequenceToken.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubSequenceTokenV2.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProvider.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProviderSettings.cs" />

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Streams;
+using OrleansServiceBus.Providers.Streams.EventHub;
 
 namespace Orleans.ServiceBus.Providers
 {
@@ -56,7 +57,7 @@ namespace Orleans.ServiceBus.Providers
         public EventHubBatchContainer(EventHubMessage eventHubMessage)
         {
             this.eventHubMessage = eventHubMessage;
-            token = new EventHubSequenceToken(eventHubMessage.Offset, eventHubMessage.SequenceNumber, 0);
+            token = new EventHubSequenceTokenV2(eventHubMessage.Offset, eventHubMessage.SequenceNumber, 0);
         }
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace Orleans.ServiceBus.Providers
         /// <returns></returns>
         public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
         {
-            return Payload.Events.Cast<T>().Select((e, i) => Tuple.Create<T, StreamSequenceToken>(e, new EventHubSequenceToken(token.EventHubOffset, token.SequenceNumber, i)));
+            return Payload.Events.Cast<T>().Select((e, i) => Tuple.Create<T, StreamSequenceToken>(e, new EventHubSequenceTokenV2(token.EventHubOffset, token.SequenceNumber, i)));
         }
 
         /// <summary>

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -228,7 +228,7 @@ namespace Orleans.ServiceBus.Providers
         /// <returns></returns>
         public virtual StreamSequenceToken GetSequenceToken(ref CachedEventHubMessage cachedMessage)
         {
-            return new EventSequenceToken(cachedMessage.SequenceNumber, 0);
+            return new EventSequenceTokenV2(cachedMessage.SequenceNumber, 0);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Orleans.ServiceBus.Providers
             Guid streamGuid = Guid.Parse(queueMessage.PartitionKey);
             string streamNamespace = queueMessage.GetStreamNamespaceProperty();
             IStreamIdentity stremIdentity = new StreamIdentity(streamGuid, streamNamespace);
-            StreamSequenceToken token = new EventSequenceToken(queueMessage.SequenceNumber, 0);
+            StreamSequenceToken token = new EventSequenceTokenV2(queueMessage.SequenceNumber, 0);
             return new StreamPosition(stremIdentity, token);
         }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using Orleans.CodeGeneration;
+using Orleans.Serialization;
+using Orleans.ServiceBus.Providers;
+
+namespace OrleansServiceBus.Providers.Streams.EventHub
+{
+    /// <summary>
+    /// Event Hub messages consist of a batch of application layer events, so EventHub tokens contain three pieces of information.
+    /// EventHubOffset - this is a unique value per partition that is used to start reading from this message in the partition.
+    /// SequenceNumber - EventHub sequence numbers are unique ordered message IDs for messages within a partition.  
+    ///   The SequenceNumber is required for uniqueness and ordering of EventHub messages within a partition.
+    /// event Index - Since each EventHub message may contain more than one application layer event, this value
+    ///   indicates which application layer event this token is for, within an EventHub message.  It is required for uniqueness
+    ///   and ordering of aplication layer events within an EventHub message.
+    /// </summary>
+    [RegisterSerializer]
+    public class EventHubSequenceTokenV2 : EventHubSequenceToken
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="eventHubOffset">EventHub offset within the partition from which this message came.</param>
+        /// <param name="sequenceNumber">EventHub sequenceNumber for this message.</param>
+        /// <param name="eventIndex">Index into a batch of events, if multiple events were delivered within a single EventHub message.</param>
+        public EventHubSequenceTokenV2(string eventHubOffset, long sequenceNumber, int eventIndex)
+            : base(eventHubOffset, sequenceNumber, eventIndex)
+        {
+        }
+        /// <summary>
+        /// Register the serializers
+        /// </summary>
+        public static void Register()
+        {
+            SerializationManager.Register(typeof(EventHubSequenceTokenV2), DeepCopy, Serialize, Deserialize);
+        }
+
+        /// <summary>
+        /// Create a deep copy of the token.
+        /// </summary>
+        /// <param name="original">The token to copy</param>
+        /// <returns>A copy</returns>
+        public static object DeepCopy(object original)
+        {
+            var source = original as EventHubSequenceTokenV2;
+            if (source == null)
+            {
+                return null;
+            }
+
+            var copy = new EventHubSequenceTokenV2(source.EventHubOffset, source.SequenceNumber, source.EventIndex);
+            SerializationContext.Current.RecordObject(original, copy);
+            return copy;
+        }
+
+        /// <summary>
+        /// Serialize the event sequence token.
+        /// </summary>
+        /// <param name="untypedInput">The object to serialize.</param>
+        /// <param name="writer">The writer to write the binary stream to.</param>
+        /// <param name="expected">The expected type.</param>
+        public static void Serialize(object untypedInput, BinaryTokenStreamWriter writer, Type expected)
+        {
+            var typed = untypedInput as EventHubSequenceTokenV2;
+            if (typed == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.Write(typed.EventHubOffset);
+            writer.Write(typed.SequenceNumber);
+            writer.Write(typed.EventIndex);
+        }
+
+        /// <summary>
+        /// Deserializes an event sequence token
+        /// </summary>
+        /// <param name="expected">The expected type.</param>
+        /// <param name="reader">The binary stream to read from.</param>
+        /// <returns></returns>
+        public static object Deserialize(Type expected, BinaryTokenStreamReader reader)
+        {
+            var deserialized = new EventHubSequenceTokenV2(reader.ReadString(), reader.ReadLong(), reader.ReadInt());
+            DeserializationContext.Current.RecordObject(deserialized);
+            return deserialized;
+        }
+    }
+}

--- a/test/NonSiloTests/Orleans.NonSiloTests.csproj
+++ b/test/NonSiloTests/Orleans.NonSiloTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="SerializationTests\SerializationOrderTests.cs" />
     <Compile Include="SerializationTests\SerializationTests.DifferentTypes.cs" />
     <Compile Include="SerializationTests\SerializationTests.ImmutableCollections.cs" />
+    <Compile Include="SerializationTests\StreamTypeSerializationTests.cs" />
     <Compile Include="Serialization\BuiltInSerializerTests.cs" />
     <Compile Include="Serialization\ILBasedSerializerTests.cs" />
     <Compile Include="Serialization\SerializerGenerationTests.cs" />
@@ -171,6 +172,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\OrleansAzureUtils\OrleansAzureUtils.csproj">
+      <Project>{792818ef-b3f8-4ce2-9886-4808713b15c4}</Project>
+      <Name>OrleansAzureUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\OrleansBondUtils\OrleansBondUtils.csproj">
       <Project>{7a6b8051-5d99-483c-b9b7-444ed57918ec}</Project>
       <Name>OrleansBondUtils</Name>
@@ -186,6 +191,10 @@
     <ProjectReference Include="..\..\src\OrleansRuntime\OrleansRuntime.csproj">
       <Project>{6ff2004c-cdf8-479c-bf27-c6bfe8ef93e0}</Project>
       <Name>OrleansRuntime</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\OrleansServiceBus\OrleansServiceBus.csproj">
+      <Project>{8BFF0092-15D2-4425-80C0-29E381702F2B}</Project>
+      <Name>OrleansServiceBus</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\OrleansTestingHost\OrleansTestingHost.csproj">
       <Project>{40ee3b00-d381-485f-9c69-ff706837deed}</Project>

--- a/test/NonSiloTests/SerializationTests/ExternalSerializerTest.cs
+++ b/test/NonSiloTests/SerializationTests/ExternalSerializerTest.cs
@@ -90,6 +90,7 @@ namespace UnitTests.Serialization
         public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
         {
             DeserializeCalled = true;
+            reader.ReadToken();
             return new FakeSerialized { SomeData = "fake deserialization" };
         }
     }

--- a/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
+++ b/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization.Formatters.Binary;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Providers.Streams.Common;
+using Orleans.Serialization;
+using Orleans.ServiceBus.Providers;
+using OrleansServiceBus.Providers.Streams.EventHub;
+using Xunit;
+using Orleans.Streams;
+using Microsoft.WindowsAzure.Storage.Queue;
+
+namespace UnitTests.Serialization
+{
+    public class StreamTypeSerializationTests
+    {
+        public StreamTypeSerializationTests()
+        {
+            // FakeSerializer definied in ExternalSerializerTest.cs
+            SerializationManager.InitializeForTesting(new List<TypeInfo> { typeof(FakeSerializer).GetTypeInfo() });
+            EventSequenceTokenV2.Register();
+            EventHubSequenceTokenV2.Register();
+            AzureQueueBatchContainerV2.Register();
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void EventSequenceToken_VerifyStillUsingFallbackSerializer()
+        {
+            var token = new EventSequenceToken(long.MaxValue, int.MaxValue);
+            VerifyUsingFallbackSerializer(token);
+   
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void AzureQueueBatchContainer_VerifyStillUsingFallbackSerializer()
+        {
+            var container = new AzureQueueBatchContainer(Guid.NewGuid(), "namespace", new List<object> {"item"}, new Dictionary<string, object>() {{"key", "value"}}, new EventSequenceToken(long.MaxValue, int.MaxValue));
+            VerifyUsingFallbackSerializer(container);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void EventHubSequenceToken_VerifyStillUsingFallbackSerializer()
+        {
+            var token = new EventHubSequenceToken("some offset", long.MaxValue, int.MaxValue);
+            VerifyUsingFallbackSerializer(token);
+        }
+
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void AzureQueueBatchContainer_VerifyBothMessageTypesCanBeDeserialized()
+        {
+            var container = new AzureQueueBatchContainer(Guid.NewGuid(), "namespace", new List<object> { "item" }, new Dictionary<string, object>() { { "key", "value" } }, new EventSequenceToken(long.MaxValue, int.MaxValue));
+            var writer = new BinaryTokenStreamWriter();
+            SerializationManager.Serialize(container, writer);
+            var bytes = writer.ToByteArray();
+
+            writer = new BinaryTokenStreamWriter();
+            var container2 = new AzureQueueBatchContainerV2(Guid.NewGuid(), "namespace", new List<object> { "item" }, new Dictionary<string, object>() { { "key", "value" } }, new EventSequenceTokenV2(long.MaxValue, int.MaxValue));
+            SerializationManager.Serialize(container2, writer);
+            var bytes2 = writer.ToByteArray();
+
+            var msg = new CloudQueueMessage(bytes);
+            var msg2 = new CloudQueueMessage(bytes2);
+            var bc1 = (IBatchContainer)AzureQueueBatchContainer.FromCloudQueueMessage(msg, 0);
+            var bc2 = (IBatchContainer)AzureQueueBatchContainer.FromCloudQueueMessage(msg2, 0);
+            Assert.NotNull(bc1);
+            Assert.NotNull(bc2);
+        }
+
+        private static void VerifyUsingFallbackSerializer(object ob)
+        {
+            var writer = new BinaryTokenStreamWriter();
+            SerializationManager.FallbackSerializer(ob, writer, ob.GetType());
+            var bytes = writer.ToByteArray();
+
+            byte[] defaultFormatterBytes;
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, ob);
+                stream.Flush();
+                defaultFormatterBytes = stream.ToArray();
+            }
+
+            var reader = new BinaryTokenStreamReader(bytes);
+            var serToken = reader.ReadToken();
+            Assert.Equal(SerializationTokenType.Fallback, serToken);
+            var length = reader.ReadInt();
+            Assert.Equal(length, defaultFormatterBytes.Length);
+            var segment = new ArraySegment<byte>(bytes, reader.CurrentPosition, bytes.Length - reader.CurrentPosition);
+            Assert.True(segment.SequenceEqual(defaultFormatterBytes));
+        }
+
+        #region EventSequenceToken2
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void EventSequenceTokenV2_DeepCopy_IfNotNull()
+        {
+            var token = new EventSequenceTokenV2(long.MaxValue, int.MaxValue);
+            var copy = EventSequenceTokenV2.DeepCopy(token) as EventSequenceToken;
+            Assert.NotNull(copy);
+            Assert.NotSame(token, copy);
+            Assert.Equal(token.EventIndex, copy.EventIndex);
+            Assert.Equal(token.SequenceNumber, copy.SequenceNumber);
+
+            var writer = new BinaryTokenStreamWriter();
+            SerializationManager.Serialize(token, writer);
+            var bytes = writer.ToByteArray();
+
+            var reader = new BinaryTokenStreamReader(bytes);
+            copy = SerializationManager.Deserialize(reader) as EventSequenceToken;
+            Assert.NotNull(copy);
+            Assert.NotSame(token, copy);
+            Assert.Equal(token.EventIndex, copy.EventIndex);
+            Assert.Equal(token.SequenceNumber, copy.SequenceNumber);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void EventSequenceTokenV2_Serialize_IfNotNull()
+        {
+            var writer = new BinaryTokenStreamWriter();
+            var token = new EventSequenceTokenV2(long.MaxValue, int.MaxValue);
+            EventSequenceTokenV2.Serialize(token, writer, null);
+            var reader = new BinaryTokenStreamReader(writer.ToByteArray());
+            var deserialized = EventSequenceTokenV2.Deserialize(typeof(EventSequenceTokenV2), reader) as EventSequenceTokenV2;
+            Assert.NotNull(deserialized);
+            Assert.NotSame(token, deserialized);
+            Assert.Equal(token.EventIndex, deserialized.EventIndex);
+            Assert.Equal(token.SequenceNumber, deserialized.SequenceNumber);
+        }
+
+        #endregion
+
+        #region EventHubSequenceToken2
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void EventHubSequenceTokenV2_DeepCopy_IfNotNull()
+        {
+            var token = new EventHubSequenceTokenV2("name", long.MaxValue, int.MaxValue);
+            var copy = EventHubSequenceTokenV2.DeepCopy(token) as EventSequenceToken;
+            Assert.NotNull(copy);
+            Assert.NotSame(token, copy);
+            Assert.Equal(token.EventIndex, copy.EventIndex);
+            Assert.Equal(token.SequenceNumber, copy.SequenceNumber);
+
+            var writer = new BinaryTokenStreamWriter();
+            SerializationManager.Serialize(token, writer);
+            var bytes = writer.ToByteArray();
+
+            var reader = new BinaryTokenStreamReader(bytes);
+            copy = SerializationManager.Deserialize(reader) as EventHubSequenceTokenV2;
+            Assert.NotNull(copy);
+            Assert.NotSame(token, copy);
+            Assert.Equal(token.EventIndex, copy.EventIndex);
+            Assert.Equal(token.SequenceNumber, copy.SequenceNumber);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void EventHubSequenceTokenV2_Serialize_IfNotNull()
+        {
+            var writer = new BinaryTokenStreamWriter();
+            var token = new EventHubSequenceTokenV2("name", long.MaxValue, int.MaxValue);
+            EventHubSequenceTokenV2.Serialize(token, writer, null);
+            var reader = new BinaryTokenStreamReader(writer.ToByteArray());
+            var deserialized = EventHubSequenceTokenV2.Deserialize(typeof (EventHubSequenceTokenV2), reader) as EventHubSequenceTokenV2;
+            Assert.NotNull(deserialized);
+            Assert.NotSame(token, deserialized);
+            Assert.Equal(token.EventIndex, deserialized.EventIndex);
+            Assert.Equal(token.SequenceNumber, deserialized.SequenceNumber);
+        }
+        #endregion
+
+        #region AzureQueueBatchContainer2
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void AzureQueueBatchContainerV2_DeepCopy_IfNotNullAndUsingExternalSerializer()
+        {
+            var container = CreateAzureQueueBatchContainer();
+            var copy = AzureQueueBatchContainerV2.DeepCopy(container) as AzureQueueBatchContainerV2;
+            ValidateIdenticalQueueBatchContainerButNotSame(container, copy);
+            copy = SerializationManager.DeepCopy(container) as AzureQueueBatchContainerV2;
+            ValidateIdenticalQueueBatchContainerButNotSame(container, copy);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void AzureQueueBatchContainerV2_Serialize_IfNotNull()
+        {
+            var container = CreateAzureQueueBatchContainer();
+            var writer = new BinaryTokenStreamWriter();
+            AzureQueueBatchContainerV2.Serialize(container, writer, null);
+            var reader = new BinaryTokenStreamReader(writer.ToByteArray());
+            var deserialized = AzureQueueBatchContainerV2.Deserialize(typeof (AzureQueueBatchContainer), reader) as AzureQueueBatchContainerV2;
+            ValidateIdenticalQueueBatchContainerButNotSame(container, deserialized);
+
+            writer = new BinaryTokenStreamWriter();
+            SerializationManager.Serialize(container, writer);
+            reader = new BinaryTokenStreamReader(writer.ToByteArray());
+            deserialized = SerializationManager.Deserialize<AzureQueueBatchContainerV2>(reader);
+            ValidateIdenticalQueueBatchContainerButNotSame(container, deserialized);
+        }
+
+        private static AzureQueueBatchContainerV2 CreateAzureQueueBatchContainer()
+        {
+            return new AzureQueueBatchContainerV2(
+                Guid.NewGuid(), 
+                "some namespace", 
+                new List<object> { new FakeSerialized { SomeData = "text"} }, 
+                new Dictionary<string, object>
+                {
+                    { "some key", new FakeSerialized { SomeData = "text 2" } }
+                },
+                new EventSequenceTokenV2(long.MaxValue, int.MaxValue));
+        }
+
+        private static void ValidateIdenticalQueueBatchContainerButNotSame(AzureQueueBatchContainerV2 orig, AzureQueueBatchContainerV2 copy)
+        {
+            Assert.NotNull(copy);
+            Assert.NotSame(orig, copy);
+            Assert.NotNull(copy.SequenceToken);
+            Assert.Equal(orig.SequenceToken, copy.SequenceToken);
+            Assert.NotSame(orig.SequenceToken, copy.SequenceToken);
+            Assert.Equal(orig.StreamGuid, copy.StreamGuid);
+            Assert.Equal(orig.StreamNamespace, copy.StreamNamespace);
+            Assert.Equal(orig.StreamNamespace, "some namespace");
+            Assert.NotNull(copy.RequestContext);
+            Assert.NotSame(orig.RequestContext, copy.RequestContext);
+            foreach (var kv in orig.RequestContext)
+            {
+                Assert.True(copy.RequestContext.ContainsKey(kv.Key));
+            }
+
+            Assert.True(copy.RequestContext.ContainsKey("some key"));
+        }
+
+        #endregion
+    }
+}

--- a/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
@@ -45,7 +45,7 @@ namespace Tester.TestStreamProviders.EventHub
             public override StreamPosition GetStreamPosition(EventData queueMessage)
             {
                 IStreamIdentity stremIdentity = new StreamIdentity(partitionStreamGuid, null);
-                StreamSequenceToken token = new EventSequenceToken(queueMessage.SequenceNumber, 0);
+                StreamSequenceToken token = new EventSequenceTokenV2(queueMessage.SequenceNumber, 0);
                 return new StreamPosition(stremIdentity, token);
             }
         }

--- a/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
@@ -53,7 +53,7 @@ namespace UnitTests.OrleansRuntime.Streams
 
             public int Compare(TestCachedMessage cachedMessage, StreamSequenceToken token)
             {
-                var myToken = new EventSequenceToken(cachedMessage.SequenceNumber, cachedMessage.EventIndex);
+                var myToken = new EventSequenceTokenV2(cachedMessage.SequenceNumber, cachedMessage.EventIndex);
                 return myToken.CompareTo(token);
             }
 
@@ -88,7 +88,7 @@ namespace UnitTests.OrleansRuntime.Streams
 
             public StreamSequenceToken GetSequenceToken(ref TestCachedMessage cachedMessage)
             {
-                return new EventSequenceToken(cachedMessage.SequenceNumber, cachedMessage.EventIndex);
+                return new EventSequenceTokenV2(cachedMessage.SequenceNumber, cachedMessage.EventIndex);
             }
 
             public StreamPosition GetStreamPosition(TestQueueMessage queueMessage)
@@ -174,12 +174,12 @@ namespace UnitTests.OrleansRuntime.Streams
                 last++;
                 sequenceNumber += 2;
             }
-            Assert.Equal(block.OldestMessageIndex, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceToken(0), TestCacheDataComparer.Instance));
-            Assert.Equal(block.OldestMessageIndex, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceToken(1), TestCacheDataComparer.Instance));
-            Assert.Equal(block.NewestMessageIndex, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceToken(sequenceNumber - 2), TestCacheDataComparer.Instance));
-            Assert.Equal(block.NewestMessageIndex - 1, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceToken(sequenceNumber - 3), TestCacheDataComparer.Instance));
-            Assert.Equal(50, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceToken(sequenceNumber / 2), TestCacheDataComparer.Instance));
-            Assert.Equal(50, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceToken(sequenceNumber / 2 + 1), TestCacheDataComparer.Instance));
+            Assert.Equal(block.OldestMessageIndex, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(0), TestCacheDataComparer.Instance));
+            Assert.Equal(block.OldestMessageIndex, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(1), TestCacheDataComparer.Instance));
+            Assert.Equal(block.NewestMessageIndex, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(sequenceNumber - 2), TestCacheDataComparer.Instance));
+            Assert.Equal(block.NewestMessageIndex - 1, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(sequenceNumber - 3), TestCacheDataComparer.Instance));
+            Assert.Equal(50, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(sequenceNumber / 2), TestCacheDataComparer.Instance));
+            Assert.Equal(50, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(sequenceNumber / 2 + 1), TestCacheDataComparer.Instance));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -200,7 +200,7 @@ namespace UnitTests.OrleansRuntime.Streams
                 var message = new TestQueueMessage
                 {
                     StreamGuid = stream.Guid,
-                    SequenceToken = new EventSequenceToken(sequenceNumber)
+                    SequenceToken = new EventSequenceTokenV2(sequenceNumber)
                 };
 
                 // add message to end of block
@@ -246,7 +246,7 @@ namespace UnitTests.OrleansRuntime.Streams
             var message = new TestQueueMessage
             {
                 StreamGuid = StreamGuid,
-                SequenceToken = new EventSequenceToken(sequenceNumber)
+                SequenceToken = new EventSequenceTokenV2(sequenceNumber)
             };
             AddAndCheck(block, dataAdapter, message, first, last);
         }

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -138,13 +138,13 @@ namespace UnitTests.OrleansRuntime.Streams
 
             public StreamSequenceToken GetSequenceToken(ref TestCachedMessage cachedMessage)
             {
-                return new EventSequenceToken(cachedMessage.SequenceNumber);
+                return new EventSequenceTokenV2(cachedMessage.SequenceNumber);
             }
 
             public StreamPosition GetStreamPosition(TestQueueMessage queueMessage)
             {
                 IStreamIdentity streamIdentity = new StreamIdentity(queueMessage.StreamGuid, queueMessage.StreamNamespace);
-                StreamSequenceToken sequenceToken = new EventSequenceToken(queueMessage.SequenceNumber);
+                StreamSequenceToken sequenceToken = new EventSequenceTokenV2(queueMessage.SequenceNumber);
                 return new StreamPosition(streamIdentity, sequenceToken);
             }
 
@@ -231,7 +231,7 @@ namespace UnitTests.OrleansRuntime.Streams
             }
 
             // get cursor for stream1, walk all the events in the stream using the cursor
-            object stream1Cursor = cache.GetCursor(stream1, new EventSequenceToken(startOfCache));
+            object stream1Cursor = cache.GetCursor(stream1, new EventSequenceTokenV2(startOfCache));
             int stream1EventCount = 0;
             while (cache.TryGetNextMessage(stream1Cursor, out batch))
             {
@@ -245,7 +245,7 @@ namespace UnitTests.OrleansRuntime.Streams
             Assert.Equal((sequenceNumber - startOfCache) / 2, stream1EventCount);
 
             // get cursor for stream2, walk all the events in the stream using the cursor
-            object stream2Cursor = cache.GetCursor(stream2, new EventSequenceToken(startOfCache));
+            object stream2Cursor = cache.GetCursor(stream2, new EventSequenceTokenV2(startOfCache));
             int stream2EventCount = 0;
             while (cache.TryGetNextMessage(stream2Cursor, out batch))
             {
@@ -311,7 +311,7 @@ namespace UnitTests.OrleansRuntime.Streams
             IStreamIdentity streamId = new StreamIdentity(Guid.NewGuid(), TestStreamNamespace);
 
             // No data in cache, cursors should not throw.
-            object cursor = cache.GetCursor(streamId, new EventSequenceToken(sequenceNumber++));
+            object cursor = cache.GetCursor(streamId, new EventSequenceTokenV2(sequenceNumber++));
             Assert.NotNull(cursor);
 
             // try to iterate, should throw
@@ -347,7 +347,7 @@ namespace UnitTests.OrleansRuntime.Streams
             ex = null;
             try
             {
-                cache.GetCursor(streamId, new EventSequenceToken(10));
+                cache.GetCursor(streamId, new EventSequenceTokenV2(10));
             }
             catch (QueueCacheMissException cacheMissException)
             {
@@ -356,7 +356,7 @@ namespace UnitTests.OrleansRuntime.Streams
             Assert.NotNull(ex);
 
             // Get valid cursor into cache
-            cursor = cache.GetCursor(streamId, new EventSequenceToken(13));
+            cursor = cache.GetCursor(streamId, new EventSequenceTokenV2(13));
             // query once, to make sure cursor is good
             gotNext = cache.TryGetNextMessage(cursor, out batch);
             Assert.NotNull(cursor);

--- a/test/TesterInternal/StreamingTests/AzureQueueAdapterTests.cs
+++ b/test/TesterInternal/StreamingTests/AzureQueueAdapterTests.cs
@@ -130,7 +130,7 @@ namespace UnitTests.StorageTests
             Assert.Equal(NumBatches, receivedBatches);
 
             // check to see if all the events are in the cache and we can enumerate through them
-            StreamSequenceToken firstInCache = new EventSequenceToken(0);
+            StreamSequenceToken firstInCache = new EventSequenceTokenV2(0);
             foreach (KeyValuePair<QueueId, HashSet<IStreamIdentity>> kvp in streamsPerQueue)
             {
                 var receiver = receivers[kvp.Key];

--- a/test/TesterInternal/StreamingTests/SQSAdapterTests.cs
+++ b/test/TesterInternal/StreamingTests/SQSAdapterTests.cs
@@ -129,7 +129,7 @@ namespace UnitTests.Streaming
             Assert.Equal(NumBatches, receivedBatches);
 
             // check to see if all the events are in the cache and we can enumerate through them
-            StreamSequenceToken firstInCache = new EventSequenceToken(0);
+            StreamSequenceToken firstInCache = new EventSequenceTokenV2(0);
             foreach (KeyValuePair<QueueId, HashSet<IStreamIdentity>> kvp in streamsPerQueue)
             {
                 var receiver = receivers[kvp.Key];

--- a/vNext/src/OrleansProviders/OrleansProviders.csproj
+++ b/vNext/src/OrleansProviders/OrleansProviders.csproj
@@ -48,6 +48,9 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\src\OrleansProviders\Streams\Common\EventSequenceTokenV2.cs">
+      <Link>Streams\Common\EventSequenceTokenV2.cs</Link>
+    </Compile>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>


### PR DESCRIPTION
- implement serializers for AzureQueueBatchContainer and EventSequenceToken.  They were routed to the fallback serializer which caused them to be incompatible with external serializers
- added unit tests to verify serialization/deserialization with external serializers.
