### PR TITLE
Reduce allocations when logging

### DIFF
--- a/src/Orleans/Logging/LoggerExtensions.cs
+++ b/src/Orleans/Logging/LoggerExtensions.cs
@@ -6,6 +6,8 @@ namespace Orleans.Runtime
 {
     public static class LoggerExtensions
     {
+        private static readonly object[] EmptyObjectArray = new object[0];
+
         /// <summary>
         /// Finds or creates a logger named after the existing logger with the appended name added.
         /// </summary>
@@ -28,6 +30,18 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Writes a log entry at the Verbose severity level.
+        /// Verbose is suitable for debugging information that should usually not be logged in production.
+        /// Verbose is lower than Info.
+        /// </summary>
+        /// <param name="logger">The logger</param>
+        /// <param name="message">The log message.</param>
+        public static void Verbose(this Logger logger, string message)
+        {
+            logger.Log(0, Severity.Verbose, message, EmptyObjectArray, null);
+        }
+
+        /// <summary>
         /// Writes a log entry at the Verbose2 severity level.
         /// Verbose2 is lower than Verbose.
         /// </summary>
@@ -37,6 +51,17 @@ namespace Orleans.Runtime
         public static void Verbose2(this Logger logger, string format, params object[] args)
         {
             logger.Log(0, Severity.Verbose2, format, args, null);
+        }
+
+        /// <summary>
+        /// Writes a log entry at the Verbose2 severity level.
+        /// Verbose2 is lower than Verbose.
+        /// </summary>
+        /// <param name="logger">The logger</param>
+        /// <param name="message">The log message.</param>
+        public static void Verbose2(this Logger logger, string message)
+        {
+            logger.Log(0, Severity.Verbose2, message, EmptyObjectArray, null);
         }
 
         /// <summary>
@@ -52,6 +77,17 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Writes a log entry at the Verbose3 severity level.
+        /// Verbose3 is the lowest severity level.
+        /// </summary>
+        /// <param name="logger">The logger</param>
+        /// <param name="message">The log message.</param>
+        public static void Verbose3(this Logger logger, string message)
+        {
+            logger.Log(0, Severity.Verbose3, message, EmptyObjectArray, null);
+        }
+
+        /// <summary>
         /// Writes a log entry at the Info severity level.
         /// Info is suitable for information that does not indicate an error but that should usually be logged in production.
         /// Info is lower than Warning.
@@ -62,6 +98,18 @@ namespace Orleans.Runtime
         public static void Info(this Logger logger, string format, params object[] args)
         {
             logger.Log(0, Severity.Info, format, args, null);
+        }
+
+        /// <summary>
+        /// Writes a log entry at the Info severity level.
+        /// Info is suitable for information that does not indicate an error but that should usually be logged in production.
+        /// Info is lower than Warning.
+        /// </summary>
+        /// <param name="logger">Target logger.</param>
+        /// <param name="message">The log message.</param>
+        public static void Info(this Logger logger, string message)
+        {
+            logger.Log(0, Severity.Info, message, EmptyObjectArray, null);
         }
 
         /// <summary>
@@ -79,6 +127,19 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Writes a log entry at the Verbose severity level, with the specified log id code.
+        /// Verbose is suitable for debugging information that should usually not be logged in production.
+        /// Verbose is lower than Info.
+        /// </summary>
+        /// <param name="logger">The logger</param>
+        /// <param name="logCode">The log code associated with this message.</param>
+        /// <param name="message">The log message.</param>
+        public static void Verbose(this Logger logger, int logCode, string message)
+        {
+            logger.Log(logCode, Severity.Verbose, message, EmptyObjectArray, null);
+        }
+
+        /// <summary>
         /// Writes a log entry at the Verbose2 severity level, with the specified log id code.
         /// Verbose2 is lower than Verbose.
         /// </summary>
@@ -89,6 +150,18 @@ namespace Orleans.Runtime
         public static void Verbose2(this Logger logger, int logCode, string format, params object[] args)
         {
             logger.Log(logCode, Severity.Verbose2, format, args, null);
+        }
+
+        /// <summary>
+        /// Writes a log entry at the Verbose2 severity level, with the specified log id code.
+        /// Verbose2 is lower than Verbose.
+        /// </summary>
+        /// <param name="logger">The logger</param>
+        /// <param name="logCode">The log code associated with this message.</param>
+        /// <param name="message">The log message.</param>
+        public static void Verbose2(this Logger logger, int logCode, string message)
+        {
+            logger.Log(logCode, Severity.Verbose2, message, EmptyObjectArray, null);
         }
 
         /// <summary>
@@ -105,6 +178,18 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Writes a log entry at the Verbose3 severity level, with the specified log id code.
+        /// Verbose3 is the lowest severity level.
+        /// </summary>
+        /// <param name="logger">The logger</param>
+        /// <param name="logCode">The log code associated with this message.</param>
+        /// <param name="message">The log message.</param>
+        public static void Verbose3(this Logger logger, int logCode, string message)
+        {
+            logger.Log(logCode, Severity.Verbose3, message, EmptyObjectArray, null);
+        }
+
+        /// <summary>
         /// Writes a log entry at the Info severity level, with the specified log id code.
         /// Info is suitable for information that does not indicate an error but that should usually be logged in production.
         /// Info is lower than Warning.
@@ -116,6 +201,19 @@ namespace Orleans.Runtime
         public static void Info(this Logger logger, int logCode, string format, params object[] args)
         {
             logger.Log(logCode, Severity.Info, format, args, null);
+        }
+
+        /// <summary>
+        /// Writes a log entry at the Info severity level, with the specified log id code.
+        /// Info is suitable for information that does not indicate an error but that should usually be logged in production.
+        /// Info is lower than Warning.
+        /// </summary>
+        /// <param name="logger">The logger</param>
+        /// <param name="logCode">The log code associated with this message.</param>
+        /// <param name="message">The log message.</param>
+        public static void Info(this Logger logger, int logCode, string message)
+        {
+            logger.Log(logCode, Severity.Info, message, EmptyObjectArray, null);
         }
 
         /// <summary>
@@ -149,7 +247,7 @@ namespace Orleans.Runtime
         /// <param name="exception">An exception related to the warning, if any.</param>
         public static void Warn(this Logger logger, int logCode, string message, Exception exception = null)
         {
-            logger.Log(logCode, Severity.Warning, message, new object[] { }, exception);
+            logger.Log(logCode, Severity.Warning, message, EmptyObjectArray, exception);
         }
 
         /// <summary>
@@ -162,7 +260,7 @@ namespace Orleans.Runtime
         /// <param name="exception">An exception related to the error, if any.</param>
         public static void Error(this Logger logger, int logCode, string message, Exception exception = null)
         {
-            logger.Log(logCode, Severity.Error, message, new object[] { }, exception);
+            logger.Log(logCode, Severity.Error, message, EmptyObjectArray, exception);
         }
 
         #region Internal log methods using ErrorCode categorization.
@@ -171,17 +269,33 @@ namespace Orleans.Runtime
         {
             logger.Log((int)errorCode, Severity.Verbose, format, args, null);
         }
+        internal static void Verbose(this Logger logger, ErrorCode errorCode, string message)
+        {
+            logger.Log((int)errorCode, Severity.Verbose, message, EmptyObjectArray, null);
+        }
         internal static void Verbose2(this Logger logger, ErrorCode errorCode, string format, params object[] args)
         {
             logger.Log((int)errorCode, Severity.Verbose2, format, args, null);
+        }
+        internal static void Verbose2(this Logger logger, ErrorCode errorCode, string message)
+        {
+            logger.Log((int)errorCode, Severity.Verbose2, message, EmptyObjectArray, null);
         }
         internal static void Verbose3(this Logger logger, ErrorCode errorCode, string format, params object[] args)
         {
             logger.Log((int)errorCode, Severity.Verbose3, format, args, null);
         }
+        internal static void Verbose3(this Logger logger, ErrorCode errorCode, string message)
+        {
+            logger.Log((int)errorCode, Severity.Verbose3, message, EmptyObjectArray, null);
+        }
         internal static void Info(this Logger logger, ErrorCode errorCode, string format, params object[] args)
         {
             logger.Log((int)errorCode, Severity.Info, format, args, null);
+        }
+        internal static void Info(this Logger logger, ErrorCode errorCode, string message)
+        {
+            logger.Log((int)errorCode, Severity.Info, message, EmptyObjectArray, null);
         }
         internal static void Warn(this Logger logger, ErrorCode errorCode, string format, params object[] args)
         {
@@ -189,11 +303,11 @@ namespace Orleans.Runtime
         }
         internal static void Warn(this Logger logger, ErrorCode errorCode, string message, Exception exception)
         {
-            logger.Log((int)errorCode, Severity.Warning, message, new object[] { }, exception);
+            logger.Log((int)errorCode, Severity.Warning, message, EmptyObjectArray, exception);
         }
         internal static void Error(this Logger logger, ErrorCode errorCode, string message, Exception exception = null)
         {
-            logger.Log((int)errorCode, Severity.Error, message, new object[] { }, exception);
+            logger.Log((int)errorCode, Severity.Error, message, EmptyObjectArray, exception);
         }
 
         internal static void Assert(this Logger logger, ErrorCode errorCode, bool condition, string message = null)


### PR DESCRIPTION
`params` has a cost associated even when no parameters are passed, so this adds overloads to `LoggerExtensions` methods in order to provide non-allocating alternatives.