### PR TITLE
.NET Standard: Remove prerelease BinaryFormatter & fix dependent code

### DIFF
--- a/src/Orleans/CodeGeneration/GeneratedAssembly.cs
+++ b/src/Orleans/CodeGeneration/GeneratedAssembly.cs
@@ -1,9 +1,11 @@
 namespace Orleans.CodeGeneration
 {
+    using System;
+
     /// <summary>
     /// Represents a generated assembly.
     /// </summary>
-    [System.Serializable]
+    [Serializable]
     public class GeneratedAssembly
     {
         /// <summary>

--- a/src/Orleans/IDs/GuidId.cs
+++ b/src/Orleans/IDs/GuidId.cs
@@ -11,7 +11,10 @@ namespace Orleans.Runtime
     /// </summary>
     [Serializable]
     [Immutable]
-    public sealed class GuidId : IEquatable<GuidId>, IComparable<GuidId>, ISerializable
+    public sealed class GuidId : IEquatable<GuidId>, IComparable<GuidId>
+#if !NETSTANDARD
+        , ISerializable
+#endif
     {
         private static readonly Lazy<Interner<Guid, GuidId>> guidIdInternCache = new Lazy<Interner<Guid, GuidId>>(
                     () => new Interner<Guid, GuidId>(InternerConstants.SIZE_LARGE, InternerConstants.DefaultCacheCleanupFreq));
@@ -39,23 +42,23 @@ namespace Orleans.Runtime
             return guidIdInternCache.Value.FindOrCreate(guid, () => new GuidId(guid));
         }
 
-        #region IComparable<GuidId> Members
+#region IComparable<GuidId> Members
 
         public int CompareTo(GuidId other)
         {
             return this.Guid.CompareTo(other.Guid);
         }
 
-        #endregion
+#endregion
 
-        #region IEquatable<GuidId> Members
+#region IEquatable<GuidId> Members
 
         public bool Equals(GuidId other)
         {
             return other != null && this.Guid.Equals(other.Guid);
         }
 
-        #endregion
+#endregion
 
         public override bool Equals(object obj)
         {
@@ -99,7 +102,7 @@ namespace Orleans.Runtime
             return GuidId.GetGuidId(guid);
         }
 
-        #region Operators
+#region Operators
 
         public static bool operator ==(GuidId a, GuidId b)
         {
@@ -114,9 +117,9 @@ namespace Orleans.Runtime
             return !(a == b);
         }
 
-        #endregion
-
-        #region ISerializable Members
+#endregion
+#if !NETSTANDARD
+#region ISerializable Members
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -129,6 +132,7 @@ namespace Orleans.Runtime
             Guid = (Guid) info.GetValue("Guid", typeof(Guid));
         }
 
-        #endregion
+#endregion
+#endif
     }
 }

--- a/src/Orleans/IDs/StreamId.cs
+++ b/src/Orleans/IDs/StreamId.cs
@@ -11,7 +11,10 @@ namespace Orleans.Streams
     /// </summary>
     [Serializable]
     [Immutable]
