### PR TITLE
Several build fixes for vNext solution and support command line

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,1 +1,2 @@
-"%~dp0src\Build.cmd"
+cmd /c "%~dp0src\Build.cmd"
+REM cmd /c "%~dp0vNext\src\Build.cmd"

--- a/src/Orleans.SDK.targets
+++ b/src/Orleans.SDK.targets
@@ -82,6 +82,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 " />
     <MakeDir Directories="$(IntermediateOutputPath)Generated"/>
     <Delete Files="$(ProjectDir)Properties\orleans.codegen.cs" ContinueOnError="true" />
+    <MakeDir Directories="$(ProjectDir)Properties"/>
     <Touch Files="$(ProjectDir)Properties\orleans.codegen.cs"
       Condition="!Exists('$(ProjectDir)Properties\orleans.codegen.cs')"
       ForceTouch="true"

--- a/src/Orleans/Runtime/RequestContext.cs
+++ b/src/Orleans/Runtime/RequestContext.cs
@@ -24,9 +24,6 @@ namespace Orleans.Runtime
     /// Information stored in RequestContext is propagated from 
     /// Orleans clients to Orleans grains automatically 
     /// by the Orleans runtime.
-    /// RequestContext data is not automatically propagated across 
-    /// TPL thread-switch boundaries -- <see cref="CallContext"/> 
-    /// for that type of functionality.
     /// </para>
     /// </remarks>
     public static class RequestContext

--- a/vNext/src/Build.cmd
+++ b/vNext/src/Build.cmd
@@ -1,0 +1,104 @@
+@REM NOTE: This script must be run from a Visual Studio command prompt window
+
+@setlocal
+@ECHO off
+
+SET CMDHOME=%~dp0.
+if "%VisualStudioVersion%" == "" (
+    @REM Try to find VS command prompt init script
+    where /Q VsDevCmd.bat
+    if ERRORLEVEL 1 (
+        if exist "%VS140COMNTOOLS%" (
+            call "%VS140COMNTOOLS%VsDevCmd.bat"
+        )
+    ) else (
+        @REM VsDevCmd.bat is in PATH, so just exec it.
+        VsDevCmd.bat
+    )
+)
+if "%VisualStudioVersion%" == "" (
+    echo Could not determine Visual Studio version in the system. Cannot continue.
+    exit /b 1
+)
+@ECHO VisualStudioVersion = %VisualStudioVersion%
+
+@REM Get path to MSBuild Binaries
+if exist "%ProgramFiles%\MSBuild\14.0\bin" SET MSBUILDEXEDIR=%ProgramFiles%\MSBuild\14.0\bin
+if exist "%ProgramFiles(x86)%\MSBuild\14.0\bin" SET MSBUILDEXEDIR=%ProgramFiles(x86)%\MSBuild\14.0\bin
+
+@REM Can't multi-block if statement when check condition contains '(' and ')' char, so do as single line checks
+if NOT "%MSBUILDEXEDIR%" == "" SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe
+if NOT "%MSBUILDEXEDIR%" == "" GOTO :MsBuildFound
+
+@REM Try to find VS command prompt init script
+where /Q MsBuild.exe
+if ERRORLEVEL 1 (
+    echo Could not find MSBuild in the system. Cannot continue.
+    exit /b 1
+) else (
+    @REM MsBuild.exe is in PATH, so just use it.
+   SET MSBUILDEXE=MSBuild.exe
+ )
+:MsBuildFound
+@ECHO MsBuild Location = %MSBUILDEXE%
+
+SET VERSION_FILE=%CMDHOME%\Build\Version.txt
+
+if EXIST "%VERSION_FILE%" (
+    @Echo Using version number from file %VERSION_FILE%
+    FOR /F "usebackq tokens=1,2,3,4 delims=." %%i in (`type "%VERSION_FILE%"`) do set PRODUCT_VERSION=%%i.%%j.%%k
+) else (
+    @Echo ERROR: Unable to read version number from file %VERSION_FILE%
+    SET PRODUCT_VERSION=1.0
+)
+@Echo PRODUCT_VERSION=%PRODUCT_VERSION%
+
+if "%builduri%" == "" set builduri=Build.cmd
+
+set PROJ=%CMDHOME%\Orleans.sln
+
+@echo ===== Building %PROJ% =====
+
+@echo Build Debug ==============================
+
+SET CONFIGURATION=Debug
+SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
+
+"%MSBUILDEXE%" /nr:False /m /p:Configuration=%CONFIGURATION% "%PROJ%"
+@if ERRORLEVEL 1 GOTO :ErrorStop
+@echo BUILD ok for %CONFIGURATION% %PROJ%
+
+@echo Build Release ============================
+
+SET CONFIGURATION=Release
+SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
+
+"%MSBUILDEXE%" /nr:False /m /p:Configuration=%CONFIGURATION% "%PROJ%"
+@if ERRORLEVEL 1 GOTO :ErrorStop
+@echo BUILD ok for %CONFIGURATION% %PROJ%
+
+set STEP=VSIX
+
+if "%VSSDK140Install%" == "" (
+    @echo Visual Studio 2015 SDK not installed - Skipping building VSIX
+    @GOTO :BuildFinished
+)
+
+@echo Build VSIX ============================
+
+set PROJ=%CMDHOME%\OrleansVSTools\OrleansVSTools.sln
+SET OutDir=%OutDir%\VSIX
+"%MSBUILDEXE%" /nr:False /m /p:Configuration=%CONFIGURATION% "%PROJ%"
+@if ERRORLEVEL 1 GOTO :ErrorStop
+@echo BUILD ok for VSIX package for %PROJ%
+
+:BuildFinished
+@echo ===== Build succeeded for %PROJ% =====
+@GOTO :EOF
+
+:ErrorStop
+set RC=%ERRORLEVEL%
+if "%STEP%" == "" set STEP=%CONFIGURATION%
+@echo ===== Build FAILED for %PROJ% -- %STEP% with error %RC% - CANNOT CONTINUE =====
+exit /B %RC%
+:EOF

