### PR TITLE
RuntimeType serialization

### DIFF
--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -1637,7 +1637,7 @@ namespace Orleans.Serialization
 
         internal static void SerializeType(object obj, BinaryTokenStreamWriter stream, Type expected)
         {
-            stream.Write(((Type)obj).OrleansTypeName());
+            stream.Write(((Type)obj).OrleansTypeKeyString());
         }
 
         internal static object DeserializeType(Type expected, BinaryTokenStreamReader stream)

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -267,6 +267,10 @@ namespace Orleans.Serialization
             Register(typeof(TimeSpan), BuiltInTypes.CopyTimeSpan, BuiltInTypes.SerializeTimeSpan, BuiltInTypes.DeserializeTimeSpan);
             Register(typeof(DateTimeOffset), BuiltInTypes.CopyDateTimeOffset, BuiltInTypes.SerializeDateTimeOffset, BuiltInTypes.DeserializeDateTimeOffset);
             Register(typeof(Type), BuiltInTypes.CopyType, BuiltInTypes.SerializeType, BuiltInTypes.DeserializeType);
+            // ReSharper disable PossibleMistakenCallToGetType.2
+            // RuntimeType is internal but can be obtained indirectly by calling GetType().
+            Register(typeof(object).GetType(), BuiltInTypes.CopyType, BuiltInTypes.SerializeType, BuiltInTypes.DeserializeType);
+            // ReSharper restore PossibleMistakenCallToGetType.2
             Register(typeof(Guid), BuiltInTypes.CopyGuid, BuiltInTypes.SerializeGuid, BuiltInTypes.DeserializeGuid);
             Register(typeof(IPAddress), BuiltInTypes.CopyIPAddress, BuiltInTypes.SerializeIPAddress, BuiltInTypes.DeserializeIPAddress);
             Register(typeof(IPEndPoint), BuiltInTypes.CopyIPEndPoint, BuiltInTypes.SerializeIPEndPoint, BuiltInTypes.DeserializeIPEndPoint);

--- a/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
@@ -39,9 +39,10 @@ namespace UnitTests.Serialization
             Default,
             BinaryFormatterFallbackSerializer,
             IlBasedFallbackSerializer,
+            NoFallback
         }
 
-        public static object[] Serializers =
+        public static object[] FallbackSerializers =
         {
             new object[] { SerializerToUse.Default },
 #if !NETSTANDARD_TODO
@@ -66,6 +67,9 @@ namespace UnitTests.Serialization
                     fallback = typeof(BinaryFormatterSerializer).GetTypeInfo();
                     break;
 #endif
+                    case SerializerToUse.NoFallback:
+                    fallback = typeof(SupportsNothingSerializer).GetTypeInfo();
+                    break;
                 default:
                     throw new InvalidOperationException("Invalid Serializer was selected");
             }
