### PR TITLE
Update to Consul 0.7.0.3 package, fixed #2488

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansConsulUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansConsulUtils.nuspec
@@ -20,7 +20,7 @@
     <dependencies>
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
-	  <dependency id="Consul" version="0.6.4.1" />
+      <dependency id="Consul" version="0.7.0.3" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OrleansConsulUtils/project.json
+++ b/src/OrleansConsulUtils/project.json
@@ -1,6 +1,6 @@
-{
+﻿{
   "dependencies": {
-    "Consul": "0.6.4.1"
+    "Consul": "0.7.0.3"
   },
   "frameworks": {
     "net451": {}


### PR DESCRIPTION
Consul 0.7.0.0 introduced the usage of ```CancellationToken``` arguments for all remote calls, this caused a ```MethodNotFoundException``` as described and discovered in #2488, this PR fixes that by upgrading to newer package.