### PR TITLE
Fix #2517 & cleanup timer tests

### DIFF
--- a/test/DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/DefaultCluster.Tests/TimerOrleansTest.cs
@@ -113,8 +113,8 @@ namespace DefaultCluster.Tests.TimerTests
             output.WriteLine("value = " + last);
             Assert.True(last >= 10 && last <= 12, $"last >= 10 && last <= 12. Actual: last = {last}");
 
-            // Restart the silo.
-            HostedCluster.RestartSilo(HostedCluster.Primary);
+            // Restart the grain.
+            await grain.Deactivate();
             stopwatch.Restart();
             period = await grain.GetTimerPeriod();
 
@@ -132,7 +132,7 @@ namespace DefaultCluster.Tests.TimerTests
             Assert.True(
                 last <= maximalNumTicks,
                 $"Assert: last <= maximalNumTicks. Actual: last = {last}, maximalNumTicks = {maximalNumTicks}");
-            //mgmtGrain.ResumeHost(Orleans.SiloAddress).Wait();
+
             output.WriteLine(
                 "Total Elaped time = " + (stopwatch.Elapsed.TotalSeconds) + " sec. Expected Ticks = " + maximalNumTicks +
                 ". Actual ticks = " + last);

--- a/test/DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/DefaultCluster.Tests/TimerOrleansTest.cs
@@ -25,89 +25,117 @@ namespace DefaultCluster.Tests.TimerTests
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Timers")]
-        public void TimerOrleansTest_Basic()
+        public async Task TimerOrleansTest_Basic()
         {
             for (int i = 0; i < 10; i++)
             {
-                ITimerGrain grain = GrainClient.GrainFactory.GetGrain<ITimerGrain>(GetRandomGrainId());
-                TimeSpan period = grain.GetTimerPeriod().Result;
-                Thread.Sleep(period.Multiply(10));
-                int last = grain.GetCounter().Result;
-                output.WriteLine("value = " + last);
-                //Assert.True(10 == last || 9 == last, last.ToString());
+                var grain = GrainFactory.GetGrain<ITimerGrain>(GetRandomGrainId());
+                var period = await grain.GetTimerPeriod();
+                var timeout = period.Multiply(50);
+                var stopwatch = Stopwatch.StartNew();
+                var last = 0;
+                while (stopwatch.Elapsed < timeout && last < 10)
+                {
+                    await Task.Delay(period.Divide(2));
+                    last = await grain.GetCounter();
+                }
 
-                grain.StopDefaultTimer().Wait();
-                Thread.Sleep(period.Multiply(10));
-                int curr = grain.GetCounter().Result;
-                //Assert.True(curr == last || curr == last + 1, curr.ToString() + " " + last.ToString());
+                output.WriteLine("value = " + last);
+                Assert.True(last >= 10 & last <= 12, last.ToString());
+
+                await grain.StopDefaultTimer();
+                await Task.Delay(period.Multiply(2));
+                var curr = await grain.GetCounter();
+                Assert.True(curr == last || curr == last + 1, "curr == last || curr == last + 1");
             }
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Timers")]
-        public void TimerOrleansTest_Parallel()
+        public async Task TimerOrleansTest_Parallel()
         {
             TimeSpan period = TimeSpan.Zero;
             List<ITimerGrain> grains = new List<ITimerGrain>();
             for (int i = 0; i < 10; i++)
             {
-                ITimerGrain grain = GrainClient.GrainFactory.GetGrain<ITimerGrain>(GetRandomGrainId());
+                ITimerGrain grain = GrainFactory.GetGrain<ITimerGrain>(GetRandomGrainId());
                 grains.Add(grain);
-                period = grain.GetTimerPeriod().Result; // activate grains
+                period = await grain.GetTimerPeriod(); // activate grains
             }
 
-            Thread.Sleep(period.Multiply(10));
+            var tasks = new List<Task>(grains.Count);
             for (int i = 0; i < grains.Count; i++)
             {
                 ITimerGrain grain = grains[i];
-                int last = grain.GetCounter().Result;
-                output.WriteLine("value = " + last);
-                //Assert.Equal(10, last);
+                tasks.Add(
+                    Task.Run(
+                        async () =>
+                        {
+                            int last = await grain.GetCounter();
+                            var stopwatch = Stopwatch.StartNew();
+                            var timeout = period.Multiply(50);
+                            while (stopwatch.Elapsed < timeout && last < 10)
+                            {
+                                await Task.Delay(period.Divide(2));
+                                last = await grain.GetCounter();
+                            }
+
+                            output.WriteLine("value = " + last);
+                            Assert.True(last >= 10 && last <= 12, "last >= 10 && last <= 12");
+                        }));
             }
+
+            await Task.WhenAll(tasks);
             for (int i = 0; i < grains.Count; i++)
             {
                 ITimerGrain grain = grains[i];
-                grain.StopDefaultTimer().Wait();
+                await grain.StopDefaultTimer();
             }
         }
 
+
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Timers")]
-        public void TimerOrleansTest_Migration()
+        public async Task TimerOrleansTest_Migration()
         {
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
+            ITimerGrain grain = GrainFactory.GetGrain<ITimerGrain>(GetRandomGrainId());
+            TimeSpan period = await grain.GetTimerPeriod();
 
-            ITimerGrain grain = GrainClient.GrainFactory.GetGrain<ITimerGrain>(GetRandomGrainId());
-            TimeSpan period = grain.GetTimerPeriod().Result;
-            Thread.Sleep(period.Multiply(10));
-            int last = grain.GetCounter().Result;
+            // Ensure that the grain works as it should.
+            var last = await grain.GetCounter();
+            var stopwatch = Stopwatch.StartNew();
+            var timeout = period.Multiply(50);
+            while (stopwatch.Elapsed < timeout && last < 10)
+            {
+                await Task.Delay(period.Divide(2));
+                last = await grain.GetCounter();
+            }
+
+            last = await grain.GetCounter();
             output.WriteLine("value = " + last);
-            Assert.True(last >= 10 && last <= 11, "last = " + last.ToString(CultureInfo.InvariantCulture));
+            Assert.True(last >= 10 && last <= 12, $"last >= 10 && last <= 12. Actual: last = {last}");
 
-            var additionalSilo = this.HostedCluster.StartAdditionalSilo();
-            try
+            // Restart the silo.
+            HostedCluster.RestartSilo(HostedCluster.Primary);
+            stopwatch.Restart();
+            period = await grain.GetTimerPeriod();
+
+            // Poke the grain and ensure it still works as it should.
+            last = await grain.GetCounter();
+            while (stopwatch.Elapsed < timeout && last < 10)
             {
-                //IManagementGrain mgmtGrain = Orleans.Silo.SystemManagement;
-                //mgmtGrain.SuspendHost(Orleans.SiloAddress).Wait();
-
-                Thread.Sleep(period.Multiply(10));
-                grain.StopDefaultTimer().Wait();
-                stopwatch.Stop();
-
-                last = grain.GetCounter().Result;
-                Assert.True(last >= 20);
-                double maximalNumTicks = stopwatch.Elapsed.Divide(grain.GetTimerPeriod().Result);
-                Assert.True(last <= maximalNumTicks);
-                //mgmtGrain.ResumeHost(Orleans.SiloAddress).Wait();
-                output.WriteLine("Total Elaped time = " + (stopwatch.ElapsedMilliseconds / 1000.0) + " sec. Expected Ticks = " + maximalNumTicks + ". Actual ticks = " + last);
+                await Task.Delay(period.Divide(2));
+                last = await grain.GetCounter();
             }
-            finally
-            {
-                if (this.HostedCluster.SecondarySilos.Count > 1)
-                {
-                    // do not leave unnecessarily too many silos running
-                    this.HostedCluster.StopSilo(additionalSilo);
-                }
-            }
+
+            last = await grain.GetCounter();
+            Assert.True(last >= 10 && last <= 12, $"last >= 10 && last <= 12. Actual: last = {last}");
+            double maximalNumTicks = stopwatch.Elapsed.Divide(period);
+            Assert.True(
+                last <= maximalNumTicks,
+                $"Assert: last <= maximalNumTicks. Actual: last = {last}, maximalNumTicks = {maximalNumTicks}");
+            //mgmtGrain.ResumeHost(Orleans.SiloAddress).Wait();
+            output.WriteLine(
+                "Total Elaped time = " + (stopwatch.Elapsed.TotalSeconds) + " sec. Expected Ticks = " + maximalNumTicks +
+                ". Actual ticks = " + last);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Timers")]
@@ -122,7 +150,7 @@ namespace DefaultCluster.Tests.TimerTests
             Exception error = null;
             try
             {
-                grain = GrainClient.GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
+                grain = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
 
                 await grain.StartTimer(testName, delay);
 
@@ -154,57 +182,6 @@ namespace DefaultCluster.Tests.TimerTests
             {
                 Assert.True(false, $"Test {testName} failed with error {error}");
             }
-        }
-    }
-
-    public class TimerGrainReferenceProxy // : UnitTestGrains.ITimerGrain
-    {
-        private readonly ITimerGrain grain;
-        private readonly ITimerPersistantGrain persistantGrain;
-        private readonly bool persistant;
-
-        public TimerGrainReferenceProxy(bool persist)
-        {
-            persistant = persist;
-            if (persistant)
-            {
-                persistantGrain = GrainClient.GrainFactory.GetGrain<ITimerPersistantGrain>(TestUtils.GetRandomGrainId());
-            }
-            else
-            {
-                grain = GrainClient.GrainFactory.GetGrain<ITimerGrain>(TestUtils.GetRandomGrainId());
-            }
-        }
-
-        public Task StopDefaultTimer()
-        {
-            if (persistant) return persistantGrain.StopDefaultTimer();
-            else return grain.StopDefaultTimer();
-        }
-        public Task<TimeSpan> GetTimerPeriod()
-        {
-            if (persistant) return persistantGrain.GetTimerPeriod();
-            else return grain.GetTimerPeriod();
-        }
-        public Task<int> GetCounter()
-        {
-            if (persistant) return persistantGrain.GetCounter();
-            else return grain.GetCounter();
-        }
-        public Task SetCounter(int value)
-        {
-            if (persistant) return persistantGrain.SetCounter(value);
-            else return grain.SetCounter(value);
-        }
-        public Task StartTimer(string timerName)
-        {
-            if (persistant) return persistantGrain.StartTimer(timerName);
-            else return grain.StartTimer(timerName);
-        }
-        public Task StopTimer(string timerName)
-        {
-            if (persistant) return persistantGrain.StopTimer(timerName);
-            else return grain.StopTimer(timerName);
         }
     }
 }

