### PR TITLE
Reduce usage of statics in IRuntimeClient implementation & usage

### DIFF
--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -252,12 +252,6 @@ namespace Orleans
             return GetLogger(GetType().Name);
         }
 
-        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-        internal string CaptureRuntimeEnvironment()
-        {
-            return RuntimeClient.Current.CaptureRuntimeEnvironment();
-        }
-
         private void EnsureRuntime()
         {
             if (Runtime == null)

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Core\IStatefulGrain.cs" />
     <Compile Include="GrainDirectory\MultiClusterStatus.cs" />
     <Compile Include="Providers\ProviderStateManager.cs" />
+    <Compile Include="Runtime\IGrainTimer.cs" />
     <Compile Include="Runtime\ILocalSiloDetails.cs" />
     <Compile Include="Runtime\RingRange.cs" />
     <Compile Include="Serialization\IExternalSerializer.cs" />
@@ -127,7 +128,6 @@
     <Compile Include="Messaging\Response.cs" />
     <Compile Include="Providers\IControllable.cs" />
     <Compile Include="Providers\StorageProviderUtils.cs" />
-    <Compile Include="Runtime\GrainRuntime.cs" />
     <Compile Include="Runtime\IAddressable.cs" />
     <Compile Include="Placement\PreferLocalPlacement.cs" />
     <Compile Include="AssemblyLoader\AssemblyLoader.cs" />

--- a/src/Orleans/Runtime/IActivationData.cs
+++ b/src/Orleans/Runtime/IActivationData.cs
@@ -15,6 +15,7 @@ namespace Orleans.Runtime
         ActivationAddress Address { get; }
         void DelayDeactivation(TimeSpan timeSpan);
         IStorageProvider StorageProvider { get; }
-        IDisposable RegisterTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period);
+        IGrainTimer RegisterTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period);
+        void OnTimerDisposed(IGrainTimer timer);
     }
 }

--- a/src/Orleans/Runtime/IGrainTimer.cs
+++ b/src/Orleans/Runtime/IGrainTimer.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime
+{
+    internal interface IGrainTimer : IDisposable
+    {
+        void Start();
+
+        void Stop();
+
+        Task GetCurrentlyExecutingTickTask();
+    }
+}

--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
-using Orleans.Storage;
 
 namespace Orleans.Runtime
 {
@@ -43,12 +42,6 @@ namespace Orleans.Runtime
 
         void ReceiveResponse(Message message);
 
-        /// <summary>
-        /// Return the currently storage provider configured for this grain, or null if no storage provider configured for this grain.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">If called from outside grain class</exception>
-        IStorageProvider CurrentStorageProvider { get; }
-
         Task<IGrainReminder> RegisterOrUpdateReminder(string reminderName, TimeSpan dueTime, TimeSpan period);
 
         Task UnregisterReminder(IGrainReminder reminder);
@@ -65,26 +58,14 @@ namespace Orleans.Runtime
 
         void DeleteObjectReference(IAddressable obj);
 
-        IActivationData CurrentActivationData { get; }
-
-        ActivationAddress CurrentActivationAddress { get; }
-
         SiloAddress CurrentSilo { get; }
-
-        void DeactivateOnIdle(ActivationId id);
 
         Streams.IStreamProviderManager CurrentStreamProviderManager { get; }
 
         Streams.IStreamProviderRuntime CurrentStreamProviderRuntime { get; }
 
         IGrainTypeResolver GrainTypeResolver { get; }
-
-        string CaptureRuntimeEnvironment();
-
-        IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType = null);
-
-        SiloStatus GetSiloStatus(SiloAddress siloAddress);
-
+        
         void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo);
     }
 }

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -12,7 +12,6 @@ using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
-using Orleans.Storage;
 using Orleans.Streams;
 
 namespace Orleans
@@ -88,22 +87,7 @@ namespace Orleans
         {
             get { return CurrentActivationAddress.ToString(); }
         }
-
-        public IActivationData CurrentActivationData
-        {
-            get { return null; }
-        }
-
-        public IAddressable CurrentGrain
-        {
-            get { return null; }
-        }
-
-        public IStorageProvider CurrentStorageProvider
-        {
-            get { throw new InvalidOperationException("Storage provider only available from inside grain"); }
-        }
-
+        
         internal IList<Uri> Gateways
         {
             get
@@ -832,12 +816,7 @@ namespace Orleans
         {
             throw new InvalidOperationException("GetReminders can only be called from inside a grain");
         }
-
-        public SiloStatus GetSiloStatus(SiloAddress silo)
-        {
-            throw new InvalidOperationException("GetSiloStatus can only be called on the silo.");
-        }
-
+        
         public async Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context, string activityName)
         {
             await Task.Run(asyncFunction); // No grain context on client - run on .NET thread pool
@@ -865,11 +844,6 @@ namespace Orleans
             LocalObjectData ignore;
             if (!localObjects.TryRemove(reference.ObserverId, out ignore))
                 throw new ArgumentException("Reference is not associated with a local object.", "reference");
-        }
-
-        public void DeactivateOnIdle(ActivationId id)
-        {
-            throw new InvalidOperationException();
         }
 
         #endregion Implementation of IRuntimeClient
