### PR TITLE
[WIP] OrleansDockerUtils -> Docker and Docker Swarm Clusters for Orleans

### DIFF
--- a/src/NuGet/Microsoft.Orleans.Docker.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Docker.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Orleans.Docker</id>
+    <version>$version$</version>
+    <title>Microsoft Orleans Docker Support</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,Orleans</owners>
+    <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
+    <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
+    <summary>
+      Support for hosting Microsoft Orleans on Docker containers.
+    </summary>
+    <description>
+      Support for hosting Microsoft Orleans on Docker containers.
+    </description>
+    <copyright>Copyright Microsoft 2016</copyright>
+    <tags>Microsoft Orleans Docker Container Swarm</tags>
+    <dependencies>
+      <dependency id="Microsoft.Orleans.Core" version="$version$" />
+      <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
+      <dependency id="Docker.DotNet" version="2.124.3" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.Orleans.Docker.dll" target="lib\net451" />
+    <file src="Microsoft.Orleans.Docker.pdb" target="lib\net451" />
+    <file src="Microsoft.Orleans.Docker.xml" target="lib\net451" />
+    <file src="$SRC_DIR$OrleansDockerUtils\**\*.cs" exclude="*\obj\**\*" target="src" />
+  </files>
+</package>

--- a/src/NuGet/Microsoft.Orleans.Docker.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Docker.nuspec
@@ -21,6 +21,8 @@
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
       <dependency id="Docker.DotNet" version="2.124.3" />
