### PR TITLE
LoadShedQueueFlowControl cast fix

### DIFF
--- a/src/OrleansRuntime/Streams/LoadShedQueueFlowController.cs
+++ b/src/OrleansRuntime/Streams/LoadShedQueueFlowController.cs
@@ -29,7 +29,7 @@ namespace Orleans.Streams
         {
             if (percentOfSiloSheddingLimit < 0.0 || percentOfSiloSheddingLimit > 100.0) throw new ArgumentOutOfRangeException(nameof(percentOfSiloSheddingLimit), "Percent value must be between 0-100");
             // Start shedding before silo reaches shedding limit.
-            return new LoadShedQueueFlowController(Silo.CurrentSilo.LocalConfig.LoadSheddingLimit * (percentOfSiloSheddingLimit / 100));
+            return new LoadShedQueueFlowController((int)(Silo.CurrentSilo.LocalConfig.LoadSheddingLimit * (percentOfSiloSheddingLimit / 100.0)));
         }
 
         /// <summary>


### PR DESCRIPTION
Math cleanup for improved usability introduced cast bug, where percentage calculation was alway zero.
Percision math is used for calculation and cast to integer afterwards.