### PR TITLE
Convert AppDomain test hooks to SystemTarget

### DIFF
--- a/src/Orleans/Runtime/Constants.cs
+++ b/src/Orleans/Runtime/Constants.cs
@@ -41,6 +41,7 @@ namespace Orleans.Runtime
         public static readonly GrainId MultiClusterOracleId = GrainId.GetSystemTargetGrainId(23);
         public static readonly GrainId ClusterDirectoryServiceId = GrainId.GetSystemTargetGrainId(24);
         public static readonly GrainId StreamProviderManagerAgentSystemTargetId = GrainId.GetSystemTargetGrainId(25);
+        public static readonly GrainId TestHooksSystemTargetId = GrainId.GetSystemTargetGrainId(26);
 
         public const int PULLING_AGENTS_MANAGER_SYSTEM_TARGET_TYPE_CODE = 254;
         public const int PULLING_AGENT_SYSTEM_TARGET_TYPE_CODE = 255;

--- a/src/OrleansRuntime/Catalog/ActivationCollector.cs
+++ b/src/OrleansRuntime/Catalog/ActivationCollector.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.TestHooks;
 
 namespace Orleans.Runtime
 {
@@ -332,9 +333,15 @@ namespace Orleans.Runtime
                 condemned.Add(activation);
             }
 
-            if (Silo.CurrentSilo.TestHook.Debug_OnDecideToCollectActivation != null)
+            try
             {
-                Silo.CurrentSilo.TestHook.Debug_OnDecideToCollectActivation(activation.Grain);
+                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, activation.Address.Silo);
+                testHook?.DecideToCollectActivation(activation.Grain);
+            }
+            catch (Exception exc)
+            {
+
+                throw;
             }
         }
 

--- a/src/OrleansRuntime/Messaging/MessageCenter.cs
+++ b/src/OrleansRuntime/Messaging/MessageCenter.cs
@@ -12,6 +12,7 @@ namespace Orleans.Runtime.Messaging
         private IncomingMessageAcceptor ima;
         private static readonly Logger log = LogManager.GetLogger("Orleans.Messaging.MessageCenter");
         private Action<Message> rerouteHandler;
+        internal Func<Message, bool> ShouldDrop;
 
         // ReSharper disable NotAccessedField.Local
         private IntValueStatistic sendQueueLengthCounter;

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -60,6 +60,8 @@
     <Compile Include="Catalog\GrainCreator.cs" />
     <Compile Include="Counters\CounterConfigData.cs" />
     <Compile Include="Messaging\ObjectPool.cs" />
+    <Compile Include="Silo\TestHooks\ITestHooksSystemTarget.cs" />
+    <Compile Include="Silo\TestHooks\TestHooksSystemTarget.cs" />
     <Compile Include="Startup\ConfigureServicesBuilder.cs" />
     <Compile Include="Startup\StartupBuilder.cs" />
     <Compile Include="MultiClusterNetwork\MultiClusterData.cs" />

--- a/src/OrleansRuntime/Properties/AssemblyInfo.cs
+++ b/src/OrleansRuntime/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("TesterInternal")]
 [assembly: InternalsVisibleTo("TestInternalGrains")]
 [assembly: InternalsVisibleTo("Orleans.NonSiloTests")]
+[assembly: InternalsVisibleTo("OrleansTestingHost")]

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.CodeGeneration;
 using Orleans.GrainDirectory;
-using Orleans.MultiCluster;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.ConsistentRing;
@@ -139,7 +138,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Test hook connection for white-box testing of silo.
         /// </summary>
-        private TestHooksSystemTarget testHook;
+        internal TestHooksSystemTarget testHook;
         
         /// <summary>
         /// Creates and initializes the silo from the specified config data.
@@ -337,7 +336,6 @@ namespace Orleans.Runtime
 
             StringValueStatistic.FindOrCreate(StatisticNames.SILO_START_TIME,
                 () => LogFormatter.PrintDate(startTime)); // this will help troubleshoot production deployment when looking at MDS logs.
-            
 
             logger.Info(ErrorCode.SiloInitializingFinished, "-------------- Started silo {0}, ConsistentHashCode {1:X} --------------", SiloAddress.ToLongString(), SiloAddress.GetConsistentHashCode());
         }
@@ -877,8 +875,6 @@ namespace Orleans.Runtime
                     SystemStatus.Current = SystemStatus.Stopping;
                 }
                 
-                if (testHook != null && !testHook.ExecuteFastKillInProcessExit) return;
-
                 logger.Info(ErrorCode.SiloStopping, "Silo.HandleProcessExit() - starting to FastKill()");
                 FastKill();
             }

--- a/src/OrleansRuntime/Silo/TestHooks/ITestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/ITestHooksSystemTarget.cs
@@ -1,0 +1,35 @@
+﻿using Orleans.CodeGeneration;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.TestHooks
+{
+    internal interface ITestHooksSystemTarget : ISystemTarget
+    {
+        Task<SiloAddress> GetPrimaryTargetSilo(uint key);
+        Task<string> GetConsistentRingProviderString();
+        Task<bool> HasStatisticsProvider();
+        Task<Guid> GetServiceId();
+        Task<IEnumerable<string>> GetStorageProviderNames();
+        Task<IEnumerable<string>> GetStreamProviderNames();
+        Task<IEnumerable<string>> GetAllSiloProviderNames();
+        Task SuppressFastKillInHandleProcessExit();
+        Task<IDictionary<GrainId, IGrainInfo>> GetDirectoryForTypeNamesContaining(string expr);
+        Task BlockSiloCommunication(IPEndPoint destination, double lost_percentage);
+        Task UnblockSiloCommunication();
+        Task<bool> ShouldDrop(Message msg);
+        Task<int> UnregisterGrainForTesting(GrainId grain);
+        Task SetDirectoryLazyDeregistrationDelay(TimeSpan timeSpan);
+        Task SetMaxForwardCount(int val);
+        Task DecideToCollectActivation(GrainId grainId);
+        Task RegisterTestHooksObserver(ITestHooksObserver observer);
+    }
+
+    internal interface ITestHooksObserver : IGrainObserver
+    {
+        void OnCollectActivation(GrainId grainId);
+    }
+
+}

--- a/src/OrleansRuntime/Silo/TestHooks/ITestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/ITestHooksSystemTarget.cs
@@ -1,35 +1,23 @@
-﻿using Orleans.CodeGeneration;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace Orleans.Runtime.TestHooks
 {
-    internal interface ITestHooksSystemTarget : ISystemTarget
+    internal interface ITestHooks
     {
-        Task<SiloAddress> GetPrimaryTargetSilo(uint key);
-        Task<string> GetConsistentRingProviderString();
+        Task<SiloAddress> GetConsistentRingPrimaryTargetSilo(uint key);
+        Task<string> GetConsistentRingProviderDiagnosticInfo();
         Task<bool> HasStatisticsProvider();
         Task<Guid> GetServiceId();
-        Task<IEnumerable<string>> GetStorageProviderNames();
-        Task<IEnumerable<string>> GetStreamProviderNames();
-        Task<IEnumerable<string>> GetAllSiloProviderNames();
-        Task SuppressFastKillInHandleProcessExit();
-        Task<IDictionary<GrainId, IGrainInfo>> GetDirectoryForTypeNamesContaining(string expr);
-        Task BlockSiloCommunication(IPEndPoint destination, double lost_percentage);
-        Task UnblockSiloCommunication();
-        Task<bool> ShouldDrop(Message msg);
+        Task<ICollection<string>> GetStorageProviderNames();
+        Task<ICollection<string>> GetStreamProviderNames();
+        Task<ICollection<string>> GetAllSiloProviderNames();
         Task<int> UnregisterGrainForTesting(GrainId grain);
-        Task SetDirectoryLazyDeregistrationDelay(TimeSpan timeSpan);
-        Task SetMaxForwardCount(int val);
-        Task DecideToCollectActivation(GrainId grainId);
-        Task RegisterTestHooksObserver(ITestHooksObserver observer);
+        Task LatchIsOverloaded(bool overloaded, TimeSpan latchPeriod);
     }
 
-    internal interface ITestHooksObserver : IGrainObserver
+    internal interface ITestHooksSystemTarget : ITestHooks, ISystemTarget
     {
-        void OnCollectActivation(GrainId grainId);
     }
-
 }

--- a/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -1,15 +1,10 @@
-﻿using Orleans.CodeGeneration;
-using Orleans.Providers;
-using Orleans.Runtime.ConsistentRing;
-using Orleans.Runtime.GrainDirectory;
-using Orleans.Runtime.Placement;
-using System;
-using System.Collections.Concurrent;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Runtime.Serialization;
 using System.Threading.Tasks;