-    internal class StreamId : IStreamIdentity, IRingIdentifier<StreamId>, IEquatable<StreamId>, IComparable<StreamId>, ISerializable
+    internal class StreamId : IStreamIdentity, IRingIdentifier<StreamId>, IEquatable<StreamId>, IComparable<StreamId>
+#if !NETSTANDARD
+        , ISerializable
+#endif
     {
         [NonSerialized]
         private static readonly Lazy<Interner<StreamIdInternerKey, StreamId>> streamIdInternCache = new Lazy<Interner<StreamIdInternerKey, StreamId>>(
@@ -45,23 +48,23 @@ namespace Orleans.Streams
             return streamIdInternCache.Value.FindOrCreate(key, () => new StreamId(key));
         }
 
-        #region IComparable<StreamId> Members
+#region IComparable<StreamId> Members
 
         public int CompareTo(StreamId other)
         {
             return key.CompareTo(other.key);
         }
 
-        #endregion
+#endregion
 
-        #region IEquatable<StreamId> Members
+#region IEquatable<StreamId> Members
 
         public bool Equals(StreamId other)
         {
             return other != null && key.Equals(other.key);
         }
 
-        #endregion
+#endregion
 
         public override bool Equals(object obj)
         {
@@ -107,7 +110,8 @@ namespace Orleans.Streams
                 String.Format("{0}{1}-{2}", Namespace != null ? (String.Format("{0}-", Namespace)) : "", Guid, ProviderName);
         }
 
-        #region ISerializable Members
+#if !NETSTANDARD
+#region ISerializable Members
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -126,7 +130,8 @@ namespace Orleans.Streams
             var nameSpace = (string) info.GetValue("Namespace", typeof(string));
             key = new StreamIdInternerKey(guid, providerName, nameSpace);
         }
-        #endregion
+#endregion
+#endif
     }
 
     [Serializable]

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Reflection;
-using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
@@ -13,7 +11,10 @@ namespace Orleans.Runtime
     /// This is the base class for all typed grain references.
     /// </summary>
     [Serializable]
-    public class GrainReference : IAddressable, IEquatable<GrainReference>, ISerializable
+    public class GrainReference : IAddressable, IEquatable<GrainReference>
+#if !NETSTANDARD
+        , System.Runtime.Serialization.ISerializable
+#endif
     {
         private readonly string genericArguments;
         private readonly GuidId observerId;
@@ -642,10 +643,10 @@ namespace Orleans.Runtime
             //return FromGrainId(GrainId.FromParsableString(grainIdStr), generic);
         }
 
-
+#if !NETSTANDARD
         #region ISerializable Members
 
-        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             // Use the AddValue method to specify serialized values.
             info.AddValue("GrainId", GrainId.ToParsableString(), typeof(string));
@@ -664,7 +665,7 @@ namespace Orleans.Runtime
         }
 
         // The special constructor is used to deserialize values. 
-        protected GrainReference(SerializationInfo info, StreamingContext context)
+        protected GrainReference(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             // Reset the property value using the GetValue method.
             var grainIdStr = info.GetString("GrainId");
@@ -686,5 +687,6 @@ namespace Orleans.Runtime
         }
 
         #endregion
+#endif
     }
 }

--- a/src/Orleans/Serialization/ILSerializerGenerator.cs
+++ b/src/Orleans/Serialization/ILSerializerGenerator.cs
@@ -293,7 +293,7 @@ namespace Orleans.Serialization
                 type.GetAllFields()
                     .Where(
                         field =>
-                        field.GetCustomAttribute<NonSerializedAttribute>() == null && !field.IsStatic
+                        field.GetCustomAttributes().All(attr => attr.GetType().Name != "NonSerializedAttribute") && !field.IsStatic
                         && IsSupportedFieldType(field.FieldType.GetTypeInfo())
                         && (fieldFilter == null || fieldFilter(field)))
                     .ToList();

--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Net;
-using System.Runtime.Serialization.Formatters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Orleans.Runtime;
@@ -36,7 +35,9 @@ namespace Orleans.Serialization
                 MissingMemberHandling = MissingMemberHandling.Ignore,
                 NullValueHandling = NullValueHandling.Ignore,
                 ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-                TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
+#if !NETSTANDARD
+                TypeNameAssemblyFormat = System.Runtime.Serialization.Formatters.FormatterAssemblyStyle.Simple,
+#endif
                 Formatting = Formatting.None
             };
 
