### PR TITLE
Fix #2358: Invoke interceptor broken for generic grains

### DIFF
--- a/src/Orleans/CodeGeneration/GrainInterfaceUtils.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceUtils.cs
@@ -115,11 +115,11 @@ namespace Orleans.CodeGeneration
             var dict = new Dictionary<int, Type>();
 
             if (IsGrainInterface(type))
-                dict.Add(ComputeInterfaceId(type), type);
-
+                dict.Add(GetGrainInterfaceId(type), type);
+            
             Type[] interfaces = type.GetInterfaces();
             foreach (Type interfaceType in interfaces.Where(i => !checkIsGrainInterface || IsGrainInterface(i)))
-                dict.Add(ComputeInterfaceId(interfaceType), interfaceType);
+                dict.Add(GetGrainInterfaceId(interfaceType), interfaceType);
 
             return dict;
         }
@@ -163,13 +163,6 @@ namespace Orleans.CodeGeneration
         public static bool IsGrainType(Type grainType)
         {
             return typeof (IGrain).IsAssignableFrom(grainType);
-        }
-
-        public static int ComputeInterfaceId(Type interfaceType)
-        {
-            var ifaceName = TypeUtils.GetFullName(interfaceType);
-            var ifaceId = Utils.CalculateIdHash(ifaceName);
-            return ifaceId;
         }
 
         public static int GetGrainClassTypeCode(Type grainClass)