--- a/vNext/src/Build.cmd
+++ b/vNext/src/Build.cmd
@@ -55,42 +55,30 @@ if EXIST "%VERSION_FILE%" (
 
 if "%builduri%" == "" set builduri=Build.cmd
 
-set PROJ=%CMDHOME%\Orleans.sln
+set PROJ=%CMDHOME%\Orleans.vNext.sln
+
+:: Restore nuget packages before building the solution
+"%MSBUILDEXE%" %CMDHOME%\..\..\src\Before.Orleans.sln.targets /p:SolutionPath=%PROJ%
 
 @echo ===== Building %PROJ% =====
 
 @echo Build Debug ==============================
 
 SET CONFIGURATION=Debug
-SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
+SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%\
 
-"%MSBUILDEXE%" /nr:False /m /p:Configuration=%CONFIGURATION% "%PROJ%"
+"%MSBUILDEXE%" /nr:False /m /p:Configuration=%CONFIGURATION% /p:GenerateProjectSpecificOutputFolder=false "%PROJ%"
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD ok for %CONFIGURATION% %PROJ%
 
 @echo Build Release ============================
 
 SET CONFIGURATION=Release
-SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
+SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%\
 
-"%MSBUILDEXE%" /nr:False /m /p:Configuration=%CONFIGURATION% "%PROJ%"
+"%MSBUILDEXE%" /nr:False /m /p:Configuration=%CONFIGURATION% /p:GenerateProjectSpecificOutputFolder=false "%PROJ%"
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD ok for %CONFIGURATION% %PROJ%
-
-set STEP=VSIX
-
-if "%VSSDK140Install%" == "" (
-    @echo Visual Studio 2015 SDK not installed - Skipping building VSIX
-    @GOTO :BuildFinished
-)
-
-@echo Build VSIX ============================
-
-set PROJ=%CMDHOME%\OrleansVSTools\OrleansVSTools.sln
-SET OutDir=%OutDir%\VSIX
-"%MSBUILDEXE%" /nr:False /m /p:Configuration=%CONFIGURATION% "%PROJ%"
-@if ERRORLEVEL 1 GOTO :ErrorStop
-@echo BUILD ok for VSIX package for %PROJ%
 
 :BuildFinished
 @echo ===== Build succeeded for %PROJ% =====

--- a/vNext/src/Orleans.SDK.targets
+++ b/vNext/src/Orleans.SDK.targets
@@ -82,6 +82,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 " />
     <MakeDir Directories="$(IntermediateOutputPath)Generated"/>
     <Delete Files="$(ProjectDir)Properties\orleans.codegen.cs" ContinueOnError="true" />
+    <MakeDir Directories="$(ProjectDir)Properties"/>
     <Touch Files="$(ProjectDir)Properties\orleans.codegen.cs"
       Condition="!Exists('$(ProjectDir)Properties\orleans.codegen.cs')"
       ForceTouch="true"

--- a/vNext/src/Orleans/Shims/AppDomain.cs
+++ b/vNext/src/Orleans/Shims/AppDomain.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+#pragma warning disable 67
 
 namespace Orleans
 {

--- a/vNext/src/OrleansProviders/OrleansProviders.csproj
+++ b/vNext/src/OrleansProviders/OrleansProviders.csproj
@@ -48,7 +48,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\src\Build\GlobalAssemblyInfo.cs">
+    <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="..\..\..\src\OrleansProviders\BuiltInProvidersConfigurationExtensions.cs">

--- a/vNext/src/OrleansProviders/project.json
+++ b/vNext/src/OrleansProviders/project.json
@@ -5,13 +5,7 @@
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "NETStandard.Library": "1.6.0",
     "System.Collections.NonGeneric": "4.0.1",
-    "System.Diagnostics.TraceSource": "4.0.0",
-    "System.Reflection.Emit.Lightweight": "4.0.1",
-    "System.Reflection.TypeExtensions": "4.1.0",
     "System.Runtime": "4.1.0",
-    "System.Runtime.Serialization.Formatters": "4.0.0-rc3-24212-01",
-    "System.Threading.Thread": "4.0.0",
-    "System.Xml.XmlDocument": "4.0.1"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/vNext/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/vNext/src/OrleansRuntime/OrleansRuntime.csproj
@@ -440,6 +440,9 @@
     <Compile Include="..\..\..\src\OrleansRuntime\Streams\StreamProviderManagerAgent.cs">
       <Link>Streams\StreamProviderManagerAgent.cs</Link>
     </Compile>
+    <Compile Include="..\Build\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\orleans.codegen.cs" />
   </ItemGroup>

--- a/vNext/src/OrleansRuntime/project.json
+++ b/vNext/src/OrleansRuntime/project.json
@@ -1,15 +1,10 @@
 ﻿{
   "supports": {},
   "dependencies": {
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "NETStandard.Library": "1.6.0",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0",
-    "System.Reflection.Emit.Lightweight": "4.0.1",
-    "System.Reflection.TypeExtensions": "4.1.0",
-    "System.Runtime": "4.1.0",
-    "System.Runtime.Serialization.Formatters": "4.0.0-rc3-24212-01",
-    "System.Threading.Thread": "4.0.0",
-    "System.Xml.XmlDocument": "4.0.1"
+    "System.Runtime": "4.1.0"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/vNext/test/NonSiloTests/project.json
+++ b/vNext/test/NonSiloTests/project.json
@@ -1,7 +1,5 @@
 ﻿{
   "dependencies": {
-    "System.Management.Automation": "6.1.7601.17515",
-    "System.Xml.XmlDocument": "4.0.1",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14",

--- a/vNext/test/Tester/project.json
+++ b/vNext/test/Tester/project.json
@@ -6,32 +6,7 @@
     "Newtonsoft.Json": "9.0.1",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14",
-
-
-
-
-    "System.Collections.Immutable": "1.2.0",
-    "System.Security.Cryptography.Algorithms": "4.2.0",
-    "System.Xml.XmlDocument": "4.0.1",
-    "System.Xml.XPath.XmlDocument": "4.0.1",
-    "System.ComponentModel.TypeConverter": "4.1.0",
-    "System.Linq.Expressions": "4.1.0",
-    "System.Diagnostics.Process": "4.1.0",
-    "System.Threading.Thread": "4.0.0",
-    "System.Diagnostics.TraceSource": "4.0.0",
-    "System.Reflection.TypeExtensions": "4.1.0",
-    "System.Net.NameResolution": "4.0.0",
-    "System.Net.NetworkInformation": "4.1.0",
-    "System.Runtime.Serialization.Formatters": "4.0.0-rc3-24212-01",
-    "System.Runtime.Serialization.Primitives": "4.1.1",
-    "System.Reflection.Emit": "4.0.1",
-    "System.Reflection.Emit.Lightweight": "4.0.1",
-    "System.Diagnostics.FileVersionInfo": "4.0.0",
-    "System.Threading.ThreadPool": "4.0.10",
-
-    "Microsoft.Extensions.DependencyInjection": "1.0.0",
-    "System.Runtime": "4.1.0"
+    "Xunit.SkippableFact": "1.2.14"
   },
   "frameworks": {
     "net462": {}


### PR DESCRIPTION
This PR supersedes #2215.
There's several fixes to how we build the vNext solution.
Also added a build script for the command line that can be used from CI (although it's not enabled by the CI build yet, since the build agent doesn't support .NET 4.6.2 but will soon).