### PR TITLE
Removed unused ClientType from GrainServiceConfiguration

### DIFF
--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -1114,9 +1114,9 @@ namespace Orleans.Runtime.Configuration
             return ProviderConfigurationUtility.GetAllProviderConfigurations(ProviderConfigurations);
         }
 
-        public void RegisterGrainService(string serviceName, string clientType, string serviceType, IDictionary<string, string> properties = null)
+        public void RegisterGrainService(string serviceName, string serviceType, IDictionary<string, string> properties = null)
         {
-            GrainServiceConfigurationsUtility.RegisterGrainService(GrainServiceConfigurations, serviceName, clientType, serviceType, properties);
+            GrainServiceConfigurationsUtility.RegisterGrainService(GrainServiceConfigurations, serviceName, serviceType, properties);
         }
     }
 }

--- a/src/Orleans/Configuration/GrainServiceConfiguration.cs
+++ b/src/Orleans/Configuration/GrainServiceConfiguration.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime.Configuration
 
     internal static class GrainServiceConfigurationsUtility
     {
-        internal static void RegisterGrainService(GrainServiceConfigurations grainServicesConfig, string serviceName, string clientType, string serviceType, IDictionary<string, string> properties = null)
+        internal static void RegisterGrainService(GrainServiceConfigurations grainServicesConfig, string serviceName, string serviceType, IDictionary<string, string> properties = null)
         {
             if (grainServicesConfig.GrainServices.ContainsKey(serviceName))
                 throw new InvalidOperationException(
@@ -39,7 +39,7 @@ namespace Orleans.Runtime.Configuration
 
             var config = new GrainServiceConfiguration(
                 properties ?? new Dictionary<string, string>(),
-                serviceName, clientType, serviceType);
+                serviceName, serviceType);
 
             grainServicesConfig.GrainServices.Add(config.Name, config);
         }
@@ -48,7 +48,6 @@ namespace Orleans.Runtime.Configuration
     public interface IGrainServiceConfiguration
     {
         string Name { get; set; }
-        string ClientType { get; set; }
         string ServiceType { get; set; }
         IDictionary<string, string> Properties { get; set; }
     }
@@ -58,17 +57,15 @@ namespace Orleans.Runtime.Configuration
     {
 
         public string Name { get; set; }
-        public string ClientType { get; set; }
         public string ServiceType { get; set; }
         public IDictionary<string, string> Properties { get; set; }
 
         public GrainServiceConfiguration() {}
 
-        public GrainServiceConfiguration(IDictionary<string, string> properties, string serviceName, string clientType, string serviceType)
+        public GrainServiceConfiguration(IDictionary<string, string> properties, string serviceName, string serviceType)
         {
             Properties = properties;
             Name = serviceName;
-            ClientType = clientType;
             ServiceType = serviceType;
         }
 
@@ -88,15 +85,6 @@ namespace Orleans.Runtime.Configuration
             if (alreadyLoaded != null && alreadyLoaded.ContainsKey(Name))
             {
                 return;
-            }
-
-            if (child.HasAttribute("ClientType"))
-            {
-                ClientType = child.GetAttribute("ClientType");
-            }
-            else
-            {
-                throw new FormatException("Missing 'ClientType' attribute on 'GrainService' element");
             }
 
             if (child.HasAttribute("ServiceType"))

--- a/test/Tester/GrainServiceTests/GrainServiceTests.cs
+++ b/test/Tester/GrainServiceTests/GrainServiceTests.cs
@@ -16,7 +16,7 @@ namespace Tester
         {
             var options = new TestClusterOptions(1);
             options.ClusterConfiguration.UseStartupType<GrainServiceStartup>();
-            options.ClusterConfiguration.Globals.RegisterGrainService("CustomGrainService", "Tester.CustomGrainServiceClient, Tester", "Tester.CustomGrainService, Tester", 
+            options.ClusterConfiguration.Globals.RegisterGrainService("CustomGrainService", "Tester.CustomGrainService, Tester", 
                 new Dictionary<string,string> {{"test-property", "xyz"}});
 
             return new TestCluster(options);


### PR DESCRIPTION
A follow-up to #2459 and #2531. Removed unused ClientType property from GrainServiceConfiguration.

@jamescarter-le, any objections?