@@ -937,16 +911,6 @@ namespace Orleans
         public IGrainTypeResolver GrainTypeResolver
         {
             get { return grainInterfaceMap; }
-        }
-
-        public string CaptureRuntimeEnvironment()
-        {
-            throw new NotImplementedException();
-        }
-
-        public IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType = null)
-        {
-            throw new NotImplementedException();
         }
 
         public void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo)

--- a/src/Orleans/SystemTargetInterfaces/ISystemTarget.cs
+++ b/src/Orleans/SystemTargetInterfaces/ISystemTarget.cs
@@ -22,10 +22,4 @@ namespace Orleans
         SiloAddress Silo { get; }
         GrainId GrainId { get; }
     }
-
-    // Common internal interface for SystemTarget and ActivationData.
-    internal interface IInvokable
-    {
-        IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType = null);
-    }
 }

--- a/src/OrleansRuntime/Core/GrainRuntime.cs
+++ b/src/OrleansRuntime/Core/GrainRuntime.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime
 {
     internal class GrainRuntime : IGrainRuntime
     {
-        private readonly IRuntimeClient runtimeClient;
+        private readonly ISiloRuntimeClient runtimeClient;
 
         public GrainRuntime(
             GlobalConfiguration globalConfig,
@@ -17,7 +17,7 @@ namespace Orleans.Runtime
             IReminderRegistry reminderRegistry,
             IStreamProviderManager streamProviderManager,
             IServiceProvider serviceProvider,
-            IRuntimeClient runtimeClient)
+            ISiloRuntimeClient runtimeClient)
         {
             this.runtimeClient = runtimeClient;
             ServiceId = globalConfig.ServiceId;

--- a/src/OrleansRuntime/Core/IInvokable.cs
+++ b/src/OrleansRuntime/Core/IInvokable.cs
@@ -1,0 +1,12 @@
+using Orleans.CodeGeneration;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Common internal interface for SystemTarget and ActivationData.
+    /// </summary>
+    internal interface IInvokable
+    {
+        IGrainMethodInvoker GetInvoker(GrainTypeManager typeManager, int interfaceId, string genericGrainType = null);
+    }
+}

--- a/src/OrleansRuntime/Core/ISiloRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/ISiloRuntimeClient.cs
@@ -53,5 +53,9 @@ namespace Orleans.Runtime
         Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
             where TExtension : IGrainExtension
             where TExtensionInterface : IGrainExtension;
+
+        IActivationData CurrentActivationData { get; }
+
+        void DeactivateOnIdle(ActivationId id);
     }
 }

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -342,7 +342,7 @@ namespace Orleans.Runtime
                         CancellationSourcesExtension.RegisterCancellationTokens(target, request, logger, this);
                     }
 
-                    var invoker = invokable.GetInvoker(this.typeManager, request.InterfaceId, message.GenericGrainType);
+                    var invoker = invokable.GetInvoker(typeManager, request.InterfaceId, message.GenericGrainType);
 
                     if (invoker is IGrainExtensionMethodInvoker
                         && !(target is IGrainExtension))
@@ -754,7 +754,7 @@ namespace Orleans.Runtime
 
         public IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType = null)
         {
-            return this.typeManager.GetInvoker(interfaceId, genericGrainType);
+            return typeManager.GetInvoker(interfaceId, genericGrainType);
         }
 
         public void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo)

--- a/src/OrleansRuntime/Core/SystemTarget.cs
+++ b/src/OrleansRuntime/Core/SystemTarget.cs
@@ -29,12 +29,12 @@ namespace Orleans.Runtime
 
         internal SchedulingContext SchedulingContext { get; }
 
