### PR TITLE
EventHub flow control customization knobs

### DIFF
--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -335,12 +335,11 @@ namespace Orleans.Streams
                 }
 
                 if (IsShutdown) return; // timer was already removed, last tick
-                
-                int maxCacheAddCount = queueCache?.GetMaxAddCount() ?? QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG;
 
                 // loop through the queue until it is empty.
                 while (!IsShutdown) // timer will be set to null when we are asked to shudown. 
                 {
+                    int maxCacheAddCount = queueCache?.GetMaxAddCount() ?? QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG;
                     // If read succeeds and there is more data, we continue reading.
                     // If read succeeds and there is no more data, we breack out of loop
                     // If read fails, we try again, with backoff policy.

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -33,11 +33,12 @@ namespace Orleans.ServiceBus.Providers
         /// Construct EventHub queue cache.
         /// </summary>
         /// <param name="defaultMaxAddCount">Default max number of items that can be added to the cache between purge calls.</param>
+        /// <param name="flowControlTreashold">percentage of unprocesses cache that triggers flow control</param>
         /// <param name="checkpointer">Logic used to store queue position.</param>
         /// <param name="cacheDataAdapter">Performs data transforms appropriate for the various types of queue data.</param>
         /// <param name="comparer">Compares cached data</param>
         /// <param name="logger"></param>
-        protected EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, TCachedMessage> cacheDataAdapter, ICacheDataComparer<TCachedMessage> comparer, Logger logger)
+        protected EventHubQueueCache(int defaultMaxAddCount, double flowControlTreashold, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, TCachedMessage> cacheDataAdapter, ICacheDataComparer<TCachedMessage> comparer, Logger logger)
         {
             this.defaultMaxAddCount = defaultMaxAddCount;
             Checkpointer = checkpointer;
@@ -45,7 +46,7 @@ namespace Orleans.ServiceBus.Providers
             cacheDataAdapter.PurgeAction = cache.Purge;
             cache.OnPurged = OnPurge;
 
-            cachePressureMonitor = new AveragingCachePressureMonitor(logger);
+            cachePressureMonitor = new AveragingCachePressureMonitor(flowControlTreashold, logger);
         }
 
         /// <summary>
@@ -145,16 +146,17 @@ namespace Orleans.ServiceBus.Providers
     internal class AveragingCachePressureMonitor
     {
         private static readonly TimeSpan checkPeriod = TimeSpan.FromSeconds(2);
-        const double pressureThreshold = 1.0 / 3.0;
         private readonly Logger logger;
 
         private double accumulatedCachePressure;
         private double cachePressureContributionCount;
         private DateTime nextCheckedTime;
         private bool isUnderPressure;
+        private double flowControlTreashold;
 
-        public AveragingCachePressureMonitor(Logger logger)
+        public AveragingCachePressureMonitor(double flowControlTreashold, Logger logger)
         {
+            this.flowControlTreashold = flowControlTreashold;
             this.logger = logger.GetSubLogger("flowcontrol", "-");
             nextCheckedTime = DateTime.MinValue;
             isUnderPressure = false;
@@ -164,7 +166,7 @@ namespace Orleans.ServiceBus.Providers
         {
             // Weight unhealthy contributions thrice as much as healthy ones.
             // This is a crude compensation for the fact that healthy consumers wil consume more often than unhealthy ones.
-            double weight = cachePressureContribution < pressureThreshold ? 1.0 : 3.0;
+            double weight = cachePressureContribution < flowControlTreashold ? 1.0 : 3.0;
             accumulatedCachePressure += cachePressureContribution * weight;
             cachePressureContributionCount += weight;
         }
@@ -191,13 +193,13 @@ namespace Orleans.ServiceBus.Providers
 
             double pressure = accumulatedCachePressure / cachePressureContributionCount;
             bool wasUnderPressure = isUnderPressure;
-            isUnderPressure = pressure > pressureThreshold;
+            isUnderPressure = pressure > flowControlTreashold;
             // If we changed state, log
             if (isUnderPressure != wasUnderPressure)
             {
                 logger.Info(isUnderPressure
-                    ? $"Ingesting messages too fast. Throttling message reading. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {pressureThreshold}"
-                    : $"Message ingestion is healthy. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {pressureThreshold}");
+                    ? $"Ingesting messages too fast. Throttling message reading. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {flowControlTreashold}"
+                    : $"Message ingestion is healthy. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {flowControlTreashold}");
             }
             cachePressureContributionCount = 0.0;
             accumulatedCachePressure = 0.0;
@@ -209,15 +211,17 @@ namespace Orleans.ServiceBus.Providers
     /// </summary>
     public class EventHubQueueCache : EventHubQueueCache<CachedEventHubMessage>
     {
+        private const double DefaultThreashold = 1.0 / 3.0;
+        
         private readonly Logger log;
 
         /// <summary>
         /// Construct cache given a buffer pool.  Will use default data adapter
         /// </summary>
-        /// <param name="checkpointer"></param>
-        /// <param name="bufferPool"></param>
-        /// <param name="timePurge"></param>
-        /// <param name="logger"></param>
+        /// <param name="checkpointer">queue checkpoint writer</param>
+        /// <param name="bufferPool">buffer pool cache should use for raw buffers</param>
+        /// <param name="timePurge">predicate used to trigger time based purges</param>
+        /// <param name="logger">cache logger</param>
         public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, Logger logger)
             : this(checkpointer, new EventHubDataAdapter(bufferPool, timePurge), EventHubDataComparer.Instance, logger)
         {
@@ -226,12 +230,27 @@ namespace Orleans.ServiceBus.Providers
         /// <summary>
         /// Construct cache given a custom data adapter.
         /// </summary>
-        /// <param name="checkpointer"></param>
-        /// <param name="cacheDataAdapter"></param>
-        /// <param name="comparer"></param>
-        /// <param name="logger"></param>
+        /// <param name="checkpointer">queue checkpoint writer</param>
+        /// <param name="cacheDataAdapter">adapts queue data to cache</param>
+        /// <param name="comparer">compares stream information to cached data</param>
+        /// <param name="logger">cache logger</param>
         public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger)
-            : base(EventHubAdapterReceiver.MaxMessagesPerRead, checkpointer, cacheDataAdapter, comparer, logger)
+            : base(EventHubAdapterReceiver.MaxMessagesPerRead, DefaultThreashold, checkpointer, cacheDataAdapter, comparer, logger)
+        {
+            log = logger.GetSubLogger("messagecache", "-");
+        }
+
+        /// <summary>
+        /// Construct cache given a custom data adapter.
+        /// </summary>
+        /// <param name="defaultMaxAddCount">Max number of message that can be added to cache from single read</param>
+        /// <param name="flowControlTreashold">percentage of unprocesses cache that triggers flow control</param>
+        /// <param name="checkpointer">queue checkpoint writer</param>
+        /// <param name="cacheDataAdapter">adapts queue data to cache</param>
+        /// <param name="comparer">compares stream information to cached data</param>
+        /// <param name="logger">cache logger</param>
+        public EventHubQueueCache(int defaultMaxAddCount, double flowControlTreashold, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger)
+            : base(defaultMaxAddCount, flowControlTreashold, checkpointer, cacheDataAdapter, comparer, logger)
         {
             log = logger.GetSubLogger("messagecache", "-");
         }


### PR DESCRIPTION
Allow event hub cache users to specify max read count and flow control threshold.