### PR TITLE
Fix invocation interception for grain extensions

### DIFF
--- a/test/Tester/InvocationInterceptTests.cs
+++ b/test/Tester/InvocationInterceptTests.cs
@@ -30,7 +30,7 @@ namespace UnitTests.General
         /// Ensures that the invocation interceptor is invoked around method calls.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>
-        [Fact, TestCategory("Functional")]
+        [Fact, TestCategory("Functional"), TestCategory("MethodInterception")]
         public async Task PreInvocationCallbackTest()
         {
             var grain = GrainFactory.GetGrain<ISimplePersistentGrain>(random.Next());
@@ -45,7 +45,7 @@ namespace UnitTests.General
         /// Ensures that the invocation interceptor is invoked for stream subscribers.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>
-        [Fact, TestCategory("Functional")]
+        [Fact, TestCategory("Functional"), TestCategory("MethodInterception")]
         public async Task PreInvocationCallbackWithStreamTest()
         {
             var streamProvider = GrainClient.GetStreamProvider("SMSProvider");


### PR DESCRIPTION
I broke the `PreInvocationCallbackWithStreamTest` test with #2502.
The test checks that `IGrainExtension`s can have their methods intercepted by grains. Previously we were passing a `null` `MethodInfo` parameter to the interceptor, since the correct implementation method could not be found.

#2502 broke that by throwing an exception in the event that an implementation method cannot be found.

This PR fixes it again by mapping the interface method to the extension method in the event that the incoming request is destined for the extension object.

As you can see, it's a very simple fix. Functionals are running.