### PR TITLE
Initial work to make SerializationManager non-static (#2547)

### DIFF
--- a/src/Orleans/Cancellation/GrainCancellationToken.cs
+++ b/src/Orleans/Cancellation/GrainCancellationToken.cs
@@ -96,7 +96,7 @@ namespace Orleans
         {
             var ctw = (GrainCancellationToken)obj;
             var canceled = ctw.CancellationToken.IsCancellationRequested;
-            var stream = context.Stream;
+            var stream = context.StreamWriter;
             stream.Write(canceled);
             stream.Write(ctw.Id);
         }
@@ -104,7 +104,7 @@ namespace Orleans
         [DeserializerMethod]
         internal static object DeserializeGrainCancellationToken(Type expected, IDeserializationContext context)
         {
-            var stream = context.Stream;
+            var stream = context.StreamReader;
             var cancellationRequested = stream.ReadToken() == SerializationTokenType.True;
             var tokenId = stream.ReadGuid();
             return new GrainCancellationToken(tokenId, cancellationRequested);

--- a/src/Orleans/Cancellation/GrainCancellationToken.cs
+++ b/src/Orleans/Cancellation/GrainCancellationToken.cs
@@ -92,24 +92,26 @@ namespace Orleans
         #region Serialization
 
         [SerializerMethod]
-        internal static void SerializeGrainCancellationToken(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGrainCancellationToken(object obj, ISerializationContext context, Type expected)
         {
             var ctw = (GrainCancellationToken)obj;
             var canceled = ctw.CancellationToken.IsCancellationRequested;
+            var stream = context.Stream;
             stream.Write(canceled);
             stream.Write(ctw.Id);
         }
 
         [DeserializerMethod]
-        internal static object DeserializeGrainCancellationToken(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGrainCancellationToken(Type expected, IDeserializationContext context)
         {
+            var stream = context.Stream;
             var cancellationRequested = stream.ReadToken() == SerializationTokenType.True;
             var tokenId = stream.ReadGuid();
             return new GrainCancellationToken(tokenId, cancellationRequested);
         }
 
         [CopierMethod]
-        internal static object CopyGrainCancellationToken(object obj)
+        internal static object CopyGrainCancellationToken(object obj, ICopyContext context)
         {
             var gct = (GrainCancellationToken) obj;
             return new GrainCancellationToken(gct.Id, gct.IsCancellationRequested);

--- a/src/Orleans/Cancellation/GrainCancellationToken.cs
+++ b/src/Orleans/Cancellation/GrainCancellationToken.cs
@@ -96,17 +96,17 @@ namespace Orleans
         {
             var ctw = (GrainCancellationToken)obj;
             var canceled = ctw.CancellationToken.IsCancellationRequested;
-            var stream = context.StreamWriter;
-            stream.Write(canceled);
-            stream.Write(ctw.Id);
+            var writer = context.StreamWriter;
+            writer.Write(canceled);
+            writer.Write(ctw.Id);
         }
 
         [DeserializerMethod]
         internal static object DeserializeGrainCancellationToken(Type expected, IDeserializationContext context)
         {
-            var stream = context.StreamReader;
-            var cancellationRequested = stream.ReadToken() == SerializationTokenType.True;
-            var tokenId = stream.ReadGuid();
+            var reader = context.StreamReader;
+            var cancellationRequested = reader.ReadToken() == SerializationTokenType.True;
+            var tokenId = reader.ReadGuid();
             return new GrainCancellationToken(tokenId, cancellationRequested);
         }
 

--- a/src/Orleans/Cancellation/GrainCancellationTokenSource.cs
+++ b/src/Orleans/Cancellation/GrainCancellationTokenSource.cs
@@ -100,19 +100,19 @@ namespace Orleans
         #region Serialization
 
         [SerializerMethod]
-        internal static void SerializeGrainCancellationTokenSource(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGrainCancellationTokenSource(object obj, ISerializationContext context, Type expected)
         {
             throw new NotSupportedException("GrainCancellationTokenSource can not be serialized");
         }
 
         [DeserializerMethod]
-        internal static object DeserializeGrainCancellationTokenSource(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGrainCancellationTokenSource(Type expected, IDeserializationContext context)
         {
             throw new NotSupportedException("GrainCancellationTokenSource can not be deserialized");
         }
 
         [CopierMethod]
-        internal static object CopyGrainCancellationTokenSource(object obj)
+        internal static object CopyGrainCancellationTokenSource(object obj, ICopyContext context)
         {
             throw new NotSupportedException("GrainCancellationTokenSource can not be deep copied");
         }

--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -235,7 +235,7 @@ namespace Orleans
     }
 
     /// <summary>
-    /// Used to mark a method as providinga serializer function for that type.
+    /// Used to mark a method as providing a serializer function for that type.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class SerializerMethodAttribute : Attribute

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -1188,12 +1188,12 @@ namespace Orleans.Runtime
             {
                 HeadersContainer input = (HeadersContainer)untypedInput;
                 var headers = input.GetHeadersMask();
-                var stream = context.StreamWriter;
-                stream.Write((int)headers);
+                var writer = context.StreamWriter;
+                writer.Write((int)headers);
                 if ((headers & Headers.CACHE_INVALIDATION_HEADER) != Headers.NONE)
                 {
                     var count = input.CacheInvalidationHeader.Count;
-                    stream.Write(input.CacheInvalidationHeader.Count);
+                    writer.Write(input.CacheInvalidationHeader.Count);
                     for (int i = 0; i < count; i++)
                     {
                         WriteObj(context, typeof(ActivationAddress), input.CacheInvalidationHeader[i]);
@@ -1202,89 +1202,89 @@ namespace Orleans.Runtime
 
                 if ((headers & Headers.CATEGORY) != Headers.NONE)
                 {
-                    stream.Write((byte)input.Category);
+                    writer.Write((byte)input.Category);
                 }
 
                 if ((headers & Headers.DEBUG_CONTEXT) != Headers.NONE)
-                    stream.Write(input.DebugContext);
+                    writer.Write(input.DebugContext);
 
                 if ((headers & Headers.DIRECTION) != Headers.NONE)
-                    stream.Write((byte)input.Direction.Value);
+                    writer.Write((byte)input.Direction.Value);
 
                 if ((headers & Headers.EXPIRATION) != Headers.NONE)
-                    stream.Write(input.Expiration.Value);
+                    writer.Write(input.Expiration.Value);
 
                 if ((headers & Headers.FORWARD_COUNT) != Headers.NONE)
-                    stream.Write(input.ForwardCount);
+                    writer.Write(input.ForwardCount);
 
                 if ((headers & Headers.GENERIC_GRAIN_TYPE) != Headers.NONE)
-                    stream.Write(input.GenericGrainType);
+                    writer.Write(input.GenericGrainType);
 
                 if ((headers & Headers.CORRELATION_ID) != Headers.NONE)
-                    stream.Write(input.Id);
+                    writer.Write(input.Id);
 
                 if ((headers & Headers.ALWAYS_INTERLEAVE) != Headers.NONE)
-                    stream.Write(input.IsAlwaysInterleave);
+                    writer.Write(input.IsAlwaysInterleave);
 
                 if ((headers & Headers.IS_NEW_PLACEMENT) != Headers.NONE)
-                    stream.Write(input.IsNewPlacement);
+                    writer.Write(input.IsNewPlacement);
 
                 if ((headers & Headers.READ_ONLY) != Headers.NONE)
-                    stream.Write(input.IsReadOnly);
+                    writer.Write(input.IsReadOnly);
 
                 if ((headers & Headers.IS_UNORDERED) != Headers.NONE)
-                    stream.Write(input.IsUnordered);
+                    writer.Write(input.IsUnordered);
 
                 if ((headers & Headers.NEW_GRAIN_TYPE) != Headers.NONE)
-                    stream.Write(input.NewGrainType);
+                    writer.Write(input.NewGrainType);
 
                 if ((headers & Headers.REJECTION_INFO) != Headers.NONE)
-                    stream.Write(input.RejectionInfo);
+                    writer.Write(input.RejectionInfo);
 
                 if ((headers & Headers.REJECTION_TYPE) != Headers.NONE)
-                    stream.Write((byte)input.RejectionType);
+                    writer.Write((byte)input.RejectionType);
 
                 if ((headers & Headers.REQUEST_CONTEXT) != Headers.NONE)
                 {
                     var requestData = input.RequestContextData;
                     var count = requestData.Count;
-                    stream.Write(count);
+                    writer.Write(count);
                     foreach (var d in requestData)
                     {
-                        stream.Write(d.Key);
+                        writer.Write(d.Key);
                         SerializationManager.SerializeInner(d.Value, context, typeof(object));
                     }
                 }
 
                 if ((headers & Headers.RESEND_COUNT) != Headers.NONE)
-                    stream.Write(input.ResendCount);
+                    writer.Write(input.ResendCount);
 
                 if ((headers & Headers.RESULT) != Headers.NONE)
-                    stream.Write((byte)input.Result);
+                    writer.Write((byte)input.Result);
 
                 if ((headers & Headers.SENDING_ACTIVATION) != Headers.NONE)
                 {
-                    stream.Write(input.SendingActivation);
+                    writer.Write(input.SendingActivation);
                 }
 
                 if ((headers & Headers.SENDING_GRAIN) != Headers.NONE)
                 {
-                    stream.Write(input.SendingGrain);
+                    writer.Write(input.SendingGrain);
                 }
 
                 if ((headers & Headers.SENDING_SILO) != Headers.NONE)
                 {
-                    stream.Write(input.SendingSilo);
+                    writer.Write(input.SendingSilo);
                 }
 
                 if ((headers & Headers.TARGET_ACTIVATION) != Headers.NONE)
                 {
-                    stream.Write(input.TargetActivation);
+                    writer.Write(input.TargetActivation);
                 }
 
                 if ((headers & Headers.TARGET_GRAIN) != Headers.NONE)
                 {
-                    stream.Write(input.TargetGrain);
+                    writer.Write(input.TargetGrain);
                 }
 
                 if ((headers & Headers.TARGET_OBSERVER) != Headers.NONE)
@@ -1294,7 +1294,7 @@ namespace Orleans.Runtime
 
                 if ((headers & Headers.TARGET_SILO) != Headers.NONE)
                 {
-                    stream.Write(input.TargetSilo);
+                    writer.Write(input.TargetSilo);
                 }
             }
 
@@ -1302,13 +1302,13 @@ namespace Orleans.Runtime
             public static object Deserializer(Type expected, IDeserializationContext context)
             {
                 var result = new HeadersContainer();
-                var stream = context.StreamReader;
+                var reader = context.StreamReader;
                 context.RecordObject(result);
-                var headers = (Headers)stream.ReadInt();
+                var headers = (Headers)reader.ReadInt();
 
                 if ((headers & Headers.CACHE_INVALIDATION_HEADER) != Headers.NONE)
                 {
-                    var n = stream.ReadInt();
+                    var n = reader.ReadInt();
                     if (n > 0)
                     {
                        var list = result.CacheInvalidationHeader = new List<ActivationAddress>(n);
@@ -1320,84 +1320,84 @@ namespace Orleans.Runtime
                 }
 
                 if ((headers & Headers.CATEGORY) != Headers.NONE)
-                    result.Category = (Categories)stream.ReadByte();
+                    result.Category = (Categories)reader.ReadByte();
 
                 if ((headers & Headers.DEBUG_CONTEXT) != Headers.NONE)
-                    result.DebugContext = stream.ReadString();
+                    result.DebugContext = reader.ReadString();
 
                 if ((headers & Headers.DIRECTION) != Headers.NONE)
-                    result.Direction = (Message.Directions)stream.ReadByte();
+                    result.Direction = (Message.Directions)reader.ReadByte();
 
                 if ((headers & Headers.EXPIRATION) != Headers.NONE)
-                    result.Expiration = stream.ReadDateTime();
+                    result.Expiration = reader.ReadDateTime();
 
                 if ((headers & Headers.FORWARD_COUNT) != Headers.NONE)
-                    result.ForwardCount = stream.ReadInt();
+                    result.ForwardCount = reader.ReadInt();
 
                 if ((headers & Headers.GENERIC_GRAIN_TYPE) != Headers.NONE)
-                    result.GenericGrainType = stream.ReadString();
+                    result.GenericGrainType = reader.ReadString();
 
                 if ((headers & Headers.CORRELATION_ID) != Headers.NONE)
                     result.Id = (Orleans.Runtime.CorrelationId)ReadObj(typeof(Orleans.Runtime.CorrelationId), context);
 
                 if ((headers & Headers.ALWAYS_INTERLEAVE) != Headers.NONE)
-                    result.IsAlwaysInterleave = ReadBool(stream);
+                    result.IsAlwaysInterleave = ReadBool(reader);
 
                 if ((headers & Headers.IS_NEW_PLACEMENT) != Headers.NONE)
-                    result.IsNewPlacement = ReadBool(stream);
+                    result.IsNewPlacement = ReadBool(reader);
 
                 if ((headers & Headers.READ_ONLY) != Headers.NONE)
-                    result.IsReadOnly = ReadBool(stream);
+                    result.IsReadOnly = ReadBool(reader);
 
                 if ((headers & Headers.IS_UNORDERED) != Headers.NONE)
-                    result.IsUnordered = ReadBool(stream);
+                    result.IsUnordered = ReadBool(reader);
 
                 if ((headers & Headers.NEW_GRAIN_TYPE) != Headers.NONE)
-                    result.NewGrainType = stream.ReadString();
+                    result.NewGrainType = reader.ReadString();
 
                 if ((headers & Headers.REJECTION_INFO) != Headers.NONE)
-                    result.RejectionInfo = stream.ReadString();
+                    result.RejectionInfo = reader.ReadString();
 
                 if ((headers & Headers.REJECTION_TYPE) != Headers.NONE)
-                    result.RejectionType = (RejectionTypes)stream.ReadByte();
+                    result.RejectionType = (RejectionTypes)reader.ReadByte();
 
                 if ((headers & Headers.REQUEST_CONTEXT) != Headers.NONE)
                 {
-                    var c = stream.ReadInt();
+                    var c = reader.ReadInt();
                     var requestData = new Dictionary<string, object>(c);
                     for (int i = 0; i < c; i++)
                     {
-                        requestData[stream.ReadString()] = SerializationManager.DeserializeInner(null, context);
+                        requestData[reader.ReadString()] = SerializationManager.DeserializeInner(null, context);
                     }
                     result.RequestContextData = requestData;
                 }
 
                 if ((headers & Headers.RESEND_COUNT) != Headers.NONE)
-                    result.ResendCount = stream.ReadInt();
+                    result.ResendCount = reader.ReadInt();
 
                 if ((headers & Headers.RESULT) != Headers.NONE)
-                    result.Result = (Orleans.Runtime.Message.ResponseTypes)stream.ReadByte();
+                    result.Result = (Orleans.Runtime.Message.ResponseTypes)reader.ReadByte();
 
                 if ((headers & Headers.SENDING_ACTIVATION) != Headers.NONE)
-                    result.SendingActivation = stream.ReadActivationId();
+                    result.SendingActivation = reader.ReadActivationId();
 
                 if ((headers & Headers.SENDING_GRAIN) != Headers.NONE)
-                    result.SendingGrain = stream.ReadGrainId();
+                    result.SendingGrain = reader.ReadGrainId();
 
                 if ((headers & Headers.SENDING_SILO) != Headers.NONE)
-                    result.SendingSilo = stream.ReadSiloAddress();
+                    result.SendingSilo = reader.ReadSiloAddress();
 
                 if ((headers & Headers.TARGET_ACTIVATION) != Headers.NONE) 
-                    result.TargetActivation = stream.ReadActivationId();
+                    result.TargetActivation = reader.ReadActivationId();
 
                 if ((headers & Headers.TARGET_GRAIN) != Headers.NONE)
-                    result.TargetGrain = stream.ReadGrainId();
+                    result.TargetGrain = reader.ReadGrainId();
 
                 if ((headers & Headers.TARGET_OBSERVER) != Headers.NONE)
                     result.TargetObserverId = (Orleans.Runtime.GuidId)ReadObj(typeof(Orleans.Runtime.GuidId), context);
 
                 if ((headers & Headers.TARGET_SILO) != Headers.NONE)
-                    result.TargetSilo = stream.ReadSiloAddress();
+                    result.TargetSilo = reader.ReadSiloAddress();
 
                 return (HeadersContainer)result;
             }

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -483,29 +483,29 @@ namespace Orleans.Runtime
         [SerializerMethod]
         protected internal static void SerializeGrainReference(object obj, ISerializationContext context, Type expected)
         {
-            var stream = context.StreamWriter;
+            var writer = context.StreamWriter;
             var input = (GrainReference)obj;
-            stream.Write(input.GrainId);
+            writer.Write(input.GrainId);
             if (input.IsSystemTarget)
             {
-                stream.Write((byte)1);
-                stream.Write(input.SystemTargetSilo);
+                writer.Write((byte)1);
+                writer.Write(input.SystemTargetSilo);
             }
             else
             {
-                stream.Write((byte)0);
+                writer.Write((byte)0);
             }
 
             if (input.IsObserverReference)
             {
-                input.observerId.SerializeToStream(stream);
+                input.observerId.SerializeToStream(writer);
             }
 
             // store as null, serialize as empty.
             var genericArg = String.Empty;
             if (input.HasGenericArgument)
                 genericArg = input.genericArguments;
-            stream.Write(genericArg);
+            writer.Write(genericArg);
         }
 
         /// <summary> Deserializer function for grain reference.</summary>
@@ -513,22 +513,22 @@ namespace Orleans.Runtime
         [DeserializerMethod]
         protected internal static object DeserializeGrainReference(Type t, IDeserializationContext context)
         {
-            var stream = context.StreamReader;
-            GrainId id = stream.ReadGrainId();
+            var reader = context.StreamReader;
+            GrainId id = reader.ReadGrainId();
             SiloAddress silo = null;
             GuidId observerId = null;
-            byte siloAddressPresent = stream.ReadByte();
+            byte siloAddressPresent = reader.ReadByte();
             if (siloAddressPresent != 0)
             {
-                silo = stream.ReadSiloAddress();
+                silo = reader.ReadSiloAddress();
             }
             bool expectObserverId = id.IsClient;
             if (expectObserverId)
             {
-                observerId = GuidId.DeserializeFromStream(stream);
+                observerId = GuidId.DeserializeFromStream(reader);
             }
             // store as null, serialize as empty.
-            var genericArg = stream.ReadString();
+            var genericArg = reader.ReadString();
             if (String.IsNullOrEmpty(genericArg))
                 genericArg = null;
 

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -483,7 +483,7 @@ namespace Orleans.Runtime
         [SerializerMethod]
         protected internal static void SerializeGrainReference(object obj, ISerializationContext context, Type expected)
         {
-            var stream = context.Stream;
+            var stream = context.StreamWriter;
             var input = (GrainReference)obj;
             stream.Write(input.GrainId);
             if (input.IsSystemTarget)
@@ -513,7 +513,7 @@ namespace Orleans.Runtime
         [DeserializerMethod]
         protected internal static object DeserializeGrainReference(Type t, IDeserializationContext context)
         {
-            var stream = context.Stream;
+            var stream = context.StreamReader;
             GrainId id = stream.ReadGrainId();
             SiloAddress silo = null;
             GuidId observerId = null;

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -481,8 +481,9 @@ namespace Orleans.Runtime
         /// <summary> Serializer function for grain reference.</summary>
         /// <seealso cref="SerializationManager"/>
         [SerializerMethod]
-        protected internal static void SerializeGrainReference(object obj, BinaryTokenStreamWriter stream, Type expected)
+        protected internal static void SerializeGrainReference(object obj, ISerializationContext context, Type expected)
         {
+            var stream = context.Stream;
             var input = (GrainReference)obj;
             stream.Write(input.GrainId);
             if (input.IsSystemTarget)
@@ -510,8 +511,9 @@ namespace Orleans.Runtime
         /// <summary> Deserializer function for grain reference.</summary>
         /// <seealso cref="SerializationManager"/>
         [DeserializerMethod]
-        protected internal static object DeserializeGrainReference(Type t, BinaryTokenStreamReader stream)
+        protected internal static object DeserializeGrainReference(Type t, IDeserializationContext context)
         {
+            var stream = context.Stream;
             GrainId id = stream.ReadGrainId();
             SiloAddress silo = null;
             GuidId observerId = null;
@@ -540,7 +542,7 @@ namespace Orleans.Runtime
         /// <summary> Copier function for grain reference. </summary>
         /// <seealso cref="SerializationManager"/>
         [CopierMethod]
-        protected internal static object CopyGrainReference(object original)
+        protected internal static object CopyGrainReference(object original, ICopyContext context)
         {
             return (GrainReference)original;
         }

--- a/src/Orleans/Serialization/BinaryFormatterSerializer.cs
+++ b/src/Orleans/Serialization/BinaryFormatterSerializer.cs
@@ -23,7 +23,7 @@ namespace Orleans.Serialization
             return itemType.GetTypeInfo().IsSerializable;
         }
 
-        public object DeepCopy(object source)
+        public object DeepCopy(object source, ICopyContext context)
         {
             if (source == null)
             {
@@ -44,8 +44,9 @@ namespace Orleans.Serialization
             return ret;
         }
 
-        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
+            var writer = context.Stream;
             if (writer == null)
             {
                 throw new ArgumentNullException("writer");
@@ -70,11 +71,12 @@ namespace Orleans.Serialization
             writer.Write(bytes);
         }
 
-        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        public object Deserialize(Type expectedType, IDeserializationContext context)
         {
+            var reader = context.Stream;
             if (reader == null)
             {
-                throw new ArgumentNullException("reader");
+                throw new ArgumentNullException(nameof(reader));
             }
 
             var n = reader.ReadInt();

--- a/src/Orleans/Serialization/BinaryFormatterSerializer.cs
+++ b/src/Orleans/Serialization/BinaryFormatterSerializer.cs
@@ -46,7 +46,7 @@ namespace Orleans.Serialization
 
         public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
-            var writer = context.Stream;
+            var writer = context.StreamWriter;
             if (writer == null)
             {
                 throw new ArgumentNullException("writer");
@@ -73,7 +73,7 @@ namespace Orleans.Serialization
 
         public object Deserialize(Type expectedType, IDeserializationContext context)
         {
-            var reader = context.Stream;
+            var reader = context.StreamReader;
             if (reader == null)
             {
                 throw new ArgumentNullException(nameof(reader));

--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -21,59 +21,59 @@ namespace Orleans.Serialization
         #endregion
 
         #region Generic collections
-        internal static void SerializeGenericReadOnlyCollection(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericReadOnlyCollection(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeReadOnlyCollection), nameof(DeserializeReadOnlyCollection), nameof(DeepCopyReadOnlyCollection), generics);
 
-            concretes.Item1(original, stream, expected);
+            concretes.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericReadOnlyCollection(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericReadOnlyCollection(Type expected, IDeserializationContext context)
         {
             var generics = expected.GetGenericArguments();
             var concretes = RegisterConcreteMethods(expected, nameof(SerializeReadOnlyCollection), nameof(DeserializeReadOnlyCollection), nameof(DeepCopyReadOnlyCollection), generics);
 
-            return concretes.Item2(expected, stream);
+            return concretes.Item2(expected, context);
         }
 
-        internal static object CopyGenericReadOnlyCollection(object original)
+        internal static object CopyGenericReadOnlyCollection(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeReadOnlyCollection), nameof(DeserializeReadOnlyCollection), nameof(DeepCopyReadOnlyCollection), generics);
 
-            return concretes.Item3(original);
+            return concretes.Item3(original, context);
         }
 
-        internal static void SerializeReadOnlyCollection<T>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeReadOnlyCollection<T>(object obj, ISerializationContext context, Type expected)
         {
             var collection = (ReadOnlyCollection<T>)obj;
-            stream.Write(collection.Count);
+            context.Stream.Write(collection.Count);
             foreach (var element in collection)
             {
-                SerializationManager.SerializeInner(element, stream, typeof(T));
+                SerializationManager.SerializeInner(element, context, typeof(T));
             }
         }
 
-        internal static object DeserializeReadOnlyCollection<T>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeReadOnlyCollection<T>(Type expected, IDeserializationContext context)
         {
-            var count = stream.ReadInt();
+            var count = context.Stream.ReadInt();
             var list = new List<T>(count);
 
-            DeserializationContext.Current.RecordObject(list);
+            context.RecordObject(list);
             for (var i = 0; i < count; i++)
             {
-                list.Add((T)SerializationManager.DeserializeInner(typeof(T), stream));
+                list.Add((T)SerializationManager.DeserializeInner(typeof(T), context));
             }
 
             var ret = new ReadOnlyCollection<T>(list);
-            DeserializationContext.Current.RecordObject(ret);
+            context.RecordObject(ret);
             return ret;
         }
 
-        internal static object DeepCopyReadOnlyCollection<T>(object original)
+        internal static object DeepCopyReadOnlyCollection<T>(object original, ICopyContext context)
         {
             var collection = (ReadOnlyCollection<T>)original;
 
@@ -83,65 +83,65 @@ namespace Orleans.Serialization
             }
 
             var innerList = new List<T>(collection.Count);
-            innerList.AddRange(collection.Select(element => (T)SerializationManager.DeepCopyInner(element)));
+            innerList.AddRange(collection.Select(element => (T)SerializationManager.DeepCopyInner(element, context)));
 
             var retVal = new ReadOnlyCollection<T>(innerList);
-            SerializationContext.Current.RecordObject(original, retVal);
+            context.RecordCopy(original, retVal);
             return retVal;
         }
 
         #region Lists
 
-        internal static void SerializeGenericList(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericList(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeList), nameof(DeserializeList), nameof(DeepCopyList), generics);
 
-            concretes.Item1(original, stream, expected);
+            concretes.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericList(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericList(Type expected, IDeserializationContext context)
         {
             var generics = expected.GetGenericArguments();
             var concretes = RegisterConcreteMethods(expected, nameof(SerializeList), nameof(DeserializeList), nameof(DeepCopyList), generics);
 
-            return concretes.Item2(expected, stream);
+            return concretes.Item2(expected, context);
         }
 
-        internal static object CopyGenericList(object original)
+        internal static object CopyGenericList(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeList), nameof(DeserializeList), nameof(DeepCopyList), generics);
 
-            return concretes.Item3(original);
+            return concretes.Item3(original, context);
         }
 
-        internal static void SerializeList<T>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeList<T>(object obj, ISerializationContext context, Type expected)
         {
             var list = (List<T>)obj;
-            stream.Write(list.Count);
+            context.Stream.Write(list.Count);
             foreach (var element in list)
             {
-                SerializationManager.SerializeInner(element, stream, typeof(T));
+                SerializationManager.SerializeInner(element, context, typeof(T));
             }
         }
 
-        internal static object DeserializeList<T>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeList<T>(Type expected, IDeserializationContext context)
         {
-            var count = stream.ReadInt();
+            var count = context.Stream.ReadInt();
             var list = new List<T>(count);
-            DeserializationContext.Current.RecordObject(list);
+            context.RecordObject(list);
 
             for (var i = 0; i < count; i++)
             {
-                list.Add((T)SerializationManager.DeserializeInner(typeof(T), stream));
+                list.Add((T)SerializationManager.DeserializeInner(typeof(T), context));
             }
             return list;
         }
 
-        internal static object DeepCopyList<T>(object original)
+        internal static object DeepCopyList<T>(object original, ICopyContext context)
         {
             var list = (List<T>)original;
 
@@ -152,8 +152,8 @@ namespace Orleans.Serialization
 
             // set the list capacity, to avoid list resizing.
             var retVal = new List<T>(list.Count);
-            SerializationContext.Current.RecordObject(original, retVal);
-            retVal.AddRange(list.Select(element => (T)SerializationManager.DeepCopyInner(element)));
+            context.RecordCopy(original, retVal);
+            retVal.AddRange(list.Select(element => (T)SerializationManager.DeepCopyInner(element, context)));
             return retVal;
         }
 
@@ -161,55 +161,55 @@ namespace Orleans.Serialization
 
         #region LinkedLists
 
-        internal static void SerializeGenericLinkedList(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericLinkedList(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeLinkedList), nameof(DeserializeLinkedList), nameof(DeepCopyLinkedList), generics);
 
-            concretes.Item1(original, stream, expected);
+            concretes.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericLinkedList(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericLinkedList(Type expected, IDeserializationContext context)
         {
             var generics = expected.GetGenericArguments();
             var concretes = RegisterConcreteMethods(expected, nameof(SerializeLinkedList), nameof(DeserializeLinkedList), nameof(DeepCopyLinkedList), generics);
 
-            return concretes.Item2(expected, stream);
+            return concretes.Item2(expected, context);
         }
 
-        internal static object CopyGenericLinkedList(object original)
+        internal static object CopyGenericLinkedList(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeLinkedList), nameof(DeserializeLinkedList), nameof(DeepCopyLinkedList), generics);
 
-            return concretes.Item3(original);
+            return concretes.Item3(original, context);
         }
 
-        internal static void SerializeLinkedList<T>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeLinkedList<T>(object obj, ISerializationContext context, Type expected)
         {
             var list = (LinkedList<T>)obj;
-            stream.Write(list.Count);
+            context.Stream.Write(list.Count);
             foreach (var element in list)
             {
-                SerializationManager.SerializeInner(element, stream, typeof(T));
+                SerializationManager.SerializeInner(element, context, typeof(T));
             }
         }
 
-        internal static object DeserializeLinkedList<T>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeLinkedList<T>(Type expected, IDeserializationContext context)
         {
-            var count = stream.ReadInt();
+            var count = context.Stream.ReadInt();
             var list = new LinkedList<T>();
-            DeserializationContext.Current.RecordObject(list);
+            context.RecordObject(list);
             for (var i = 0; i < count; i++)
             {
-                list.AddLast((T)SerializationManager.DeserializeInner(typeof(T), stream));
+                list.AddLast((T)SerializationManager.DeserializeInner(typeof(T), context));
             }
             return list;
         }
 
-        internal static object DeepCopyLinkedList<T>(object original)
+        internal static object DeepCopyLinkedList<T>(object original, ICopyContext context)
         {
             var list = (LinkedList<T>)original;
 
@@ -219,10 +219,10 @@ namespace Orleans.Serialization
             }
 
             var retVal = new LinkedList<T>();
-            SerializationContext.Current.RecordObject(original, retVal);
+            context.RecordCopy(original, retVal);
             foreach (var item in list)
             {
-                retVal.AddLast((T)SerializationManager.DeepCopyInner(item));
+                retVal.AddLast((T)SerializationManager.DeepCopyInner(item, context));
             }
             return retVal;
         }
@@ -231,59 +231,59 @@ namespace Orleans.Serialization
 
         #region HashSets
 
-        internal static void SerializeGenericHashSet(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericHashSet(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeHashSet), nameof(DeserializeHashSet), nameof(DeepCopyHashSet), generics);
 
-            concretes.Item1(original, stream, expected);
+            concretes.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericHashSet(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericHashSet(Type expected, IDeserializationContext context)
         {
             var generics = expected.GetGenericArguments();
             var concretes = RegisterConcreteMethods(expected, nameof(SerializeHashSet), nameof(DeserializeHashSet), nameof(DeepCopyHashSet), generics);
 
-            return concretes.Item2(expected, stream);
+            return concretes.Item2(expected, context);
         }
 
-        internal static object CopyGenericHashSet(object original)
+        internal static object CopyGenericHashSet(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeHashSet), nameof(DeserializeHashSet), nameof(DeepCopyHashSet), generics);
 
-            return concretes.Item3(original);
+            return concretes.Item3(original, context);
         }
 
-        internal static void SerializeHashSet<T>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeHashSet<T>(object obj, ISerializationContext context, Type expected)
         {
             var set = (HashSet<T>)obj;
             SerializationManager.SerializeInner(set.Comparer.Equals(EqualityComparer<T>.Default) ? null : set.Comparer,
-                stream, typeof(IEqualityComparer<T>));
-            stream.Write(set.Count);
+                context, typeof(IEqualityComparer<T>));
+            context.Stream.Write(set.Count);
             foreach (var element in set)
             {
-                SerializationManager.SerializeInner(element, stream, typeof(T));
+                SerializationManager.SerializeInner(element, context, typeof(T));
             }
         }
 
-        internal static object DeserializeHashSet<T>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeHashSet<T>(Type expected, IDeserializationContext context)
         {
             var comparer =
-                (IEqualityComparer<T>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<T>), stream);
-            var count = stream.ReadInt();
+                (IEqualityComparer<T>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<T>), context);
+            var count = context.Stream.ReadInt();
             var set = new HashSet<T>(comparer);
-            DeserializationContext.Current.RecordObject(set);
+            context.RecordObject(set);
             for (var i = 0; i < count; i++)
             {
-                set.Add((T)SerializationManager.DeserializeInner(typeof(T), stream));
+                set.Add((T)SerializationManager.DeserializeInner(typeof(T), context));
             }
             return set;
         }
 
-        internal static object DeepCopyHashSet<T>(object original)
+        internal static object DeepCopyHashSet<T>(object original, ICopyContext context)
         {
             var set = (HashSet<T>)original;
 
@@ -293,67 +293,67 @@ namespace Orleans.Serialization
             }
 
             var retVal = new HashSet<T>(set.Comparer);
-            SerializationContext.Current.RecordObject(original, retVal);
+            context.RecordCopy(original, retVal);
             foreach (var item in set)
             {
-                retVal.Add((T)SerializationManager.DeepCopyInner(item));
+                retVal.Add((T)SerializationManager.DeepCopyInner(item, context));
             }
             return retVal;
         }
 
-        internal static void SerializeGenericSortedSet(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericSortedSet(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeSortedSet), nameof(DeserializeSortedSet), nameof(DeepCopySortedSet), generics);
 
-            concretes.Item1(original, stream, expected);
+            concretes.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericSortedSet(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericSortedSet(Type expected, IDeserializationContext context)
         {
             var generics = expected.GetGenericArguments();
             var concretes = RegisterConcreteMethods(expected, nameof(SerializeSortedSet), nameof(DeserializeSortedSet), nameof(DeepCopySortedSet), generics);
 
-            return concretes.Item2(expected, stream);
+            return concretes.Item2(expected, context);
         }
 
-        internal static object CopyGenericSortedSet(object original)
+        internal static object CopyGenericSortedSet(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeSortedSet), nameof(DeserializeSortedSet), nameof(DeepCopySortedSet), generics);
 
-            return concretes.Item3(original);
+            return concretes.Item3(original, context);
         }
 
-        internal static void SerializeSortedSet<T>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeSortedSet<T>(object obj, ISerializationContext context, Type expected)
         {
             var set = (SortedSet<T>)obj;
             SerializationManager.SerializeInner(set.Comparer.Equals(Comparer<T>.Default) ? null : set.Comparer,
-                stream, typeof(IComparer<T>));
-            stream.Write(set.Count);
+                context, typeof(IComparer<T>));
+            context.Stream.Write(set.Count);
             foreach (var element in set)
             {
-                SerializationManager.SerializeInner(element, stream, typeof(T));
+                SerializationManager.SerializeInner(element, context, typeof(T));
             }
         }
 
-        internal static object DeserializeSortedSet<T>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeSortedSet<T>(Type expected, IDeserializationContext context)
         {
             var comparer =
-                (IComparer<T>)SerializationManager.DeserializeInner(typeof(IComparer<T>), stream);
-            var count = stream.ReadInt();
+                (IComparer<T>)SerializationManager.DeserializeInner(typeof(IComparer<T>), context);
+            var count = context.Stream.ReadInt();
             var set = new SortedSet<T>(comparer);
-            DeserializationContext.Current.RecordObject(set);
+            context.RecordObject(set);
             for (var i = 0; i < count; i++)
             {
-                set.Add((T)SerializationManager.DeserializeInner(typeof(T), stream));
+                set.Add((T)SerializationManager.DeserializeInner(typeof(T), context));
             }
             return set;
         }
 
-        internal static object DeepCopySortedSet<T>(object original)
+        internal static object DeepCopySortedSet<T>(object original, ICopyContext context)
         {
             var set = (SortedSet<T>)original;
 
@@ -363,10 +363,10 @@ namespace Orleans.Serialization
             }
 
             var retVal = new SortedSet<T>(set.Comparer);
-            SerializationContext.Current.RecordObject(original, retVal);
+            context.RecordCopy(original, retVal);
             foreach (var item in set)
             {
-                retVal.Add((T)SerializationManager.DeepCopyInner(item));
+                retVal.Add((T)SerializationManager.DeepCopyInner(item, context));
             }
             return retVal;
         }
@@ -374,55 +374,55 @@ namespace Orleans.Serialization
 
         #region Queues
 
-        internal static void SerializeGenericQueue(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericQueue(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeQueue), nameof(DeserializeQueue), nameof(DeepCopyQueue), generics);
 
-            concretes.Item1(original, stream, expected);
+            concretes.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericQueue(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericQueue(Type expected, IDeserializationContext context)
         {
             var generics = expected.GetGenericArguments();
             var concretes = RegisterConcreteMethods(expected, nameof(SerializeQueue), nameof(DeserializeQueue), nameof(DeepCopyQueue), generics);
 
-            return concretes.Item2(expected, stream);
+            return concretes.Item2(expected, context);
         }
 
-        internal static object CopyGenericQueue(object original)
+        internal static object CopyGenericQueue(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeQueue), nameof(DeserializeQueue), nameof(DeepCopyQueue), generics);
 
-            return concretes.Item3(original);
+            return concretes.Item3(original, context);
         }
 
-        internal static void SerializeQueue<T>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeQueue<T>(object obj, ISerializationContext context, Type expected)
         {
             var queue = (Queue<T>)obj;
-            stream.Write(queue.Count);
+            context.Stream.Write(queue.Count);
             foreach (var element in queue)
             {
-                SerializationManager.SerializeInner(element, stream, typeof(T));
+                SerializationManager.SerializeInner(element, context, typeof(T));
             }
         }
 
-        internal static object DeserializeQueue<T>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeQueue<T>(Type expected, IDeserializationContext context)
         {
-            var count = stream.ReadInt();
+            var count = context.Stream.ReadInt();
             var queue = new Queue<T>();
-            DeserializationContext.Current.RecordObject(queue);
+            context.RecordObject(queue);
             for (var i = 0; i < count; i++)
             {
-                queue.Enqueue((T)SerializationManager.DeserializeInner(typeof(T), stream));
+                queue.Enqueue((T)SerializationManager.DeserializeInner(typeof(T), context));
             }
             return queue;
         }
 
-        internal static object DeepCopyQueue<T>(object original)
+        internal static object DeepCopyQueue<T>(object original, ICopyContext context)
         {
             var queue = (Queue<T>)original;
 
@@ -432,10 +432,10 @@ namespace Orleans.Serialization
             }
 
             var retVal = new Queue<T>(queue.Count);
-            SerializationContext.Current.RecordObject(original, retVal);
+            context.RecordCopy(original, retVal);
             foreach (var item in queue)
             {
-                retVal.Enqueue((T)SerializationManager.DeepCopyInner(item));
+                retVal.Enqueue((T)SerializationManager.DeepCopyInner(item, context));
             }
             return retVal;
         }
@@ -444,51 +444,51 @@ namespace Orleans.Serialization
 
         #region Stacks
 
-        internal static void SerializeGenericStack(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericStack(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeStack), nameof(DeserializeStack), nameof(DeepCopyStack), generics);
 
-            concretes.Item1(original, stream, expected);
+            concretes.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericStack(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericStack(Type expected, IDeserializationContext context)
         {
             var generics = expected.GetGenericArguments();
             var concretes = RegisterConcreteMethods(expected, nameof(SerializeStack), nameof(DeserializeStack), nameof(DeepCopyStack), generics);
 
-            return concretes.Item2(expected, stream);
+            return concretes.Item2(expected, context);
         }
 
-        internal static object CopyGenericStack(object original)
+        internal static object CopyGenericStack(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeStack), nameof(DeserializeStack), nameof(DeepCopyStack), generics);
 
-            return concretes.Item3(original);
+            return concretes.Item3(original, context);
         }
 
-        internal static void SerializeStack<T>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeStack<T>(object obj, ISerializationContext context, Type expected)
         {
             var stack = (Stack<T>)obj;
-            stream.Write(stack.Count);
+            context.Stream.Write(stack.Count);
             foreach (var element in stack)
             {
-                SerializationManager.SerializeInner(element, stream, typeof(T));
+                SerializationManager.SerializeInner(element, context, typeof(T));
             }
         }
 
-        internal static object DeserializeStack<T>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeStack<T>(Type expected, IDeserializationContext context)
         {
-            var count = stream.ReadInt();
+            var count = context.Stream.ReadInt();
             var list = new List<T>(count);
             var stack = new Stack<T>(count);
-            DeserializationContext.Current.RecordObject(stack);
+            context.RecordObject(stack);
             for (var i = 0; i < count; i++)
             {
-                list.Add((T)SerializationManager.DeserializeInner(typeof(T), stream));
+                list.Add((T)SerializationManager.DeserializeInner(typeof(T), context));
             }
 
             for (var i = count - 1; i >= 0; i--)
@@ -499,7 +499,7 @@ namespace Orleans.Serialization
             return stack;
         }
 
-        internal static object DeepCopyStack<T>(object original)
+        internal static object DeepCopyStack<T>(object original, ICopyContext context)
         {
             var stack = (Stack<T>)original;
 
@@ -509,10 +509,10 @@ namespace Orleans.Serialization
             }
 
             var retVal = new Stack<T>();
-            SerializationContext.Current.RecordObject(original, retVal);
+            context.RecordCopy(original, retVal);
             foreach (var item in stack.Reverse())
             {
-                retVal.Push((T)SerializationManager.DeepCopyInner(item));
+                retVal.Push((T)SerializationManager.DeepCopyInner(item, context));
             }
             return retVal;
         }
@@ -521,56 +521,56 @@ namespace Orleans.Serialization
 
         #region Dictionaries
 
-        internal static void SerializeGenericDictionary(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericDictionary(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
 
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeDictionary), nameof(DeserializeDictionary), nameof(CopyDictionary));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericDictionary(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericDictionary(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeDictionary), nameof(DeserializeDictionary), nameof(CopyDictionary));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static object CopyGenericDictionary(object original)
+        internal static object CopyGenericDictionary(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeDictionary), nameof(DeserializeDictionary), nameof(CopyDictionary));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static void SerializeDictionary<K, V>(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeDictionary<K, V>(object original, ISerializationContext context, Type expected)
         {
             var dict = (Dictionary<K, V>)original;
             SerializationManager.SerializeInner(dict.Comparer.Equals(EqualityComparer<K>.Default) ? null : dict.Comparer,
-                                           stream, typeof(IEqualityComparer<K>));
-            stream.Write(dict.Count);
+                                           context, typeof(IEqualityComparer<K>));
+            context.Stream.Write(dict.Count);
             foreach (var pair in dict)
             {
-                SerializationManager.SerializeInner(pair.Key, stream, typeof(K));
-                SerializationManager.SerializeInner(pair.Value, stream, typeof(V));
+                SerializationManager.SerializeInner(pair.Key, context, typeof(K));
+                SerializationManager.SerializeInner(pair.Value, context, typeof(V));
             }
         }
 
