### PR TITLE
Check IAddressable before DeepCopy

### DIFF
--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -705,15 +705,18 @@ namespace Orleans.CodeGenerator
                     return getValueExpression;
                 }
 
-                ExpressionSyntax deepCopyValueExpression;
-
                 // Addressable arguments must be converted to references before passing.
+                ExpressionSyntax deepCopyValueExpression;
                 if (typeof(IAddressable).IsAssignableFrom(this.FieldInfo.FieldType)
                     && this.FieldInfo.FieldType.GetTypeInfo().IsInterface)
                 {
                     var getAsReference = getValueExpression.Member(
                         (IAddressable grain) => grain.AsReference<IGrain>(),
                         this.FieldInfo.FieldType);
+
+                    // If the value is a Grain at runtime, convert it to a strongly-typed GrainReference
+                    // using value.AsReference<TInterface>().
+                    // C#: value is Grain ? value.AsReference<TInterface>() : value;
                     deepCopyValueExpression =
                         SF.ConditionalExpression(
                             SF.BinaryExpression(

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -711,10 +711,16 @@ namespace Orleans.CodeGenerator
                 if (typeof(IAddressable).IsAssignableFrom(this.FieldInfo.FieldType)
                     && this.FieldInfo.FieldType.GetTypeInfo().IsInterface)
                 {
+                    var getAsReference = getValueExpression.Member(
+                        (IAddressable grain) => grain.AsReference<IGrain>(),
+                        this.FieldInfo.FieldType);
                     deepCopyValueExpression =
                         SF.ConditionalExpression(
-                            SF.BinaryExpression(SyntaxKind.IsExpression, getValueExpression, typeof(Grain).GetTypeSyntax()),
-                            SF.InvocationExpression(getValueExpression.Member("AsReference", this.FieldInfo.FieldType)),
+                            SF.BinaryExpression(
+                                SyntaxKind.IsExpression,
+                                getValueExpression,
+                                typeof(Grain).GetTypeSyntax()),
+                            SF.InvocationExpression(getAsReference),
                             getValueExpression);
                 }
                 else

--- a/test/TestGrainInterfaces/IChainedGrain.cs
+++ b/test/TestGrainInterfaces/IChainedGrain.cs
@@ -11,8 +11,15 @@ namespace UnitTests.GrainInterfaces
         //[ReadOnly]
         Task<int> GetCalculatedValue();
         Task SetNext(IChainedGrain next);
+        Task SetNextNested(ChainGrainHolder next);
         //[ReadOnly]
         Task Validate(bool nextIsSet);
         Task PassThis(IChainedGrain next);
+        Task PassThisNested(ChainGrainHolder next);
+    }
+    
+    public class ChainGrainHolder
+    {
+        public IChainedGrain Next { get; set; }
     }
 }

--- a/test/TestGrains/ChainedGrain.cs
+++ b/test/TestGrains/ChainedGrain.cs
@@ -61,6 +61,11 @@ namespace UnitTests.Grains
             return TaskDone.Done;
         }
 
+        public Task SetNextNested(ChainGrainHolder next)
+        {
+            State.Next = next.Next;
+            return TaskDone.Done;
+        }
 
         public Task Validate(bool nextIsSet)
         {
@@ -78,6 +83,11 @@ namespace UnitTests.Grains
         public Task PassThis(IChainedGrain next)
         {
             return next.SetNext(this);
+        }
+
+        public Task PassThisNested(ChainGrainHolder next)
+        {
+            return next.Next.SetNextNested(new ChainGrainHolder { Next = this });
         }
 
         #endregion

--- a/test/TesterInternal/GrainReferenceTest.cs
+++ b/test/TesterInternal/GrainReferenceTest.cs
@@ -48,6 +48,15 @@ namespace UnitTests.General
             g1.PassThis(g2).Wait();
         }
 
+        [Fact, TestCategory("Functional"), TestCategory("GrainReference")]
+        public void GrainReference_Pass_this_Nested()
+        {
+            IChainedGrain g1 = GrainClient.GrainFactory.GetGrain<IChainedGrain>(GetRandomGrainId());
+            IChainedGrain g2 = GrainClient.GrainFactory.GetGrain<IChainedGrain>(GetRandomGrainId());
+
+            g1.PassThisNested(new ChainGrainHolder { Next = g2 }).Wait();
+        }
+
         [Fact, TestCategory("Functional"), TestCategory("Serialization"), TestCategory("GrainReference")]
         public void GrainReference_DotNet_Serialization()
         {


### PR DESCRIPTION
Modified CodeGenerator to check if the item being DeepCopied is an IAddressable before DeepCopying, converting to IGrainReference if so.

Details provided in https://github.com/dotnet/orleans/issues/2382