+using Orleans.CodeGeneration;
+using Orleans.Providers;
+using Orleans.Runtime.ConsistentRing;
 
 namespace Orleans.Runtime.TestHooks
 {
@@ -20,25 +15,20 @@ namespace Orleans.Runtime.TestHooks
     internal class TestHooksSystemTarget : SystemTarget, ITestHooksSystemTarget
     {
         private readonly Silo silo;
-        internal bool ExecuteFastKillInProcessExit;
-        private ObserverSubscriptionManager<ITestHooksObserver> subsManager;
         private readonly IConsistentRingProvider consistentRingProvider;
-        private ConcurrentDictionary<IPEndPoint, double> SimulatedMessageLoss;
 
-        internal TestHooksSystemTarget(Silo s) : base(Constants.TestHooksSystemTargetId, s.SiloAddress)
+        internal TestHooksSystemTarget(Silo silo) : base(Constants.TestHooksSystemTargetId, silo.SiloAddress)
         {
-            silo = s;
-            ExecuteFastKillInProcessExit = true;
-            subsManager = new ObserverSubscriptionManager<ITestHooksObserver>();
-            consistentRingProvider = CheckReturnBoundaryReference("ring provider", silo.RingProvider);
+            this.silo = silo;
+            consistentRingProvider = silo.RingProvider;
         }
 
-        public Task<SiloAddress> GetPrimaryTargetSilo(uint key)
+        public Task<SiloAddress> GetConsistentRingPrimaryTargetSilo(uint key)
         {
             return Task.FromResult(consistentRingProvider.GetPrimaryTargetSilo(key));
         }
 
-        public Task<string> GetConsistentRingProviderString()
+        public Task<string> GetConsistentRingProviderDiagnosticInfo()
         {
             return Task.FromResult(consistentRingProvider.ToString());
         }
@@ -47,87 +37,13 @@ namespace Orleans.Runtime.TestHooks
 
         public Task<Guid> GetServiceId() => Task.FromResult(silo.GlobalConfig.ServiceId);
 
-        public Task<IEnumerable<string>> GetStorageProviderNames() => Task.FromResult(silo.StorageProviderManager.GetProviderNames());
+        public Task<ICollection<string>> GetStorageProviderNames() => Task.FromResult<ICollection<string>>(silo.StorageProviderManager.GetProviderNames().ToList());
 
-        public Task<IEnumerable<string>> GetStreamProviderNames() => Task.FromResult(silo.StreamProviderManager.GetStreamProviders().Select(p => ((IProvider)p).Name).AsEnumerable());
+        public Task<ICollection<string>> GetStreamProviderNames() => Task.FromResult<ICollection<string>>(silo.StreamProviderManager.GetStreamProviders().Select(p => ((IProvider)p).Name).ToList());
 
-        public Task<IEnumerable<string>> GetAllSiloProviderNames() => Task.FromResult(silo.AllSiloProviders.Select(p => ((IProvider)p).Name).AsEnumerable());
-
-        public Task SuppressFastKillInHandleProcessExit()
-        {
-            ExecuteFastKillInProcessExit = false;
-            return TaskDone.Done;
-        }
-
-        public Task<IDictionary<GrainId, IGrainInfo>> GetDirectoryForTypeNamesContaining(string expr)
-        {
-            var x = new Dictionary<GrainId, IGrainInfo>();
-            foreach (var kvp in ((LocalGrainDirectory)silo.LocalGrainDirectory).DirectoryPartition.GetItems())
-            {
-                if (kvp.Key.IsSystemTarget || kvp.Key.IsClient || !kvp.Key.IsGrain)
-                    continue;// Skip system grains, system targets and clients
-                if (((Catalog)silo.Catalog).GetGrainTypeName(kvp.Key).Contains(expr))
-                    x.Add(kvp.Key, kvp.Value);
-            }
-            return Task.FromResult(x as IDictionary<GrainId, IGrainInfo>);
-        }
-        
-        public Task BlockSiloCommunication(IPEndPoint destination, double lost_percentage)
-        {
-            if (SimulatedMessageLoss == null)
-                SimulatedMessageLoss = new ConcurrentDictionary<IPEndPoint, double>();
-
-            SimulatedMessageLoss[destination] = lost_percentage;
-
-            return TaskDone.Done;
-        }
-
-        public Task UnblockSiloCommunication()
-        {
-            SimulatedMessageLoss = null;
-            return TaskDone.Done;
-        }
-
-        private readonly SafeRandom random = new SafeRandom();
-
-        public Task<bool> ShouldDrop(Message msg)
-        {
-            var should = false;
-            if (SimulatedMessageLoss != null)
-            {
-                double blockedpercentage;
-                SimulatedMessageLoss.TryGetValue(msg.TargetSilo.Endpoint, out blockedpercentage);
-                should = (random.NextDouble() * 100 < blockedpercentage);
-            }
-
-            return Task.FromResult(should);
-        }
+        public Task<ICollection<string>> GetAllSiloProviderNames() => Task.FromResult<ICollection<string>>(silo.AllSiloProviders.Select(p => p.Name).ToList());
 
         public Task<int> UnregisterGrainForTesting(GrainId grain) => Task.FromResult(((Catalog)silo.Catalog).UnregisterGrainForTesting(grain));
-
-        public Task SetDirectoryLazyDeregistrationDelay(TimeSpan timeSpan)
-        {
-            silo.OrleansConfig.Globals.DirectoryLazyDeregistrationDelay = timeSpan;
-            return TaskDone.Done;
-        }
-
-        public Task SetMaxForwardCount(int val)
-        {
-            silo.OrleansConfig.Globals.MaxForwardCount = val;
-            return TaskDone.Done;
-        }
-
-        public Task DecideToCollectActivation(GrainId grainId)
-        {
-            subsManager.Notify(s => s.OnCollectActivation(grainId));
-            return TaskDone.Done;
-        }
-
-        public Task RegisterTestHooksObserver(ITestHooksObserver observer)
-        {
-            subsManager.Subscribe(observer);
-            return TaskDone.Done;
-        }
 
         public Task AddCachedAssembly(string targetAssemblyName, GeneratedAssembly cachedAssembly)
         {
@@ -135,20 +51,17 @@ namespace Orleans.Runtime.TestHooks
             return TaskDone.Done;
         }
 
-        private static T CheckReturnBoundaryReference<T>(string what, T obj) where T : class
+        public Task LatchIsOverloaded(bool overloaded, TimeSpan latchPeriod)
         {
-            if (obj == null) return null;
-            if (
-#if !NETSTANDARD_TODO
-                    obj is MarshalByRefObject ||
-#endif
-                    obj is ISerializable)
-            {
-                // Referernce to the provider can safely be passed across app-domain boundary in unit test process
-                return obj;
-            }
-            throw new InvalidOperationException(string.Format("Cannot return reference to {0} {1} if it is not MarshalByRefObject or Serializable",
-                what, TypeUtils.GetFullName(obj.GetType())));
+            this.silo.Metrics.LatchIsOverload(overloaded);
+            
+            Task.Delay(latchPeriod).ContinueWith(t => UnlatchIsOverloaded()).Ignore();
+            return TaskDone.Done;
+        }
+
+        private void UnlatchIsOverloaded()
+        {
+            this.silo.Metrics.UnlatchIsOverloaded();
         }
     }
 }