-        internal static object DeserializeDictionary<K, V>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeDictionary<K, V>(Type expected, IDeserializationContext context)
         {
-            var comparer = (IEqualityComparer<K>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<K>), stream);
-            var count = stream.ReadInt();
+            var comparer = (IEqualityComparer<K>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<K>), context);
+            var count = context.Stream.ReadInt();
             var dict = new Dictionary<K, V>(count, comparer);
-            DeserializationContext.Current.RecordObject(dict);
+            context.RecordObject(dict);
             for (var i = 0; i < count; i++)
             {
-                var key = (K)SerializationManager.DeserializeInner(typeof(K), stream);
-                var value = (V)SerializationManager.DeserializeInner(typeof(V), stream);
+                var key = (K)SerializationManager.DeserializeInner(typeof(K), context);
+                var value = (V)SerializationManager.DeserializeInner(typeof(V), context);
                 dict[key] = value;
             }
             return dict;
         }
 
-        internal static object CopyDictionary<K, V>(object original)
+        internal static object CopyDictionary<K, V>(object original, ICopyContext context)
         {
             var dict = (Dictionary<K, V>)original;
             if (typeof(K).IsOrleansShallowCopyable() && typeof(V).IsOrleansShallowCopyable())
@@ -579,63 +579,63 @@ namespace Orleans.Serialization
             }
 
             var result = new Dictionary<K, V>(dict.Count, dict.Comparer);
-            SerializationContext.Current.RecordObject(original, result);
+            context.RecordCopy(original, result);
             foreach (var pair in dict)
             {
-                result[(K)SerializationManager.DeepCopyInner(pair.Key)] = (V)SerializationManager.DeepCopyInner(pair.Value);
+                result[(K)SerializationManager.DeepCopyInner(pair.Key, context)] = (V)SerializationManager.DeepCopyInner(pair.Value, context);
             }
 
             return result;
         }
 