--- a/src/Orleans/Core/InterceptedMethodInvokerCache.cs
+++ b/src/Orleans/Core/InterceptedMethodInvokerCache.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Orleans.CodeGeneration;
-using Orleans.Runtime;
 
 namespace Orleans
 {
@@ -16,9 +14,9 @@ namespace Orleans
         /// <summary>
         /// The map from implementation types to interface ids to invoker.
         /// </summary>
-        private readonly ConcurrentDictionary<Type, ConcurrentDictionary<int, InterceptedMethodInvoker>> invokers =
-            new ConcurrentDictionary<Type, ConcurrentDictionary<int, InterceptedMethodInvoker>>();
-
+        private readonly ConcurrentDictionary<Type, Dictionary<int, InterceptedMethodInvoker>> invokers =
+            new ConcurrentDictionary<Type, Dictionary<int, InterceptedMethodInvoker>>();
+        
         /// <summary>
         /// Returns a grain method invoker which calls the grain's implementation of <see cref="IGrainInvokeInterceptor"/>
         /// if it exists, otherwise calling the provided <paramref name="invoker"/> directly.
@@ -34,74 +32,142 @@ namespace Orleans
         /// </returns>
         public InterceptedMethodInvoker GetOrCreate(Type implementationType, int interfaceId, IGrainMethodInvoker invoker)
         {
-            var implementation = invokers.GetOrAdd(
-                implementationType,
-                _ => new ConcurrentDictionary<int, InterceptedMethodInvoker>());
-
-            InterceptedMethodInvoker interceptedMethodInvoker;
-            if (implementation.TryGetValue(interfaceId, out interceptedMethodInvoker))
+            // Get or create the mapping between interfaceId and invoker for the provided type.
+            Dictionary<int, InterceptedMethodInvoker> invokerMap;
+            if (!this.invokers.TryGetValue(implementationType, out invokerMap))
             {
-                return interceptedMethodInvoker;
+                // Generate an the invoker mapping using the provided invoker.
+                this.invokers[implementationType] = invokerMap = GetInterfaceToImplementationMap(implementationType, invoker);
             }
 
-            // Create a mapping between the interface and the implementation.
-            return implementation.GetOrAdd(
-                interfaceId,
-                _ => CreateInterceptedMethodInvoker(implementationType, interfaceId, invoker));
+            // Attempt to get the invoker for the provided interfaceId.
+            InterceptedMethodInvoker interceptedMethodInvoker;
+            if (!invokerMap.TryGetValue(interfaceId, out interceptedMethodInvoker))
+            {
+                throw new InvalidOperationException(
+                    $"Type {implementationType} does not implement interface with id {interfaceId} ({interfaceId:X}).");
+            }
+
+            return interceptedMethodInvoker;
         }
 
         /// <summary>
-        /// Returns a new <see cref="InterceptedMethodInvoker"/> for the provided values.
+        /// Maps the interfaces of the provided <paramref name="implementationType"/>.
         /// </summary>
-        /// <param name="implementationType">The grain type.</param>
-        /// <param name="interfaceId">The interface id.</param>
-        /// <param name="invoker">The invoker.</param>
-        /// <returns>A new <see cref="InterceptedMethodInvoker"/> for the provided values.</returns>
-        private static InterceptedMethodInvoker CreateInterceptedMethodInvoker(
+        /// <param name="implementationType">The implementation type.</param>
+        /// <param name="invoker">The grain method invoker.</param>
+        /// <returns>The mapped interface.</returns>
+        private static Dictionary<int, InterceptedMethodInvoker> GetInterfaceToImplementationMap(
             Type implementationType,
-            int interfaceId,
             IGrainMethodInvoker invoker)
         {
-            // If a grain extension is being invoked, the implementation map must match the methods on the extension
-            // and not the grain implementation.
-            var extensionMap = invoker as IGrainExtensionMap;
-            if (extensionMap != null)
+            // This method creates a map from interfaceId -> intercepted invoker.
+            if (implementationType.IsConstructedGenericType) return GetGenericInterfaceInvoker(implementationType, invoker);
+            var implementationTypeInfo = implementationType.GetTypeInfo();
+            var interfaces = implementationType.GetInterfaces();
+
+            // Create an invoker for every interface on the provided type.
+            var result = new Dictionary<int, InterceptedMethodInvoker>(interfaces.Length);
+            foreach (var iface in interfaces)
             {
-                IGrainExtension extension;
-                if (extensionMap.TryGetExtension(interfaceId, out extension))
+                var methods = GrainInterfaceUtils.GetMethods(iface);
+
+                // Map every method on this interface from the definition interface onto the implementation class.
+                var methodMap = new Dictionary<int, MethodInfo>(methods.Length);
+                var mapping = default(InterfaceMapping);
+                foreach (var method in methods)
                 {
-                    implementationType = extension.GetType();
+                    // If this method is not from the expected interface (eg, because it's from a parent interface), then
+                    // get the mapping for the interface which it does belong to.
+                    if (mapping.InterfaceType != method.DeclaringType)
+                    {
+                        mapping = implementationTypeInfo.GetRuntimeInterfaceMap(method.DeclaringType);
+                    }
+
+                    // Find the index of the interface method and then get the implementation method at that position.
+                    for (var k = 0; k < mapping.InterfaceMethods.Length; k++)
+                    {
+                        if (mapping.InterfaceMethods[k] != method) continue;
+                        methodMap[GrainInterfaceUtils.ComputeMethodId(method)] = mapping.TargetMethods[k];
+                        break;
+                    }
                 }
+
+                // Add the resulting map of methodId -> method to the interface map.
+                var interfaceId = GrainInterfaceUtils.GetGrainInterfaceId(iface);
+                result[interfaceId] = new InterceptedMethodInvoker(invoker, methodMap);
             }
 
-            var implementationMap = GetInterfaceToImplementationMap(interfaceId, implementationType);
-            return new InterceptedMethodInvoker(invoker, implementationMap);
+            return result;
         }
 
         /// <summary>
-        /// Maps the provided <paramref name="interfaceId"/> to the provided <paramref name="implementationType"/>.
+        /// Maps the interfaces of the provided <paramref name="implementationType"/>.
         /// </summary>
-        /// <param name="interfaceId">The interface id.</param>
-        /// <param name="implementationType">The implementation type.</param>
+        /// <param name="implementationType">The implementation type, which must be a concrete generic type.</param>
+        /// <param name="invoker">The grain method invoker.</param>
         /// <returns>The mapped interface.</returns>
-        private static Dictionary<int, MethodInfo> GetInterfaceToImplementationMap(
-            int interfaceId,
-            Type implementationType)
+        private static Dictionary<int, InterceptedMethodInvoker> GetGenericInterfaceInvoker(
+            Type implementationType,
+            IGrainMethodInvoker invoker)
         {
-            var interfaceTypes = GrainInterfaceUtils.GetRemoteInterfaces(implementationType);
-            
-            // Get all interface mappings of all interfaces.
-            var interfaceMapping = implementationType
-                .GetInterfaces()
-                .Select(i => implementationType.GetTypeInfo().GetRuntimeInterfaceMap(i))
-                .SelectMany(map => map.InterfaceMethods
-                    .Zip(map.TargetMethods, (interfaceMethod, targetMethod) => new { interfaceMethod, targetMethod }))
-                .ToArray();
+            // This method creates a a map interfaceId -> intercepted invoker.
+            // It is important to note that the interfaceId and methodId are computed based upon the non-concrete
+            // version of the implementation type. During code generation, the concrete type would not be available
+            // and therefore the generic type definition is used.
+            if (!implementationType.IsConstructedGenericType)
+            {
+                throw new InvalidOperationException(
+                    $"Type {implementationType} passed to {nameof(GetGenericInterfaceInvoker)} is not a constructed generic type");
+            }
 
-            // Map the grain interface methods to the implementation methods.
-            return GrainInterfaceUtils.GetMethods(interfaceTypes[interfaceId])
-                .ToDictionary(GrainInterfaceUtils.ComputeMethodId,
-                    m => interfaceMapping.SingleOrDefault(pair => pair.interfaceMethod == m)?.targetMethod);
+            var genericClass = implementationType.GetGenericTypeDefinition();
+            var genericClassTypeInfo = genericClass.GetTypeInfo();
+            var implementationTypeInfo = implementationType.GetTypeInfo();
+
+            var genericInterfaces = genericClass.GetInterfaces();
+            var concreteInterfaces = implementationType.GetInterfaces();
+
+            // Create an invoker for every interface on the provided type.
+            var result = new Dictionary<int, InterceptedMethodInvoker>(genericInterfaces.Length);
+            for (var i = 0; i < genericInterfaces.Length; i++)
+            {
+                // Because these methods are identical except for type parameters, their methods should also be identical except
+                // for type parameters, including identical ordering. That is the assumption.
+                var genericMethods = GrainInterfaceUtils.GetMethods(genericInterfaces[i]);
+                var concreteInterfaceMethods = GrainInterfaceUtils.GetMethods(concreteInterfaces[i]);
+
+                // Map every method on this interface from the definition interface onto the implementation class.
+                var methodMap = new Dictionary<int, MethodInfo>(genericMethods.Length);
+                var genericMap = default(InterfaceMapping);
+                var concreteMap = default(InterfaceMapping);
+                for (var j = 0; j < genericMethods.Length; j++)
+                {
+                    // If this method is not from the expected interface (eg, because it's from a parent interface), then
+                    // get the mapping for the interface which it does belong to.
+                    var genericInterfaceMethod = genericMethods[j];
+                    if (genericMap.InterfaceType != genericInterfaceMethod.DeclaringType)
+                    {
+                        genericMap = genericClassTypeInfo.GetRuntimeInterfaceMap(genericInterfaceMethod.DeclaringType);
+                        concreteMap = implementationTypeInfo.GetRuntimeInterfaceMap(concreteInterfaceMethods[j].DeclaringType);
+                    }
+
+                    // Determine the position in the definition's map which the target method belongs to and take the implementation
+                    // from the same position on the implementation's map.
+                    for (var k = 0; k < genericMap.InterfaceMethods.Length; k++)
+                    {
+                        if (genericMap.InterfaceMethods[k] != genericInterfaceMethod) continue;
+                        methodMap[GrainInterfaceUtils.ComputeMethodId(genericInterfaceMethod)] = concreteMap.TargetMethods[k];
+                        break;
+                    }
+                }
+
+                // Add the resulting map of methodId -> method to the interface map.
+                var interfaceId = GrainInterfaceUtils.GetGrainInterfaceId(genericInterfaces[i]);
+                result[interfaceId] = new InterceptedMethodInvoker(invoker, methodMap);
+            }
+
+            return result;
         }
     }
 }

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -885,7 +885,7 @@ namespace Orleans.Runtime
             if (interfaces.Count != 1)
                 throw new InvalidOperationException($"Extension type {handlerType.FullName} implements more than one grain interface.");
 