--- a/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -1,0 +1,154 @@
+﻿using Orleans.CodeGeneration;
+using Orleans.Providers;
+using Orleans.Runtime.ConsistentRing;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Placement;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.TestHooks
+{
+
+    /// <summary>
+    /// Test hook functions for white box testing implemented as a SystemTarget
+    /// </summary>
+    internal class TestHooksSystemTarget : SystemTarget, ITestHooksSystemTarget
+    {
+        private readonly Silo silo;
+        internal bool ExecuteFastKillInProcessExit;
+        private ObserverSubscriptionManager<ITestHooksObserver> subsManager;
+        private readonly IConsistentRingProvider consistentRingProvider;
+        private ConcurrentDictionary<IPEndPoint, double> SimulatedMessageLoss;
+
+        internal TestHooksSystemTarget(Silo s) : base(Constants.TestHooksSystemTargetId, s.SiloAddress)
+        {
+            silo = s;
+            ExecuteFastKillInProcessExit = true;
+            subsManager = new ObserverSubscriptionManager<ITestHooksObserver>();
+            consistentRingProvider = CheckReturnBoundaryReference("ring provider", silo.RingProvider);
+        }
+
+        public Task<SiloAddress> GetPrimaryTargetSilo(uint key)
+        {
+            return Task.FromResult(consistentRingProvider.GetPrimaryTargetSilo(key));
+        }
+
+        public Task<string> GetConsistentRingProviderString()
+        {
+            return Task.FromResult(consistentRingProvider.ToString());
+        }
+
+        public Task<bool> HasStatisticsProvider() => Task.FromResult(silo.StatisticsProviderManager != null);
+
+        public Task<Guid> GetServiceId() => Task.FromResult(silo.GlobalConfig.ServiceId);
+
+        public Task<IEnumerable<string>> GetStorageProviderNames() => Task.FromResult(silo.StorageProviderManager.GetProviderNames());
+
+        public Task<IEnumerable<string>> GetStreamProviderNames() => Task.FromResult(silo.StreamProviderManager.GetStreamProviders().Select(p => ((IProvider)p).Name).AsEnumerable());
+
+        public Task<IEnumerable<string>> GetAllSiloProviderNames() => Task.FromResult(silo.AllSiloProviders.Select(p => ((IProvider)p).Name).AsEnumerable());
+
+        public Task SuppressFastKillInHandleProcessExit()
+        {
+            ExecuteFastKillInProcessExit = false;
+            return TaskDone.Done;
+        }
+
+        public Task<IDictionary<GrainId, IGrainInfo>> GetDirectoryForTypeNamesContaining(string expr)
+        {
+            var x = new Dictionary<GrainId, IGrainInfo>();
+            foreach (var kvp in ((LocalGrainDirectory)silo.LocalGrainDirectory).DirectoryPartition.GetItems())
+            {
+                if (kvp.Key.IsSystemTarget || kvp.Key.IsClient || !kvp.Key.IsGrain)
+                    continue;// Skip system grains, system targets and clients
+                if (((Catalog)silo.Catalog).GetGrainTypeName(kvp.Key).Contains(expr))
+                    x.Add(kvp.Key, kvp.Value);
+            }
+            return Task.FromResult(x as IDictionary<GrainId, IGrainInfo>);
+        }
+        
+        public Task BlockSiloCommunication(IPEndPoint destination, double lost_percentage)
+        {
+            if (SimulatedMessageLoss == null)
+                SimulatedMessageLoss = new ConcurrentDictionary<IPEndPoint, double>();
+
+            SimulatedMessageLoss[destination] = lost_percentage;
+
+            return TaskDone.Done;
+        }
+
+        public Task UnblockSiloCommunication()
+        {
+            SimulatedMessageLoss = null;
+            return TaskDone.Done;
+        }
+
+        private readonly SafeRandom random = new SafeRandom();
+
+        public Task<bool> ShouldDrop(Message msg)
+        {
+            var should = false;
+            if (SimulatedMessageLoss != null)
+            {
+                double blockedpercentage;
+                SimulatedMessageLoss.TryGetValue(msg.TargetSilo.Endpoint, out blockedpercentage);
+                should = (random.NextDouble() * 100 < blockedpercentage);
+            }
+
+            return Task.FromResult(should);
+        }
+
+        public Task<int> UnregisterGrainForTesting(GrainId grain) => Task.FromResult(((Catalog)silo.Catalog).UnregisterGrainForTesting(grain));
+
+        public Task SetDirectoryLazyDeregistrationDelay(TimeSpan timeSpan)
+        {
+            silo.OrleansConfig.Globals.DirectoryLazyDeregistrationDelay = timeSpan;
+            return TaskDone.Done;
+        }
+
+        public Task SetMaxForwardCount(int val)
+        {
+            silo.OrleansConfig.Globals.MaxForwardCount = val;
+            return TaskDone.Done;
+        }
+
+        public Task DecideToCollectActivation(GrainId grainId)
+        {
+            subsManager.Notify(s => s.OnCollectActivation(grainId));
+            return TaskDone.Done;
+        }
+
+        public Task RegisterTestHooksObserver(ITestHooksObserver observer)
+        {
+            subsManager.Subscribe(observer);
+            return TaskDone.Done;
+        }
+
+        public Task AddCachedAssembly(string targetAssemblyName, GeneratedAssembly cachedAssembly)
+        {
+            CodeGeneratorManager.AddGeneratedAssembly(targetAssemblyName, cachedAssembly);
+            return TaskDone.Done;
+        }
+
+        private static T CheckReturnBoundaryReference<T>(string what, T obj) where T : class
+        {
+            if (obj == null) return null;
+            if (
+#if !NETSTANDARD_TODO
+                    obj is MarshalByRefObject ||
+#endif
+                    obj is ISerializable)
+            {
+                // Referernce to the provider can safely be passed across app-domain boundary in unit test process
+                return obj;
+            }
+            throw new InvalidOperationException(string.Format("Cannot return reference to {0} {1} if it is not MarshalByRefObject or Serializable",
+                what, TypeUtils.GetFullName(obj.GetType())));
+        }
+    }
+}

--- a/src/OrleansTestingHost/AppDomainSiloHandle.cs
+++ b/src/OrleansTestingHost/AppDomainSiloHandle.cs
@@ -82,7 +82,7 @@ namespace Orleans.TestingHost
                 AppDomain = appDomain,
                 additionalAssemblies = additionalAssemblies,
 #if !NETSTANDARD_TODO
-                TestHook = siloHost.TestHook,
+                AppDomainTestHook = siloHost.AppDomainTestHook,
 #endif
             };
 

--- a/src/OrleansTestingHost/AppDomainSiloHost.cs
+++ b/src/OrleansTestingHost/AppDomainSiloHost.cs
@@ -129,7 +129,7 @@ namespace Orleans.TestingHost
             if (obj == null) return null;
             if (obj is MarshalByRefObject || obj is ISerializable)
             {
-                // Referernce to the provider can safely be passed across app-domain boundary in unit test process
+                // Reference to the provider can safely be passed across app-domain boundary in unit test process
                 return obj;
             }
             throw new InvalidOperationException(

--- a/src/OrleansTestingHost/AppDomainSiloHost.cs
+++ b/src/OrleansTestingHost/AppDomainSiloHost.cs
@@ -1,8 +1,18 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Runtime.Serialization;
 using Orleans.CodeGeneration;
+using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Messaging;
+using Orleans.Runtime.Placement;
+using Orleans.Runtime.TestHooks;
+using Orleans.Storage;
 
 namespace Orleans.TestingHost
 {
@@ -18,13 +28,17 @@ namespace Orleans.TestingHost
         public AppDomainSiloHost(string name, Silo.SiloType siloType, ClusterConfiguration config)
         {
             this.silo = new Silo(name, siloType, config);
+            this.silo.InitializeTestHooksSystemTarget();
+            this.AppDomainTestHook = new AppDomainTestHooks(this.silo);
         }
 
         /// <summary> SiloAddress for this silo. </summary>
         public SiloAddress SiloAddress => silo.SiloAddress;
 
-        /// <summary>Gets the Silo test hook (NOTE: this will be removed really soon, and was migrated here temporarily)</summary>
-        public Silo.TestHooks TestHook => silo.TestHook;
+        /// <summary>Gets the Silo test hook</summary>
+        internal ITestHooks TestHook => GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, this.SiloAddress);
+
+        internal AppDomainTestHooks AppDomainTestHook { get; }
 
         /// <summary>Methods for optimizing the code generator.</summary>
         public class CodeGeneratorOptimizer : MarshalByRefObject
@@ -85,6 +99,89 @@ namespace Orleans.TestingHost
         public void Shutdown()
         {
             silo.Shutdown();
+        }
+    }
+
+    /// <summary>
+    /// Test hook functions for white box testing.
+    /// NOTE: this class has to and will be removed entirely. This requires the tests that currently rely on it, to assert using different mechanisms, such as with grains.
+    /// </summary>
+    internal class AppDomainTestHooks : MarshalByRefObject
+    {
+        private readonly Silo silo;
+
+        public AppDomainTestHooks(Silo silo)
+        {
+            this.silo = silo;
+        }
+
+        internal IBootstrapProvider GetBootstrapProvider(string name)
+        {
+            IBootstrapProvider provider = silo.BootstrapProviders.First(p => p.Name.Equals(name));
+            return CheckReturnBoundaryReference("bootstrap provider", provider);
+        }
+
+        /// <summary>Find the named storage provider loaded in this silo. </summary>
+        internal IStorageProvider GetStorageProvider(string name) => CheckReturnBoundaryReference("storage provider", (IStorageProvider)silo.StorageProviderManager.GetProvider(name));
+
+        private static T CheckReturnBoundaryReference<T>(string what, T obj) where T : class
+        {
+            if (obj == null) return null;
+            if (obj is MarshalByRefObject || obj is ISerializable)
+            {
+                // Referernce to the provider can safely be passed across app-domain boundary in unit test process
+                return obj;
+            }
+            throw new InvalidOperationException(
+                $"Cannot return reference to {what} {TypeUtils.GetFullName(obj.GetType())} if it is not MarshalByRefObject or Serializable");
+        }
+
+        public IDictionary<GrainId, IGrainInfo> GetDirectoryForTypeNamesContaining(string expr)
+        {
+            var x = new Dictionary<GrainId, IGrainInfo>();
+            foreach (var kvp in ((LocalGrainDirectory)silo.LocalGrainDirectory).DirectoryPartition.GetItems())
+            {
+                if (kvp.Key.IsSystemTarget || kvp.Key.IsClient || !kvp.Key.IsGrain)
+                    continue;// Skip system grains, system targets and clients
+                if (((Catalog)silo.Catalog).GetGrainTypeName(kvp.Key).Contains(expr))
+                    x.Add(kvp.Key, kvp.Value);
+            }
+            return x;
+        }
+        
+        // store silos for which we simulate faulty communication
+        // number indicates how many percent of requests are lost
+        private ConcurrentDictionary<IPEndPoint, double> simulatedMessageLoss;
+        private readonly SafeRandom random = new SafeRandom();
+
+        internal void BlockSiloCommunication(IPEndPoint destination, double lossPercentage)
+        {
+            if (simulatedMessageLoss == null)
+                simulatedMessageLoss = new ConcurrentDictionary<IPEndPoint, double>();
+
+            simulatedMessageLoss[destination] = lossPercentage;
+
+            var mc = (MessageCenter)silo.LocalMessageCenter;
+            mc.ShouldDrop = ShouldDrop;
+        }
+
+        internal void UnblockSiloCommunication()
+        {
+            var mc = (MessageCenter)silo.LocalMessageCenter;
+            mc.ShouldDrop = null;
+            simulatedMessageLoss.Clear();
+        }
+        
+        private bool ShouldDrop(Message msg)
+        {
+            if (simulatedMessageLoss != null)
+            {
+                double blockedpercentage;
+                simulatedMessageLoss.TryGetValue(msg.TargetSilo.Endpoint, out blockedpercentage);
+                return (random.NextDouble() * 100 < blockedpercentage);
+            }
+            else
+                return false;
         }
     }
 }

