### PR TITLE
Remove unused [Factory] attribute

### DIFF
--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-using System.Reflection;
 using Orleans.GrainDirectory;
 namespace Orleans
 {
@@ -282,64 +280,6 @@ namespace Orleans
             /// The name of the storage provider to ne used for persisting state for this grain.
             /// </summary>
             public string ProviderName { get; set; }
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Interface)]
-    internal sealed class FactoryAttribute : Attribute
-    {
-        public enum FactoryTypes
-        {
-            Grain,
-            ClientObject,
-            Both
-        };
-
-        private readonly FactoryTypes factoryType;
-
-        public FactoryAttribute(FactoryTypes factoryType)
-        {
-            this.factoryType = factoryType;
-        }
-
-        internal static FactoryTypes CollectFactoryTypesSpecified(Type type)
-        {
-            var attribs = type.GetTypeInfo().GetCustomAttributes(typeof(FactoryAttribute), inherit: true).ToArray();
-
-            // if no attributes are specified, we default to FactoryTypes.Grain.
-            if (0 == attribs.Length)
-                return FactoryTypes.Grain;
-            
-            // otherwise, we'll consider all of them and aggregate the specifications
-            // like flags.
-            FactoryTypes? result = null;
-            foreach (var i in attribs)
-            {
-                var a = (FactoryAttribute)i;
-                if (result.HasValue)
-                {
-                    if (a.factoryType == FactoryTypes.Both)
-                        result = a.factoryType;
-                    else if (a.factoryType != result.Value)
-                        result = FactoryTypes.Both;
-                }
-                else
-                    result = a.factoryType;
-            }
-
-            if (result.Value == FactoryTypes.Both)
-            {
-                throw 
-                    new NotSupportedException(
-                        "Orleans doesn't currently support generating both a grain and a client object factory but we really want to!");
-            }
-            
-            return result.Value;
-        }
-
-        public static FactoryTypes CollectFactoryTypesSpecified<T>()
-        {
-            return CollectFactoryTypesSpecified(typeof(T));
         }
     }
 

--- a/src/Orleans/Streams/Internal/IStreamGrainExtensions.cs
+++ b/src/Orleans/Streams/Internal/IStreamGrainExtensions.cs
@@ -6,7 +6,6 @@ using Orleans.Runtime;
 namespace Orleans.Streams
 {
     // This is the extension interface for stream consumers
-    [Factory(FactoryAttribute.FactoryTypes.ClientObject)]
     internal interface IStreamConsumerExtension : IGrainExtension
     {
         Task<StreamHandshakeToken> DeliverImmutable(GuidId subscriptionId, Immutable<object> item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken);
@@ -18,7 +17,6 @@ namespace Orleans.Streams
     }
 
     // This is the extension interface for stream producers
-    [Factory(FactoryAttribute.FactoryTypes.ClientObject)]
     internal interface IStreamProducerExtension : IGrainExtension
     {
         [AlwaysInterleave]

--- a/test/TestInternalGrainInterfaces/IClientAddressableTestClientObject.cs
+++ b/test/TestInternalGrainInterfaces/IClientAddressableTestClientObject.cs
@@ -3,7 +3,6 @@ using Orleans;
 
 namespace UnitTests.GrainInterfaces
 {
-    [Factory(FactoryAttribute.FactoryTypes.ClientObject)]
     public interface IClientAddressableTestClientObject : IGrainWithIntegerKey
     {
         Task<string> OnHappyPath(string message);

--- a/test/TestInternalGrainInterfaces/IClientAddressableTestGrain.cs
+++ b/test/TestInternalGrainInterfaces/IClientAddressableTestGrain.cs
@@ -3,7 +3,6 @@ using Orleans;
 
 namespace UnitTests.GrainInterfaces
 {
-    [Factory(FactoryAttribute.FactoryTypes.Grain)]
     public interface IClientAddressableTestGrain : IGrainWithIntegerKey
     {
         Task SetTarget(IClientAddressableTestClientObject target);

--- a/test/TestInternalGrainInterfaces/IClientAddressableTestProducer.cs
+++ b/test/TestInternalGrainInterfaces/IClientAddressableTestProducer.cs
@@ -3,7 +3,6 @@ using Orleans;
 
 namespace UnitTests.GrainInterfaces
 {
-    [Factory(FactoryAttribute.FactoryTypes.ClientObject)]
     public interface IClientAddressableTestProducer : IGrainWithIntegerKey
     {
         Task<int> Poll();


### PR DESCRIPTION
Removes the unused `[Factory(factoryType)]` attribute, which is a remnant from the old code generator.