### PR TITLE
Heterogenous silos support 

### DIFF
--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -170,6 +170,10 @@ namespace Orleans.Runtime.Configuration
         /// The number of seconds to attempt to join a cluster of silos before giving up.
         /// </summary>
         public TimeSpan MaxJoinAttemptTime { get; set; }
+        /// <summary>
+        /// The number of seconds to refresh the cluster grain interface map
+        /// </summary>
+        public TimeSpan TypeMapRefreshTimeout { get; set; }
         internal ConfigValue<int> ExpectedClusterSizeConfigValue { get; set; }
         /// <summary>
         /// The expected size of a cluster. Need not be very accurate, can be an overestimate.
@@ -470,6 +474,7 @@ namespace Orleans.Runtime.Configuration
         private static readonly TimeSpan DEFAULT_LIVENESS_DEATH_VOTE_EXPIRATION_TIMEOUT = TimeSpan.FromSeconds(120);
         private static readonly TimeSpan DEFAULT_LIVENESS_I_AM_ALIVE_TABLE_PUBLISH_TIMEOUT = TimeSpan.FromMinutes(5);
         private static readonly TimeSpan DEFAULT_LIVENESS_MAX_JOIN_ATTEMPT_TIME = TimeSpan.FromMinutes(5); // 5 min
+        private static readonly TimeSpan DEFAULT_REFRESH_CLUSTER_INTERFACEMAP_TIME = TimeSpan.FromMinutes(1);
         private const int DEFAULT_LIVENESS_NUM_MISSED_PROBES_LIMIT = 3;
         private const int DEFAULT_LIVENESS_NUM_PROBED_SILOS = 3;
         private const int DEFAULT_LIVENESS_NUM_VOTES_FOR_DEATH_DECLARATION = 2;
@@ -522,6 +527,7 @@ namespace Orleans.Runtime.Configuration
             UseLivenessGossip = DEFAULT_LIVENESS_USE_LIVENESS_GOSSIP;
             ValidateInitialConnectivity = DEFAULT_VALIDATE_INITIAL_CONNECTIVITY;
             MaxJoinAttemptTime = DEFAULT_LIVENESS_MAX_JOIN_ATTEMPT_TIME;
+            TypeMapRefreshTimeout = DEFAULT_REFRESH_CLUSTER_INTERFACEMAP_TIME;
             MaxMultiClusterGateways = DEFAULT_MAX_MULTICLUSTER_GATEWAYS;
             BackgroundGossipInterval = DEFAULT_BACKGROUND_GOSSIP_INTERVAL;
             UseGlobalSingleInstanceByDefault = DEFAULT_USE_GLOBAL_SINGLE_INSTANCE;

--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -173,7 +173,7 @@ namespace Orleans.Runtime.Configuration
         /// <summary>
         /// The number of seconds to refresh the cluster grain interface map
         /// </summary>
-        public TimeSpan TypeMapRefreshTimeout { get; set; }
+        public TimeSpan TypeMapRefreshInterval { get; set; }
         internal ConfigValue<int> ExpectedClusterSizeConfigValue { get; set; }
         /// <summary>
         /// The expected size of a cluster. Need not be very accurate, can be an overestimate.
@@ -527,7 +527,7 @@ namespace Orleans.Runtime.Configuration
             UseLivenessGossip = DEFAULT_LIVENESS_USE_LIVENESS_GOSSIP;
             ValidateInitialConnectivity = DEFAULT_VALIDATE_INITIAL_CONNECTIVITY;
             MaxJoinAttemptTime = DEFAULT_LIVENESS_MAX_JOIN_ATTEMPT_TIME;
-            TypeMapRefreshTimeout = DEFAULT_REFRESH_CLUSTER_INTERFACEMAP_TIME;
+            TypeMapRefreshInterval = DEFAULT_REFRESH_CLUSTER_INTERFACEMAP_TIME;
             MaxMultiClusterGateways = DEFAULT_MAX_MULTICLUSTER_GATEWAYS;
             BackgroundGossipInterval = DEFAULT_BACKGROUND_GOSSIP_INTERVAL;
             UseGlobalSingleInstanceByDefault = DEFAULT_USE_GLOBAL_SINGLE_INSTANCE;

--- a/src/Orleans/Configuration/NodeConfiguration.cs
+++ b/src/Orleans/Configuration/NodeConfiguration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -212,6 +213,8 @@ namespace Orleans.Runtime.Configuration
 
         public Dictionary<string, SearchOption> AdditionalAssemblyDirectories { get; set; }
 
+        public List<string> ExcludedGrainTypes { get; set; }
+
         public string SiloShutdownEventName { get; set; }
 
         internal const string DEFAULT_NODE_NAME = "default";
@@ -270,6 +273,7 @@ namespace Orleans.Runtime.Configuration
             UseNagleAlgorithm = false;
 
             AdditionalAssemblyDirectories = new Dictionary<string, SearchOption>();
+            ExcludedGrainTypes = new List<string>();
         }
 
         public NodeConfiguration(NodeConfiguration other)
@@ -320,6 +324,7 @@ namespace Orleans.Runtime.Configuration
 
             StartupTypeName = other.StartupTypeName;
             AdditionalAssemblyDirectories = other.AdditionalAssemblyDirectories;
+            ExcludedGrainTypes = other.ExcludedGrainTypes.ToList();
         }
 
         public override string ToString()
@@ -487,7 +492,6 @@ namespace Orleans.Runtime.Configuration
                     case "AdditionalAssemblyDirectories":
                         ConfigUtilities.ParseAdditionalAssemblyDirectories(AdditionalAssemblyDirectories, child);
                         break;
-
                 }
             }
         }

--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -1093,6 +1093,8 @@ namespace Orleans
         GlobalSingleInstance_MaintainerException = GlobalSingleInstanceBase + 3,
         GlobalSingleInstance_MultipleOwners = GlobalSingleInstanceBase + 4,
 
