### PR TITLE
ClientGenerator: do not emit error.txt after failed codegen

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -378,7 +378,6 @@ namespace Orleans.CodeGeneration
             }
             catch (Exception ex)
             {
-                File.WriteAllText("error.txt", ex.Message + Environment.NewLine + ex.StackTrace);
                 Console.WriteLine("-- Code-gen FAILED -- \n{0}", LogFormatter.PrintException(ex));
                 return 3;
             }


### PR DESCRIPTION
As discussed in #2431