### PR TITLE
Reduce allocations in Interner

### DIFF
--- a/src/Orleans/IDs/ActivationId.cs
+++ b/src/Orleans/IDs/ActivationId.cs
@@ -66,7 +66,7 @@ namespace Orleans.Runtime
 
         private static ActivationId FindOrCreate(UniqueKey key)
         {
-            return interner.FindOrCreate(key, () => new ActivationId(key));
+            return interner.FindOrCreate(key, k => new ActivationId(k));
         }
 
         public override bool Equals(UniqueIdentifier obj)

--- a/src/Orleans/IDs/GrainId.cs
+++ b/src/Orleans/IDs/GrainId.cs
@@ -150,7 +150,7 @@ namespace Orleans.Runtime
         private static GrainId FindOrCreateGrainId(UniqueKey key)
         {
             // Note: This is done here to avoid a wierd cyclic dependency / static initialization ordering problem involving the GrainId, Constants & Interner classes
-            if (grainIdInternCache != null) return grainIdInternCache.FindOrCreate(key, () => new GrainId(key));
+            if (grainIdInternCache != null) return grainIdInternCache.FindOrCreate(key, k => new GrainId(k));
 
             lock (lockable)
             {
@@ -159,7 +159,7 @@ namespace Orleans.Runtime
                     grainIdInternCache = new Interner<UniqueKey, GrainId>(INTERN_CACHE_INITIAL_SIZE, internCacheCleanupInterval);
                 }
             }
-            return grainIdInternCache.FindOrCreate(key, () => new GrainId(key));
+            return grainIdInternCache.FindOrCreate(key, k => new GrainId(k));
         }
 
         #region IEquatable<GrainId> Members

--- a/src/Orleans/IDs/GuidId.cs
+++ b/src/Orleans/IDs/GuidId.cs
@@ -36,7 +36,7 @@ namespace Orleans.Runtime
 
         private static GuidId FindOrCreateGuidId(Guid guid)
         {
-            return guidIdInternCache.Value.FindOrCreate(guid, () => new GuidId(guid));
+            return guidIdInternCache.Value.FindOrCreate(guid, g => new GuidId(g));
         }
 
         #region IComparable<GuidId> Members

--- a/src/Orleans/IDs/Interner.cs
+++ b/src/Orleans/IDs/Interner.cs
@@ -60,7 +60,7 @@ namespace Orleans
         private readonly SafeTimer cacheCleanupTimer;
 
         [NonSerialized]
-        private readonly ConcurrentDictionary<K, WeakReference> internCache;
+        private readonly ConcurrentDictionary<K, WeakReference<T>> internCache;
 
         public Interner()
             : this(InternerConstants.SIZE_SMALL)
@@ -77,7 +77,7 @@ namespace Orleans
 
             logger = LogManager.GetLogger(internCacheName, LoggerType.Runtime);
 
-            this.internCache = new ConcurrentDictionary<K, WeakReference>(concurrencyLevel, initialSize);
+            this.internCache = new ConcurrentDictionary<K, WeakReference<T>>(concurrencyLevel, initialSize);
 
             this.cacheCleanupInterval = (cleanupFreq <= TimeSpan.Zero) ? Constants.INFINITE_TIMESPAN : cleanupFreq;
             if (Constants.INFINITE_TIMESPAN != cacheCleanupInterval)
