### PR TITLE
Expose IMembershipOracle & related interfaces

### DIFF
--- a/src/Orleans/Messaging/IGatewayListProvider.cs
+++ b/src/Orleans/Messaging/IGatewayListProvider.cs
@@ -24,12 +24,12 @@ namespace Orleans.Messaging
         Task<IList<Uri>> GetGateways();
 
         /// <summary>
-        /// Specifies how often this IGatewayListProvider is refreshed, to have a bound on max staleness of its returned infomation.
+        /// Specifies how often this IGatewayListProvider is refreshed, to have a bound on max staleness of its returned information.
         /// </summary>
         TimeSpan MaxStaleness { get; }
 
         /// <summary>
-        /// Specifies whether this IGatewayListProvider ever refreshes its returned infomation, or always returns the same gw list.
+        /// Specifies whether this IGatewayListProvider ever refreshes its returned information, or always returns the same gw list.
         /// (currently only the static config based StaticGatewayListProvider is not updatable. All others are.)
         /// </summary>
         bool IsUpdatable { get; }
@@ -49,7 +49,7 @@ namespace Orleans.Messaging
     /// Optionally, some GatewayListProviders may be able to notify a listener if an updated gw information is available.
     /// This is optional and not required.
     /// </summary>
-    internal interface IGatewayListObservable
+    public interface IGatewayListObservable
     {
         bool SubscribeToGatewayNotificationEvents(IGatewayListListener listener);
 

--- a/src/Orleans/Runtime/ILocalSiloDetails.cs
+++ b/src/Orleans/Runtime/ILocalSiloDetails.cs
@@ -3,8 +3,13 @@ namespace Orleans.Runtime
     /// <summary>
     /// Details of the local silo.
     /// </summary>
-    internal interface ILocalSiloDetails
+    public interface ILocalSiloDetails
     {
+        /// <summary>
+        /// Gets the name of this silo.
+        /// </summary>
+        string Name { get; }
+
         /// <summary>
         /// Gets the address of this silo's inter-silo endpoint.
         /// </summary>

--- a/src/OrleansRuntime/Core/IHealthCheckParticipant.cs
+++ b/src/OrleansRuntime/Core/IHealthCheckParticipant.cs
@@ -1,10 +1,17 @@
 using System;
 
-
 namespace Orleans.Runtime
 {
-    internal interface IHealthCheckParticipant
+    /// <summary>
+    /// Interface for health check participants.
+    /// </summary>
+    public interface IHealthCheckParticipant
     {
+        /// <summary>
+        /// Returns a value indicating the health of this instance.
+        /// </summary>
+        /// <param name="lastCheckTime">The last time which this participant's health was checked.</param>
+        /// <returns><see langword="true"/> if the participant is healthy, <see langword="false"/> otherwise.</returns>
         bool CheckHealth(DateTime lastCheckTime);
     }
 }

--- a/src/OrleansRuntime/MembershipService/IMembershipOracle.cs
+++ b/src/OrleansRuntime/MembershipService/IMembershipOracle.cs
@@ -1,7 +1,9 @@
 ﻿namespace Orleans.Runtime
 {
-    // The local interface of Membership Oracles.
-    internal interface IMembershipOracle : ISiloStatusOracle, IHealthCheckParticipant
+    /// <summary>
+    /// Authoritative source for cluster membership.
+    /// </summary>
+    public interface IMembershipOracle : ISiloStatusOracle, IHealthCheckParticipant
     {
     }
 }

--- a/src/OrleansRuntime/MembershipService/ISiloStatusListener.cs
+++ b/src/OrleansRuntime/MembershipService/ISiloStatusListener.cs
@@ -1,15 +1,18 @@
 ﻿namespace Orleans.Runtime
 {
-    // Interface to receive notifications from ISiloStatusOracle about status updates of different silos.
-    // To be implemented by different in-silo runtime components that are interested in silo status notifications from ISiloStatusOracle.
-    internal interface ISiloStatusListener
+    /// <summary>
+    /// Interface for types which listen to silo status change notifications.
+    /// </summary>
+    /// <remarks>
+    /// To be implemented by different in-silo runtime components that are interested in silo status notifications from ISiloStatusOracle.
+    /// </remarks>
+    public interface ISiloStatusListener
     {
         /// <summary>
         /// Receive notifications about silo status events. 
         /// </summary>
         /// <param name="updatedSilo">A silo to update about.</param>
         /// <param name="status">The status of a silo.</param>
-        /// <returns></returns>
         void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status);
     }
 }

--- a/src/OrleansRuntime/MembershipService/ISiloStatusOracle.cs
+++ b/src/OrleansRuntime/MembershipService/ISiloStatusOracle.cs
@@ -4,9 +4,10 @@ using System.Threading.Tasks;
 
 namespace Orleans.Runtime
 {
-    // Interface for local, per-silo authorative source of information about status of other silos.
-    // A local interface for local communication between in-silo runtime components and this ISiloStatusOracle.
-    internal interface ISiloStatusOracle
+    /// <summary>
+    /// Authoritative local, per-silo source for information about the status of other silos.
+    /// </summary>
+    public interface ISiloStatusOracle
     {
         /// <summary>
         /// Current status of this silo.
@@ -66,13 +67,11 @@ namespace Orleans.Runtime
         /// <returns>A list of silo statuses.</returns>
         Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false);
 
-
         /// <summary>
         /// Get a list of silos that are designated to function as gateways.
         /// </summary>
         /// <returns></returns>
         IReadOnlyList<SiloAddress> GetApproximateMultiClusterGateways();
-
 
         /// <summary>
         /// Get the name of a silo. 

--- a/test/NonSiloTests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSiloTests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -761,6 +761,7 @@ namespace UnitTests.SchedulerTests
         private class MockSiloDetails : ILocalSiloDetails
         {
             public SiloAddress SiloAddress { get; set; }
+            public string Name { get; set; } = Guid.NewGuid().ToString();
         }
     }
 }


### PR DESCRIPTION
This PR exposes the interfaces required for external implementations of `IMembershipOracle`.
It also exposes `ILocalSiloDetails`, because it's useful to have when implementing `IMembershipOracle`.

Required by #2542.

cc @galvesribeiro