+        TypeManagerBase = Runtime + 4200,
+        TypeManager_GetSiloGrainInterfaceMapError = TypeManagerBase + 1,
     }
 }
 // ReSharper restore InconsistentNaming

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -278,7 +278,7 @@ namespace Orleans.Messaging
         public Task<IGrainTypeResolver> GetTypeCodeMap(GrainFactory grainFactory)
         {
             var silo = GetLiveGatewaySiloAddress();
-            return GetTypeManager(silo, grainFactory).GetTypeCodeMap(silo);
+            return GetTypeManager(silo, grainFactory).GetClusterTypeCodeMap();
         }
 
         public Task<Streams.ImplicitStreamSubscriberTable> GetImplicitStreamSubscriberTable(GrainFactory grainFactory)
@@ -397,9 +397,9 @@ namespace Orleans.Messaging
 
         #endregion
 
-        private ITypeManager GetTypeManager(SiloAddress destination, GrainFactory grainFactory)
+        private IClusterTypeManager GetTypeManager(SiloAddress destination, GrainFactory grainFactory)
         {
-            return grainFactory.GetSystemTarget<ITypeManager>(Constants.TypeManagerId, destination);
+            return grainFactory.GetSystemTarget<IClusterTypeManager>(Constants.TypeManagerId, destination);
         }
 
         private SiloAddress GetLiveGatewaySiloAddress()

--- a/src/Orleans/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans/Runtime/GrainInterfaceMap.cs
@@ -74,18 +74,23 @@ namespace Orleans.Runtime
 
         private readonly bool localTestMode;
         private readonly HashSet<string> loadedGrainAsemblies;
+		
+		private readonly PlacementStrategy defaultPlacementStrategy;
 
-        private readonly PlacementStrategy defaultPlacementStrategy;
+        internal IList<int> SupportedGrainTypes
+        {
+            get { return implementationIndex.Keys.ToList(); }
+        }
 
         public GrainInterfaceMap(bool localTestMode, PlacementStrategy defaultPlacementStrategy)
         {
-            this.defaultPlacementStrategy = defaultPlacementStrategy;
             table = new Dictionary<int, GrainInterfaceData>();
             typeToInterfaceData = new Dictionary<string, GrainInterfaceData>();
             primaryImplementations = new Dictionary<string, string>();
             implementationIndex = new Dictionary<int, GrainClassData>();
             unordered = new HashSet<int>();
             this.localTestMode = localTestMode;
+            this.defaultPlacementStrategy = defaultPlacementStrategy;
             if(localTestMode) // if we are running in test mode, we'll build a list of loaded grain assemblies to help with troubleshooting deployment issue
                 loadedGrainAsemblies = new HashSet<string>();
         }

--- a/src/Orleans/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans/Runtime/GrainInterfaceMap.cs
@@ -67,7 +67,6 @@ namespace Orleans.Runtime
         private readonly Dictionary<int, GrainInterfaceData> table;
         private readonly HashSet<int> unordered;
 
-        [NonSerialized]
         private readonly Dictionary<int, GrainClassData> implementationIndex;
 
         [NonSerialized] // Client shouldn't need this
@@ -89,6 +88,38 @@ namespace Orleans.Runtime
             this.localTestMode = localTestMode;
             if(localTestMode) // if we are running in test mode, we'll build a list of loaded grain assemblies to help with troubleshooting deployment issue
                 loadedGrainAsemblies = new HashSet<string>();
+        }
+
+        internal void AddMap(GrainInterfaceMap map)
+        {
+            foreach (var kvp in map.typeToInterfaceData)
+            {
+                if (!typeToInterfaceData.ContainsKey(kvp.Key))
+                {
+                    typeToInterfaceData.Add(kvp.Key, kvp.Value);
+                }
+            }
+
+            foreach (var kvp in map.table)
+            {
+                if (!table.ContainsKey(kvp.Key))
+                {
+                    table.Add(kvp.Key, kvp.Value);
+                }
+            }
+
+            foreach (var grainClassTypeCode in map.unordered)
+            {
+                unordered.Add(grainClassTypeCode);
+            }
+
+            foreach (var kvp in map.implementationIndex)
+            {
+                if (!implementationIndex.ContainsKey(kvp.Key))
+                {
+                    implementationIndex.Add(kvp.Key, kvp.Value);
+                }
+            }
         }
 
         internal void AddEntry(int interfaceId, Type iface, int grainTypeCode, string grainInterface, string grainClass, string assembly, 
@@ -170,6 +201,14 @@ namespace Orleans.Runtime
             lock (this)
             {
                 return table.ContainsKey(interfaceId);
+            }
+        }
+
+        internal bool ContainsGrainImplementation(int typeCode)
+        {
+            lock (this)
+            {
+                return implementationIndex.ContainsKey(typeCode);
             }
         }
 

--- a/src/Orleans/Runtime/ITypeManager.cs
+++ b/src/Orleans/Runtime/ITypeManager.cs
@@ -6,10 +6,23 @@ namespace Orleans.Runtime
     /// <summary>
     /// Client gateway interface for obtaining the grain interface/type map.
     /// </summary>
-    internal interface ITypeManager : ISystemTarget
+    internal interface IClusterTypeManager : ISystemTarget
     {
-        Task<IGrainTypeResolver> GetTypeCodeMap(SiloAddress silo);
+        /// <summary>
+        /// Acquires grain interface map for all grain types supported across the entire cluster
+        /// </summary>
+        /// <returns></returns>
+        Task<IGrainTypeResolver> GetClusterTypeCodeMap();
 
         Task<Streams.ImplicitStreamSubscriberTable> GetImplicitStreamSubscriberTable(SiloAddress silo);
+    }
+
+    internal interface ISiloTypeManager : ISystemTarget
+    {
+        /// <summary>
+        /// Acquires grain interface map for all grain types supported by hosted silo.
+        /// </summary>
+        /// <returns></returns>
+        Task<GrainInterfaceMap> GetSiloTypeCodeMap();
     }
 }

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -119,6 +119,7 @@ namespace Orleans.Runtime
 
 
         public GrainTypeManager GrainTypeManager { get; private set; }