@@ -99,7 +103,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("BVT"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [MemberData(nameof(FallbackSerializers))]
         public void Serialize_ComplexClass(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -132,7 +136,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("BVT"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ComplexStruct(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -151,7 +155,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ActivationAddress(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -170,7 +174,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_EmptyList(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -184,7 +188,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_BasicDictionaries(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -203,7 +207,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ReadOnlyDictionary(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -223,36 +227,8 @@ namespace UnitTests.Serialization
             ValidateReadOnlyDictionary(readOnlySource2, deserialized, "int/date");
         }
 
-        [Serializable]
-        public class CaseInsensitiveStringEquality : EqualityComparer<string>
-        {
-            public override bool Equals(string x, string y)
-            {
-                return x.Equals(y, StringComparison.OrdinalIgnoreCase);
-            }
-
-            public override int GetHashCode(string obj)
-            {
-                return obj.ToLowerInvariant().GetHashCode();
-            }
-        }
-
-        [Serializable]
-        public class Mod5IntegerComparer : EqualityComparer<int>
-        {
-            public override bool Equals(int x, int y)
-            {
-                return ((x - y) % 5) == 0;
-            }
-
-            public override int GetHashCode(int obj)
-            {
-                return obj % 5;
-            }
-        }
-
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_DictionaryWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -272,17 +248,6 @@ namespace UnitTests.Serialization
             ValidateDictionary<int, DateTime>(source2, deserialized, "int/date");
             Dictionary<int, DateTime> result2 = (Dictionary<int, DateTime>)deserialized;
             Assert.Equal<DateTime>(source2[3], result2[13]);  //Round trip for case insensitive int/DateTime dictionary lost the custom comparer"
-        }
-
-        [Serializable]
-        class CaseInsensitiveStringComparer : Comparer<string>
-        {
-            public override int Compare(string x, string y)
-            {
-                var x1 = x.ToLowerInvariant();
-                var y1 = y.ToLowerInvariant();
-                return Comparer<string>.Default.Compare(x1, y1);
-            }
         }
 
         public enum IntEnum
@@ -335,7 +300,7 @@ namespace UnitTests.Serialization
         }*/
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_SortedDictionaryWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -348,7 +313,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_SortedListWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -361,7 +326,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_HashSetWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -382,7 +347,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_Stack(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -405,7 +370,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_SortedSetWithComparer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -426,7 +391,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_Array(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -449,7 +414,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ArrayOfArrays(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -514,7 +479,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ArrayOfArrayOfArrays(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -528,7 +493,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ReadOnlyCollection(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -588,7 +553,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ObjectIdentity(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -630,7 +595,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [MemberData(nameof(FallbackSerializers))]
         public void Serialize_Unrecognized(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -657,7 +622,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_Immutable(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -683,7 +648,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_Uri_Multithreaded(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -741,7 +706,7 @@ namespace UnitTests.Serialization
         //}
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_GrainReference(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -757,7 +722,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_GrainReference_ViaStandardSerializer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -774,7 +739,7 @@ namespace UnitTests.Serialization
         
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_GrainBase_ViaStandardSerializer(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -789,7 +754,7 @@ namespace UnitTests.Serialization
         }
         
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ValidateBuildSegmentListWithLengthLimit(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -853,7 +818,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void SerializationTests_IsOrleansShallowCopyable(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -1016,7 +981,7 @@ namespace UnitTests.Serialization
         }
 
         [Theory, TestCategory("Functional"), TestCategory("Serialization")]
-        [MemberData(nameof(Serializers))]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_CircularReference(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);
@@ -1032,6 +997,30 @@ namespace UnitTests.Serialization
             deserialized = (CircularTest1)OrleansSerializationLoop(c1, true);
             Assert.Equal(c1.CircularTest2.CircularTest1List.Count, deserialized.CircularTest2.CircularTest1List.Count);
             Assert.Same(deserialized, deserialized.CircularTest2.CircularTest1List[0]);
+        }
+
+        public class SupportsNothingSerializer : IExternalSerializer
+        {
+            public void Initialize(Logger logger)
+            {
+            }
+
+            public bool IsSupportedType(Type itemType) => false;
+
+            public object DeepCopy(object source)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+            {
+                throw new NotSupportedException();
+            }
+
+            public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+            {
+                throw new NotSupportedException();
+            }
         }
     }
 }

--- a/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
@@ -137,6 +137,23 @@ namespace UnitTests.Serialization
 
         [Theory, TestCategory("BVT"), TestCategory("Serialization")]
         [InlineData(SerializerToUse.NoFallback)]
+        public void Serialize_Type(SerializerToUse serializerToUse)
+        {
+            InitializeSerializer(serializerToUse);
+
+            // Test serialization of Type.
+            var expected = typeof(int);
+            var actual = (Type)OrleansSerializationLoop(expected);
+            Assert.Equal(expected.AssemblyQualifiedName, actual.AssemblyQualifiedName);
+
+            // Test serialization of RuntimeType.
+            expected = 8.GetType();
+            actual = (Type)OrleansSerializationLoop(expected);
+            Assert.Equal(expected.AssemblyQualifiedName, actual.AssemblyQualifiedName);
+        }
+
+        [Theory, TestCategory("BVT"), TestCategory("Serialization")]
+        [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ComplexStruct(SerializerToUse serializerToUse)
         {
             InitializeSerializer(serializerToUse);

--- a/test/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/test/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -37,6 +37,44 @@ public class Outsider { }
 
 namespace UnitTests.GrainInterfaces
 {
+    [Serializable]
+    public class CaseInsensitiveStringEquality : EqualityComparer<string>
+    {
+        public override bool Equals(string x, string y)
+        {
+            return x.Equals(y, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode(string obj)
+        {
+            return obj.ToLowerInvariant().GetHashCode();
+        }
+    }
+
+    [Serializable]
+    public class Mod5IntegerComparer : EqualityComparer<int>
+    {
+        public override bool Equals(int x, int y)
+        {
+            return ((x - y) % 5) == 0;
+        }
+
+        public override int GetHashCode(int obj)
+        {
+            return obj % 5;
+        }
+    }
+
+    [Serializable]
+    public class CaseInsensitiveStringComparer : Comparer<string>
+    {
+        public override int Compare(string x, string y)
+        {
+            var x1 = x.ToLowerInvariant();
+            var y1 = y.ToLowerInvariant();
+            return Comparer<string>.Default.Compare(x1, y1);
+        }
+    }
 
     [Serializable]
     public class RootType


### PR DESCRIPTION
The first commit ensures that the fallback serializer is not available for most of the tests in BuiltInSerializerTests - most tests should pass without the fallback.

The second commit registers a serializer for `RuntimeType` (the runtime type of `Type` 😉), aligns the serializer with the deserializer, and adds a test.