### PR TITLE
Make Release nuget packages also contain build date in vNext

### DIFF
--- a/vNext/src/Build.cmd
+++ b/vNext/src/Build.cmd
@@ -55,7 +55,7 @@ call %_dotnet% build %BUILD_FLAGS% /p:ArtefactDirectory=%OutputPath%\ /p:Configu
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD ok for %CONFIGURATION% %PROJ%
 
-call "%CMDHOME%\NuGet\CreateOrleansPackages.bat" %_dotnet% %OutputPath% %VERSION_FILE% %CMDHOME%\ false
+call "%CMDHOME%\NuGet\CreateOrleansPackages.bat" %_dotnet% %OutputPath% %VERSION_FILE% %CMDHOME%\ true
 @if ERRORLEVEL 1 GOTO :ErrorStop
 
 REM set STEP=VSIX


### PR DESCRIPTION
This makes the release packages also contain a build date for now.
For example packages will now be called something like:
`Microsoft.Orleans.OrleansRuntime.2.0.0-preview1-201612021300`
instead of just:
`Microsoft.Orleans.OrleansRuntime.2.0.0-preview1`