### PR TITLE
Fix type assertion in AdaptiveDirectoryCacheMaintainer

### DIFF
--- a/src/OrleansRuntime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/OrleansRuntime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -22,10 +22,15 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        internal static AsynchAgent CreateGrainDirectoryCacheMaintainer(LocalGrainDirectory router, IGrainDirectoryCache<TValue> cache)
+        internal static AsynchAgent CreateGrainDirectoryCacheMaintainer(
+            LocalGrainDirectory router,
+            IGrainDirectoryCache<TValue> cache,
+            Func<List<ActivationAddress>, TValue> updateFunc)
         {
-            return cache is AdaptiveGrainDirectoryCache<TValue> ? 
-                new AdaptiveDirectoryCacheMaintainer<TValue>(router, cache) : null;
+            var adaptiveCache = cache as AdaptiveGrainDirectoryCache<TValue>;
+            return adaptiveCache != null
+                ? new AdaptiveDirectoryCacheMaintainer<TValue>(router, adaptiveCache, updateFunc)
+                : null;
         }
     }
 

--- a/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
@@ -110,7 +110,11 @@ namespace Orleans.Runtime.GrainDirectory
                     DirectoryCache = GrainDirectoryCacheFactory<IReadOnlyList<Tuple<SiloAddress, ActivationId>>>.CreateGrainDirectoryCache(globalConfig);
                 }
             });
-            maintainer = GrainDirectoryCacheFactory<IReadOnlyList<Tuple<SiloAddress, ActivationId>>>.CreateGrainDirectoryCacheMaintainer(this, this.DirectoryCache);
+            maintainer =
+                GrainDirectoryCacheFactory<IReadOnlyList<Tuple<SiloAddress, ActivationId>>>.CreateGrainDirectoryCacheMaintainer(
+                    this,
+                    this.DirectoryCache,
+                    activations => activations.Select(a => Tuple.Create(a.Silo, a.Activation)).ToList().AsReadOnly());
             GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig);
 
             if (globalConfig.SeedNodes.Count > 0)


### PR DESCRIPTION
Fixes an error in `AdaptiveDirectoryCacheMaintainer` which was performing a type check which would never succeed. `TValue` in the below code is always `IReadOnlyList<Tuple<SiloAddress, ActivationId>>`, but the type check assumed it was `List<Tuple<SiloAddress, ActivationId>>`.

See the `//TODO:` below for the source of the error.

This removes the check and pushes the responsibility onto the caller.