### PR TITLE
EventHubStreamProvider improvements

### DIFF
--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -149,6 +149,10 @@ namespace Orleans.Providers.Streams.Common
 
         IInternalAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> stream)
         {
+            if (queueAdapter.Direction == StreamProviderDirection.ReadOnly)
+            {
+                throw new InvalidOperationException($"Stream provider {queueAdapter.Name} is ReadOnly.");
+            }
             return new PersistentStreamProducer<T>((StreamImpl<T>)stream, providerRuntime, queueAdapter, IsRewindable);
         }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/DefaultEventHubReceiverMonitor.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/DefaultEventHubReceiverMonitor.cs
@@ -30,6 +30,15 @@ namespace Orleans.ServiceBus.Providers
         }
 
         /// <summary>
+        /// Track attempts to initialize the receiver.
+        /// </summary>
+        /// <param name="success">True if read succeeded, false if read failed.</param>
+        public void TrackInitialization(bool success)
+        {
+            logger.TrackMetric("Initialization", success ? 0 : 1, LogProperties);
+        }
+
+        /// <summary>
         /// Track attempts to read from the partition.    Tracked per partition read operation.
         /// </summary>
         /// <param name="success">True if read succeeded, false if read failed.</param>
@@ -58,6 +67,15 @@ namespace Orleans.ServiceBus.Providers
         public void TrackAgeOfMessagesRead(TimeSpan newest, TimeSpan oldest)
         {
             logger.TrackMetric("AgeOfMessagesBeingProcessed", newest, LogProperties);
+        }
+
+        /// <summary>
+        /// Track attempts to shutdown the receiver.
+        /// </summary>
+        /// <param name="success">True if read succeeded, false if read failed.</param>
+        public void TrackShutdown(bool success)
+        {
+            logger.TrackMetric("Shutdown", success ? 0 : 1, LogProperties);
         }
     }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -1,4 +1,5 @@
 ﻿
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -40,31 +41,37 @@ namespace Orleans.ServiceBus.Providers
         private const int ReceiverShutdown = 0;
         private const int ReceiverRunning = 1;
 
-        public int GetMaxAddCount() { return flowController.GetMaxAddCount(); }
+        public int GetMaxAddCount()
+        {
+            return flowController.GetMaxAddCount();
+        }
 
         public EventHubAdapterReceiver(EventHubPartitionSettings settings,
-            Func<string, IStreamQueueCheckpointer<string>, Logger,IEventHubQueueCache> cacheFactory,
+            Func<string, IStreamQueueCheckpointer<string>, Logger, IEventHubQueueCache> cacheFactory,
             Func<string, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory,
             Logger baseLogger,
-            IEventHubReceiverMonitor monitor = null)
+            IEventHubReceiverMonitor monitor)
         {
             if (settings == null) throw new ArgumentNullException(nameof(settings));
             if (cacheFactory == null) throw new ArgumentNullException(nameof(cacheFactory));
             if (checkpointerFactory == null) throw new ArgumentNullException(nameof(checkpointerFactory));
             if (baseLogger == null) throw new ArgumentNullException(nameof(baseLogger));
+            if (monitor == null) throw new ArgumentNullException(nameof(monitor));
             this.settings = settings;
             this.cacheFactory = cacheFactory;
             this.checkpointerFactory = checkpointerFactory;
             this.baseLogger = baseLogger;
             this.logger = baseLogger.GetSubLogger("receiver", "-");
-            this.monitor = monitor ?? new DefaultEventHubReceiverMonitor(settings.Hub.Path, settings.Partition, baseLogger.GetSubLogger("monitor", "-"));
+            this.monitor = monitor;
         }
 
         public Task Initialize(TimeSpan timeout)
         {
             logger.Info("Initializing EventHub partition {0}-{1}.", settings.Hub.Path, settings.Partition);
             // if receiver was already running, do nothing
-            return ReceiverRunning == Interlocked.Exchange(ref recieverState, ReceiverRunning) ? TaskDone.Done : Initialize();
+            return ReceiverRunning == Interlocked.Exchange(ref recieverState, ReceiverRunning)
+                ? TaskDone.Done
+                : Initialize();
         }
 
         /// <summary>
