### PR TITLE
Azurequeueprovider messagevisibilityconfig

### DIFF
--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapter.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapter.cs
@@ -11,6 +11,7 @@ namespace Orleans.Providers.Streams.AzureQueue
     {
         protected readonly string DeploymentId;
         protected readonly string DataConnectionString;
+        protected readonly TimeSpan? VisibilityTimeout;
         private readonly HashRingBasedStreamQueueMapper streamQueueMapper;
         protected readonly ConcurrentDictionary<QueueId, AzureQueueDataManager> Queues = new ConcurrentDictionary<QueueId, AzureQueueDataManager>();
 
@@ -19,7 +20,7 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         public StreamProviderDirection Direction { get { return StreamProviderDirection.ReadWrite; } }
 
-        public AzureQueueAdapter(HashRingBasedStreamQueueMapper streamQueueMapper, string dataConnectionString, string deploymentId, string providerName)
+        public AzureQueueAdapter(HashRingBasedStreamQueueMapper streamQueueMapper, string dataConnectionString, string deploymentId, string providerName, TimeSpan? messageVisibilityTimeout = null)
         {
             if (String.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
             if (String.IsNullOrEmpty(deploymentId)) throw new ArgumentNullException("deploymentId");
@@ -27,25 +28,26 @@ namespace Orleans.Providers.Streams.AzureQueue
             DataConnectionString = dataConnectionString;
             DeploymentId = deploymentId;
             Name = providerName;
+            VisibilityTimeout = messageVisibilityTimeout;
             this.streamQueueMapper = streamQueueMapper;
         }
 
         public IQueueAdapterReceiver CreateReceiver(QueueId queueId)
         {
-            return AzureQueueAdapterReceiver.Create(queueId, DataConnectionString, DeploymentId);
+            return AzureQueueAdapterReceiver.Create(queueId, DataConnectionString, DeploymentId, VisibilityTimeout);
         }
 
         public async Task QueueMessageBatchAsync<T>(Guid streamGuid, String streamNamespace, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext)
         {
             if(token != null)
             {
-                throw new ArgumentException("AzureQueue stream provider currebtly does not support non-null StreamSequenceToken.", "token");
+                throw new ArgumentException("AzureQueue stream provider currently does not support non-null StreamSequenceToken.", "token");
             }
             var queueId = streamQueueMapper.GetQueueForStream(streamGuid, streamNamespace);
             AzureQueueDataManager queue;
             if (!Queues.TryGetValue(queueId, out queue))
             {
-                var tmpQueue = new AzureQueueDataManager(queueId.ToString(), DeploymentId, DataConnectionString);
+                var tmpQueue = new AzureQueueDataManager(queueId.ToString(), DeploymentId, DataConnectionString, VisibilityTimeout);
                 await tmpQueue.InitQueueAsync();
                 queue = Queues.GetOrAdd(queueId, tmpQueue);
             }

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapter.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapter.cs
@@ -11,7 +11,7 @@ namespace Orleans.Providers.Streams.AzureQueue
     {
         protected readonly string DeploymentId;
         protected readonly string DataConnectionString;
-        protected readonly TimeSpan? VisibilityTimeout;
+        protected readonly TimeSpan? MessageVisibilityTimeout;
         private readonly HashRingBasedStreamQueueMapper streamQueueMapper;
         protected readonly ConcurrentDictionary<QueueId, AzureQueueDataManager> Queues = new ConcurrentDictionary<QueueId, AzureQueueDataManager>();
 
@@ -28,13 +28,13 @@ namespace Orleans.Providers.Streams.AzureQueue
             DataConnectionString = dataConnectionString;
             DeploymentId = deploymentId;
             Name = providerName;
-            VisibilityTimeout = messageVisibilityTimeout;
+            MessageVisibilityTimeout = messageVisibilityTimeout;
             this.streamQueueMapper = streamQueueMapper;
         }
 
         public IQueueAdapterReceiver CreateReceiver(QueueId queueId)
         {
-            return AzureQueueAdapterReceiver.Create(queueId, DataConnectionString, DeploymentId, VisibilityTimeout);
+            return AzureQueueAdapterReceiver.Create(queueId, DataConnectionString, DeploymentId, MessageVisibilityTimeout);
         }
 
         public async Task QueueMessageBatchAsync<T>(Guid streamGuid, String streamNamespace, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext)
@@ -47,7 +47,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             AzureQueueDataManager queue;
             if (!Queues.TryGetValue(queueId, out queue))
             {
-                var tmpQueue = new AzureQueueDataManager(queueId.ToString(), DeploymentId, DataConnectionString, VisibilityTimeout);
+                var tmpQueue = new AzureQueueDataManager(queueId.ToString(), DeploymentId, DataConnectionString, MessageVisibilityTimeout);
                 await tmpQueue.InitQueueAsync();
                 queue = Queues.GetOrAdd(queueId, tmpQueue);
             }

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -21,7 +21,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         private string providerName;
         private int cacheSize;
         private int numQueues;
-        private TimeSpan? visibilityTimeout;
+        private TimeSpan? messageVisibilityTimeout;
         private HashRingBasedStreamQueueMapper streamQueueMapper;
         private IQueueAdapterCache adapterCache;
 
@@ -29,8 +29,8 @@ namespace Orleans.Providers.Streams.AzureQueue
         public const string DataConnectionStringPropertyName = "DataConnectionString";
         /// <summary>"DeploymentId".</summary>
         public const string DeploymentIdPropertyName = "DeploymentId";
-        /// <summary>"VisibilityTimeout".</summary>
-        public const string VisibilityTimeoutPropertyName = "VisibilityTimeout";
+        /// <summary>"MessageVisibilityTimeout".</summary>
+        public const string MessageVisibilityTimeoutPropertyName = "VisibilityTimeout";
 
         /// <summary>
         /// Application level failure handler override.
@@ -45,21 +45,21 @@ namespace Orleans.Providers.Streams.AzureQueue
                 throw new ArgumentException(String.Format("{0} property not set", DataConnectionStringPropertyName));
             if (!config.Properties.TryGetValue(DeploymentIdPropertyName, out deploymentId))
                 throw new ArgumentException(String.Format("{0} property not set", DeploymentIdPropertyName));
-            string queueMessageVisibilityTimeoutRaw;
-            if (config.Properties.TryGetValue(VisibilityTimeoutPropertyName, out queueMessageVisibilityTimeoutRaw))
+            string messageVisibilityTimeoutRaw;
+            if (config.Properties.TryGetValue(MessageVisibilityTimeoutPropertyName, out messageVisibilityTimeoutRaw))
             {
-                TimeSpan visibilityTimeoutTemp;
-                if (!TimeSpan.TryParse(queueMessageVisibilityTimeoutRaw, out visibilityTimeoutTemp))
+                TimeSpan messageVisibilityTimeoutTemp;
+                if (!TimeSpan.TryParse(messageVisibilityTimeoutRaw, out messageVisibilityTimeoutTemp))
                 {
                     throw new ArgumentException(String.Format("Failed to parse {0} value '{1}' as a TimeSpan",
-                        VisibilityTimeoutPropertyName, queueMessageVisibilityTimeoutRaw));
+                        MessageVisibilityTimeoutPropertyName, messageVisibilityTimeoutRaw));
                 }
 
-                visibilityTimeout = visibilityTimeoutTemp;
+                messageVisibilityTimeout = messageVisibilityTimeoutTemp;
             }
             else
             {
-                visibilityTimeout = null;
+                messageVisibilityTimeout = null;
             }
             
             cacheSize = SimpleQueueAdapterCache.ParseSize(config, CacheSizeDefaultValue);
@@ -85,7 +85,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <summary>Creates the Azure Queue based adapter.</summary>
         public virtual Task<IQueueAdapter> CreateAdapter()
         {
-            var adapter = new AzureQueueAdapter(streamQueueMapper, dataConnectionString, deploymentId, providerName, visibilityTimeout);
+            var adapter = new AzureQueueAdapter(streamQueueMapper, dataConnectionString, deploymentId, providerName, messageVisibilityTimeout);
             return Task.FromResult<IQueueAdapter>(adapter);
         }
 

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -21,13 +21,13 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         public QueueId Id { get; private set; }
 
-        public static IQueueAdapterReceiver Create(QueueId queueId, string dataConnectionString, string deploymentId)
+        public static IQueueAdapterReceiver Create(QueueId queueId, string dataConnectionString, string deploymentId, TimeSpan? messageVisibilityTimeout = null)
         {
             if (queueId == null) throw new ArgumentNullException("queueId");
             if (String.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
             if (String.IsNullOrEmpty(deploymentId)) throw new ArgumentNullException("deploymentId");
             
-            var queue = new AzureQueueDataManager(queueId.ToString(), deploymentId, dataConnectionString);
+            var queue = new AzureQueueDataManager(queueId.ToString(), deploymentId, dataConnectionString, messageVisibilityTimeout);
             return new AzureQueueAdapterReceiver(queueId, queue);
         }
 

--- a/test/TesterInternal/StreamingTests/AzureQueueAdapterTests.cs
+++ b/test/TesterInternal/StreamingTests/AzureQueueAdapterTests.cs
@@ -36,7 +36,7 @@ namespace UnitTests.StorageTests
             this.deploymentId = MakeDeploymentId();
             LogManager.Initialize(new NodeConfiguration());
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
-            SerializationTestEnvironment.Initialize();
+            SerializationManager.InitializeForTesting();
         }
         
         public void Dispose()
@@ -50,7 +50,8 @@ namespace UnitTests.StorageTests
             var properties = new Dictionary<string, string>
                 {
                     {AzureQueueAdapterFactory.DataConnectionStringPropertyName, TestDefaultConfiguration.DataConnectionString},
-                    {AzureQueueAdapterFactory.DeploymentIdPropertyName, deploymentId}
+                    {AzureQueueAdapterFactory.DeploymentIdPropertyName, deploymentId},
+                    {AzureQueueAdapterFactory.MessageVisibilityTimeoutPropertyName, "00:00:30" }
                 };
             var config = new ProviderConfiguration(properties, "type", "name");
 


### PR DESCRIPTION
When using the Azure Queue based stream provider, I occasionally see both warnings about queue message deletes being slow coupled with errors related to message deletes failing. The errors appear to be happening because, while waiting to be deleted, the message visibility timeout expires and the message becomes visible in the queue again which renders the poprecipt invalid and causes a 404 on delete. This change allows for configuring the message visibility timeout value to allow for a larger window for both processing and deletes to be completed. Setting the timeout to 2min (vs 30sec default) has eliminated these errors for me, even in cases where I still see the slowness warnings.