--- a/src/OrleansTestingHost/Properties/AssemblyInfo.cs
+++ b/src/OrleansTestingHost/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
-﻿
-using System;
+﻿using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -19,3 +19,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("40ee3b00-d381-485f-9c69-ff706837deed")]
+[assembly: InternalsVisibleTo("TesterInternal")]

--- a/src/OrleansTestingHost/SiloHandle.cs
+++ b/src/OrleansTestingHost/SiloHandle.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.TestHooks;
 
 namespace Orleans.TestingHost
 {
@@ -16,8 +16,11 @@ namespace Orleans.TestingHost
         /// <summary> Get or set the name of the silo </summary>
         public string Name { get; set; }
 
-        /// <summary> Get or set the address of the silo </summary>
+        /// <summary>Get or set the address of the silo</summary>
         public SiloAddress SiloAddress { get; set; }
+
+        /// <summary>Get the proxy address of the silo</summary>
+        public SiloAddress ProxyAddress => SiloAddress.New(this.NodeConfiguration.ProxyGatewayEndpoint, 0);
 
         /// <summary>Gets whether the remote silo is expected to be active</summary>
         public abstract bool IsActive { get; }
@@ -29,10 +32,13 @@ namespace Orleans.TestingHost
         /// <param name="stopGracefully">Specifies whether the silo should be stopped gracefully or abruptly.</param>
         public abstract void StopSilo(bool stopGracefully);
 
-        /// <summary>Gets the Silo test hook 
+        /// <summary>Gets the Silo test hook</summary>
+        internal ITestHooks TestHook => GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, this.ProxyAddress);
+
+        /// <summary>Gets the Silo test hook that uses AppDomain remoting
         /// (NOTE: this will be removed really soon, and was migrated here temporarily. It does not respect the abstraction
         /// as this only works with AppDomains for now, but we'll be removing TestHooks with AppDomains entirely)</summary>
-        public Silo.TestHooks TestHook { get; set; }
+        internal AppDomainTestHooks AppDomainTestHook { get; set; }
 
         /// <summary> A string that represents the current SiloHandle </summary>
         public override string ToString()

--- a/test/TestGrainInterfaces/IStatsCollectorGrain.cs
+++ b/test/TestGrainInterfaces/IStatsCollectorGrain.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Orleans;
+
+namespace UnitTests.Stats
+{
+    public interface IStatsCollectorGrain : IGrainWithIntegerKey
+    {
+        Task ReportMetricsCalled();
+        Task ReportStatsCalled();
+
+        Task<long> GetReportMetricsCallCount();
+        Task<long> GetReportStatsCallCount();
+    }
+}

--- a/test/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/test/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -105,6 +105,7 @@
     <Compile Include="ISimpleGrain.cs" />
     <Compile Include="ISimplePersistentGrain.cs" />
     <Compile Include="ILivenessTestGrain.cs" />
+    <Compile Include="IStatsCollectorGrain.cs" />
     <Compile Include="IStreamingGrain.cs" />
     <Compile Include="IStreamingImmutabilityTestGrain.cs" />
     <Compile Include="IStreamInterceptionGrain.cs" />

--- a/test/TestGrains/StatsCollectorGrain.cs
+++ b/test/TestGrains/StatsCollectorGrain.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using Orleans;
+using Orleans.Placement;
+
+namespace UnitTests.Stats
+{
+    [PreferLocalPlacement]
+    public class StatsCollectorGrain : Grain, IStatsCollectorGrain
+    {
+        private long numStatsCalls = -1;
+        private long numMetricsCalls = -1;
+
+        public Task ReportMetricsCalled()
+        {
+            numStatsCalls++;
+            return TaskDone.Done;
+        }
+
+        public Task ReportStatsCalled()
+        {
+            numMetricsCalls++;
+            return TaskDone.Done;
+        }
+
+        public Task<long> GetReportMetricsCallCount()
+        {
+            return Task.FromResult(numMetricsCalls);
+        }
+
+        public Task<long> GetReportStatsCallCount()
+        {
+            return Task.FromResult(numStatsCalls);
+        }
+    }
+}

--- a/test/TestGrains/StatsCollectorGrain.cs
+++ b/test/TestGrains/StatsCollectorGrain.cs
@@ -7,8 +7,8 @@ namespace UnitTests.Stats
     [PreferLocalPlacement]
     public class StatsCollectorGrain : Grain, IStatsCollectorGrain
     {
-        private long numStatsCalls = -1;
-        private long numMetricsCalls = -1;
+        private long numStatsCalls;
+        private long numMetricsCalls;
 
         public Task ReportMetricsCalled()
         {

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -116,6 +116,7 @@
     <Compile Include="GrainInterfaceHierarchyGrains.cs" />
     <Compile Include="LivenessTestGrain.cs" />
     <Compile Include="SpecializedSimpleGenericGrain.cs" />
+    <Compile Include="StatsCollectorGrain.cs" />
     <Compile Include="StreamCheckpoint.cs" />
     <Compile Include="StreamInterceptionGrain.cs" />
     <Compile Include="ValueTypeTestGrain.cs" />

--- a/test/TestInternalGrains/ActivationGCTestGrains.cs
+++ b/test/TestInternalGrains/ActivationGCTestGrains.cs
@@ -4,7 +4,6 @@ using Orleans;
 using Orleans.Concurrency;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
-using Orleans.Runtime.TestHooks;
 
 namespace UnitTests.Grains
 {
@@ -24,7 +23,7 @@ namespace UnitTests.Grains
         }
     }
 
-    internal class BusyActivationGcTestGrain1: Grain, IBusyActivationGcTestGrain1, ITestHooksObserver
+    public class BusyActivationGcTestGrain1: Grain, IBusyActivationGcTestGrain1
     {
         private int burstCount = 0;
 
@@ -51,11 +50,11 @@ namespace UnitTests.Grains
             }
 
             burstCount = count;
-            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, GrainReference.SystemTargetSilo);
-            return testHook.RegisterTestHooksObserver(this);
+            InsideRuntimeClient.Current.Catalog.ActivationCollector.Debug_OnDecideToCollectActivation = OnCollectActivation;
+            return TaskDone.Done;
         }
 
-        public void OnCollectActivation(GrainId grainId)
+        private void OnCollectActivation(GrainId grainId)
         {
             int other = grainId.GetTypeCode();
             int self = Data.Address.Grain.GetTypeCode();

--- a/test/TestInternalGrains/Properties/AssemblyInfo.cs
+++ b/test/TestInternalGrains/Properties/AssemblyInfo.cs
@@ -18,4 +18,3 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("UnitTests")]
 [assembly: InternalsVisibleTo("UnitTestGrainInterfaces")]
 [assembly: InternalsVisibleTo("UnitTestGrains")]
-[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/TestInternalGrains/Properties/AssemblyInfo.cs
+++ b/test/TestInternalGrains/Properties/AssemblyInfo.cs
@@ -18,3 +18,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("UnitTests")]
 [assembly: InternalsVisibleTo("UnitTestGrainInterfaces")]
 [assembly: InternalsVisibleTo("UnitTestGrains")]
