### PR TITLE
Enable xUnit text settings in .NET Standard Tester project

### DIFF
--- a/vNext/test/Tester/Tester.csproj
+++ b/vNext/test/Tester/Tester.csproj
@@ -48,6 +48,10 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="project.json" />
+    <None Include="..\..\..\test\Tester\Tester.xunit.runner.json">
+      <Link>Tester.xunit.runner.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
This allows us to continue porting tests to the .NET Standard project.
Required for #2364, since it requires a separately configured cluster to function correctly.