-        public IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType = null)
+        public IGrainMethodInvoker GetInvoker(GrainTypeManager typeManager, int interfaceId, string genericGrainType = null)
         {
             if (lastInvoker != null && interfaceId == lastInvoker.InterfaceId)
                 return lastInvoker;
 
-            var invoker = GrainTypeManager.Instance.GetInvoker(interfaceId);
+            var invoker = typeManager.GetInvoker(interfaceId);
             lastInvoker = invoker;
             
             return lastInvoker;

--- a/src/OrleansRuntime/GrainDirectory/ClientObserverRegistrar.cs
+++ b/src/OrleansRuntime/GrainDirectory/ClientObserverRegistrar.cs
@@ -20,7 +20,7 @@ namespace Orleans.Runtime
         private readonly OrleansTaskScheduler scheduler;
         private readonly ClusterConfiguration orleansConfig;
         private readonly Logger logger;
-        private GrainTimer clientRefreshTimer;
+        private IGrainTimer clientRefreshTimer;
         private Gateway gateway;
 
 

--- a/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -25,7 +25,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
         private readonly TimeSpan backgroundGossipInterval;
         private TimeSpan resendActiveStatusAfter;
 
-        private GrainTimer timer;
+        private IGrainTimer timer;
         private ISiloStatusOracle siloStatusOracle;
         private MultiClusterConfiguration injectedConfig;
 

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -58,6 +58,8 @@
     <Compile Include="Cancellation\CancellationSourcesExtension.cs" />
     <Compile Include="Catalog\ActivationState.cs" />
     <Compile Include="Catalog\GrainCreator.cs" />
+    <Compile Include="Core\GrainRuntime.cs" />
+    <Compile Include="Core\IInvokable.cs" />
     <Compile Include="Core\ISiloRuntimeClient.cs" />
     <Compile Include="Counters\CounterConfigData.cs" />
     <Compile Include="Messaging\ObjectPool.cs" />

--- a/src/OrleansRuntime/ReminderService/LocalReminderService.cs
+++ b/src/OrleansRuntime/ReminderService/LocalReminderService.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime.ReminderService
         private IRingRange myRange;
         private long localTableSequence;
         private int rangeSerialNumber;
-        private GrainTimer listRefresher; // timer that refreshes our list of reminders to reflect global reminder table
+        private IGrainTimer listRefresher; // timer that refreshes our list of reminders to reflect global reminder table
         private readonly TaskCompletionSource<bool> startedTask;
         private readonly CancellationTokenSource stoppedCancellationTokenSource;
         private uint initialReadCallCount = 0;
@@ -41,6 +41,7 @@ namespace Orleans.Runtime.ReminderService
         private readonly Logger logger;
         private readonly GlobalConfiguration config;
         private readonly TimeSpan initTimeout;
+        private readonly ISiloRuntimeClient runtimeClient;
 
         internal LocalReminderService(
             SiloAddress addr,
@@ -49,7 +50,8 @@ namespace Orleans.Runtime.ReminderService
             OrleansTaskScheduler localScheduler,
             IReminderTable reminderTable,
             GlobalConfiguration config,
-            TimeSpan initTimeout)
+            TimeSpan initTimeout,
+            ISiloRuntimeClient runtimeClient)
             : base(id, addr)
         {
             logger = LogManager.GetLogger("ReminderService", LoggerType.Runtime);
@@ -60,6 +62,7 @@ namespace Orleans.Runtime.ReminderService
             this.reminderTable = reminderTable;
             this.config = config;
             this.initTimeout = initTimeout;
+            this.runtimeClient = runtimeClient;
             status = ReminderServiceStatus.Booting;
             myRange = null;
             localTableSequence = 0;
@@ -555,7 +558,7 @@ namespace Orleans.Runtime.ReminderService
 
             internal ReminderIdentity Identity { get; private set; }
             internal string ETag;
-            internal GrainTimer Timer;
+            internal IGrainTimer Timer;
             internal long LocalSequenceNumber; // locally, we use this for resolving races between the periodic table reader, and any concurrent local register/unregister requests
 
             internal LocalReminderData(ReminderEntry entry)

--- a/src/OrleansRuntime/ReminderService/LocalReminderServiceFactory.cs
+++ b/src/OrleansRuntime/ReminderService/LocalReminderServiceFactory.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime
             logger = LogManager.GetLogger("ReminderFactory", LoggerType.Runtime);
         }
 
-        internal IReminderService CreateReminderService(Silo silo, IGrainFactory grainFactory, TimeSpan iniTimeSpan)
+        internal IReminderService CreateReminderService(Silo silo, IGrainFactory grainFactory, TimeSpan iniTimeSpan, ISiloRuntimeClient runtimeClient)
         {
             var reminderServiceType = silo.GlobalConfig.ReminderServiceType;
             logger.Info("Creating reminder system target for type={0}", Enum.GetName(typeof(GlobalConfiguration.ReminderServiceProviderType), reminderServiceType));
@@ -27,7 +27,8 @@ namespace Orleans.Runtime
                 silo.LocalScheduler, 
                 ReminderTable.Singleton, 
                 silo.GlobalConfig,
-                iniTimeSpan);
+                iniTimeSpan,
+                runtimeClient);
         }
     }
 }