-            var interfaceId = GrainInterfaceUtils.ComputeInterfaceId(interfaces.First());
+            var interfaceId = GrainInterfaceUtils.GetGrainInterfaceId(interfaces.First());
             var invoker = typeManager.GetInvoker(interfaceId);
             if (invoker != null)
                 return (IGrainExtensionMethodInvoker)invoker;

--- a/src/OrleansRuntime/Core/SystemTarget.cs
+++ b/src/OrleansRuntime/Core/SystemTarget.cs
@@ -8,7 +8,6 @@ namespace Orleans.Runtime
     internal abstract class SystemTarget : ISystemTarget, ISystemTargetBase, IInvokable
     {
         private IGrainMethodInvoker lastInvoker;
-        private readonly SchedulingContext schedulingContext;
         private Message running;
         
         protected SystemTarget(GrainId grainId, SiloAddress silo) 
@@ -21,14 +20,14 @@ namespace Orleans.Runtime
             GrainId = grainId;
             Silo = silo;
             ActivationId = ActivationId.GetSystemActivation(grainId, silo);
-            schedulingContext = new SchedulingContext(this, lowPriority);
+            SchedulingContext = new SchedulingContext(this, lowPriority);
         }
 
-        public SiloAddress Silo { get; private set; }
-        public GrainId GrainId { get; private set; }
+        public SiloAddress Silo { get; }
+        public GrainId GrainId { get; }
         public ActivationId ActivationId { get; set; }
 
