### PR TITLE
GrainReferenceGenerator should not call .AsReference<T>() where T is a class

### DIFF
--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -262,7 +262,7 @@ namespace Orleans.CodeGenerator
 
             // Addressable arguments must be converted to references before passing.
             if (typeof(IAddressable).IsAssignableFrom(arg.ParameterType)
-                && (typeof(Grain).IsAssignableFrom(arg.ParameterType) || arg.ParameterType.GetTypeInfo().IsInterface))
+                && arg.ParameterType.GetTypeInfo().IsInterface)
             {
                 return
                     SF.ConditionalExpression(


### PR DESCRIPTION
Low pri.
Response to [a comment](https://github.com/dotnet/orleans/pull/2383/files#r86830788) on #2383.

Fixes a corner case: we do not support concrete `Grain` classes as the static type of a grain method parameter. We current attempt to cast grain instances to grain class types.

This fixes that. It does not add any new functionality, but the runtime error will now say "Cannot pass a grain object ...." instead of ~"Cannot find generated GrainReference class for interface '<your grain class type here>'".