-        internal static void SerializeGenericReadOnlyDictionary(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericReadOnlyDictionary(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeReadOnlyDictionary), nameof(DeserializeReadOnlyDictionary), nameof(CopyReadOnlyDictionary));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericReadOnlyDictionary(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericReadOnlyDictionary(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeReadOnlyDictionary), nameof(DeserializeReadOnlyDictionary), nameof(CopyReadOnlyDictionary));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static object CopyGenericReadOnlyDictionary(object original)
+        internal static object CopyGenericReadOnlyDictionary(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeReadOnlyDictionary), nameof(DeserializeReadOnlyDictionary), nameof(CopyReadOnlyDictionary));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static void SerializeReadOnlyDictionary<K, V>(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeReadOnlyDictionary<K, V>(object original, ISerializationContext context, Type expected)
         {
             var dict = (ReadOnlyDictionary<K, V>)original;
-            stream.Write(dict.Count);
+            context.Stream.Write(dict.Count);
             foreach (var pair in dict)
             {
-                SerializationManager.SerializeInner(pair.Key, stream, typeof(K));
-                SerializationManager.SerializeInner(pair.Value, stream, typeof(V));
+                SerializationManager.SerializeInner(pair.Key, context, typeof(K));
+                SerializationManager.SerializeInner(pair.Value, context, typeof(V));
             }
         }
 
-        internal static object DeserializeReadOnlyDictionary<K, V>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeReadOnlyDictionary<K, V>(Type expected, IDeserializationContext context)
         {
-            var count = stream.ReadInt();
+            var count = context.Stream.ReadInt();
             var dict = new Dictionary<K, V>(count);
             for (var i = 0; i < count; i++)
             {
-                var key = (K)SerializationManager.DeserializeInner(typeof(K), stream);
-                var value = (V)SerializationManager.DeserializeInner(typeof(V), stream);
+                var key = (K)SerializationManager.DeserializeInner(typeof(K), context);
+                var value = (V)SerializationManager.DeserializeInner(typeof(V), context);
                 dict[key] = value;
             }
 
             var retVal = new ReadOnlyDictionary<K, V>(dict);
-            DeserializationContext.Current.RecordObject(retVal);
+            context.RecordObject(retVal);
             return retVal;
         }
 
-        internal static object CopyReadOnlyDictionary<K, V>(object original)
+        internal static object CopyReadOnlyDictionary<K, V>(object original, ICopyContext context)
         {
             if (typeof(K).IsOrleansShallowCopyable() && typeof(V).IsOrleansShallowCopyable())
             {
@@ -646,52 +646,52 @@ namespace Orleans.Serialization
             var innerDict = new Dictionary<K, V>(dict.Count);
             foreach (var pair in dict)
             {
-                innerDict[(K)SerializationManager.DeepCopyInner(pair.Key)] = (V)SerializationManager.DeepCopyInner(pair.Value);
+                innerDict[(K)SerializationManager.DeepCopyInner(pair.Key, context)] = (V)SerializationManager.DeepCopyInner(pair.Value, context);
             }
 
             var retVal = new ReadOnlyDictionary<K, V>(innerDict);
-            SerializationContext.Current.RecordObject(original, retVal);
+            context.RecordCopy(original, retVal);
             return retVal;
         }
 
-        internal static void SerializeStringObjectDictionary(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeStringObjectDictionary(object original, ISerializationContext context, Type expected)
         {
             var dict = (Dictionary<string, object>)original;
             SerializationManager.SerializeInner(dict.Comparer.Equals(EqualityComparer<string>.Default) ? null : dict.Comparer,
-                                           stream, typeof(IEqualityComparer<string>));
-            stream.Write(dict.Count);
+                                           context, typeof(IEqualityComparer<string>));
+            context.Stream.Write(dict.Count);
             foreach (var pair in dict)
             {
-                //stream.WriteTypeHeader(stringType, stringType);
-                stream.Write(pair.Key);
-                SerializationManager.SerializeInner(pair.Value, stream, objectType);
+                //context.Stream.WriteTypeHeader(stringType, stringType);
+                context.Stream.Write(pair.Key);
+                SerializationManager.SerializeInner(pair.Value, context, objectType);
             }
         }
 
-        internal static object DeserializeStringObjectDictionary(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeStringObjectDictionary(Type expected, IDeserializationContext context)
         {
-            var comparer = (IEqualityComparer<string>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<string>), stream);
-            var count = stream.ReadInt();
+            var comparer = (IEqualityComparer<string>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<string>), context);
+            var count = context.Stream.ReadInt();
             var dict = new Dictionary<string, object>(count, comparer);
-            DeserializationContext.Current.RecordObject(dict);
+            context.RecordObject(dict);
             for (var i = 0; i < count; i++)
             {
-                //stream.ReadFullTypeHeader(stringType); // Skip the type header, which will be string
-                var key = stream.ReadString();
-                var value = SerializationManager.DeserializeInner(null, stream);
+                //context.Stream.ReadFullTypeHeader(stringType); // Skip the type header, which will be string
+                var key = context.Stream.ReadString();
+                var value = SerializationManager.DeserializeInner(null, context);
                 dict[key] = value;
             }
             return dict;
         }
 
-        internal static object CopyStringObjectDictionary(object original)
+        internal static object CopyStringObjectDictionary(object original, ICopyContext context)
         {
             var dict = (Dictionary<string, object>)original;
             var result = new Dictionary<string, object>(dict.Count, dict.Comparer);
-            SerializationContext.Current.RecordObject(original, result);
+            context.RecordCopy(original, result);
             foreach (var pair in dict)
             {
-                result[pair.Key] = SerializationManager.DeepCopyInner(pair.Value);
+                result[pair.Key] = SerializationManager.DeepCopyInner(pair.Value, context);
             }
 
             return result;
@@ -701,54 +701,54 @@ namespace Orleans.Serialization
 
         #region SortedDictionaries
 
-        internal static void SerializeGenericSortedDictionary(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericSortedDictionary(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeSortedDictionary), nameof(DeserializeSortedDictionary), nameof(CopySortedDictionary));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericSortedDictionary(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericSortedDictionary(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeSortedDictionary), nameof(DeserializeSortedDictionary), nameof(CopySortedDictionary));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static object CopyGenericSortedDictionary(object original)
+        internal static object CopyGenericSortedDictionary(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeSortedDictionary), nameof(DeserializeSortedDictionary), nameof(CopySortedDictionary));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static void SerializeSortedDictionary<K, V>(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeSortedDictionary<K, V>(object original, ISerializationContext context, Type expected)
         {
             var dict = (SortedDictionary<K, V>)original;
-            SerializationManager.SerializeInner(dict.Comparer.Equals(Comparer<K>.Default) ? null : dict.Comparer, stream, typeof(IComparer<K>));
-            stream.Write(dict.Count);
+            SerializationManager.SerializeInner(dict.Comparer.Equals(Comparer<K>.Default) ? null : dict.Comparer, context, typeof(IComparer<K>));
+            context.Stream.Write(dict.Count);
             foreach (var pair in dict)
             {
-                SerializationManager.SerializeInner(pair.Key, stream, typeof(K));
-                SerializationManager.SerializeInner(pair.Value, stream, typeof(V));
+                SerializationManager.SerializeInner(pair.Key, context, typeof(K));
+                SerializationManager.SerializeInner(pair.Value, context, typeof(V));
             }
         }
 
-        internal static object DeserializeSortedDictionary<K, V>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeSortedDictionary<K, V>(Type expected, IDeserializationContext context)
         {
-            var comparer = (IComparer<K>)SerializationManager.DeserializeInner(typeof(IComparer<K>), stream);
-            var count = stream.ReadInt();
+            var comparer = (IComparer<K>)SerializationManager.DeserializeInner(typeof(IComparer<K>), context);
+            var count = context.Stream.ReadInt();
             var dict = new SortedDictionary<K, V>(comparer);
-            DeserializationContext.Current.RecordObject(dict);
+            context.RecordObject(dict);
             for (var i = 0; i < count; i++)
             {
-                var key = (K)SerializationManager.DeserializeInner(typeof(K), stream);
-                var value = (V)SerializationManager.DeserializeInner(typeof(V), stream);
+                var key = (K)SerializationManager.DeserializeInner(typeof(K), context);
+                var value = (V)SerializationManager.DeserializeInner(typeof(V), context);
                 dict[key] = value;
             }
             return dict;
         }
 
-        internal static object CopySortedDictionary<K, V>(object original)
+        internal static object CopySortedDictionary<K, V>(object original, ICopyContext context)
         {
             var dict = (SortedDictionary<K, V>)original;
             if (typeof(K).IsOrleansShallowCopyable() && typeof(V).IsOrleansShallowCopyable())
@@ -757,10 +757,10 @@ namespace Orleans.Serialization
             }
 
             var result = new SortedDictionary<K, V>(dict.Comparer);
-            SerializationContext.Current.RecordObject(original, result);
+            context.RecordCopy(original, result);
             foreach (var pair in dict)
             {
-                result[(K)SerializationManager.DeepCopyInner(pair.Key)] = (V)SerializationManager.DeepCopyInner(pair.Value);
+                result[(K)SerializationManager.DeepCopyInner(pair.Key, context)] = (V)SerializationManager.DeepCopyInner(pair.Value, context);
             }
 
             return result;
@@ -770,54 +770,54 @@ namespace Orleans.Serialization
 
         #region SortedLists
 
-        internal static void SerializeGenericSortedList(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericSortedList(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeSortedList), nameof(DeserializeSortedList), nameof(CopySortedList));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericSortedList(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericSortedList(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeSortedList), nameof(DeserializeSortedList), nameof(CopySortedList));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static object CopyGenericSortedList(object original)
+        internal static object CopyGenericSortedList(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeSortedList), nameof(DeserializeSortedList), nameof(CopySortedList));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static void SerializeSortedList<K, V>(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeSortedList<K, V>(object original, ISerializationContext context, Type expected)
         {
             var list = (SortedList<K, V>)original;
-            SerializationManager.SerializeInner(list.Comparer.Equals(Comparer<K>.Default) ? null : list.Comparer, stream, typeof(IComparer<K>));
-            stream.Write(list.Count);
+            SerializationManager.SerializeInner(list.Comparer.Equals(Comparer<K>.Default) ? null : list.Comparer, context, typeof(IComparer<K>));
+            context.Stream.Write(list.Count);
             foreach (var pair in list)
             {
-                SerializationManager.SerializeInner(pair.Key, stream, typeof(K));
-                SerializationManager.SerializeInner(pair.Value, stream, typeof(V));
+                SerializationManager.SerializeInner(pair.Key, context, typeof(K));
+                SerializationManager.SerializeInner(pair.Value, context, typeof(V));
             }
         }
 
-        internal static object DeserializeSortedList<K, V>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeSortedList<K, V>(Type expected, IDeserializationContext context)
         {
-            var comparer = (IComparer<K>)SerializationManager.DeserializeInner(typeof(IComparer<K>), stream);
-            var count = stream.ReadInt();
+            var comparer = (IComparer<K>)SerializationManager.DeserializeInner(typeof(IComparer<K>), context);
+            var count = context.Stream.ReadInt();
             var list = new SortedList<K, V>(count, comparer);
-            DeserializationContext.Current.RecordObject(list);
+            context.RecordObject(list);
             for (var i = 0; i < count; i++)
             {
-                var key = (K)SerializationManager.DeserializeInner(typeof(K), stream);
-                var value = (V)SerializationManager.DeserializeInner(typeof(V), stream);
+                var key = (K)SerializationManager.DeserializeInner(typeof(K), context);
+                var value = (V)SerializationManager.DeserializeInner(typeof(V), context);
                 list[key] = value;
             }
             return list;
         }
 
-        internal static object CopySortedList<K, V>(object original)
+        internal static object CopySortedList<K, V>(object original, ICopyContext context)
         {
             var list = (SortedList<K, V>)original;
             if (typeof(K).IsOrleansShallowCopyable() && typeof(V).IsOrleansShallowCopyable())
@@ -826,10 +826,10 @@ namespace Orleans.Serialization
             }
 
             var result = new SortedList<K, V>(list.Count, list.Comparer);
-            SerializationContext.Current.RecordObject(original, result);
+            context.RecordCopy(original, result);
             foreach (var pair in list)
             {
-                result[(K)SerializationManager.DeepCopyInner(pair.Key)] = (V)SerializationManager.DeepCopyInner(pair.Value);
+                result[(K)SerializationManager.DeepCopyInner(pair.Key, context)] = (V)SerializationManager.DeepCopyInner(pair.Value, context);
             }
 
             return result;
@@ -841,373 +841,373 @@ namespace Orleans.Serialization
 
         #region Immutable Collections
 
-        internal static void SerializeGenericImmutableDictionary(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericImmutableDictionary(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableDictionary), nameof(DeserializeImmutableDictionary), nameof(CopyImmutableDictionary));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericImmutableDictionary(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericImmutableDictionary(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeImmutableDictionary), nameof(DeserializeImmutableDictionary), nameof(CopyImmutableDictionary));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static object CopyGenericImmutableDictionary(object original)
+        internal static object CopyGenericImmutableDictionary(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableDictionary), nameof(DeserializeImmutableDictionary), nameof(CopyImmutableDictionary));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static object CopyImmutableDictionary<K, V>(object original)
+        internal static object CopyImmutableDictionary<K, V>(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeImmutableDictionary<K, V>(object untypedInput, BinaryTokenStreamWriter stream, Type typeExpected)
+        internal static void SerializeImmutableDictionary<K, V>(object untypedInput, ISerializationContext context, Type typeExpected)
         {
             var dict = (ImmutableDictionary<K, V>)untypedInput;
-            SerializationManager.SerializeInner(dict.KeyComparer.Equals(EqualityComparer<K>.Default) ? null : dict.KeyComparer, stream, typeof(IEqualityComparer<K>));
-            SerializationManager.SerializeInner(dict.ValueComparer.Equals(EqualityComparer<V>.Default) ? null : dict.ValueComparer, stream, typeof(IEqualityComparer<V>));
+            SerializationManager.SerializeInner(dict.KeyComparer.Equals(EqualityComparer<K>.Default) ? null : dict.KeyComparer, context, typeof(IEqualityComparer<K>));
+            SerializationManager.SerializeInner(dict.ValueComparer.Equals(EqualityComparer<V>.Default) ? null : dict.ValueComparer, context, typeof(IEqualityComparer<V>));
 
-            stream.Write(dict.Count);
+            context.Stream.Write(dict.Count);
             foreach (var pair in dict)
             {
-                SerializationManager.SerializeInner(pair.Key, stream, typeof(K));
-                SerializationManager.SerializeInner(pair.Value, stream, typeof(V));
+                SerializationManager.SerializeInner(pair.Key, context, typeof(K));
+                SerializationManager.SerializeInner(pair.Value, context, typeof(V));
             }
         }
 
-        internal static object DeserializeImmutableDictionary<K, V>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeImmutableDictionary<K, V>(Type expected, IDeserializationContext context)
         {
-            var keyComparer = SerializationManager.DeserializeInner<IEqualityComparer<K>>(stream);
-            var valueComparer = SerializationManager.DeserializeInner<IEqualityComparer<V>>(stream);
-            var count = stream.ReadInt();
+            var keyComparer = SerializationManager.DeserializeInner<IEqualityComparer<K>>(context);
+            var valueComparer = SerializationManager.DeserializeInner<IEqualityComparer<V>>(context);
+            var count = context.Stream.ReadInt();
             var dictBuilder = ImmutableDictionary.CreateBuilder(keyComparer, valueComparer);
             for (var i = 0; i < count; i++)
             {
-                var key = SerializationManager.DeserializeInner<K>(stream);
-                var value = SerializationManager.DeserializeInner<V>(stream);
+                var key = SerializationManager.DeserializeInner<K>(context);
+                var value = SerializationManager.DeserializeInner<V>(context);
                 dictBuilder.Add(key, value);
             }
             var dict = dictBuilder.ToImmutable();
-            DeserializationContext.Current.RecordObject(dict);
+            context.RecordObject(dict);
 
             return dict;
         }
 
-        internal static void SerializeGenericImmutableList(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericImmutableList(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableList), nameof(DeserializeImmutableList), nameof(CopyImmutableList));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericImmutableList(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericImmutableList(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeImmutableList), nameof(DeserializeImmutableList), nameof(CopyImmutableList));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static object CopyGenericImmutableList(object original)
+        internal static object CopyGenericImmutableList(object original, ICopyContext context)
         {
             var t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableList), nameof(DeserializeImmutableList), nameof(CopyImmutableList));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static void SerializeImmutableList<T>(object untypedInput, BinaryTokenStreamWriter stream, Type typeExpected)
+        internal static void SerializeImmutableList<T>(object untypedInput, ISerializationContext context, Type typeExpected)
         {
             var list = (ImmutableList<T>)untypedInput;
-            stream.Write(list.Count);
+            context.Stream.Write(list.Count);
             foreach (var element in list)
             {
-                SerializationManager.SerializeInner(element, stream, typeof(T));
+                SerializationManager.SerializeInner(element, context, typeof(T));
             }
         }
 
-        internal static object DeserializeImmutableList<T>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeImmutableList<T>(Type expected, IDeserializationContext context)
         {
-            var count = stream.ReadInt();
+            var count = context.Stream.ReadInt();
             var listBuilder = ImmutableList.CreateBuilder<T>();
 
             for (var i = 0; i < count; i++)
             {
-                listBuilder.Add(SerializationManager.DeserializeInner<T>(stream));
+                listBuilder.Add(SerializationManager.DeserializeInner<T>(context));
             }
             var list = listBuilder.ToImmutable();
-            DeserializationContext.Current.RecordObject(list);
+            context.RecordObject(list);
             return list;
         }
 
-        internal static object CopyImmutableList<K>(object original)
+        internal static object CopyImmutableList<K>(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static object CopyGenericImmutableHashSet(object original)
+        internal static object CopyGenericImmutableHashSet(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableHashSet), nameof(DeserializeImmutableHashSet), nameof(CopyImmutableHashSet));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static void SerializeGenericImmutableHashSet(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericImmutableHashSet(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableHashSet), nameof(DeserializeImmutableHashSet), nameof(CopyImmutableHashSet));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericImmutableHashSet(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericImmutableHashSet(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeImmutableHashSet), nameof(DeserializeImmutableHashSet), nameof(CopyImmutableHashSet));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
         
-        internal static object CopyImmutableHashSet<K>(object original)
+        internal static object CopyImmutableHashSet<K>(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeImmutableHashSet<K>(object untypedInput, BinaryTokenStreamWriter stream, Type typeExpected)
+        internal static void SerializeImmutableHashSet<K>(object untypedInput, ISerializationContext context, Type typeExpected)
         {
             var dict = (ImmutableHashSet<K>)untypedInput;
-            SerializationManager.SerializeInner(dict.KeyComparer.Equals(EqualityComparer<K>.Default) ? null : dict.KeyComparer, stream, typeof(IEqualityComparer<K>));
+            SerializationManager.SerializeInner(dict.KeyComparer.Equals(EqualityComparer<K>.Default) ? null : dict.KeyComparer, context, typeof(IEqualityComparer<K>));
 
-            stream.Write(dict.Count);
+            context.Stream.Write(dict.Count);
             foreach (var pair in dict)
             {
-                SerializationManager.SerializeInner(pair, stream, typeof(K));
+                SerializationManager.SerializeInner(pair, context, typeof(K));
             }
         }
 
-        internal static object DeserializeImmutableHashSet<K>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeImmutableHashSet<K>(Type expected, IDeserializationContext context)
         {
-            var keyComparer = SerializationManager.DeserializeInner<IEqualityComparer<K>>(stream);
-            var count = stream.ReadInt();
+            var keyComparer = SerializationManager.DeserializeInner<IEqualityComparer<K>>(context);
+            var count = context.Stream.ReadInt();
             var dictBuilder = ImmutableHashSet.CreateBuilder(keyComparer);
             for (var i = 0; i < count; i++)
             {
-                var key = SerializationManager.DeserializeInner<K>(stream);
+                var key = SerializationManager.DeserializeInner<K>(context);
                 dictBuilder.Add(key);
             }
             var dict = dictBuilder.ToImmutable();
-            DeserializationContext.Current.RecordObject(dict);
+            context.RecordObject(dict);
 
             return dict;
         }
 
-        internal static object CopyGenericImmutableSortedSet(object original)
+        internal static object CopyGenericImmutableSortedSet(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableSortedSet), nameof(DeserializeImmutableSortedSet), nameof(CopyImmutableSortedSet));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static object DeserializeGenericImmutableSortedSet(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericImmutableSortedSet(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeImmutableSortedSet), nameof(DeserializeImmutableSortedSet), nameof(CopyImmutableSortedSet));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static void SerializeGenericImmutableSortedSet(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericImmutableSortedSet(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableSortedSet), nameof(DeserializeImmutableSortedSet), nameof(CopyImmutableSortedSet));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object CopyImmutableSortedSet<K>(object original)
+        internal static object CopyImmutableSortedSet<K>(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeImmutableSortedSet<K>(object untypedInput, BinaryTokenStreamWriter stream, Type typeExpected)
+        internal static void SerializeImmutableSortedSet<K>(object untypedInput, ISerializationContext context, Type typeExpected)
         {
             var dict = (ImmutableSortedSet<K>)untypedInput;
-            SerializationManager.SerializeInner(dict.KeyComparer.Equals(Comparer<K>.Default) ? null : dict.KeyComparer, stream, typeof(IComparer<K>));
+            SerializationManager.SerializeInner(dict.KeyComparer.Equals(Comparer<K>.Default) ? null : dict.KeyComparer, context, typeof(IComparer<K>));
 
-            stream.Write(dict.Count);
+            context.Stream.Write(dict.Count);
             foreach (var pair in dict)
             {
-                SerializationManager.SerializeInner(pair, stream, typeof(K));
+                SerializationManager.SerializeInner(pair, context, typeof(K));
             }
         }
 
-        internal static object DeserializeImmutableSortedSet<K>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeImmutableSortedSet<K>(Type expected, IDeserializationContext context)
         {
-            var keyComparer = SerializationManager.DeserializeInner<IComparer<K>>(stream);
-            var count = stream.ReadInt();
+            var keyComparer = SerializationManager.DeserializeInner<IComparer<K>>(context);
+            var count = context.Stream.ReadInt();
             var dictBuilder = ImmutableSortedSet.CreateBuilder(keyComparer);
             for (var i = 0; i < count; i++)
             {
-                var key = SerializationManager.DeserializeInner<K>(stream);
+                var key = SerializationManager.DeserializeInner<K>(context);
                 dictBuilder.Add(key);
             }
             var dict = dictBuilder.ToImmutable();
-            DeserializationContext.Current.RecordObject(dict);
+            context.RecordObject(dict);
 
             return dict;
         }
 
-        internal static object CopyGenericImmutableSortedDictionary(object original)
+        internal static object CopyGenericImmutableSortedDictionary(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableSortedDictionary), nameof(DeserializeImmutableSortedDictionary), nameof(CopyImmutableSortedDictionary));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static object DeserializeGenericImmutableSortedDictionary(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericImmutableSortedDictionary(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeImmutableSortedDictionary), nameof(DeserializeImmutableSortedDictionary), nameof(CopyImmutableSortedDictionary));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static void SerializeGenericImmutableSortedDictionary(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericImmutableSortedDictionary(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableSortedDictionary), nameof(DeserializeImmutableSortedDictionary), nameof(CopyImmutableSortedDictionary));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object CopyImmutableSortedDictionary<K, V>(object original)
+        internal static object CopyImmutableSortedDictionary<K, V>(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeImmutableSortedDictionary<K, V>(object untypedInput, BinaryTokenStreamWriter stream, Type typeExpected)
+        internal static void SerializeImmutableSortedDictionary<K, V>(object untypedInput, ISerializationContext context, Type typeExpected)
         {
             var dict = (ImmutableSortedDictionary<K, V>)untypedInput;
-            SerializationManager.SerializeInner(dict.KeyComparer.Equals(Comparer<K>.Default) ? null : dict.KeyComparer, stream, typeof(IComparer<K>));
-            SerializationManager.SerializeInner(dict.ValueComparer.Equals(EqualityComparer<V>.Default) ? null : dict.ValueComparer, stream, typeof(IEqualityComparer<V>));
+            SerializationManager.SerializeInner(dict.KeyComparer.Equals(Comparer<K>.Default) ? null : dict.KeyComparer, context, typeof(IComparer<K>));
+            SerializationManager.SerializeInner(dict.ValueComparer.Equals(EqualityComparer<V>.Default) ? null : dict.ValueComparer, context, typeof(IEqualityComparer<V>));
 
-            stream.Write(dict.Count);
+            context.Stream.Write(dict.Count);
             foreach (var pair in dict)
             {
-                SerializationManager.SerializeInner(pair.Key, stream, typeof(K));
-                SerializationManager.SerializeInner(pair.Value, stream, typeof(V));
+                SerializationManager.SerializeInner(pair.Key, context, typeof(K));
+                SerializationManager.SerializeInner(pair.Value, context, typeof(V));
             }
         }
 
-        internal static object DeserializeImmutableSortedDictionary<K, V>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeImmutableSortedDictionary<K, V>(Type expected, IDeserializationContext context)
         {
-            var keyComparer = SerializationManager.DeserializeInner<IComparer<K>>(stream);
-            var valueComparer = SerializationManager.DeserializeInner<IEqualityComparer<V>>(stream);
-            var count = stream.ReadInt();
+            var keyComparer = SerializationManager.DeserializeInner<IComparer<K>>(context);
+            var valueComparer = SerializationManager.DeserializeInner<IEqualityComparer<V>>(context);
+            var count = context.Stream.ReadInt();
             var dictBuilder = ImmutableSortedDictionary.CreateBuilder(keyComparer, valueComparer);
             for (var i = 0; i < count; i++)
             {
-                var key = SerializationManager.DeserializeInner<K>(stream);
-                var value = SerializationManager.DeserializeInner<V>(stream);
+                var key = SerializationManager.DeserializeInner<K>(context);
+                var value = SerializationManager.DeserializeInner<V>(context);
                 dictBuilder.Add(key, value);
             }
             var dict = dictBuilder.ToImmutable();
-            DeserializationContext.Current.RecordObject(dict);
+            context.RecordObject(dict);
 
             return dict;
         }
 
-        internal static object CopyGenericImmutableArray(object original)
+        internal static object CopyGenericImmutableArray(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableArray), nameof(DeserializeImmutableArray), nameof(CopyImmutableArray));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static object DeserializeGenericImmutableArray(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericImmutableArray(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeImmutableArray), nameof(DeserializeImmutableArray), nameof(CopyImmutableArray));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static void SerializeGenericImmutableArray(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericImmutableArray(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableArray), nameof(DeserializeImmutableArray), nameof(CopyImmutableArray));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object CopyImmutableArray<K>(object original)
+        internal static object CopyImmutableArray<K>(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeImmutableArray<K>(object untypedInput, BinaryTokenStreamWriter stream, Type typeExpected)
+        internal static void SerializeImmutableArray<K>(object untypedInput, ISerializationContext context, Type typeExpected)
         {
             var dict = (ImmutableArray<K>)untypedInput;
 
-            stream.Write(dict.Length);
+            context.Stream.Write(dict.Length);
             foreach (var pair in dict)
             {
-                SerializationManager.SerializeInner(pair, stream, typeof(K));
+                SerializationManager.SerializeInner(pair, context, typeof(K));
             }
         }
 
-        internal static object DeserializeImmutableArray<K>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeImmutableArray<K>(Type expected, IDeserializationContext context)
         {
-            var count = stream.ReadInt();
+            var count = context.Stream.ReadInt();
             var dictBuilder = ImmutableArray.CreateBuilder<K>();
             for (var i = 0; i < count; i++)
             {
-                var key = SerializationManager.DeserializeInner<K>(stream);
+                var key = SerializationManager.DeserializeInner<K>(context);
                 dictBuilder.Add(key);
             }
             var dict = dictBuilder.ToImmutable();
-            DeserializationContext.Current.RecordObject(dict);
+            context.RecordObject(dict);
 
             return dict;
         }
-        internal static object CopyGenericImmutableQueue(object original)
+        internal static object CopyGenericImmutableQueue(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableQueue), nameof(DeserializeImmutableQueue), nameof(CopyImmutableQueue));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static object DeserializeGenericImmutableQueue(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericImmutableQueue(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeImmutableQueue), nameof(DeserializeImmutableQueue), nameof(CopyImmutableQueue));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static void SerializeGenericImmutableQueue(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericImmutableQueue(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutableQueue), nameof(DeserializeImmutableQueue), nameof(CopyImmutableQueue));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object CopyImmutableQueue<K>(object original)
+        internal static object CopyImmutableQueue<K>(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeImmutableQueue<K>(object untypedInput, BinaryTokenStreamWriter stream, Type typeExpected)
+        internal static void SerializeImmutableQueue<K>(object untypedInput, ISerializationContext context, Type typeExpected)
         {
             var queue = (ImmutableQueue<K>)untypedInput;
 
-            stream.Write(queue.Count());
+            context.Stream.Write(queue.Count());
             foreach (var item in queue)
             {
-                SerializationManager.SerializeInner(item, stream, typeof(K));
+                SerializationManager.SerializeInner(item, context, typeof(K));
             }
         }
 
-        internal static object DeserializeImmutableQueue<K>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeImmutableQueue<K>(Type expected, IDeserializationContext context)
         {
-            var count = stream.ReadInt();
+            var count = context.Stream.ReadInt();
             var items = new K[count];
             for (var i = 0; i < count; i++)
             {
-                var key = SerializationManager.DeserializeInner<K>(stream);
+                var key = SerializationManager.DeserializeInner<K>(context);
                 items[i] = key;
             }
             var queues = ImmutableQueue.CreateRange(items);
 
-            DeserializationContext.Current.RecordObject(queues);
+            context.RecordObject(queues);
 
             return queues;
         }
@@ -1217,226 +1217,226 @@ namespace Orleans.Serialization
 
         #region Tuples
 
-        internal static void SerializeTuple(object raw, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeTuple(object raw, ISerializationContext context, Type expected)
         {
             Type t = raw.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeTuple) + generics.Length, nameof(DeserializeTuple) + generics.Length, nameof(DeepCopyTuple) + generics.Length, generics);
 
-            concretes.Item1(raw, stream, expected);
+            concretes.Item1(raw, context, expected);
         }
 
-        internal static object DeserializeTuple(Type t, BinaryTokenStreamReader stream)
+        internal static object DeserializeTuple(Type t, IDeserializationContext context)
         {
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeTuple) + generics.Length, nameof(DeserializeTuple) + generics.Length, nameof(DeepCopyTuple) + generics.Length, generics);
 
-            return concretes.Item2(t, stream);
+            return concretes.Item2(t, context);
         }
 
-        internal static object DeepCopyTuple(object original)
+        internal static object DeepCopyTuple(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var generics = t.GetGenericArguments();
             var concretes = RegisterConcreteMethods(t, nameof(SerializeTuple) + generics.Length, nameof(DeserializeTuple) + generics.Length, nameof(DeepCopyTuple) + generics.Length, generics);
 
-            return concretes.Item3(original);
+            return concretes.Item3(original, context);
         }
 
-        internal static object DeepCopyTuple1<T1>(object original)
+        internal static object DeepCopyTuple1<T1>(object original, ICopyContext context)
         {
             var input = (Tuple<T1>)original;
-            var result = new Tuple<T1>((T1)SerializationManager.DeepCopyInner(input.Item1));
-            SerializationContext.Current.RecordObject(original, result);
+            var result = new Tuple<T1>((T1)SerializationManager.DeepCopyInner(input.Item1, context));
+            context.RecordCopy(original, result);
             return result;
         }
 
-        internal static void SerializeTuple1<T1>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeTuple1<T1>(object obj, ISerializationContext context, Type expected)
         {
             var input = (Tuple<T1>)obj;
-            SerializationManager.SerializeInner(input.Item1, stream, typeof(T1));
+            SerializationManager.SerializeInner(input.Item1, context, typeof(T1));
         }
 
-        internal static object DeserializeTuple1<T1>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeTuple1<T1>(Type expected, IDeserializationContext context)
         {
-            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), stream);
+            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), context);
             return new Tuple<T1>(item1);
         }
 
-        internal static object DeepCopyTuple2<T1, T2>(object original)
+        internal static object DeepCopyTuple2<T1, T2>(object original, ICopyContext context)
         {
             var input = (Tuple<T1, T2>)original;
-            var result = new Tuple<T1, T2>((T1)SerializationManager.DeepCopyInner(input.Item1), (T2)SerializationManager.DeepCopyInner(input.Item2));
-            SerializationContext.Current.RecordObject(original, result);
+            var result = new Tuple<T1, T2>((T1)SerializationManager.DeepCopyInner(input.Item1, context), (T2)SerializationManager.DeepCopyInner(input.Item2, context));
+            context.RecordCopy(original, result);
             return result;
         }
 
-        internal static void SerializeTuple2<T1, T2>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeTuple2<T1, T2>(object obj, ISerializationContext context, Type expected)
         {
             var input = (Tuple<T1, T2>)obj;
-            SerializationManager.SerializeInner(input.Item1, stream, typeof(T1));
-            SerializationManager.SerializeInner(input.Item2, stream, typeof(T2));
+            SerializationManager.SerializeInner(input.Item1, context, typeof(T1));
+            SerializationManager.SerializeInner(input.Item2, context, typeof(T2));
         }
 
-        internal static object DeserializeTuple2<T1, T2>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeTuple2<T1, T2>(Type expected, IDeserializationContext context)
         {
-            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), stream);
-            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), stream);
+            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), context);
+            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), context);
             return new Tuple<T1, T2>(item1, item2);
         }
 
-        internal static object DeepCopyTuple3<T1, T2, T3>(object original)
+        internal static object DeepCopyTuple3<T1, T2, T3>(object original, ICopyContext context)
         {
             var input = (Tuple<T1, T2, T3>)original;
-            var result = new Tuple<T1, T2, T3>((T1)SerializationManager.DeepCopyInner(input.Item1), (T2)SerializationManager.DeepCopyInner(input.Item2),
-                (T3)SerializationManager.DeepCopyInner(input.Item3));
-            SerializationContext.Current.RecordObject(original, result);
+            var result = new Tuple<T1, T2, T3>((T1)SerializationManager.DeepCopyInner(input.Item1, context), (T2)SerializationManager.DeepCopyInner(input.Item2, context),
+                (T3)SerializationManager.DeepCopyInner(input.Item3, context));
+            context.RecordCopy(original, result);
             return result;
         }
 
-        internal static void SerializeTuple3<T1, T2, T3>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeTuple3<T1, T2, T3>(object obj, ISerializationContext context, Type expected)
         {
             var input = (Tuple<T1, T2, T3>)obj;
-            SerializationManager.SerializeInner(input.Item1, stream, typeof(T1));
-            SerializationManager.SerializeInner(input.Item2, stream, typeof(T2));
-            SerializationManager.SerializeInner(input.Item3, stream, typeof(T3));
+            SerializationManager.SerializeInner(input.Item1, context, typeof(T1));
+            SerializationManager.SerializeInner(input.Item2, context, typeof(T2));
+            SerializationManager.SerializeInner(input.Item3, context, typeof(T3));
         }
 
-        internal static object DeserializeTuple3<T1, T2, T3>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeTuple3<T1, T2, T3>(Type expected, IDeserializationContext context)
         {
-            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), stream);
-            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), stream);
-            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), stream);
+            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), context);
+            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), context);
+            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), context);
             return new Tuple<T1, T2, T3>(item1, item2, item3);
         }
 
-        internal static object DeepCopyTuple4<T1, T2, T3, T4>(object original)
+        internal static object DeepCopyTuple4<T1, T2, T3, T4>(object original, ICopyContext context)
         {
             var input = (Tuple<T1, T2, T3, T4>)original;
-            var result = new Tuple<T1, T2, T3, T4>((T1)SerializationManager.DeepCopyInner(input.Item1), (T2)SerializationManager.DeepCopyInner(input.Item2),
-                (T3)SerializationManager.DeepCopyInner(input.Item3),
-                (T4)SerializationManager.DeepCopyInner(input.Item4));
-            SerializationContext.Current.RecordObject(original, result);
+            var result = new Tuple<T1, T2, T3, T4>((T1)SerializationManager.DeepCopyInner(input.Item1, context), (T2)SerializationManager.DeepCopyInner(input.Item2, context),
+                (T3)SerializationManager.DeepCopyInner(input.Item3, context),
+                (T4)SerializationManager.DeepCopyInner(input.Item4, context));
+            context.RecordCopy(original, result);
             return result;
         }
 
-        internal static void SerializeTuple4<T1, T2, T3, T4>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeTuple4<T1, T2, T3, T4>(object obj, ISerializationContext context, Type expected)
         {
             var input = (Tuple<T1, T2, T3, T4>)obj;
-            SerializationManager.SerializeInner(input.Item1, stream, typeof(T1));
-            SerializationManager.SerializeInner(input.Item2, stream, typeof(T2));
-            SerializationManager.SerializeInner(input.Item3, stream, typeof(T3));
-            SerializationManager.SerializeInner(input.Item4, stream, typeof(T4));
+            SerializationManager.SerializeInner(input.Item1, context, typeof(T1));
+            SerializationManager.SerializeInner(input.Item2, context, typeof(T2));
+            SerializationManager.SerializeInner(input.Item3, context, typeof(T3));
+            SerializationManager.SerializeInner(input.Item4, context, typeof(T4));
         }
 
-        internal static object DeserializeTuple4<T1, T2, T3, T4>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeTuple4<T1, T2, T3, T4>(Type expected, IDeserializationContext context)
         {
-            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), stream);
-            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), stream);
-            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), stream);
-            var item4 = (T4)SerializationManager.DeserializeInner(typeof(T4), stream);
+            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), context);
+            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), context);
+            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), context);
+            var item4 = (T4)SerializationManager.DeserializeInner(typeof(T4), context);
             return new Tuple<T1, T2, T3, T4>(item1, item2, item3, item4);
         }
 
-        internal static object DeepCopyTuple5<T1, T2, T3, T4, T5>(object original)
+        internal static object DeepCopyTuple5<T1, T2, T3, T4, T5>(object original, ICopyContext context)
         {
             var input = (Tuple<T1, T2, T3, T4, T5>)original;
-            var result = new Tuple<T1, T2, T3, T4, T5>((T1)SerializationManager.DeepCopyInner(input.Item1), (T2)SerializationManager.DeepCopyInner(input.Item2),
-                (T3)SerializationManager.DeepCopyInner(input.Item3),
-                (T4)SerializationManager.DeepCopyInner(input.Item4),
-                (T5)SerializationManager.DeepCopyInner(input.Item5));
-            SerializationContext.Current.RecordObject(original, result);
+            var result = new Tuple<T1, T2, T3, T4, T5>((T1)SerializationManager.DeepCopyInner(input.Item1, context), (T2)SerializationManager.DeepCopyInner(input.Item2, context),
+                (T3)SerializationManager.DeepCopyInner(input.Item3, context),
+                (T4)SerializationManager.DeepCopyInner(input.Item4, context),
+                (T5)SerializationManager.DeepCopyInner(input.Item5, context));
+            context.RecordCopy(original, result);
             return result;
         }
 
-        internal static void SerializeTuple5<T1, T2, T3, T4, T5>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeTuple5<T1, T2, T3, T4, T5>(object obj, ISerializationContext context, Type expected)
         {
             var input = (Tuple<T1, T2, T3, T4, T5>)obj;
-            SerializationManager.SerializeInner(input.Item1, stream, typeof(T1));
-            SerializationManager.SerializeInner(input.Item2, stream, typeof(T2));
-            SerializationManager.SerializeInner(input.Item3, stream, typeof(T3));
-            SerializationManager.SerializeInner(input.Item4, stream, typeof(T4));
-            SerializationManager.SerializeInner(input.Item5, stream, typeof(T5));
+            SerializationManager.SerializeInner(input.Item1, context, typeof(T1));
+            SerializationManager.SerializeInner(input.Item2, context, typeof(T2));
+            SerializationManager.SerializeInner(input.Item3, context, typeof(T3));
+            SerializationManager.SerializeInner(input.Item4, context, typeof(T4));
+            SerializationManager.SerializeInner(input.Item5, context, typeof(T5));
         }
 
-        internal static object DeserializeTuple5<T1, T2, T3, T4, T5>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeTuple5<T1, T2, T3, T4, T5>(Type expected, IDeserializationContext context)
         {
-            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), stream);
-            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), stream);
-            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), stream);
-            var item4 = (T4)SerializationManager.DeserializeInner(typeof(T4), stream);
-            var item5 = (T5)SerializationManager.DeserializeInner(typeof(T5), stream);
+            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), context);
+            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), context);
+            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), context);
+            var item4 = (T4)SerializationManager.DeserializeInner(typeof(T4), context);
+            var item5 = (T5)SerializationManager.DeserializeInner(typeof(T5), context);
             return new Tuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
         }
 
-        internal static object DeepCopyTuple6<T1, T2, T3, T4, T5, T6>(object original)
+        internal static object DeepCopyTuple6<T1, T2, T3, T4, T5, T6>(object original, ICopyContext context)
         {
             var input = (Tuple<T1, T2, T3, T4, T5, T6>)original;
-            var result = new Tuple<T1, T2, T3, T4, T5, T6>((T1)SerializationManager.DeepCopyInner(input.Item1), (T2)SerializationManager.DeepCopyInner(input.Item2),
-                (T3)SerializationManager.DeepCopyInner(input.Item3),
-                (T4)SerializationManager.DeepCopyInner(input.Item4),
-                (T5)SerializationManager.DeepCopyInner(input.Item5),
-                (T6)SerializationManager.DeepCopyInner(input.Item6));
-            SerializationContext.Current.RecordObject(original, result);
+            var result = new Tuple<T1, T2, T3, T4, T5, T6>((T1)SerializationManager.DeepCopyInner(input.Item1, context), (T2)SerializationManager.DeepCopyInner(input.Item2, context),
+                (T3)SerializationManager.DeepCopyInner(input.Item3, context),
+                (T4)SerializationManager.DeepCopyInner(input.Item4, context),
+                (T5)SerializationManager.DeepCopyInner(input.Item5, context),
+                (T6)SerializationManager.DeepCopyInner(input.Item6, context));
+            context.RecordCopy(original, result);
             return result;
         }
 
-        internal static void SerializeTuple6<T1, T2, T3, T4, T5, T6>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeTuple6<T1, T2, T3, T4, T5, T6>(object obj, ISerializationContext context, Type expected)
         {
             var input = (Tuple<T1, T2, T3, T4, T5, T6>)obj;
-            SerializationManager.SerializeInner(input.Item1, stream, typeof(T1));
-            SerializationManager.SerializeInner(input.Item2, stream, typeof(T2));
-            SerializationManager.SerializeInner(input.Item3, stream, typeof(T3));
-            SerializationManager.SerializeInner(input.Item4, stream, typeof(T4));
-            SerializationManager.SerializeInner(input.Item5, stream, typeof(T5));
-            SerializationManager.SerializeInner(input.Item6, stream, typeof(T6));
+            SerializationManager.SerializeInner(input.Item1, context, typeof(T1));
+            SerializationManager.SerializeInner(input.Item2, context, typeof(T2));
+            SerializationManager.SerializeInner(input.Item3, context, typeof(T3));
+            SerializationManager.SerializeInner(input.Item4, context, typeof(T4));
+            SerializationManager.SerializeInner(input.Item5, context, typeof(T5));
+            SerializationManager.SerializeInner(input.Item6, context, typeof(T6));
         }
 
-        internal static object DeserializeTuple6<T1, T2, T3, T4, T5, T6>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeTuple6<T1, T2, T3, T4, T5, T6>(Type expected, IDeserializationContext context)
         {
-            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), stream);
-            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), stream);
-            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), stream);
-            var item4 = (T4)SerializationManager.DeserializeInner(typeof(T4), stream);
-            var item5 = (T5)SerializationManager.DeserializeInner(typeof(T5), stream);
-            var item6 = (T6)SerializationManager.DeserializeInner(typeof(T6), stream);
+            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), context);
+            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), context);
+            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), context);
+            var item4 = (T4)SerializationManager.DeserializeInner(typeof(T4), context);
+            var item5 = (T5)SerializationManager.DeserializeInner(typeof(T5), context);
+            var item6 = (T6)SerializationManager.DeserializeInner(typeof(T6), context);
             return new Tuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
         }
 