+[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -295,7 +295,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             {
                 // Wait a bit
                 TimeSpan pause = lazyDeregistrationDelay.Multiply(2);
-                logger.Info("Pausing for {0} because DoLazyDeregistration=True", pause);
+                logger.Info($"Pausing for {0} because we are using lazy deregistration", pause);
                 await Task.Delay(pause);
             }
 

--- a/test/TesterInternal/General/BootstrapProviderTests.cs
+++ b/test/TesterInternal/General/BootstrapProviderTests.cs
@@ -97,7 +97,7 @@ namespace UnitTests.General
 
             foreach (SiloHandle silo in silos)
             {
-                var providers = silo.TestHook.GetAllSiloProviderNames().ToList();
+                var providers = await silo.TestHook.GetAllSiloProviderNames();
 
                 Assert.Contains("bootstrap1", providers);
                 Assert.Contains("bootstrap2", providers);
@@ -127,7 +127,7 @@ namespace UnitTests.General
             List<SiloHandle> silos = HostedCluster.GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                MockBootstrapProvider provider = (MockBootstrapProvider)siloHandle.TestHook.GetBootstrapProvider(providerName);
+                MockBootstrapProvider provider = (MockBootstrapProvider)siloHandle.AppDomainTestHook.GetBootstrapProvider(providerName);
                 Assert.NotNull(provider);
                 providerInUse = provider;
             }

--- a/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
+++ b/test/TesterInternal/General/ConsistentRingProviderTests_Silo.cs
@@ -202,12 +202,12 @@ namespace UnitTests.General
             {
                 double next = random.NextDouble();
                 uint randomKey = (uint)((double)RangeFactory.RING_SIZE * next);
-                SiloAddress s = this.HostedCluster.Primary.TestHook.ConsistentRingProvider.GetPrimaryTargetSilo(randomKey);
+                SiloAddress s = this.HostedCluster.Primary.TestHook.GetConsistentRingPrimaryTargetSilo(randomKey).Result;
                 if (responsibleSilo.Equals(s))
                     return randomKey;
             }
             throw new Exception(String.Format("Could not pick a key that silo {0} will be responsible for. Primary.Ring = \n{1}",
-                responsibleSilo, this.HostedCluster.Primary.TestHook.ConsistentRingProvider));
+                responsibleSilo, this.HostedCluster.Primary.TestHook.GetConsistentRingProviderDiagnosticInfo().Result));
         }
 
         private void VerificationScenario(uint testKey)
@@ -240,7 +240,7 @@ namespace UnitTests.General
 
         private void VerifyKey(uint key, List<SiloAddress> silos)
         {
-            SiloAddress truth = this.HostedCluster.Primary.TestHook.ConsistentRingProvider.GetPrimaryTargetSilo(key); //expected;
+            SiloAddress truth = this.HostedCluster.Primary.TestHook.GetConsistentRingPrimaryTargetSilo(key).Result; //expected;
             //if (truth == null) // if the truth isn't passed, we compute it here
             //{
             //    truth = silos.Find(siloAddr => (key <= siloAddr.GetConsistentHashCode()));
@@ -253,7 +253,7 @@ namespace UnitTests.General
             // lookup for 'key' should return 'truth' on all silos
             foreach (var siloHandle in this.HostedCluster.GetActiveSilos()) // do this for each silo
             {
-                SiloAddress s = siloHandle.TestHook.ConsistentRingProvider.GetPrimaryTargetSilo((uint)key);
+                SiloAddress s = siloHandle.TestHook.GetConsistentRingPrimaryTargetSilo((uint)key).Result;
                 Assert.Equal(truth, s);
             }
         }

--- a/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
+++ b/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
@@ -11,7 +11,6 @@ using TestGrainInterfaces;
 using Orleans.Runtime.Configuration;
 using Xunit;
 using Xunit.Abstractions;
-using Orleans.Runtime.TestHooks;
 
 // ReSharper disable InconsistentNaming
 
@@ -138,16 +137,16 @@ namespace Tests.GeoClusterTests
 
         #region Test creation of independent grains
 
-        private async Task IndependentCreation()
+        private Task IndependentCreation()
         {
             int offset = random.Next();
 
-            int base_own0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Owned)).Count;
-            int base_own1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Owned)).Count;
-            int base_requested0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.RequestedOwnership)).Count;
-            int base_requested1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.RequestedOwnership)).Count;
-            int base_doubtful0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful)).Count;
-            int base_doubtful1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful)).Count;
+            int base_own0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Owned).Count;
+            int base_own1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Owned).Count;
+            int base_requested0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.RequestedOwnership).Count;
+            int base_requested1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.RequestedOwnership).Count;
+            int base_doubtful0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful).Count;
+            int base_doubtful1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful).Count;
 
             WriteLog("Counts: Cluster 0 => Owned={0} Requested={1} Doubtful={2}", base_own0, base_requested0, base_doubtful0);
             WriteLog("Counts: Cluster 1 => Owned={0} Requested={1} Doubtful={2}", base_own1, base_requested1, base_doubtful1);
@@ -163,12 +162,12 @@ namespace Tests.GeoClusterTests
 
             // We expect all requests to resolve, and all created activations are in state OWNED
 
-            int own0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Owned)).Count;
-            int own1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Owned)).Count;
-            int doubtful0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful)).Count;
-            int doubtful1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful)).Count;
-            int requested0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.RequestedOwnership)).Count;
-            int requested1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.RequestedOwnership)).Count;
+            int own0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Owned).Count;
+            int own1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Owned).Count;
+            int doubtful0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful).Count;
+            int doubtful1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful).Count;
+            int requested0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.RequestedOwnership).Count;
+            int requested1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.RequestedOwnership).Count;
 
             WriteLog("Counts: Cluster 0 => Owned={0} Requested={1} Doubtful={2}", own0, requested0, doubtful0);
             WriteLog("Counts: Cluster 1 => Owned={0} Requested={1} Doubtful={2}", own1, requested1, doubtful1);
@@ -180,6 +179,8 @@ namespace Tests.GeoClusterTests
             Assert.Equal(doubtful1, base_doubtful1);
             Assert.Equal(requested0, base_requested0);
             Assert.Equal(requested1, base_requested1);
+
+            return TaskDone.Done;
         }
 
         #endregion
@@ -194,14 +195,14 @@ namespace Tests.GeoClusterTests
         // The clients all invoke grain "g", in parallel, and then wait on a signal by the main thread (this function). The main thread, then 
         // wakes up the clients, after which they invoke "g+1", and so on.
 
-        private async Task CreationRace()
+        private Task CreationRace()
         {
             WriteLog("Starting ConcurrentCreation");
 
             var offset = random.Next();
 
             // take inventory now so we can exclude pre-existing entries from the validation
-            var baseline = await GetGrainActivations();
+            var baseline = GetGrainActivations();
 
             // We use two objects to coordinate client threads and the main thread. coordWakeup is an object that is used to signal the coordinator
             // thread. toWait is used to signal client threads.
@@ -270,9 +271,11 @@ namespace Tests.GeoClusterTests
                 thread.Join();
             }
 
-            var grains = await GetGrainActivations(baseline);
+            var grains = GetGrainActivations(baseline);
 
             ValidateClusterRaceResults(results, grains);
+
+            return TaskDone.Done;
         }
 
         private volatile int threadsDone;
@@ -350,20 +353,20 @@ namespace Tests.GeoClusterTests
         {
             int offset = random.Next();
 
-            int base_own0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Owned)).Count;
-            int base_own1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Owned)).Count;
-            int base_requested0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.RequestedOwnership)).Count;
-            int base_requested1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.RequestedOwnership)).Count;
-            int base_doubtful0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful)).Count;
-            int base_doubtful1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful)).Count;
-            int base_cached0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Cached)).Count;
-            int base_cached1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Cached)).Count;
+            int base_own0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Owned).Count;
+            int base_own1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Owned).Count;
+            int base_requested0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.RequestedOwnership).Count;
+            int base_requested1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.RequestedOwnership).Count;
+            int base_doubtful0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful).Count;
+            int base_doubtful1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful).Count;
+            int base_cached0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Cached).Count;
+            int base_cached1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Cached).Count;
 
             WriteLog("Counts: Cluster 0 => Owned={0} Requested={1} Doubtful={2} Cached={3}", base_own0, base_requested0, base_doubtful0, base_cached0);
             WriteLog("Counts: Cluster 1 => Owned={0} Requested={1} Doubtful={2} Cached={3}", base_own1, base_requested1, base_doubtful1, base_cached1);
 
             // take inventory now so we can exclude pre-existing entries from the validation
-            var baseline = await GetGrainActivations();
+            var baseline = GetGrainActivations();
 
             // Turn off intercluster messaging to simulate a partition.
             BlockAllClusterCommunication(cluster0, cluster1);
@@ -397,8 +400,8 @@ namespace Tests.GeoClusterTests
             });
 
             // Validate that all the created grains are in DOUBTFUL, one activation in each cluster.
-            Assert.True((await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful)).Count == numGrains);
-            Assert.True((await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful)).Count == numGrains);
+            Assert.True(GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful).Count == numGrains);
+            Assert.True(GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful).Count == numGrains);
 
             WriteLog("Restoring inter-cluster communication");
 
