### PR TITLE
Fix AppDomain shim to work well in .NET Core

### DIFF
--- a/test/TestGrains/ExternalTypeGrain.cs
+++ b/test/TestGrains/ExternalTypeGrain.cs
@@ -8,9 +8,6 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    /// <summary>
-    /// A simple grain that allows to set two arguments and then multiply them.
-    /// </summary>
     public class ExternalTypeGrain : Grain, IExternalTypeGrain
     {
         public Task GetAbstractModel(IEnumerable<NameObjectCollectionBase> list)

--- a/test/Tester/ExternalTypesTests.cs
+++ b/test/Tester/ExternalTypesTests.cs
@@ -8,19 +8,14 @@ using Xunit;
 
 namespace UnitTests.General
 {
-    /// <summary>
-    /// Unit tests for grains implementing generic interfaces
-    /// </summary>
     public class ExternalTypesTests : HostedTestClusterEnsureDefaultStarted
     {
-#if !NETSTANDARD_TODO
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
         public async Task ExternalTypesTest_GrainWithAbstractExternalTypeParam()
         {
             var grainWitAbstractTypeParam = GrainClient.GrainFactory.GetGrain<IExternalTypeGrain>(0);
             await grainWitAbstractTypeParam.GetAbstractModel(new List<NameObjectCollectionBase>() { new NameValueCollection() });
         }
-#endif
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
         public async Task ExternalTypesTest_GrainWithEnumExternalTypeParam()


### PR DESCRIPTION
- Load referenced assemblies.
- Use application base path, as when using .NET Core the relative path is not where the application is deployed, but it is in the probing path as expected.