@@ -63,7 +64,7 @@ namespace Orleans.Serialization
                 bool useFullAssemblyNames;
                 if (bool.TryParse(config.Properties[UseFullAssemblyNamesProperty], out useFullAssemblyNames) && useFullAssemblyNames)
                 {
-                    settings.TypeNameAssemblyFormat = FormatterAssemblyStyle.Full;
+                    settings.TypeNameAssemblyFormat = System.Runtime.Serialization.Formatters.FormatterAssemblyStyle.Full;
                 }
             }
 

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -695,7 +695,7 @@ namespace Orleans.Serialization
                             {
                                 // the lookup registers the serializer.
                             }
-                            else if (!typeInfo.IsSerializable)
+                            else if (!typeInfo.IsMarkedAsSerializable())
                             {
                                 // Comparers with no fields can be safely dealt with as just a type name
                                 var comparer = false;

--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -42,6 +42,11 @@ namespace Orleans.Serialization
             shallowCopyableTypes[typeof(CancellationToken)] = true;
         }
 
+        public static bool IsMarkedAsSerializable(this TypeInfo type)
+        {
+            return type.IsSerializable || type.GetCustomAttributes().Any(attr => attr.GetType().Name == "SerializableAttribute");
+        }
+
         internal static bool IsOrleansShallowCopyable(this Type t)
         {
             bool result;

--- a/src/Orleans/Streams/Internal/StreamImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamImpl.cs
@@ -4,12 +4,16 @@ using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 using Orleans.Runtime;
+using Orleans.Serialization;
 
 namespace Orleans.Streams
 {
     [Serializable]
     [Immutable]
-    internal class StreamImpl<T> : IStreamIdentity, IAsyncStream<T>, IStreamControl, ISerializable
+    internal class StreamImpl<T> : IStreamIdentity, IAsyncStream<T>, IStreamControl
+#if !NETSTANDARD
+        , ISerializable
+#endif
     {
         private readonly StreamId                               streamId;
         private readonly bool                                   isRewindable;
@@ -156,7 +160,7 @@ namespace Orleans.Streams
             return RuntimeClient.Current.CurrentStreamProviderManager.GetProvider(streamId.ProviderName) as IInternalStreamProvider;
         }
 
-        #region IComparable<IAsyncStream<T>> Members
+#region IComparable<IAsyncStream<T>> Members
 
         public int CompareTo(IAsyncStream<T> other)
         {
@@ -164,9 +168,9 @@ namespace Orleans.Streams
             return o == null ? 1 : streamId.CompareTo(o.streamId);
         }
 
-        #endregion
+#endregion
 
-        #region IEquatable<IAsyncStream<T>> Members
+#region IEquatable<IAsyncStream<T>> Members
 
         public virtual bool Equals(IAsyncStream<T> other)
         {
@@ -174,7 +178,7 @@ namespace Orleans.Streams
             return o != null && streamId.Equals(o.streamId);
         }
 
-        #endregion
+#endregion
 
         public override bool Equals(object obj)
         {
@@ -191,8 +195,9 @@ namespace Orleans.Streams
         {
             return streamId.ToString();
         }
-                
-        #region ISerializable Members
+
+#if !NETSTANDARD
+#region ISerializable Members
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -210,6 +215,7 @@ namespace Orleans.Streams
             initLock = new object();
         }
 
-        #endregion
+#endregion
+#endif
     }
 }

--- a/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
+++ b/src/Orleans/Streams/Predicates/FilterPredicateWrapperData.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using System.Runtime.Serialization;
 using Orleans.Runtime;