-        internal static object DeepCopyTuple7<T1, T2, T3, T4, T5, T6, T7>(object original)
+        internal static object DeepCopyTuple7<T1, T2, T3, T4, T5, T6, T7>(object original, ICopyContext context)
         {
             var input = (Tuple<T1, T2, T3, T4, T5, T6, T7>)original;
-            var result = new Tuple<T1, T2, T3, T4, T5, T6, T7>((T1)SerializationManager.DeepCopyInner(input.Item1), (T2)SerializationManager.DeepCopyInner(input.Item2),
-                (T3)SerializationManager.DeepCopyInner(input.Item3),
-                (T4)SerializationManager.DeepCopyInner(input.Item4),
-                (T5)SerializationManager.DeepCopyInner(input.Item5),
-                (T6)SerializationManager.DeepCopyInner(input.Item6),
-                (T7)SerializationManager.DeepCopyInner(input.Item7));
-            SerializationContext.Current.RecordObject(original, result);
+            var result = new Tuple<T1, T2, T3, T4, T5, T6, T7>((T1)SerializationManager.DeepCopyInner(input.Item1, context), (T2)SerializationManager.DeepCopyInner(input.Item2, context),
+                (T3)SerializationManager.DeepCopyInner(input.Item3, context),
+                (T4)SerializationManager.DeepCopyInner(input.Item4, context),
+                (T5)SerializationManager.DeepCopyInner(input.Item5, context),
+                (T6)SerializationManager.DeepCopyInner(input.Item6, context),
+                (T7)SerializationManager.DeepCopyInner(input.Item7, context));
+            context.RecordCopy(original, result);
             return result;
         }
 
-        internal static void SerializeTuple7<T1, T2, T3, T4, T5, T6, T7>(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeTuple7<T1, T2, T3, T4, T5, T6, T7>(object obj, ISerializationContext context, Type expected)
         {
             var input = (Tuple<T1, T2, T3, T4, T5, T6, T7>)obj;
-            SerializationManager.SerializeInner(input.Item1, stream, typeof(T1));
-            SerializationManager.SerializeInner(input.Item2, stream, typeof(T2));
-            SerializationManager.SerializeInner(input.Item3, stream, typeof(T3));
-            SerializationManager.SerializeInner(input.Item4, stream, typeof(T4));
-            SerializationManager.SerializeInner(input.Item5, stream, typeof(T5));
-            SerializationManager.SerializeInner(input.Item6, stream, typeof(T6));
-            SerializationManager.SerializeInner(input.Item7, stream, typeof(T7));
+            SerializationManager.SerializeInner(input.Item1, context, typeof(T1));
+            SerializationManager.SerializeInner(input.Item2, context, typeof(T2));
+            SerializationManager.SerializeInner(input.Item3, context, typeof(T3));
+            SerializationManager.SerializeInner(input.Item4, context, typeof(T4));
+            SerializationManager.SerializeInner(input.Item5, context, typeof(T5));
+            SerializationManager.SerializeInner(input.Item6, context, typeof(T6));
+            SerializationManager.SerializeInner(input.Item7, context, typeof(T7));
         }
 
-        internal static object DeserializeTuple7<T1, T2, T3, T4, T5, T6, T7>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeTuple7<T1, T2, T3, T4, T5, T6, T7>(Type expected, IDeserializationContext context)
         {
-            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), stream);
-            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), stream);
-            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), stream);
-            var item4 = (T4)SerializationManager.DeserializeInner(typeof(T4), stream);
-            var item5 = (T5)SerializationManager.DeserializeInner(typeof(T5), stream);
-            var item6 = (T6)SerializationManager.DeserializeInner(typeof(T6), stream);
-            var item7 = (T7)SerializationManager.DeserializeInner(typeof(T7), stream);
+            var item1 = (T1)SerializationManager.DeserializeInner(typeof(T1), context);
+            var item2 = (T2)SerializationManager.DeserializeInner(typeof(T2), context);
+            var item3 = (T3)SerializationManager.DeserializeInner(typeof(T3), context);
+            var item4 = (T4)SerializationManager.DeserializeInner(typeof(T4), context);
+            var item5 = (T5)SerializationManager.DeserializeInner(typeof(T5), context);
+            var item6 = (T6)SerializationManager.DeserializeInner(typeof(T6), context);
+            var item7 = (T7)SerializationManager.DeserializeInner(typeof(T7), context);
             return new Tuple<T1, T2, T3, T4, T5, T6, T7>(item1, item2, item3, item4, item5, item6, item7);
         }
 
@@ -1444,41 +1444,41 @@ namespace Orleans.Serialization
 
         #region KeyValuePairs
 
-        internal static void SerializeGenericKeyValuePair(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericKeyValuePair(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeKeyValuePair), nameof(DeserializeKeyValuePair), nameof(CopyKeyValuePair));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericKeyValuePair(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericKeyValuePair(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeKeyValuePair), nameof(DeserializeKeyValuePair), nameof(CopyKeyValuePair));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static object CopyGenericKeyValuePair(object original)
+        internal static object CopyGenericKeyValuePair(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeKeyValuePair), nameof(DeserializeKeyValuePair), nameof(CopyKeyValuePair));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static void SerializeKeyValuePair<TK, TV>(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeKeyValuePair<TK, TV>(object original, ISerializationContext context, Type expected)
         {
             var pair = (KeyValuePair<TK, TV>)original;
-            SerializationManager.SerializeInner(pair.Key, stream, typeof(TK));
-            SerializationManager.SerializeInner(pair.Value, stream, typeof(TV));
+            SerializationManager.SerializeInner(pair.Key, context, typeof(TK));
+            SerializationManager.SerializeInner(pair.Value, context, typeof(TV));
         }
 
-        internal static object DeserializeKeyValuePair<K, V>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeKeyValuePair<K, V>(Type expected, IDeserializationContext context)
         {
-            var key = (K)SerializationManager.DeserializeInner(typeof(K), stream);
-            var value = (V)SerializationManager.DeserializeInner(typeof(V), stream);
+            var key = (K)SerializationManager.DeserializeInner(typeof(K), context);
+            var value = (V)SerializationManager.DeserializeInner(typeof(V), context);
             return new KeyValuePair<K, V>(key, value);
         }
 
-        internal static object CopyKeyValuePair<TK, TV>(object original)
+        internal static object CopyKeyValuePair<TK, TV>(object original, ICopyContext context)
         {
             var pair = (KeyValuePair<TK, TV>)original;
             if (typeof(TK).IsOrleansShallowCopyable() && typeof(TV).IsOrleansShallowCopyable())
@@ -1486,8 +1486,8 @@ namespace Orleans.Serialization
                 return pair;    // KeyValuePair is a struct, so there's already been a copy at this point
             }
 
-            var result = new KeyValuePair<TK, TV>((TK)SerializationManager.DeepCopyInner(pair.Key), (TV)SerializationManager.DeepCopyInner(pair.Value));
-            SerializationContext.Current.RecordObject(original, result);
+            var result = new KeyValuePair<TK, TV>((TK)SerializationManager.DeepCopyInner(pair.Key, context), (TV)SerializationManager.DeepCopyInner(pair.Value, context));
+            context.RecordCopy(original, result);
             return result;
         }
 
@@ -1495,52 +1495,52 @@ namespace Orleans.Serialization
 
         #region Nullables
 
-        internal static void SerializeGenericNullable(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericNullable(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeNullable), nameof(DeserializeNullable), nameof(CopyNullable));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericNullable(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericNullable(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeNullable), nameof(DeserializeNullable), nameof(CopyNullable));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static object CopyGenericNullable(object original)
+        internal static object CopyGenericNullable(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeNullable), nameof(DeserializeNullable), nameof(CopyNullable));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static void SerializeNullable<T>(object original, BinaryTokenStreamWriter stream, Type expected) where T : struct
+        internal static void SerializeNullable<T>(object original, ISerializationContext context, Type expected) where T : struct
         {
             var obj = (T?)original;
             if (obj.HasValue)
             {
-                SerializationManager.SerializeInner(obj.Value, stream, typeof(T));
+                SerializationManager.SerializeInner(obj.Value, context, typeof(T));
             }
             else
             {
-                stream.WriteNull();
+                context.Stream.WriteNull();
             }
         }
 
-        internal static object DeserializeNullable<T>(Type expected, BinaryTokenStreamReader stream) where T : struct
+        internal static object DeserializeNullable<T>(Type expected, IDeserializationContext context) where T : struct
         {
-            if (stream.PeekToken() == SerializationTokenType.Null)
+            if (context.Stream.PeekToken() == SerializationTokenType.Null)
             {
-                stream.ReadToken();
+                context.Stream.ReadToken();
                 return new T?();
             }
 
-            var val = (T)SerializationManager.DeserializeInner(typeof(T), stream);
+            var val = (T)SerializationManager.DeserializeInner(typeof(T), context);
             return new Nullable<T>(val);
         }
 
-        internal static object CopyNullable<T>(object original) where T : struct
+        internal static object CopyNullable<T>(object original, ICopyContext context) where T : struct
         {
             return original;    // Everything is a struct, so a direct copy is fine
         }
@@ -1549,39 +1549,39 @@ namespace Orleans.Serialization
 
         #region Immutables
 
-        internal static void SerializeGenericImmutable(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGenericImmutable(object original, ISerializationContext context, Type expected)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutable), nameof(DeserializeImmutable), nameof(CopyImmutable));
-            concreteMethods.Item1(original, stream, expected);
+            concreteMethods.Item1(original, context, expected);
         }
 
