### PR TITLE
Explicitly specify no deps for net462 in Orleans.PlatformServices nuget

### DIFF
--- a/vNext/src/NuGet/Microsoft.Orleans.PlatformServices.nuspec
+++ b/vNext/src/NuGet/Microsoft.Orleans.PlatformServices.nuspec
@@ -21,6 +21,8 @@
       <group targetFramework=".NETStandard1.5">
         <dependency id="System.Runtime.Loader" version="4.3.0" />
       </group>
+      <group targetFramework=".NETFramework4.6.2">
+      </group>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
When using project.json + full framework, the pre-release Orleans.PlatformServices nuget fails installation with the message:
```
System.Runtime.Loader 4.3.0 provides a compile-time reference assembly for System.Runtime.Loader on .NETFramework,Version=v4.6.2, but there is no run-time assembly compatible with win.
One or more packages are incompatible with .NETFramework,Version=v4.6.2 (win).
System.Runtime.Loader 4.3.0 provides a compile-time reference assembly for System.Runtime.Loader on .NETFramework,Version=v4.6.2, but there is no run-time assembly compatible with win-anycpu.
One or more packages are incompatible with .NETFramework,Version=v4.6.2 (win-anycpu).
```

This PR fixes that by explicitly specifying that no dependencies are required in the PlatformServices nuget when using the full framework.