--- a/src/OrleansRuntime/ReminderService/LocalReminderServiceFactory.cs
+++ b/src/OrleansRuntime/ReminderService/LocalReminderServiceFactory.cs
@@ -27,8 +27,7 @@ namespace Orleans.Runtime
                 silo.LocalScheduler, 
                 ReminderTable.Singleton, 
                 silo.GlobalConfig,
-                iniTimeSpan,
-                runtimeClient);
+                iniTimeSpan);
         }
     }
 }

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -428,7 +428,7 @@ namespace Orleans.Runtime
             {
                 // start the reminder service system target
                 reminderService = Services.GetRequiredService<LocalReminderServiceFactory>()
-                                          .CreateReminderService(this, grainFactory, initTimeout);
+                                          .CreateReminderService(this, grainFactory, initTimeout, this.runtimeClient);
                 RegisterSystemTarget((SystemTarget) reminderService);
             }
 

--- a/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -25,6 +25,7 @@ namespace Orleans.Streams
         private static readonly CounterStatistic counterConsumersAdded;
         private static readonly CounterStatistic counterConsumersRemoved;
         private static readonly CounterStatistic counterConsumersTotal;
+        private readonly ISiloStatusOracle siloStatusOracle;
 
         static PubSubRendezvousGrain()
         {
@@ -34,6 +35,11 @@ namespace Orleans.Streams
             counterConsumersAdded   = CounterStatistic.FindOrCreate(StatisticNames.STREAMS_PUBSUB_CONSUMERS_ADDED);
             counterConsumersRemoved = CounterStatistic.FindOrCreate(StatisticNames.STREAMS_PUBSUB_CONSUMERS_REMOVED);
             counterConsumersTotal   = CounterStatistic.FindOrCreate(StatisticNames.STREAMS_PUBSUB_CONSUMERS_TOTAL);
+        }
+
+        public PubSubRendezvousGrain(ISiloStatusOracle siloStatusOracle)
+        {
+            this.siloStatusOracle = siloStatusOracle;
         }
 
         public override async Task OnActivateAsync()
@@ -74,20 +80,20 @@ namespace Orleans.Streams
         }
 
         /// accept and notify only Active producers.
-        private static bool IsActiveProducer(IStreamProducerExtension producer)
+        private bool IsActiveProducer(IStreamProducerExtension producer)
         {
             var grainRef = producer as GrainReference;
             if (grainRef !=null && grainRef.GrainId.IsSystemTarget && grainRef.IsInitializedSystemTarget)
-                return RuntimeClient.Current.GetSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Active;
+                return this.siloStatusOracle.GetApproximateSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Active;
             
             return true;
         }
 
-        private static bool IsDeadProducer(IStreamProducerExtension producer)
+        private bool IsDeadProducer(IStreamProducerExtension producer)
         {
             var grainRef = producer as GrainReference;
             if (grainRef != null && grainRef.GrainId.IsSystemTarget && grainRef.IsInitializedSystemTarget)
-                return RuntimeClient.Current.GetSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Dead;
+                return this.siloStatusOracle.GetApproximateSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Dead;
             
             return false;
         }

--- a/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -84,7 +84,7 @@ namespace Orleans.Streams
         {
             var grainRef = producer as GrainReference;
             if (grainRef !=null && grainRef.GrainId.IsSystemTarget && grainRef.IsInitializedSystemTarget)
-                return this.siloStatusOracle.GetApproximateSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Active;
+                return siloStatusOracle.GetApproximateSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Active;
             
             return true;
         }
@@ -93,7 +93,7 @@ namespace Orleans.Streams
         {
             var grainRef = producer as GrainReference;
             if (grainRef != null && grainRef.GrainId.IsSystemTarget && grainRef.IsInitializedSystemTarget)
-                return this.siloStatusOracle.GetApproximateSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Dead;
+                return siloStatusOracle.GetApproximateSiloStatus(grainRef.SystemTargetSilo) == SiloStatus.Dead;
             
             return false;
         }

