### PR TITLE
Fix codegen to handle generated file smarter.

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -122,12 +122,14 @@ namespace Orleans.CodeGeneration
 
             ConsoleText.WriteStatus("Orleans-CodeGen - Generated file written {0}", outputFileName);
 
+#if !NETSTANDARD
             // Copy intermediate file to permanent location, if newer.
             ConsoleText.WriteStatus(
                 "Orleans-CodeGen - Updating IntelliSense file {0} -> {1}",
                 outputFileName,
                 options.CodeGenFile);
             UpdateIntellisenseFile(options.CodeGenFile, outputFileName);
+#endif
 
             return true;
         }
@@ -345,6 +347,7 @@ namespace Orleans.CodeGeneration
                     return 2;
                 }
 
+#if !NETSTANDARD
                 if (string.IsNullOrEmpty(options.CodeGenFile))
                 {
                     Console.WriteLine(
@@ -352,6 +355,7 @@ namespace Orleans.CodeGeneration
                         Path.Combine("Properties", "orleans.codegen.cs"));
                     return 2;
                 }
+#endif
 
                 options.SourcesDir = Path.Combine(options.InputLib.DirectoryName, "Generated");
 

--- a/vNext/src/ClientGenerator/ClientGenerator.csproj
+++ b/vNext/src/ClientGenerator/ClientGenerator.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
 
   <PropertyGroup Label="Configuration">
-    <DefineConstants></DefineConstants>
+    <DefineConstants>NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/vNext/src/Orleans.SDK.targets
+++ b/vNext/src/Orleans.SDK.targets
@@ -41,31 +41,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </Otherwise>
   </Choose>
 
-  <!-- include the codegen file in the project if it isn't there already -->
-  <Target Name="OrleansCodeGenerationFileInclude"
-          BeforeTargets="BeforeBuild">
-
-    <FindInList
-      List="@(Compile)"
-      ItemSpecToFind="Properties\orleans.codegen.cs"
-      CaseSensitive="false">
-      <Output TaskParameter="ItemFound" ItemName="CodegenCsAlreadyDefined"/>
-    </FindInList>
-
-    <ItemGroup Condition="'@(CodegenCsAlreadyDefined)'==''">
-      <Compile Include="Properties\orleans.codegen.cs" />
-    </ItemGroup>
-  </Target>
-
-  <!-- This target is run just before Clean for any Orleans project -->
-  <Target Name="OrleansCodeGenerationClean"
-          BeforeTargets="Clean"
-          Condition="'$(OrleansCodeGenPrecompile)'!='true'"
-          Inputs="$(ProjectDir)Properties\orleans.codegen.cs"
-          Outputs="AlwaysRun">
-    <Delete Files="$(ProjectDir)Properties\orleans.codegen.cs" ContinueOnError="true" />
-  </Target>
-
   <!-- This target is run just before Compile for an Orleans Grain Interface Project -->
   <Target Name="OrleansCodeGeneration"
           AfterTargets="BeforeCompile;ResolveReferences"
@@ -79,17 +54,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 - OrleansReferencesBase=$(OrleansReferencesBase)
 - OrleansSDK=$(OrleansSDK)
 - Using CodeGenToolExe location=$(CodeGenToolExe)
-" />
+" />      
     <MakeDir Directories="$(IntermediateOutputPath)Generated"/>
-    <Delete Files="$(ProjectDir)Properties\orleans.codegen.cs" ContinueOnError="true" />
-    <MakeDir Directories="$(ProjectDir)Properties"/>
-    <Touch Files="$(ProjectDir)Properties\orleans.codegen.cs"
-      Condition="!Exists('$(ProjectDir)Properties\orleans.codegen.cs')"
-      ForceTouch="true"
-      AlwaysCreate="true"
-      ContinueOnError="true" />
     <PropertyGroup>
       <ArgsFile>$(IntermediateOutputPath)$(TargetName).codegen.args.txt</ArgsFile>
+      <CodeGenFilename>$(IntermediateOutputPath)Generated\$(TargetName).codegen.cs</CodeGenFilename>
       <ExcludeCodeGen>$(DefineConstants);EXCLUDE_CODEGEN</ExcludeCodeGen>
     </PropertyGroup>
     <ItemGroup>
@@ -101,6 +70,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Message Text="[OrleansCodeGeneration] - Code-gen args file=$(ArgsFile)"/>
     <WriteLinesToFile Overwrite="true" File="$(ArgsFile)" Lines="@(CodeGenArgs)"/>
     <Message Text="[OrleansCodeGeneration] - Precompiled assembly"/>
-    <Exec Command='"$(CodeGenToolExe)" "@$(ArgsFile)"' />
+    <Exec Command="&quot;$(CodeGenToolExe)&quot; &quot;@$(ArgsFile)&quot;" Outputs="$(CodeGenFilename)">
+       <Output TaskParameter="Outputs" ItemName="Compile" />
+       <Output TaskParameter="Outputs" ItemName="FileWrites" />
+    </Exec>
   </Target>
 </Project>

