### PR TITLE
CodeGen: runtime codegen should check accessibility of grain interfaces.

### DIFF
--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -269,6 +269,26 @@ namespace Orleans.Serialization
         }
 
         /// <summary>
+        /// Returns <see langword="true"/> if the provided <paramref name="type"/> is publicly accessible and <see langword="false"/> otherwise.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>
+        /// <see langword="true"/> if the provided <paramref name="type"/> is publicly accessible and <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool IsTypePublic(Type type)
+        {
+            while (true)
+            {
+                var typeInfo = type.GetTypeInfo();
+
+                if (!typeInfo.IsPublic) return false;
+                if (typeInfo.BaseType == null) return true;
+
+                type = typeInfo.BaseType;
+            }
+        }
+
+        /// <summary>
         /// Returns true if <paramref name="fromAssembly"/> has exposed its internals to <paramref name="toAssembly"/>, false otherwise.
         /// </summary>
         /// <param name="fromAssembly">The assembly containing internal types.</param>

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -1,3 +1,5 @@
+using Orleans.Serialization;
+
 namespace Orleans.CodeGenerator
 {
     using System;
@@ -504,15 +506,20 @@ namespace Orleans.CodeGenerator
                 RecordType(type, module, targetAssembly, includedTypes);
             }
             
+            // Consider generic arguments to base types and implemented interfaces for code generation.
             ConsiderGenericBaseTypeArguments(typeInfo, module, targetAssembly, includedTypes);
             ConsiderGenericInterfacesArguments(typeInfo, module, targetAssembly, includedTypes);
-
-            // Collect the types which require code generation.
+            
+            // Include grain interface types.
             if (GrainInterfaceUtils.IsGrainInterface(type))
             {
-                if (Logger.IsVerbose2) Logger.Verbose2("Will generate code for: {0}", type.GetParseableName());
-                
-                includedTypes.Add(type);
+                // If code generation is being performed at runtime, the interface must be accessible to the generated code.
+                if (!runtime || TypeUtilities.IsTypePublic(type))
+                {
+                    if (Logger.IsVerbose2) Logger.Verbose2("Will generate code for: {0}", type.GetParseableName());
+
+                    includedTypes.Add(type);
+                }
             }
         }
 

--- a/test/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/test/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -8,6 +8,11 @@ namespace UnitTests.GrainInterfaces
 {
     using Orleans.Concurrency;
 
+    internal interface IInternalPingGrain : IGrainWithIntegerKey
+    {
+        Task Ping();
+    }
+
     public interface ISomeGrain : IGrainWithIntegerKey
     {
         Task Do(Outsider o);

--- a/test/TesterInternal/CodeGeneratorTests_AccessibilityChecks.cs
+++ b/test/TesterInternal/CodeGeneratorTests_AccessibilityChecks.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans;
+using Tester.CodeGenTests;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace UnitTests.General
+{
+    [TestCategory("BVT"), TestCategory("CodeGen")]
+    public class CodeGeneratorTests_AccessibilityChecks : HostedTestClusterEnsureDefaultStarted
+    {
+        /// <summary>
+        /// Tests that compile-time code generation supports classes marked as internal and that
+        /// runtime code generation does not.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        [Fact]
+        public async Task CodeGenInterfaceAccessibilityCheckTest()
+        {
+            // Runtime codegen does not support internal interfaces.
+            Assert.Throws<InvalidOperationException>(() => GrainFactory.GetGrain<IRuntimeInternalPingGrain>(9));
+
+            // Compile-time codegen supports internal interfaces.
+            var grain = GrainFactory.GetGrain<IInternalPingGrain>(0);
+            await grain.Ping();
+        }
+    }
+
+    internal interface IRuntimeInternalPingGrain : IGrainWithIntegerKey
+    {
+        Task Ping();
+    }
+
+    internal class InternalPingGrain : Grain, IInternalPingGrain, IRuntimeInternalPingGrain
+    {
+        public Task Ping() => Task.FromResult(0);
+    }
+}

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="ActivationsLifeCycleTests\ActivationCollectorTests.cs" />
     <Compile Include="ActivationsLifeCycleTests\DeactivateOnIdleTests.cs" />
+    <Compile Include="CodeGeneratorTests_AccessibilityChecks.cs" />
     <Compile Include="CollectionFixtures.cs" />
     <Compile Include="ConnectionStringFixture.cs" />
     <Compile Include="ErrorInjectionStorageProvider.cs" />


### PR DESCRIPTION
Runtime codegen cannot support `internal` grain interfaces, whereas compile-time codegen can.

This change makes the code generator take that into account and adds a test to verify the correct behavior.