-        internal static object DeserializeGenericImmutable(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGenericImmutable(Type expected, IDeserializationContext context)
         {
             var concreteMethods = RegisterConcreteMethods(expected, nameof(SerializeImmutable), nameof(DeserializeImmutable), nameof(CopyImmutable));
-            return concreteMethods.Item2(expected, stream);
+            return concreteMethods.Item2(expected, context);
         }
 
-        internal static object CopyGenericImmutable(object original)
+        internal static object CopyGenericImmutable(object original, ICopyContext context)
         {
             Type t = original.GetType();
             var concreteMethods = RegisterConcreteMethods(t, nameof(SerializeImmutable), nameof(DeserializeImmutable), nameof(CopyImmutable));
-            return concreteMethods.Item3(original);
+            return concreteMethods.Item3(original, context);
         }
 
-        internal static void SerializeImmutable<T>(object original, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeImmutable<T>(object original, ISerializationContext context, Type expected)
         {
             var obj = (Immutable<T>)original;
-            SerializationManager.SerializeInner(obj.Value, stream, typeof(T));
+            SerializationManager.SerializeInner(obj.Value, context, typeof(T));
         }
 
-        internal static object DeserializeImmutable<T>(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeImmutable<T>(Type expected, IDeserializationContext context)
         {
-            var val = (T)SerializationManager.DeserializeInner(typeof(T), stream);
+            var val = (T)SerializationManager.DeserializeInner(typeof(T), context);
             return new Immutable<T>(val);
         }
 
-        internal static object CopyImmutable<T>(object original)
+        internal static object CopyImmutable<T>(object original, ICopyContext context)
         {
             return original;    // Immutable means never having to make a copy...
         }
@@ -1594,18 +1594,18 @@ namespace Orleans.Serialization
 
         #region TimeSpan
 
-        internal static void SerializeTimeSpan(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeTimeSpan(object obj, ISerializationContext context, Type expected)
         {
             var ts = (TimeSpan)obj;
-            stream.Write(ts.Ticks);
+            context.Stream.Write(ts.Ticks);
         }
 
-        internal static object DeserializeTimeSpan(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeTimeSpan(Type expected, IDeserializationContext context)
         {
-            return new TimeSpan(stream.ReadLong());
+            return new TimeSpan(context.Stream.ReadLong());
         }
 
-        internal static object CopyTimeSpan(object obj)
+        internal static object CopyTimeSpan(object obj, ICopyContext context)
         {
             return obj; // TimeSpan is a value type 
         }
@@ -1614,19 +1614,19 @@ namespace Orleans.Serialization
 
         #region DateTimeOffset
 
-        internal static void SerializeDateTimeOffset(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeDateTimeOffset(object obj, ISerializationContext context, Type expected)
         {
             var dts = (DateTimeOffset)obj;
-            stream.Write(dts.DateTime.Ticks);
-            stream.Write(dts.Offset.Ticks);
+            context.Stream.Write(dts.DateTime.Ticks);
+            context.Stream.Write(dts.Offset.Ticks);
         }
 
-        internal static object DeserializeDateTimeOffset(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeDateTimeOffset(Type expected, IDeserializationContext context)
         {
-            return new DateTimeOffset(stream.ReadLong(), new TimeSpan(stream.ReadLong()));
+            return new DateTimeOffset(context.Stream.ReadLong(), new TimeSpan(context.Stream.ReadLong()));
         }
 
-        internal static object CopyDateTimeOffset(object obj)
+        internal static object CopyDateTimeOffset(object obj, ICopyContext context)
         {
             return obj; // DateTimeOffset is a value type 
         }
@@ -1635,17 +1635,17 @@ namespace Orleans.Serialization
 
         #region Type
 
-        internal static void SerializeType(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeType(object obj, ISerializationContext context, Type expected)
         {
-            stream.Write(((Type)obj).OrleansTypeKeyString());
+            context.Stream.Write(((Type)obj).OrleansTypeKeyString());
         }
 
-        internal static object DeserializeType(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeType(Type expected, IDeserializationContext context)
         {
-            return SerializationManager.ResolveTypeName(stream.ReadString());
+            return SerializationManager.ResolveTypeName(context.Stream.ReadString());
         }
 
-        internal static object CopyType(object obj)
+        internal static object CopyType(object obj, ICopyContext context)
         {
             return obj; // Type objects are effectively immutable
         }
@@ -1654,19 +1654,19 @@ namespace Orleans.Serialization
 
         #region GUID
 
-        internal static void SerializeGuid(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGuid(object obj, ISerializationContext context, Type expected)
         {
             var guid = (Guid)obj;
-            stream.Write(guid.ToByteArray());
+            context.Stream.Write(guid.ToByteArray());
         }
 
-        internal static object DeserializeGuid(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGuid(Type expected, IDeserializationContext context)
         {
-            var bytes = stream.ReadBytes(16);
+            var bytes = context.Stream.ReadBytes(16);
             return new Guid(bytes);
         }
 
-        internal static object CopyGuid(object obj)
+        internal static object CopyGuid(object obj, ICopyContext context)
         {
             return obj; // Guids are value types
         }
@@ -1678,19 +1678,19 @@ namespace Orleans.Serialization
         [ThreadStatic]
         static private TypeConverter uriConverter;
 
-        internal static void SerializeUri(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeUri(object obj, ISerializationContext context, Type expected)
         {
             if (uriConverter == null) uriConverter = TypeDescriptor.GetConverter(typeof(Uri));
-            stream.Write(uriConverter.ConvertToInvariantString(obj));
+            context.Stream.Write(uriConverter.ConvertToInvariantString(obj));
         }
 
-        internal static object DeserializeUri(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeUri(Type expected, IDeserializationContext context)
         {
             if (uriConverter == null) uriConverter = TypeDescriptor.GetConverter(typeof(Uri));
-            return uriConverter.ConvertFromInvariantString(stream.ReadString());
+            return uriConverter.ConvertFromInvariantString(context.Stream.ReadString());
         }
 
-        internal static object CopyUri(object obj)
+        internal static object CopyUri(object obj, ICopyContext context)
         {
             return obj; // URIs are immutable
         }
@@ -1703,120 +1703,120 @@ namespace Orleans.Serialization
 
         #region Basic types
 
-        internal static void SerializeGrainId(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeGrainId(object obj, ISerializationContext context, Type expected)
         {
             var id = (GrainId)obj;
-            stream.Write(id);
+            context.Stream.Write(id);
         }
 
-        internal static object DeserializeGrainId(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeGrainId(Type expected, IDeserializationContext context)
         {
-            return stream.ReadGrainId();
+            return context.Stream.ReadGrainId();
         }
 
-        internal static object CopyGrainId(object original)
+        internal static object CopyGrainId(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeActivationId(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeActivationId(object obj, ISerializationContext context, Type expected)
         {
             var id = (ActivationId)obj;
-            stream.Write(id);
+            context.Stream.Write(id);
         }
 
-        internal static object DeserializeActivationId(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeActivationId(Type expected, IDeserializationContext context)
         {
-            return stream.ReadActivationId();
+            return context.Stream.ReadActivationId();
         }
 
-        internal static object CopyActivationId(object original)
+        internal static object CopyActivationId(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeActivationAddress(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeActivationAddress(object obj, ISerializationContext context, Type expected)
         {
             var addr = (ActivationAddress)obj;
-            stream.Write(addr);
+            context.Stream.Write(addr);
         }
 
-        internal static object DeserializeActivationAddress(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeActivationAddress(Type expected, IDeserializationContext context)
         {
-            return stream.ReadActivationAddress();
+            return context.Stream.ReadActivationAddress();
         }
 
-        internal static object CopyActivationAddress(object original)
+        internal static object CopyActivationAddress(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeIPAddress(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeIPAddress(object obj, ISerializationContext context, Type expected)
         {
             var ip = (IPAddress)obj;
-            stream.Write(ip);
+            context.Stream.Write(ip);
         }
 
-        internal static object DeserializeIPAddress(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeIPAddress(Type expected, IDeserializationContext context)
         {
-            return stream.ReadIPAddress();
+            return context.Stream.ReadIPAddress();
         }
 
-        internal static object CopyIPAddress(object original)
+        internal static object CopyIPAddress(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeIPEndPoint(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeIPEndPoint(object obj, ISerializationContext context, Type expected)
         {
             var ep = (IPEndPoint)obj;
-            stream.Write(ep);
+            context.Stream.Write(ep);
         }
 
-        internal static object DeserializeIPEndPoint(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeIPEndPoint(Type expected, IDeserializationContext context)
         {
-            return stream.ReadIPEndPoint();
+            return context.Stream.ReadIPEndPoint();
         }
 
-        internal static object CopyIPEndPoint(object original)
+        internal static object CopyIPEndPoint(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeCorrelationId(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeCorrelationId(object obj, ISerializationContext context, Type expected)
         {
             var id = (CorrelationId)obj;
-            stream.Write(id);
+            context.Stream.Write(id);
         }
 
-        internal static object DeserializeCorrelationId(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeCorrelationId(Type expected, IDeserializationContext context)
         {
-            var bytes = stream.ReadBytes(CorrelationId.SIZE_BYTES);
+            var bytes = context.Stream.ReadBytes(CorrelationId.SIZE_BYTES);
             return new CorrelationId(bytes);
         }
 
-        internal static object CopyCorrelationId(object original)
+        internal static object CopyCorrelationId(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static void SerializeSiloAddress(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeSiloAddress(object obj, ISerializationContext context, Type expected)
         {
             var addr = (SiloAddress)obj;
-            stream.Write(addr);
+            context.Stream.Write(addr);
         }
 
-        internal static object DeserializeSiloAddress(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeSiloAddress(Type expected, IDeserializationContext context)
         {
-            return stream.ReadSiloAddress();
+            return context.Stream.ReadSiloAddress();
         }
 
-        internal static object CopySiloAddress(object original)
+        internal static object CopySiloAddress(object original, ICopyContext context)
         {
             return original;
         }
 
-        internal static object CopyTaskId(object original)
+        internal static object CopyTaskId(object original, ICopyContext context)
         {
             return original;
         }
@@ -1825,28 +1825,28 @@ namespace Orleans.Serialization
 
         #region InvokeMethodRequest
 
-        internal static void SerializeInvokeMethodRequest(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeInvokeMethodRequest(object obj, ISerializationContext context, Type expected)
         {
             var request = (InvokeMethodRequest)obj;
 
-            stream.Write(request.InterfaceId);
-            stream.Write(request.MethodId);
-            stream.Write(request.Arguments != null ? request.Arguments.Length : 0);
+            context.Stream.Write(request.InterfaceId);
+            context.Stream.Write(request.MethodId);
+            context.Stream.Write(request.Arguments != null ? request.Arguments.Length : 0);
             if (request.Arguments != null)
             {
                 foreach (var arg in request.Arguments)
                 {
-                    SerializationManager.SerializeInner(arg, stream, null);
+                    SerializationManager.SerializeInner(arg, context, null);
                 }
             }
         }
 
-        internal static object DeserializeInvokeMethodRequest(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeInvokeMethodRequest(Type expected, IDeserializationContext context)
         {
-            int iid = stream.ReadInt();
-            int mid = stream.ReadInt();
+            int iid = context.Stream.ReadInt();
+            int mid = context.Stream.ReadInt();
 
-            int argCount = stream.ReadInt();
+            int argCount = context.Stream.ReadInt();
             object[] args = null;
 
             if (argCount > 0)
@@ -1854,14 +1854,14 @@ namespace Orleans.Serialization
                 args = new object[argCount];
                 for (var i = 0; i < argCount; i++)
                 {
-                    args[i] = SerializationManager.DeserializeInner(null, stream);
+                    args[i] = SerializationManager.DeserializeInner(null, context);
                 }
             }
 
             return new InvokeMethodRequest(iid, mid, args);
         }
 
-        internal static object CopyInvokeMethodRequest(object original)
+        internal static object CopyInvokeMethodRequest(object original, ICopyContext context)
         {
             var request = (InvokeMethodRequest)original;
 
@@ -1871,12 +1871,12 @@ namespace Orleans.Serialization
                 args = new object[request.Arguments.Length];
                 for (var i = 0; i < request.Arguments.Length; i++)
                 {
-                    args[i] = SerializationManager.DeepCopyInner(request.Arguments[i]);
+                    args[i] = SerializationManager.DeepCopyInner(request.Arguments[i], context);
                 }
             }
 
             var result = new InvokeMethodRequest(request.InterfaceId, request.MethodId, args);
-            SerializationContext.Current.RecordObject(original, result);
+            context.RecordCopy(original, result);
             return result;
         }
 
@@ -1884,20 +1884,20 @@ namespace Orleans.Serialization
 
         #region Response
 
-        internal static void SerializeOrleansResponse(object obj, BinaryTokenStreamWriter stream, Type expected)
+        internal static void SerializeOrleansResponse(object obj, ISerializationContext context, Type expected)
         {
             var resp = (Response)obj;
 
-            SerializationManager.SerializeInner(resp.ExceptionFlag ? resp.Exception : resp.Data, stream, null);
+            SerializationManager.SerializeInner(resp.ExceptionFlag ? resp.Exception : resp.Data, context, null);
         }
 
-        internal static object DeserializeOrleansResponse(Type expected, BinaryTokenStreamReader stream)
+        internal static object DeserializeOrleansResponse(Type expected, IDeserializationContext context)
         {
-            var obj = SerializationManager.DeserializeInner(null, stream);
+            var obj = SerializationManager.DeserializeInner(null, context);
             return new Response(obj);
         }
 
-        internal static object CopyOrleansResponse(object original)
+        internal static object CopyOrleansResponse(object original, ICopyContext context)
         {
             var resp = (Response)original;
 
@@ -1906,8 +1906,8 @@ namespace Orleans.Serialization
                 return original;
             }
 
-            var result = new Response(SerializationManager.DeepCopyInner(resp.Data));
-            SerializationContext.Current.RecordObject(original, result);
+            var result = new Response(SerializationManager.DeepCopyInner(resp.Data, context));
+            context.RecordCopy(original, result);
             return result;
         }
 
@@ -1925,15 +1925,15 @@ namespace Orleans.Serialization
                 genericArgs = t.GetGenericArguments();
             }
 
-            var genericCopier = typeof(BuiltInTypes).GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == copierName).FirstOrDefault();
+            var genericCopier = typeof(BuiltInTypes).GetMethods(BindingFlags.Static | BindingFlags.NonPublic).First(m => m.Name == copierName);
             var concreteCopier = genericCopier.MakeGenericMethod(genericArgs);
             var copier = (SerializationManager.DeepCopier)concreteCopier.CreateDelegate(typeof(SerializationManager.DeepCopier));
 
-            var genericSerializer = typeof(BuiltInTypes).GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == serializerName).FirstOrDefault();
+            var genericSerializer = typeof(BuiltInTypes).GetMethods(BindingFlags.Static | BindingFlags.NonPublic).First(m => m.Name == serializerName);
             var concreteSerializer = genericSerializer.MakeGenericMethod(genericArgs);
             var serializer = (SerializationManager.Serializer)concreteSerializer.CreateDelegate(typeof(SerializationManager.Serializer));
 
-            var genericDeserializer = typeof(BuiltInTypes).GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == deserializerName).FirstOrDefault();
+            var genericDeserializer = typeof(BuiltInTypes).GetMethods(BindingFlags.Static | BindingFlags.NonPublic).First(m => m.Name == deserializerName);
             var concreteDeserializer = genericDeserializer.MakeGenericMethod(genericArgs);
             var deserializer =
                 (SerializationManager.Deserializer)concreteDeserializer.CreateDelegate(typeof(SerializationManager.Deserializer));
@@ -1951,15 +1951,15 @@ namespace Orleans.Serialization
                 genericArgs = concreteType.GetGenericArguments();
             }
 
-            var genericCopier = definingType.GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == copierName).FirstOrDefault();
+            var genericCopier = definingType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic).First(m => m.Name == copierName);
             var concreteCopier = genericCopier.MakeGenericMethod(genericArgs);
             var copier = (SerializationManager.DeepCopier)concreteCopier.CreateDelegate(typeof(SerializationManager.DeepCopier));
 
-            var genericSerializer = definingType.GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == serializerName).FirstOrDefault();
+            var genericSerializer = definingType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic).First(m => m.Name == serializerName);
             var concreteSerializer = genericSerializer.MakeGenericMethod(genericArgs);
             var serializer = (SerializationManager.Serializer)concreteSerializer.CreateDelegate(typeof(SerializationManager.Serializer));
 
-            var genericDeserializer = definingType.GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).Where(m => m.Name == deserializerName).FirstOrDefault();
+            var genericDeserializer = definingType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic).First(m => m.Name == deserializerName);
             var concreteDeserializer = genericDeserializer.MakeGenericMethod(genericArgs);
             var deserializer =
                 (SerializationManager.Deserializer)concreteDeserializer.CreateDelegate(typeof(SerializationManager.Deserializer));

--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -50,7 +50,7 @@ namespace Orleans.Serialization
         internal static void SerializeReadOnlyCollection<T>(object obj, ISerializationContext context, Type expected)
         {
             var collection = (ReadOnlyCollection<T>)obj;
-            context.Stream.Write(collection.Count);
+            context.StreamWriter.Write(collection.Count);
             foreach (var element in collection)
             {
                 SerializationManager.SerializeInner(element, context, typeof(T));
@@ -59,7 +59,7 @@ namespace Orleans.Serialization
 
         internal static object DeserializeReadOnlyCollection<T>(Type expected, IDeserializationContext context)
         {
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var list = new List<T>(count);
 
             context.RecordObject(list);
@@ -121,7 +121,7 @@ namespace Orleans.Serialization
         internal static void SerializeList<T>(object obj, ISerializationContext context, Type expected)
         {
             var list = (List<T>)obj;
-            context.Stream.Write(list.Count);
+            context.StreamWriter.Write(list.Count);
             foreach (var element in list)
             {
                 SerializationManager.SerializeInner(element, context, typeof(T));
@@ -130,7 +130,7 @@ namespace Orleans.Serialization
 
         internal static object DeserializeList<T>(Type expected, IDeserializationContext context)
         {
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var list = new List<T>(count);
             context.RecordObject(list);
 
@@ -190,7 +190,7 @@ namespace Orleans.Serialization
         internal static void SerializeLinkedList<T>(object obj, ISerializationContext context, Type expected)
         {
             var list = (LinkedList<T>)obj;
-            context.Stream.Write(list.Count);
+            context.StreamWriter.Write(list.Count);
             foreach (var element in list)
             {
                 SerializationManager.SerializeInner(element, context, typeof(T));
@@ -199,7 +199,7 @@ namespace Orleans.Serialization
 
         internal static object DeserializeLinkedList<T>(Type expected, IDeserializationContext context)
         {
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var list = new LinkedList<T>();
             context.RecordObject(list);
             for (var i = 0; i < count; i++)
@@ -262,7 +262,7 @@ namespace Orleans.Serialization
             var set = (HashSet<T>)obj;
             SerializationManager.SerializeInner(set.Comparer.Equals(EqualityComparer<T>.Default) ? null : set.Comparer,
                 context, typeof(IEqualityComparer<T>));
-            context.Stream.Write(set.Count);
+            context.StreamWriter.Write(set.Count);
             foreach (var element in set)
             {
                 SerializationManager.SerializeInner(element, context, typeof(T));
@@ -273,7 +273,7 @@ namespace Orleans.Serialization
         {
             var comparer =
                 (IEqualityComparer<T>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<T>), context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var set = new HashSet<T>(comparer);
             context.RecordObject(set);
             for (var i = 0; i < count; i++)
@@ -332,7 +332,7 @@ namespace Orleans.Serialization
             var set = (SortedSet<T>)obj;
             SerializationManager.SerializeInner(set.Comparer.Equals(Comparer<T>.Default) ? null : set.Comparer,
                 context, typeof(IComparer<T>));
-            context.Stream.Write(set.Count);
+            context.StreamWriter.Write(set.Count);
             foreach (var element in set)
             {
                 SerializationManager.SerializeInner(element, context, typeof(T));
@@ -343,7 +343,7 @@ namespace Orleans.Serialization
         {
             var comparer =
                 (IComparer<T>)SerializationManager.DeserializeInner(typeof(IComparer<T>), context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var set = new SortedSet<T>(comparer);
             context.RecordObject(set);
             for (var i = 0; i < count; i++)
@@ -403,7 +403,7 @@ namespace Orleans.Serialization
         internal static void SerializeQueue<T>(object obj, ISerializationContext context, Type expected)
         {
             var queue = (Queue<T>)obj;
-            context.Stream.Write(queue.Count);
+            context.StreamWriter.Write(queue.Count);
             foreach (var element in queue)
             {
                 SerializationManager.SerializeInner(element, context, typeof(T));
@@ -412,7 +412,7 @@ namespace Orleans.Serialization
 
         internal static object DeserializeQueue<T>(Type expected, IDeserializationContext context)
         {
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var queue = new Queue<T>();
             context.RecordObject(queue);
             for (var i = 0; i < count; i++)
@@ -473,7 +473,7 @@ namespace Orleans.Serialization
         internal static void SerializeStack<T>(object obj, ISerializationContext context, Type expected)
         {
             var stack = (Stack<T>)obj;
-            context.Stream.Write(stack.Count);
+            context.StreamWriter.Write(stack.Count);
             foreach (var element in stack)
             {
                 SerializationManager.SerializeInner(element, context, typeof(T));
@@ -482,7 +482,7 @@ namespace Orleans.Serialization
 
         internal static object DeserializeStack<T>(Type expected, IDeserializationContext context)
         {
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var list = new List<T>(count);
             var stack = new Stack<T>(count);
             context.RecordObject(stack);
@@ -547,7 +547,7 @@ namespace Orleans.Serialization
             var dict = (Dictionary<K, V>)original;
             SerializationManager.SerializeInner(dict.Comparer.Equals(EqualityComparer<K>.Default) ? null : dict.Comparer,
                                            context, typeof(IEqualityComparer<K>));
-            context.Stream.Write(dict.Count);
+            context.StreamWriter.Write(dict.Count);
             foreach (var pair in dict)
             {
                 SerializationManager.SerializeInner(pair.Key, context, typeof(K));
@@ -558,7 +558,7 @@ namespace Orleans.Serialization
         internal static object DeserializeDictionary<K, V>(Type expected, IDeserializationContext context)
         {
             var comparer = (IEqualityComparer<K>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<K>), context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var dict = new Dictionary<K, V>(count, comparer);
             context.RecordObject(dict);
             for (var i = 0; i < count; i++)
@@ -611,7 +611,7 @@ namespace Orleans.Serialization
         internal static void SerializeReadOnlyDictionary<K, V>(object original, ISerializationContext context, Type expected)
         {
             var dict = (ReadOnlyDictionary<K, V>)original;
-            context.Stream.Write(dict.Count);
+            context.StreamWriter.Write(dict.Count);
             foreach (var pair in dict)
             {
                 SerializationManager.SerializeInner(pair.Key, context, typeof(K));
@@ -621,7 +621,7 @@ namespace Orleans.Serialization
 
         internal static object DeserializeReadOnlyDictionary<K, V>(Type expected, IDeserializationContext context)
         {
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var dict = new Dictionary<K, V>(count);
             for (var i = 0; i < count; i++)
             {
@@ -659,11 +659,11 @@ namespace Orleans.Serialization
             var dict = (Dictionary<string, object>)original;
             SerializationManager.SerializeInner(dict.Comparer.Equals(EqualityComparer<string>.Default) ? null : dict.Comparer,
                                            context, typeof(IEqualityComparer<string>));
-            context.Stream.Write(dict.Count);
+            context.StreamWriter.Write(dict.Count);
             foreach (var pair in dict)
             {
                 //context.Stream.WriteTypeHeader(stringType, stringType);
-                context.Stream.Write(pair.Key);
+                context.StreamWriter.Write(pair.Key);
                 SerializationManager.SerializeInner(pair.Value, context, objectType);
             }
         }
@@ -671,13 +671,13 @@ namespace Orleans.Serialization
         internal static object DeserializeStringObjectDictionary(Type expected, IDeserializationContext context)
         {
             var comparer = (IEqualityComparer<string>)SerializationManager.DeserializeInner(typeof(IEqualityComparer<string>), context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var dict = new Dictionary<string, object>(count, comparer);
             context.RecordObject(dict);
             for (var i = 0; i < count; i++)
             {
                 //context.Stream.ReadFullTypeHeader(stringType); // Skip the type header, which will be string
-                var key = context.Stream.ReadString();
+                var key = context.StreamReader.ReadString();
                 var value = SerializationManager.DeserializeInner(null, context);
                 dict[key] = value;
             }
@@ -725,7 +725,7 @@ namespace Orleans.Serialization
         {
             var dict = (SortedDictionary<K, V>)original;
             SerializationManager.SerializeInner(dict.Comparer.Equals(Comparer<K>.Default) ? null : dict.Comparer, context, typeof(IComparer<K>));
-            context.Stream.Write(dict.Count);
+            context.StreamWriter.Write(dict.Count);
             foreach (var pair in dict)
             {
                 SerializationManager.SerializeInner(pair.Key, context, typeof(K));
@@ -736,7 +736,7 @@ namespace Orleans.Serialization
         internal static object DeserializeSortedDictionary<K, V>(Type expected, IDeserializationContext context)
         {
             var comparer = (IComparer<K>)SerializationManager.DeserializeInner(typeof(IComparer<K>), context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var dict = new SortedDictionary<K, V>(comparer);
             context.RecordObject(dict);
             for (var i = 0; i < count; i++)
@@ -794,7 +794,7 @@ namespace Orleans.Serialization
         {
             var list = (SortedList<K, V>)original;
             SerializationManager.SerializeInner(list.Comparer.Equals(Comparer<K>.Default) ? null : list.Comparer, context, typeof(IComparer<K>));
-            context.Stream.Write(list.Count);
+            context.StreamWriter.Write(list.Count);
             foreach (var pair in list)
             {
                 SerializationManager.SerializeInner(pair.Key, context, typeof(K));
@@ -805,7 +805,7 @@ namespace Orleans.Serialization
         internal static object DeserializeSortedList<K, V>(Type expected, IDeserializationContext context)
         {
             var comparer = (IComparer<K>)SerializationManager.DeserializeInner(typeof(IComparer<K>), context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var list = new SortedList<K, V>(count, comparer);
             context.RecordObject(list);
             for (var i = 0; i < count; i++)
@@ -872,7 +872,7 @@ namespace Orleans.Serialization
             SerializationManager.SerializeInner(dict.KeyComparer.Equals(EqualityComparer<K>.Default) ? null : dict.KeyComparer, context, typeof(IEqualityComparer<K>));
             SerializationManager.SerializeInner(dict.ValueComparer.Equals(EqualityComparer<V>.Default) ? null : dict.ValueComparer, context, typeof(IEqualityComparer<V>));
 
-            context.Stream.Write(dict.Count);
+            context.StreamWriter.Write(dict.Count);
             foreach (var pair in dict)
             {
                 SerializationManager.SerializeInner(pair.Key, context, typeof(K));
@@ -884,7 +884,7 @@ namespace Orleans.Serialization
         {
             var keyComparer = SerializationManager.DeserializeInner<IEqualityComparer<K>>(context);
             var valueComparer = SerializationManager.DeserializeInner<IEqualityComparer<V>>(context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var dictBuilder = ImmutableDictionary.CreateBuilder(keyComparer, valueComparer);
             for (var i = 0; i < count; i++)
             {
@@ -921,7 +921,7 @@ namespace Orleans.Serialization
         internal static void SerializeImmutableList<T>(object untypedInput, ISerializationContext context, Type typeExpected)
         {
             var list = (ImmutableList<T>)untypedInput;
-            context.Stream.Write(list.Count);
+            context.StreamWriter.Write(list.Count);
             foreach (var element in list)
             {
                 SerializationManager.SerializeInner(element, context, typeof(T));
@@ -930,7 +930,7 @@ namespace Orleans.Serialization
 
         internal static object DeserializeImmutableList<T>(Type expected, IDeserializationContext context)
         {
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var listBuilder = ImmutableList.CreateBuilder<T>();
 
             for (var i = 0; i < count; i++)
@@ -977,7 +977,7 @@ namespace Orleans.Serialization
             var dict = (ImmutableHashSet<K>)untypedInput;
             SerializationManager.SerializeInner(dict.KeyComparer.Equals(EqualityComparer<K>.Default) ? null : dict.KeyComparer, context, typeof(IEqualityComparer<K>));
 
-            context.Stream.Write(dict.Count);
+            context.StreamWriter.Write(dict.Count);
             foreach (var pair in dict)
             {
                 SerializationManager.SerializeInner(pair, context, typeof(K));
@@ -987,7 +987,7 @@ namespace Orleans.Serialization
         internal static object DeserializeImmutableHashSet<K>(Type expected, IDeserializationContext context)
         {
             var keyComparer = SerializationManager.DeserializeInner<IEqualityComparer<K>>(context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var dictBuilder = ImmutableHashSet.CreateBuilder(keyComparer);
             for (var i = 0; i < count; i++)
             {
@@ -1030,7 +1030,7 @@ namespace Orleans.Serialization
             var dict = (ImmutableSortedSet<K>)untypedInput;
             SerializationManager.SerializeInner(dict.KeyComparer.Equals(Comparer<K>.Default) ? null : dict.KeyComparer, context, typeof(IComparer<K>));
 
-            context.Stream.Write(dict.Count);
+            context.StreamWriter.Write(dict.Count);
             foreach (var pair in dict)
             {
                 SerializationManager.SerializeInner(pair, context, typeof(K));
@@ -1040,7 +1040,7 @@ namespace Orleans.Serialization
         internal static object DeserializeImmutableSortedSet<K>(Type expected, IDeserializationContext context)
         {
             var keyComparer = SerializationManager.DeserializeInner<IComparer<K>>(context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var dictBuilder = ImmutableSortedSet.CreateBuilder(keyComparer);
             for (var i = 0; i < count; i++)
             {
@@ -1084,7 +1084,7 @@ namespace Orleans.Serialization
             SerializationManager.SerializeInner(dict.KeyComparer.Equals(Comparer<K>.Default) ? null : dict.KeyComparer, context, typeof(IComparer<K>));
             SerializationManager.SerializeInner(dict.ValueComparer.Equals(EqualityComparer<V>.Default) ? null : dict.ValueComparer, context, typeof(IEqualityComparer<V>));
 
-            context.Stream.Write(dict.Count);
+            context.StreamWriter.Write(dict.Count);
             foreach (var pair in dict)
             {
                 SerializationManager.SerializeInner(pair.Key, context, typeof(K));
@@ -1096,7 +1096,7 @@ namespace Orleans.Serialization
         {
             var keyComparer = SerializationManager.DeserializeInner<IComparer<K>>(context);
             var valueComparer = SerializationManager.DeserializeInner<IEqualityComparer<V>>(context);
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var dictBuilder = ImmutableSortedDictionary.CreateBuilder(keyComparer, valueComparer);
             for (var i = 0; i < count; i++)
             {
@@ -1139,7 +1139,7 @@ namespace Orleans.Serialization
         {
             var dict = (ImmutableArray<K>)untypedInput;
 
-            context.Stream.Write(dict.Length);
+            context.StreamWriter.Write(dict.Length);
             foreach (var pair in dict)
             {
                 SerializationManager.SerializeInner(pair, context, typeof(K));
@@ -1148,7 +1148,7 @@ namespace Orleans.Serialization
 
         internal static object DeserializeImmutableArray<K>(Type expected, IDeserializationContext context)
         {
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var dictBuilder = ImmutableArray.CreateBuilder<K>();
             for (var i = 0; i < count; i++)
             {
@@ -1189,7 +1189,7 @@ namespace Orleans.Serialization
         {
             var queue = (ImmutableQueue<K>)untypedInput;
 
-            context.Stream.Write(queue.Count());
+            context.StreamWriter.Write(queue.Count());
             foreach (var item in queue)
             {
                 SerializationManager.SerializeInner(item, context, typeof(K));
@@ -1198,7 +1198,7 @@ namespace Orleans.Serialization
 
         internal static object DeserializeImmutableQueue<K>(Type expected, IDeserializationContext context)
         {
-            var count = context.Stream.ReadInt();
+            var count = context.StreamReader.ReadInt();
             var items = new K[count];
             for (var i = 0; i < count; i++)
             {
@@ -1524,15 +1524,15 @@ namespace Orleans.Serialization
             }
             else
             {
-                context.Stream.WriteNull();
+                context.StreamWriter.WriteNull();
             }
         }
 
         internal static object DeserializeNullable<T>(Type expected, IDeserializationContext context) where T : struct
         {
-            if (context.Stream.PeekToken() == SerializationTokenType.Null)
+            if (context.StreamReader.PeekToken() == SerializationTokenType.Null)
             {
-                context.Stream.ReadToken();
+                context.StreamReader.ReadToken();
                 return new T?();
             }
 
@@ -1597,12 +1597,12 @@ namespace Orleans.Serialization
         internal static void SerializeTimeSpan(object obj, ISerializationContext context, Type expected)
         {
             var ts = (TimeSpan)obj;
-            context.Stream.Write(ts.Ticks);
+            context.StreamWriter.Write(ts.Ticks);
         }
 
         internal static object DeserializeTimeSpan(Type expected, IDeserializationContext context)
         {
-            return new TimeSpan(context.Stream.ReadLong());
+            return new TimeSpan(context.StreamReader.ReadLong());
         }
 
         internal static object CopyTimeSpan(object obj, ICopyContext context)
@@ -1617,13 +1617,13 @@ namespace Orleans.Serialization
         internal static void SerializeDateTimeOffset(object obj, ISerializationContext context, Type expected)
         {
             var dts = (DateTimeOffset)obj;
-            context.Stream.Write(dts.DateTime.Ticks);
-            context.Stream.Write(dts.Offset.Ticks);
+            context.StreamWriter.Write(dts.DateTime.Ticks);
+            context.StreamWriter.Write(dts.Offset.Ticks);
         }
 
         internal static object DeserializeDateTimeOffset(Type expected, IDeserializationContext context)
         {
-            return new DateTimeOffset(context.Stream.ReadLong(), new TimeSpan(context.Stream.ReadLong()));
+            return new DateTimeOffset(context.StreamReader.ReadLong(), new TimeSpan(context.StreamReader.ReadLong()));
         }
 
         internal static object CopyDateTimeOffset(object obj, ICopyContext context)
@@ -1637,12 +1637,12 @@ namespace Orleans.Serialization
 
         internal static void SerializeType(object obj, ISerializationContext context, Type expected)
         {
-            context.Stream.Write(((Type)obj).OrleansTypeKeyString());
+            context.StreamWriter.Write(((Type)obj).OrleansTypeKeyString());
         }
 
         internal static object DeserializeType(Type expected, IDeserializationContext context)
         {
-            return SerializationManager.ResolveTypeName(context.Stream.ReadString());
+            return SerializationManager.ResolveTypeName(context.StreamReader.ReadString());
         }
 
         internal static object CopyType(object obj, ICopyContext context)
@@ -1657,12 +1657,12 @@ namespace Orleans.Serialization
         internal static void SerializeGuid(object obj, ISerializationContext context, Type expected)
         {
             var guid = (Guid)obj;
-            context.Stream.Write(guid.ToByteArray());
+            context.StreamWriter.Write(guid.ToByteArray());
         }
 
         internal static object DeserializeGuid(Type expected, IDeserializationContext context)
         {
-            var bytes = context.Stream.ReadBytes(16);
+            var bytes = context.StreamReader.ReadBytes(16);
             return new Guid(bytes);
         }
 
@@ -1681,13 +1681,13 @@ namespace Orleans.Serialization
         internal static void SerializeUri(object obj, ISerializationContext context, Type expected)
         {
             if (uriConverter == null) uriConverter = TypeDescriptor.GetConverter(typeof(Uri));
-            context.Stream.Write(uriConverter.ConvertToInvariantString(obj));
+            context.StreamWriter.Write(uriConverter.ConvertToInvariantString(obj));
         }
 
         internal static object DeserializeUri(Type expected, IDeserializationContext context)
         {
             if (uriConverter == null) uriConverter = TypeDescriptor.GetConverter(typeof(Uri));
-            return uriConverter.ConvertFromInvariantString(context.Stream.ReadString());
+            return uriConverter.ConvertFromInvariantString(context.StreamReader.ReadString());
         }
 
         internal static object CopyUri(object obj, ICopyContext context)
@@ -1706,12 +1706,12 @@ namespace Orleans.Serialization
         internal static void SerializeGrainId(object obj, ISerializationContext context, Type expected)
         {
             var id = (GrainId)obj;
-            context.Stream.Write(id);
+            context.StreamWriter.Write(id);
         }
 
         internal static object DeserializeGrainId(Type expected, IDeserializationContext context)
         {
-            return context.Stream.ReadGrainId();
+            return context.StreamReader.ReadGrainId();
         }
 
         internal static object CopyGrainId(object original, ICopyContext context)
@@ -1722,12 +1722,12 @@ namespace Orleans.Serialization
         internal static void SerializeActivationId(object obj, ISerializationContext context, Type expected)
         {
             var id = (ActivationId)obj;
-            context.Stream.Write(id);
+            context.StreamWriter.Write(id);
         }
 
         internal static object DeserializeActivationId(Type expected, IDeserializationContext context)
         {
-            return context.Stream.ReadActivationId();
+            return context.StreamReader.ReadActivationId();
         }
 
         internal static object CopyActivationId(object original, ICopyContext context)
@@ -1738,12 +1738,12 @@ namespace Orleans.Serialization
         internal static void SerializeActivationAddress(object obj, ISerializationContext context, Type expected)
         {
             var addr = (ActivationAddress)obj;
-            context.Stream.Write(addr);
+            context.StreamWriter.Write(addr);
         }
 
         internal static object DeserializeActivationAddress(Type expected, IDeserializationContext context)
         {
-            return context.Stream.ReadActivationAddress();
+            return context.StreamReader.ReadActivationAddress();
         }
 
         internal static object CopyActivationAddress(object original, ICopyContext context)
@@ -1754,12 +1754,12 @@ namespace Orleans.Serialization
         internal static void SerializeIPAddress(object obj, ISerializationContext context, Type expected)
         {
             var ip = (IPAddress)obj;
-            context.Stream.Write(ip);
+            context.StreamWriter.Write(ip);
         }
 
         internal static object DeserializeIPAddress(Type expected, IDeserializationContext context)
         {
-            return context.Stream.ReadIPAddress();
+            return context.StreamReader.ReadIPAddress();
         }
 
         internal static object CopyIPAddress(object original, ICopyContext context)
@@ -1770,12 +1770,12 @@ namespace Orleans.Serialization
         internal static void SerializeIPEndPoint(object obj, ISerializationContext context, Type expected)
         {
             var ep = (IPEndPoint)obj;
-            context.Stream.Write(ep);
+            context.StreamWriter.Write(ep);
         }
 
         internal static object DeserializeIPEndPoint(Type expected, IDeserializationContext context)
         {
-            return context.Stream.ReadIPEndPoint();
+            return context.StreamReader.ReadIPEndPoint();
         }
 
         internal static object CopyIPEndPoint(object original, ICopyContext context)
@@ -1786,12 +1786,12 @@ namespace Orleans.Serialization
         internal static void SerializeCorrelationId(object obj, ISerializationContext context, Type expected)
         {
             var id = (CorrelationId)obj;
-            context.Stream.Write(id);
+            context.StreamWriter.Write(id);
         }
 
         internal static object DeserializeCorrelationId(Type expected, IDeserializationContext context)
         {
-            var bytes = context.Stream.ReadBytes(CorrelationId.SIZE_BYTES);
+            var bytes = context.StreamReader.ReadBytes(CorrelationId.SIZE_BYTES);
             return new CorrelationId(bytes);
         }
 
@@ -1803,12 +1803,12 @@ namespace Orleans.Serialization
         internal static void SerializeSiloAddress(object obj, ISerializationContext context, Type expected)
         {
             var addr = (SiloAddress)obj;
-            context.Stream.Write(addr);
+            context.StreamWriter.Write(addr);
         }
 
         internal static object DeserializeSiloAddress(Type expected, IDeserializationContext context)
         {
-            return context.Stream.ReadSiloAddress();
+            return context.StreamReader.ReadSiloAddress();
         }
 
         internal static object CopySiloAddress(object original, ICopyContext context)
@@ -1829,9 +1829,9 @@ namespace Orleans.Serialization
         {
             var request = (InvokeMethodRequest)obj;
 
-            context.Stream.Write(request.InterfaceId);
-            context.Stream.Write(request.MethodId);
-            context.Stream.Write(request.Arguments != null ? request.Arguments.Length : 0);
+            context.StreamWriter.Write(request.InterfaceId);
+            context.StreamWriter.Write(request.MethodId);
+            context.StreamWriter.Write(request.Arguments != null ? request.Arguments.Length : 0);
             if (request.Arguments != null)
             {
                 foreach (var arg in request.Arguments)
@@ -1843,10 +1843,10 @@ namespace Orleans.Serialization
 
         internal static object DeserializeInvokeMethodRequest(Type expected, IDeserializationContext context)
         {
-            int iid = context.Stream.ReadInt();
-            int mid = context.Stream.ReadInt();
+            int iid = context.StreamReader.ReadInt();
+            int mid = context.StreamReader.ReadInt();
 
-            int argCount = context.Stream.ReadInt();
+            int argCount = context.StreamReader.ReadInt();
             object[] args = null;
 
             if (argCount > 0)

--- a/src/Orleans/Serialization/DeserializationContext.cs
+++ b/src/Orleans/Serialization/DeserializationContext.cs
@@ -5,7 +5,7 @@ namespace Orleans.Serialization
 {
     public interface IDeserializationContext
     {
-        BinaryTokenStreamReader Stream { get; }
+        BinaryTokenStreamReader StreamReader { get; }
         int CurrentObjectOffset { get; set; }
         void RecordObject(object obj);
         object FetchReferencedObject(int offset);
@@ -20,7 +20,7 @@ namespace Orleans.Serialization
             taggedObjects = new Dictionary<int, object>();
         }
 
-        public BinaryTokenStreamReader Stream { get; set; }
+        public BinaryTokenStreamReader StreamReader { get; set; }
 
         internal void Reset()
         {

--- a/src/Orleans/Serialization/DeserializationContext.cs
+++ b/src/Orleans/Serialization/DeserializationContext.cs
@@ -1,25 +1,26 @@
-using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Orleans.Serialization
 {
-    public class DeserializationContext
+    public interface IDeserializationContext
     {
-        [ThreadStatic]
-        private static DeserializationContext ctx;
+        BinaryTokenStreamReader Stream { get; }
+        int CurrentObjectOffset { get; set; }
+        void RecordObject(object obj);
+        object FetchReferencedObject(int offset);
+    }
 
-        public static DeserializationContext Current
-        {
-            get { return ctx ?? (ctx = new DeserializationContext()); }
-        }
-
+    public class DeserializationContext : IDeserializationContext
+    {
         private readonly Dictionary<int, object> taggedObjects;
 
-        private DeserializationContext()
+        public DeserializationContext()
         {
             taggedObjects = new Dictionary<int, object>();
         }
+
+        public BinaryTokenStreamReader Stream { get; set; }
 
         internal void Reset()
         {
@@ -27,19 +28,14 @@ namespace Orleans.Serialization
             CurrentObjectOffset = 0;
         }
 
-        internal int CurrentObjectOffset { get; set; }
-
-        internal void RecordObject(int offset, object obj)
-        {
-            taggedObjects[offset] = obj;
-        }
+        public int CurrentObjectOffset { get; set; }
 
         public void RecordObject(object obj)
         {
             taggedObjects[CurrentObjectOffset] = obj;
         }
 
-        internal object FetchReferencedObject(int offset)
+        public object FetchReferencedObject(int offset)
         {
             object result;
             if (!taggedObjects.TryGetValue(offset, out result))

--- a/src/Orleans/Serialization/IExternalSerializer.cs
+++ b/src/Orleans/Serialization/IExternalSerializer.cs
@@ -29,23 +29,24 @@ namespace Orleans.Serialization
         /// Tries to create a copy of source.
         /// </summary>
         /// <param name="source">The item to create a copy of</param>
+        /// <param name="context">The context in which the object is being copied.</param>
         /// <returns>The copy</returns>
-        object DeepCopy(object source);
+        object DeepCopy(object source, ICopyContext context);
 
         /// <summary>
         /// Tries to serialize an item.
         /// </summary>
         /// <param name="item">The instance of the object being serialized</param>
-        /// <param name="writer">The writer used for serialization</param>
+        /// <param name="context">The context in which the object is being serialized.</param>
         /// <param name="expectedType">The type that the deserializer will expect</param>
-        void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType);
+        void Serialize(object item, ISerializationContext context, Type expectedType);
 
         /// <summary>
         /// Tries to deserialize an item.
         /// </summary>
-        /// <param name="reader">The reader used for binary deserialization</param>
-        /// <param name="expectedType">The type that should be deserialzied</param>
+        /// <param name="context">The context in which the object is being deserialized.</param>
+        /// <param name="expectedType">The type that should be deserialized</param>
         /// <returns>The deserialized object</returns>
-        object Deserialize(Type expectedType, BinaryTokenStreamReader reader);
+        object Deserialize(Type expectedType, IDeserializationContext context);
     }
 }

--- a/src/Orleans/Serialization/ILBasedSerializer.cs
+++ b/src/Orleans/Serialization/ILBasedSerializer.cs
@@ -58,7 +58,7 @@
             this.typeSerializer = new SerializerBundle(
                 typeof(Type),
                 new SerializationManager.SerializerMethods(
-                    original => original,
+                    (original, context) => original,
                     (original, writer, expected) => { this.WriteNamedType((Type)original, writer); },
                     (expected, reader) => this.ReadNamedType(reader)));
             this.generateSerializer = this.GenerateSerializer;
@@ -80,80 +80,68 @@
         public bool IsSupportedType(Type t)
             => this.serializers.ContainsKey(t) || ILSerializerGenerator.IsSupportedType(t.GetTypeInfo());
 
-        /// <summary>
-        /// Tries to create a copy of source.
-        /// </summary>
-        /// <param name="source">The item to create a copy of</param>
-        /// <returns>The copy</returns>
-        public object DeepCopy(object source)
+        /// <inheritdoc />
+        public object DeepCopy(object source, ICopyContext context)
         {
             if (source == null) return null;
             Type type = source.GetType();
-            return this.serializers.GetOrAdd(type, this.generateSerializer).Methods.DeepCopy(source);
+            return this.serializers.GetOrAdd(type, this.generateSerializer).Methods.DeepCopy(source, context);
         }
 
-        /// <summary>
-        /// Tries to serialize an item.
-        /// </summary>
-        /// <param name="item">The instance of the object being serialized</param>
-        /// <param name="writer">The writer used for serialization</param>
-        /// <param name="expectedType">The type that the deserializer will expect</param>
-        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        /// <inheritdoc />
+        public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
             if (item == null)
             {
-                writer.WriteNull();
+                context.Stream.WriteNull();
                 return;
             }
 
             var actualType = item.GetType();
-            this.WriteType(actualType, expectedType, writer);
-            this.serializers.GetOrAdd(actualType, this.generateSerializer).Methods.Serialize(item, writer, expectedType);
+            this.WriteType(actualType, expectedType, context);
+            this.serializers.GetOrAdd(actualType, this.generateSerializer).Methods.Serialize(item, context, expectedType);
         }
 
-        /// <summary>
-        /// Tries to deserialize an item.
-        /// </summary>
-        /// <param name="expectedType">The type that should be deserialzied</param>
-        /// <param name="reader">The reader used for binary deserialization</param>
-        /// <returns>The deserialized object</returns>
-        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        /// <inheritdoc />
+        public object Deserialize(Type expectedType, IDeserializationContext context)
         {
+            var reader = context.Stream;
             var token = reader.ReadToken();
             if (token == SerializationTokenType.Null) return null;
-            var actualType = this.ReadType(token, reader, expectedType);
+            var actualType = this.ReadType(token, context, expectedType);
             return this.serializers.GetOrAdd(actualType, this.generateSerializer)
-                       .Methods.Deserialize(expectedType, reader);
+                       .Methods.Deserialize(expectedType, context);
         }
 
-        private void WriteType(Type actualType, Type expectedType, BinaryTokenStreamWriter writer)
+        private void WriteType(Type actualType, Type expectedType, ISerializationContext context)
         {
             if (actualType == expectedType)
             {
-                writer.Write((byte)SerializationTokenType.ExpectedType);
+                context.Stream.Write((byte)SerializationTokenType.ExpectedType);
             }
             else
             {
-                writer.Write((byte)SerializationTokenType.NamedType);
-                this.WriteNamedType(actualType, writer);
+                context.Stream.Write((byte)SerializationTokenType.NamedType);
+                this.WriteNamedType(actualType, context);
             }
         }
 
-        private Type ReadType(SerializationTokenType token, BinaryTokenStreamReader reader, Type expectedType)
+        private Type ReadType(SerializationTokenType token, IDeserializationContext context, Type expectedType)
         {
             switch (token)
             {
                 case SerializationTokenType.ExpectedType:
                     return expectedType;
                 case SerializationTokenType.NamedType:
-                    return this.ReadNamedType(reader);
+                    return this.ReadNamedType(context);
                 default:
                     throw new NotSupportedException($"{nameof(SerializationTokenType)} of {token} is not supported.");
             }
         }
 
-        private Type ReadNamedType(BinaryTokenStreamReader reader)
+        private Type ReadNamedType(IDeserializationContext context)
         {
+            var reader = context.Stream;
             var hashCode = reader.ReadInt();
             var count = reader.ReadUShort();
             var typeName = reader.ReadBytes(count);
@@ -162,8 +150,9 @@
                 k => Type.GetType(Encoding.UTF8.GetString(k.TypeName), throwOnError: true));
         }
 
-        private void WriteNamedType(Type type, BinaryTokenStreamWriter writer)
+        private void WriteNamedType(Type type, ISerializationContext context)
         {
+            var writer = context.Stream;
             var key = this.typeCache.GetOrAdd(type, t => new TypeKey(Encoding.UTF8.GetBytes(t.AssemblyQualifiedName)));
             writer.Write(key.HashCode);
             writer.Write((ushort)key.TypeName.Length);

--- a/src/Orleans/Serialization/ILBasedSerializer.cs
+++ b/src/Orleans/Serialization/ILBasedSerializer.cs
@@ -93,7 +93,7 @@
         {
             if (item == null)
             {
-                context.Stream.WriteNull();
+                context.StreamWriter.WriteNull();
                 return;
             }
 
@@ -105,7 +105,7 @@
         /// <inheritdoc />
         public object Deserialize(Type expectedType, IDeserializationContext context)
         {
-            var reader = context.Stream;
+            var reader = context.StreamReader;
             var token = reader.ReadToken();
             if (token == SerializationTokenType.Null) return null;
             var actualType = this.ReadType(token, context, expectedType);
@@ -117,11 +117,11 @@
         {
             if (actualType == expectedType)
             {
-                context.Stream.Write((byte)SerializationTokenType.ExpectedType);
+                context.StreamWriter.Write((byte)SerializationTokenType.ExpectedType);
             }
             else
             {
-                context.Stream.Write((byte)SerializationTokenType.NamedType);
+                context.StreamWriter.Write((byte)SerializationTokenType.NamedType);
                 this.WriteNamedType(actualType, context);
             }
         }
@@ -141,7 +141,7 @@
 
         private Type ReadNamedType(IDeserializationContext context)
         {
-            var reader = context.Stream;
+            var reader = context.StreamReader;
             var hashCode = reader.ReadInt();
             var count = reader.ReadUShort();
             var typeName = reader.ReadBytes(count);
@@ -152,7 +152,7 @@
 
         private void WriteNamedType(Type type, ISerializationContext context)
         {
-            var writer = context.Stream;
+            var writer = context.StreamWriter;
             var key = this.typeCache.GetOrAdd(type, t => new TypeKey(Encoding.UTF8.GetBytes(t.AssemblyQualifiedName)));
             writer.Write(key.HashCode);
             writer.Write((ushort)key.TypeName.Length);

--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -82,57 +82,51 @@ namespace Orleans.Serialization
             return settings;
         }
 
-        /// <summary>
-        /// Initializes the serializer
-        /// </summary>
-        /// <param name="logger">The logger to use to capture any serialization events</param>
+        /// <inheritdoc />
         public void Initialize(Logger logger)
         {
             this.logger = logger;
         }
 
-        /// <summary>
-        /// Informs the serialization manager whether this serializer supports the type for serialization.
-        /// </summary>
-        /// <param name="itemType">The type of the item to be serialized</param>
-        /// <returns>A value indicating whether the item can be serialized.</returns>
+        /// <inheritdoc />
         public bool IsSupportedType(Type itemType)
         {
             return true;
         }
 
-        /// <summary>
-        /// Creates a deep copy of an object
-        /// </summary>
-        /// <param name="source">The source object to be copy</param>
-        /// <returns>The copy that was created</returns>
-        public object DeepCopy(object source)
+        /// <inheritdoc />
+        public object DeepCopy(object source, ICopyContext context)
         {
             if (source == null)
             {
                 return null;
             }
 
-            var writer = new BinaryTokenStreamWriter();
-            Serialize(source, writer, source.GetType());
-            var retVal = Deserialize(source.GetType(), new BinaryTokenStreamReader(writer.ToByteArray()));
-            writer.ReleaseBuffers();
+            var serializationContext = new SerializationContext
+            {
+                Stream = new BinaryTokenStreamWriter()
+            };
+            
+            Serialize(source, serializationContext, source.GetType());
+            var deserializationContext = new DeserializationContext
+            {
+                Stream = new BinaryTokenStreamReader(serializationContext.Stream.ToBytes())
+            };
+
+            var retVal = Deserialize(source.GetType(), deserializationContext);
+            serializationContext.Stream.ReleaseBuffers();
             return retVal;
         }
 
-        /// <summary>
-        /// Deserializes an object from a binary stream
-        /// </summary>
-        /// <param name="expectedType">The type that is expected to be deserialized</param>
-        /// <param name="reader">The <see cref="BinaryTokenStreamReader"/></param>
-        /// <returns>The deserialized object</returns>
-        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        /// <inheritdoc />
+        public object Deserialize(Type expectedType, IDeserializationContext context)
         {
-            if (reader == null)
+            if (context == null)
             {
-                throw new ArgumentNullException("reader");
+                throw new ArgumentNullException(nameof(context));
             }
 
+            var reader = context.Stream;
             var str = reader.ReadString();
             return JsonConvert.DeserializeObject(str, expectedType, defaultSettings);
         }
@@ -141,15 +135,16 @@ namespace Orleans.Serialization
         /// Serializes an object to a binary stream
         /// </summary>
         /// <param name="item">The object to serialize</param>
-        /// <param name="writer">The <see cref="BinaryTokenStreamWriter"/></param>
+        /// <param name="context">The serialization context.</param>
         /// <param name="expectedType">The type the deserializer should expect</param>
-        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
-            if (writer == null)
+            if (context == null)
             {
-                throw new ArgumentNullException("writer");
+                throw new ArgumentNullException(nameof(context));
             }
 
+            var writer = context.Stream;
             if (item == null)
             {
                 writer.WriteNull();

--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -104,17 +104,17 @@ namespace Orleans.Serialization
 
             var serializationContext = new SerializationContext
             {
-                Stream = new BinaryTokenStreamWriter()
+                StreamWriter = new BinaryTokenStreamWriter()
             };
             
             Serialize(source, serializationContext, source.GetType());
             var deserializationContext = new DeserializationContext
             {
-                Stream = new BinaryTokenStreamReader(serializationContext.Stream.ToBytes())
+                StreamReader = new BinaryTokenStreamReader(serializationContext.StreamWriter.ToBytes())
             };
 
             var retVal = Deserialize(source.GetType(), deserializationContext);
-            serializationContext.Stream.ReleaseBuffers();
+            serializationContext.StreamWriter.ReleaseBuffers();
             return retVal;
         }
 
@@ -126,7 +126,7 @@ namespace Orleans.Serialization
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var reader = context.Stream;
+            var reader = context.StreamReader;
             var str = reader.ReadString();
             return JsonConvert.DeserializeObject(str, expectedType, defaultSettings);
         }
@@ -144,7 +144,7 @@ namespace Orleans.Serialization
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var writer = context.Stream;
+            var writer = context.StreamWriter;
             if (item == null)
             {
                 writer.WriteNull();

--- a/src/Orleans/Serialization/ReflectedSerializationMethodInfo.cs
+++ b/src/Orleans/Serialization/ReflectedSerializationMethodInfo.cs
@@ -12,7 +12,7 @@ namespace Orleans.Serialization
     internal class ReflectedSerializationMethodInfo
     {
         /// <summary>
-        /// A reference to the <see cref="SerializationContext.Stream"/> getter.
+        /// A reference to the <see cref="SerializationContext.StreamWriter"/> getter.
         /// </summary>
         public readonly MethodInfo GetStreamFromSerializationContext;
 
@@ -85,8 +85,8 @@ namespace Orleans.Serialization
             
             this.RecordObjectWhileCopying = TypeUtils.Method((ICopyContext ctx) => ctx.RecordCopy(default(object), default(object)));
 
-            this.GetStreamFromDeserializationContext = TypeUtils.Property((IDeserializationContext ctx) => ctx.Stream).GetMethod;
-            this.GetStreamFromSerializationContext = TypeUtils.Property((ISerializationContext ctx) => ctx.Stream).GetMethod;
+            this.GetStreamFromDeserializationContext = TypeUtils.Property((IDeserializationContext ctx) => ctx.StreamReader).GetMethod;
+            this.GetStreamFromSerializationContext = TypeUtils.Property((ISerializationContext ctx) => ctx.StreamWriter).GetMethod;
 
             this.RecordObjectWhileDeserializing = TypeUtils.Method((IDeserializationContext ctx) => ctx.RecordObject(default(object)));
             this.SerializerDelegate =

--- a/src/Orleans/Serialization/ReflectedSerializationMethodInfo.cs
+++ b/src/Orleans/Serialization/ReflectedSerializationMethodInfo.cs
@@ -12,12 +12,17 @@ namespace Orleans.Serialization
     internal class ReflectedSerializationMethodInfo
     {
         /// <summary>
-        /// A reference to the <see cref="SerializationContext.Current"/> getter method.
+        /// A reference to the <see cref="SerializationContext.Stream"/> getter.
         /// </summary>
-        public readonly MethodInfo GetCurrentSerializationContext;
+        public readonly MethodInfo GetStreamFromSerializationContext;
 
         /// <summary>
-        /// A reference to the <see cref="SerializationContext.RecordObject(object, object)"/> method.
+        /// A reference to the getter for <see cref="SerializationManager.CurrentDeserializationContext"/>.
+        /// </summary>
+        public readonly MethodInfo GetStreamFromDeserializationContext;
+
+        /// <summary>
+        /// A reference to the <see cref="SerializationContext.RecordCopy"/> method.
         /// </summary>
         public readonly MethodInfo RecordObjectWhileCopying;
 
@@ -27,24 +32,19 @@ namespace Orleans.Serialization
         public readonly MethodInfo DeepCopyInner;
 
         /// <summary>
-        /// A reference to the <see cref="SerializationManager.SerializeInner(object, BinaryTokenStreamWriter, Type)"/> method.
+        /// A reference to the <see cref="SerializationManager.SerializeInner(object, ISerializationContext, Type)"/> method.
         /// </summary>
         public readonly MethodInfo SerializeInner;
 
         /// <summary>
-        /// A reference to the <see cref="SerializationManager.DeserializeInner(Type, BinaryTokenStreamReader)"/> method.
+        /// A reference to the <see cref="SerializationManager.DeserializeInner(Type, IDeserializationContext)"/> method.
         /// </summary>
         public readonly MethodInfo DeserializeInner;
 
         /// <summary>
-        /// A reference to the <see cref="DeserializationContext.RecordObject(object)"/> method.
+        /// A reference to the <see cref="IDeserializationContext.RecordObject(object)"/> method.
         /// </summary>
         public readonly MethodInfo RecordObjectWhileDeserializing;
-
-        /// <summary>
-        /// A reference to the getter for <see cref="DeserializationContext.Current"/>.
-        /// </summary>
-        public readonly MethodInfo GetCurrentDeserializationContext;
 
         /// <summary>
         /// A reference to a method which returns an uninitialized object of the provided type.
@@ -78,20 +78,21 @@ namespace Orleans.Serialization
 #else
             this.GetUninitializedObject = TypeUtils.Method(() => FormatterServices.GetUninitializedObject(typeof(int)));
 #endif
-            this.GetTypeFromHandle = TypeUtils.Method(() => Type.GetTypeFromHandle(typeof(int).TypeHandle));
-            this.DeepCopyInner = TypeUtils.Method(() => SerializationManager.DeepCopyInner(typeof(int)));
-            this.SerializeInner = TypeUtils.Method(() => SerializationManager.SerializeInner(default(object), default(BinaryTokenStreamWriter), default(Type)));
-            this.DeserializeInner = TypeUtils.Method(() => SerializationManager.DeserializeInner(default(Type), default(BinaryTokenStreamReader)));
+            this.GetTypeFromHandle = TypeUtils.Method(() => Type.GetTypeFromHandle(typeof(Type).TypeHandle));
+            this.DeepCopyInner = TypeUtils.Method(() => SerializationManager.DeepCopyInner(default(Type), default(ICopyContext)));
+            this.SerializeInner = TypeUtils.Method(() => SerializationManager.SerializeInner(default(object), default(ISerializationContext), default(Type)));
+            this.DeserializeInner = TypeUtils.Method(() => SerializationManager.DeserializeInner(default(Type), default(IDeserializationContext)));
+            
+            this.RecordObjectWhileCopying = TypeUtils.Method((ICopyContext ctx) => ctx.RecordCopy(default(object), default(object)));
 
-            this.GetCurrentSerializationContext = TypeUtils.Property((object _) => SerializationContext.Current).GetMethod;
-            this.RecordObjectWhileCopying = TypeUtils.Method((SerializationContext ctx) => ctx.RecordObject(default(object), default(object)));
+            this.GetStreamFromDeserializationContext = TypeUtils.Property((IDeserializationContext ctx) => ctx.Stream).GetMethod;
+            this.GetStreamFromSerializationContext = TypeUtils.Property((ISerializationContext ctx) => ctx.Stream).GetMethod;
 
-            this.GetCurrentDeserializationContext = TypeUtils.Property((object _) => DeserializationContext.Current).GetMethod;
-            this.RecordObjectWhileDeserializing = TypeUtils.Method((DeserializationContext ctx) => ctx.RecordObject(default(object)));
+            this.RecordObjectWhileDeserializing = TypeUtils.Method((IDeserializationContext ctx) => ctx.RecordObject(default(object)));
             this.SerializerDelegate =
-                TypeUtils.Method((SerializationManager.Serializer del) => del.Invoke(default(object), default(BinaryTokenStreamWriter), default(Type)));
-            this.DeserializerDelegate = TypeUtils.Method((SerializationManager.Deserializer del) => del.Invoke(default(Type), default(BinaryTokenStreamReader)));
-            this.DeepCopierDelegate = TypeUtils.Method((SerializationManager.DeepCopier del) => del.Invoke(default(object)));
+                TypeUtils.Method((SerializationManager.Serializer del) => del.Invoke(default(object), default(ISerializationContext), default(Type)));
+            this.DeserializerDelegate = TypeUtils.Method((SerializationManager.Deserializer del) => del.Invoke(default(Type), default(IDeserializationContext)));
+            this.DeepCopierDelegate = TypeUtils.Method((SerializationManager.DeepCopier del) => del.Invoke(default(object), default(ICopyContext)));
         }
     }
 }

--- a/src/Orleans/Serialization/SerializationContext.cs
+++ b/src/Orleans/Serialization/SerializationContext.cs
@@ -19,7 +19,7 @@ namespace Orleans.Serialization
 
     public interface ISerializationContext
     {
-        BinaryTokenStreamWriter Stream { get; }
+        BinaryTokenStreamWriter StreamWriter { get; }
         void RecordObject(object original);
         int CheckObjectWhileSerializing(object raw);
     }
@@ -52,7 +52,7 @@ namespace Orleans.Serialization
             }
         }
 
-        public BinaryTokenStreamWriter Stream { get; set; }
+        public BinaryTokenStreamWriter StreamWriter { get; set; }
 
         private readonly Dictionary<object, Record> processedObjects;
 
@@ -83,7 +83,7 @@ namespace Orleans.Serialization
 
         public void RecordObject(object original)
         {
-            processedObjects[original] = new Record(this.Stream.CurrentOffset);
+            processedObjects[original] = new Record(this.StreamWriter.CurrentOffset);
         }
         
         // Returns an object suitable for insertion if this is a back-reference, or null if it's new

--- a/src/Orleans/Serialization/SerializationContext.cs
+++ b/src/Orleans/Serialization/SerializationContext.cs
@@ -3,6 +3,27 @@ using System.Collections.Generic;
 
 namespace Orleans.Serialization
 {
+    public interface ICopyContext
+    {
+        /// <summary>
+        /// Record an object-to-copy mapping into the current serialization context.
+        /// Used for maintaining the .NET object graph during serialization operations.
+        /// Used in generated code.
+        /// </summary>
+        /// <param name="original">Original object.</param>
+        /// <param name="copy">Copy object that will be the serialized form of the original.</param>
+        void RecordCopy(object original, object copy);
+
+        object CheckObjectWhileCopying(object raw);
+    }
+
+    public interface ISerializationContext
+    {
+        BinaryTokenStreamWriter Stream { get; }
+        void RecordObject(object original);
+        int CheckObjectWhileSerializing(object raw);
+    }
+
     /// <summary>
     /// Maintains context information for current thread during serialization operations.
     /// </summary>
@@ -11,19 +32,8 @@ namespace Orleans.Serialization
     /// record the mapping of original object to the copied instance of that object
     /// so that object identity can be preserved when serializing .NET object graphs.
     /// </remarks>
-    public class SerializationContext
+    public class SerializationContext : ICopyContext, ISerializationContext
     {
-        [ThreadStatic]
-        private static SerializationContext ctx;
-
-        /// <summary>
-        /// The current serialization context in use for this thread.
-        /// Used in generated code.
-        /// </summary>
-        public static SerializationContext Current {
-            get { return ctx ?? (ctx = new SerializationContext()); }
-        }
-
         private struct Record
         {
             public readonly object Copy;
@@ -42,21 +52,18 @@ namespace Orleans.Serialization
             }
         }
 
+        public BinaryTokenStreamWriter Stream { get; set; }
+
         private readonly Dictionary<object, Record> processedObjects;
 
-        private readonly Dictionary<Type, short> processedTypes;
-
-        private SerializationContext()
+        public SerializationContext()
         {
-            processedObjects = new Dictionary<object, Record>(new ReferenceEqualsComparer());
-            processedTypes = new Dictionary<Type, short>();
+            processedObjects = new Dictionary<object, Record>(ReferenceEqualsComparer.Instance);
         }
 
         internal void Reset()
         {
             processedObjects.Clear();
-            processedTypes.Clear();
-            this.nextTypeIndex = 0;
         }
 
         /// <summary>
@@ -66,7 +73,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="original">Original object.</param>
         /// <param name="copy">Copy object that will be the serialized form of the original.</param>
-        public void RecordObject(object original, object copy)
+        public void RecordCopy(object original, object copy)
         {
             if (!processedObjects.ContainsKey(original))
             {
@@ -74,28 +81,13 @@ namespace Orleans.Serialization
             }
         }
 
-        internal void RecordObject(object original, int offset)
+        public void RecordObject(object original)
         {
-            processedObjects[original] = new Record(offset);
+            processedObjects[original] = new Record(this.Stream.CurrentOffset);
         }
-
-        private short nextTypeIndex;
-
-        internal short CheckTypeWhileSerializing(Type type)
-        {
-            short typeIndex;
-            if (!processedTypes.TryGetValue(type, out typeIndex)) typeIndex = -1;
-            
-            return typeIndex;
-        }
-
-        internal void RecordType(Type type)
-        {
-            this.processedTypes[type] = this.nextTypeIndex++;
-        }
-
+        
         // Returns an object suitable for insertion if this is a back-reference, or null if it's new
-        internal object CheckObjectWhileCopying(object raw)
+        public object CheckObjectWhileCopying(object raw)
         {
             Record record;
             bool found = processedObjects.TryGetValue(raw, out record);
@@ -108,7 +100,7 @@ namespace Orleans.Serialization
         }
 
         // Returns an offset where the first version of this object was seen, or -1 if it's new
-        internal int CheckObjectWhileSerializing(object raw)
+        public int CheckObjectWhileSerializing(object raw)
         {
             Record record;
             bool found = processedObjects.TryGetValue(raw, out record);

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1129,7 +1129,7 @@ namespace Orleans.Serialization
 
             var context = CurrentSerializationContext;
             context.Reset();
-            context.Stream = stream;
+            context.StreamWriter = stream;
             SerializeInner(raw, context, null);
             context.Reset();
             
@@ -1149,7 +1149,7 @@ namespace Orleans.Serialization
         [SuppressMessage("Microsoft.Usage", "CA2201:DoNotRaiseReservedExceptionTypes")]
         public static void SerializeInner(object obj, ISerializationContext context, Type expected)
         {
-            var stream = context.Stream;
+            var stream = context.StreamWriter;
 
             // Nulls get special handling
             if (obj == null)
@@ -1269,7 +1269,7 @@ namespace Orleans.Serialization
         // We assume that all lower bounds are 0, since creating an array with lower bound !=0 is hard in .NET 4.0+
         private static void SerializeArray(Array array, ISerializationContext context, Type expected, Type et)
         {
-            var stream = context.Stream;
+            var stream = context.StreamWriter;
 
             // First check for one of the optimized cases
             if (array.Rank == 1)
@@ -1429,7 +1429,7 @@ namespace Orleans.Serialization
             {
                 var context = CurrentSerializationContext;
                 context.Reset();
-                context.Stream = stream;
+                context.StreamWriter = stream;
                 SerializeInner(raw, context, null);
                 context.Reset();
                 result = stream.ToByteArray();
@@ -1485,7 +1485,7 @@ namespace Orleans.Serialization
 
             var context = CurrentDeserializationContext;
             context.Reset();
-            context.Stream = stream;
+            context.StreamReader = stream;
             result = DeserializeInner(t, context);
             context.Reset();
             
@@ -1517,8 +1517,8 @@ namespace Orleans.Serialization
         public static object DeserializeInner(Type expected, IDeserializationContext context)
         {
             var previousOffset = context.CurrentObjectOffset;
-            var stream = context.Stream;
-            context.CurrentObjectOffset = context.Stream.CurrentPosition;
+            var stream = context.StreamReader;
+            context.CurrentObjectOffset = context.StreamReader.CurrentPosition;
 
             try
             {
@@ -1613,7 +1613,7 @@ namespace Orleans.Serialization
 
         private static object DeserializeArray(Type resultType, IDeserializationContext context)
         {
-            var stream = context.Stream;
+            var stream = context.StreamReader;
             var lengths = ReadArrayLengths(resultType.GetArrayRank(), stream);
             var rank = lengths.Length;
             var et = resultType.GetElementType();
@@ -1781,7 +1781,7 @@ namespace Orleans.Serialization
         {
             var context = CurrentDeserializationContext;
             context.Reset();
-            context.Stream = new BinaryTokenStreamReader(data);
+            context.StreamReader = new BinaryTokenStreamReader(data);
             var result = DeserializeInner<T>(context);
             context.Reset();
             return result;
@@ -1875,7 +1875,7 @@ namespace Orleans.Serialization
                 FallbackSerializations.Increment();
             }
 
-            context.Stream.Write(SerializationTokenType.Fallback);
+            context.StreamWriter.Write(SerializationTokenType.Fallback);
             fallbackSerializer.Serialize(raw, context, t);
 
             if (StatisticsCollector.CollectSerializationStats)

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1149,12 +1149,12 @@ namespace Orleans.Serialization
         [SuppressMessage("Microsoft.Usage", "CA2201:DoNotRaiseReservedExceptionTypes")]
         public static void SerializeInner(object obj, ISerializationContext context, Type expected)
         {
-            var stream = context.StreamWriter;
+            var writer = context.StreamWriter;
 
             // Nulls get special handling
             if (obj == null)
             {
-                stream.WriteNull();
+                writer.WriteNull();
                 return;
             }
 
@@ -1164,14 +1164,14 @@ namespace Orleans.Serialization
             // Enums are extra-special
             if (typeInfo.IsEnum)
             {
-                stream.WriteTypeHeader(t, expected);
-                WriteEnum(obj, stream, t);
+                writer.WriteTypeHeader(t, expected);
+                WriteEnum(obj, writer, t);
 
                 return;
             }
 
             // Check for simple types
-            if (stream.TryWriteSimpleObject(obj)) return;
+            if (writer.TryWriteSimpleObject(obj)) return;
 
             // Check for primitives
             // At this point, we're either an object or a non-trivial value type
@@ -1182,7 +1182,7 @@ namespace Orleans.Serialization
                 int reference = context.CheckObjectWhileSerializing(obj);
                 if (reference >= 0)
                 {
-                    stream.WriteReference(reference);
+                    writer.WriteReference(reference);
                     return;
                 }
 
@@ -1192,8 +1192,8 @@ namespace Orleans.Serialization
             // If we're simply a plain old unadorned, undifferentiated object, life is easy
             if (t.TypeHandle.Equals(objectTypeHandle))
             {
-                stream.Write(SerializationTokenType.SpecifiedType);
-                stream.Write(SerializationTokenType.Object);
+                writer.Write(SerializationTokenType.SpecifiedType);
+                writer.Write(SerializationTokenType.Object);
                 return;
             }
 
@@ -1208,7 +1208,7 @@ namespace Orleans.Serialization
             IExternalSerializer serializer;
             if (TryLookupExternalSerializer(t, out serializer))
             {
-                stream.WriteTypeHeader(t, expected);
+                writer.WriteTypeHeader(t, expected);
                 serializer.Serialize(obj, context, expected);
                 return;
             }
@@ -1216,7 +1216,7 @@ namespace Orleans.Serialization
             Serializer ser = GetSerializer(t);
             if (ser != null)
             {
-                stream.WriteTypeHeader(t, expected);
+                writer.WriteTypeHeader(t, expected);
                 ser(obj, context, expected);
                 return;
             }
@@ -1269,111 +1269,111 @@ namespace Orleans.Serialization
         // We assume that all lower bounds are 0, since creating an array with lower bound !=0 is hard in .NET 4.0+
         private static void SerializeArray(Array array, ISerializationContext context, Type expected, Type et)
         {
-            var stream = context.StreamWriter;
+            var writer = context.StreamWriter;
 
             // First check for one of the optimized cases
             if (array.Rank == 1)
             {
                 if (et.TypeHandle.Equals(byteTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.ByteArray);
-                    stream.Write(array.Length);
-                    stream.Write((byte[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.ByteArray);
+                    writer.Write(array.Length);
+                    writer.Write((byte[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(sbyteTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.SByteArray);
-                    stream.Write(array.Length);
-                    stream.Write((sbyte[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.SByteArray);
+                    writer.Write(array.Length);
+                    writer.Write((sbyte[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(boolTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.BoolArray);
-                    stream.Write(array.Length);
-                    stream.Write((bool[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.BoolArray);
+                    writer.Write(array.Length);
+                    writer.Write((bool[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(charTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.CharArray);
-                    stream.Write(array.Length);
-                    stream.Write((char[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.CharArray);
+                    writer.Write(array.Length);
+                    writer.Write((char[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(shortTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.ShortArray);
-                    stream.Write(array.Length);
-                    stream.Write((short[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.ShortArray);
+                    writer.Write(array.Length);
+                    writer.Write((short[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(intTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.IntArray);
-                    stream.Write(array.Length);
-                    stream.Write((int[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.IntArray);
+                    writer.Write(array.Length);
+                    writer.Write((int[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(longTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.LongArray);
-                    stream.Write(array.Length);
-                    stream.Write((long[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.LongArray);
+                    writer.Write(array.Length);
+                    writer.Write((long[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(ushortTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.UShortArray);
-                    stream.Write(array.Length);
-                    stream.Write((ushort[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.UShortArray);
+                    writer.Write(array.Length);
+                    writer.Write((ushort[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(uintTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.UIntArray);
-                    stream.Write(array.Length);
-                    stream.Write((uint[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.UIntArray);
+                    writer.Write(array.Length);
+                    writer.Write((uint[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(ulongTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.ULongArray);
-                    stream.Write(array.Length);
-                    stream.Write((ulong[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.ULongArray);
+                    writer.Write(array.Length);
+                    writer.Write((ulong[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(floatTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.FloatArray);
-                    stream.Write(array.Length);
-                    stream.Write((float[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.FloatArray);
+                    writer.Write(array.Length);
+                    writer.Write((float[])array);
                     return;
                 }
                 if (et.TypeHandle.Equals(doubleTypeHandle))
                 {
-                    stream.Write(SerializationTokenType.SpecifiedType);
-                    stream.Write(SerializationTokenType.DoubleArray);
-                    stream.Write(array.Length);
-                    stream.Write((double[])array);
+                    writer.Write(SerializationTokenType.SpecifiedType);
+                    writer.Write(SerializationTokenType.DoubleArray);
+                    writer.Write(array.Length);
+                    writer.Write((double[])array);
                     return;
                 }
             }
 
             // Write the array header
-            stream.WriteArrayHeader(array, expected);
+            writer.WriteArrayHeader(array, expected);
 
             // Figure out the array size
             var rank = array.Rank;
@@ -1517,7 +1517,7 @@ namespace Orleans.Serialization
         public static object DeserializeInner(Type expected, IDeserializationContext context)
         {
             var previousOffset = context.CurrentObjectOffset;
-            var stream = context.StreamReader;
+            var reader = context.StreamReader;
             context.CurrentObjectOffset = context.StreamReader.CurrentPosition;
 
             try
@@ -1526,7 +1526,7 @@ namespace Orleans.Serialization
                 // We'll allow a cast exception higher up to catch this.
                 SerializationTokenType token;
                 object result;
-                if (stream.TryReadSimpleType(out result, out token))
+                if (reader.TryReadSimpleType(out result, out token))
                 {
                     return result;
                 }
@@ -1534,7 +1534,7 @@ namespace Orleans.Serialization
                 // Special serializations (reference, fallback)
                 if (token == SerializationTokenType.Reference)
                 {
-                    var offset = stream.ReadInt();
+                    var offset = reader.ReadInt();
                     result = context.FetchReferencedObject(offset);
                     return result;
                 }
@@ -1557,7 +1557,7 @@ namespace Orleans.Serialization
                 }
                 else if (token == SerializationTokenType.SpecifiedType)
                 {
-                    resultType = stream.ReadSpecifiedTypeHeader();
+                    resultType = reader.ReadSpecifiedTypeHeader();
                 }
                 else
                 {
@@ -1574,7 +1574,7 @@ namespace Orleans.Serialization
                 // Handle enums
                 if (resultTypeInfo.IsEnum)
                 {
-                    result = ReadEnum(stream, resultType);
+                    result = ReadEnum(reader, resultType);
                     return result;
                 }
 
@@ -1613,8 +1613,8 @@ namespace Orleans.Serialization
 
         private static object DeserializeArray(Type resultType, IDeserializationContext context)
         {
-            var stream = context.StreamReader;
-            var lengths = ReadArrayLengths(resultType.GetArrayRank(), stream);
+            var reader = context.StreamReader;
+            var lengths = ReadArrayLengths(resultType.GetArrayRank(), reader);
             var rank = lengths.Length;
             var et = resultType.GetElementType();
 
@@ -1622,83 +1622,83 @@ namespace Orleans.Serialization
             if (rank == 1)
             {
                 if (et.TypeHandle.Equals(byteTypeHandle))
-                    return stream.ReadBytes(lengths[0]);
+                    return reader.ReadBytes(lengths[0]);
 
                 if (et.TypeHandle.Equals(sbyteTypeHandle))
                 {
                     var result = new sbyte[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(shortTypeHandle))
                 {
                     var result = new short[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(intTypeHandle))
                 {
                     var result = new int[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(longTypeHandle))
                 {
                     var result = new long[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(ushortTypeHandle))
                 {
                     var result = new ushort[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(uintTypeHandle))
                 {
                     var result = new uint[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(ulongTypeHandle))
                 {
                     var result = new ulong[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(doubleTypeHandle))
                 {
                     var result = new double[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(floatTypeHandle))
                 {
                     var result = new float[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(charTypeHandle))
                 {
                     var result = new char[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
                 if (et.TypeHandle.Equals(boolTypeHandle))
                 {
                     var result = new bool[lengths[0]];
                     var n = Buffer.ByteLength(result);
-                    stream.ReadBlockInto(result, n);
+                    reader.ReadBlockInto(result, n);
                     return result;
                 }
             }

--- a/src/Orleans/Utils/ReferenceEqualsComparer.cs
+++ b/src/Orleans/Utils/ReferenceEqualsComparer.cs
@@ -6,6 +6,11 @@ namespace Orleans
     internal class ReferenceEqualsComparer : EqualityComparer<object>
     {
         /// <summary>
+        /// Gets an instance of this class.
+        /// </summary>
+        public static ReferenceEqualsComparer Instance { get; } = new ReferenceEqualsComparer();
+
+        /// <summary>
         /// Defines object equality by reference equality (eq, in LISP).
         /// </summary>
         /// <returns>

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
@@ -40,8 +40,9 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// Creates a deep copy of an object
         /// </summary>
         /// <param name="original">The object to create a copy of</param>
+        /// <param name="context">The copy context.</param>
         /// <returns>The copy.</returns>
-        public static object DeepCopy(object original)
+        public static object DeepCopy(object original, ICopyContext context)
         {
             var source = original as AzureQueueBatchContainerV2;
             if (source == null)
@@ -50,11 +51,20 @@ namespace Orleans.Providers.Streams.AzureQueue
             }
 
             var copy = new AzureQueueBatchContainerV2();
-            SerializationContext.Current.RecordObject(original, copy);
+            context.RecordCopy(original, copy);
             var token = source.sequenceToken == null ? null : new EventSequenceTokenV2(source.sequenceToken.SequenceNumber, source.sequenceToken.EventIndex);
-            var events = source.events?.Select(SerializationManager.DeepCopyInner).ToList();
-            var context = source.requestContext?.ToDictionary(kv => kv.Key, kv => SerializationManager.DeepCopyInner(kv.Value));
-            copy.SetValues(source.StreamGuid, source.StreamNamespace, events, context, token);
+            List<object> events = null;
+            if (source.events != null)
+            {
+                events = new List<object>(source.events.Count);
+                foreach (var item in source.events)
+                {
+                    events.Add(SerializationManager.DeepCopyInner(item, context));
+                }
+            }
+            
+            var ctx = source.requestContext?.ToDictionary(kv => kv.Key, kv => SerializationManager.DeepCopyInner(kv.Value, context));
+            copy.SetValues(source.StreamGuid, source.StreamNamespace, events, ctx, token);
             return copy;
         }
 
@@ -62,9 +72,9 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// Serializes the container to the binary stream.
         /// </summary>
         /// <param name="untypedInput">The object to serialize</param>
-        /// <param name="writer">The stream to write to</param>
+        /// <param name="context">The serialization context.</param>
         /// <param name="expected">The expected type</param>
-        public static void Serialize(object untypedInput, BinaryTokenStreamWriter writer, Type expected)
+        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
         {
             var typed = untypedInput as AzureQueueBatchContainerV2;
             if (typed == null)
@@ -72,29 +82,30 @@ namespace Orleans.Providers.Streams.AzureQueue
                 throw new SerializationException();
             }
 
-            writer.Write(typed.StreamGuid);
-            writer.Write(typed.StreamNamespace);
-            WriteOrSerializeInner(typed.sequenceToken, writer);
-            WriteOrSerializeInner(typed.events, writer);
-            WriteOrSerializeInner(typed.requestContext, writer);
+            context.Stream.Write(typed.StreamGuid);
+            context.Stream.Write(typed.StreamNamespace);
+            WriteOrSerializeInner(typed.sequenceToken, context);
+            WriteOrSerializeInner(typed.events, context);
+            WriteOrSerializeInner(typed.requestContext, context);
         }
 
         /// <summary>
         /// Deserializes the container from the data stream.
         /// </summary>
         /// <param name="expected">The expected type</param>
-        /// <param name="reader">The stream reader</param>
+        /// <param name="context">The deserialization context.</param>
         /// <returns>The deserialized value</returns>
-        public static object Deserialize(Type expected, BinaryTokenStreamReader reader)
+        public static object Deserialize(Type expected, IDeserializationContext context)
         {
+            var reader = context.Stream;
             var deserialized = new AzureQueueBatchContainerV2();
-            DeserializationContext.Current.RecordObject(deserialized);
+            context.RecordObject(deserialized);
             var guid = reader.ReadGuid();
             var ns = reader.ReadString();
-            var eventToken = SerializationManager.DeserializeInner<EventSequenceTokenV2>(reader);
-            var events = SerializationManager.DeserializeInner<List<object>>(reader);
-            var context = SerializationManager.DeserializeInner<Dictionary<string, object>>(reader);
-            deserialized.SetValues(guid, ns, events, context, eventToken);
+            var eventToken = SerializationManager.DeserializeInner<EventSequenceTokenV2>(context);
+            var events = SerializationManager.DeserializeInner<List<object>>(context);
+            var ctx = SerializationManager.DeserializeInner<Dictionary<string, object>>(context);
+            deserialized.SetValues(guid, ns, events, ctx, eventToken);
             return deserialized;
         }
 
@@ -106,15 +117,15 @@ namespace Orleans.Providers.Streams.AzureQueue
             SerializationManager.Register(typeof(AzureQueueBatchContainerV2), DeepCopy, Serialize, Deserialize);
         }
 
-        private static void WriteOrSerializeInner<T>(T val, BinaryTokenStreamWriter writer) where T : class
+        private static void WriteOrSerializeInner<T>(T val, ISerializationContext context) where T : class
         {
             if (val == null)
             {
-                writer.WriteNull();
+                context.Stream.WriteNull();
             }
             else
             {
-                SerializationManager.SerializeInner(val, writer, val.GetType());
+                SerializationManager.SerializeInner(val, context, val.GetType());
             }
         }
 

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
@@ -82,8 +82,8 @@ namespace Orleans.Providers.Streams.AzureQueue
                 throw new SerializationException();
             }
 
-            context.Stream.Write(typed.StreamGuid);
-            context.Stream.Write(typed.StreamNamespace);
+            context.StreamWriter.Write(typed.StreamGuid);
+            context.StreamWriter.Write(typed.StreamNamespace);
             WriteOrSerializeInner(typed.sequenceToken, context);
             WriteOrSerializeInner(typed.events, context);
             WriteOrSerializeInner(typed.requestContext, context);
@@ -97,7 +97,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <returns>The deserialized value</returns>
         public static object Deserialize(Type expected, IDeserializationContext context)
         {
-            var reader = context.Stream;
+            var reader = context.StreamReader;
             var deserialized = new AzureQueueBatchContainerV2();
             context.RecordObject(deserialized);
             var guid = reader.ReadGuid();
@@ -121,7 +121,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         {
             if (val == null)
             {
-                context.Stream.WriteNull();
+                context.StreamWriter.WriteNull();
             }
             else
             {

--- a/src/OrleansBondUtils/BondSerializer.cs
+++ b/src/OrleansBondUtils/BondSerializer.cs
@@ -88,7 +88,7 @@ namespace Orleans.Serialization
                 throw new ArgumentOutOfRangeException("no deserializer provided for the selected type", "expectedType");
             }
 
-            var inputStream = InputStream.Create(context.Stream);
+            var inputStream = InputStream.Create(context.StreamReader);
             var bondReader = new BondBinaryReader(inputStream);
             return deserializer.Deserialize(bondReader);
         }
@@ -110,7 +110,7 @@ namespace Orleans.Serialization
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var writer = context.Stream;
+            var writer = context.StreamWriter;
             if (item == null)
             {
                 writer.WriteNull();

--- a/src/OrleansBondUtils/BondSerializer.cs
+++ b/src/OrleansBondUtils/BondSerializer.cs
@@ -49,12 +49,8 @@ namespace Orleans.Serialization
             return true;
         }
 
-        /// <summary>
-        /// Creates a deep copy of an object
-        /// </summary>
-        /// <param name="source">The source object to be copy</param>
-        /// <returns>The copy that was created</returns>
-        public object DeepCopy(object source)
+        /// <inheritdoc />
+        public object DeepCopy(object source, ICopyContext context)
         {
             if (source == null)
             {
@@ -71,22 +67,17 @@ namespace Orleans.Serialization
             return clonerInfo.Invoke(source);
         }
 
-        /// <summary>
-        /// Deserializes an object from a binary stream
-        /// </summary>
-        /// <param name="expectedType">The type that is expected to be deserialized</param>
-        /// <param name="reader">The <see cref="BinaryTokenStreamReader"/></param>
-        /// <returns>The deserialized object</returns>
-        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        /// <inheritdoc />
+        public object Deserialize(Type expectedType, IDeserializationContext context)
         {
             if (expectedType == null)
             {
-                throw new ArgumentNullException("reader");
+                throw new ArgumentNullException(nameof(expectedType));
             }
 
-            if (reader == null)
+            if (context == null)
             {
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var typeHandle = expectedType.TypeHandle;
@@ -97,15 +88,12 @@ namespace Orleans.Serialization
                 throw new ArgumentOutOfRangeException("no deserializer provided for the selected type", "expectedType");
             }
 
-            var inputStream = InputStream.Create(reader);
+            var inputStream = InputStream.Create(context.Stream);
             var bondReader = new BondBinaryReader(inputStream);
             return deserializer.Deserialize(bondReader);
         }
 
-        /// <summary>
-        /// Initializes the external serializer
-        /// </summary>
-        /// <param name="logger">The logger to use to capture any serialization events</param>
+        /// <inheritdoc />
         public void Initialize(Logger logger)
         {
             ClonerInfoDictionary = new ConcurrentDictionary<RuntimeTypeHandle, ClonerInfo>();
@@ -114,19 +102,15 @@ namespace Orleans.Serialization
             this.logger = logger;
         }
 
-        /// <summary>
-        /// Serializes an object to a binary stream
-        /// </summary>
-        /// <param name="item">The object to serialize</param>
-        /// <param name="writer">The <see cref="BinaryTokenStreamWriter"/></param>
-        /// <param name="expectedType">The type the deserializer should expect</param>
-        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        /// <inheritdoc />
+        public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
-            if (writer == null)
+            if (context == null)
             {
-                throw new ArgumentNullException("writer");
+                throw new ArgumentNullException(nameof(context));
             }
 
+            var writer = context.Stream;
             if (item == null)
             {
                 writer.WriteNull();

--- a/src/OrleansBondUtils/InputStream.cs
+++ b/src/OrleansBondUtils/InputStream.cs
@@ -102,7 +102,7 @@ namespace Orleans.Serialization
         {
             if (reader == null)
             {
-                throw new ArgumentNullException("reader");
+                throw new ArgumentNullException(nameof(reader));
             }
 
             return new InputStream(reader);

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -148,8 +148,8 @@ namespace Orleans.CodeGenerator
         private static MemberDeclarationSyntax GenerateDeserializerMethod(Type type, List<FieldInfoMember> fields)
         {
             Expression<Action> deserializeInner =
-                () => SerializationManager.DeserializeInner(default(Type), default(BinaryTokenStreamReader));
-            var streamParameter = SF.IdentifierName("stream");
+                () => SerializationManager.DeserializeInner(default(Type), default(IDeserializationContext));
+            var contextParameter = SF.IdentifierName("context");
 
             var resultDeclaration =
                 SF.LocalDeclarationStatement(
@@ -165,14 +165,8 @@ namespace Orleans.CodeGenerator
             if (!type.GetTypeInfo().IsValueType)
             {
                 // Record the result for cyclic deserialization.
-                Expression<Action> recordObject = () => DeserializationContext.Current.RecordObject(default(object));
-                var currentSerializationContext =
-                    SyntaxFactory.AliasQualifiedName(
-                        SF.IdentifierName(SF.Token(SyntaxKind.GlobalKeyword)),
-                        SF.IdentifierName("Orleans"))
-                        .Qualify("Serialization")
-                        .Qualify("DeserializationContext")
-                        .Qualify("Current");
+                Expression<Action<IDeserializationContext>> recordObject = ctx => ctx.RecordObject(default(object));
+                var currentSerializationContext = contextParameter;
                 body.Add(
                     SF.ExpressionStatement(
                         recordObject.Invoke(currentSerializationContext)
@@ -186,7 +180,7 @@ namespace Orleans.CodeGenerator
                     deserializeInner.Invoke()
                         .AddArgumentListArguments(
                             SF.Argument(SF.TypeOfExpression(field.Type)),
-                            SF.Argument(streamParameter));
+                            SF.Argument(contextParameter));
                 body.Add(
                     SF.ExpressionStatement(
                         field.GetSetter(
@@ -200,7 +194,7 @@ namespace Orleans.CodeGenerator
                     .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.StaticKeyword))
                     .AddParameterListParameters(
                         SF.Parameter(SF.Identifier("expected")).WithType(typeof(Type).GetTypeSyntax()),
-                        SF.Parameter(SF.Identifier("stream")).WithType(typeof(BinaryTokenStreamReader).GetTypeSyntax()))
+                        SF.Parameter(SF.Identifier("context")).WithType(typeof(IDeserializationContext).GetTypeSyntax()))
                     .AddBodyStatements(body.ToArray())
                     .AddAttributeLists(
                         SF.AttributeList()
@@ -211,7 +205,8 @@ namespace Orleans.CodeGenerator
         {
             Expression<Action> serializeInner =
                 () =>
-                SerializationManager.SerializeInner(default(object), default(BinaryTokenStreamWriter), default(Type));
+                SerializationManager.SerializeInner(default(object), default(ISerializationContext), default(Type));
+            var contextParameter = SF.IdentifierName("context");
 
             var body = new List<StatementSyntax>
             {
@@ -234,7 +229,7 @@ namespace Orleans.CodeGenerator
                         serializeInner.Invoke()
                             .AddArgumentListArguments(
                                 SF.Argument(field.GetGetter(inputExpression, forceAvoidCopy: true)),
-                                SF.Argument(SF.IdentifierName("stream")),
+                                SF.Argument(contextParameter),
                                 SF.Argument(SF.TypeOfExpression(field.FieldInfo.FieldType.GetTypeSyntax())))));
             }
 
@@ -243,7 +238,7 @@ namespace Orleans.CodeGenerator
                     .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.StaticKeyword))
                     .AddParameterListParameters(
                         SF.Parameter(SF.Identifier("untypedInput")).WithType(typeof(object).GetTypeSyntax()),
-                        SF.Parameter(SF.Identifier("stream")).WithType(typeof(BinaryTokenStreamWriter).GetTypeSyntax()),
+                        SF.Parameter(SF.Identifier("context")).WithType(typeof(ISerializationContext).GetTypeSyntax()),
                         SF.Parameter(SF.Identifier("expected")).WithType(typeof(Type).GetTypeSyntax()))
                     .AddBodyStatements(body.ToArray())
                     .AddAttributeLists(
@@ -288,24 +283,18 @@ namespace Orleans.CodeGenerator
                                     .WithInitializer(SF.EqualsValueClause(GetObjectCreationExpressionSyntax(type))))));
 
                 // Record this serialization.
-                Expression<Action> recordObject =
-                    () => SerializationContext.Current.RecordObject(default(object), default(object));
-                var currentSerializationContext =
-                    SyntaxFactory.AliasQualifiedName(
-                        SF.IdentifierName(SF.Token(SyntaxKind.GlobalKeyword)),
-                        SF.IdentifierName("Orleans"))
-                        .Qualify("Serialization")
-                        .Qualify("SerializationContext")
-                        .Qualify("Current");
+                Expression<Action<ICopyContext>> recordObject =
+                    ctx => ctx.RecordCopy(default(object), default(object));
+                var context = SF.IdentifierName("context");
                 body.Add(
                     SF.ExpressionStatement(
-                        recordObject.Invoke(currentSerializationContext)
+                        recordObject.Invoke(context)
                             .AddArgumentListArguments(SF.Argument(originalVariable), SF.Argument(resultVariable))));
 
                 // Copy all members from the input to the result.
                 foreach (var field in fields)
                 {
-                    body.Add(SF.ExpressionStatement(field.GetSetter(resultVariable, field.GetGetter(inputVariable))));
+                    body.Add(SF.ExpressionStatement(field.GetSetter(resultVariable, field.GetGetter(inputVariable, context))));
                 }
 
                 body.Add(SF.ReturnStatement(resultVariable));
@@ -313,12 +302,13 @@ namespace Orleans.CodeGenerator
 
             return
                 SF.MethodDeclaration(typeof(object).GetTypeSyntax(), "DeepCopier")
-                    .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.StaticKeyword))
-                    .AddParameterListParameters(
-                        SF.Parameter(SF.Identifier("original")).WithType(typeof(object).GetTypeSyntax()))
-                    .AddBodyStatements(body.ToArray())
-                    .AddAttributeLists(
-                        SF.AttributeList().AddAttributes(SF.Attribute(typeof(CopierMethodAttribute).GetNameSyntax())));
+                  .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.StaticKeyword))
+                  .AddParameterListParameters(
+                      SF.Parameter(SF.Identifier("original")).WithType(typeof(object).GetTypeSyntax()),
+                      SF.Parameter(SF.Identifier("context")).WithType(typeof(ICopyContext).GetTypeSyntax()))
+                  .AddBodyStatements(body.ToArray())
+                  .AddAttributeLists(
+                      SF.AttributeList().AddAttributes(SF.Attribute(typeof(CopierMethodAttribute).GetNameSyntax())));
         }
 
         /// <summary>
@@ -689,12 +679,13 @@ namespace Orleans.CodeGenerator
             }
 
             /// <summary>
-            /// Returns syntax for retrieving the value of this field, deep copying it if neccessary.
+            /// Returns syntax for retrieving the value of this field, deep copying it if necessary.
             /// </summary>
             /// <param name="instance">The instance of the containing type.</param>
+            /// <param name="serializationContextExpression">The expression used to retrieve the serialization context.</param>
             /// <param name="forceAvoidCopy">Whether or not to ensure that no copy of the field is made.</param>
             /// <returns>Syntax for retrieving the value of this field.</returns>
-            public ExpressionSyntax GetGetter(ExpressionSyntax instance, bool forceAvoidCopy = false)
+            public ExpressionSyntax GetGetter(ExpressionSyntax instance, ExpressionSyntax serializationContextExpression = null, bool forceAvoidCopy = false)
             {
                 // Retrieve the value of the field.
                 var getValueExpression = this.GetValueExpression(instance);
@@ -737,11 +728,14 @@ namespace Orleans.CodeGenerator
                 }
 
                 // Deep-copy the value.
-                Expression<Action> deepCopyInner = () => SerializationManager.DeepCopyInner(default(object));
+                Expression<Action> deepCopyInner = () => SerializationManager.DeepCopyInner(default(object), default(ICopyContext));
                 var typeSyntax = this.FieldInfo.FieldType.GetTypeSyntax();
                 return SF.CastExpression(
                     typeSyntax,
-                    deepCopyInner.Invoke().AddArgumentListArguments(SF.Argument(deepCopyValueExpression)));
+                    deepCopyInner.Invoke()
+                                 .AddArgumentListArguments(
+                                     SF.Argument(deepCopyValueExpression),
+                                     SF.Argument(serializationContextExpression)));
             }
 
             /// <summary>

--- a/src/OrleansGoogleUtils/ProtobufSerializer.cs
+++ b/src/OrleansGoogleUtils/ProtobufSerializer.cs
@@ -74,7 +74,7 @@ namespace Orleans.Serialization
                 // Special handling for null value. 
                 // Since in this ProtobufSerializer we are usually writing the data lengh as 4 bytes
                 // we also have to write the Null object as 4 bytes lengh of zero.
-                context.Stream.Write(0);
+                context.StreamWriter.Write(0);
                 return;
             }
 
@@ -94,8 +94,8 @@ namespace Orleans.Serialization
             // Alternatively, we could force to always append to BinaryTokenStreamWriter, but that could create a lot of small ArraySegments.
             // The plan is to ask the ProtoBuff team to add support for some "InputStream" interface, like Bond does.
             byte[] outBytes = iMessage.ToByteArray();
-            context.Stream.Write(outBytes.Length);
-            context.Stream.Write(outBytes);
+            context.StreamWriter.Write(outBytes.Length);
+            context.StreamWriter.Write(outBytes);
         }
         
         /// <inheritdoc />
@@ -118,7 +118,7 @@ namespace Orleans.Serialization
                 throw new ArgumentException("No parser found for the expected type " + expectedType, nameof(expectedType));
             }
 
-            var reader = context.Stream;
+            var reader = context.StreamReader;
             int length = reader.ReadInt();
             byte[] data = reader.ReadBytes(length);
 

--- a/src/OrleansGoogleUtils/ProtobufSerializer.cs
+++ b/src/OrleansGoogleUtils/ProtobufSerializer.cs
@@ -49,12 +49,8 @@ namespace Orleans.Serialization
             return false;
         }
 
-        /// <summary>
-        /// Creates a deep copy of an object
-        /// </summary>
-        /// <param name="source">The source object to be copy</param>
-        /// <returns>The copy that was created</returns>
-        public object DeepCopy(object source)
+        /// <inheritdoc />
+        public object DeepCopy(object source, ICopyContext context)
         {
             if (source == null)
             {
@@ -65,25 +61,20 @@ namespace Orleans.Serialization
             return dynamicSource.Clone();
         }
 
-        /// <summary>
-        /// Serializes an object to a binary stream
-        /// </summary>
-        /// <param name="item">The object to serialize</param>
-        /// <param name="writer">The <see cref="BinaryTokenStreamWriter"/></param>
-        /// <param name="expectedType">The type the deserializer should expect</param>
-        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        /// <inheritdoc />
+        public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
-            if (writer == null)
+            if (context == null)
             {
-                throw new ArgumentNullException("writer");
+                throw new ArgumentNullException(nameof(context));
             }
 
             if (item == null)
             {
                 // Special handling for null value. 
-                // Since in this ProtobufSerializer we are usualy writing the data lengh as 4 bytes
+                // Since in this ProtobufSerializer we are usually writing the data lengh as 4 bytes
                 // we also have to write the Null object as 4 bytes lengh of zero.
-                writer.Write(0);
+                context.Stream.Write(0);
                 return;
             }
 
@@ -103,35 +94,31 @@ namespace Orleans.Serialization
             // Alternatively, we could force to always append to BinaryTokenStreamWriter, but that could create a lot of small ArraySegments.
             // The plan is to ask the ProtoBuff team to add support for some "InputStream" interface, like Bond does.
             byte[] outBytes = iMessage.ToByteArray();
-            writer.Write(outBytes.Length);
-            writer.Write(outBytes);
+            context.Stream.Write(outBytes.Length);
+            context.Stream.Write(outBytes);
         }
-
-        /// <summary>
-        /// Deserializes an object from a binary stream
-        /// </summary>
-        /// <param name="expectedType">The type that is expected to be deserialized</param>
-        /// <param name="reader">The <see cref="BinaryTokenStreamReader"/></param>
-        /// <returns>The deserialized object</returns>
-        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        
+        /// <inheritdoc />
+        public object Deserialize(Type expectedType, IDeserializationContext context)
         {
             if (expectedType == null)
             {
-                throw new ArgumentNullException("expectedType");
+                throw new ArgumentNullException(nameof(expectedType));
             }
 
-            if (reader == null)
+            if (context == null)
             {
-                throw new ArgumentNullException("reader");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var typeHandle = expectedType.TypeHandle;
             MessageParser parser = null;
             if (!Parsers.TryGetValue(typeHandle, out parser))
             {
-                throw new ArgumentException("No parser found for the expected type " + expectedType, "expectedType");
+                throw new ArgumentException("No parser found for the expected type " + expectedType, nameof(expectedType));
             }
 
+            var reader = context.Stream;
             int length = reader.ReadInt();
             byte[] data = reader.ReadBytes(length);
 

--- a/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
@@ -62,7 +62,7 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="expected">The expected type.</param>
         public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
         {
-            var writer = context.Stream;
+            var writer = context.StreamWriter;
             var typed = untypedInput as EventSequenceTokenV2;
             if (typed == null)
             {
@@ -82,7 +82,7 @@ namespace Orleans.Providers.Streams.Common
         /// <returns></returns>
         public static object Deserialize(Type expected, IDeserializationContext context)
         {
-            var reader = context.Stream;
+            var reader = context.StreamReader;
             var result = new EventSequenceTokenV2(reader.ReadLong(), reader.ReadInt());
             context.RecordObject(result);
             return result;

--- a/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
@@ -39,8 +39,9 @@ namespace Orleans.Providers.Streams.Common
         /// Create a deep copy of the token.
         /// </summary>
         /// <param name="original">The token to copy</param>
+        /// <param name="context">The serialization context.</param>
         /// <returns>A copy</returns>
-        public static object DeepCopy(object original)
+        public static object DeepCopy(object original, ICopyContext context)
         {
             var source = original as EventSequenceTokenV2;
             if (source == null)
@@ -49,7 +50,7 @@ namespace Orleans.Providers.Streams.Common
             }
 
             var copy = new EventSequenceTokenV2(source.SequenceNumber, source.EventIndex);
-            SerializationContext.Current.RecordObject(original, copy);
+            context.RecordCopy(original, copy);
             return copy;
         }
 
@@ -57,10 +58,11 @@ namespace Orleans.Providers.Streams.Common
         /// Serialize the event sequence token.
         /// </summary>
         /// <param name="untypedInput">The object to serialize.</param>
-        /// <param name="writer">The writer to write the binary stream to.</param>
+        /// <param name="context">The serialization context.</param>
         /// <param name="expected">The expected type.</param>
-        public static void Serialize(object untypedInput, BinaryTokenStreamWriter writer, Type expected)
+        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
         {
+            var writer = context.Stream;
             var typed = untypedInput as EventSequenceTokenV2;
             if (typed == null)
             {
@@ -76,12 +78,13 @@ namespace Orleans.Providers.Streams.Common
         /// Deserializes an event sequence token
         /// </summary>
         /// <param name="expected">The expected type.</param>
-        /// <param name="reader">The binary stream to read from.</param>
+        /// <param name="context">The deserialization context.</param>
         /// <returns></returns>
-        public static object Deserialize(Type expected, BinaryTokenStreamReader reader)
+        public static object Deserialize(Type expected, IDeserializationContext context)
         {
+            var reader = context.Stream;
             var result = new EventSequenceTokenV2(reader.ReadLong(), reader.ReadInt());
-            DeserializationContext.Current.RecordObject(result);
+            context.RecordObject(result);
             return result;
         }
     }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
@@ -39,8 +39,9 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
         /// Create a deep copy of the token.
         /// </summary>
         /// <param name="original">The token to copy</param>
+        /// <param name="context">The serialization context.</param>
         /// <returns>A copy</returns>
-        public static object DeepCopy(object original)
+        public static object DeepCopy(object original, ICopyContext context)
         {
             var source = original as EventHubSequenceTokenV2;
             if (source == null)
@@ -49,7 +50,7 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
             }
 
             var copy = new EventHubSequenceTokenV2(source.EventHubOffset, source.SequenceNumber, source.EventIndex);
-            SerializationContext.Current.RecordObject(original, copy);
+            context.RecordCopy(original, copy);
             return copy;
         }
 
@@ -57,11 +58,12 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
         /// Serialize the event sequence token.
         /// </summary>
         /// <param name="untypedInput">The object to serialize.</param>
-        /// <param name="writer">The writer to write the binary stream to.</param>
+        /// <param name="context">The serialization context.</param>
         /// <param name="expected">The expected type.</param>
-        public static void Serialize(object untypedInput, BinaryTokenStreamWriter writer, Type expected)
+        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
         {
             var typed = untypedInput as EventHubSequenceTokenV2;
+            var writer = context.Stream;
             if (typed == null)
             {
                 writer.WriteNull();
@@ -77,12 +79,13 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
         /// Deserializes an event sequence token
         /// </summary>
         /// <param name="expected">The expected type.</param>
-        /// <param name="reader">The binary stream to read from.</param>
+        /// <param name="context">The deserialization context.</param>
         /// <returns></returns>
-        public static object Deserialize(Type expected, BinaryTokenStreamReader reader)
+        public static object Deserialize(Type expected, IDeserializationContext context)
         {
+            var reader = context.Stream;
             var deserialized = new EventHubSequenceTokenV2(reader.ReadString(), reader.ReadLong(), reader.ReadInt());
-            DeserializationContext.Current.RecordObject(deserialized);
+            context.RecordObject(deserialized);
             return deserialized;
         }
     }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
@@ -63,7 +63,7 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
         public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
         {
             var typed = untypedInput as EventHubSequenceTokenV2;
-            var writer = context.Stream;
+            var writer = context.StreamWriter;
             if (typed == null)
             {
                 writer.WriteNull();
@@ -83,7 +83,7 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
         /// <returns></returns>
         public static object Deserialize(Type expected, IDeserializationContext context)
         {
-            var reader = context.Stream;
+            var reader = context.StreamReader;
             var deserialized = new EventHubSequenceTokenV2(reader.ReadString(), reader.ReadLong(), reader.ReadInt());
             context.RecordObject(deserialized);
             return deserialized;

--- a/test/DefaultCluster.Tests/JsonGrainTests.cs
+++ b/test/DefaultCluster.Tests/JsonGrainTests.cs
@@ -63,12 +63,12 @@ namespace DefaultCluster.Tests.General
             {
                 var input = (JObject)untypedInput;
                 string str = input.ToString();
-                SerializationManager.Serialize(str, context.Stream);
+                SerializationManager.Serialize(str, context.StreamWriter);
             }
 
             public static object Deserializer(Type expected, IDeserializationContext context)
             {
-                var str = (string)SerializationManager.Deserialize(typeof(string), context.Stream);
+                var str = (string)SerializationManager.Deserialize(typeof(string), context.StreamReader);
                 return JObject.Parse(str);
             }
 

--- a/test/DefaultCluster.Tests/JsonGrainTests.cs
+++ b/test/DefaultCluster.Tests/JsonGrainTests.cs
@@ -1,13 +1,11 @@
 ﻿using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using Orleans;
 using Orleans.CodeGeneration;
 using Orleans.Serialization;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using System;
-using Newtonsoft.Json;
 
 namespace DefaultCluster.Tests.General
 {
@@ -20,7 +18,7 @@ namespace DefaultCluster.Tests.General
         public async Task JSON_GetGrain()
         {
             int id = random.Next();
-            var grain = GrainClient.GrainFactory.GetGrain<IJsonEchoGrain>(id);
+            var grain = GrainFactory.GetGrain<IJsonEchoGrain>(id);
             await grain.Ping();
         }
 
@@ -28,7 +26,7 @@ namespace DefaultCluster.Tests.General
         public async Task JSON_EchoJson()
         {
             int id = random.Next();
-            var grain = GrainClient.GrainFactory.GetGrain<IJsonEchoGrain>(id);
+            var grain = GrainFactory.GetGrain<IJsonEchoGrain>(id);
 
             // Compare to: SerializationTests_JObject_Example1
             const string json = 
@@ -54,23 +52,23 @@ namespace DefaultCluster.Tests.General
                 Register();
             }
 
-            public static object DeepCopier(object original)
+            public static object DeepCopier(object original, ICopyContext context)
             {
                 // I assume JObject is immutable, so no need to deep copy.
                 // Alternatively, can copy via JObject.ToString and JObject.Parse().
                 return original;
             }
 
-            public static void Serializer(object untypedInput, BinaryTokenStreamWriter stream, Type expected)
+            public static void Serializer(object untypedInput, ISerializationContext context, Type expected)
             {
-                var input = (JObject)(untypedInput);
+                var input = (JObject)untypedInput;
                 string str = input.ToString();
-                SerializationManager.Serialize(str, stream);
+                SerializationManager.Serialize(str, context.Stream);
             }
 
-            public static object Deserializer(Type expected, BinaryTokenStreamReader stream)
+            public static object Deserializer(Type expected, IDeserializationContext context)
             {
-                var str = (string)(SerializationManager.Deserialize(typeof(string), stream));
+                var str = (string)SerializationManager.Deserialize(typeof(string), context.Stream);
                 return JObject.Parse(str);
             }
 

--- a/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
@@ -527,7 +527,7 @@ namespace UnitTests.Serialization
             { }
 
             [CopierMethod]
-            static private object Copy(object input)
+            static private object Copy(object input, ICopyContext context)
             {
                 return input;
             }
@@ -1024,17 +1024,17 @@ namespace UnitTests.Serialization
 
             public bool IsSupportedType(Type itemType) => false;
 
-            public object DeepCopy(object source)
+            public object DeepCopy(object source, ICopyContext context)
             {
                 throw new NotSupportedException();
             }
 
-            public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+            public void Serialize(object item, ISerializationContext context, Type expectedType)
             {
                 throw new NotSupportedException();
             }
 
-            public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+            public object Deserialize(Type expectedType, IDeserializationContext context)
             {
                 throw new NotSupportedException();
             }

--- a/test/NonSiloTests/Serialization/ILBasedSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/ILBasedSerializerTests.cs
@@ -32,7 +32,7 @@ namespace UnitTests.Serialization
             var serializers = generator.GenerateSerializer(input.GetType(), f => f.Name != "One", f => f.Name != "Three");
             var writer = new SerializationContext
             {
-                Stream = new BinaryTokenStreamWriter()
+                StreamWriter = new BinaryTokenStreamWriter()
             };
             var copy = (FieldTest)serializers.DeepCopy(input, writer);
             Assert.Equal(1, copy.One);
@@ -42,7 +42,7 @@ namespace UnitTests.Serialization
             serializers.Serialize(input, writer, input.GetType());
             var reader = new DeserializationContext
             {
-                Stream = new BinaryTokenStreamReader(writer.Stream.ToByteArray())
+                StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
             };
             var deserialized = (FieldTest)serializers.Deserialize(input.GetType(), reader);
 

--- a/test/NonSiloTests/Serialization/ILBasedSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/ILBasedSerializerTests.cs
@@ -30,14 +30,20 @@ namespace UnitTests.Serialization
 
             var generator = new ILSerializerGenerator();
             var serializers = generator.GenerateSerializer(input.GetType(), f => f.Name != "One", f => f.Name != "Three");
-            var copy = (FieldTest)serializers.DeepCopy(input);
+            var writer = new SerializationContext
+            {
+                Stream = new BinaryTokenStreamWriter()
+            };
+            var copy = (FieldTest)serializers.DeepCopy(input, writer);
             Assert.Equal(1, copy.One);
             Assert.Equal(2, copy.Two);
             Assert.Equal(0, copy.Three);
-
-            var writer = new BinaryTokenStreamWriter();
+            
             serializers.Serialize(input, writer, input.GetType());
-            var reader = new BinaryTokenStreamReader(writer.ToByteArray());
+            var reader = new DeserializationContext
+            {
+                Stream = new BinaryTokenStreamReader(writer.Stream.ToByteArray())
+            };
             var deserialized = (FieldTest)serializers.Deserialize(input.GetType(), reader);
 
             Assert.Equal(0, deserialized.One);

--- a/test/NonSiloTests/SerializationTests/ConfigurationTests/SerializationProviderTests.cs
+++ b/test/NonSiloTests/SerializationTests/ConfigurationTests/SerializationProviderTests.cs
@@ -96,19 +96,19 @@ namespace UnitTests.Serialization
             return itemType == typeof(FakeSerialized);
         }
 
-        public object DeepCopy(object source)
+        public object DeepCopy(object source, ICopyContext context)
         {
             DeepCopyCalled = true;
             return null;
         }
 
-        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
             SerializeCalled = true;
-            writer.WriteNull();
+            context.Stream.WriteNull();
         }
 
-        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        public object Deserialize(Type expectedType, IDeserializationContext context)
         {
             DeserializeCalled = true;
             return new FakeSerialized { SomeData = "fake deserialization" };

--- a/test/NonSiloTests/SerializationTests/ConfigurationTests/SerializationProviderTests.cs
+++ b/test/NonSiloTests/SerializationTests/ConfigurationTests/SerializationProviderTests.cs
@@ -105,7 +105,7 @@ namespace UnitTests.Serialization
         public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
             SerializeCalled = true;
-            context.Stream.WriteNull();
+            context.StreamWriter.WriteNull();
         }
 
         public object Deserialize(Type expectedType, IDeserializationContext context)

--- a/test/NonSiloTests/SerializationTests/SerializationOrderTests.cs
+++ b/test/NonSiloTests/SerializationTests/SerializationOrderTests.cs
@@ -92,18 +92,18 @@ namespace UnitTests.Serialization
                 return SupportedTypes == null ? false : SupportedTypes.Contains(itemType);
             }
 
-            public object DeepCopy(object source)
+            public object DeepCopy(object source, ICopyContext context)
             {
                 DeepCopyCalled = true;
                 return source;
             }
 
-            public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+            public void Serialize(object item, ISerializationContext context, Type expectedType)
             {
                 SerializeCalled = true;
             }
 
-            public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+            public object Deserialize(Type expectedType, IDeserializationContext context)
             {
                 DeserializeCalled = true;
                 return null;
@@ -137,18 +137,18 @@ namespace UnitTests.Serialization
                 return SupportedTypes == null ? false : SupportedTypes.Contains(itemType);
             }
 
-            public object DeepCopy(object source)
+            public object DeepCopy(object source, ICopyContext context)
             {
                 DeepCopyCalled = true;
                 return source;
             }
 
-            public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+            public void Serialize(object item, ISerializationContext context, Type expectedType)
             {
                 SerializeCalled = true;
             }
 
-            public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+            public object Deserialize(Type expectedType, IDeserializationContext context)
             {
                 DeserializeCalled = true;
                 return null;
@@ -171,20 +171,20 @@ namespace UnitTests.Serialization
             }
 
             [CopierMethod]
-            private static object Copy(object input)
+            private static object Copy(object input, ICopyContext context)
             {
                 CopyWasCalled = true;
                 return input;
             }
 
             [SerializerMethod]
-            private static void Serialize(object input, BinaryTokenStreamWriter stream, Type expected)
+            private static void Serialize(object input, ISerializationContext context, Type expected)
             {
                 SerializeWasCalled = true;
             }
 
             [DeserializerMethod]
-            private static object Deserialize(Type expected, BinaryTokenStreamReader stream)
+            private static object Deserialize(Type expected, IDeserializationContext context)
             {
                 DeserializeWasCalled = true;
                 return null;

--- a/test/NonSiloTests/SerializationTests/SerializationTests.DifferentTypes.cs
+++ b/test/NonSiloTests/SerializationTests/SerializationTests.DifferentTypes.cs
@@ -84,7 +84,7 @@ namespace UnitTests.Serialization
             public ICollection<TestTypeA> Collection { get; set; }
         }
 
-        [global::Orleans.CodeGeneration.RegisterSerializerAttribute()]
+        [Orleans.CodeGeneration.RegisterSerializerAttribute()]
         internal class TestTypeASerialization
         {
 
@@ -93,32 +93,32 @@ namespace UnitTests.Serialization
                 Register();
             }
 
-            public static object DeepCopier(object original)
+            public static object DeepCopier(object original, ICopyContext context)
             {
-                TestTypeA input = ((TestTypeA)(original));
+                TestTypeA input = (TestTypeA)original;
                 TestTypeA result = new TestTypeA();
-                Orleans.Serialization.SerializationContext.Current.RecordObject(original, result);
-                result.Collection = ((System.Collections.Generic.ICollection<TestTypeA>)(Orleans.Serialization.SerializationManager.DeepCopyInner(input.Collection)));
+                context.RecordCopy(original, result);
+                result.Collection = (ICollection<TestTypeA>)SerializationManager.DeepCopyInner(input.Collection, context);
                 return result;
             }
 
-            public static void Serializer(object untypedInput, Orleans.Serialization.BinaryTokenStreamWriter stream, System.Type expected)
+            public static void Serializer(object untypedInput, ISerializationContext context, Type expected)
             {
-                TestTypeA input = ((TestTypeA)(untypedInput));
-                Orleans.Serialization.SerializationManager.SerializeInner(input.Collection, stream, typeof(System.Collections.Generic.ICollection<TestTypeA>));
+                TestTypeA input = (TestTypeA)untypedInput;
+                SerializationManager.SerializeInner(input.Collection, context, typeof(ICollection<TestTypeA>));
             }
 
-            public static object Deserializer(System.Type expected, global::Orleans.Serialization.BinaryTokenStreamReader stream)
+            public static object Deserializer(Type expected, IDeserializationContext context)
             {
                 TestTypeA result = new TestTypeA();
-                DeserializationContext.Current.RecordObject(result);
-                result.Collection = ((System.Collections.Generic.ICollection<TestTypeA>)(Orleans.Serialization.SerializationManager.DeserializeInner(typeof(System.Collections.Generic.ICollection<TestTypeA>), stream)));
+                context.RecordObject(result);
+                result.Collection = (ICollection<TestTypeA>)SerializationManager.DeserializeInner(typeof(ICollection<TestTypeA>), context);
                 return result;
             }
 
             public static void Register()
             {
-                global::Orleans.Serialization.SerializationManager.Register(typeof(TestTypeA), DeepCopier, Serializer, Deserializer);
+                SerializationManager.Register(typeof(TestTypeA), DeepCopier, Serializer, Deserializer);
             }
         }
 

--- a/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
+++ b/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
@@ -67,13 +67,13 @@ namespace UnitTests.Serialization
         {
             var writer = new SerializationContext
             {
-                Stream = new BinaryTokenStreamWriter()
+                StreamWriter = new BinaryTokenStreamWriter()
             };
             var token = new EventSequenceTokenV2(long.MaxValue, int.MaxValue);
             EventSequenceTokenV2.Serialize(token, writer, null);
             var reader = new DeserializationContext
             {
-                Stream = new BinaryTokenStreamReader(writer.Stream.ToByteArray())
+                StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
             };
 
             var deserialized = EventSequenceTokenV2.Deserialize(typeof(EventSequenceTokenV2), reader) as EventSequenceTokenV2;
@@ -114,14 +114,14 @@ namespace UnitTests.Serialization
         {
             var writer = new SerializationContext
             {
-                Stream = new BinaryTokenStreamWriter()
+                StreamWriter = new BinaryTokenStreamWriter()
             };
 
             var token = new EventHubSequenceTokenV2("name", long.MaxValue, int.MaxValue);
             EventHubSequenceTokenV2.Serialize(token, writer, null);
             var reader = new DeserializationContext
             {
-                Stream = new BinaryTokenStreamReader(writer.Stream.ToByteArray())
+                StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
             };
             var deserialized = EventHubSequenceTokenV2.Deserialize(typeof (EventHubSequenceTokenV2), reader) as EventHubSequenceTokenV2;
             Assert.NotNull(deserialized);

--- a/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
+++ b/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
@@ -44,7 +44,7 @@ namespace UnitTests.Serialization
         public void EventSequenceTokenV2_DeepCopy_IfNotNull()
         {
             var token = new EventSequenceTokenV2(long.MaxValue, int.MaxValue);
-            var copy = EventSequenceTokenV2.DeepCopy(token) as EventSequenceToken;
+            var copy = EventSequenceTokenV2.DeepCopy(token, new SerializationContext()) as EventSequenceToken;
             Assert.NotNull(copy);
             Assert.NotSame(token, copy);
             Assert.Equal(token.EventIndex, copy.EventIndex);
@@ -65,10 +65,17 @@ namespace UnitTests.Serialization
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
         public void EventSequenceTokenV2_Serialize_IfNotNull()
         {
-            var writer = new BinaryTokenStreamWriter();
+            var writer = new SerializationContext
+            {
+                Stream = new BinaryTokenStreamWriter()
+            };
             var token = new EventSequenceTokenV2(long.MaxValue, int.MaxValue);
             EventSequenceTokenV2.Serialize(token, writer, null);
-            var reader = new BinaryTokenStreamReader(writer.ToByteArray());
+            var reader = new DeserializationContext
+            {
+                Stream = new BinaryTokenStreamReader(writer.Stream.ToByteArray())
+            };
+
             var deserialized = EventSequenceTokenV2.Deserialize(typeof(EventSequenceTokenV2), reader) as EventSequenceTokenV2;
             Assert.NotNull(deserialized);
             Assert.NotSame(token, deserialized);
@@ -84,7 +91,7 @@ namespace UnitTests.Serialization
         public void EventHubSequenceTokenV2_DeepCopy_IfNotNull()
         {
             var token = new EventHubSequenceTokenV2("name", long.MaxValue, int.MaxValue);
-            var copy = EventHubSequenceTokenV2.DeepCopy(token) as EventSequenceToken;
+            var copy = EventHubSequenceTokenV2.DeepCopy(token, new SerializationContext()) as EventSequenceToken;
             Assert.NotNull(copy);
             Assert.NotSame(token, copy);
             Assert.Equal(token.EventIndex, copy.EventIndex);
@@ -105,10 +112,17 @@ namespace UnitTests.Serialization
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
         public void EventHubSequenceTokenV2_Serialize_IfNotNull()
         {
-            var writer = new BinaryTokenStreamWriter();
+            var writer = new SerializationContext
+            {
+                Stream = new BinaryTokenStreamWriter()
+            };
+
             var token = new EventHubSequenceTokenV2("name", long.MaxValue, int.MaxValue);
             EventHubSequenceTokenV2.Serialize(token, writer, null);
-            var reader = new BinaryTokenStreamReader(writer.ToByteArray());
+            var reader = new DeserializationContext
+            {
+                Stream = new BinaryTokenStreamReader(writer.Stream.ToByteArray())
+            };
             var deserialized = EventHubSequenceTokenV2.Deserialize(typeof (EventHubSequenceTokenV2), reader) as EventHubSequenceTokenV2;
             Assert.NotNull(deserialized);
             Assert.NotSame(token, deserialized);

--- a/test/NonSiloTests/SerializerTests/CustomSerializerTests.cs
+++ b/test/NonSiloTests/SerializerTests/CustomSerializerTests.cs
@@ -51,7 +51,7 @@ namespace NonSiloTests.UnitTests.SerializerTests
         {
             SerializeCounter++;
             var obj = input as ClassWithCustomSerializer;
-            var stream = context.Stream;
+            var stream = context.StreamWriter;
             stream.Write(obj.IntProperty);
             stream.Write(obj.StringProperty);
         }
@@ -61,7 +61,7 @@ namespace NonSiloTests.UnitTests.SerializerTests
         {
             DeserializeCounter++;
             var result = new ClassWithCustomSerializer();
-            var stream = context.Stream;
+            var stream = context.StreamReader;
             result.IntProperty = stream.ReadInt();
             result.StringProperty = stream.ReadString();
             return result;

--- a/test/NonSiloTests/SerializerTests/CustomSerializerTests.cs
+++ b/test/NonSiloTests/SerializerTests/CustomSerializerTests.cs
@@ -23,7 +23,7 @@ namespace NonSiloTests.UnitTests.SerializerTests
         }
 
         [CopierMethod]
-        private static object Copy(object input)
+        private static object Copy(object input, ICopyContext context)
         {
             CopyCounter++;
             var obj = input as ClassWithCustomCopier;
@@ -47,19 +47,21 @@ namespace NonSiloTests.UnitTests.SerializerTests
         }
 
         [SerializerMethod]
-        private static void Serialize(object input, BinaryTokenStreamWriter stream, Type expected)
+        private static void Serialize(object input, ISerializationContext context, Type expected)
         {
             SerializeCounter++;
             var obj = input as ClassWithCustomSerializer;
+            var stream = context.Stream;
             stream.Write(obj.IntProperty);
             stream.Write(obj.StringProperty);
         }
 
         [DeserializerMethod]
-        private static object Deserialize(Type expected, BinaryTokenStreamReader stream)
+        private static object Deserialize(Type expected, IDeserializationContext context)
         {
             DeserializeCounter++;
             var result = new ClassWithCustomSerializer();
+            var stream = context.Stream;
             result.IntProperty = stream.ReadInt();
             result.StringProperty = stream.ReadString();
             return result;

--- a/test/TestGrains/MessageSerializationGrain.cs
+++ b/test/TestGrains/MessageSerializationGrain.cs
@@ -69,18 +69,18 @@
 
         public bool IsSupportedType(Type itemType) => itemType == typeof(SimpleType);
 
-        public object DeepCopy(object source)
+        public object DeepCopy(object source, ICopyContext context)
         {
             return source;
         }
 
-        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
             var typed = (SimpleType)item;
-            writer.Write(typed.Number);
+            context.Stream.Write(typed.Number);
         }
 
-        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        public object Deserialize(Type expectedType, IDeserializationContext context)
         {
             throw new NotSupportedException(FailureMessage);
         }

--- a/test/TestGrains/MessageSerializationGrain.cs
+++ b/test/TestGrains/MessageSerializationGrain.cs
@@ -77,7 +77,7 @@
         public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
             var typed = (SimpleType)item;
-            context.Stream.Write(typed.Number);
+            context.StreamWriter.Write(typed.Number);
         }
 
         public object Deserialize(Type expectedType, IDeserializationContext context)

--- a/test/Tester/FakeSerializer.cs
+++ b/test/Tester/FakeSerializer.cs
@@ -41,13 +41,13 @@ namespace Tester.Serialization
         public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
             SerializeCalled = true;
-            context.Stream.WriteNull();
+            context.StreamWriter.WriteNull();
         }
 
         public object Deserialize(Type expectedType, IDeserializationContext context)
         {
             DeserializeCalled = true;
-            context.Stream.ReadToken();
+            context.StreamReader.ReadToken();
             return (FakeSerialized)Activator.CreateInstance(expectedType);
         }
     }

--- a/test/Tester/FakeSerializer.cs
+++ b/test/Tester/FakeSerializer.cs
@@ -32,22 +32,22 @@ namespace Tester.Serialization
             return typeof(FakeSerialized).IsAssignableFrom(itemType);
         }
 
-        public object DeepCopy(object source)
+        public object DeepCopy(object source, ICopyContext context)
         {
             DeepCopyCalled = true;
             return null;
         }
 
-        public void Serialize(object item, BinaryTokenStreamWriter writer, Type expectedType)
+        public void Serialize(object item, ISerializationContext context, Type expectedType)
         {
             SerializeCalled = true;
-            writer.WriteNull();
+            context.Stream.WriteNull();
         }
 
-        public object Deserialize(Type expectedType, BinaryTokenStreamReader reader)
+        public object Deserialize(Type expectedType, IDeserializationContext context)
         {
             DeserializeCalled = true;
-            reader.ReadToken();
+            context.Stream.ReadToken();
             return (FakeSerialized)Activator.CreateInstance(expectedType);
         }
     }

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -42,23 +42,23 @@ namespace UnitTests.Serialization
                 Register();
             }
 
-            public static object DeepCopier(object original)
+            public static object DeepCopier(object original, ICopyContext context)
             {
                 // I assume JObject is immutable, so no need to deep copy.
                 // Alternatively, can copy via JObject.ToString and JObject.Parse().
                 return original;
             }
 
-            public static void Serializer(object untypedInput, BinaryTokenStreamWriter stream, Type expected)
+            public static void Serializer(object untypedInput, ISerializationContext context, Type expected)
             {
-                var input = (JObject)(untypedInput);
+                var input = (JObject)untypedInput;
                 string str = input.ToString();
-                SerializationManager.Serialize(str, stream);
+                SerializationManager.Serialize(str, context.Stream);
             }
 
-            public static object Deserializer(Type expected, BinaryTokenStreamReader stream)
+            public static object Deserializer(Type expected, IDeserializationContext context)
             {
-                var str = (string)(SerializationManager.Deserialize(typeof(string), stream));
+                var str = (string)SerializationManager.Deserialize(typeof(string), context.Stream);
                 return JObject.Parse(str);
             }
 
@@ -146,22 +146,22 @@ namespace UnitTests.Serialization
                 Register();
             }
 
-            public static object DeepCopier(object original)
+            public static object DeepCopier(object original, ICopyContext context)
             {
                 // I assume JObject is immutable, so no need to deep copy.
                 // Alternatively, can copy via JObject.ToString and JObject.Parse().
                 return original;
             }
 
-            public static void Serialize(object obj, BinaryTokenStreamWriter stream, Type expected)
+            public static void Serialize(object obj, ISerializationContext context, Type expected)
             {
                 var str = JsonConvert.SerializeObject(obj, Settings);
-                SerializationManager.Serialize(str, stream);
+                SerializationManager.Serialize(str, context.Stream);
             }
 
-            public static object Deserialize(Type expected, BinaryTokenStreamReader stream)
+            public static object Deserialize(Type expected, IDeserializationContext context)
             {
-                var str = (string)SerializationManager.Deserialize(typeof(string), stream);
+                var str = (string)SerializationManager.Deserialize(typeof(string), context.Stream);
                 return JsonConvert.DeserializeObject(str, expected);
             }
 

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -53,12 +53,12 @@ namespace UnitTests.Serialization
             {
                 var input = (JObject)untypedInput;
                 string str = input.ToString();
-                SerializationManager.Serialize(str, context.Stream);
+                SerializationManager.Serialize(str, context.StreamWriter);
             }
 
             public static object Deserializer(Type expected, IDeserializationContext context)
             {
-                var str = (string)SerializationManager.Deserialize(typeof(string), context.Stream);
+                var str = (string)SerializationManager.Deserialize(typeof(string), context.StreamReader);
                 return JObject.Parse(str);
             }
 
@@ -156,12 +156,12 @@ namespace UnitTests.Serialization
             public static void Serialize(object obj, ISerializationContext context, Type expected)
             {
                 var str = JsonConvert.SerializeObject(obj, Settings);
-                SerializationManager.Serialize(str, context.Stream);
+                SerializationManager.Serialize(str, context.StreamWriter);
             }
 
             public static object Deserialize(Type expected, IDeserializationContext context)
             {
-                var str = (string)SerializationManager.Deserialize(typeof(string), context.Stream);
+                var str = (string)SerializationManager.Deserialize(typeof(string), context.StreamReader);
                 return JsonConvert.DeserializeObject(str, expected);
             }
 

--- a/test/Tester/SerializationTests/SerializationTestsUtils.cs
+++ b/test/Tester/SerializationTests/SerializationTestsUtils.cs
@@ -9,10 +9,10 @@ namespace Tester.SerializationTests
         {
             var writer = new SerializationContext
             {
-                Stream = new BinaryTokenStreamWriter()
+                StreamWriter = new BinaryTokenStreamWriter()
             };
             SerializationManager.FallbackSerializer(ob, writer, ob.GetType());
-            var bytes = writer.Stream.ToByteArray();
+            var bytes = writer.StreamWriter.ToByteArray();
 
             var reader = new BinaryTokenStreamReader(bytes);
             var serToken = reader.ReadToken();

--- a/test/Tester/SerializationTests/SerializationTestsUtils.cs
+++ b/test/Tester/SerializationTests/SerializationTestsUtils.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Orleans.Serialization;
+﻿using Orleans.Serialization;
 using Xunit;
 
 namespace Tester.SerializationTests
@@ -12,9 +7,12 @@ namespace Tester.SerializationTests
     {
         public static void VerifyUsingFallbackSerializer(object ob)
         {
-            var writer = new BinaryTokenStreamWriter();
+            var writer = new SerializationContext
+            {
+                Stream = new BinaryTokenStreamWriter()
+            };
             SerializationManager.FallbackSerializer(ob, writer, ob.GetType());
-            var bytes = writer.ToByteArray();
+            var bytes = writer.Stream.ToByteArray();
 
             var reader = new BinaryTokenStreamReader(bytes);
             var serToken = reader.ReadToken();

--- a/test/TesterAzureUtils/StreamTypeSerializationTests.cs
+++ b/test/TesterAzureUtils/StreamTypeSerializationTests.cs
@@ -57,7 +57,7 @@ namespace Tester.AzureUtils.Streaming
         public void AzureQueueBatchContainerV2_DeepCopy_IfNotNullAndUsingExternalSerializer()
         {
             var container = CreateAzureQueueBatchContainer();
-            var copy = AzureQueueBatchContainerV2.DeepCopy(container) as AzureQueueBatchContainerV2;
+            var copy = AzureQueueBatchContainerV2.DeepCopy(container, new SerializationContext()) as AzureQueueBatchContainerV2;
             ValidateIdenticalQueueBatchContainerButNotSame(container, copy);
             copy = SerializationManager.DeepCopy(container) as AzureQueueBatchContainerV2;
             ValidateIdenticalQueueBatchContainerButNotSame(container, copy);
@@ -67,16 +67,23 @@ namespace Tester.AzureUtils.Streaming
         public void AzureQueueBatchContainerV2_Serialize_IfNotNull()
         {
             var container = CreateAzureQueueBatchContainer();
-            var writer = new BinaryTokenStreamWriter();
+            var writer = new SerializationContext
+            {
+                Stream = new BinaryTokenStreamWriter()
+            };
             AzureQueueBatchContainerV2.Serialize(container, writer, null);
-            var reader = new BinaryTokenStreamReader(writer.ToByteArray());
+            var reader = new DeserializationContext
+            {
+                Stream = new BinaryTokenStreamReader(writer.Stream.ToByteArray())
+            };
+
             var deserialized = AzureQueueBatchContainerV2.Deserialize(typeof(AzureQueueBatchContainer), reader) as AzureQueueBatchContainerV2;
             ValidateIdenticalQueueBatchContainerButNotSame(container, deserialized);
 
-            writer = new BinaryTokenStreamWriter();
-            SerializationManager.Serialize(container, writer);
-            reader = new BinaryTokenStreamReader(writer.ToByteArray());
-            deserialized = SerializationManager.Deserialize<AzureQueueBatchContainerV2>(reader);
+            var streamWriter = new BinaryTokenStreamWriter();
+            SerializationManager.Serialize(container, streamWriter);
+            var streamReader = new BinaryTokenStreamReader(streamWriter.ToByteArray());
+            deserialized = SerializationManager.Deserialize<AzureQueueBatchContainerV2>(streamReader);
             ValidateIdenticalQueueBatchContainerButNotSame(container, deserialized);
         }
 

--- a/test/TesterAzureUtils/StreamTypeSerializationTests.cs
+++ b/test/TesterAzureUtils/StreamTypeSerializationTests.cs
@@ -69,12 +69,12 @@ namespace Tester.AzureUtils.Streaming
             var container = CreateAzureQueueBatchContainer();
             var writer = new SerializationContext
             {
-                Stream = new BinaryTokenStreamWriter()
+                StreamWriter = new BinaryTokenStreamWriter()
             };
             AzureQueueBatchContainerV2.Serialize(container, writer, null);
             var reader = new DeserializationContext
             {
-                Stream = new BinaryTokenStreamReader(writer.Stream.ToByteArray())
+                StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
             };
 
             var deserialized = AzureQueueBatchContainerV2.Deserialize(typeof(AzureQueueBatchContainer), reader) as AzureQueueBatchContainerV2;


### PR DESCRIPTION
This is an implementation of #2547, & is related to #467.

This change moves `SerializationContext.Current` & `DeserializationContext.Current` to `SerializationManager`, keeps them static, but makes them private. It continues to use static `SerializationManager` methods in the generated code, but it passes in all of the context information required - so we can begin to remove global state from those methods down the track.