@@ -412,14 +415,14 @@ namespace Tests.GeoClusterTests
 
             WriteLog("Validation of conflict resolution");
 
-            int own0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Owned)).Count;
-            int own1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Owned)).Count;
-            int doubtful0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful)).Count;
-            int doubtful1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful)).Count;
-            int requested0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.RequestedOwnership)).Count;
-            int requested1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.RequestedOwnership)).Count;
-            int cached0 = (await GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Cached)).Count;
-            int cached1 = (await GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Cached)).Count;
+            int own0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Owned).Count;
+            int own1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Owned).Count;
+            int doubtful0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Doubtful).Count;
+            int doubtful1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Doubtful).Count;
+            int requested0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.RequestedOwnership).Count;
+            int requested1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.RequestedOwnership).Count;
+            int cached0 = GetGrainsInClusterWithStatus(cluster0, GrainDirectoryEntryStatus.Cached).Count;
+            int cached1 = GetGrainsInClusterWithStatus(cluster1, GrainDirectoryEntryStatus.Cached).Count;
 
             WriteLog("Counts: Cluster 0 => Owned={0} Requested={1} Doubtful={2} Cached={3}", own0, requested0, doubtful0, cached0);
             WriteLog("Counts: Cluster 1 => Owned={0} Requested={1} Doubtful={2} Cached={3}", own1, requested1, doubtful1, cached1);
@@ -431,7 +434,7 @@ namespace Tests.GeoClusterTests
             Assert.Equal(requested1, base_requested1);
 
             // each grain should have one activation per cluster
-            var grains = await GetGrainActivations(baseline);
+            var grains = GetGrainActivations(baseline);
             foreach (var kvp in grains)
             {
                 GrainId key = kvp.Key;
@@ -497,15 +500,14 @@ namespace Tests.GeoClusterTests
 
         #region Helper methods 
 
-        private async Task<List<GrainId>> GetGrainsInClusterWithStatus(string clusterId, GrainDirectoryEntryStatus? status = null)
+        private List<GrainId> GetGrainsInClusterWithStatus(string clusterId, GrainDirectoryEntryStatus? status = null)
         {
             List<GrainId> grains = new List<GrainId>();
             var silos = Clusters[clusterId].Silos;
             int totalSoFar = 0;
             foreach (var silo in silos)
             {
-                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.Silo.SiloAddress);
-                var dir = await testHook.GetDirectoryForTypeNamesContaining("ClusterTestGrain");
+                var dir = silo.AppDomainTestHook.GetDirectoryForTypeNamesContaining("ClusterTestGrain");
                 foreach (var grainKeyValue in dir)
                 {
                     GrainId grainId = grainKeyValue.Key;
@@ -532,7 +534,7 @@ namespace Tests.GeoClusterTests
             return grains;
         }
 
-        private async Task<Dictionary<GrainId, List<IActivationInfo>>> GetGrainActivations(Dictionary<GrainId, List<IActivationInfo>> exclude = null)
+        private Dictionary<GrainId, List<IActivationInfo>> GetGrainActivations(Dictionary<GrainId, List<IActivationInfo>> exclude = null)
         {
             var grains = new Dictionary<GrainId, List<IActivationInfo>>();
 
@@ -541,8 +543,7 @@ namespace Tests.GeoClusterTests
             foreach (var kvp in Clusters)
                 foreach (var silo in kvp.Value.Silos)
                 {
-                    var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.Silo.SiloAddress);
-                    var dir = await testHook.GetDirectoryForTypeNamesContaining("ClusterTestGrain");
+                    var dir = silo.AppDomainTestHook.GetDirectoryForTypeNamesContaining("ClusterTestGrain");
 
                     foreach (var grainKeyValue in dir)
                     {

--- a/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -13,7 +13,6 @@ using Tester;
 using TestExtensions;
 using Xunit;
 using Xunit.Abstractions;
-using Orleans.Runtime.TestHooks;
 
 namespace Tests.GeoClusterTests
 {
@@ -69,7 +68,7 @@ namespace Tests.GeoClusterTests
             catch (Exception e)
             {
                 WriteLog("--- Exception observed in {0}: {1})", name, e);
-                throw e;
+                throw;
             }
         }
 
@@ -82,7 +81,7 @@ namespace Tests.GeoClusterTests
             catch (Exception e)
             {
                 WriteLog("Equality assertion failed; expected={0}, actual={1} comment={2}", expected, actual, comment);
-                throw e;
+                throw;
             }
         }
 
@@ -248,7 +247,7 @@ namespace Tests.GeoClusterTests
             catch (Exception e)
             {
                 WriteLog("Exception caught in test cleanup function: {0}", e);
-                throw e;
+                throw;
             }
 
             stopwatch.Stop();
@@ -372,15 +371,11 @@ namespace Tests.GeoClusterTests
         public void BlockAllClusterCommunication(string from, string to)
         {
             foreach (var silo in Clusters[from].Silos)
-            {
-                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.SiloAddress);
                 foreach (var dest in Clusters[to].Silos)
                 {
                     WriteLog("Blocking {0}->{1}", silo, dest);
-
-                    testHook.BlockSiloCommunication(dest.SiloAddress.Endpoint, 100).Wait();
+                    silo.AppDomainTestHook.BlockSiloCommunication(dest.SiloAddress.Endpoint, 100);
                 }
-            }
         }
 
         public void UnblockAllClusterCommunication(string from)
@@ -388,8 +383,7 @@ namespace Tests.GeoClusterTests
             foreach (var silo in Clusters[from].Silos)
             {
                 WriteLog("Unblocking {0}", silo);
-                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.Silo.SiloAddress);
-                testHook.UnblockSiloCommunication().Wait();
+                silo.AppDomainTestHook.UnblockSiloCommunication();
             }
         }
   

--- a/test/TesterInternal/StorageTests/AWSUtils/Base_PersistenceGrainTests_AWSStore.cs
+++ b/test/TesterInternal/StorageTests/AWSUtils/Base_PersistenceGrainTests_AWSStore.cs
@@ -348,9 +348,8 @@ namespace UnitTests.StorageTests.AWSUtils
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var silo in silos)
             {
-                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.Silo.SiloAddress);
                 string provider = providerType.FullName;
-                List<string> providers = (await testHook.GetStorageProviderNames()).ToList();
+                ICollection<string> providers = await silo.TestHook.GetStorageProviderNames();
                 Assert.True(providers.Contains(provider), $"No storage provider found: {provider}");
             }
         }

--- a/test/TesterInternal/StorageTests/AWSUtils/Base_PersistenceGrainTests_AWSStore.cs
+++ b/test/TesterInternal/StorageTests/AWSUtils/Base_PersistenceGrainTests_AWSStore.cs
@@ -1,5 +1,6 @@
 ﻿using Orleans;
 using Orleans.Runtime;
+using Orleans.Runtime.TestHooks;
 using Orleans.TestingHost;
 using System;
 using System.Collections.Generic;
@@ -342,13 +343,14 @@ namespace UnitTests.StorageTests.AWSUtils
         }
 
 
-        protected void Persistence_Silo_StorageProvider_AWS(Type providerType)
+        protected async Task Persistence_Silo_StorageProvider_AWS(Type providerType)
         {
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var silo in silos)
             {
+                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.Silo.SiloAddress);
                 string provider = providerType.FullName;
-                List<string> providers = silo.TestHook.GetStorageProviderNames().ToList();
+                List<string> providers = (await testHook.GetStorageProviderNames()).ToList();
                 Assert.True(providers.Contains(provider), $"No storage provider found: {provider}");
             }
         }

--- a/test/TesterInternal/StorageTests/AWSUtils/PersistenceGrainTests_AWSDynamoDBStore.cs
+++ b/test/TesterInternal/StorageTests/AWSUtils/PersistenceGrainTests_AWSDynamoDBStore.cs
@@ -118,9 +118,9 @@ namespace UnitTests.StorageTests
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public void Persistence_Silo_StorageProvider_AWSDynamoDBStore()
+        public Task Persistence_Silo_StorageProvider_AWSDynamoDBStore()
         {
-            base.Persistence_Silo_StorageProvider_AWS(typeof(DynamoDBStorageProvider));
+            return base.Persistence_Silo_StorageProvider_AWS(typeof(DynamoDBStorageProvider));
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -67,12 +67,11 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var silo in silos)
             {
-                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.Silo.SiloAddress);
-                List<string> providers = (await testHook.GetStorageProviderNames()).ToList();
+                ICollection<string> providers = await silo.TestHook.GetStorageProviderNames();
                 Assert.NotNull(providers); // Null provider manager
                 Assert.True(providers.Count > 0, "Some providers loaded");
                 const string providerName = "test1";
-                IStorageProvider storageProvider = silo.TestHook.GetStorageProvider(providerName);
+                IStorageProvider storageProvider = silo.AppDomainTestHook.GetStorageProvider(providerName);
                 Assert.NotNull(storageProvider);
             }
         }
