### PR TITLE
Removes deadlocking and corrupted hashing

### DIFF
--- a/src/OrleansSQLUtils/Storage/Provider/AdoGrainKey.cs
+++ b/src/OrleansSQLUtils/Storage/Provider/AdoGrainKey.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text;
 
 
@@ -100,7 +101,7 @@ namespace Orleans.Storage
             string keyExtension = null;
             if(IsLongKey)
             {
-                primaryKey = N1Key.ToString();
+                primaryKey = N1Key.ToString(CultureInfo.InvariantCulture);
                 keyExtension = StringKey;
             }
             else if(IsGuidKey)
@@ -114,7 +115,7 @@ namespace Orleans.Storage
             }
 
             const string GrainIdAndExtensionSeparator = "#";
-            return primaryKey + string.Format($"{primaryKey}{(keyExtension != null ? GrainIdAndExtensionSeparator + keyExtension : string.Empty)}");
+            return string.Format($"{primaryKey}{(keyExtension != null ? GrainIdAndExtensionSeparator + keyExtension : string.Empty)}");
         }
 
 

--- a/src/OrleansSQLUtils/Storage/Provider/AdoNetStorageProvider.cs
+++ b/src/OrleansSQLUtils/Storage/Provider/AdoNetStorageProvider.cs
@@ -227,12 +227,14 @@ namespace Orleans.Storage
             string storageVersion = null;
             try
             {
+                var grainIdHash = HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(grainId.GetHashBytes());
+                var grainTypeHash = HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(Encoding.UTF8.GetBytes(baseGrainType));
                 var clearRecord = (await Storage.ReadAsync(CurrentOperationalQueries.ClearState, command =>
                 {
-                    command.AddParameter("GrainIdHash", HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(grainId.GetHashBytes()));
+                    command.AddParameter("GrainIdHash", grainIdHash);
                     command.AddParameter("GrainIdN0", grainId.N0Key);
                     command.AddParameter("GrainIdN1", grainId.N1Key);
-                    command.AddParameter("GrainTypeHash", HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(Encoding.UTF8.GetBytes(baseGrainType)));
+                    command.AddParameter("GrainTypeHash", grainTypeHash);
                     command.AddParameter("GrainTypeString", baseGrainType);
                     command.AddParameter("GrainIdExtensionString", grainId.StringKey);
                     command.AddParameter("ServiceId", ServiceId);
@@ -287,12 +289,14 @@ namespace Orleans.Storage
 
                 var commandBehavior = choice.PreferStreaming ? CommandBehavior.SequentialAccess : CommandBehavior.Default;
                 var grainStateType = grainState.State.GetType();
+                var grainIdHash = HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(grainId.GetHashBytes());
+                var grainTypeHash = HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(Encoding.UTF8.GetBytes(baseGrainType));
                 var readRecords = (await Storage.ReadAsync(CurrentOperationalQueries.ReadFromStorage, (command =>
                 {
-                    command.AddParameter("GrainIdHash", HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(grainId.GetHashBytes()));
+                    command.AddParameter("GrainIdHash", grainIdHash);
                     command.AddParameter("GrainIdN0", grainId.N0Key);
                     command.AddParameter("GrainIdN1", grainId.N1Key);
-                    command.AddParameter("GrainTypeHash", HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(Encoding.UTF8.GetBytes(baseGrainType)));
+                    command.AddParameter("GrainTypeHash", grainTypeHash);
                     command.AddParameter("GrainTypeString", baseGrainType);
                     command.AddParameter("GrainIdExtensionString", grainId.StringKey);
                     command.AddParameter("ServiceId", ServiceId);
@@ -402,19 +406,20 @@ namespace Orleans.Storage
             string storageVersion = null;
             try
             {
-
+                var grainIdHash = HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(grainId.GetHashBytes());
+                var grainTypeHash = HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(Encoding.UTF8.GetBytes(baseGrainType));
                 var writeRecord = await Storage.ReadAsync(CurrentOperationalQueries.WriteToStorage, command =>
                 {
-                    command.AddParameter("GrainIdHash", HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(grainId.GetHashBytes()));
+                    command.AddParameter("GrainIdHash", grainIdHash);
                     command.AddParameter("GrainIdN0", grainId.N0Key);
                     command.AddParameter("GrainIdN1", grainId.N1Key);
-                    command.AddParameter("GrainTypeHash", HashPicker.PickHasher(ServiceId, Name, baseGrainType, grainReference, grainState).Hash(Encoding.UTF8.GetBytes(baseGrainType)));
-                    command.AddParameter("GrainTypeString", (string)baseGrainType);
+                    command.AddParameter("GrainTypeHash", grainTypeHash);
+                    command.AddParameter("GrainTypeString", baseGrainType);
                     command.AddParameter("GrainIdExtensionString", grainId.StringKey);
                     command.AddParameter("ServiceId", ServiceId);
                     command.AddParameter("GrainStateVersion", !string.IsNullOrWhiteSpace(grainState.ETag) ? int.Parse(grainState.ETag, CultureInfo.InvariantCulture) : default(int?));
 
-                    SerializationChoice serializer = StorageSerializationPicker.PickSerializer(ServiceId, Name, (string)baseGrainType, grainReference, grainState);
+                    SerializationChoice serializer = StorageSerializationPicker.PickSerializer(ServiceId, Name, baseGrainType, grainReference, grainState);
                     command.AddParameter("PayloadBinary", (byte[])(serializer.Serializer.Tag == UseBinaryFormatPropertyName ? serializer.Serializer.Serialize(data) : null));
                     command.AddParameter("PayloadJson", (string)(serializer.Serializer.Tag == UseJsonFormatPropertyName ? serializer.Serializer.Serialize(data) : null));
                     command.AddParameter("PayloadXml", (string)(serializer.Serializer.Tag == UseXmlFormatPropertyName ? serializer.Serializer.Serialize(data) : null));

--- a/src/OrleansSQLUtils/Storage/Provider/IStorageHashPicker.cs
+++ b/src/OrleansSQLUtils/Storage/Provider/IStorageHashPicker.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 namespace Orleans.Storage
 {
     /// <summary>
-    /// A picker to choose from provided hash functions.
+    /// A picker to choose from provided hash functions. Provides agility to update or change hashing functionality for both built-in and custom operations.
     /// </summary>
-    /// <remarks>Provider agility to update or change hashing functionality for both built-in and custom operations.</remarks>
+    /// <remarks>The returned hash needs to be thread safe or a unique instance.</remarks>
     public interface IStorageHasherPicker
     {
         /// <summary>

--- a/src/OrleansSQLUtils/Storage/Provider/OrleansDefaultHasher.cs
+++ b/src/OrleansSQLUtils/Storage/Provider/OrleansDefaultHasher.cs
@@ -1,7 +1,4 @@
-﻿using Orleans;
-
-
-namespace Orleans.Storage
+﻿namespace Orleans.Storage
 {
     /// <summary>
     /// A default implementation uses the same hash as Orleans in grains placement.

--- a/test/TesterInternal/StorageTests/AWSUtils/DynamoDBStorageProviderTests.cs
+++ b/test/TesterInternal/StorageTests/AWSUtils/DynamoDBStorageProviderTests.cs
@@ -46,7 +46,7 @@ namespace UnitTests.StorageTests.AWSUtils
         [SkippableFact, TestCategory("Functional")]
         internal async Task WriteRead100StatesInParallel()
         {
-            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteRead100StatesInParallel();
+            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel();
         }
     }
 }

--- a/test/TesterInternal/StorageTests/Relational/AdotNetProviderFunctionalityTests.cs
+++ b/test/TesterInternal/StorageTests/Relational/AdotNetProviderFunctionalityTests.cs
@@ -1,0 +1,86 @@
+﻿using Orleans;
+using Orleans.Storage;
+using System;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+
+namespace UnitTests.StorageTests.Relational
+{
+    /// <summary>
+    /// Tests for various helper classes.
+    /// </summary>
+    public class AdotNetProviderFunctionalityTests
+    {
+        [TestCategory("Functional"), TestCategory("Persistence")]
+        [Fact]
+        public void AdoNetStorageProviderGrainTypeHashing()
+        {
+            //This way of using the hasher is like ADO.NET Storage provider would use it. This tests
+            //the hasher is thread safe.
+            var adonetDefaultHasher = new StorageHasherPicker(new[] { new OrleansDefaultHasher() }); ;
+            const int TestGrainHash = 1491221312;
+            var grainType = "Grains.PersonGrain";
+            Parallel.For(0, 1000000, i =>
+            {
+                //These parameters can be null in this test.
+                int grainTypeHash = adonetDefaultHasher.PickHasher(null, null, null, null, null, null).Hash(Encoding.UTF8.GetBytes(grainType));
+                Assert.Equal(TestGrainHash, grainTypeHash);
+            });
+        }
+
+
+
+        [TestCategory("Functional"), TestCategory("Persistence")]
+        [Fact]
+        public void LongGrainIdToN1KeyAreSame()
+        {
+            const long LongGrainId = 1001;
+            var longGrainIdAsN1 = new AdoGrainKey(LongGrainId, null);
+
+            Assert.Equal(longGrainIdAsN1.N1Key, LongGrainId);
+        }
+
+
+        [TestCategory("Functional"), TestCategory("Persistence")]
+        [Fact]
+        public void LongGrainIdToStringAreSame()
+        {
+            const long LongGrainId = 1001;
+            var longGrainIdAsString = new AdoGrainKey(LongGrainId, null).ToString();
+
+            Assert.Equal(longGrainIdAsString, LongGrainId.ToString(CultureInfo.InvariantCulture));
+        }
+
+
+        [TestCategory("Functional"), TestCategory("Persistence")]
+        [Fact]
+        public void LongGrainIdWithExtensionAreSame()
+        {
+            const long LongGrainId = 1001;
+            const string ExtensionKey = "ExtensionKey";
+            var longGrainIdWitExtensionAsString = new AdoGrainKey(LongGrainId, ExtensionKey).ToString();
+
+            //AdoGrainKey helper class splits the grain key and extension key using character '#'.
+            //The key and its extension are the two distinct elements.
+            var grainKeys = longGrainIdWitExtensionAsString.Split(new[] { "#" }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(2, grainKeys.Length);
+
+            Assert.Equal(grainKeys[0], LongGrainId.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal(grainKeys[1], ExtensionKey);
+        }
+
+
+        [TestCategory("Functional"), TestCategory("Persistence")]
+        [Fact]
+        public void GuidGrainIdWithExtensionAreSame()
+        {
+            Guid guidId = Guid.Parse("751D8030-9C84-4A91-816E-E95F64CE7588");
+            var guidIdAsString = new AdoGrainKey(guidId, null).ToString();
+
+            Assert.Equal(guidIdAsString, guidId.ToString());
+        }
+    }
+}

--- a/test/TesterInternal/StorageTests/Relational/MySqlStorageTests.cs
+++ b/test/TesterInternal/StorageTests/Relational/MySqlStorageTests.cs
@@ -15,6 +15,7 @@ namespace UnitTests.StorageTests.Relational
     /// <remarks>To duplicate these tests to any back-end, not just for relational, copy and paste this class,
     /// optionally remove <see cref="RelationalStorageTests"/> inheritance and implement a provider and environment
     /// setup as done in <see cref="CommonFixture"/> and how it delegates it.</remarks>
+    [TestCategory("MySql")]
     public class MySqlStorageTests: RelationalStorageTests, IDisposable, IClassFixture<CommonFixture>
     {
         /// <summary>
@@ -22,16 +23,11 @@ namespace UnitTests.StorageTests.Relational
         /// </summary>
         private const string AdoNetInvariant = AdoNetInvariants.InvariantNameMySql;
 
-        /// <summary>
-        /// The category of this back-end vendor.
-        /// </summary>
-        public const string VendorCategory = "MySql";
-
 
         public MySqlStorageTests(CommonFixture commonFixture) : base(AdoNetInvariant, commonFixture)
         {
             //XUnit.NET will automatically call this constructor before every test method run.
-            Skip.If(PersistenceStorageTests == null, $"Persistence storage not available for {VendorCategory}.");
+            Skip.If(PersistenceStorageTests == null, $"Persistence storage not available for MySql.");
         }
 
 
@@ -41,7 +37,7 @@ namespace UnitTests.StorageTests.Relational
         }
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task WriteReadCyrillic()
         {
             await PersistenceStorageTests.PersistenceStorage_Relational_WriteReadIdCyrillic();
@@ -49,14 +45,14 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task WriteRead100StatesInParallel()
         {
             await Relational_WriteReadWriteRead100StatesInParallel();
         }
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_HashCollisionTests()
         {
             await Relational_HashCollisionTests();
@@ -64,7 +60,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task ChangeStorageFormatFromBinaryToJson_WriteRead(string grainType, GrainReference grainReference, GrainState<TestState1> grainState)
         {
             await Relational_ChangeStorageFormatFromBinaryToJsonInMemory_WriteRead(grainType, grainReference, grainState);
@@ -72,7 +68,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException()
         {
             await Relational_WriteDuplicateFailsWithInconsistentStateException();
@@ -80,7 +76,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task WriteInconsistentFailsWithIncosistentStateException()
         {
             await Relational_WriteInconsistentFailsWithIncosistentStateException();
@@ -88,7 +84,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task PersistenceStorage_StorageDataSetPlain_IntegerKey_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestState1> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -96,7 +92,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<Guid>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetPlain_GuidKey_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestState1> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -104,7 +100,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetPlain_StringKey_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestState1> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -112,7 +108,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSet2CyrillicIdsAndGrainNames<string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task DataSet2_Cyrillic_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -120,7 +116,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<long, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_IntegerKey_Generic_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -128,7 +124,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<Guid, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_GuidKey_Generic_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -136,7 +132,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_StringKey_Generic_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -144,7 +140,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MySql")]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_Json_WriteRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await Relational_Json_WriteRead(grainType, grainReference, grainState);
@@ -152,7 +148,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGenericHuge<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MySql")]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGenericHuge_Json_WriteReadStreaming(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await Relational_Json_WriteReadStreaming(grainType, grainReference, grainState);
@@ -160,7 +156,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_Xml_WriteRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await Relational_Xml_WriteRead(grainType, grainReference, grainState);
@@ -168,7 +164,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGenericHuge<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGenericHuge_Xml_WriteReadStreaming(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await Relational_Xml_WriteReadStreaming(grainType, grainReference, grainState);

--- a/test/TesterInternal/StorageTests/Relational/RelationalStorageTests.cs
+++ b/test/TesterInternal/StorageTests/Relational/RelationalStorageTests.cs
@@ -64,14 +64,14 @@ namespace UnitTests.StorageTests.Relational
 
         internal async Task Relational_WriteReadWriteRead100StatesInParallel()
         {
-            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteRead100StatesInParallel(nameof(Relational_WriteReadWriteRead100StatesInParallel));
+            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel(nameof(Relational_WriteReadWriteRead100StatesInParallel));
         }
 
 
         internal async Task Relational_HashCollisionTests()
         {
             ((AdoNetStorageProvider)PersistenceStorageTests.Storage).HashPicker = ConstantHasher;
-            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteRead100StatesInParallel(nameof(Relational_HashCollisionTests));
+            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel(nameof(Relational_HashCollisionTests), 2);
         }
 
 

--- a/test/TesterInternal/StorageTests/Relational/SqlServerStorageTests.cs
+++ b/test/TesterInternal/StorageTests/Relational/SqlServerStorageTests.cs
@@ -19,6 +19,7 @@ namespace UnitTests.StorageTests.Relational
     /// <remarks>To duplicate these tests to any back-end, not just for relational, copy and paste this class,
     /// optionally remove <see cref="RelationalStorageTests"/> inheritance and implement a provider and environment
     /// setup as done in <see cref="CommonFixture"/> and how it delegates it.</remarks>
+    [TestCategory("SqlServer")]
     public class SqlServerStorageTests: RelationalStorageTests, IDisposable, IClassFixture<CommonFixture>
     {
         /// <summary>
@@ -26,16 +27,11 @@ namespace UnitTests.StorageTests.Relational
         /// </summary>
         private const string AdoNetInvariant = AdoNetInvariants.InvariantNameSqlServer;
 
-        /// <summary>
-        /// The category of this back-end vendor.
-        /// </summary>
-        public const string VendorCategory = "SqlServer";
-
 
         public SqlServerStorageTests(CommonFixture commonFixture) : base(AdoNetInvariant, commonFixture)
         {
             //XUnit.NET will automatically call this constructor before every test method run.
-            Skip.If(PersistenceStorageTests == null, $"Persistence storage not available for {VendorCategory}.");
+            Skip.If(PersistenceStorageTests == null, $"Persistence storage not available for SqlServer.");
         }
 
 
@@ -45,7 +41,7 @@ namespace UnitTests.StorageTests.Relational
         }
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task WriteReadCyrillic()
         {
             await PersistenceStorageTests.PersistenceStorage_Relational_WriteReadIdCyrillic();
@@ -53,14 +49,14 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task WriteReadWriteRead100StatesInParallel()
         {
             await Relational_WriteReadWriteRead100StatesInParallel();
         }
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_HashCollisionTests()
         {
             await Relational_HashCollisionTests();
@@ -68,7 +64,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task ChangeStorageFormatFromBinaryToJson_WriteRead(string grainType, GrainReference grainReference, GrainState<TestState1> grainState)
         {
             await Relational_ChangeStorageFormatFromBinaryToJsonInMemory_WriteRead(grainType, grainReference, grainState);
@@ -76,7 +72,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task WriteDuplicateFailsWithInconsistentStateException()
         {
             await Relational_WriteDuplicateFailsWithInconsistentStateException();
@@ -84,7 +80,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task WriteInconsistentFailsWithIncosistentStateException()
         {
             await Relational_WriteInconsistentFailsWithIncosistentStateException();
@@ -92,7 +88,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetPlain_IntegerKey_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestState1> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -100,7 +96,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<Guid>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetPlain_GuidKey_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestState1> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -108,7 +104,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task PersistenceStorage_StorageDataSetPlain_StringKey_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestState1> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -116,7 +112,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSet2CyrillicIdsAndGrainNames<string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task DataSet2_Cyrillic_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -124,7 +120,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<long, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_IntegerKey_Generic_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -132,7 +128,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<Guid, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_GuidKey_Generic_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -140,7 +136,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_StringKey_Generic_WriteClearRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await PersistenceStorageTests.Store_WriteClearRead(grainType, grainReference, grainState);
@@ -148,7 +144,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MySql")]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_Json_WriteRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await Relational_Json_WriteRead(grainType, grainReference, grainState);
@@ -156,7 +152,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGenericHuge<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MySql")]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGenericHuge_Json_WriteReadStreaming(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await Relational_Json_WriteReadStreaming(grainType, grainReference, grainState);
@@ -164,7 +160,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGeneric_Xml_WriteRead(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await Relational_Xml_WriteRead(grainType, grainReference, grainState);
@@ -172,7 +168,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGenericHuge<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence"), TestCategory(VendorCategory)]
+        [TestCategory("Functional"), TestCategory("Persistence")]
         internal async Task StorageDataSetGenericHuge_Xml_WriteReadStreaming(string grainType, GrainReference grainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await Relational_Xml_WriteReadStreaming(grainType, grainReference, grainState);

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -67,6 +67,7 @@
     <Compile Include="StorageTests\AWSUtils\DynamoDBStorageTests.cs" />
     <Compile Include="StorageTests\AWSUtils\PersistenceGrainTests_AWSDynamoDBStore.cs" />
     <Compile Include="StorageTests\AWSUtils\UnitTestDynamoDBStorage.cs" />
+    <Compile Include="StorageTests\Relational\AdotNetProviderFunctionalityTests.cs" />
     <Compile Include="StorageTests\Relational\StreamingTestRelationalStoragePicker.cs" />
     <Compile Include="StorageTests\Relational\TestDataSets\StorageDateSetGenericHuge.cs" />
     <Compile Include="StreamingTests\PubSubRendezvousGrainTests.cs" />


### PR DESCRIPTION
* Removes deadlocking on rapid insert of initial
grain states by rearranging locking functionality.

* Removes a problem that was mainly seen in highly
concurrent grain state hashing where the hash of
the state grain type was corrupted in some minor ratio.
This basically led some grain states to be unretrievable.

* Adds a directive to prohibit lock escalation. This could
become a problem if the Storage table gets large and concurrent
operations exceed the threshold (5000) locks in which case
SQL Server reacts by tacking a table lock for operations. On
a large table this would be very problematic.

* Minor clean up on logging where the grain ID was logged twice
concatenated and testing where "MySQL" was applied to SQL Server tests
and some tests added to ensure some helper classes function as
intended.

Fixes #2393.