### PR TITLE
Reduce use of globals in SiloProviderRuntime

### DIFF
--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -139,7 +139,7 @@ namespace Orleans.Providers
                     var obj = ((GrainFactory)this.GrainFactory).CreateObjectReference<TExtensionInterface>(extension);
 
                     addressable = obj;
-
+                     
                     if (null == addressable)
                     {
                         throw new NullReferenceException("addressable");
@@ -173,13 +173,6 @@ namespace Orleans.Providers
         public IConsistentRingProviderForGrains GetConsistentRingProvider(int mySubRangeIndex, int numSubRanges)
         {
             throw new NotImplementedException("GetConsistentRingProvider");
-        }
-
-        public bool InSilo { get { return false; } }
-
-        public object GetCurrentSchedulingContext()
-        {
-            return null;
         }
     }
 }

--- a/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
+++ b/src/Orleans/Streams/Providers/IStreamProviderRuntime.cs
@@ -14,12 +14,16 @@ namespace Orleans.Streams
     {
         /// <summary>
         /// Retrieves the opaque identity of currently executing grain or client object. 
-        /// Just for logging purposes.
         /// </summary>
+        /// <remarks>Exposed for logging purposes.</remarks>
         string ExecutingEntityIdentity();
 
         SiloAddress ExecutingSiloAddress { get; }
 
+        /// <summary>
+        /// Returns the stream directory.
+        /// </summary>
+        /// <returns>The stream directory.</returns>
         StreamDirectory GetStreamDirectory();
 
         void RegisterSystemTarget(ISystemTarget target);
@@ -48,11 +52,6 @@ namespace Orleans.Streams
         /// <param name="numSubRanges">Total number of sub ranges within this silo range.</param>
         /// <returns></returns>
         IConsistentRingProviderForGrains GetConsistentRingProvider(int mySubRangeIndex, int numSubRanges);
-
-        /// <summary>Return true if this runtime executes inside silo, false otherwise (on the client).</summary>
-        bool InSilo { get; }
-
-        object GetCurrentSchedulingContext();
     }
 
         /// <summary>

