### PR TITLE
Extract ReminderRegistry implementation from InsideRuntimeClient

### DIFF
--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -42,14 +42,6 @@ namespace Orleans.Runtime
 
         void ReceiveResponse(Message message);
 
-        Task<IGrainReminder> RegisterOrUpdateReminder(string reminderName, TimeSpan dueTime, TimeSpan period);
-
-        Task UnregisterReminder(IGrainReminder reminder);
-
-        Task<IGrainReminder> GetReminder(string reminderName);
-
-        Task<List<IGrainReminder>> GetReminders();
-
         Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context, string activityName);
 
         void Reset(bool cleanup);

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -807,26 +807,6 @@ namespace Orleans
         {
             return responseTimeout;
         }
-
-        public Task<IGrainReminder> RegisterOrUpdateReminder(string reminderName, TimeSpan dueTime, TimeSpan period)
-        {
-            throw new InvalidOperationException("RegisterReminder can only be called from inside a grain");
-        }
-
-        public Task UnregisterReminder(IGrainReminder reminder)
-        {
-            throw new InvalidOperationException("UnregisterReminder can only be called from inside a grain");
-        }
-
-        public Task<IGrainReminder> GetReminder(string reminderName)
-        {
-            throw new InvalidOperationException("GetReminder can only be called from inside a grain");
-        }
-
-        public Task<List<IGrainReminder>> GetReminders()
-        {
-            throw new InvalidOperationException("GetReminders can only be called from inside a grain");
-        }
         
         public async Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context, string activityName)
         {

--- a/src/Orleans/Timers/IRemindable.cs
+++ b/src/Orleans/Timers/IRemindable.cs
@@ -10,7 +10,7 @@ namespace Orleans
     public interface IRemindable : IGrain
     {
         /// <summary>
-        /// Receieve a new Reminder.
+        /// Receive a new Reminder.
         /// </summary>
         /// <param name="reminderName">Name of this Reminder</param>
         /// <param name="status">Status of this Reminder tick</param>
@@ -31,7 +31,7 @@ namespace Orleans
 
         /// <summary>
         /// The status of a tick when the tick is delivered to the registrar grain.
-        /// In case of failures, it may happen that a tick is not delievered on time. The app can notice such missed missed ticks as follows.
+        /// In case of failures, it may happen that a tick is not delivered on time. The app can notice such missed missed ticks as follows.
         /// Upon receiving a tick, the app can calculate the theoretical number of ticks since start of the reminder as: 
         /// curCount = (Now - FirstTickTime) / Period
         /// The app can keep track of it as 'count'. Upon receiving a tick, the number of missed ticks = curCount - count - 1

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -604,13 +604,6 @@ namespace Orleans.Runtime
         {
             get { return MySilo.ToLongString(); }
         }
-        public IAddressable CurrentGrain
-        {
-            get
-            {
-                return CurrentActivationData == null ? null : CurrentActivationData.GrainInstance;
-            }
-        }
 
         public IActivationData CurrentActivationData
         {
@@ -626,67 +619,12 @@ namespace Orleans.Runtime
                 return null;
             }
         }
-        public ActivationAddress CurrentActivationAddress
-        {
-            get
-            {
-                return CurrentActivationData == null ? null : CurrentActivationData.Address;
-            }
-        }
+
         public SiloAddress CurrentSilo
         {
             get { return MySilo; }
         }
-
-        public Task<IGrainReminder> RegisterOrUpdateReminder(string reminderName, TimeSpan dueTime, TimeSpan period)
-        {
-            return GetReminderService("RegisterOrUpdateReminder", reminderName)
-                .RegisterOrUpdateReminder(reminderName, dueTime, period);
-        }
-
-        public Task UnregisterReminder(IGrainReminder reminder)
-        {
-            return GetReminderService("UnregisterReminder", reminder.ReminderName)
-                .UnregisterReminder(reminder);
-        }
-
-        public Task<IGrainReminder> GetReminder(string reminderName)
-        {
-            return GetReminderService("GetReminder", reminderName)
-                .GetReminder(reminderName);
-        }
-
-        public Task<List<IGrainReminder>> GetReminders()
-        {
-            return GetReminderService("GetReminders", String.Empty)
-                .GetReminders();
-        }
-
-        private IReminderRegistry GetReminderService(
-            string operation,
-            string reminderName)
-        {
-            CheckValidReminderServiceType(operation);
-            var grainRef = CurrentActivationData.GrainReference;
-            SiloAddress destination = MapGrainReferenceToSiloRing(grainRef);
-            if (logger.IsVerbose)
-            {
-                logger.Verbose("{0} for reminder {1}, grainRef: {2} responsible silo: {3}/x{4, 8:X8} based on {5}",
-                    operation,
-                    reminderName,
-                    grainRef.ToDetailedString(),
-                    destination,
-                    destination.GetConsistentHashCode(),
-                    ConsistentRingProvider.ToString());
-            }
-
-            // Code above left in to preserve the existing logging, if not required we can remove MapGrainReferenceToSiloRing from InsideRuntimeClient.
-
-            // We use the IReminderRegistry which as a GrainServiceClient is responsible for resolving the correctly partitioned GrainService for the CallerGrainReference.
-            var reminderRegistry = (IReminderRegistry) Silo.CurrentSilo.Services.GetService(typeof(IReminderRegistry));
-            return reminderRegistry;
-        }
-
+        
         public async Task ExecAsync(Func<Task> asyncFunction, ISchedulingContext context, string activityName)
         {
             // Schedule call back to grain context

--- a/src/OrleansRuntime/ReminderService/ReminderRegistry.cs
+++ b/src/OrleansRuntime/ReminderService/ReminderRegistry.cs
@@ -8,7 +8,7 @@ namespace Orleans.Runtime.ReminderService
 {
     internal class ReminderRegistry : GrainServiceClient<IReminderService>, IReminderRegistry
     {
-        private const UInt32 MAX_SUPPORTED_TIMEOUT = (uint)0xfffffffe;
+        private const uint MaxSupportedTimeout = 0xfffffffe;
 
         public ReminderRegistry(IServiceProvider serviceProvider) : base(serviceProvider)
         {
@@ -18,26 +18,35 @@ namespace Orleans.Runtime.ReminderService
         {
             // Perform input volatility checks that are consistent with System.Threading.Timer
             // http://referencesource.microsoft.com/#mscorlib/system/threading/timer.cs,c454f2afe745d4d3,references
-            var dueTm = (long)dueTime.TotalMilliseconds;
+            var dueTm = (long) dueTime.TotalMilliseconds;
             if (dueTm < -1)
-                throw new ArgumentOutOfRangeException("dueTime", "Cannot use negative dueTime to create a reminder");
-            if (dueTm > MAX_SUPPORTED_TIMEOUT)
-                throw new ArgumentOutOfRangeException("dueTime", String.Format("Cannot use value larger than {0} for dueTime when creating a reminder", MAX_SUPPORTED_TIMEOUT));
+                throw new ArgumentOutOfRangeException(nameof(dueTime), "Cannot use negative dueTime to create a reminder");
+            if (dueTm > MaxSupportedTimeout)
+                throw new ArgumentOutOfRangeException(
+                    nameof(dueTime),
+                    $"Cannot use value larger than {MaxSupportedTimeout}ms for dueTime when creating a reminder");
 
-            var periodTm = (long)period.TotalMilliseconds;
+            var periodTm = (long) period.TotalMilliseconds;
             if (periodTm < -1)
-                throw new ArgumentOutOfRangeException("period", "Cannot use negative period to create a reminder");
-            if (periodTm > MAX_SUPPORTED_TIMEOUT)
-                throw new ArgumentOutOfRangeException("period", String.Format("Cannot use value larger than {0} for period when creating a reminder", MAX_SUPPORTED_TIMEOUT));
+                throw new ArgumentOutOfRangeException(nameof(period), "Cannot use negative period to create a reminder");
+            if (periodTm > MaxSupportedTimeout)
+                throw new ArgumentOutOfRangeException(
+                    nameof(period),
+                    $"Cannot use value larger than {MaxSupportedTimeout}ms for period when creating a reminder");
 
             if (period < Constants.MinReminderPeriod)
             {
-                string msg = string.Format("Cannot register reminder {0} as requested period ({1}) is less than minimum allowed reminder period ({2})", reminderName, period, Constants.MinReminderPeriod);
+                var msg =
+                    string.Format(
+                        "Cannot register reminder {0} as requested period ({1}) is less than minimum allowed reminder period ({2})",
+                        reminderName,
+                        period,
+                        Constants.MinReminderPeriod);
                 throw new ArgumentException(msg);
             }
-            if (String.IsNullOrEmpty(reminderName))
+            if (string.IsNullOrEmpty(reminderName))
             {
-                throw new ArgumentException("Cannot use null or empty name for the reminder", "reminderName");
+                throw new ArgumentException("Cannot use null or empty name for the reminder", nameof(reminderName));
             }
 
             return GrainService.RegisterOrUpdateReminder(CallingGrainReference, reminderName, dueTime, period);
@@ -50,9 +59,9 @@ namespace Orleans.Runtime.ReminderService
 
         public Task<IGrainReminder> GetReminder(string reminderName)
         {
-            if (String.IsNullOrEmpty(reminderName))
+            if (string.IsNullOrEmpty(reminderName))
             {
-                throw new ArgumentException("Cannot use null or empty name for the reminder", "reminderName");
+                throw new ArgumentException("Cannot use null or empty name for the reminder", nameof(reminderName));
             }
 
             return GrainService.GetReminder(CallingGrainReference, reminderName);


### PR DESCRIPTION
The guts of `ReminderRegistry` are in `InsideRuntimeClient`. `ReminderRegistry` adds some additional guards around those methods and calls into `InsideRuntimeClient` via the global `RuntimeClient.Current`.

The intention of this PR is to remove those globals and clean up the code a little bit.

* Shifts most of the reminder-related parts from `InsideRuntimeClient` and into `ReminderRegistry`
* Removes usage of globals from `ReminderRegistry`
* Removes the reminder-related methods from `IRuntimeClient` (they were not applicable for external clients), replacing them with a single `GetReminderService` method on `ISiloRuntimeClient`
* Removes some unused properties from `InsideRuntimeClient`

Related to #467