### PR TITLE
Mark TestServioceFabric as a testing project.

### DIFF
--- a/test/TestServiceFabric/TestServiceFabric.csproj
+++ b/test/TestServiceFabric/TestServiceFabric.csproj
@@ -82,6 +82,9 @@
       <Name>TestExtensions</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Mark TestServioceFabric as a testing project.

Visual Studio [2015] on my machine keeps adding this annotation to the `TestServiceFabric.csproj` file to mark it as a project containing test cases to detect / run.

``` xml
<ItemGroup>
  <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
</ItemGroup>
```

More info about this is available in this Stack Overflow question / answer:

http://stackoverflow.com/questions/18614342/what-is-service-include-in-a-csproj-file-for