--- a/test/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/TestInternalGrains/PersistenceTestGrains.cs
@@ -16,6 +16,30 @@ using Xunit;
 
 namespace UnitTests.Grains
 {
+    internal static class TestRuntimeEnvironmentUtility
+    {
+        public static string CaptureRuntimeEnvironment()
+        {
+            var callStack = Utils.GetStackTrace(1); // Don't include this method in stack trace
+            return String.Format(
+                "   TaskScheduler={0}" + Environment.NewLine
+                + "   RuntimeContext={1}" + Environment.NewLine
+                + "   WorkerPoolThread={2}" + Environment.NewLine
+                + "   WorkerPoolThread.CurrentWorkerThread.ManagedThreadId={3}" + Environment.NewLine
+                + "   Thread.CurrentThread.ManagedThreadId={4}" + Environment.NewLine
+                + "   StackTrace=" + Environment.NewLine
+                + "   {5}",
+                TaskScheduler.Current,
+                RuntimeContext.Current,
+                WorkerPoolThread.CurrentWorkerThread == null ? "null" : WorkerPoolThread.CurrentWorkerThread.Name,
+                WorkerPoolThread.CurrentWorkerThread == null
+                    ? "null"
+                    : WorkerPoolThread.CurrentWorkerThread.ManagedThreadId.ToString(CultureInfo.InvariantCulture),
+                System.Threading.Thread.CurrentThread.ManagedThreadId,
+                callStack);
+        }
+    }
+
     [Serializable]
     public class PersistenceTestGrainState
     {
@@ -745,23 +769,18 @@ namespace UnitTests.Grains
         {
             if (executing)
             {
-                var errorMsg = String.Format(
-                    "Found out that this grain is already in the middle of execution."
-                    + " Single threaded-ness violation!"
-                    + ".\n{0}",
-                    CaptureRuntimeEnvironment());
-                logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
+                var errorMsg = "Found out that this grain is already in the middle of execution."
+                               + " Single threaded-ness violation!\n" +
+                               TestRuntimeEnvironmentUtility.CaptureRuntimeEnvironment();
+                this.logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
                 throw new Exception(errorMsg);
                 //Environment.Exit(1);
             }
 
             if (RuntimeContext.Current == null || RuntimeContext.Current.ActivationContext == null)
             {
-                var errorMsg = String.Format(
-                    "Found RuntimeContext.Current == null."
-                    + ".\n{0}",
-                    CaptureRuntimeEnvironment());
-                logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
+                var errorMsg = "Found RuntimeContext.Current == null.\n" + TestRuntimeEnvironmentUtility.CaptureRuntimeEnvironment();
+                this.logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
                 throw new Exception(errorMsg);
                 //Environment.Exit(1);
             }
@@ -800,7 +819,7 @@ namespace UnitTests.Grains
             new Tuple<string, Severity>("Scheduler", Severity.Info),
             new Tuple<string, Severity>("Scheduler.ActivationTaskScheduler", Severity.Info)
         };
-
+        
         public NonReentrentStressGrainWithoutState(OrleansTaskScheduler scheduler)
         {
             this.scheduler = scheduler;
@@ -917,8 +936,10 @@ namespace UnitTests.Grains
                     "Found out that grain {0} is already in the middle of execution."
                     + "\n Single threaded-ness violation!"
                     + "\n {1} \n Call Stack={2}",
-                    _id, CaptureRuntimeEnvironment(), callStack);
-                logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
+                    this._id,
+                    TestRuntimeEnvironmentUtility.CaptureRuntimeEnvironment(),
+                    callStack);
+                this.logger.Error(1, "\n\n\n\n" + errorMsg + "\n\n\n\n");
                 this.scheduler.DumpSchedulerStatus();
                 LogManager.Flush();
                 //Environment.Exit(1);


### PR DESCRIPTION
More of the same. I'm very wary of making any of these PRs large, so this isn't a huge step forward.

Generally speaking, this moves additional members from `IRuntimeClient` to `ISiloRuntimeClient` and entirely removes some members.

This also removes some of the usages of `RuntimeClient.Current`, which is one of the main goals of this series of PRs.

* Introduces an interface, `IGrainTimer` from the class `GrainTimer` in order to cleanly separate existing `IActivationData` interface from its only implementation, `ActivationData` (we could remove `IActivationData` if we don't think it's useful and use `ActivationData` instead)
* `IInvokable` was moved from `Orleans` to `OrleansRuntime` and `GrainTypeManager` was added as a parameter. I felt adding a parameter here was better than requiring that the implementations (`SystemTarget` and `ActivationData`) add an extra field.
* `GrainRuntime` moved to from `Orleans` to `OrleansRuntime`. It's a trivial implementation of `IGrainRuntime` and moving it there lets us implement it using internal interfaces without losing anything.