--- a/vNext/src/Orleans/Orleans.csproj
+++ b/vNext/src/Orleans/Orleans.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs" />
-    <Compile Include="..\..\..\src\Orleans\**\*.cs" Exclude="..\..\..\src\Orleans\Properties\**\*.cs;..\..\..\src\Orleans\Statistics\RuntimeStatisticsGroup.cs" />
+    <Compile Include="..\..\..\src\Orleans\**\*.cs" Exclude="..\..\..\src\Orleans\Properties\**\*.cs;..\..\..\src\Orleans\bin\**\*.cs;..\..\..\src\Orleans\obj\**\*.cs;..\..\..\src\Orleans\Statistics\RuntimeStatisticsGroup.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vNext/src/Orleans/Orleans.csproj
+++ b/vNext/src/Orleans/Orleans.csproj
@@ -22,12 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Make sure we not include it twice because of globbing.  -->
-    <Compile Remove="Properties\orleans.codegen.cs" />
-    <Compile Include="Properties\orleans.codegen.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="..\..\..\src\Orleans\Configuration\OrleansConfiguration.xsd">
       <Link>Configuration\OrleansConfiguration.xsd</Link>
       <SubType>Designer</SubType>
@@ -143,7 +137,6 @@
     <!-- Clean Generated directory -->
     <Message Text="[OrleansDllBootstrapUsingCodeGen] - Deleting/cleaning generated files for Project=$(ProjectName)" />
     <MakeDir Directories="$(IntermediateOutputPath)Generated" />
-    <Touch Files="$(ProjectDir)Properties\orleans.codegen.cs" ForceTouch="true" AlwaysCreate="true" ContinueOnError="true" Condition="!Exists('$(ProjectDir)Properties\orleans.codegen.cs')" />
     <PropertyGroup>
       <BootstrapOutputPath>$(ProjectDir)\$(IntermediateOutputPath)Bootstrap\</BootstrapOutputPath>
       <BootstrapOutputPath Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(ProjectDir)$(IntermediateOutputPath)Bootstrap\</BootstrapOutputPath>
@@ -160,6 +153,7 @@
     <Message Text="[OrleansDllBootstrapUsingCodeGen] - Preprocessing $(TargetName)$(TargetExt) with ClientGenerator.exe" Importance="high" />
     <PropertyGroup>
       <ArgsFile>$(IntermediateOutputPath)$(TargetName).codegen.args.txt</ArgsFile>
+      <CodeGenFilename>$(BootstrapOutputPath)Generated\orleans.codegen.cs</CodeGenFilename>
     </PropertyGroup>
     <ItemGroup>
       <CodeGenArgs Include="/bootstrap" />
@@ -169,7 +163,10 @@
     </ItemGroup>
     <WriteLinesToFile Overwrite="true" File="$(ArgsFile)" Lines="@(CodeGenArgs)" />
     <Message Text="[OrleansDllBootstrapUsingCodeGen] - Invoking Code Generator" />
-    <Exec Command="&quot;$(BootstrapOutputPath)ClientGenerator.exe&quot; &quot;@$(ArgsFile)&quot;" />
+    <Exec Command="&quot;$(BootstrapOutputPath)ClientGenerator.exe&quot; &quot;@$(ArgsFile)&quot;" Outputs="$(CodeGenFilename)">
+       <Output TaskParameter="Outputs" ItemName="Compile" />
+       <Output TaskParameter="Outputs" ItemName="FileWrites" />
+    </Exec>
   </Target>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/vNext/src/OrleansProviders/OrleansProviders.csproj
+++ b/vNext/src/OrleansProviders/OrleansProviders.csproj
@@ -18,7 +18,7 @@
   
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs" />
-    <Compile Include="..\..\..\src\OrleansProviders\**\*.cs" Exclude="..\..\..\src\OrleansProviders\Properties\**\*.cs" />
+    <Compile Include="..\..\..\src\OrleansProviders\**\*.cs" Exclude="..\..\..\src\OrleansProviders\Properties\*.cs;..\..\..\src\OrleansProviders\bin\**\*.cs;..\..\..\src\OrleansProviders\obj\**\*.cs" />
   </ItemGroup>
  
   <ItemGroup>

--- a/vNext/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/vNext/src/OrleansRuntime/OrleansRuntime.csproj
@@ -18,7 +18,7 @@
   
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs" />
-    <Compile Include="..\..\..\src\OrleansRuntime\**\*.cs" Exclude="..\..\..\src\OrleansRuntime\Properties\*.cs" />
+    <Compile Include="..\..\..\src\OrleansRuntime\**\*.cs" Exclude="..\..\..\src\OrleansRuntime\Properties\*.cs;..\..\..\src\OrleansRuntime\bin\**\*.cs;..\..\..\src\OrleansRuntime\obj\**\*.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/vNext/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/vNext/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -19,7 +19,7 @@
   
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs" />
-    <Compile Include="..\..\..\src\OrleansTestingHost\**\*.cs" Exclude="..\..\..\src\OrleansTestingHost\Properties\*.cs;..\..\..\src\OrleansTestingHost\TestingSiloHost.cs;..\..\..\src\OrleansTestingHost\TestingSiloOptions.cs" />
+    <Compile Include="..\..\..\src\OrleansTestingHost\**\*.cs" Exclude="..\..\..\src\OrleansTestingHost\Properties\*.cs;..\..\..\src\OrleansTestingHost\bin\**\*.cs;..\..\..\src\OrleansTestingHost\obj\**\*.cs;..\..\..\src\OrleansTestingHost\TestingSiloHost.cs;..\..\..\src\OrleansTestingHost\TestingSiloOptions.cs" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
Fix codegen to not include orleans.codegen.cs in project file for vNext.
File inclusion in compile is done in a proper way dynamically.
Codegen file is created and used beneath the obj folder.