### PR TITLE
CodeGen: fix check on parameters to generic types with serializers

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1091,7 +1091,10 @@ namespace Orleans.Serialization
                 Serializer ser;
                 if (serializers.TryGetValue(t.TypeHandle, out ser)) return true;
                 var typeInfo = t.GetTypeInfo();
-                return typeInfo.IsGenericType && serializers.TryGetValue(typeInfo.GetGenericTypeDefinition().TypeHandle, out ser);
+                if (!typeInfo.IsGenericType) return false;
+                var genericTypeDefinition = typeInfo.GetGenericTypeDefinition();
+                return serializers.TryGetValue(genericTypeDefinition.TypeHandle, out ser) &&
+                       typeInfo.GetGenericArguments().All(type => HasSerializer(type));
             }
         }
 

--- a/src/Orleans/Serialization/TypeUtilities.cs
+++ b/src/Orleans/Serialization/TypeUtilities.cs
@@ -209,7 +209,7 @@ namespace Orleans.Serialization
                 // Guard against invalid type constraints, which appear when generating code for some languages.
                 foreach (var parameter in typeInfo.GenericTypeParameters)
                 {
-                    if (parameter.GetTypeInfo().GetGenericParameterConstraints().Any(IsSpecialClass))
+                    if (parameter.GetTypeInfo().GetGenericParameterConstraints().Any(t => IsSpecialClass(t)))
                     {
                         return true;
                     }

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -72,6 +72,7 @@ namespace Orleans.CodeGenerator
                     ErrorCode.CodeGenIgnoringTypes,
                     "Skipping serializer generation for nested type {0}. If this type is used frequently, you may wish to consider making it non-nested.",
                     t.Name);
+                return false;
             }
 
             if (t.IsConstructedGenericType)
@@ -91,7 +92,7 @@ namespace Orleans.CodeGenerator
                 return RecordTypeToGenerate(typeInfo.GetGenericTypeDefinition(), module, targetAssembly);
             }
 
-            if (typeInfo.IsOrleansPrimitive() || (SerializationManager.GetSerializer(t) != null) ||
+            if (typeInfo.IsOrleansPrimitive() || SerializationManager.HasSerializer(t) ||
                 typeof(IAddressable).GetTypeInfo().IsAssignableFrom(t)) return false;
 
             if (typeInfo.Namespace != null && (typeInfo.Namespace.Equals("System") || typeInfo.Namespace.StartsWith("System.")))
@@ -105,9 +106,9 @@ namespace Orleans.CodeGenerator
             if (TypeUtils.HasAllSerializationMethods(t)) return false;
 
             // This check is here and not within TypeUtilities.IsTypeIsInaccessibleForSerialization() to prevent potential infinite recursions 
-            var skipSerialzerGeneration =
+            var skipSerializerGeneration =
                 t.GetAllFields().Any(field => IsFieldInaccessibleForSerialization(module, targetAssembly, field));
-            if (skipSerialzerGeneration)
+            if (skipSerializerGeneration)
             {
                 return false;
             }

--- a/test/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/test/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
@@ -286,5 +287,22 @@ namespace UnitTests.GrainInterfaces
         where T : struct
     {
         public T Value { get; set; }
+    }
+
+    // This class should not have a serializer generated for it, since the serializer would not be able to access
+    // the nested private class.
+    [Serializable]
+    public class ClassWithNestedPrivateClassInListField
+    {
+        private readonly List<NestedPrivateClass> coolBeans = new List<NestedPrivateClass>
+        {
+            new NestedPrivateClass()
+        };
+
+        public IEnumerable CoolBeans => this.coolBeans;
+
+        private class NestedPrivateClass
+        {
+        }
     }
 }


### PR DESCRIPTION
Fixes #2433.

The issue was that our check to see if a type already has a serializer wasn't checking if each of the generic type parameters also had serializers, so accessibility checks were broken for those types.