@@ -84,7 +83,7 @@ namespace UnitTests.StorageTests
             foreach (var silo in silos)
             {
                 const string providerName = "LowerCase";
-                IStorageProvider storageProvider = silo.TestHook.GetStorageProvider(providerName);
+                IStorageProvider storageProvider = silo.AppDomainTestHook.GetStorageProvider(providerName);
                 Assert.NotNull(storageProvider);
             }
         }
@@ -97,7 +96,7 @@ namespace UnitTests.StorageTests
             const string providerName = "NotPresent";
             Assert.Throws<KeyNotFoundException>(() =>
             {
-                IStorageProvider store = silo.TestHook.GetStorageProvider(providerName);
+                IStorageProvider store = silo.AppDomainTestHook.GetStorageProvider(providerName);
             });
         }
 
@@ -1149,7 +1148,7 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                MockStorageProvider provider = (MockStorageProvider)siloHandle.TestHook.GetStorageProvider(providerName);
+                MockStorageProvider provider = (MockStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
                 provider.SetValue<TState>(grainType, (GrainReference)grain, "Field1", newValue);
             }
         }
@@ -1159,7 +1158,7 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider)siloHandle.TestHook.GetStorageProvider(providerName);
+                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
                 provider.SetErrorInjection(errorInjectionPoint);
             }
         }
@@ -1209,7 +1208,7 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                MockStorageProvider provider = (MockStorageProvider)siloHandle.TestHook.GetStorageProvider(providerName);
+                MockStorageProvider provider = (MockStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
                 Assert.NotNull(provider);
                 if (provider.ReadCount > 0)
                 {
@@ -1235,7 +1234,7 @@ namespace UnitTests.StorageTests
             {
                 foreach (var providerName in mockStorageProviders)
                 {
-                    MockStorageProvider provider = (MockStorageProvider)siloHandle.TestHook.GetStorageProvider(providerName);
+                    MockStorageProvider provider = (MockStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
                     if (provider != null)
                     {
                         provider.ResetHistory();

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -62,12 +62,13 @@ namespace UnitTests.StorageTests
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
-        public void Persistence_Silo_StorageProviders()
+        public async Task Persistence_Silo_StorageProviders()
         {
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var silo in silos)
             {
-                List<string> providers = silo.TestHook.GetStorageProviderNames().ToList();
+                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.Silo.SiloAddress);
+                List<string> providers = (await testHook.GetStorageProviderNames()).ToList();
                 Assert.NotNull(providers); // Null provider manager
                 Assert.True(providers.Count > 0, "Some providers loaded");
                 const string providerName = "test1";

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureBlobStore.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureBlobStore.cs
@@ -118,9 +118,9 @@ namespace UnitTests.StorageTests
 
       
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Azure")]
-        public void Persistence_Silo_StorageProvider_AzureBlobStore()
+        public Task Persistence_Silo_StorageProvider_AzureBlobStore()
         {
-            base.Persistence_Silo_StorageProvider_Azure(typeof(AzureBlobStorage));
+            return base.Persistence_Silo_StorageProvider_Azure(typeof(AzureBlobStorage));
         }
 
     }

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureStore.cs
@@ -16,6 +16,7 @@ using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using Xunit.Abstractions;
+using Orleans.Runtime.TestHooks;
 
 // ReSharper disable RedundantAssignment
 // ReSharper disable UnusedVariable
@@ -350,13 +351,14 @@ namespace UnitTests.StorageTests
         }
 
        
-        protected void Persistence_Silo_StorageProvider_Azure(Type providerType)
+        protected async Task Persistence_Silo_StorageProvider_Azure(Type providerType)
         {
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var silo in silos)
             {
+                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.Silo.SiloAddress);
                 string provider = providerType.FullName;
-                List<string> providers = silo.TestHook.GetStorageProviderNames().ToList();
+                List<string> providers = (await testHook.GetStorageProviderNames()).ToList();
                 Assert.True(providers.Contains(provider), $"No storage provider found: {provider}");
             }
         }

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureStore.cs
@@ -16,7 +16,6 @@ using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using Xunit.Abstractions;
-using Orleans.Runtime.TestHooks;
 
 // ReSharper disable RedundantAssignment
 // ReSharper disable UnusedVariable
@@ -356,9 +355,8 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var silo in silos)
             {
-                var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.Silo.SiloAddress);
                 string provider = providerType.FullName;
-                List<string> providers = (await testHook.GetStorageProviderNames()).ToList();
+                List<string> providers = (await silo.TestHook.GetStorageProviderNames()).ToList();
                 Assert.True(providers.Contains(provider), $"No storage provider found: {provider}");
             }
         }

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureTableStore.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests_AzureTableStore.cs
@@ -121,9 +121,9 @@ namespace UnitTests.StorageTests
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Azure")]
-        public void Persistence_Silo_StorageProvider_AzureTableStore()
+        public Task Persistence_Silo_StorageProvider_AzureTableStore()
         {
-            base.Persistence_Silo_StorageProvider_Azure(typeof(AzureTableStorage));
+            return base.Persistence_Silo_StorageProvider_Azure(typeof(AzureTableStorage));
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Azure")]

--- a/test/TesterInternal/StreamProvidersTests.cs
+++ b/test/TesterInternal/StreamProvidersTests.cs
@@ -10,6 +10,9 @@ using UnitTests.Grains;
 using UnitTests.StreamingTests;
 using Xunit;
 using Xunit.Abstractions;
+using System.Threading.Tasks;
+using Orleans.Runtime.TestHooks;
+using Orleans.Runtime;
 
 namespace UnitTests.Streaming
 {
@@ -70,12 +73,13 @@ namespace UnitTests.Streaming
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Config"), TestCategory("ServiceId"), TestCategory("Providers")]
-        public void ServiceId_ProviderRuntime()
+        public async Task ServiceId_ProviderRuntime()
         {
             Guid thisRunServiceId = this.HostedCluster.Globals.ServiceId;
 
             SiloHandle siloHandle = this.HostedCluster.GetActiveSilos().First();
-            Guid serviceId = siloHandle.TestHook.ServiceId;
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, siloHandle.Silo.SiloAddress);
+            Guid serviceId = await testHook.GetServiceId();
             Assert.Equal(thisRunServiceId, serviceId);  // "ServiceId active in silo"
 
             // ServiceId is not currently available in client config
@@ -84,7 +88,7 @@ namespace UnitTests.Streaming
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Config"), TestCategory("ServiceId")]
-        public void ServiceId_SiloRestart()
+        public async Task ServiceId_SiloRestart()
         {
             Guid configServiceId = this.HostedCluster.Globals.ServiceId;
 
@@ -106,7 +110,8 @@ namespace UnitTests.Streaming
             Assert.NotEqual(initialDeploymentId, this.HostedCluster.DeploymentId);  // "DeploymentId different after restart."
 
             SiloHandle siloHandle = this.HostedCluster.GetActiveSilos().First();
-            Guid serviceId = siloHandle.TestHook.ServiceId;
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, siloHandle.Silo.SiloAddress);
+            Guid serviceId = await testHook.GetServiceId();
             Assert.Equal(ServiceId, serviceId);  // "ServiceId active in silo"
 
             // ServiceId is not currently available in client config

--- a/test/TesterInternal/StreamProvidersTests.cs
+++ b/test/TesterInternal/StreamProvidersTests.cs
@@ -78,8 +78,7 @@ namespace UnitTests.Streaming
             Guid thisRunServiceId = this.HostedCluster.Globals.ServiceId;
 
             SiloHandle siloHandle = this.HostedCluster.GetActiveSilos().First();
-            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, siloHandle.Silo.SiloAddress);
-            Guid serviceId = await testHook.GetServiceId();
+            Guid serviceId = await siloHandle.TestHook.GetServiceId();
             Assert.Equal(thisRunServiceId, serviceId);  // "ServiceId active in silo"
 
             // ServiceId is not currently available in client config
@@ -110,8 +109,7 @@ namespace UnitTests.Streaming
             Assert.NotEqual(initialDeploymentId, this.HostedCluster.DeploymentId);  // "DeploymentId different after restart."
 
             SiloHandle siloHandle = this.HostedCluster.GetActiveSilos().First();
-            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, siloHandle.Silo.SiloAddress);
-            Guid serviceId = await testHook.GetServiceId();
+            Guid serviceId = await siloHandle.TestHook.GetServiceId();
             Assert.Equal(ServiceId, serviceId);  // "ServiceId active in silo"
 
             // ServiceId is not currently available in client config

--- a/test/TesterInternal/StreamingTests/DynamicStreamProviderConfigurationTests.cs
+++ b/test/TesterInternal/StreamingTests/DynamicStreamProviderConfigurationTests.cs
@@ -17,6 +17,7 @@ using TestGrainInterfaces;
 using TestGrains;
 using UnitTests.Grains;
 using Xunit;
