### PR TITLE
Fix for "Console output caused Orleans Worker Role to restart"

### DIFF
--- a/src/Orleans/CodeGeneration/GrainInterfaceUtils.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceUtils.cs
@@ -190,8 +190,11 @@ namespace Orleans.CodeGeneration
             List<string> violations;
             if (!TryValidateInterfaceRules(type, out violations))
             {
-                foreach (var violation in violations)
-                    ConsoleText.WriteLine("ERROR: " + violation);
+                if (ConsoleText.IsConsoleAvailable)
+                {
+                    foreach (var violation in violations)
+                        ConsoleText.WriteLine("ERROR: " + violation);
+                }
 
                 throw new RulesViolationException(
                     string.Format("{0} does not conform to the grain interface rules.", type.FullName), violations);

--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -206,7 +206,7 @@ namespace Orleans.Runtime.Configuration
 
             DefaultTraceLevel = Severity.Info;
             TraceLevelOverrides = new List<Tuple<string, Severity>>();
-            TraceToConsole = true;
+            TraceToConsole = ConsoleText.IsConsoleAvailable;
             TraceFilePattern = "{0}-{1}.log";
             LargeMessageWarningThreshold = Constants.LARGE_OBJECT_HEAP_THRESHOLD;
             PropagateActivityId = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;

--- a/src/Orleans/Configuration/ITraceConfiguration.cs
+++ b/src/Orleans/Configuration/ITraceConfiguration.cs
@@ -33,7 +33,7 @@ namespace Orleans.Runtime.Configuration
         IList<Tuple<string, Severity>> TraceLevelOverrides { get; }
         /// <summary>
         /// The TraceToConsole attribute specifies whether trace output should be written to the console.
-        /// The default is not to write trace data to the console.
+        /// The default is write trace data to the console if available.
         /// </summary>
         bool TraceToConsole { get; set; }
         /// <summary>

--- a/src/Orleans/Configuration/NodeConfiguration.cs
+++ b/src/Orleans/Configuration/NodeConfiguration.cs
@@ -251,7 +251,7 @@ namespace Orleans.Runtime.Configuration
 
             DefaultTraceLevel = Severity.Info;
             TraceLevelOverrides = new List<Tuple<string, Severity>>();
-            TraceToConsole = true;
+            TraceToConsole = ConsoleText.IsConsoleAvailable;
             TraceFilePattern = "{0}-{1}.log";
             LargeMessageWarningThreshold = Constants.LARGE_OBJECT_HEAP_THRESHOLD;
             PropagateActivityId = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;

--- a/src/Orleans/Logging/ConsoleText.cs
+++ b/src/Orleans/Logging/ConsoleText.cs
@@ -4,6 +4,18 @@ namespace Orleans.Runtime
 {
     internal static class ConsoleText
     {
+        public static bool IsConsoleAvailable
+        {
+            get
+            {
+#if !NETSTANDARD
+                return Environment.UserInteractive;
+#else
+                return true;
+#endif
+            }
+        }
+
         public static void WriteError(string msg)
         {
             WriteLine(ConsoleColor.Red, msg);


### PR DESCRIPTION
Issue #2464 

By default in the config we output log to the console (`TraceToConsole` set to `true`). The proposed fix is to check if a console is available and use that value as the default for `TraceToConsole`