--- a/src/Orleans/Streams/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans/Streams/PubSub/ImplicitStreamSubscriberTable.cs
@@ -11,7 +11,7 @@ namespace Orleans.Streams
     {
         private readonly Dictionary<string, HashSet<int>> table;
 
-        internal ImplicitStreamSubscriberTable()
+        public ImplicitStreamSubscriberTable()
         {
             table = new Dictionary<string, HashSet<int>>();
         }

--- a/src/OrleansRuntime/Cancellation/CancellationSourcesExtension.cs
+++ b/src/OrleansRuntime/Cancellation/CancellationSourcesExtension.cs
@@ -45,7 +45,12 @@ namespace Orleans.Runtime
         /// <param name="target"></param>
         /// <param name="request"></param>
         /// <param name="logger"></param>
-        internal static void RegisterCancellationTokens(IAddressable target, InvokeMethodRequest request, Logger logger)
+        /// <param name="siloRuntimeClient"></param>
+        internal static void RegisterCancellationTokens(
+            IAddressable target,
+            InvokeMethodRequest request,
+            Logger logger,
+            ISiloRuntimeClient siloRuntimeClient)
         {
             for (var i = 0; i < request.Arguments.Length; i++)
             {
@@ -54,10 +59,10 @@ namespace Orleans.Runtime
                 var grainToken = ((GrainCancellationToken) request.Arguments[i]);
 
                 CancellationSourcesExtension cancellationExtension;
-                if (!SiloProviderRuntime.Instance.TryGetExtensionHandler(out cancellationExtension))
+                if (!siloRuntimeClient.TryGetExtensionHandler(out cancellationExtension))
                 {
                     cancellationExtension = new CancellationSourcesExtension();
-                    if (!SiloProviderRuntime.Instance.TryAddExtension(cancellationExtension))
+                    if (!siloRuntimeClient.TryAddExtension(cancellationExtension))
                     {
                         logger.Error(
                             ErrorCode.CancellationExtensionCreationFailed,

--- a/src/OrleansRuntime/Catalog/GrainCreator.cs
+++ b/src/OrleansRuntime/Catalog/GrainCreator.cs
@@ -30,14 +30,7 @@ namespace Orleans.Runtime
         {
             this.services = services;
             this.grainRuntime = new Lazy<IGrainRuntime>(getGrainRuntime);
-            if (services != null)
-            {
-                this.createFactory = type => ActivatorUtilities.CreateFactory(type, Type.EmptyTypes);
-            }
-            else
-            {
-                this.createFactory = type => (sp, args) => Activator.CreateInstance(type);
-            }
+            this.createFactory = type => ActivatorUtilities.CreateFactory(type, Type.EmptyTypes);
         }
 
         /// <summary>

--- a/src/OrleansRuntime/Core/BootstrapProviderManager.cs
+++ b/src/OrleansRuntime/Core/BootstrapProviderManager.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
-using Orleans.Runtime.Providers;
 
 namespace Orleans.Runtime
 {
@@ -29,9 +28,10 @@ namespace Orleans.Runtime
 
         // Explicitly typed, for backward compat
         public async Task LoadAppBootstrapProviders(
+            IProviderRuntime providerRuntime,
             IDictionary<string, ProviderCategoryConfiguration> configs)
         {
-            await pluginManager.LoadAndInitPluginProviders(configCategoryName, configs);
+            await pluginManager.LoadAndInitPluginProviders(providerRuntime, configCategoryName, configs);
         }
 
 
@@ -57,7 +57,7 @@ namespace Orleans.Runtime
 
             public IProvider GetProvider(string name)
             {
-                return providerLoader != null ? providerLoader.GetProvider(name) : null;
+                return providerLoader?.GetProvider(name);
             }
 
             public IList<T> GetProviders()
@@ -66,7 +66,9 @@ namespace Orleans.Runtime
             }
 
             internal async Task LoadAndInitPluginProviders(
-                string configCategoryName, IDictionary<string, ProviderCategoryConfiguration> configs)
+                IProviderRuntime providerRuntime,
+                string configCategoryName,
+                IDictionary<string, ProviderCategoryConfiguration> configs)
             {
                 ProviderCategoryConfiguration categoryConfig;
                 if (!configs.TryGetValue(configCategoryName, out categoryConfig)) return;
@@ -76,7 +78,7 @@ namespace Orleans.Runtime
                 logger.Info(ErrorCode.SiloCallingProviderInit, "Calling Init for {0} classes", typeof(T).Name);
 
                 // Await here to force any errors to show this method name in stack trace, for better diagnostics
-                await providerLoader.InitProviders(SiloProviderRuntime.Instance);
+                await providerLoader.InitProviders(providerRuntime);
             }
         }
     }

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -579,7 +579,7 @@ namespace Orleans.Runtime
             // message.
             var strategy = targetAddress.Grain.IsGrain ? catalog.GetGrainPlacementStrategy(targetAddress.Grain) : null;
             var placementResult = await this.placementDirectorsManager.SelectOrAddActivation(
-                message.SendingAddress, message.TargetGrain, InsideRuntimeClient.Current.Catalog, strategy);
+                message.SendingAddress, message.TargetGrain, this.catalog, strategy);
 
             if (placementResult.IsNewPlacement && targetAddress.Grain.IsClient)
             {

--- a/src/OrleansRuntime/Core/ISiloRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/ISiloRuntimeClient.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.Streams;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Runtime client methods accessible on silos.
+    /// </summary>
+    internal interface ISiloRuntimeClient : IRuntimeClient
+    {
+        /// <summary>
+        /// Gets the stream directory.
+        /// </summary>
+        /// <returns>The stream directory.</returns>
+        StreamDirectory GetStreamDirectory();
+
+        /// <summary>
+        /// Retrieves the opaque identity of currently executing grain or client object. 
+        /// </summary>
+        /// <remarks>Exposed for logging purposes.</remarks>
+        string ExecutingEntityIdentity();
+        
+        /// <summary>
+        /// Attempts to add the provided extension handler to the currently executing grain.
+        /// </summary>
+        /// <param name="handler">The extension handler.</param>
+        /// <returns><see langword="true"/> if the operation succeeded; <see langword="false" /> otherwise.</returns>
+        bool TryAddExtension(IGrainExtension handler);
+
+        /// <summary>
+        /// Attempts to retrieve the specified extension type from the currently executing grain.
+        /// </summary>
+        /// <typeparam name="TExtension">The type of the extension.</typeparam>
+        /// <param name="result">The extension, or <see langword="null" /> if it was not available.</param>
+        /// <returns><see langword="true"/> if the operation succeeded; <see langword="false" /> otherwise.</returns>
+        bool TryGetExtensionHandler<TExtension>(out TExtension result) where TExtension : IGrainExtension;
+
+        /// <summary>
+        /// Removes the provided extension handler from the currently executing grain.
+        /// </summary>
+        /// <param name="handler">The extension handler to remove.</param>
+        void RemoveExtension(IGrainExtension handler);
+
+        /// <summary>
+        /// Binds an extension to the currently executing grain if it does not already have an extension of the specified
+        /// <typeparamref name="TExtensionInterface"/>.
+        /// </summary>
+        /// <typeparam name="TExtension">The type of the extension (e.g. StreamConsumerExtension).</typeparam>
+        /// <typeparam name="TExtensionInterface">The public interface type of the implementation.</typeparam>
+        /// <param name="newExtensionFunc">A factory function that constructs a new extension object.</param>
+        /// <returns>A tuple, containing first the extension and second an addressable reference to the extension's interface.</returns>
+        Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
+            where TExtension : IGrainExtension
+            where TExtensionInterface : IGrainExtension;
+    }
+}

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Cancellation\CancellationSourcesExtension.cs" />
     <Compile Include="Catalog\ActivationState.cs" />
     <Compile Include="Catalog\GrainCreator.cs" />
+    <Compile Include="Core\ISiloRuntimeClient.cs" />
     <Compile Include="Counters\CounterConfigData.cs" />
     <Compile Include="Messaging\ObjectPool.cs" />
     <Compile Include="Silo\SiloInitializationParameters.cs" />

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Runtime;
 using System.Text;
@@ -237,6 +238,7 @@ namespace Orleans.Runtime
                     services.TryAddSingleton(sp => sp.GetRequiredService<Catalog>().Dispatcher);
                     services.TryAddSingleton<InsideRuntimeClient>();
                     services.TryAddExisting<IRuntimeClient, InsideRuntimeClient>();
+                    services.TryAddExisting<ISiloRuntimeClient, InsideRuntimeClient>();
                     services.TryAddSingleton<MembershipFactory>();
                     services.TryAddSingleton<MultiClusterOracleFactory>();
                     services.TryAddSingleton<LocalReminderServiceFactory>();
@@ -253,6 +255,9 @@ namespace Orleans.Runtime
                     services.TryAddSingleton<MultiClusterOracleFactory>();
                     services.TryAddSingleton<LocalReminderServiceFactory>();
                     services.TryAddSingleton<ClientObserverRegistrar>();
+                    services.TryAddSingleton<SiloProviderRuntime>();
+                    services.TryAddExisting<IStreamProviderRuntime, SiloProviderRuntime>();
+                    services.TryAddSingleton<ImplicitStreamSubscriberTable>();
 
                     // Placement
                     services.TryAddSingleton<PlacementDirectorsManager>();
@@ -264,14 +269,7 @@ namespace Orleans.Runtime
                     services.TryAddSingleton<ClientObserversPlacementDirector>();
                     
                     services.TryAddSingleton<Func<IGrainRuntime>>(sp => () => sp.GetRequiredService<IGrainRuntime>());
-                    if (usingCustomServiceProvider)
-                    {
-                        services.TryAddSingleton<GrainCreator>();
-                    }
-                    else
-                    {
-                        services.TryAddSingleton(sp => new GrainCreator(null, sp.GetRequiredService<Func<IGrainRuntime>>()));
-                    }
+                    services.TryAddSingleton<GrainCreator>();
 
                     if (initializationParams.GlobalConfig.UseVirtualBucketsConsistentRing)
                     {
@@ -351,7 +349,7 @@ namespace Orleans.Runtime
 
             membershipFactory = Services.GetRequiredService<MembershipFactory>();
             membershipOracle = Services.GetRequiredService<IMembershipOracle>();
-
+            
             SystemStatus.Current = SystemStatus.Created;
 
             StringValueStatistic.FindOrCreate(StatisticNames.SILO_START_TIME,
@@ -369,7 +367,8 @@ namespace Orleans.Runtime
             RegisterSystemTarget(siloControl);
 
             logger.Verbose("Creating {0} System Target", "StreamProviderUpdateAgent");
-            RegisterSystemTarget(new StreamProviderManagerAgent(this, allSiloProviders));
+            RegisterSystemTarget(
+                new StreamProviderManagerAgent(this, allSiloProviders, Services.GetRequiredService<IStreamProviderRuntime>()));
 
             logger.Verbose("Creating {0} System Target", "DeploymentLoadPublisher");
             RegisterSystemTarget(Services.GetRequiredService<DeploymentLoadPublisher>());
@@ -384,7 +383,8 @@ namespace Orleans.Runtime
             logger.Verbose("Creating {0} System Target", "ClientObserverRegistrar + TypeManager");
 
             this.RegisterSystemTarget(this.Services.GetRequiredService<ClientObserverRegistrar>());
-            typeManager = new TypeManager(SiloAddress, this.grainTypeManager, membershipOracle, LocalScheduler, GlobalConfig.TypeMapRefreshInterval);
+            var implicitStreamSubscriberTable = Services.GetRequiredService<ImplicitStreamSubscriberTable>();
+            typeManager = new TypeManager(SiloAddress, this.grainTypeManager, membershipOracle, LocalScheduler, GlobalConfig.TypeMapRefreshInterval, implicitStreamSubscriberTable);
             this.RegisterSystemTarget(typeManager);
 
             logger.Verbose("Creating {0} System Target", "MembershipOracle");
@@ -494,11 +494,14 @@ namespace Orleans.Runtime
 
             // Set up an execution context for this thread so that the target creation steps can use asynch values.
             RuntimeContext.InitializeMainThread();
+            
+            // Initialize the implicit stream subscribers table.
+            var implicitStreamSubscriberTable = Services.GetRequiredService<ImplicitStreamSubscriberTable>();
+            implicitStreamSubscriberTable.InitImplicitStreamSubscribers(this.grainTypeManager.GrainClassTypeData.Select(t => t.Value.Type).ToArray());
 
-            SiloProviderRuntime.Initialize(GlobalConfig, SiloAddress.ToLongString(), grainFactory, Services);
-            SiloProviderRuntime.Instance.StreamingInitialize();
-            runtimeClient.CurrentStreamProviderRuntime = SiloProviderRuntime.Instance;
-            statisticsProviderManager = new StatisticsProviderManager("Statistics", SiloProviderRuntime.Instance);
+            var siloProviderRuntime = Services.GetRequiredService<SiloProviderRuntime>();
+            runtimeClient.CurrentStreamProviderRuntime = siloProviderRuntime;
+            statisticsProviderManager = new StatisticsProviderManager("Statistics", siloProviderRuntime);
             string statsProviderName =  statisticsProviderManager.LoadProvider(GlobalConfig.ProviderConfigurations)
                 .WaitForResultWithThrow(initTimeout);
             if (statsProviderName != null)
@@ -528,7 +531,7 @@ namespace Orleans.Runtime
             if (logger.IsVerbose) {  logger.Verbose("System grains created successfully."); }
 
             // Initialize storage providers once we have a basic silo runtime environment operating
-            storageProviderManager = new StorageProviderManager(grainFactory, Services);
+            storageProviderManager = new StorageProviderManager(grainFactory, Services, siloProviderRuntime);
             scheduler.QueueTask(
                 () => storageProviderManager.LoadStorageProviders(GlobalConfig.ProviderConfigurations),
                 providerManagerSystemTarget.SchedulingContext)
@@ -540,7 +543,7 @@ namespace Orleans.Runtime
             // Load and init stream providers before silo becomes active
             var siloStreamProviderManager = (StreamProviderManager)grainRuntime.StreamProviderManager;
             scheduler.QueueTask(
-                () => siloStreamProviderManager.LoadStreamProviders(GlobalConfig.ProviderConfigurations, SiloProviderRuntime.Instance),
+                () => siloStreamProviderManager.LoadStreamProviders(GlobalConfig.ProviderConfigurations, siloProviderRuntime),
                     providerManagerSystemTarget.SchedulingContext)
                         .WaitWithThrow(initTimeout);
             runtimeClient.CurrentStreamProviderManager = siloStreamProviderManager;
@@ -606,7 +609,7 @@ namespace Orleans.Runtime
 
                 this.bootstrapProviderManager = new BootstrapProviderManager();
                 this.scheduler.QueueTask(
-                    () => this.bootstrapProviderManager.LoadAppBootstrapProviders(this.GlobalConfig.ProviderConfigurations),
+                    () => this.bootstrapProviderManager.LoadAppBootstrapProviders(siloProviderRuntime, this.GlobalConfig.ProviderConfigurations),
                     this.providerManagerSystemTarget.SchedulingContext)
                         .WaitWithThrow(this.initTimeout);
                 this.BootstrapProviders = this.bootstrapProviderManager.GetProviders(); // Data hook for testing & diagnotics

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -1,34 +1,55 @@
 using System;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-
-using Microsoft.Extensions.DependencyInjection;
 
 using Orleans.CodeGeneration;
 using Orleans.Concurrency;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.ConsistentRing;
-using Orleans.Runtime.Scheduler;
 using Orleans.Streams;
 
 namespace Orleans.Runtime.Providers
 {
     internal class SiloProviderRuntime : ISiloSideStreamProviderRuntime
-    { 
-        private static volatile SiloProviderRuntime instance;
-        private static readonly object syncRoot = new Object();
-
-        private IStreamPubSub grainBasedPubSub;
-        private IStreamPubSub implictPubSub;
-        private IStreamPubSub combinedGrainBasedAndImplicitPubSub;
-
-        private ImplicitStreamSubscriberTable implicitStreamSubscriberTable;
+    {
+        private readonly Silo silo;
+        private readonly IConsistentRingProvider consistentRingProvider;
+        private readonly ISiloRuntimeClient runtimeClient;
+        private readonly IStreamPubSub grainBasedPubSub;
+        private readonly IStreamPubSub implictPubSub;
+        private readonly IStreamPubSub combinedGrainBasedAndImplicitPubSub;
+        
         private InvokeInterceptor invokeInterceptor;
 
-        public IGrainFactory GrainFactory { get; private set; }
-        public IServiceProvider ServiceProvider { get; private set; }
+        public IGrainFactory GrainFactory { get; }
+        public IServiceProvider ServiceProvider { get; }
+
+        public Guid ServiceId { get; }
+        public string SiloIdentity { get; }
+
+        public SiloProviderRuntime(
+            Silo silo,
+            GlobalConfiguration config,
+            IGrainFactory grainFactory,
+            IConsistentRingProvider consistentRingProvider,
+            ISiloRuntimeClient runtimeClient,
+            IServiceProvider serviceProvider,
+            ImplicitStreamSubscriberTable implicitStreamSubscriberTable)
+        {
+            this.silo = silo;
+            this.consistentRingProvider = consistentRingProvider;
+            this.runtimeClient = runtimeClient;
+            this.ServiceId = config.ServiceId;
+            this.SiloIdentity = silo.SiloAddress.ToLongString();
+            this.GrainFactory = grainFactory;
+            this.ServiceProvider = serviceProvider;
+
+            this.grainBasedPubSub = new GrainBasedPubSubRuntime(this.GrainFactory);
+            var tmp = new ImplicitStreamPubSub(implicitStreamSubscriberTable);
+            this.implictPubSub = tmp;
+            this.combinedGrainBasedAndImplicitPubSub = new StreamPubSubImpl(this.grainBasedPubSub, tmp);
+        }
 
         public void SetInvokeInterceptor(InvokeInterceptor interceptor)
         {
@@ -40,79 +61,21 @@ namespace Orleans.Runtime.Providers
             return this.invokeInterceptor;
         }
 
-        public Guid ServiceId { get; private set; }
-        public string SiloIdentity { get; private set; }
-
-        private SiloProviderRuntime()
-        {
-        }
-
-        internal static void Initialize(GlobalConfiguration config, string siloIdentity, IGrainFactory grainFactory, IServiceProvider serviceProvider)
-        {
-            Instance.ServiceId = config.ServiceId;
-            Instance.SiloIdentity = siloIdentity;
-            Instance.GrainFactory = grainFactory;
-            Instance.ServiceProvider = serviceProvider;
-        }
-
-        public static SiloProviderRuntime Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (syncRoot)
-                    {
-                        if (instance == null)
-                            instance = new SiloProviderRuntime();
-                    }
-                }
-                return instance;
-            }
-        }
-
-        public ImplicitStreamSubscriberTable ImplicitStreamSubscriberTable { get { return implicitStreamSubscriberTable; } }
-
-        public void StreamingInitialize()
-        {
-            this.implicitStreamSubscriberTable = new ImplicitStreamSubscriberTable();
-            this.grainBasedPubSub = new GrainBasedPubSubRuntime(this.GrainFactory);
-            var tmp = new ImplicitStreamPubSub(this.implicitStreamSubscriberTable);
-            this.implictPubSub = tmp;
-            this.combinedGrainBasedAndImplicitPubSub = new StreamPubSubImpl(this.grainBasedPubSub, tmp);
-
-            var typeManager = this.ServiceProvider.GetRequiredService<GrainTypeManager>();
-            Type[] types = typeManager.GrainClassTypeData.Select(t => t.Value.Type).ToArray();
-            this.ImplicitStreamSubscriberTable.InitImplicitStreamSubscribers(types);
-        }
-
-        public StreamDirectory GetStreamDirectory()
-        {
-            var currentActivation = GetCurrentActivationData();
-            return currentActivation.GetStreamDirectory();
-        }
-
         public Logger GetLogger(string loggerName)
         {
             return LogManager.GetLogger(loggerName, LoggerType.Provider);
         }
 
-        public string ExecutingEntityIdentity()
-        {
-            var currentActivation = GetCurrentActivationData();
-            return currentActivation.Address.ToString();
-        }
-
-        public SiloAddress ExecutingSiloAddress { get { return Silo.CurrentSilo.SiloAddress; } }
+        public SiloAddress ExecutingSiloAddress => this.silo.SiloAddress;
 
         public void RegisterSystemTarget(ISystemTarget target)
         {
-            Silo.CurrentSilo.RegisterSystemTarget((SystemTarget)target);
+            this.silo.RegisterSystemTarget((SystemTarget)target);
         }
 
         public void UnRegisterSystemTarget(ISystemTarget target)
         {
-            Silo.CurrentSilo.UnregisterSystemTarget((SystemTarget)target);
+            this.silo.UnregisterSystemTarget((SystemTarget)target);
         }
 
         public IStreamPubSub PubSub(StreamPubSubType pubSubType)
@@ -132,100 +95,9 @@ namespace Orleans.Runtime.Providers
 
         public IConsistentRingProviderForGrains GetConsistentRingProvider(int mySubRangeIndex, int numSubRanges)
         {
-            return new EquallyDividedRangeRingProvider(InsideRuntimeClient.Current.ConsistentRingProvider, mySubRangeIndex, numSubRanges);
+            return new EquallyDividedRangeRingProvider(this.consistentRingProvider, mySubRangeIndex, numSubRanges);
         }
-
-        public bool InSilo { get { return true; } }
-
-        public Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
-            where TExtension : IGrainExtension
-            where TExtensionInterface : IGrainExtension
-        {
-            TExtension extension;
-            if (!TryGetExtensionHandler(out extension))
-            {
-                extension = newExtensionFunc();
-                if (!TryAddExtension(extension))
-                    throw new OrleansException("Failed to register " + typeof(TExtension).Name);
-            }
-
-            IAddressable currentGrain = RuntimeClient.Current.CurrentActivationData.GrainInstance;
-            var currentTypedGrain = currentGrain.AsReference<TExtensionInterface>();
-
-            return Task.FromResult(Tuple.Create(extension, currentTypedGrain));
-        }
-
-        /// <summary>
-        /// Adds the specified extension handler to the currently running activation.
-        /// This method must be called during an activation turn.
-        /// </summary>
-        /// <param name="handler"></param>
-        /// <returns></returns>
-        internal bool TryAddExtension(IGrainExtension handler)
-        {
-            var currentActivation = GetCurrentActivationData();
-            var invoker = TryGetExtensionInvoker(handler.GetType());
-            if (invoker == null)
-                throw new InvalidOperationException("Extension method invoker was not generated for an extension interface");
-            
-            return currentActivation.TryAddExtension(invoker, handler);
-        }
-
-        private static ActivationData GetCurrentActivationData()
-        {
-            var context = RuntimeContext.Current.ActivationContext as SchedulingContext;
-            if (context == null || context.Activation == null)
-                throw new InvalidOperationException("Attempting to GetCurrentActivationData when not in an activation scope");
-            
-            var currentActivation = context.Activation;
-            return currentActivation;
-        }
-
-        /// <summary>
-        /// Removes the specified extension handler (and any other extension that implements the same interface ID)
-        /// from the currently running activation.
-        /// This method must be called during an activation turn.
-        /// </summary>
-        /// <param name="handler"></param>
-        internal void RemoveExtension(IGrainExtension handler)
-        {
-            var currentActivation = GetCurrentActivationData();
-            currentActivation.RemoveExtension(handler);
-        }
-
-        internal bool TryGetExtensionHandler<TExtension>(out TExtension result)
-        {
-            var currentActivation = GetCurrentActivationData();
-            IGrainExtension untypedResult;
-            if (currentActivation.TryGetExtensionHandler(typeof(TExtension), out untypedResult))
-            {
-                result = (TExtension)untypedResult;
-                return true;
-            }
-            
-            result = default(TExtension);
-            return false;
-        }
-
-        private static IGrainExtensionMethodInvoker TryGetExtensionInvoker(Type handlerType)
-        {
-            var interfaces = CodeGeneration.GrainInterfaceUtils.GetRemoteInterfaces(handlerType).Values;
-            if(interfaces.Count != 1)
-                throw new InvalidOperationException(String.Format("Extension type {0} implements more than one grain interface.", handlerType.FullName));
-
-            var interfaceId = CodeGeneration.GrainInterfaceUtils.ComputeInterfaceId(interfaces.First());
-            var invoker = GrainTypeManager.Instance.GetInvoker(interfaceId);
-            if (invoker != null)
-                return (IGrainExtensionMethodInvoker) invoker;
-            
-            throw new ArgumentException("Provider extension handler type " + handlerType + " was not found in the type manager", "handler");
-        }
-
-        public object GetCurrentSchedulingContext()
-        {
-            return RuntimeContext.CurrentActivationContext;
-        }
-
+        
         public async Task<IPersistentStreamPullingManager> InitializePullingAgents(
             string streamProviderName,
             IQueueAdapterFactory adapterFactory,
@@ -233,7 +105,7 @@ namespace Orleans.Runtime.Providers
             PersistentStreamProviderConfig config)
         {
             IStreamQueueBalancer queueBalancer = StreamQueueBalancerFactory.Create(
-                config.BalancerType, streamProviderName, Silo.CurrentSilo.LocalSiloStatusOracle, Silo.CurrentSilo.OrleansConfig, this, adapterFactory.GetStreamQueueMapper(), config.SiloMaturityPeriod);
+                config.BalancerType, streamProviderName, this.silo.LocalSiloStatusOracle, this.silo.OrleansConfig, this, adapterFactory.GetStreamQueueMapper(), config.SiloMaturityPeriod);
             var managerId = GrainId.NewSystemTargetGrainIdByTypeCode(Constants.PULLING_AGENTS_MANAGER_SYSTEM_TARGET_TYPE_CODE);
             var manager = new PersistentStreamPullingManager(managerId, streamProviderName, this, this.PubSub(config.PubSubType), adapterFactory, queueBalancer, config);
             this.RegisterSystemTarget(manager);
@@ -244,9 +116,16 @@ namespace Orleans.Runtime.Providers
             return pullingAgentManager;
         }
 
-        public Task<object> CallInvokeInterceptor(MethodInfo method, InvokeMethodRequest request, IAddressable target, IGrainMethodInvoker invoker)
+        /// <inheritdoc />
+        public string ExecutingEntityIdentity() => runtimeClient.ExecutingEntityIdentity();
+
+        /// <inheritdoc />
+        public StreamDirectory GetStreamDirectory() => runtimeClient.GetStreamDirectory();
+
+        /// <inheritdoc />
+        public Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc) where TExtension : IGrainExtension where TExtensionInterface : IGrainExtension
         {
-            return this.invokeInterceptor(method, request, (IGrain)target, invoker);
+            return runtimeClient.BindExtension<TExtension, TExtensionInterface>(newExtensionFunc);
         }
     }
 }