@@ -98,29 +98,32 @@ namespace Orleans
         /// <returns>Object with specified key - either previous cached copy or newly created</returns>
         public T FindOrCreate(K key, Func<K, T> creatorFunc)
         {
-            T obj = null;
-            WeakReference cacheEntry = internCache.GetOrAdd(key,
-                k =>
-                {
-                    obj = creatorFunc(k);
-                    return new WeakReference(obj);
-                });
-            if (cacheEntry != null)
+            T result;
+            WeakReference<T> cacheEntry;
+
+            // Attempt to get the existing value from cache.
+            internCache.TryGetValue(key, out cacheEntry);
+
+            // If no cache entry exists, create and insert a new one using the creator function.
+            if (cacheEntry == null)
             {
-                if (cacheEntry.IsAlive)
-                {
-                    // Re-use cached object
-                    obj = cacheEntry.Target as T;
-                }
+                result = creatorFunc(key);
+                cacheEntry = new WeakReference<T>(result);
+                internCache[key] = cacheEntry;
+                return result;
             }
-            if (obj == null)
+
+            // If a cache entry did exist, determine if it still holds a valid value.
+            cacheEntry.TryGetTarget(out result);
+            if (result == null)
             {
-                // Create new object
-                obj = creatorFunc(key);
-                cacheEntry = new WeakReference(obj);
-                obj = internCache.AddOrUpdate(key, cacheEntry, (k, w) => cacheEntry).Target as T;
+                // Create new object and ensure the entry is still valid by re-inserting it into the cache.
+                result = creatorFunc(key);
+                cacheEntry.SetTarget(result);
+                internCache[key] = cacheEntry;
             }
-            return obj;
+
+            return result;
         }
 
         /// <summary>
@@ -131,19 +134,8 @@ namespace Orleans
         public bool TryFind(K key, out T obj)
         {
             obj = null;
-            WeakReference cacheEntry;
-            if (internCache.TryGetValue(key, out cacheEntry))
-            {
-                if (cacheEntry != null)
-                {
-                    if (cacheEntry.IsAlive)
-                    {
-                        obj = cacheEntry.Target as T;
-                        return obj != null;
-                    }
-                }
-            }
-            return false;
+            WeakReference<T> cacheEntry;
+            return internCache.TryGetValue(key, out cacheEntry) && cacheEntry != null && cacheEntry.TryGetTarget(out obj);
         }
 
         /// <summary>
@@ -157,51 +149,6 @@ namespace Orleans
             return FindOrCreate(key, _ => obj);
         }
 