+using Orleans.Serialization;
 
 namespace Orleans.Streams
 {
@@ -13,7 +14,10 @@ namespace Orleans.Streams
     /// Predicate filter functions must be staic (non-abstract) methods, so full class name and method name are sufficient info to rehydrate.
     /// </summary>
     [Serializable]
-    internal class FilterPredicateWrapperData : IStreamFilterPredicateWrapper, ISerializable
+    internal class FilterPredicateWrapperData : IStreamFilterPredicateWrapper
+#if !NETSTANDARD
+        , ISerializable
+#endif
     {
         public object FilterData { get; private set; }
 
@@ -37,7 +41,8 @@ namespace Orleans.Streams
             DehydrateStaticFunc(pred);
         }
 
-        #region ISerializable methods
+#if !NETSTANDARD
+#region ISerializable methods
         protected FilterPredicateWrapperData(SerializationInfo info, StreamingContext context)
         {
             FilterData = info.GetValue(SER_FIELD_DATA, typeof(object));
@@ -52,7 +57,8 @@ namespace Orleans.Streams
             info.AddValue(SER_FIELD_METHOD, methodName);
             info.AddValue(SER_FIELD_CLASS,  className);
         }
-        #endregion
+#endregion
+#endif
 
         public bool ShouldReceive(IStreamIdentity stream, object filterData, object item)
         {

--- a/src/Orleans/Streams/Predicates/OrFilter.cs
+++ b/src/Orleans/Streams/Predicates/OrFilter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Orleans.Serialization;
 
 namespace Orleans.Streams
 {
@@ -8,7 +9,10 @@ namespace Orleans.Streams
     /// This class is a [Serializable] holder for a logical-or composite predicate function.
     /// </summary>
     [Serializable]
-    internal class OrFilter : IStreamFilterPredicateWrapper, ISerializable
+    internal class OrFilter : IStreamFilterPredicateWrapper
+#if !NETSTANDARD
+        , ISerializable
+#endif
     {
         public object FilterData
         {
@@ -37,7 +41,8 @@ namespace Orleans.Streams
             filters.Add(filter);
         }
 
-        #region ISerializable methods
+#if !NETSTANDARD
+#region ISerializable methods
         protected OrFilter(SerializationInfo info, StreamingContext context)
         {
             filters = (List<IStreamFilterPredicateWrapper>)info.GetValue("Filters", serializedType);
@@ -46,7 +51,8 @@ namespace Orleans.Streams
         {
             info.AddValue("Filters", this.filters, serializedType);
         }
-        #endregion
+#endregion
+#endif
 
         public bool ShouldReceive(IStreamIdentity stream, object filterData, object item)
         {

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -62,9 +62,6 @@ namespace Orleans.CodeGenerator
                 .AddAttributes(
                     CodeGeneratorCommon.GetGeneratedCodeAttributeSyntax(),
 #if !NETSTANDARD
-                    // we could add Serializable attribute if we want, but that would require that the target
-                    // project depends on System.Runtime.Serialization.Formatters, which is currently in preview
-                    SF.Attribute(typeof(SerializableAttribute).GetNameSyntax()),
                     SF.Attribute(typeof(ExcludeFromCodeCoverageAttribute).GetNameSyntax()),
 #endif
                     markerAttribute);

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -11,6 +11,8 @@ namespace Orleans.CodeGenerator
     using Orleans.Async;
     using Orleans.CodeGeneration;
     using Orleans.Runtime;
+    using Orleans.Serialization;
+
     using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
     using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -347,7 +349,7 @@ namespace Orleans.CodeGenerator
                                           && knownAssemblyAttribute.TreatTypesAsSerializable;
                 foreach (var type in TypeUtils.GetDefinedTypes(assembly, Logger))
                 {
-                    var considerForSerialization = considerAllTypesForSerialization || type.GetTypeInfo().IsSerializable;
+                    var considerForSerialization = considerAllTypesForSerialization || type.GetTypeInfo().IsMarkedAsSerializable();
                     ConsiderType(type, runtime, targetAssembly, includedTypes, considerForSerialization);
                 }
             }

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -118,7 +118,7 @@ namespace Orleans.CodeGenerator
 
         private static bool IsFieldInaccessibleForSerialization(Module module, Assembly targetAssembly, FieldInfo field)
         {
-            return field.GetCustomAttribute<NonSerializedAttribute>() == null
+            return field.GetCustomAttributes().All(attr => attr.GetType().Name != "NonSerializedAttribute")
                    && !SerializationManager.HasSerializer(field.FieldType)
                    && TypeUtilities.IsTypeIsInaccessibleForSerialization(field.FieldType, module, targetAssembly);
         }

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -554,7 +554,7 @@ namespace Orleans.CodeGenerator
         {
             var result =
                 type.GetAllFields()
-                    .Where(field => field.GetCustomAttribute<NonSerializedAttribute>() == null)
+                    .Where(field => field.GetCustomAttributes().All(attr => attr.GetType().Name != "NonSerializedAttribute"))
                     .Select((info, i) => new FieldInfoMember { FieldInfo = info, FieldNumber = i })
                     .ToList();
             result.Sort(FieldInfoMember.Comparer.Instance);

--- a/src/OrleansTestingHost/AppDomainSiloHost.cs
+++ b/src/OrleansTestingHost/AppDomainSiloHost.cs
@@ -20,7 +20,7 @@ namespace Orleans.TestingHost
     public class AppDomainSiloHost : MarshalByRefObject
     {
         private readonly Silo silo;
-
+        
         /// <summary>Creates and initializes a silo in the current app domain.</summary>
         /// <param name="name">Name of this silo.</param>
         /// <param name="siloType">Type of this silo.</param>
@@ -32,8 +32,30 @@ namespace Orleans.TestingHost
             this.AppDomainTestHook = new AppDomainTestHooks(this.silo);
         }
 
+#if NETSTANDARD
+        /// <summary>Creates and initializes a silo in the current app domain.</summary>
+        /// <param name="name">Name of this silo.</param>
+        /// <param name="siloType">Type of this silo.</param>
+        /// <param name="serializedClusterConfig">Serialized cluster config data to be used for this silo.</param>
+        public AppDomainSiloHost(string name, Silo.SiloType siloType, byte[] serializedClusterConfig)
+        {
+            var serializer = new Wire.Serializer(new Wire.SerializerOptions(preserveObjectReferences: true));
+            ClusterConfiguration config;
+            using (var stream = new MemoryStream(serializedClusterConfig))
+            {
+                config = serializer.Deserialize<ClusterConfiguration>(stream);
+            }
+
+            this.silo = new Silo(name, siloType, config);
+            this.silo.InitializeTestHooksSystemTarget();
+            this.AppDomainTestHook = new AppDomainTestHooks(this.silo);
+        }
+#endif
+
         /// <summary> SiloAddress for this silo. </summary>
         public SiloAddress SiloAddress => silo.SiloAddress;
+
+        public string GetSiloAddressString() => SiloAddress.ToParsableString();
 
         /// <summary>Gets the Silo test hook</summary>
         internal ITestHooks TestHook => GrainClient.InternalGrainFactory.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, this.SiloAddress);

--- a/src/OrleansTestingHost/Utils/TestingUtils.cs
+++ b/src/OrleansTestingHost/Utils/TestingUtils.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Net;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -87,18 +86,20 @@ namespace Orleans.TestingHost.Utils
             throw new TimeoutException(message);
         }
 
+#if !NETSTANDARD
         /// <summary> Serialize and deserialize the input </summary>
         /// <typeparam name="T">The type of the input</typeparam>
         /// <param name="input">The input to serialize and deserialize</param>
         /// <returns>Input that have been serialized and then deserialized</returns>
         public static T RoundTripDotNetSerializer<T>(T input)
         {
-            IFormatter formatter = new BinaryFormatter();
+            IFormatter formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
             MemoryStream stream = new MemoryStream(new byte[100000], true);
             formatter.Serialize(stream, input);
             stream.Position = 0;
             T output = (T)formatter.Deserialize(stream);
             return output;
         }
+#endif
     }
 }

--- a/test/NonSiloTests/General/Identifiertests.cs
+++ b/test/NonSiloTests/General/Identifiertests.cs
@@ -479,9 +479,10 @@ namespace UnitTests.General
 
             roundTripped = SerializationManager.RoundTripSerializationForTesting(grainRef);
             Assert.Equal(grainRef, roundTripped); // GrainReference.OrleansSerializer
-
+#if !NETSTANDARD
             roundTripped = TestingUtils.RoundTripDotNetSerializer(grainRef);
             Assert.Equal(grainRef, roundTripped); // GrainReference.DotNetSerializer
+#endif
         }
 
         private GrainReference RoundTripGrainReferenceToKey(GrainReference input)

--- a/test/NonSiloTests/OrleansRuntime/ExceptionsTests.cs
+++ b/test/NonSiloTests/OrleansRuntime/ExceptionsTests.cs
@@ -15,6 +15,7 @@ namespace UnitTests.OrleansRuntime
             SerializationManager.Initialize(null);
         }
 