+
         public SiloAddress LocalSilo { get; private set; }
         internal ISiloStatusOracle SiloStatusOracle { get; set; }
         internal readonly ActivationCollector ActivationCollector;
@@ -199,6 +200,15 @@ namespace Orleans.Runtime
         /// Gets the dispatcher used by this instance.
         /// </summary>
         public Dispatcher Dispatcher { get; }
+
+        public IList<SiloAddress> GetCompatibleSiloList(GrainId grain)
+        {
+            var typeCode = grain.GetTypeCode();
+            var compatibleSilos = GrainTypeManager.GetSupportedSilos(typeCode).Intersect(AllActiveSilos).ToList();
+            if (compatibleSilos.Count == 0)
+                throw new OrleansException($"TypeCode ${typeCode} not supported in the cluster");
+            return compatibleSilos;
+        }
 
         internal void SetStorageManager(IStorageProviderManager storageManager)
         {

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -15,7 +15,7 @@ namespace Orleans.Runtime
     internal class GrainTypeManager
     {
         private IDictionary<string, GrainTypeData> grainTypes;
-        private IReadOnlyDictionary<SiloAddress, GrainInterfaceMap> grainInterfaceMapsBySilo;
+        private IDictionary<SiloAddress, GrainInterfaceMap> grainInterfaceMapsBySilo;
         private Dictionary<int, IList<SiloAddress>> supportedSilosByTypeCode;
         private readonly Logger logger = LogManager.GetLogger("GrainTypeManager");
         private readonly GrainInterfaceMap grainInterfaceMap;
@@ -24,9 +24,9 @@ namespace Orleans.Runtime
         private static readonly object lockable = new object();
 		private readonly PlacementStrategy defaultPlacementStrategy;
 
-        internal IReadOnlyDictionary<SiloAddress, GrainInterfaceMap> GrainInterfaceMapsBySilo
+        internal IDictionary<SiloAddress, GrainInterfaceMap> GrainInterfaceMapsBySilo
         {
-            get { return grainInterfaceMapsBySilo; }
+            get { return new Dictionary<SiloAddress, GrainInterfaceMap>(grainInterfaceMapsBySilo); }
         }
 
         public static GrainTypeManager Instance { get; private set; }
@@ -150,7 +150,7 @@ namespace Orleans.Runtime
                 throw new OrleansException(String.Format("Unexpected: Cannot find an implementation class for grain interface {0}", typeCode));
         }
 
-        internal void SetInterfaceMapsBySilo(IReadOnlyDictionary<SiloAddress, GrainInterfaceMap> value)
+        internal void SetInterfaceMapsBySilo(IDictionary<SiloAddress, GrainInterfaceMap> value)
         {
             grainInterfaceMapsBySilo = value;
             RebuildFullGrainInterfaceMap();

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -15,7 +15,7 @@ namespace Orleans.Runtime
     internal class GrainTypeManager
     {
         private IDictionary<string, GrainTypeData> grainTypes;
-        private IDictionary<SiloAddress, GrainInterfaceMap> grainInterfaceMapsBySilo;
+        private Dictionary<SiloAddress, GrainInterfaceMap> grainInterfaceMapsBySilo;
         private Dictionary<int, IList<SiloAddress>> supportedSilosByTypeCode;
         private readonly Logger logger = LogManager.GetLogger("GrainTypeManager");
         private readonly GrainInterfaceMap grainInterfaceMap;
@@ -24,9 +24,9 @@ namespace Orleans.Runtime
         private static readonly object lockable = new object();
 		private readonly PlacementStrategy defaultPlacementStrategy;
 
-        internal IDictionary<SiloAddress, GrainInterfaceMap> GrainInterfaceMapsBySilo
+        internal IReadOnlyDictionary<SiloAddress, GrainInterfaceMap> GrainInterfaceMapsBySilo
         {
-            get { return new Dictionary<SiloAddress, GrainInterfaceMap>(grainInterfaceMapsBySilo); }
+            get { return grainInterfaceMapsBySilo; }
         }
 
         public static GrainTypeManager Instance { get; private set; }
@@ -150,7 +150,7 @@ namespace Orleans.Runtime
                 throw new OrleansException(String.Format("Unexpected: Cannot find an implementation class for grain interface {0}", typeCode));
         }
 
-        internal void SetInterfaceMapsBySilo(IDictionary<SiloAddress, GrainInterfaceMap> value)
+        internal void SetInterfaceMapsBySilo(Dictionary<SiloAddress, GrainInterfaceMap> value)
         {
             grainInterfaceMapsBySilo = value;
             RebuildFullGrainInterfaceMap();

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -219,7 +219,7 @@ namespace Orleans.Runtime
             return grainTypes.TryGetValue(name, out result);
         }
 
-        internal IGrainTypeResolver GetTypeCodeMap()
+        internal GrainInterfaceMap GetTypeCodeMap()
         {
             // the map is immutable at this point
             return grainInterfaceMap;

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -15,7 +15,7 @@ namespace Orleans.Runtime
     internal class GrainTypeManager
     {
         private IDictionary<string, GrainTypeData> grainTypes;
-        private IDictionary<SiloAddress, GrainInterfaceMap> grainInterfaceMapsBySilo;
+        private IReadOnlyDictionary<SiloAddress, GrainInterfaceMap> grainInterfaceMapsBySilo;
         private Dictionary<int, IList<SiloAddress>> supportedSilosByTypeCode;
         private readonly Logger logger = LogManager.GetLogger("GrainTypeManager");
         private readonly GrainInterfaceMap grainInterfaceMap;
@@ -24,9 +24,9 @@ namespace Orleans.Runtime
         private static readonly object lockable = new object();
 		private readonly PlacementStrategy defaultPlacementStrategy;
 
-        internal IDictionary<SiloAddress, GrainInterfaceMap> GrainInterfaceMapsBySilo
+        internal IReadOnlyDictionary<SiloAddress, GrainInterfaceMap> GrainInterfaceMapsBySilo
         {
-            get { return new Dictionary<SiloAddress, GrainInterfaceMap>(grainInterfaceMapsBySilo); }
+            get { return grainInterfaceMapsBySilo; }
         }
 
         public static GrainTypeManager Instance { get; private set; }
@@ -150,7 +150,7 @@ namespace Orleans.Runtime
                 throw new OrleansException(String.Format("Unexpected: Cannot find an implementation class for grain interface {0}", typeCode));
         }
 
-        internal void SetInterfaceMapsBySilo(IDictionary<SiloAddress, GrainInterfaceMap> value)
+        internal void SetInterfaceMapsBySilo(IReadOnlyDictionary<SiloAddress, GrainInterfaceMap> value)
         {
             grainInterfaceMapsBySilo = value;
             RebuildFullGrainInterfaceMap();

--- a/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
+++ b/src/OrleansRuntime/GrainTypeManager/SiloAssemblyLoader.cs
@@ -13,17 +13,21 @@ namespace Orleans.Runtime
 {
     internal class SiloAssemblyLoader
     {
+        private readonly List<string> excludedGrains;
         private readonly LoggerImpl logger = LogManager.GetLogger("AssemblyLoader.Silo");
         private List<string> discoveredAssemblyLocations;
         private Dictionary<string, SearchOption> directories;
 
         public SiloAssemblyLoader(NodeConfiguration nodeConfig)
-            : this(nodeConfig.AdditionalAssemblyDirectories)
+            : this(nodeConfig.AdditionalAssemblyDirectories, nodeConfig.ExcludedGrainTypes)
         {
         }
 
-        public SiloAssemblyLoader(IDictionary<string, SearchOption> additionalDirectories)
+        public SiloAssemblyLoader(IDictionary<string, SearchOption> additionalDirectories, IEnumerable<string> excludedGrains = null)
         {
+            this.excludedGrains = excludedGrains != null
+                ? new List<string>(excludedGrains)
+                : new List<string>();
             var exeRoot = Path.GetDirectoryName(typeof(SiloAssemblyLoader).GetTypeInfo().Assembly.Location);
             var appRoot = Path.Combine(exeRoot, "Applications");
             var cwd = Directory.GetCurrentDirectory();
@@ -80,6 +84,9 @@ namespace Orleans.Runtime
             foreach (var grainType in grainTypes)
             {
                 var className = TypeUtils.GetFullName(grainType);
+                if (excludedGrains.Contains(className))
+                    continue;
+
                 if (result.ContainsKey(className))
                     throw new InvalidOperationException(
                         string.Format("Precondition violated: GetLoadedGrainTypes should not return a duplicate type ({0})", className));

--- a/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime
         private bool hasToRefreshClusterGrainInterfaceMap;
         private readonly AsyncTaskSafeTimer refreshClusterGrainInterfaceMapTimer;
 
-        internal TypeManager(SiloAddress myAddr, GrainTypeManager grainTypeManager, ISiloStatusOracle oracle, OrleansTaskScheduler scheduler)
+        internal TypeManager(SiloAddress myAddr, GrainTypeManager grainTypeManager, ISiloStatusOracle oracle, OrleansTaskScheduler scheduler, TimeSpan refreshClusterMapTimeout)
             : base(Constants.TypeManagerId, myAddr)
         {
             if (grainTypeManager == null)
@@ -34,7 +34,7 @@ namespace Orleans.Runtime
                     OnRefreshClusterMapTimer,
                     null,
                     TimeSpan.Zero,  // Force to do it once right now
-                    TimeSpan.FromMilliseconds(500)); // TODO Config
+                    refreshClusterMapTimeout); 
         }
 
 

--- a/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
@@ -1,17 +1,38 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Runtime.Providers;
+using Orleans.Runtime.Scheduler;
 
 namespace Orleans.Runtime
 {
     internal class TypeManager : SystemTarget, IClusterTypeManager, ISiloTypeManager
     {
+        private readonly Logger logger = LogManager.GetLogger("TypeManager");
         private readonly GrainTypeManager grainTypeManager;
+        private readonly ISiloStatusOracle statusOracle;
+        private readonly OrleansTaskScheduler scheduler;
+        private readonly AsyncTaskSafeTimer refreshClusterGrainInterfaceMapTimer;
 
-        internal TypeManager(SiloAddress myAddr, GrainTypeManager grainTypeManager)
+        internal TypeManager(SiloAddress myAddr, GrainTypeManager grainTypeManager, ISiloStatusOracle oracle, OrleansTaskScheduler scheduler)
             : base(Constants.TypeManagerId, myAddr)
         {
+            if (grainTypeManager == null)
+                throw new ArgumentNullException(nameof(grainTypeManager));
+            if (oracle == null)
+                throw new ArgumentNullException(nameof(oracle));
+            if (scheduler == null)
+                throw new ArgumentNullException(nameof(scheduler));
+
             this.grainTypeManager = grainTypeManager;
+            statusOracle = oracle;
+            this.scheduler = scheduler;
+            this.refreshClusterGrainInterfaceMapTimer = new AsyncTaskSafeTimer(
+                    OnRefreshClusterMapTimer,
+                    null,
+                    TimeSpan.Zero,  // Force to do it once right now
+                    TimeSpan.FromMilliseconds(500)); // TODO Config
         }
 
 
@@ -33,6 +54,68 @@ namespace Orleans.Runtime
                 throw new InvalidOperationException("the implicit stream subscriber table is not initialized");
             }
             return Task.FromResult(table);
+        }
+
+        private async Task OnRefreshClusterMapTimer(object _)
+        {
+
+            logger.Info("OnRefreshClusterMapTimer: refresh start");
+            var activeSilos = statusOracle.GetApproximateSiloStatuses(onlyActive: true);
+            var knownSilosClusterGrainInterfaceMap = grainTypeManager.GrainInterfaceMapsBySilo;
+
+            // Build the new map. Always start by himself
+            var newSilosClusterGrainInterfaceMap = new Dictionary<SiloAddress, GrainInterfaceMap>
+            {
+                {this.Silo, grainTypeManager.GetTypeCodeMap()}
+            };
+            var getGrainInterfaceMapTasks = new List<Task<KeyValuePair<SiloAddress, GrainInterfaceMap>>>();
+
+
+            foreach (var siloAddress in activeSilos.Keys)
+            {
+                if (siloAddress.Equals(this.Silo)) continue;
+
+                GrainInterfaceMap value;
+                if (knownSilosClusterGrainInterfaceMap.TryGetValue(siloAddress, out value))
+                {
+                    logger.Verbose3($"OnRefreshClusterMapTimer: value already found locally for {siloAddress}");
+                    newSilosClusterGrainInterfaceMap[siloAddress] = value;
+                }
+                else
+                {
+                    // Value not found, let's get it
+                    logger.Verbose3($"OnRefreshClusterMapTimer: value not found locally for {siloAddress}");
+                    getGrainInterfaceMapTasks.Add(GetTargetSiloGrainInterfaceMap(siloAddress));
+                }
+            }
+
+            if (getGrainInterfaceMapTasks.Any())
+            {
+                foreach (var keyValuePair in await Task.WhenAll(getGrainInterfaceMapTasks))
+                {
+                    if (keyValuePair.Value != null)
+                        newSilosClusterGrainInterfaceMap.Add(keyValuePair.Key, keyValuePair.Value);
+                }
+            }
+
+            grainTypeManager.SetInterfaceMapsBySilo(newSilosClusterGrainInterfaceMap);
+        }
+
+        private async Task<KeyValuePair<SiloAddress, GrainInterfaceMap>> GetTargetSiloGrainInterfaceMap(SiloAddress siloAddress)
+        {
+            try
+            {
+                var remoteTypeManager = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<ISiloTypeManager>(Constants.TypeManagerId, siloAddress);
+                var siloTypeCodeMap = await scheduler.QueueTask(() => remoteTypeManager.GetSiloTypeCodeMap(), SchedulingContext);
+                return new KeyValuePair<SiloAddress, GrainInterfaceMap>(siloAddress, siloTypeCodeMap);
+            }
+            catch (Exception ex)
+            {
+				// Will be retried on the next timer hit
+                logger.Error(ErrorCode.TypeManager_GetSiloGrainInterfaceMapError, $"Exception when trying to get GrainInterfaceMap for silos {siloAddress}", ex);
+                
+                return new KeyValuePair<SiloAddress, GrainInterfaceMap>(siloAddress, null);
+            }
         }
     }
 }

--- a/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
@@ -4,7 +4,7 @@ using Orleans.Runtime.Providers;
 
 namespace Orleans.Runtime
 {
-    internal class TypeManager : SystemTarget, ITypeManager
+    internal class TypeManager : SystemTarget, IClusterTypeManager, ISiloTypeManager
     {
         private readonly GrainTypeManager grainTypeManager;
 
@@ -15,7 +15,12 @@ namespace Orleans.Runtime
         }
 
 
-        public Task<IGrainTypeResolver> GetTypeCodeMap(SiloAddress silo)
+        public Task<IGrainTypeResolver> GetClusterTypeCodeMap()
+        {
+            return Task.FromResult<IGrainTypeResolver>(grainTypeManager.ClusterGrainInterfaceMap);
+        }
+
+        public Task<GrainInterfaceMap> GetSiloTypeCodeMap()
         {
             return Task.FromResult(grainTypeManager.GetTypeCodeMap());
         }

--- a/src/OrleansRuntime/Placement/ActivationCountPlacementDirector.cs
+++ b/src/OrleansRuntime/Placement/ActivationCountPlacementDirector.cs
@@ -89,11 +89,13 @@ namespace Orleans.Runtime.Placement
 
         public Task<PlacementResult> SelectSiloPowerOfK(PlacementStrategy strategy, GrainId grain, IPlacementContext context)
         {
-            // Exclude overloaded silos
+            var compatibleSilos = context.GetCompatibleSiloList(grain);
+            // Exclude overloaded and non-compatible silos
             var relevantSilos = new List<CachedLocalStat>();
             foreach (CachedLocalStat current in localCache.Values)
             {
                 if (IsSiloOverloaded(current.SiloStats)) continue;
+                if (!compatibleSilos.Contains(current.Address)) continue;
 
                 relevantSilos.Add(current);
             }

--- a/src/OrleansRuntime/Placement/IPlacementContext.cs
+++ b/src/OrleansRuntime/Placement/IPlacementContext.cs
@@ -24,6 +24,8 @@ namespace Orleans.Runtime.Placement
 
         List<SiloAddress> AllActiveSilos { get; }
 
+        IList<SiloAddress> GetCompatibleSiloList(GrainId grain);
+
         SiloAddress LocalSilo { get; }
 
         SiloStatus LocalSiloStatus { get; }
@@ -67,6 +69,16 @@ namespace Orleans.Runtime.Placement
             PlacementStrategy unused;
             MultiClusterRegistrationStrategy unusedActivationStrategy;
             @this.GetGrainTypeInfo(typeCode, out grainClass, out unused, out unusedActivationStrategy, genericArguments);
+            return grainClass;
+        }
+
+        public static string GetGrainTypeNameAndSupportedSilos(this IPlacementContext @this, GrainId grainId, out IList<SiloAddress> supportedSiloAddresses, string genericArguments = null)
+        {
+            string grainClass;
+            PlacementStrategy unused;
+            MultiClusterRegistrationStrategy unusedActivationStrategy;
+            @this.GetGrainTypeInfo(grainId.GetTypeCode(), out grainClass, out unused, out unusedActivationStrategy, genericArguments);
+            supportedSiloAddresses = @this.GetCompatibleSiloList(grainId);
             return grainClass;
         }
 

--- a/src/OrleansRuntime/Placement/IPlacementContext.cs
+++ b/src/OrleansRuntime/Placement/IPlacementContext.cs
@@ -70,16 +70,6 @@ namespace Orleans.Runtime.Placement
             return grainClass;
         }
 
-        public static string GetGrainTypeNameAndSupportedSilos(this IPlacementContext @this, GrainId grainId, out IList<SiloAddress> supportedSiloAddresses, string genericArguments = null)
-        {
-            string grainClass;
-            PlacementStrategy unused;
-            MultiClusterRegistrationStrategy unusedActivationStrategy;
-            @this.GetGrainTypeInfo(grainId.GetTypeCode(), out grainClass, out unused, out unusedActivationStrategy, genericArguments);
-            supportedSiloAddresses = @this.GetCompatibleSiloList(grainId);
-            return grainClass;
-        }
-
         public static string GetGrainTypeName(this IPlacementContext @this, GrainId grainId, string genericArguments = null)
         {
             return @this.GetGrainTypeName(grainId.GetTypeCode(), genericArguments);

--- a/src/OrleansRuntime/Placement/IPlacementContext.cs
+++ b/src/OrleansRuntime/Placement/IPlacementContext.cs
@@ -22,8 +22,6 @@ namespace Orleans.Runtime.Placement
 
         bool LocalLookup(GrainId grain, out List<ActivationData> addresses);
 
-        List<SiloAddress> AllActiveSilos { get; }
-
         IList<SiloAddress> GetCompatibleSiloList(GrainId grain);
 
         SiloAddress LocalSilo { get; }

--- a/src/OrleansRuntime/Placement/PreferLocalPlacementDirector.cs
+++ b/src/OrleansRuntime/Placement/PreferLocalPlacementDirector.cs
@@ -15,8 +15,8 @@ namespace Orleans.Runtime.Placement
         public override Task<PlacementResult> 
             OnAddActivation(PlacementStrategy strategy, GrainId grain, IPlacementContext context)
         {
-            // if local silo is not active, revert to random placement
-            if (context.LocalSiloStatus != SiloStatus.Active)
+            // if local silo is not active or does not support this type of grain, revert to random placement
+            if (context.LocalSiloStatus != SiloStatus.Active || !context.GetCompatibleSiloList(grain).Contains(context.LocalSilo))
                 return base.OnAddActivation(strategy, grain, context);
 
             var grainType = context.GetGrainTypeName(grain);

--- a/src/OrleansRuntime/Placement/RandomPlacementDirector.cs
+++ b/src/OrleansRuntime/Placement/RandomPlacementDirector.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.Placement
             PlacementStrategy strategy, GrainId grain, IPlacementContext context)
         {
             var grainType = context.GetGrainTypeName(grain);
-            var allSilos = context.AllActiveSilos;
+            var allSilos = context.GetCompatibleSiloList(grain);
             return Task.FromResult(
                 PlacementResult.SpecifyCreation(allSilos[random.Next(allSilos.Count)], strategy, grainType));
         }

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -382,9 +382,10 @@ namespace Orleans.Runtime
             RegisterSystemTarget(LocalGrainDirectory.RemoteClusterGrainDirectory);
 
             logger.Verbose("Creating {0} System Target", "ClientObserverRegistrar + TypeManager");
+
             this.RegisterSystemTarget(this.Services.GetRequiredService<ClientObserverRegistrar>());
-            typeManager = new TypeManager(SiloAddress, LocalGrainTypeManager, membershipOracle, LocalScheduler);
-            RegisterSystemTarget(typeManager);
+            typeManager = new TypeManager(SiloAddress, this.grainTypeManager, membershipOracle, LocalScheduler, GlobalConfig.TypeMapRefreshTimeout);
+            this.RegisterSystemTarget(typeManager);
 
             logger.Verbose("Creating {0} System Target", "MembershipOracle");
             if (this.membershipOracle is SystemTarget)

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -419,6 +419,8 @@ namespace Orleans.Runtime
             // consistentRingProvider is not a system target per say, but it behaves like the localGrainDirectory, so it is here
             LocalSiloStatusOracle.SubscribeToSiloStatusEvents((ISiloStatusListener)RingProvider);
 
+            LocalSiloStatusOracle.SubscribeToSiloStatusEvents(typeManager);
+
             LocalSiloStatusOracle.SubscribeToSiloStatusEvents(Services.GetRequiredService<DeploymentLoadPublisher>());
 
             if (!GlobalConfig.ReminderServiceType.Equals(GlobalConfiguration.ReminderServiceProviderType.Disabled))

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -384,7 +384,7 @@ namespace Orleans.Runtime
             logger.Verbose("Creating {0} System Target", "ClientObserverRegistrar + TypeManager");
 
             this.RegisterSystemTarget(this.Services.GetRequiredService<ClientObserverRegistrar>());
-            typeManager = new TypeManager(SiloAddress, this.grainTypeManager, membershipOracle, LocalScheduler, GlobalConfig.TypeMapRefreshTimeout);
+            typeManager = new TypeManager(SiloAddress, this.grainTypeManager, membershipOracle, LocalScheduler, GlobalConfig.TypeMapRefreshInterval);
             this.RegisterSystemTarget(typeManager);
 
             logger.Verbose("Creating {0} System Target", "MembershipOracle");

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -33,6 +33,7 @@
                 var options = new TestClusterOptions(2);
                 options.ClientConfiguration.SerializationProviders.Add(typeof(OneWaySerializer).GetTypeInfo());
                 options.ClusterConfiguration.Globals.SerializationProviders.Add(typeof(OneWaySerializer).GetTypeInfo());
+                options.ClusterConfiguration.Globals.TypeMapRefreshTimeout = TimeSpan.FromMilliseconds(200);
                 return new TestCluster(options);
             }
         }

--- a/test/Tester/ExceptionPropagationTests.cs
+++ b/test/Tester/ExceptionPropagationTests.cs
@@ -33,7 +33,7 @@
                 var options = new TestClusterOptions(2);
                 options.ClientConfiguration.SerializationProviders.Add(typeof(OneWaySerializer).GetTypeInfo());
                 options.ClusterConfiguration.Globals.SerializationProviders.Add(typeof(OneWaySerializer).GetTypeInfo());
-                options.ClusterConfiguration.Globals.TypeMapRefreshTimeout = TimeSpan.FromMilliseconds(200);
+                options.ClusterConfiguration.Globals.TypeMapRefreshInterval = TimeSpan.FromMilliseconds(200);
                 return new TestCluster(options);
             }
         }

--- a/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
@@ -15,12 +15,14 @@ namespace Tester.HeterogeneousSilosTests
     public class HeterogeneousTests : OrleansTestingBase, IDisposable
     {
         private TestCluster cluster;
+        private readonly TimeSpan refreshTimeout = TimeSpan.FromMilliseconds(200);
 
         private void SetupAndDeployCluster(string defaultPlacementStrategy, params Type[] blackListedTypes)
         {
             cluster?.StopAllSilos();
             var typesName = blackListedTypes.Select(t => t.FullName).ToList();
             var options = new TestClusterOptions(1);
+            options.ClusterConfiguration.Globals.TypeMapRefreshTimeout = refreshTimeout;
             options.ClusterConfiguration.Globals.DefaultPlacementStrategy = defaultPlacementStrategy;
             options.ClusterConfiguration.Overrides[Silo.PrimarySiloName].ExcludedGrainTypes = typesName;
             cluster = new TestCluster(options);

--- a/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
@@ -15,14 +15,14 @@ namespace Tester.HeterogeneousSilosTests
     public class HeterogeneousTests : OrleansTestingBase, IDisposable
     {
         private TestCluster cluster;
-        private readonly TimeSpan refreshTimeout = TimeSpan.FromMilliseconds(200);
+        private readonly TimeSpan refreshInterval = TimeSpan.FromMilliseconds(200);
 
         private void SetupAndDeployCluster(string defaultPlacementStrategy, params Type[] blackListedTypes)
         {
             cluster?.StopAllSilos();
             var typesName = blackListedTypes.Select(t => t.FullName).ToList();
             var options = new TestClusterOptions(1);
-            options.ClusterConfiguration.Globals.TypeMapRefreshTimeout = refreshTimeout;
+            options.ClusterConfiguration.Globals.TypeMapRefreshInterval = refreshInterval;
             options.ClusterConfiguration.Globals.DefaultPlacementStrategy = defaultPlacementStrategy;
             options.ClusterConfiguration.Overrides[Silo.PrimarySiloName].ExcludedGrainTypes = typesName;
             cluster = new TestCluster(options);
@@ -61,7 +61,7 @@ namespace Tester.HeterogeneousSilosTests
         {
             SetupAndDeployCluster(defaultPlacementStrategy, blackListedTypes);
 
-            var delayTimeout = refreshTimeout.Add(refreshTimeout);
+            var delayTimeout = refreshInterval.Add(refreshInterval);
 
             // Should fail
             var exception = Assert.Throws<ArgumentException>(() => GrainFactory.GetGrain<ITestGrain>(0));

--- a/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
+using Xunit;
+
+namespace Tester.HeterogeneousSilosTests
+{
+    public class HeterogeneousTests : OrleansTestingBase, IDisposable
+    {
+        private TestCluster cluster;
+
+        private void SetupAndDeployCluster(params Type[] blackListedTypes)
+        {
+            var typesName = blackListedTypes.Select(t => t.FullName).ToList();
+            var options = new TestClusterOptions(1);
+            options.ClusterConfiguration.Overrides[Silo.PrimarySiloName].ExcludedGrainTypes = typesName;
+            cluster = new TestCluster(options);
+            cluster.Deploy();
+        }
+
+        public void Dispose()
+        {
+            cluster?.StopAllSilos();
+        }
+
+        [Fact]
+        public void GrainExcludedTest()
+        {
+            SetupAndDeployCluster(typeof(TestGrain));
+
+            // Should fail
+            var exception = Assert.Throws<ArgumentException>(() => GrainFactory.GetGrain<ITestGrain>(0));
+            Assert.Contains("Cannot find an implementation class for grain interface", exception.Message);
+
+            // Should not fail
+            GrainFactory.GetGrain<ISimpleGrainWithAsyncMethods>(0);
+        }
+    }
+}

--- a/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
@@ -61,13 +61,15 @@ namespace Tester.HeterogeneousSilosTests
         {
             SetupAndDeployCluster(defaultPlacementStrategy, blackListedTypes);
 
+            var delayTimeout = refreshTimeout.Add(refreshTimeout);
+
             // Should fail
             var exception = Assert.Throws<ArgumentException>(() => GrainFactory.GetGrain<ITestGrain>(0));
             Assert.Contains("Cannot find an implementation class for grain interface", exception.Message);
 
             // Start a new silo with TestGrain
             cluster.StartAdditionalSilo();
-            Thread.Sleep(1000);
+            await Task.Delay(delayTimeout);
 
             // Disconnect/Reconnect the client
             GrainClient.Uninitialize();
@@ -82,7 +84,7 @@ namespace Tester.HeterogeneousSilosTests
 
             // Stop the latest silos
             cluster.StopSecondarySilos();
-            Thread.Sleep(1000);
+            await Task.Delay(delayTimeout);
 
             var grain = GrainFactory.GetGrain<ITestGrain>(0);
             var orleansException = await Assert.ThrowsAsync<OrleansException>(() => grain.SetLabel("Hello world"));

--- a/test/Tester/MembershipTests/SilosStopTests.cs
+++ b/test/Tester/MembershipTests/SilosStopTests.cs
@@ -18,7 +18,7 @@ namespace UnitTests.MembershipTests
             options.ClusterConfiguration.Globals.DefaultPlacementStrategy = "ActivationCountBasedPlacement";
             options.ClusterConfiguration.Globals.NumMissedProbesLimit = 1;
             options.ClusterConfiguration.Globals.NumVotesForDeathDeclaration = 1;
-            options.ClusterConfiguration.Globals.TypeMapRefreshTimeout = TimeSpan.FromMilliseconds(100);
+            options.ClusterConfiguration.Globals.TypeMapRefreshInterval = TimeSpan.FromMilliseconds(100);
 
             // use only Primary as the gateway
             options.ClientConfiguration.Gateways = options.ClientConfiguration.Gateways.Take(1).ToList();

--- a/test/Tester/MembershipTests/SilosStopTests.cs
+++ b/test/Tester/MembershipTests/SilosStopTests.cs
@@ -18,6 +18,7 @@ namespace UnitTests.MembershipTests
             options.ClusterConfiguration.Globals.DefaultPlacementStrategy = "ActivationCountBasedPlacement";
             options.ClusterConfiguration.Globals.NumMissedProbesLimit = 1;
             options.ClusterConfiguration.Globals.NumVotesForDeathDeclaration = 1;
+            options.ClusterConfiguration.Globals.TypeMapRefreshTimeout = TimeSpan.FromMilliseconds(100);
 
             // use only Primary as the gateway
             options.ClientConfiguration.Gateways = options.ClientConfiguration.Gateways.Take(1).ToList();

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -48,6 +48,7 @@
     <Compile Include="CollectionFixtures.cs" />
     <Compile Include="DeploymentTests\DeployTest.cs" />
     <Compile Include="Forwarding\ShutdownSiloTests.cs" />
+    <Compile Include="HeterogeneousSilosTests\HeterogeneousTests.cs" />
     <Compile Include="MethodInterceptionTests.cs" />
     <Compile Include="General\JsonGrainTests.cs" />
     <Compile Include="PSClientTests\PSClientTests.cs" />

--- a/test/TesterInternal/General/ElasticPlacementTest.cs
+++ b/test/TesterInternal/General/ElasticPlacementTest.cs
@@ -32,7 +32,7 @@ namespace UnitTests.General
 
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
             options.ClientConfiguration.GatewayProvider = ClientConfiguration.GatewayProviderType.AzureTable;
-            options.ClusterConfiguration.Globals.TypeMapRefreshTimeout = TimeSpan.FromMilliseconds(100);
+            options.ClusterConfiguration.Globals.TypeMapRefreshInterval = TimeSpan.FromMilliseconds(100);
 
             return new TestCluster(options);
         }

--- a/test/TesterInternal/General/ElasticPlacementTest.cs
+++ b/test/TesterInternal/General/ElasticPlacementTest.cs
@@ -32,6 +32,7 @@ namespace UnitTests.General
 
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
             options.ClientConfiguration.GatewayProvider = ClientConfiguration.GatewayProviderType.AzureTable;
+            options.ClusterConfiguration.Globals.TypeMapRefreshTimeout = TimeSpan.FromMilliseconds(100);
 
             return new TestCluster(options);
         }


### PR DESCRIPTION
This is a PR for #2379 

Currently, the GrainInterfaceMap is built on each silo, and is sent to clients when they connect to a gateway.

### Proposed changes 
I tried to divide the PR in logical commits so it is easier to review:
- To test this functionality easily, I added a list of grain types that are ignored by the AssemblyLoader. (bbc118d and f793f2f). 
- Add a notion of “cluster wide” GrainInterfaceMap, that is a merge of all GrainInterfaceMaps built locally on each silo. (568cf00, 4bdc77a and 3aab754)
- Expose this new global GrainInterfaceMap to the clients (3aab754)
- Rebuild the global GrainInterfaceMap when new silos join the cluster (a259b31 and adf6ea1)
- Modify PlacementDirector to only consider “compatible”silos. (83057de and 77e80d8)

### How and when the global GrainInterfaceMap is recalculated
To avoid race conditions and complicated error handling, we choose to refresh the GrainInterfaceMap using a timer: every timer tick, if a silo joined the cluster since the last computation, we will get the local GrainInterfaceMap from the new silo and merge it into the global map. If this fails, it will be retried on the next tick. This process is done on each silo in the cluster.
The drawback of this approach is that a silo that joined the cluster will not be chosen for placement by other silos until this timer fire. I don’t think this is an issue, and the timer interval can be tweaked in configuration.

### Current implementation limitations
- When a new GrainInterfaceMap is computed, it is not pushed to clients. Client will need to disconnect/reconnect to get a refreshed type map.
- The “excluded grain types” should be use for test only