-        /// <summary>
-        /// Intern the specified object, replacing any previous cached copy of object with specified key if the new object has a more derived type than the cached object
-        /// </summary>
-        /// <param name="key">object key</param>
-        /// <param name="obj">object to be interned</param>
-        /// <returns>Interned copy of the object with specified key</returns>
-        public T InternAndUpdateWithMoreDerived(K key, T obj)
-        {
-            T obj1 = obj;
-            WeakReference cacheEntry = internCache.GetOrAdd(key, k => new WeakReference(obj1));
-            if (cacheEntry != null)
-            {
-                if (cacheEntry.IsAlive)
-                {
-                    T obj2 = cacheEntry.Target as T;
-
-                    // Decide whether the old object or the new one has the most specific / derived type
-                    Type tNew = obj.GetType();
-                    Type tOld = obj2.GetType();
-                    if (tNew != tOld && tOld.IsAssignableFrom(tNew))
-                    {
-                        // Keep and use the more specific type
-                        cacheEntry.Target = obj;
-                        return obj;
-                    }
-                    else
-                    {
-                        // Re-use cached object
-                        return obj2;
-                    }
-                }
-                else
-                {
-                    cacheEntry.Target = obj;
-                    return obj;
-                }
-            }
-            else
-            {
-                cacheEntry = new WeakReference(obj);
-                obj = internCache.AddOrUpdate(key, cacheEntry, (k, w) => cacheEntry).Target as T;
-                return obj;
-            }
-        }
-
         public void StopAndClear()
         {
             internCache.Clear();
@@ -213,13 +160,10 @@ namespace Orleans
             List<T> values = new List<T>();
             foreach (var e in internCache)
             {
-                if (e.Value != null && e.Value.IsAlive && e.Value.Target != null)
+                T value;
+                if (e.Value != null && e.Value.TryGetTarget(out value))
                 {
-                    T obj = e.Value.Target as T;
-                    if (obj != null)
-                    {
-                        values.Add(obj);
-                    }
+                    values.Add(value);
                 }
             }
             return values;
@@ -239,9 +183,10 @@ namespace Orleans
 
             foreach (var e in internCache)
             {
-                if (e.Value == null || e.Value.IsAlive == false || e.Value.Target == null)
+                T ignored;
+                if (e.Value == null || e.Value.TryGetTarget(out ignored) == false)
                 {
-                    WeakReference weak;
+                    WeakReference<T> weak;
                     bool ok = internCache.TryRemove(e.Key, out weak);
                     if (!ok)
                     {
@@ -261,20 +206,6 @@ namespace Orleans
             {
                 if (logger.IsVerbose2) logger.Verbose2(ErrorCode.Runtime_Error_100296, "Removed {0} / {1} unused {2} entries in {3}", numRemoved, numEntries, internCacheName, clock.Elapsed);
             }
-        }
-
-        private string PrintInternerContent()
-        {
-            StringBuilder s = new StringBuilder();
-
-            foreach (var e in internCache)
-            {
-                if (e.Value != null && e.Value.IsAlive && e.Value.Target != null)
-                {
-                    s.AppendLine(String.Format("{0}->{1}", e.Key, e.Value.Target));
-                }
-            }
-            return s.ToString();
         }
 
         public void Dispose()

--- a/src/Orleans/IDs/QueueId.cs
+++ b/src/Orleans/IDs/QueueId.cs
@@ -35,7 +35,7 @@ namespace Orleans.Streams
         private static QueueId FindOrCreateQueueId(string queuePrefix, uint id, uint hash)
         {
             var key = new QueueId(queuePrefix, id, hash);
-            return queueIdInternCache.Value.FindOrCreate(key, () => key);
+            return queueIdInternCache.Value.FindOrCreate(key, k => k);
         }
 
         public string GetStringNamePrefix()

--- a/src/Orleans/IDs/StreamId.cs
+++ b/src/Orleans/IDs/StreamId.cs
@@ -42,7 +42,7 @@ namespace Orleans.Streams
 
         private static StreamId FindOrCreateStreamId(StreamIdInternerKey key)
         {
-            return streamIdInternCache.Value.FindOrCreate(key, () => new StreamId(key));
+            return streamIdInternCache.Value.FindOrCreate(key, k => new StreamId(k));
         }
 
         #region IComparable<StreamId> Members

--- a/src/Orleans/Logging/LogManager.cs
+++ b/src/Orleans/Logging/LogManager.cs
@@ -245,7 +245,7 @@ namespace Orleans.Runtime
         internal static LoggerImpl GetLogger(string loggerName, LoggerType logType)
         {
             return loggerStoreInternCache != null ?
-                loggerStoreInternCache.FindOrCreate(loggerName, () => new LoggerImpl(loggerName, logType)) :
+                loggerStoreInternCache.FindOrCreate(loggerName, name => new LoggerImpl(name, logType)) :
                 new LoggerImpl(loggerName, logType);
         }
 

--- a/test/NonSiloTests/General/Identifiertests.cs
+++ b/test/NonSiloTests/General/Identifiertests.cs
@@ -273,8 +273,8 @@ namespace UnitTests.General
         {
             Interner<string, string> interner = new Interner<string, string>();
             const string str = "1";
-            string r1 = interner.FindOrCreate("1", () => str);
-            string r2 = interner.FindOrCreate("1", () => null); // Should always be found
+            string r1 = interner.FindOrCreate("1", _ => str);
+            string r2 = interner.FindOrCreate("1", _ => null); // Should always be found
 
             Assert.Equal(r1, r2); // 1: Objects should be equal
             Assert.Same(r1, r2); // 2: Objects should be same / intern'ed
@@ -326,26 +326,26 @@ namespace UnitTests.General
             var obj2 = new B();
             var obj3 = new B();
 
-            var r1 = interner.FindOrCreate(1, () => obj1);
+            var r1 = interner.FindOrCreate(1, _ => obj1);
             Assert.Equal(obj1, r1); // Objects should be equal
             Assert.Same(obj1, r1); // Objects should be same / intern'ed
 
-            var r2 = interner.FindOrCreate(2, () => obj2);
+            var r2 = interner.FindOrCreate(2, _ => obj2);
             Assert.Equal(obj2, r2); // Objects should be equal
             Assert.Same(obj2, r2); // Objects should be same / intern'ed
 
             // FindOrCreate should not replace instances of same class
-            var r3 = interner.FindOrCreate(2, () => obj3);
+            var r3 = interner.FindOrCreate(2, _ => obj3);
             Assert.Same(obj2, r3); // FindOrCreate should return previous object
             Assert.NotSame(obj3, r3); // FindOrCreate should not replace previous object of same class
 
             // FindOrCreate should not replace cached instances with instances of most derived class
-            var r4 = interner.FindOrCreate(1, () => obj2);
+            var r4 = interner.FindOrCreate(1, _ => obj2);
             Assert.Same(obj1, r4); // FindOrCreate return previously cached object
             Assert.NotSame(obj2, r4); // FindOrCreate should not replace previously cached object
 
             // FindOrCreate should not replace cached instances with instances of less derived class
-            var r5 = interner.FindOrCreate(2, () => obj1);
+            var r5 = interner.FindOrCreate(2, _ => obj1);
             Assert.NotSame(obj1, r5); // FindOrCreate should not replace previously cached object
             Assert.Same(obj2, r5); // FindOrCreate return previously cached object
         }

--- a/test/NonSiloTests/General/Identifiertests.cs
+++ b/test/NonSiloTests/General/Identifiertests.cs
@@ -287,38 +287,6 @@ namespace UnitTests.General
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
-        public void ID_Intern_derived_class()
-        {
-            Interner<int, A> interner = new Interner<int, A>();
-            var obj1 = new A();
-            var obj2 = new B();
-            var obj3 = new B();
-
-            var r1 = interner.InternAndUpdateWithMoreDerived(1, obj1);
-            Assert.Equal(obj1, r1); // Objects should be equal
-            Assert.Same(obj1, r1); // Objects should be same / intern'ed
-
-            var r2 = interner.InternAndUpdateWithMoreDerived(2, obj2);
-            Assert.Equal(obj2, r2); // Objects should be equal
-            Assert.Same(obj2, r2); // Objects should be same / intern'ed
-
-            // Interning should not replace instances of same class
-            var r3 = interner.InternAndUpdateWithMoreDerived(2, obj3);
-            Assert.Same(obj2, r3); // Interning should return previous object
-            Assert.NotSame(obj3, r3); // Interning should not replace previous object of same class
-
-            // Interning should return instances of most derived class
-            var r4 = interner.InternAndUpdateWithMoreDerived(1, obj2);
-            Assert.Same(obj2, r4); // Interning should return most derived object
-            Assert.NotSame(obj1, r4); // Interning should replace cached instances of less derived object
-
-            // Interning should not return instances of less derived class
-            var r5 = interner.InternAndUpdateWithMoreDerived(2, obj1);
-            Assert.NotSame(obj1, r5); // Interning should not return less derived object
-            Assert.Same(obj2, r5); // Interning should return previously cached instances of more derived object
-        }
-
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void ID_Intern_FindOrCreate_derived_class()
         {
             Interner<int, A> interner = new Interner<int, A>();


### PR DESCRIPTION
Cleans up the `Interner` class so that allocations do not occur on the hot path.

* Avoid allocating a closure for the `createFunc` parameter if possible
* Avoid closure allocations within `Interner.FindOrCreate`
* Converted to `WeakReference<T>` instead of `WeakReference` in order to simplify the code.