--- a/src/OrleansRuntime/Storage/StorageProviderManager.cs
+++ b/src/OrleansRuntime/Storage/StorageProviderManager.cs
@@ -4,18 +4,18 @@ using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
-using Orleans.Runtime.Providers;
 using Orleans.Storage;
 
 namespace Orleans.Runtime.Storage
 {
     internal class StorageProviderManager : IStorageProviderManager, IStorageProviderRuntime
     {
+        private readonly IProviderRuntime providerRuntime;
         private ProviderLoader<IStorageProvider> storageProviderLoader;
-        private IProviderRuntime providerRuntime;
 
-        public StorageProviderManager(IGrainFactory grainFactory, IServiceProvider serviceProvider)
+        public StorageProviderManager(IGrainFactory grainFactory, IServiceProvider serviceProvider, IProviderRuntime providerRuntime)
         {
+            this.providerRuntime = providerRuntime;
             GrainFactory = grainFactory;
             ServiceProvider = serviceProvider;
         }
@@ -23,7 +23,6 @@ namespace Orleans.Runtime.Storage
         internal Task LoadStorageProviders(IDictionary<string, ProviderCategoryConfiguration> configs)
         {
             storageProviderLoader = new ProviderLoader<IStorageProvider>();
-            providerRuntime = SiloProviderRuntime.Instance;
 
             if (!configs.ContainsKey(ProviderCategoryConfiguration.STORAGE_PROVIDER_CATEGORY_NAME))
                 return TaskDone.Done;
@@ -57,15 +56,9 @@ namespace Orleans.Runtime.Storage
             return LogManager.GetLogger(loggerName, LoggerType.Provider);
         }
 
-        public Guid ServiceId
-        {
-            get { return providerRuntime.ServiceId; }
-        }
+        public Guid ServiceId => providerRuntime.ServiceId;
 
-        public string SiloIdentity
-        {
-            get { return providerRuntime.SiloIdentity; }
-        }
+        public string SiloIdentity => providerRuntime.SiloIdentity;
 
         public IGrainFactory GrainFactory { get; private set; }
         public IServiceProvider ServiceProvider { get; private set; }
@@ -105,10 +98,9 @@ namespace Orleans.Runtime.Storage
         }
 
         // used only for testing
-        internal Task LoadEmptyStorageProviders(IProviderRuntime providerRtm)
+        internal Task LoadEmptyStorageProviders()
         {
             storageProviderLoader = new ProviderLoader<IStorageProvider>();
-            providerRuntime = providerRtm;
 
             storageProviderLoader.LoadProviders(new Dictionary<string, IProviderConfiguration>(), this);
             return storageProviderLoader.InitProviders(providerRuntime);

--- a/test/NonSiloTests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSiloTests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -676,7 +676,7 @@ namespace UnitTests.SchedulerTests
             {
                 SiloAddress = SiloAddress.NewLocalAddress(23)
             };
-            var grain = new NonReentrentStressGrainWithoutState(grainId, new GrainRuntime(new GlobalConfiguration(), silo, null, null, null, null, null, null));
+            var grain = NonReentrentStressGrainWithoutState.Create(grainId, new GrainRuntime(new GlobalConfiguration(), silo, null, null, null, null, null, null));
             await grain.OnActivateAsync();
 
             Task wrapped = null;

--- a/test/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/TestInternalGrains/PersistenceTestGrains.cs
@@ -800,14 +800,15 @@ namespace UnitTests.Grains
             new Tuple<string, Severity>("Scheduler.ActivationTaskScheduler", Severity.Info)
         };
 
-        public NonReentrentStressGrainWithoutState()
-        {
-        }
+        public NonReentrentStressGrainWithoutState() { }
 
-        public NonReentrentStressGrainWithoutState(IGrainIdentity identity, IGrainRuntime runtime)
+        private NonReentrentStressGrainWithoutState(IGrainIdentity identity, IGrainRuntime runtime)
             : base(identity, runtime)
         {
         }
+
+        public static NonReentrentStressGrainWithoutState Create(IGrainIdentity identity, IGrainRuntime runtime)
+            => new NonReentrentStressGrainWithoutState(identity, runtime);
 
         public override Task OnActivateAsync()
         {

--- a/test/TestInternalGrains/Properties/AssemblyInfo.cs
+++ b/test/TestInternalGrains/Properties/AssemblyInfo.cs
@@ -18,3 +18,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("UnitTests")]
 [assembly: InternalsVisibleTo("UnitTestGrainInterfaces")]
 [assembly: InternalsVisibleTo("UnitTestGrains")]
+[assembly: InternalsVisibleTo("TesterInternal")]

--- a/test/TestInternalGrains/TestExtension.cs
+++ b/test/TestInternalGrains/TestExtension.cs
@@ -4,7 +4,7 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    public class TestExtension : ITestExtension
+    internal class TestExtension : ITestExtension
     {
         private readonly ExtensionTestGrain grain;
         private readonly IGrainFactory grainFactory;

--- a/test/Tester/SimpleGrainTests.cs
+++ b/test/Tester/SimpleGrainTests.cs
@@ -51,7 +51,8 @@ namespace UnitTests.General
             Assert.Equal(12, x);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        [Fact(Skip = "Grains with multiple constructors are not supported without being explicitly registered.")]
+        [TestCategory("BVT"), TestCategory("Functional")]
         public async Task GettingGrainWithMultipleConstructorsActivesViaDefaultConstructor()
         {
             ISimpleGrain grain = GrainFactory.GetGrain<ISimpleGrain>(GetRandomGrainId(), grainClassNamePrefix: MultipleConstructorsSimpleGrain.MultipleConstructorsSimpleGrainPrefix);

--- a/test/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -40,8 +40,11 @@ namespace Tester.AzureUtils.Persistence
         {
             this.output = output;
             var testEnvironment = new SerializationTestEnvironment();
-            storageProviderManager = new StorageProviderManager(testEnvironment.GrainFactory, null);
-            storageProviderManager.LoadEmptyStorageProviders(new ClientProviderRuntime(testEnvironment.GrainFactory, null)).WaitWithThrow(TestConstants.InitTimeout);
+            storageProviderManager = new StorageProviderManager(
+                testEnvironment.GrainFactory,
+                null,
+                new ClientProviderRuntime(testEnvironment.GrainFactory, null));
+            storageProviderManager.LoadEmptyStorageProviders().WaitWithThrow(TestConstants.InitTimeout);
             providerCfgProps.Clear();
             testEnvironment.InitializeForTesting();
             LocalDataStoreInstance.LocalDataStore = null;

--- a/test/TesterInternal/StorageTests/AWSUtils/DynamoDBStorageProviderTests.cs
+++ b/test/TesterInternal/StorageTests/AWSUtils/DynamoDBStorageProviderTests.cs
@@ -25,8 +25,11 @@ namespace UnitTests.StorageTests.AWSUtils
                 throw new SkipException("Unable to connect to DynamoDB simulator");
 
             var testEnvironment = new SerializationTestEnvironment();
-            DefaultProviderRuntime = new StorageProviderManager(testEnvironment.GrainFactory, null);
-            ((StorageProviderManager)DefaultProviderRuntime).LoadEmptyStorageProviders(new ClientProviderRuntime(testEnvironment.GrainFactory, null)).WaitWithThrow(TestConstants.InitTimeout);
+            DefaultProviderRuntime = new StorageProviderManager(
+                testEnvironment.GrainFactory,
+                null,
+                new ClientProviderRuntime(testEnvironment.GrainFactory, null));
+            ((StorageProviderManager) DefaultProviderRuntime).LoadEmptyStorageProviders().WaitWithThrow(TestConstants.InitTimeout);
             testEnvironment.InitializeForTesting();
 
             var properties = new Dictionary<string, string>();
@@ -36,7 +39,7 @@ namespace UnitTests.StorageTests.AWSUtils
             provider.Init("DynamoDBStorageProviderTests", DefaultProviderRuntime, config).Wait();
             PersistenceStorageTests = new CommonStorageTests(provider);
         }
-        
+
         [SkippableFact, TestCategory("Functional")]
         internal async Task WriteReadCyrillic()
         {

--- a/test/TesterSQLUtils/StorageTests/Relational/CommonFixture.cs
+++ b/test/TesterSQLUtils/StorageTests/Relational/CommonFixture.cs
@@ -57,9 +57,11 @@ namespace UnitTests.StorageTests.Relational
         public CommonFixture()
         {
             var testEnvironment = new SerializationTestEnvironment();
-            DefaultProviderRuntime = new StorageProviderManager(testEnvironment.GrainFactory, null);
-            ((StorageProviderManager)DefaultProviderRuntime).LoadEmptyStorageProviders(
-                new ClientProviderRuntime(testEnvironment.GrainFactory, null)).WaitWithThrow(TestConstants.InitTimeout);
+            DefaultProviderRuntime = new StorageProviderManager(
+                testEnvironment.GrainFactory,
+                null,
+                new ClientProviderRuntime(testEnvironment.GrainFactory, null));
+            ((StorageProviderManager) DefaultProviderRuntime).LoadEmptyStorageProviders().WaitWithThrow(TestConstants.InitTimeout);
 
             testEnvironment.InitializeForTesting();
         }


### PR DESCRIPTION
* Removed `SiloProviderRuntime.Instance` global
* Adds a new interface, `ISiloRuntimeClient`, which contains methods moved from `SiloProviderRuntime`.
* `GrainCreator` now always uses `ActivatorUtilities.CreateFactory` instead of `Activator.CreateInstance`, meaning that grain classes with multiple public constructors cannot be constructed unless they are explicitly registered. @jdom are you fine with this? This behavior is consistent with ASP.NET as far as I know.
* Some methods on `SiloProviderRuntime` are now forwarded to `InsideRuntimeClient` where I think they are a more natural fit. We can move them elsewhere if desired.

This is working towards #467. The idea is to make multiple smaller commits to remove globals so that we can implement support for multiple distinct grain clients per AppDomain.