### PR TITLE
Propagate exceptions during message body deserialization

### DIFF
--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -456,18 +456,31 @@ namespace Orleans.Runtime
 
         // Initializes body and header but does not take ownership of byte.
         // Caller must clean up bytes
-        public Message(List<ArraySegment<byte>> header, List<ArraySegment<byte>> body, bool deserializeBody = false)
+        public Message(List<ArraySegment<byte>> header)
         {
             var input = new BinaryTokenStreamReader(header);
             Headers = SerializationManager.DeserializeMessageHeaders(input);
-            if (deserializeBody)
-            {
-                bodyObject = DeserializeBody(body);
-            }
-            else
-            {
-                bodyBytes = body;
-            }
+        }
+
+        /// <summary>
+        /// Clears the current body and sets the serialized body contents to the provided value.
+        /// </summary>
+        /// <param name="body">The serialized body contents.</param>
+        public void SetBodyBytes(List<ArraySegment<byte>> body)
+        {
+            // Dispose of the current body.
+            this.BodyObject = null;
+
+            this.bodyBytes = body;
+        }
+
+        /// <summary>
+        /// Deserializes the provided value into this instance's <see cref="BodyObject"/>.
+        /// </summary>
+        /// <param name="body">The serialized body contents.</param>
+        public void DeserializeBodyObject(List<ArraySegment<byte>> body)
+        {
+            this.BodyObject = DeserializeBody(body);
         }
 
         public Message CreateResponseMessage()

--- a/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
@@ -12,8 +12,6 @@ using Orleans.Messaging;
 
 namespace Orleans.Runtime.Messaging
 {
-    using System.Linq.Expressions;
-
     internal class IncomingMessageAcceptor : AsynchAgent
     {
         private readonly ConcurrentObjectPool<SaeaPoolWrapper> receiveEventArgsPool = new ConcurrentObjectPool<SaeaPoolWrapper>(CreateSocketReceiveAsyncEventArgsPoolWrapper);

--- a/test/NonSiloTests/SerializerTests/MessageSerializerTests.cs
+++ b/test/NonSiloTests/SerializerTests/MessageSerializerTests.cs
@@ -77,7 +77,8 @@ namespace NonSiloTests.UnitTests.SerializerTests
             headerList.Add(new ArraySegment<byte>(header));
             var bodyList = new List<ArraySegment<byte>>();
             bodyList.Add(new ArraySegment<byte>(body));
-            var resp1 = new Message(headerList, bodyList);
+            var resp1 = new Message(headerList);
+            resp1.SetBodyBytes(bodyList);
 
             //byte[] serialized = resp.FormatForSending();
             //Message resp1 = new Message(serialized, serialized.Length);

--- a/test/TestGrainInterfaces/IExceptionGrain.cs
+++ b/test/TestGrainInterfaces/IExceptionGrain.cs
@@ -28,4 +28,13 @@ namespace UnitTests.GrainInterfaces
 
         Task ThrowsSynchronousAggregateExceptionWithMultipleInnerExceptions();
     }
+
+    public interface IMessageSerializationGrain : IGrainWithIntegerKey
+    {
+        Task<object> EchoObject(object input);
+
+        Task GetUnserializableObjectChained();
+
+        Task<string> GetSiloIdentity();
+    }
 }

--- a/test/TestGrains/MessageSerializationGrain.cs
+++ b/test/TestGrains/MessageSerializationGrain.cs
@@ -1,0 +1,88 @@
+﻿namespace UnitTests.Grains
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using Orleans;
+    using Orleans.Runtime;
+    using Orleans.Serialization;
+
+    using UnitTests.GrainInterfaces;
+    
+    public class MessageSerializationGrain : Grain, IMessageSerializationGrain
+    {
+        public Task<object> EchoObject(object input) => Task.FromResult(input);
+
+        public async Task GetUnserializableObjectChained()
+        {
+            // Find a grain on another silo.
+            IMessageSerializationGrain otherGrain;
+            var id = this.GetPrimaryKeyLong();
+            var currentSiloIdentity = await this.GetSiloIdentity();
+            while (true)
+            {
+                otherGrain = this.GrainFactory.GetGrain<IMessageSerializationGrain>(++id);
+                var otherIdentity = await otherGrain.GetSiloIdentity();
+                if (!string.Equals(otherIdentity, currentSiloIdentity))
+                {
+                    break;
+                }
+            }
+
+            // Message that grain in a way which should fail.
+            await otherGrain.EchoObject(new SimpleType(35));
+        }
+
+        public Task<string> GetSiloIdentity()
+        {
+            return Task.FromResult(this.RuntimeIdentity);
+        }
+    }
+
+    [Serializable]
+    public struct SimpleType
+    {
+        static SimpleType()
+        {
+            SerializationManager.Register(typeof(SimpleType));
+        }
+
+        public SimpleType(int num)
+        {
+            this.Number = num;
+        }
+
+        public int Number { get; }
+    }
+
+    /// <summary>
+    /// Serializer which can serialize <see cref="SimpleType"/> but cannot deserialize it.
+    /// </summary>
+    [Serializable]
+    public class OneWaySerializer : IExternalSerializer
+    {
+        public const string FailureMessage = "Can't do it, sorry.";
+
+        public void Initialize(Logger logger)
+        {
+        }
+
+        public bool IsSupportedType(Type itemType) => itemType == typeof(SimpleType);
+
+        public object DeepCopy(object source)
+        {
+            return source;
+        }
+
+        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        {
+            var typed = (SimpleType)item;
+            writer.Write(typed.Number);
+        }
+
+        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        {
+            throw new NotSupportedException(FailureMessage);
+        }
+    }
+}

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -95,6 +95,7 @@
     <Compile Include="ReminderTestGrain.cs" />
     <Compile Include="RequestContextTestGrain.cs" />
     <Compile Include="SerializationGenerationGrain.cs" />
+    <Compile Include="MessageSerializationGrain.cs" />
     <Compile Include="ServiceType.cs" />
     <Compile Include="SimpleGenericGrain.cs" />
     <Compile Include="MultipleSubscriptionConsumerGrain.cs" />

--- a/vNext/test/TestGrains/TestGrains.csproj
+++ b/vNext/test/TestGrains/TestGrains.csproj
@@ -113,6 +113,9 @@
     <Compile Include="..\..\..\test\TestGrains\ValueTypeTestGrain.cs">
       <Link>ValueTypeTestGrain.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\test\TestGrains\MessageSerializationGrain.cs">
+      <Link>MessageSerializationGrain.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>


### PR DESCRIPTION
In some cases, a message body cannot be deserialized and so the message is dropped without notifying the caller. The call will eventually fail with a timeout exception but with no indication of why that timeout occurred.

This PR propagates body deserialization exceptions back to the caller.

Instead of deserializing the body in the `Message` constructor, this PR moves the assignment of the body to a separate method. This way, the partially-deserialized message is still valid and has correctly deserialized headers, so a failure response can be constructed.