@@ -74,16 +81,25 @@ namespace Orleans.ServiceBus.Providers
         /// <returns></returns>
         private async Task Initialize()
         {
-            checkpointer = await checkpointerFactory(settings.Partition);
-            cache = cacheFactory(settings.Partition, checkpointer, baseLogger);
-            flowController = new AggregatedQueueFlowController(MaxMessagesPerRead) { cache };
-            string offset = await checkpointer.Load();
-            receiver = await CreateReceiver(settings, offset, logger);
+            try
+            {
+                checkpointer = await checkpointerFactory(settings.Partition);
+                cache = cacheFactory(settings.Partition, checkpointer, baseLogger);
+                flowController = new AggregatedQueueFlowController(MaxMessagesPerRead) {cache};
+                string offset = await checkpointer.Load();
+                receiver = await CreateReceiver(settings, offset, logger);
+                monitor.TrackInitialization(true);
+            }
+            catch (Exception)
+            {
+                monitor.TrackInitialization(false);
+                throw;
+            }
         }
 
         public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
         {
-            if (recieverState==ReceiverShutdown || maxCount <= 0)
+            if (recieverState == ReceiverShutdown || maxCount <= 0)
             {
                 return new List<IBatchContainer>();
             }
@@ -91,9 +107,10 @@ namespace Orleans.ServiceBus.Providers
             // if receiver initialization failed, retry
             if (receiver == null)
             {
-                logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead, "Retrying initialization of EventHub partition {0}-{1}.", settings.Hub.Path, settings.Partition);
+                logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead,
+                    "Retrying initialization of EventHub partition {0}-{1}.", settings.Hub.Path, settings.Partition);
                 await Initialize();
-                if (receiver==null)
+                if (receiver == null)
                 {
                     // should not get here, should throw instead, but just incase.
                     return new List<IBatchContainer>();
@@ -113,7 +130,8 @@ namespace Orleans.ServiceBus.Providers
             catch (Exception ex)
             {
                 monitor.TrackRead(false);
-                logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead, "Failed to read from EventHub partition {0}-{1}. : Exception: {2}.", settings.Hub.Path,
+                logger.Warn(OrleansServiceBusErrorCode.FailedPartitionRead,
+                    "Failed to read from EventHub partition {0}-{1}. : Exception: {2}.", settings.Hub.Path,
                     settings.Partition, ex);
                 throw;
             }
@@ -170,29 +188,40 @@ namespace Orleans.ServiceBus.Providers
             return TaskDone.Done;
         }
 
-        public Task Shutdown(TimeSpan timeout)
+        public async Task Shutdown(TimeSpan timeout)
         {
-            // if receiver was already shutdown, do nothing
-            if (ReceiverShutdown == Interlocked.Exchange(ref recieverState, ReceiverShutdown))
+            try
             {
-                return TaskDone.Done;
+                // if receiver was already shutdown, do nothing
+                if (ReceiverShutdown == Interlocked.Exchange(ref recieverState, ReceiverShutdown))
+                {
+                    return;
+                }
+
+                logger.Info("Stopping reading from EventHub partition {0}-{1}", settings.Hub.Path, settings.Partition);
+
+                // clear cache and receiver
+                IEventHubQueueCache localCache = Interlocked.Exchange(ref cache, null);
+                EventHubReceiver localReceiver = Interlocked.Exchange(ref receiver, null);
+                // start closing receiver
+                Task closeTask = TaskDone.Done;
+                if (localReceiver != null)
+                {
+                    closeTask = localReceiver.CloseAsync();
+                }
+                // dispose of cache
+                localCache?.Dispose();
+
+                // finish return receiver closing task
+                await closeTask;
+
+                monitor.TrackShutdown(true);
             }
-
-            logger.Info("Stopping reading from EventHub partition {0}-{1}", settings.Hub.Path, settings.Partition);
-
-            // clear cache and receiver
-            IEventHubQueueCache localCache = Interlocked.Exchange(ref cache, null);
-            EventHubReceiver localReceiver = Interlocked.Exchange(ref receiver, null);
-            // start closing receiver
-            Task closeTask = TaskDone.Done;
-            if (localReceiver != null)
+            catch (Exception)
             {
-                closeTask = localReceiver.CloseAsync();
+                monitor.TrackShutdown(false);
+                throw;
             }
-            // dispose of cache
-            localCache?.Dispose();
-            // finish return receiver closing task
-            return closeTask;
         }
 
         private static async Task<EventHubReceiver> CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, Logger logger)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -219,7 +219,7 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="timePurge"></param>
         /// <param name="logger"></param>
         public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, Logger logger)