+#if !NETSTANDARD
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_Exception_DotNet()
         {
@@ -28,6 +29,7 @@ namespace UnitTests.OrleansRuntime
             Assert.Equal(original.ActivationToUse, output.ActivationToUse);
             Assert.Equal(original.PrimaryDirectoryForGrain, output.PrimaryDirectoryForGrain);
         }
+#endif
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_Exception_Orleans()

--- a/test/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/test/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -2,7 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
-
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+using NonSerializedAttribute = Orleans.NonSerializedAttribute;
+#endif
 
 namespace UnitTests.GrainInterfaces
 {

--- a/test/TestGrainInterfaces/ICircularStateTestGrain.cs
+++ b/test/TestGrainInterfaces/ICircularStateTestGrain.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+#endif
 
 namespace TestGrainInterfaces
 {

--- a/test/TestGrainInterfaces/IExternalTypeGrain.cs
+++ b/test/TestGrainInterfaces/IExternalTypeGrain.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using Orleans;
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+#endif
 
 namespace UnitTests.GrainInterfaces
 {

--- a/test/TestGrainInterfaces/IPersistenceTestGrains.cs
+++ b/test/TestGrainInterfaces/IPersistenceTestGrains.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+#endif
 
 // ReSharper disable InconsistentNaming
 

--- a/test/TestGrainInterfaces/IValueTypeTestGrain.cs
+++ b/test/TestGrainInterfaces/IValueTypeTestGrain.cs
@@ -4,6 +4,9 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Concurrency;
 using Orleans.Runtime.Configuration;
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+#endif
 
 namespace UnitTests.GrainInterfaces
 {

--- a/test/TestGrains/GenericGrains.cs
+++ b/test/TestGrains/GenericGrains.cs
@@ -8,6 +8,9 @@ using Orleans.Concurrency;
 using Orleans.Providers;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+#endif
 
 namespace UnitTests.Grains
 {

--- a/test/TestGrains/InitialStateGrain.cs
+++ b/test/TestGrains/InitialStateGrain.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
 using UnitTests.GrainInterfaces;
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+#endif
 
 namespace UnitTests.Grains
 {

--- a/test/TestGrains/SimplePersistentGrain.cs
+++ b/test/TestGrains/SimplePersistentGrain.cs
@@ -3,7 +3,9 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
-
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+#endif
 
 namespace UnitTests.Grains
 {

--- a/test/TestInternalGrains/EchoTaskGrain.cs
+++ b/test/TestInternalGrains/EchoTaskGrain.cs
@@ -8,7 +8,9 @@ using Orleans.Concurrency;
 using Orleans.Providers;
 using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
-
+#if NETSTANDARD
+using Serializable = System.SerializableAttribute;
+#endif
 namespace UnitTests.Grains
 {
     [Serializable]

--- a/test/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/TestInternalGrains/PersistenceTestGrains.cs
@@ -13,6 +13,9 @@ using Orleans.Runtime.Scheduler;
 using Orleans.Serialization;
 using UnitTests.GrainInterfaces;
 using Xunit;
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+#endif
 
 namespace UnitTests.Grains
 {

--- a/test/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -9,6 +9,10 @@ using Orleans.Runtime;
 using Orleans.Runtime.Providers;
 using Orleans.Streams;
 using UnitTests.GrainInterfaces;
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+using NonSerializedAttribute = Orleans.NonSerializedAttribute;
+#endif
 
 namespace UnitTests.Grains
 {

--- a/test/Tester/MemoryStorageProviderTests.cs
+++ b/test/Tester/MemoryStorageProviderTests.cs
@@ -6,6 +6,10 @@ using Orleans.Storage;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
+#if NETSTANDARD
+using SerializableAttribute = Orleans.SerializableAttribute;
+using NonSerializedAttribute = Orleans.NonSerializedAttribute;
+#endif
 
 namespace UnitTests.StorageTests
 {

--- a/vNext/src/Orleans/Orleans.csproj
+++ b/vNext/src/Orleans/Orleans.csproj
@@ -1010,6 +1010,7 @@
     <Compile Include="Properties\orleans.codegen.cs" />
     <Compile Include="Shims\AppDomain.cs" />
     <Compile Include="Shims\RuntimeStatisticsGroup.cs" />
+    <Compile Include="Shims\FormatterShim.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\src\Orleans\Configuration\OrleansConfiguration.xsd">

--- a/vNext/src/Orleans/Shims/FormatterShim.cs
+++ b/vNext/src/Orleans/Shims/FormatterShim.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Orleans
+{
+#if NETSTANDARD_TODO
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum)]
+    public class SerializableAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class NonSerializedAttribute : Attribute
+    {
+    }
+#endif
+}

--- a/vNext/src/Orleans/project.json
+++ b/vNext/src/Orleans/project.json
@@ -15,7 +15,6 @@
     "System.Reflection.Emit": "4.0.1",
     "System.Reflection.Emit.Lightweight": "4.0.1",
     "System.Reflection.TypeExtensions": "4.1.0",
-    "System.Runtime.Serialization.Formatters": "4.0.0-rc3-24212-01",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Security.Cryptography.Algorithms": "4.2.0",
     "System.Threading.Thread": "4.0.0",

--- a/vNext/src/OrleansTestingHost/project.json
+++ b/vNext/src/OrleansTestingHost/project.json
@@ -1,7 +1,8 @@
-{
+﻿{
   "dependencies": {
     "Microsoft.Extensions.Configuration": "1.0.0",
-    "Microsoft.Extensions.Configuration.Binder": "1.0.0"
+    "Microsoft.Extensions.Configuration.Binder": "1.0.0",
+    "Wire": "0.8.1"
   },
   "frameworks": {
     "net462": {}


### PR DESCRIPTION
The goal here is to remove the pre-release `System.Runtime.Serialization.Formatters` package in the vNext solution. Doing so involves removing/#ifdef-ing uses of `ISerializable`, `BinaryFormatter`, `[Serializable]`, and `[NonSerialized]`.
- Adds a shim for `[Serializable]`
- For the purposes of serialization/codegen, determines whether or not a type is marked as serializable based upon the presence of an attribute called "SerializableAttribute" rather than the concrete `System.SerializableAttribute` type or the `type.IsSerializable` property.
- Similarly for `[NonSerialized]`.
- Because `GlobalConfiguration` & co are no longer serializable from the perspective of .NET's, they cannot traverse AppDomain boundaries, so [Wire](https://github.com/akkadotnet/Wire) is used to serialize them into byte arrays in `OrleansTestingHost` when creating instances of `AppDomainSiloHost`. Note that we could use our own serialization infrastructure, but since `SerializationManager` has some static fields, we should avoid this - otherwise test results might be tainted. We could also try to cleanly uninitialize it and all related classes before constructing the `Silo`.
- Removed pre-release `System.Runtime.Serialization.Formatters` NuGet package.