-        internal SchedulingContext SchedulingContext { get { return schedulingContext; } }
+        internal SchedulingContext SchedulingContext { get; }
 
         public IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType = null)
         {

--- a/test/NonSiloTests/CodeGeneratorTests.cs
+++ b/test/NonSiloTests/CodeGeneratorTests.cs
@@ -73,8 +73,8 @@ namespace UnitTests.CodeGeneration
         [Fact(Skip = "Currently unsupported"), TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Generics")]
         public void CodeGen_EncounteredFullySpecifiedInterfacesAreEncodedDistinctly() 
         {
-            var id1 = GrainInterfaceUtils.ComputeInterfaceId(typeof(IFullySpecified<int>));
-            var id2 = GrainInterfaceUtils.ComputeInterfaceId(typeof(IFullySpecified<long>));
+            var id1 = GrainInterfaceUtils.GetGrainInterfaceId(typeof(IFullySpecified<int>));
+            var id2 = GrainInterfaceUtils.GetGrainInterfaceId(typeof(IFullySpecified<long>));
 
             Assert.NotEqual(id1, id2);
         }

--- a/test/TestGrainInterfaces/IMethodInterceptionGrain.cs
+++ b/test/TestGrainInterfaces/IMethodInterceptionGrain.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace UnitTests.GrainInterfaces
 {
@@ -10,8 +11,18 @@ namespace UnitTests.GrainInterfaces
         Task<string> NotIntercepted();
     }
 
+    public interface IGenericMethodInterceptionGrain<in T> : IGrainWithIntegerKey, IMethodFromAnotherInterface
+    {
+        Task<string> GetInputAsString(T input);
+    }
+
     public interface IMethodFromAnotherInterface
     {
         Task<string> SayHello();
+    }
+    
+    public interface ITrickyMethodInterceptionGrain : IGenericMethodInterceptionGrain<string>, IGenericMethodInterceptionGrain<bool>
+    {
+        Task<int> GetBestNumber();
     }
 }

--- a/test/TestGrains/MethodInterceptionGrain.cs
+++ b/test/TestGrains/MethodInterceptionGrain.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Globalization;
+using System.Threading.Tasks;
 
 namespace UnitTests.Grains
 {
@@ -12,7 +13,7 @@ namespace UnitTests.Grains
     {
         public async Task<object> Invoke(MethodInfo methodInfo, InvokeMethodRequest request, IGrainMethodInvoker invoker)
         {
-            if (methodInfo.Name == "One" && methodInfo.GetParameters().Length == 0)
+            if (methodInfo.Name == nameof(One) && methodInfo.GetParameters().Length == 0)
             {
                 return "intercepted one with no args";
             }
@@ -24,7 +25,7 @@ namespace UnitTests.Grains
             // done in a simpler fashion, but this demonstrates a potential usage scenario.
             var shouldMessWithResult = methodInfo.GetCustomAttribute<MessWithResultAttribute>();
             var resultString = result as string;
-            if (shouldMessWithResult != null && resultString !=null)
+            if (shouldMessWithResult != null && resultString != null)
             {
                 result = string.Concat(resultString.Reverse());
             }
@@ -57,5 +58,30 @@ namespace UnitTests.Grains
         {
             return Task.FromResult("Hello");
         }
+    }
+
+    public class GenericMethodInterceptionGrain<T> : Grain, IGenericMethodInterceptionGrain<T>, IGrainInvokeInterceptor
+    {
+        public Task<object> Invoke(MethodInfo methodInfo, InvokeMethodRequest request, IGrainMethodInvoker invoker)
+        {
+            if (methodInfo.Name == nameof(GetInputAsString))
+            {
+                return Task.FromResult<object>($"Hah! You wanted {request.Arguments[0]}, but you got me!");
+            }
+
+            return invoker.Invoke(this, request);
+        }
+
+        public Task<string> SayHello() => Task.FromResult("Hello");
+
+        public Task<string> GetInputAsString(T input) => Task.FromResult(input.ToString());
+    }
+
+    public class TrickyInterceptionGrain : GenericMethodInterceptionGrain<int>, ITrickyMethodInterceptionGrain
+    {
+        public Task<string> GetInputAsString(string input) => Task.FromResult(input);
+        public Task<string> GetInputAsString(bool input) => Task.FromResult(input.ToString(CultureInfo.InvariantCulture));
+        public Task<int> GetBestNumber() => Task.FromResult(38);
+
     }
 }

--- a/test/TestGrains/MethodInterceptionGrain.cs
+++ b/test/TestGrains/MethodInterceptionGrain.cs
@@ -77,10 +77,24 @@ namespace UnitTests.Grains
         public Task<string> GetInputAsString(T input) => Task.FromResult(input.ToString());
     }
 
-    public class TrickyInterceptionGrain : GenericMethodInterceptionGrain<int>, ITrickyMethodInterceptionGrain
+    public class TrickyInterceptionGrain : Grain, ITrickyMethodInterceptionGrain, IGrainInvokeInterceptor
     {
+        public Task<object> Invoke(MethodInfo methodInfo, InvokeMethodRequest request, IGrainMethodInvoker invoker)
+        {
+            if (methodInfo.Name == nameof(GetInputAsString))
+            {
+                return Task.FromResult<object>($"Hah! You wanted {request.Arguments[0]}, but you got me!");
+            }
+
+            return invoker.Invoke(this, request);
+        }
+
+        public Task<string> SayHello() => Task.FromResult("Hello");
+        
         public Task<string> GetInputAsString(string input) => Task.FromResult(input);
+
         public Task<string> GetInputAsString(bool input) => Task.FromResult(input.ToString(CultureInfo.InvariantCulture));
+
         public Task<int> GetBestNumber() => Task.FromResult(38);
 
     }

--- a/test/Tester/MethodInterceptionTests.cs
+++ b/test/Tester/MethodInterceptionTests.cs
@@ -1,4 +1,7 @@
-﻿using TestExtensions;
+﻿using System;
+using System.Globalization;
+using TestExtensions;
+using UnitTests.Grains;
 
 namespace Tester
 {
@@ -7,12 +10,13 @@ namespace Tester
     using UnitTests.GrainInterfaces;
     using Xunit;
 
+    [TestCategory("BVT"), TestCategory("MethodInterception")]
     public class MethodInterceptionTests : HostedTestClusterEnsureDefaultStarted
     {
-        [Fact, TestCategory("Functional"), TestCategory("MethodInterception")]
+        [Fact]
         public async Task GrainMethodInterceptionTest()
         {
-            var grain = GrainClient.GrainFactory.GetGrain<IMethodInterceptionGrain>(0);
+            var grain = GrainFactory.GetGrain<IMethodInterceptionGrain>(0);
             var result = await grain.One();
             Assert.Equal("intercepted one with no args", result);
 
@@ -24,6 +28,39 @@ namespace Tester
 
             result = await grain.SayHello();
             Assert.Equal("Hello", result);
+        }
+
+        [Fact]
+        public async Task GenericGrainMethodInterceptionTest()
+        {
+            var grain = GrainFactory.GetGrain<IGenericMethodInterceptionGrain<int>>(
+                0,
+                typeof(GenericMethodInterceptionGrain<>).Namespace + "." + nameof(GenericMethodInterceptionGrain<int>));
+            var result = await grain.GetInputAsString(679);
+            Assert.Contains("Hah!", result);
+            Assert.Contains("679", result);
+
+            result = await grain.SayHello();
+            Assert.Equal("Hello", result);
+        }
+
+        [Fact]
+        public async Task ConstructedInheritanceGenericGrainMethodInterceptionTest()
+        {
+            var grain = GrainFactory.GetGrain<ITrickyMethodInterceptionGrain>(0);
+
+            var result = await grain.GetInputAsString("2014-12-19T14:32:50Z");
+            Assert.Contains("Hah!", result);
+            Assert.Contains("2014-12-19T14:32:50Z", result);
+
+            result = await grain.SayHello();
+            Assert.Equal("Hello", result);
+
+            var bestNumber = await grain.GetBestNumber();
+            Assert.Equal(38, bestNumber);
+
+            result = await grain.GetInputAsString(true);
+            Assert.Contains(true.ToString(CultureInfo.InvariantCulture), result);
         }
     }
 }

--- a/test/Tester/MethodInterceptionTests.cs
+++ b/test/Tester/MethodInterceptionTests.cs
@@ -33,9 +33,7 @@ namespace Tester
         [Fact]
         public async Task GenericGrainMethodInterceptionTest()
         {
-            var grain = GrainFactory.GetGrain<IGenericMethodInterceptionGrain<int>>(
-                0,
-                typeof(GenericMethodInterceptionGrain<>).Namespace + "." + nameof(GenericMethodInterceptionGrain<int>));
+            var grain = GrainFactory.GetGrain<IGenericMethodInterceptionGrain<int>>(0);
             var result = await grain.GetInputAsString(679);
             Assert.Contains("Hah!", result);
             Assert.Contains("679", result);


### PR DESCRIPTION
Fixes #2358. 

* Previously there were two methods used to get an id for a grain interface, with slightly different behaviour. That seemed to be erroneous and so `ComputeInterfaceId` was removed in favour of `GetGrainInterfaceId`.
* `GetGrainInterfaceId` must take into account whether or not the grain is a constructed generic. A constructed generic cannot be a grain interface as specified in code. Therefore its generic type definition is used instead.
* The `Type.GetRuntimeInterfaceMap(Type)` method does not take into account inherited interfaces, only the current interface. This would cause interceptors to receive `null` instead of the implementation's `MethodInfo`.
* Mapping between methods on a generic interface and their counterparts on a concrete class is not entirely obvious, but it is now implemented (see `GetGenericInterfaceInvoker`). A different method was used in order to keep differences clear.
* Added an additional test to ensure this case is covered.
* Changed tests to BVTs since they're quick & fairly important.

Thank you for reporting, @dancvogel, and thanks for the prod, @richorama 😄 