### PR TITLE
ActivationCountPlacementDirector: allow null DeploymentLoadPublisher

### DIFF
--- a/src/OrleansRuntime/Placement/ActivationCountPlacementDirector.cs
+++ b/src/OrleansRuntime/Placement/ActivationCountPlacementDirector.cs
@@ -52,7 +52,6 @@ namespace Orleans.Runtime.Placement
                     "GlobalConfig.ActivationCountBasedPlacementChooseOutOf is " + globalConfig.ActivationCountBasedPlacementChooseOutOf);
 
             chooseHowMany = globalConfig.ActivationCountBasedPlacementChooseOutOf;
-            deploymentLoadPublisher = deploymentLoadPublisher;
             deploymentLoadPublisher?.SubscribeToStatisticsChangeEvents(this);
         }
 

--- a/src/OrleansRuntime/Placement/ActivationCountPlacementDirector.cs
+++ b/src/OrleansRuntime/Placement/ActivationCountPlacementDirector.cs
@@ -10,8 +10,6 @@ namespace Orleans.Runtime.Placement
 {
     internal class ActivationCountPlacementDirector : RandomPlacementDirector, ISiloStatisticsChangeListener, IPlacementDirector<ActivationCountBasedPlacement>
     {
-        private readonly DeploymentLoadPublisher deploymentLoadPublisher;
-
         private class CachedLocalStat
         {
             public SiloAddress Address { get; private set; }
@@ -54,8 +52,8 @@ namespace Orleans.Runtime.Placement
                     "GlobalConfig.ActivationCountBasedPlacementChooseOutOf is " + globalConfig.ActivationCountBasedPlacementChooseOutOf);
 
             chooseHowMany = globalConfig.ActivationCountBasedPlacementChooseOutOf;
-            this.deploymentLoadPublisher = deploymentLoadPublisher;
-            this.deploymentLoadPublisher.SubscribeToStatisticsChangeEvents(this);
+            deploymentLoadPublisher = deploymentLoadPublisher;
+            deploymentLoadPublisher?.SubscribeToStatisticsChangeEvents(this);
         }
 
         private static bool IsSiloOverloaded(SiloRuntimeStatistics stats)


### PR DESCRIPTION
Small tweak to simplify usage of `ActivationCountPlacementDirector` in our internal load tests