+      <dependency id="Docker.DotNet.BasicAuth" version="2.124.3" />
+      <dependency id="Docker.DotNet.X509" version="2.124.3" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -64,6 +64,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{014CD19F
 		NuGet\Microsoft.Orleans.Client.nuspec = NuGet\Microsoft.Orleans.Client.nuspec
 		NuGet\Microsoft.Orleans.Core.nuspec = NuGet\Microsoft.Orleans.Core.nuspec
 		NuGet\Microsoft.Orleans.CounterControl.nuspec = NuGet\Microsoft.Orleans.CounterControl.nuspec
+		NuGet\Microsoft.Orleans.Docker.nuspec = NuGet\Microsoft.Orleans.Docker.nuspec
 		NuGet\Microsoft.Orleans.EventSourcing.nuspec = NuGet\Microsoft.Orleans.EventSourcing.nuspec
 		NuGet\Microsoft.Orleans.OrleansAWSUtils.nuspec = NuGet\Microsoft.Orleans.OrleansAWSUtils.nuspec
 		NuGet\Microsoft.Orleans.OrleansAzureUtils.nuspec = NuGet\Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -215,6 +216,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TesterSQLUtils", "..\test\TesterSQLUtils\TesterSQLUtils.csproj", "{5A620DF5-1461-4B31-96E0-925BBD10773C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TesterZooKeeperUtils", "..\test\TesterZooKeeperUtils\TesterZooKeeperUtils.csproj", "{AFEC183D-C12A-4DFC-8DA9-A4895CF5D020}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansDockerUtils", "OrleansDockerUtils\OrleansDockerUtils.csproj", "{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TesterDockerUtils", "..\test\TesterDockerUtils\TesterDockerUtils.csproj", "{02C701D4-7C7E-48F0-9871-E82C40C62B2B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -558,6 +563,22 @@ Global
 		{AFEC183D-C12A-4DFC-8DA9-A4895CF5D020}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AFEC183D-C12A-4DFC-8DA9-A4895CF5D020}.Release|x64.ActiveCfg = Release|Any CPU
 		{AFEC183D-C12A-4DFC-8DA9-A4895CF5D020}.Release|x64.Build.0 = Release|Any CPU
+		{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}.Release|x64.Build.0 = Release|Any CPU
+		{02C701D4-7C7E-48F0-9871-E82C40C62B2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02C701D4-7C7E-48F0-9871-E82C40C62B2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02C701D4-7C7E-48F0-9871-E82C40C62B2B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{02C701D4-7C7E-48F0-9871-E82C40C62B2B}.Debug|x64.Build.0 = Debug|Any CPU
+		{02C701D4-7C7E-48F0-9871-E82C40C62B2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02C701D4-7C7E-48F0-9871-E82C40C62B2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02C701D4-7C7E-48F0-9871-E82C40C62B2B}.Release|x64.ActiveCfg = Release|Any CPU
+		{02C701D4-7C7E-48F0-9871-E82C40C62B2B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -609,5 +630,7 @@ Global
 		{EEEB9AC6-F50B-4275-AE72-1D56AC01A19B} = {01F3CC7E-F996-411E-AFD6-72673A826549}
 		{5A620DF5-1461-4B31-96E0-925BBD10773C} = {01F3CC7E-F996-411E-AFD6-72673A826549}
 		{AFEC183D-C12A-4DFC-8DA9-A4895CF5D020} = {01F3CC7E-F996-411E-AFD6-72673A826549}
+		{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883} = {F3C3FA92-FC69-4B94-8914-3B70E624B5B5}
+		{02C701D4-7C7E-48F0-9871-E82C40C62B2B} = {01F3CC7E-F996-411E-AFD6-72673A826549}
 	EndGlobalSection
 EndGlobal

--- a/src/OrleansDockerUtils/DockerGatewayProvider.cs
+++ b/src/OrleansDockerUtils/DockerGatewayProvider.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Orleans.Docker
         public async Task InitializeGatewayListProvider(ClientConfiguration clientConfiguration, Logger logger)
         {
             resolver = new DockerSiloResolver(
-                clientConfiguration.DeploymentId, 
-                clientConfiguration.CreateDockerClient(), 
-                logger.GetLogger); 
+                clientConfiguration.DeploymentId,
+                clientConfiguration.CreateDockerClient(),
+                logger.GetLogger);
 
             resolver.Subscribe(this);
             log = logger.GetLogger(nameof(DockerGatewayProvider));
@@ -109,7 +109,8 @@ namespace Microsoft.Orleans.Docker
 
         public void OnUpdate(DockerSiloInfo[] silos)
         {
-            gateways = silos.Select(silo => silo.GatewayAddress.ToGatewayUri()).ToList();
+            gateways = silos.Where(s => string.IsNullOrWhiteSpace(s.Gateway))
+                .Select(silo => silo.GatewayAddress.ToGatewayUri()).ToList();
 
             if (log.IsVerbose)
             {

--- a/src/OrleansDockerUtils/DockerGatewayProvider.cs
+++ b/src/OrleansDockerUtils/DockerGatewayProvider.cs
@@ -1,0 +1,135 @@
+﻿using Microsoft.Orleans.Docker.Models;
+using Microsoft.Orleans.Docker.Utilities;
+using Orleans;
+using Orleans.Messaging;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Orleans.Docker
+{
+
+    internal class DockerGatewayProvider : IGatewayListProvider, IGatewayListObservable, IDockerStatusListener, IDisposable
+    {
+        private readonly ConcurrentDictionary<IGatewayListListener, IGatewayListListener> subscribers =
+            new ConcurrentDictionary<IGatewayListListener, IGatewayListListener>();
+        private readonly TimeSpan refreshPeriod = TimeSpan.FromSeconds(30);
+        private IDockerSiloResolver resolver;
+        private List<Uri> gateways = new List<Uri>();
+        private Timer timer;
+        private Logger log;
+
+        /// <summary>
+        /// Specifies whether this IGatewayListProvider ever refreshes its returned information, or always returns the same gw list.
+        /// (currently only the static config based StaticGatewayListProvider is not updatable. All others are.)
+        /// </summary>
+        public bool IsUpdatable => true;
+
+        /// <summary>
+        /// Specifies how often this IGatewayListProvider is refreshed, to have a bound on max staleness of its returned information.
+        /// </summary>
+        public TimeSpan MaxStaleness => TimeSpan.FromSeconds(refreshPeriod.TotalSeconds * 2);
+
+        public async Task InitializeGatewayListProvider(ClientConfiguration clientConfiguration, Logger logger)
+        {
+            resolver = new DockerSiloResolver(
+                clientConfiguration.DeploymentId, 
+                clientConfiguration.CreateDockerClient(), 
+                logger.GetLogger); 
+
+            resolver.Subscribe(this);
+            log = logger.GetLogger(nameof(DockerGatewayProvider));
+            await RefreshAsync();
+            timer = new Timer(Refresh, null, refreshPeriod, refreshPeriod);
+        }
+
+        /// <summary>
+        /// Returns the list of gateways (silos) that can be used by a client to connect to Orleans cluster.
+        /// </summary>
+        public Task<IList<Uri>> GetGateways() => Task.FromResult<IList<Uri>>(gateways);
+
+        /// <summary>
+        /// Subscribes the provided <paramref name="subscriber"/> from notification events.
+        /// </summary>
+        /// <param name="subscriber">The listener.</param>
+        /// <returns>A value indicating whether the listener was subscribed.</returns>
+        public bool SubscribeToGatewayNotificationEvents(IGatewayListListener subscriber)
+        {
+            subscribers.TryAdd(subscriber, subscriber);
+            return true;
+        }
+
+        /// <summary>
+        /// Unsubscribes the provided <paramref name="listener"/> from notification events.
+        /// </summary>
+        /// <param name="listener">The listener.</param>
+        /// <returns>A value indicating whether the listener was unsubscribed.</returns>
+        public bool UnSubscribeFromGatewayNotificationEvents(IGatewayListListener listener)
+        {
+            subscribers.TryRemove(listener, out listener);
+            return true;
+        }
+
+        public void Dispose()
+        {
+            timer?.Dispose();
+            timer = null;
+            resolver.Unsubscribe(this);
+        }
+
+        /// <summary>
+        /// Refreshes the gateway list.
+        /// </summary>
+        /// <param name="state">The state object.</param>
+        private void Refresh(object state)
+        {
+            RefreshAsync().Ignore();
+        }
+
+        private async Task RefreshAsync()
+        {
+            try
+            {
+                await resolver.Refresh();
+            }
+            catch (Exception exception)
+            {
+                log.Warn(
+                    (int)ErrorCode.Docker_GatewayProvider_ExceptionRefreshingGateways,
+                    "Exception while refreshing gateways on scheduled interval",
+                    exception);
+                throw;
+            }
+        }
+
+        public void OnUpdate(DockerSiloInfo[] silos)
+        {
+            gateways = silos.Select(silo => silo.GatewayAddress.ToGatewayUri()).ToList();
+
+            if (log.IsVerbose)
+            {
+                log.Verbose($"Updating {subscribers.Count} subscribers with {gateways.Count} gateways.");
+            }
+
+            foreach (var subscriber in subscribers.Values)
+            {
+                try
+                {
+                    subscriber.GatewayListNotification(gateways);
+                }
+                catch (Exception exception)
+                {
+                    log.Warn(
+                        (int)ErrorCode.Docker_GatewayProvider_ExceptionNotifyingSubscribers,
+                        "Exception while notifying subscriber.",
+                        exception);
+                }
+            }
+        }
+    }
+}

--- a/src/OrleansDockerUtils/DockerMembershipOracle.cs
+++ b/src/OrleansDockerUtils/DockerMembershipOracle.cs
@@ -1,0 +1,147 @@
+﻿using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Orleans.Docker
+{
+    internal class DockerMembershipOracle : IMembershipOracle
+    {
+        private readonly Dictionary<SiloAddress, SiloEntry> silos = new Dictionary<SiloAddress, SiloEntry>();
+        private readonly ILocalSiloDetails localSiloDetails;
+        private readonly Logger log;
+        private readonly GlobalConfiguration globalConfig;
+
+        // Cached collection of active silos.
+        private volatile Dictionary<SiloAddress, SiloStatus> activeSilosCache;
+
+        // Cached collection of silos.
+        private volatile Dictionary<SiloAddress, SiloStatus> allSilosCache;
+
+        private Timer timer;
+        private DateTime lastRefreshTime;
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="DockerMembershipOracle"/> class
+        /// </summary>
+        /// <param name="localSiloDetails">The silo which this instance will provide membership information for.</param>
+        /// <param name="globalConfig">The cluster configuration.</param>
+        /// <param name="loggerFactory">The logger factory.</param>
+        public DockerMembershipOracle(
+            ILocalSiloDetails localSiloDetails,
+            GlobalConfiguration globalConfig,
+            Func<string, Logger> loggerFactory)
+        {
+            this.log = loggerFactory("MembershipOracle");
+            this.localSiloDetails = localSiloDetails;
+            this.globalConfig = globalConfig;
+            this.silos[SiloAddress] = new SiloEntry(SiloStatus.Created, SiloName);
+        }
+
+        /// <summary>
+        /// Status of this silo.
+        /// </summary>
+        public SiloStatus CurrentStatus => GetApproximateSiloStatus(SiloAddress);
+
+        /// <summary>
+        /// Address of this silo.
+        /// </summary>
+        public SiloAddress SiloAddress => localSiloDetails.SiloAddress;
+
+        /// <summary>
+        /// Name of this silo.
+        /// </summary>
+        public string SiloName => this.localSiloDetails.Name;
+
+        public Task BecomeActive()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool CheckHealth(DateTime lastCheckTime)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IReadOnlyList<SiloAddress> GetApproximateMultiClusterGateways()
+        {
+            throw new NotImplementedException();
+        }
+
+        public SiloStatus GetApproximateSiloStatus(SiloAddress siloAddress)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDeadSilo(SiloAddress silo)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsFunctionalDirectory(SiloAddress siloAddress)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task KillMyself()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task ShutDown()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Start()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Stop()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SubscribeToSiloStatusEvents(ISiloStatusListener observer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetSiloName(SiloAddress siloAddress, out string siloName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool UnSubscribeFromSiloStatusEvents(ISiloStatusListener observer)
+        {
+            throw new NotImplementedException();
+        }
+
+        private class SiloEntry
+        {
+            public SiloEntry(SiloStatus status, string name)
+            {
+                Status = status;
+                Name = name;
+            }
+
+            public SiloStatus Status { get; }
+            public string Name { get; }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether this entry was updated.
+            /// </summary>
+            public bool Refreshed { get; set; }
+        }
+    }
+}

--- a/src/OrleansDockerUtils/DockerMembershipOracle.cs
+++ b/src/OrleansDockerUtils/DockerMembershipOracle.cs
@@ -373,8 +373,8 @@ namespace Microsoft.Orleans.Docker
             catch (Exception exception)
             {
                 log?.Warn(
-                    (int)ErrorCode.Docker_MembershipOracle_ExceptionRefreshingPartitions,
-                    "Exception refreshing partitions.",
+                    (int)ErrorCode.Docker_MembershipOracle_ExceptionRefreshingSilos,
+                    "Exception refreshing silos.",
                     exception);
                 throw;
             }

--- a/src/OrleansDockerUtils/DockerMembershipOracle.cs
+++ b/src/OrleansDockerUtils/DockerMembershipOracle.cs
@@ -1,47 +1,19 @@
-﻿using Orleans.Runtime;
+﻿using Microsoft.Orleans.Docker.Models;
+using Microsoft.Orleans.Docker.Utilities;
+using Orleans;
+using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Orleans.Docker
 {
-    internal class DockerMembershipOracle : IMembershipOracle
+    internal class DockerMembershipOracle : IMembershipOracle, IDockerStatusListener, IDisposable
     {
-        private readonly Dictionary<SiloAddress, SiloEntry> silos = new Dictionary<SiloAddress, SiloEntry>();
-        private readonly ILocalSiloDetails localSiloDetails;
-        private readonly Logger log;
-        private readonly GlobalConfiguration globalConfig;
-
-        // Cached collection of active silos.
-        private volatile Dictionary<SiloAddress, SiloStatus> activeSilosCache;
-
-        // Cached collection of silos.
-        private volatile Dictionary<SiloAddress, SiloStatus> allSilosCache;
-
-        private Timer timer;
-        private DateTime lastRefreshTime;
-
-        /// <summary>
-        /// Initialize a new instance of the <see cref="DockerMembershipOracle"/> class
-        /// </summary>
-        /// <param name="localSiloDetails">The silo which this instance will provide membership information for.</param>
-        /// <param name="globalConfig">The cluster configuration.</param>
-        /// <param name="loggerFactory">The logger factory.</param>
-        public DockerMembershipOracle(
-            ILocalSiloDetails localSiloDetails,
-            GlobalConfiguration globalConfig,
-            Func<string, Logger> loggerFactory)
-        {
-            this.log = loggerFactory("MembershipOracle");
-            this.localSiloDetails = localSiloDetails;
-            this.globalConfig = globalConfig;
-            this.silos[SiloAddress] = new SiloEntry(SiloStatus.Created, SiloName);
-        }
-
         /// <summary>
         /// Status of this silo.
         /// </summary>
@@ -51,84 +23,438 @@ namespace Microsoft.Orleans.Docker
         /// Address of this silo.
         /// </summary>
         public SiloAddress SiloAddress => localSiloDetails.SiloAddress;
-
+        
         /// <summary>
         /// Name of this silo.
         /// </summary>
-        public string SiloName => this.localSiloDetails.Name;
+        public string SiloName => localSiloDetails.Name;
 
-        public Task BecomeActive()
+        private readonly ConcurrentDictionary<ISiloStatusListener, ISiloStatusListener> subscribers =
+            new ConcurrentDictionary<ISiloStatusListener, ISiloStatusListener>();
+        private readonly object updateLock = new object();
+        private readonly Dictionary<SiloAddress, SiloEntry> silos = new Dictionary<SiloAddress, SiloEntry>();
+        private readonly TimeSpan refreshPeriod = TimeSpan.FromSeconds(30);
+        private readonly ILocalSiloDetails localSiloDetails;
+        private readonly Logger log;
+        private readonly GlobalConfiguration globalConfig;
+        private readonly IDockerSiloResolver resolver;
+
+        // Cached collection of active silos.
+        private volatile Dictionary<SiloAddress, SiloStatus> activeSilosCache;
+
+        // Cached collection of silos.
+        private volatile Dictionary<SiloAddress, SiloStatus> allSilosCache;
+
+        // Cached collection of multicluster gateways.
+        private volatile List<SiloAddress> multiClusterSilosCache;
+
+        private Timer timer;
+        private DateTime lastRefreshTime;
+
+        /// <summary>
+        /// Initialize a new instance of the <see cref="DockerMembershipOracle"/> class
+        /// </summary>
+        /// <param name="localSiloDetails">The silo which this instance will provide membership information for.</param>
+        /// <param name="globalConfig">The cluster configuration.</param>
+        /// <param name="siloResolver">The service resolver which this instance will use.</param>
+        /// <param name="loggerFactory">The logger factory.</param>
+        public DockerMembershipOracle(
+            ILocalSiloDetails localSiloDetails,
+            GlobalConfiguration globalConfig,
+            IDockerSiloResolver siloResolver,
+            Func<string, Logger> loggerFactory)
         {
-            throw new NotImplementedException();
+            resolver = siloResolver;
+            log = loggerFactory("MembershipOracle");
+            silos[SiloAddress] = new SiloEntry(SiloStatus.Created, SiloName);
+            this.localSiloDetails = localSiloDetails;
+            this.globalConfig = globalConfig;
         }
-
+       
+        /// <summary>
+        /// Returns a value indicating the health of this instance.
+        /// </summary>
+        /// <param name="lastCheckTime">The last time which this participant's health was checked.</param>
+        /// <returns><see langword="true"/> if the participant is healthy, <see langword="false"/> otherwise.</returns>
         public bool CheckHealth(DateTime lastCheckTime)
         {
-            throw new NotImplementedException();
+            return lastRefreshTime.Add(refreshPeriod + refreshPeriod) > DateTime.UtcNow;
         }
 
         public IReadOnlyList<SiloAddress> GetApproximateMultiClusterGateways()
         {
-            throw new NotImplementedException();
+            var result = multiClusterSilosCache;
+            if (result != null) return result;
+
+            lock (updateLock)
+            {
+                if (multiClusterSilosCache != null) return multiClusterSilosCache;
+
+                // Take all the active silos if their count does not exceed the desired number of gateways
+                var maxSize = globalConfig.MaxMultiClusterGateways;
+                result = new List<SiloAddress>(silos.Keys);
+
+                // Restrict the length to the maximum size.
+                if (result.Count > maxSize)
+                {
+                    result.Sort();
+                    result.RemoveRange(maxSize, result.Count - maxSize);
+                }
+
+                multiClusterSilosCache = result;
+                return multiClusterSilosCache;
+            }
         }
 
+        /// <summary>
+        /// Get the status of a given silo. 
+        /// This method returns an approximate view on the status of a given silo. 
+        /// In particular, this oracle may think the given silo is alive, while it may already have failed.
+        /// If this oracle thinks the given silo is dead, it has been authoritatively told so by ISiloDirectory.
+        /// </summary>
+        /// <param name="siloAddress">A silo whose status we are interested in.</param>
+        /// <returns>The status of a given silo.</returns>
         public SiloStatus GetApproximateSiloStatus(SiloAddress siloAddress)
         {
-            throw new NotImplementedException();
+            SiloStatus status;
+            var allSilos = GetApproximateSiloStatuses(onlyActive: false);
+            var exists = allSilos.TryGetValue(siloAddress, out status);
+            return exists ? status : SiloStatus.None;
         }
 
+        /// <summary>
+        /// Get the statuses of all silo. 
+        /// This method returns an approximate view on the statuses of all silo.
+        /// </summary>
+        /// <param name="onlyActive">Include only silo who are currently considered to be active. If false, include all.</param>
+        /// <returns>A list of silo statuses.</returns>
         public Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false)
         {
-            throw new NotImplementedException();
+            if (onlyActive)
+            {
+                // Return just the active silos.
+                var cachedActive = activeSilosCache;
+                if (cachedActive != null) return cachedActive;
+
+                // Rebuild the cache, since it's not valid.
+                lock (updateLock)
+                {
+                    return activeSilosCache ??
+                           (activeSilosCache =
+                               silos.Where(s => s.Value.Status == SiloStatus.Active)
+                                   .ToDictionary(kv => kv.Key, kv => kv.Value.Status));
+                }
+            }
+
+            // Return all silos.
+            var cachedSilos = allSilosCache;
+            if (cachedSilos != null) return cachedSilos;
+
+            // Rebuild the cache, since it's not valid.
+            lock (updateLock)
+            {
+                return allSilosCache ??
+                       (allSilosCache =
+                           silos.ToDictionary(kv => kv.Key, kv => kv.Value.Status));
+            }
         }
 
-        public bool IsDeadSilo(SiloAddress silo)
+        /// <summary>
+        /// Determine if the current silo is dead.
+        /// </summary>
+        /// <returns>The silo so ask about.</returns>
+        public bool IsDeadSilo(SiloAddress address)
         {
-            throw new NotImplementedException();
+            if (address.Equals(SiloAddress)) return false;
+            var status = GetApproximateSiloStatus(address);
+            return status == SiloStatus.Dead;
         }
 
+        /// <summary>
+        /// Determine if the current silo is valid for creating new activations on or for directory lookups.
+        /// </summary>
+        /// <returns>The silo so ask about.</returns>
         public bool IsFunctionalDirectory(SiloAddress siloAddress)
         {
-            throw new NotImplementedException();
+            if (siloAddress.Equals(SiloAddress)) return true;
+
+            var status = GetApproximateSiloStatus(siloAddress);
+            return !status.IsTerminating();
         }
 
-        public Task KillMyself()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task ShutDown()
-        {
-            throw new NotImplementedException();
-        }
-
+        /// <summary>
+        /// Start this oracle. Will register this silo in the SiloDirectory with SiloStatus.Starting status.
+        /// </summary>
         public Task Start()
         {
-            throw new NotImplementedException();
+            timer = new Timer(
+                self => ((DockerMembershipOracle)self).RefreshAsync().Ignore(),
+                this,
+                refreshPeriod,
+                refreshPeriod);
+
+            resolver.Subscribe(this);
+            RefreshAsync().Ignore();
+            UpdateStatus(SiloStatus.Joining);
+
+            return TaskDone.Done;
         }
 
+        /// <summary>
+        /// Turns this oracle into an Active state. Will update this silo in the SiloDirectory with SiloStatus.Active status.
+        /// </summary>
+        public Task BecomeActive()
+        {
+            UpdateStatus(SiloStatus.Active);
+            return TaskDone.Done;
+        }
+
+        /// <summary>
+        /// Completely kill this oracle. Will update this silo in the SiloDirectory with SiloStatus.Dead status. 
+        /// </summary>
+        public Task KillMyself()
+        {
+            resolver.Unsubscribe(this);
+            UpdateStatus(SiloStatus.Dead);
+            return TaskDone.Done;
+        }
+
+        /// <summary>
+        /// ShutDown this oracle. Will update this silo in the SiloDirectory with SiloStatus.ShuttingDown status. 
+        /// </summary>
+        public Task ShutDown()
+        {
+            StopInternal();
+            UpdateStatus(SiloStatus.ShuttingDown);
+            return TaskDone.Done;
+        }
+        
+        /// <summary>
+        /// Stop this oracle. Will update this silo in the SiloDirectory with SiloStatus.Stopping status. 
+        /// </summary>
         public Task Stop()
         {
-            throw new NotImplementedException();
+            StopInternal();
+            UpdateStatus(SiloStatus.Stopping);
+            return TaskDone.Done;
         }
 
-        public bool SubscribeToSiloStatusEvents(ISiloStatusListener observer)
-        {
-            throw new NotImplementedException();
-        }
-
+        /// <summary>
+        /// Get the name of a silo. 
+        /// Silo name is assumed to be static and does not change across restarts of the same silo.
+        /// </summary>
+        /// <param name="siloAddress">A silo whose name we are interested in.</param>
+        /// <param name="siloName">A silo name.</param>
+        /// <returns>TTrue if could return the requested name, false otherwise.</returns>
         public bool TryGetSiloName(SiloAddress siloAddress, out string siloName)
         {
-            throw new NotImplementedException();
+            SiloEntry entry;
+            var result = silos.TryGetValue(siloAddress, out entry);
+            siloName = entry?.Name;
+            return result;
         }
 
+        /// <summary>
+        /// Subscribe to status events about all silos. 
+        /// </summary>
+        /// <param name="observer">An observer async interface to receive silo status notifications.</param>
+        /// <returns>bool value indicating that subscription succeeded or not.</returns>
+        public bool SubscribeToSiloStatusEvents(ISiloStatusListener observer)
+        {
+            subscribers[observer] = observer;
+            return true;
+        }
+
+        /// <summary>
+        /// UnSubscribe from status events about all silos. 
+        /// </summary>
+        /// <returns>bool value indicating that subscription succeeded or not.</returns>
         public bool UnSubscribeFromSiloStatusEvents(ISiloStatusListener observer)
         {
-            throw new NotImplementedException();
+            subscribers.TryRemove(observer, out observer);
+            return true;
+        }
+        
+        /// <summary>
+        /// Notifies this instance of an update to one or more partitions.
+        /// </summary>
+        /// <param name="newSilos">The updated set of partitions.</param>
+        public void OnUpdate(DockerSiloInfo[] newSilos)
+        {
+            var added = default(HashSet<SiloAddress>);
+            var removed = default(HashSet<SiloAddress>);
+            lock (updateLock)
+            {
+                foreach (var updatedSilo in newSilos)
+                {
+                    // Update the silo if it was not previously seen or if the existing entry's status
+                    // does not match the updated status.
+                    SiloEntry existing;
+                    if (!silos.TryGetValue(updatedSilo.SiloAddress, out existing))
+                    {
+                        // Add the new silo.
+                        if (added == null) added = new HashSet<SiloAddress>();
+                        added.Add(updatedSilo.SiloAddress);
+                        silos[updatedSilo.SiloAddress] = new SiloEntry(SiloStatus.Active, updatedSilo.Name)
+                        {
+                            Refreshed = true
+                        };
+                    }
+                    else
+                    {
+                        // Mark the existing silo as being refreshed.
+                        existing.Refreshed = true;
+                    }
+                }
+
+                // Identify removed silos.
+                foreach (var silo in silos)
+                {
+                    // Never remove self.
+                    if (silo.Key.Equals(SiloAddress)) continue;
+
+                    // Do not remove silos which were present in the update.
+                    if (silo.Value.Refreshed)
+                    {
+                        // Reset the refresh flag.
+                        silo.Value.Refreshed = false;
+                        continue;
+                    }
+
+                    // The silo was not present in the update, remove it.
+                    if (removed == null) removed = new HashSet<SiloAddress>();
+                    removed.Add(silo.Key);
+                }
+
+                // If any silos were removed, 
+                if (removed != null)
+                {
+                    foreach (var silo in removed)
+                    {
+                        silos.Remove(silo);
+                    }
+                }
+            }
+
+            // If anything was updated, clear the cache before notifying clients.
+            if (added != null || removed != null)
+            {
+                // Clear the caches.
+                ClearCaches();
+
+                // If any silos were added or removed, notify subscribers of the new status.
+                var siloStatusListeners = subscribers.Values.ToList();
+                if (added != null)
+                {
+                    foreach (var address in added)
+                    {
+                        NotifySubscribers(address, SiloStatus.Active, siloStatusListeners);
+                    }
+                }
+
+                if (removed != null)
+                {
+                    foreach (var address in removed)
+                    {
+                        NotifySubscribers(address, SiloStatus.Dead, siloStatusListeners);
+                    }
+                }
+            }
+        }
+
+        private async Task RefreshAsync()
+        {
+            try
+            {
+                await resolver.Refresh();
+
+                lastRefreshTime = DateTime.UtcNow;
+            }
+            catch (Exception exception)
+            {
+                log?.Warn(
+                    (int)ErrorCode.Docker_MembershipOracle_ExceptionRefreshingPartitions,
+                    "Exception refreshing partitions.",
+                    exception);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Clears the cached data.
+        /// </summary>
+        private void ClearCaches()
+        {
+            activeSilosCache = null;
+            allSilosCache = null;
+            multiClusterSilosCache = null;
+        }
+
+        /// <summary>
+        /// Updates the status of this silo.
+        /// </summary>
+        /// <param name="status">The updated status.</param>
+        private void UpdateStatus(SiloStatus status)
+        {
+            var updated = false;
+            lock (updateLock)
+            {
+                var existing = silos[SiloAddress];
+                if (existing.Status != status)
+                {
+                    updated = true;
+                    silos[SiloAddress] = new SiloEntry(status, SiloName);
+                    ClearCaches();
+                }
+            }
+
+            if (updated)
+            {
+                foreach (var subscriber in subscribers.Values)
+                {
+                    subscriber.SiloStatusChangeNotification(SiloAddress, status);
+                }
+            }
+        }
+
+        private void NotifySubscribers(SiloAddress address, SiloStatus newStatus, List<ISiloStatusListener> listeners)
+        {
+            foreach (var subscriber in listeners)
+            {
+                try
+                {
+                    subscriber.SiloStatusChangeNotification(address, newStatus);
+                }
+                catch (Exception exception)
+                {
+                    log.Warn(
+                        (int)ErrorCode.Docker_MembershipOracle_ExceptionNotifyingSubscribers,
+                        "Exception notifying subscriber.",
+                        exception);
+                }
+            }
+        }
+
+        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+        public void Dispose()
+        {
+            StopInternal();
+        }
+
+        private void StopInternal()
+        {
+            timer?.Dispose();
+            timer = null;
+            resolver.Unsubscribe(this);
         }
 
         private class SiloEntry
         {
+            /// <summary>
+            /// Gets or sets a value indicating whether this entry was updated.
+            /// </summary>
+            public bool Refreshed { get; set; }
+
             public SiloEntry(SiloStatus status, string name)
             {
                 Status = status;
@@ -136,12 +462,7 @@ namespace Microsoft.Orleans.Docker
             }
 
             public SiloStatus Status { get; }
-            public string Name { get; }
-
-            /// <summary>
-            /// Gets or sets a value indicating whether this entry was updated.
-            /// </summary>
-            public bool Refreshed { get; set; }
+            public string Name { get; }          
         }
     }
 }

--- a/src/OrleansDockerUtils/DockerSiloResolver.cs
+++ b/src/OrleansDockerUtils/DockerSiloResolver.cs
@@ -1,18 +1,23 @@
 ﻿using Docker.DotNet;
 using Docker.DotNet.Models;
 using Microsoft.Orleans.Docker.Models;
+using Microsoft.Orleans.Docker.Utilities;
+using Orleans;
 using Orleans.Runtime;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Orleans.Docker
 {
     internal class DockerSiloResolver : IDockerSiloResolver
     {
+        public DateTime LastRefreshTime { get; private set; }
+        public TimeSpan RefreshPeriod { get; } = TimeSpan.FromSeconds(30);
         private readonly ConcurrentDictionary<IDockerStatusListener, IDockerStatusListener> subscribers =
             new ConcurrentDictionary<IDockerStatusListener, IDockerStatusListener>();
         private readonly string deploymentId;
@@ -21,6 +26,8 @@ namespace Microsoft.Orleans.Docker
         private readonly DockerClient dockerClient;
         private List<DockerSiloInfo> silos;
         private const string LABEL_FILTER = "label";
+        private const string RUNNING_STATE = "running";
+        private Timer timer;
 
         public DockerSiloResolver(
             string deploymentId,
@@ -32,31 +39,47 @@ namespace Microsoft.Orleans.Docker
             log = loggerFactory?.Invoke(nameof(DockerSiloResolver));
         }
 
-
         public async Task Refresh()
         {
-            var containerList = await dockerClient.Containers.ListContainersAsync(
-                new ContainersListParameters
-                {
-                    Filters = new Dictionary<string, IDictionary<string, bool>>
-                            {
-                                {LABEL_FILTER,
-                                    new Dictionary<string, bool>
-                                        {
-                                            {$"{DockerLabels.DEPLOYMENT_ID}={deploymentId}", true},
-                                            {$"{DockerLabels.IS_DOCKER_SILO}", true}
-                                        }
-                                },
-                            }
-                });
-            var inspectionResult = await Task.WhenAll(containerList.Select(c => dockerClient.Containers.InspectContainerAsync(c.ID)));
-
-            lock (updateLock)
+            try
             {
-                silos = inspectionResult.Select(GetSiloFromContainer).ToList();
-            }
+                IList<ContainerListResponse> containerList = await dockerClient.Containers.ListContainersAsync(
+                       new ContainersListParameters
+                       {
+                           Filters = new Dictionary<string, IDictionary<string, bool>>
+                                   {
+                                        {LABEL_FILTER,
+                                            new Dictionary<string, bool>
+                                                {
+                                                    {$"{DockerLabels.DEPLOYMENT_ID}={deploymentId}", true},
+                                                    {$"{DockerLabels.IS_DOCKER_SILO}", true}
+                                                }
+                                        },
+                                   }
+                       });
 
-            NotifySubscribers();
+                ContainerInspectResponse[] inspectionResults = 
+                    await Task.WhenAll(
+                        containerList.Where(c=>c.State.Equals(RUNNING_STATE, StringComparison.OrdinalIgnoreCase))
+                        .Select(c => dockerClient.Containers.InspectContainerAsync(c.ID)));
+
+                lock (updateLock)
+                {
+                    silos = inspectionResults
+                        .Select(GetSiloFromContainer).ToList();
+                }
+
+                LastRefreshTime = DateTime.UtcNow;
+                NotifySubscribers();
+            }
+            catch (Exception exception)
+            {
+                log?.Warn(
+                    (int)ErrorCode.Docker_MembershipOracle_ExceptionRefreshingSilos,
+                    "Exception refreshing silos.",
+                    exception);
+                throw;
+            }
         }
 
         private static DockerSiloInfo GetSiloFromContainer(ContainerInspectResponse container)
@@ -79,12 +102,30 @@ namespace Microsoft.Orleans.Docker
 
         public void Subscribe(IDockerStatusListener handler)
         {
-            subscribers.TryAdd(handler, handler);
+            if (subscribers.TryAdd(handler, handler))
+                handler.OnUpdate(silos.ToArray());
+
+            if (timer == null)
+            {
+                timer = new Timer(
+                self => ((DockerSiloResolver)self).Refresh().Ignore(),
+                this,
+                RefreshPeriod,
+                RefreshPeriod);
+
+                Refresh().Ignore();
+            }
         }
 
         public void Unsubscribe(IDockerStatusListener handler)
         {
             subscribers.TryRemove(handler, out handler);
+
+            if (subscribers.Count == 0)
+            {
+                timer?.Dispose();
+                timer = null;
+            }
         }
 
         /// <summary>

--- a/src/OrleansDockerUtils/DockerSiloResolver.cs
+++ b/src/OrleansDockerUtils/DockerSiloResolver.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Orleans.Docker
 
             lock (updateLock)
             {
-                silos = inspectionResult.Select(GetSiloFromContainer).ToList(); 
+                silos = inspectionResult.Select(GetSiloFromContainer).ToList();
             }
 
             NotifySubscribers();
@@ -67,9 +67,10 @@ namespace Microsoft.Orleans.Docker
             var siloPort = container.Config.Labels[DockerLabels.SILO_PORT];
             var siloEndpoint = new IPEndPoint(siloIPAddress, int.Parse(siloPort));
 
-            var gatewayIPAddress = IPAddress.Parse(network.IPAddress);
-            var gatewayPort = container.Config.Labels[DockerLabels.GATEWAY_PORT];
-            var gatewayEndpoint = new IPEndPoint(siloIPAddress, int.Parse(gatewayPort));
+            IPEndPoint gatewayEndpoint = null;
+            string gatewayPort;
+            if (container.Config.Labels.TryGetValue(DockerLabels.GATEWAY_PORT, out gatewayPort))
+                gatewayEndpoint = new IPEndPoint(siloIPAddress, int.Parse(gatewayPort));
 
             var generation = int.Parse(container.Config.Labels[DockerLabels.GENERATION]);
 

--- a/src/OrleansDockerUtils/DockerSiloResolver.cs
+++ b/src/OrleansDockerUtils/DockerSiloResolver.cs
@@ -1,0 +1,91 @@
+﻿using Docker.DotNet;
+using Docker.DotNet.Models;
+using Microsoft.Orleans.Docker.Models;
+using Orleans.Runtime;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Microsoft.Orleans.Docker
+{
+    internal class DockerSiloResolver : IDockerSiloResolver
+    {
+        private readonly ConcurrentDictionary<IDockerStatusListener, IDockerStatusListener> subscribers =
+            new ConcurrentDictionary<IDockerStatusListener, IDockerStatusListener>();
+        private readonly string deploymentId;
+        private readonly Logger log;
+        private readonly object updateLock = new object();
+        private readonly DockerClient dockerClient;
+        private List<DockerSiloInfo> silos;
+        private const string LABEL_FILTER = "label";
+
+        public DockerSiloResolver(
+            string deploymentId,
+            DockerClient dockerClient,
+            Func<string, Logger> loggerFactory = null)
+        {
+            this.deploymentId = deploymentId;
+            this.dockerClient = dockerClient;
+            log = loggerFactory?.Invoke(nameof(DockerSiloResolver));
+        }
+
+
+        public async Task Refresh()
+        {
+            var result = await Task.WhenAll((await dockerClient.Containers.ListContainersAsync(
+                new ContainersListParameters
+                {
+                    Filters = new Dictionary<string, IDictionary<string, bool>>
+                            {
+                                {LABEL_FILTER,
+                                    new Dictionary<string, bool>
+                                        {
+                                            {$"{DockerLabels.DEPLOYMENT_ID}={deploymentId}", true},
+                                            {$"{DockerLabels.IS_DOCKER_SILO}", true}
+                                        }
+                                },
+                            }
+                })).Select(c => dockerClient.Containers.InspectContainerAsync(c.ID)));
+
+            lock (updateLock)
+            {
+                silos = result.Select(_ => 
+                {
+                    return new DockerSiloInfo(_.Config.Hostname,
+                        new IPEndPoint(IPAddress.Parse(_.NetworkSettings.Networks.First().Value.IPAddress), 
+                            int.Parse(_.Config.Labels[DockerLabels.SILO_PORT])),
+                        new IPEndPoint(IPAddress.Parse(_.NetworkSettings.Networks.First().Value.IPAddress), 
+                            int.Parse(_.Config.Labels[DockerLabels.GATEWAY_PORT])),
+                        int.Parse(_.Config.Labels[DockerLabels.GENERATION]));
+                }).ToList(); 
+            }
+
+            NotifySubscribers();
+        }
+
+        public void Subscribe(IDockerStatusListener handler)
+        {
+            subscribers.TryAdd(handler, handler);
+        }
+
+        public void Unsubscribe(IDockerStatusListener handler)
+        {
+            subscribers.TryRemove(handler, out handler);
+        }
+
+        /// <summary>
+        /// Notifies subscribers of updates.
+        /// </summary>
+        private void NotifySubscribers()
+        {
+            var copy = silos.ToArray();
+            foreach (var observer in subscribers.Values)
+            {
+                observer.OnUpdate(copy);
+            }
+        }
+    }
+}

--- a/src/OrleansDockerUtils/IDockerSiloResolver.cs
+++ b/src/OrleansDockerUtils/IDockerSiloResolver.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.Orleans.Docker
+{
+    internal interface IDockerSiloResolver
+    {
+        /// <summary>
+        /// Subscribes the provided handler for update notifications.
+        /// </summary>
+        /// <param name="handler">The update notification handler.</param>
+        void Subscribe(IDockerStatusListener handler);
+
+        /// <summary>
+        /// Unsubscribes the provided handler from update notifications.
+        /// </summary>
+        /// <param name="handler">The update notification handler.</param>
+        void Unsubscribe(IDockerStatusListener handler);
+
+        /// <summary>
+        /// Forces a refresh of the partitions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        Task Refresh();
+    }
+}

--- a/src/OrleansDockerUtils/IDockerSiloResolver.cs
+++ b/src/OrleansDockerUtils/IDockerSiloResolver.cs
@@ -1,9 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Orleans.Docker
 {
     internal interface IDockerSiloResolver
     {
+        DateTime LastRefreshTime { get; }
+        TimeSpan RefreshPeriod { get; }
+
         /// <summary>
         /// Subscribes the provided handler for update notifications.
         /// </summary>

--- a/src/OrleansDockerUtils/IDockerStatusListener.cs
+++ b/src/OrleansDockerUtils/IDockerStatusListener.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Orleans.Docker.Models;
+
+namespace Microsoft.Orleans.Docker
+{
+    /// <summary>
+    /// Listen for Docker container changes
+    /// </summary>
+    internal interface IDockerStatusListener
+    {
+        /// <summary>
+        /// Notifies this instance of an update to cluster members.
+        /// </summary>
+        /// <param name="silos">The updated set of silos.</param>
+        void OnUpdate(DockerSiloInfo[] silos);
+    }
+}

--- a/src/OrleansDockerUtils/Models/DockerLabels.cs
+++ b/src/OrleansDockerUtils/Models/DockerLabels.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Orleans.Docker.Models
+{
+    internal static class DockerLabels
+    {
+        public const string IS_DOCKER_SILO = "com.microsoft.orleans.silo";
+        public const string DEPLOYMENT_ID = "com.microsoft.orleans.deploymentid";
+        public const string SILO_PORT = "com.microsoft.orleans.siloport";
+        public const string GATEWAY_PORT = "com.microsoft.orleans.gatewayport";
+        public const string GENERATION = "com.microsoft.orleans.generation";
+    }
+}

--- a/src/OrleansDockerUtils/Models/DockerSiloInfo.cs
+++ b/src/OrleansDockerUtils/Models/DockerSiloInfo.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Orleans.Docker.Models
         {
             Name = siloName;
             Silo = SiloAddress.New(siloEndPoint, generation).ToParsableString(); 
-            Gateway = SiloAddress.New(gatewayEndPoint, generation).ToParsableString();
+            Gateway = gatewayEndPoint != null ? SiloAddress.New(gatewayEndPoint, generation).ToParsableString() : null;
         }
 
         /// <inheritdoc />

--- a/src/OrleansDockerUtils/Models/DockerSiloInfo.cs
+++ b/src/OrleansDockerUtils/Models/DockerSiloInfo.cs
@@ -1,0 +1,63 @@
+﻿using Newtonsoft.Json;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using System.Net;
+
+namespace Microsoft.Orleans.Docker.Models
+{
+    /// <summary>
+    /// Represents silo endpoints.
+    /// </summary>
+    public class DockerSiloInfo
+    {
+        /// <summary>
+        /// Gets the name of the silo.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets the silo address.
+        /// </summary>
+        [JsonProperty("silo")]
+        public string Silo { get; set; }
+
+        /// <summary>
+        /// Gets the gateway address.
+        /// </summary>
+        [JsonProperty("gw")]
+        public string Gateway { get; set; }
+
+        /// <summary>
+        /// Gets the parsed silo address.
+        /// </summary>
+        [JsonIgnore]
+        public SiloAddress SiloAddress => string.IsNullOrWhiteSpace(Silo) ? null : SiloAddress.FromParsableString(Silo);
+
+        /// <summary>
+        /// Gets the parsed gateway address.
+        /// </summary>
+        [JsonIgnore]
+        public SiloAddress GatewayAddress => string.IsNullOrWhiteSpace(Gateway) ? null : SiloAddress.FromParsableString(Gateway);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DockerSiloInfo" /> class.
+        /// </summary>
+        /// <param name="siloName">The silo name.</param>
+        /// <param name="siloEndPoint">The Inter-silo <see cref="IPEndPoint"/>.</param>
+        /// <param name="gatewayEndPoint">The Gateway <see cref="IPEndPoint"/>.</param>
+        /// <param name="generation">The silo Generation.</param>
+        public DockerSiloInfo(string siloName, IPEndPoint siloEndPoint, IPEndPoint gatewayEndPoint, int generation)
+        {
+            Name = siloName;
+            Silo = SiloAddress.New(siloEndPoint, generation).ToParsableString(); 
+            Gateway = SiloAddress.New(gatewayEndPoint, generation).ToParsableString();
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{nameof(Name)}: {Name}, {nameof(SiloAddress)}: {SiloAddress}, {nameof(GatewayAddress)}: {GatewayAddress}";
+        }
+    }
+}

--- a/src/OrleansDockerUtils/OrleansDockerExtensions.cs
+++ b/src/OrleansDockerUtils/OrleansDockerExtensions.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using System.Security.Cryptography.X509Certificates;
+using Docker.DotNet;
+
+namespace Microsoft.Orleans.Docker
+{
+    /// <summary>
+    /// Extensions for hosting Orleans in Docker containers
+    /// </summary>
+    public static class OrleansDockerExtensions
+    {
+        /// <summary>
+        /// Add Docker support to the provided service collection.
+        /// Use this overload for unsecured endpoints of Docker Daemon or Swarm (mostly dev/test)
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="deamonEndpointUri">The Docker Daemon or Swarm endpoint.</param>
+        /// <param name="deploymentId">Orleans Deployment Id.</param>
+        /// <returns>The provided service collection</returns>
+        public static IServiceCollection AddDockerSupport(
+            this IServiceCollection serviceCollection, 
+            Uri deamonEndpointUri, string deploymentId)
+        {
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Add Docker support to the provided service collection. 
+        /// Use this overload for secured endpoints of Docker Daemon or Swarm using Basic Auth (username+password)
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="deamonEndpointUri">The Docker Daemon or Swarm endpoint.</param>
+        /// <param name="deploymentId">Orleans Deployment Id.</param>
+        /// <param name="userName">The username.</param>
+        /// <param name="password">The password.</param>
+        /// <returns>The provided service collection</returns>
+        public static IServiceCollection AddDockerSupport(
+            this IServiceCollection serviceCollection, 
+            Uri deamonEndpointUri, string deploymentId,
+            string userName, string password)
+        {
+
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Add Docker support to the provided service collection. 
+        /// Use this overload for secured endpoints of Docker Daemon or Swarm using TLS (certificate)
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="deamonEndpointUri">The Docker Daemon or Swarm endpoint.</param>
+        /// <param name="deploymentId">Orleans Deployment Id.</param>
+        /// <param name="certificate">The certificate.</param>
+        /// <returns>The provided service collection.</returns>
+        public static IServiceCollection AddDockerSupport(
+            this IServiceCollection serviceCollection,
+            Uri deamonEndpointUri, string deploymentId,
+            X509Certificate2 certificate)
+        {
+
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Add Docker support to the provided service collection. 
+        /// Use this overload to provide a pre-configured <see cref="DockerClientConfiguration"/>
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="deploymentId">Orleans Deployment Id.</param>
+        /// <param name="dockerConfig">The certificate.</param>
+        /// <returns>The provided service collection.</returns>
+        public static IServiceCollection AddDockerSupport(
+            this IServiceCollection serviceCollection,
+            string deploymentId,
+            DockerClientConfiguration dockerConfig)
+        {
+
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Add support for connecting to a cluster hosted in Docker containers to the provided service collection. 
+        /// Use this overload for unsecured endpoints of Docker Daemon or Swarm (mostly dev/test)
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="deamonEndpointUri">The Docker Daemon or Swarm endpoint.</param>
+        /// <param name="deploymentId">Orleans Deployment Id.</param>
+        /// <returns>The provided service collection</returns>
+        public static IServiceCollection AddDockerClientSupport(
+            this IServiceCollection serviceCollection,
+            Uri deamonEndpointUri, string deploymentId)
+        {
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Add support for connecting to a cluster hosted in Docker containers to the provided service collection. 
+        /// Use this overload for secured endpoints of Docker Daemon or Swarm using Basic Auth (username+password)
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="deamonEndpointUri">The Docker Daemon or Swarm endpoint.</param>
+        /// <param name="deploymentId">Orleans Deployment Id.</param>
+        /// <param name="userName">The username.</param>
+        /// <param name="password">The password.</param>
+        /// <returns>The provided service collection</returns>
+        public static IServiceCollection AddDockerClientSupport(
+            this IServiceCollection serviceCollection,
+            Uri deamonEndpointUri, string deploymentId,
+            string userName, string password)
+        {
+
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Add support for connecting to a cluster hosted in Docker containers to the provided service collection. 
+        /// Use this overload for secured endpoints of Docker Daemon or Swarm using TLS (certificate)
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="deamonEndpointUri">The Docker Daemon or Swarm endpoint.</param>
+        /// <param name="deploymentId">Orleans Deployment Id.</param>
+        /// <param name="certificate">The certificate.</param>
+        /// <returns>The provided service collection.</returns>
+        public static IServiceCollection AddDockerClientSupport(
+            this IServiceCollection serviceCollection,
+            Uri deamonEndpointUri, string deploymentId,
+            X509Certificate2 certificate)
+        {
+
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Add support for connecting to a cluster hosted in Docker containers to the provided service collection. 
+        /// Use this overload to provide a pre-configured <see cref="DockerClientConfiguration"/>
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="deploymentId">Orleans Deployment Id.</param>
+        /// <param name="dockerConfig">The certificate.</param>
+        /// <returns>The provided service collection.</returns>
+        public static IServiceCollection AddDockerClientSupport(
+            this IServiceCollection serviceCollection,
+            string deploymentId,
+            DockerClientConfiguration dockerConfig)
+        {
+
+
+            return serviceCollection;
+        }
+    }
+}

--- a/src/OrleansDockerUtils/OrleansDockerUtils.csproj
+++ b/src/OrleansDockerUtils/OrleansDockerUtils.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D1855B0C-610A-4E3B-BE6F-6CC6E0B07883}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Orleans.Docker</RootNamespace>
+    <AssemblyName>Microsoft.Orleans.Docker</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Microsoft.Orleans.Docker.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Microsoft.Orleans.Docker.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Build\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="DockerMembershipOracle.cs" />
+    <Compile Include="OrleansDockerExtensions.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\ErrorCode.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj">
+      <Project>{6FF2004C-CDF8-479C-BF27-C6BFE8EF93E0}</Project>
+      <Name>OrleansRuntime</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Orleans\Orleans.csproj">
+      <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
+      <Name>Orleans</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/OrleansDockerUtils/OrleansDockerUtils.csproj
+++ b/src/OrleansDockerUtils/OrleansDockerUtils.csproj
@@ -46,7 +46,13 @@
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="DockerGatewayProvider.cs" />
+    <Compile Include="Models\DockerLabels.cs" />
     <Compile Include="DockerMembershipOracle.cs" />
+    <Compile Include="DockerSiloResolver.cs" />
+    <Compile Include="IDockerSiloResolver.cs" />
+    <Compile Include="IDockerStatusListener.cs" />
+    <Compile Include="Models\DockerSiloInfo.cs" />
     <Compile Include="OrleansDockerExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utilities\ErrorCode.cs" />

--- a/src/OrleansDockerUtils/Properties/AssemblyInfo.cs
+++ b/src/OrleansDockerUtils/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.Orleans.Docker")]
+[assembly: AssemblyDescription("Orleans - Docker Helper Classes")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d1855b0c-610a-4e3b-be6f-6cc6e0b07883")]
+
+[assembly: InternalsVisibleTo("TesterDockerUtils")]

--- a/src/OrleansDockerUtils/Utilities/ErrorCode.cs
+++ b/src/OrleansDockerUtils/Utilities/ErrorCode.cs
@@ -6,6 +6,7 @@
         DockerBase = Runtime + 4400,
         Docker_GatewayProvider_ExceptionNotifyingSubscribers = DockerBase + 1,
         Docker_GatewayProvider_ExceptionRefreshingGateways = DockerBase + 2,
-        Docker_MembershipOracle_ExceptionNotifyingSubscribers = DockerBase + 3
+        Docker_MembershipOracle_ExceptionNotifyingSubscribers = DockerBase + 3,
+        Docker_MembershipOracle_ExceptionRefreshingSilos = DockerBase + 4,
     }
 }

--- a/src/OrleansDockerUtils/Utilities/ErrorCode.cs
+++ b/src/OrleansDockerUtils/Utilities/ErrorCode.cs
@@ -6,7 +6,6 @@
         DockerBase = Runtime + 4400,
         Docker_GatewayProvider_ExceptionNotifyingSubscribers = DockerBase + 1,
         Docker_GatewayProvider_ExceptionRefreshingGateways = DockerBase + 2,
-        Docker_MembershipOracle_ExceptionNotifyingSubscribers = DockerBase + 3,
-        Docker_MembershipOracle_ExceptionRefreshingPartitions = DockerBase + 4
+        Docker_MembershipOracle_ExceptionNotifyingSubscribers = DockerBase + 3
     }
 }

--- a/src/OrleansDockerUtils/Utilities/ErrorCode.cs
+++ b/src/OrleansDockerUtils/Utilities/ErrorCode.cs
@@ -1,0 +1,8 @@
+﻿namespace Microsoft.Orleans.Docker.Utilities
+{
+    internal enum ErrorCode
+    {
+        Runtime = 100000,
+        DockerBase = Runtime + 4400
+    }
+}

--- a/src/OrleansDockerUtils/Utilities/ErrorCode.cs
+++ b/src/OrleansDockerUtils/Utilities/ErrorCode.cs
@@ -3,6 +3,10 @@
     internal enum ErrorCode
     {
         Runtime = 100000,
-        DockerBase = Runtime + 4400
+        DockerBase = Runtime + 4400,
+        Docker_GatewayProvider_ExceptionNotifyingSubscribers = DockerBase + 1,
+        Docker_GatewayProvider_ExceptionRefreshingGateways = DockerBase + 2,
+        Docker_MembershipOracle_ExceptionNotifyingSubscribers = DockerBase + 3,
+        Docker_MembershipOracle_ExceptionRefreshingPartitions = DockerBase + 4
     }
 }

--- a/src/OrleansDockerUtils/project.json
+++ b/src/OrleansDockerUtils/project.json
@@ -1,6 +1,8 @@
 ﻿{
   "dependencies": {
     "Docker.DotNet": "2.124.3",
+    "Docker.DotNet.BasicAuth": "2.124.3",
+    "Docker.DotNet.X509": "2.124.3",
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0"
   },
   "frameworks": {

--- a/src/OrleansDockerUtils/project.json
+++ b/src/OrleansDockerUtils/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "dependencies": {
+    "Docker.DotNet": "2.124.3",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0"
+  },
+  "frameworks": {
+    "net451": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}

--- a/test/TesterDockerUtils/Properties/AssemblyInfo.cs
+++ b/test/TesterDockerUtils/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TesterDockerUtils")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TesterDockerUtils")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("02c701d4-7c7e-48f0-9871-e82c40c62b2b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/TesterDockerUtils/Tester.DockerUtils.xunit.runner.json
+++ b/test/TesterDockerUtils/Tester.DockerUtils.xunit.runner.json
@@ -1,0 +1,8 @@
+﻿{
+  "appDomain": "ifAvailable",
+  "diagnosticMessages": true,
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false,
+  "methodDisplay": "classAndMethod",
+  "shadowCopy": false
+}

--- a/test/TesterDockerUtils/TesterDockerUtils.csproj
+++ b/test/TesterDockerUtils/TesterDockerUtils.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{02C701D4-7C7E-48F0-9871-E82C40C62B2B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Tester.DockerUtils</RootNamespace>
+    <AssemblyName>Tester.DockerUtils</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+    <None Include="Tester.DockerUtils.xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OrleansDockerUtils\OrleansDockerUtils.csproj">
+      <Project>{d1855b0c-610a-4e3b-be6f-6cc6e0b07883}</Project>
+      <Name>OrleansDockerUtils</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\OrleansRuntime\OrleansRuntime.csproj">
+      <Project>{6ff2004c-cdf8-479c-bf27-c6bfe8ef93e0}</Project>
+      <Name>OrleansRuntime</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Orleans\Orleans.csproj">
+      <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
+      <Name>Orleans</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestExtensions\TestExtensions.csproj">
+      <Project>{8fd242b4-eda9-42cd-ba39-e410b98add26}</Project>
+      <Name>TestExtensions</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/test/TesterDockerUtils/project.json
+++ b/test/TesterDockerUtils/project.json
@@ -1,0 +1,17 @@
+﻿{
+  "dependencies": {
+    "FluentAssertions": "4.0.0",
+    "Newtonsoft.Json": "9.0.1",
+    "xunit": "2.1.0",
+    "xunit.runner.visualstudio": "2.1.0",
+    "Xunit.SkippableFact": "1.2.14",
+    "Docker.DotNet": "2.124.3"
+  },
+  "frameworks": {
+    "net451": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}


### PR DESCRIPTION
This PR brings support to Docker and Docker Swarp cluster for Orleans.

It is based on @ReubenBond's work on SF Membership Oracle but using the Docker APIs.

The design of this Membership Oracle is to not have a MBR just as SF doesn't. It works by communicating with Docker Daemon or Swarm endpoints using https://github.com/Microsoft/Docker.DotNet which is a wrapper over Docker APIs, and leveraging the `Labels` feature of docker. 

The idea is to group a set of containers by `deploymentId` on the same host (Docker Daemon) or across multiple hosts (Swarm cluster). Whenever a client start, the  `DockerGatewayProvider` connects to Docker and query for the current list of containers which are a silo, and are in the same `deploymentId` so it can build the gateway list. After that first list, it set a timer to refresh that list from docker. The same happens at the silo side which basically find the other silos by the  `deploymentId`.

Basically there is no persistence at all neither MBR tables since all the containers can be found by the labels and when a container dies, it is automatically removed from docker list so it will not return anymore.

The hosting model is basically any container engine which implement Docker APIs (i.e. Docker Daemon, Docker Swarm, etc.). There is no change on how things are deployed or a new OrleansHost for that. All people need to do is to set the appropriate labels on the container which has the Orleans application code and everything will just works as long as the container is able to reach over network the Docker API host (i.e. the container host or Swarm manager).

There are two things that I'll implement after this PR:

1. Listen to docker stream of events and add/remove silos live -> the streams are very unstable yet and not available on production docker engines.
2. At runtime apply a label to the container mentioning that it is dead -> due to a blocker on docker for windows, commit changes to a running container isn't available yet.

This is a WIP. I was able to run manual tests here and made 2 containers and a client talk perfectly. The current code is totally usable. I've simulated adding and removing silos/containers to the cluster and they join and leave just fine.

I'm now working on get a unit test project with some `DockerFile`s so all people will need to run the tests is have Docker installed.

I appreciate any feedback while I'm working in the tests so I can address them quickly.