-            : this(checkpointer, new EventHubDataAdapter(bufferPool, timePurge), logger)
+            : this(checkpointer, new EventHubDataAdapter(bufferPool, timePurge), EventHubDataComparer.Instance, logger)
         {
         }
 
@@ -228,9 +228,10 @@ namespace Orleans.ServiceBus.Providers
         /// </summary>
         /// <param name="checkpointer"></param>
         /// <param name="cacheDataAdapter"></param>
+        /// <param name="comparer"></param>
         /// <param name="logger"></param>
-        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, Logger logger)
-            : base(EventHubAdapterReceiver.MaxMessagesPerRead, checkpointer, cacheDataAdapter, EventHubDataComparer.Instance, logger)
+        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger)
+            : base(EventHubAdapterReceiver.MaxMessagesPerRead, checkpointer, cacheDataAdapter, comparer, logger)
         {
             log = logger.GetSubLogger("messagecache", "-");
         }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubReceiverMonitor.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubReceiverMonitor.cs
@@ -9,6 +9,12 @@ namespace Orleans.ServiceBus.Providers
     public interface IEventHubReceiverMonitor
     {
         /// <summary>
+        /// Track attempts to initialize the receiver.
+        /// </summary>
+        /// <param name="success">True if read succeeded, false if read failed.</param>
+        void TrackInitialization(bool success);
+
+        /// <summary>
         /// Track attempts to read from the partition.    Tracked per partition read operation.
         /// </summary>
         /// <param name="success">True if read succeeded, false if read failed.</param>
@@ -26,5 +32,11 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="oldest">The difference between now utc on host and the eventhub enqueue time of the oldest message in a set of messages read.</param>
         /// <param name="newest">The difference between now utc on host and the eventhub enqueue time of the newest message in a set of messages read.</param>
         void TrackAgeOfMessagesRead(TimeSpan oldest, TimeSpan newest);
+
+        /// <summary>
+        /// Track attempts to shutdown the receiver.
+        /// </summary>
+        /// <param name="success">True if read succeeded, false if read failed.</param>
+        void TrackShutdown(bool success);
     }
 }

--- a/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/EventHub/StreamPerPartitionEventHubStreamProvider.cs
@@ -28,7 +28,7 @@ namespace Tester.TestStreamProviders.EventHub
                 }
                 var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterSettings.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
                 var dataAdapter = new CachedDataAdapter(partition, bufferPool, timePurgePredicate);
-                return new EventHubQueueCache(checkpointer, dataAdapter, log);
+                return new EventHubQueueCache(checkpointer, dataAdapter, EventHubDataComparer.Instance, log);
             }
         }
 


### PR DESCRIPTION
* Block writes on readonly stream providers.
* Support monitoring of initialization and shutdown of EventHub stream provider receivers.
* Support customization of EventHub stream provider direction.
* Fix incomplete EventHubStreamProvider receiver monitoring. User could not specify custom monitoring.
* Support custom data comparer in EventHubStreamProvider cache.