### PR TITLE
Avoid manual perf test to stall the entire test run

### DIFF
--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -1048,7 +1048,7 @@ namespace UnitTests.StorageTests
         public async Task Serialize_GrainState_DeepCopy_Stress()
         {
             int num = 100;
-            int loops = num * 1000;
+            int loops = num * 100;
             GrainStateContainingGrainReferences[] states = new GrainStateContainingGrainReferences[num];
             for (int i = 0; i < num; i++)
             {


### PR DESCRIPTION
Reduce number of loops of perf test. This was taking too long at max CPU and making AppDomains stop responding and stall the entire test run.
It's not a test marked BVT or Functional, so it's almost never run, but in the cases where we did manually run it, it was not working even in a very powerful desktop with lots of cores and RAM.