--- a/test/TestGrainInterfaces/ITimerGrain.cs
+++ b/test/TestGrainInterfaces/ITimerGrain.cs
@@ -13,6 +13,7 @@ namespace UnitTests.GrainInterfaces
         Task StartTimer(string timerName);
         Task StopTimer(string timerName);
         Task LongWait(TimeSpan time);
+        Task Deactivate();
     }
 
     public interface ITimerCallGrain : IGrainWithIntegerKey

--- a/test/TestGrainInterfaces/ITimerGrain.cs
+++ b/test/TestGrainInterfaces/ITimerGrain.cs
@@ -15,10 +15,6 @@ namespace UnitTests.GrainInterfaces
         Task LongWait(TimeSpan time);
     }
 
-    public interface ITimerPersistantGrain : ITimerGrain
-    {
-    }
-
     public interface ITimerCallGrain : IGrainWithIntegerKey
     {
         Task<int> GetTickCount();

--- a/test/TestInternalGrains/TimerGrain.cs
+++ b/test/TestInternalGrains/TimerGrain.cs
@@ -66,12 +66,12 @@ namespace UnitTestGrains
 
         public Task<TimeSpan> GetTimerPeriod()
         {
-            return Task<TimeSpan>.FromResult(period);
+            return Task.FromResult(period);
         }
 
         public Task<int> GetCounter()
         {
-            return Task<int>.FromResult(counter);
+            return Task.FromResult(counter);
         }
         public Task SetCounter(int value)
         {

--- a/test/TestInternalGrains/TimerGrain.cs
+++ b/test/TestInternalGrains/TimerGrain.cs
@@ -13,6 +13,7 @@ namespace UnitTestGrains
 {
     public class TimerGrain : Grain, ITimerGrain
     {
+        private bool deactivating;
         int counter = 0;
         Dictionary<string, IDisposable> allTimers;
         IDisposable defaultTimer;
@@ -24,14 +25,17 @@ namespace UnitTestGrains
 
         public override Task OnActivateAsync()
         {
+            ThrowIfDeactivating();
             logger = (Logger)this.GetLogger("TimerGrain_" + base.Data.Address.ToString());
             context = RuntimeContext.Current.ActivationContext;
             defaultTimer = this.RegisterTimer(Tick, DefaultTimerName, TimeSpan.Zero, period);
             allTimers = new Dictionary<string, IDisposable>();
             return TaskDone.Done;
         }
+
         public Task StopDefaultTimer()
         {
+            ThrowIfDeactivating();
             defaultTimer.Dispose();
             return TaskDone.Done;
         }
@@ -71,10 +75,12 @@ namespace UnitTestGrains
 
         public Task<int> GetCounter()
         {
+            ThrowIfDeactivating();
             return Task.FromResult(counter);
         }
         public Task SetCounter(int value)
         {
+            ThrowIfDeactivating();
             lock (this)
             {
                 counter = value;
@@ -83,6 +89,7 @@ namespace UnitTestGrains
         }
         public Task StartTimer(string timerName)
         {
+            ThrowIfDeactivating();
             IDisposable timer = this.RegisterTimer(Tick, timerName, TimeSpan.Zero, period);
             allTimers.Add(timerName, timer);
             return TaskDone.Done;
@@ -90,6 +97,7 @@ namespace UnitTestGrains
 
         public Task StopTimer(string timerName)
         {
+            ThrowIfDeactivating();
             IDisposable timer = allTimers[timerName];
             timer.Dispose();
             return TaskDone.Done;
@@ -97,10 +105,22 @@ namespace UnitTestGrains
 
         public Task LongWait(TimeSpan time)
         {
+            ThrowIfDeactivating();
             Thread.Sleep(time);
             return TaskDone.Done;
         }
 
+        public Task Deactivate()
+        {
+            deactivating = true;
+            DeactivateOnIdle();
+            return TaskDone.Done;
+        }
+
+        private void ThrowIfDeactivating()
+        {
+            if (deactivating) throw new InvalidOperationException("This activation is deactivating");
+        }
     }
 
     public class TimerCallGrain : Grain, ITimerCallGrain


### PR DESCRIPTION
Fix #2517 by removing that test (it doesn't add any coverage and it's flaky).

Clean up timer tests:
* Make them async
* Remove unused types
* `TimerOrleansTest_Parallel` runs the test in parallel now.