+using Orleans.Runtime.TestHooks;
 
 namespace UnitTests.StreamingTests
 {
@@ -77,8 +78,9 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Providers")]
         public async Task DynamicStreamProviderConfigurationTests_AddAndRemoveProvidersAndCheckCounters()
         {
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, fixture.HostedCluster.Primary.Silo.SiloAddress);
             //Making sure the initial provider list is empty.
-            List<string> providerNames = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
+            List<string> providerNames = (await testHook.GetStreamProviderNames()).ToList();
             Assert.Equal(0, providerNames.Count);
 
             providerNames = new List<string>(new [] { GeneratedStreamTestConstants.StreamProviderName });
@@ -102,8 +104,9 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Providers")]
         public async Task DynamicStreamProviderConfigurationTests_AddAndRemoveProvidersInBatch()
         {
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, fixture.HostedCluster.Primary.Silo.SiloAddress);
             //Making sure the initial provider list is empty.
-            List<string> providerNames = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
+            List<string> providerNames = (await testHook.GetStreamProviderNames()).ToList();
             Assert.Equal(0, providerNames.Count);
 
             providerNames = new List<string>(new[]
@@ -125,8 +128,9 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Providers")]
         public async Task DynamicStreamProviderConfigurationTests_AddAndRemoveProvidersIndividually()
         {
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, fixture.HostedCluster.Primary.Silo.SiloAddress);
             //Making sure the initial provider list is empty.
-            List<string> providerNames = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
+            List<string> providerNames = (await testHook.GetStreamProviderNames()).ToList();
             Assert.Equal(0, providerNames.Count);
 
             providerNames = new List<string>(new[] { GeneratedStreamTestConstants.StreamProviderName });
@@ -167,8 +171,9 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Providers")]
         public async Task DynamicStreamProviderConfigurationTests_AddProvidersAndThrowExceptionOnInitialization()
         {
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, fixture.HostedCluster.Primary.Silo.SiloAddress);
             //Making sure the initial provider list is empty.
-            List<string> providerNames = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
+            List<string> providerNames = (await testHook.GetStreamProviderNames()).ToList();
             Assert.Equal(0, providerNames.Count);
 
             Dictionary<string, string> providerSettings =
@@ -188,8 +193,9 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("Providers")]
         public async Task DynamicStreamProviderConfigurationTests_AddProvidersAndThrowExceptionOnStart()
         {
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, fixture.HostedCluster.Primary.Silo.SiloAddress);
             //Making sure the initial provider list is empty.
-            List<string> providerNames = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
+            List<string> providerNames = (await testHook.GetStreamProviderNames()).ToList();
             Assert.Equal(0, providerNames.Count);
             Dictionary<string, string> providerSettings =
                 new Dictionary<string, string>(fixture.DefaultStreamProviderSettings)
@@ -206,9 +212,10 @@ namespace UnitTests.StreamingTests
 
         private async Task RemoveAllProviders()
         {
-            List<string> providerNames = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, fixture.HostedCluster.Primary.Silo.SiloAddress);
+            List<string> providerNames = (await testHook.GetStreamProviderNames()).ToList();
             await RemoveProvidersAndVerify(providerNames);
-            providerNames = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
+            providerNames = (await testHook.GetStreamProviderNames()).ToList();
             Assert.Equal(0, providerNames.Count);
         }
 
@@ -232,8 +239,9 @@ namespace UnitTests.StreamingTests
 
         private async Task AddProvidersAndVerify(List<string> streamProviderNames)
         {
-            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
-            List<string> names = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, fixture.HostedCluster.Primary.Silo.SiloAddress);
+            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            List<string> names = (await testHook.GetStreamProviderNames()).ToList();
 
             IDictionary<string, bool> hasNewProvider = new Dictionary<string, bool>();
 
@@ -241,8 +249,8 @@ namespace UnitTests.StreamingTests
             SiloAddress[] address = new SiloAddress[1];
             address[0] = fixture.HostedCluster.Primary.SiloAddress;
             await mgmtGrain.UpdateStreamProviders(address, fixture.HostedCluster.ClusterConfiguration.Globals.ProviderConfigurations);
-            names = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
-            List<string> allSiloProviderNames = fixture.HostedCluster.Primary.TestHook.GetAllSiloProviderNames().ToList();
+            names = (await testHook.GetStreamProviderNames()).ToList();
+            List<string> allSiloProviderNames = (await testHook.GetAllSiloProviderNames()).ToList();
             Assert.Equal(names.Count - count, streamProviderNames.Count);
             Assert.Equal(allSiloProviderNames.Count, names.Count);
             foreach (string name in names)
@@ -270,8 +278,9 @@ namespace UnitTests.StreamingTests
 
         private async Task RemoveProvidersAndVerify(List<string> streamProviderNames)
         {
-            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
-            List<string> names = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
+            var testHook = GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, fixture.HostedCluster.Primary.Silo.SiloAddress);
+            mgmtGrain = GrainClient.GrainFactory.GetGrain<IManagementGrain>(RuntimeInterfaceConstants.SYSTEM_MANAGEMENT_ID);
+            List<string> names = (await testHook.GetStreamProviderNames()).ToList();
             int Count = names.Count;
             foreach (string name in streamProviderNames)
             {
@@ -282,8 +291,8 @@ namespace UnitTests.StreamingTests
             SiloAddress[] address = new SiloAddress[1];
             address[0] = fixture.HostedCluster.Primary.SiloAddress;
             await mgmtGrain.UpdateStreamProviders(address, fixture.HostedCluster.ClusterConfiguration.Globals.ProviderConfigurations);
-            names = fixture.HostedCluster.Primary.TestHook.GetStreamProviderNames().ToList();
-            List<string> allSiloProviderNames = fixture.HostedCluster.Primary.TestHook.GetAllSiloProviderNames().ToList();
+            names = (await testHook.GetStreamProviderNames()).ToList();
+            List<string> allSiloProviderNames = (await testHook.GetAllSiloProviderNames()).ToList();
             Assert.Equal(Count - names.Count, streamProviderNames.Count);
             Assert.Equal(allSiloProviderNames.Count, names.Count);
             foreach (String name in streamProviderNames)

--- a/test/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
+++ b/test/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
@@ -116,7 +116,7 @@ namespace UnitTests.StreamingTests
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider)siloHandle.TestHook.GetStorageProvider(providerName);
+                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
                 provider.SetErrorInjection(errorInjectionPoint);
             }
         }

--- a/test/TesterInternal/TestUtils.cs
+++ b/test/TesterInternal/TestUtils.cs
@@ -77,8 +77,7 @@ namespace UnitTests.TestHelper
         /// <param name="siloHandle">The target silo that should provide this information from it's cache</param>
         internal static Task<DetailedGrainReport> GetDetailedGrainReport(GrainId grainId, SiloHandle siloHandle)
         {
-            var proxyAddress = SiloAddress.New(siloHandle.NodeConfiguration.ProxyGatewayEndpoint, 0);
-            var siloControl = GrainClient.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, proxyAddress);
+            var siloControl = GrainClient.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, siloHandle.ProxyAddress);
             return siloControl.GetDetailedGrainReport(grainId);
         }
     }

--- a/test/TesterInternal/TimeoutTests.cs
+++ b/test/TesterInternal/TimeoutTests.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 
 namespace UnitTests
 {
-    // if we paralellize tests, this should run in isolation
+    // if we parallelize tests, this should run in isolation 
     public class TimeoutTests : HostedTestClusterEnsureDefaultStarted, IDisposable
     {
         private readonly ITestOutputHelper output;

--- a/vNext/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/vNext/src/OrleansRuntime/OrleansRuntime.csproj
@@ -394,6 +394,12 @@
     <Compile Include="..\..\..\src\OrleansRuntime\Silo\SiloProviderRuntime.cs">
       <Link>Silo\SiloProviderRuntime.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\src\OrleansRuntime\Silo\TestHooks\ITestHooksSystemTarget.cs">
+      <Link>Silo\TestHooks\ITestHooksSystemTarget.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\src\OrleansRuntime\Silo\TestHooks\TestHooksSystemTarget.cs">
+      <Link>Silo\TestHooks\TestHooksSystemTarget.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\src\OrleansRuntime\Silo\Watchdog.cs">
       <Link>Silo\Watchdog.cs</Link>
     </Compile>

--- a/vNext/src/OrleansRuntime/Properties/AssemblyInfo.cs
+++ b/vNext/src/OrleansRuntime/Properties/AssemblyInfo.cs
@@ -14,5 +14,6 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
+[assembly: InternalsVisibleTo("OrleansTestingHost")]
 [assembly: InternalsVisibleTo("Orleans.NonSiloTests")]
 [assembly: InternalsVisibleTo("TestInternalGrains")]

--- a/vNext/test/Tester/Tester.csproj
+++ b/vNext/test/Tester/Tester.csproj
@@ -43,7 +43,6 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This is so that we can eventually run the tests without the need to use AppDomains, as they are not available in .NET Core.

This PR is related to #2145