### PR TITLE
Fix conflicthing VS setting which makes debugging stalls

### DIFF
--- a/Samples/AzureWebSample/OrleansAzureSample/OrleansAzureSample.ccproj
+++ b/Samples/AzureWebSample/OrleansAzureSample/OrleansAzureSample.ccproj
@@ -12,7 +12,6 @@
     <AssemblyName>OrleansAzureSample</AssemblyName>
     <StartDevelopmentStorage>True</StartDevelopmentStorage>
     <Name>OrleansAzureSample</Name>
-    <UseIISExpressByDefault>False</UseIISExpressByDefault>
     <UseEmulatorExpressByDefault>False</UseEmulatorExpressByDefault>
     <UseWebProjectPorts>True</UseWebProjectPorts>
   </PropertyGroup>


### PR DESCRIPTION
Fix issue: #2475 

VS Debugger cannot attach to the web role process because of the conflicting setting of using IISExpress or IIS between the Web role and the Web project itself.
