### PR TITLE
Simplify initialization of DI container

### DIFF
--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Runtime;
 using System.Text;
 using System.Threading;

--- a/src/OrleansRuntime/Startup/StartupBuilder.cs
+++ b/src/OrleansRuntime/Startup/StartupBuilder.cs
@@ -10,10 +10,9 @@ namespace Orleans.Runtime.Startup
     /// </summary>
     internal class StartupBuilder
     {
-        internal static IServiceProvider ConfigureStartup(string startupTypeName, Action<IServiceCollection, bool> registerSystemTypes)
+        internal static IServiceProvider ConfigureStartup(string startupTypeName, IServiceCollection serviceCollection)
         {
             var usingCustomServiceProvider = false;
-            IServiceCollection serviceCollection = new ServiceCollection();
             ConfigureServicesBuilder servicesMethod = null;
             Type startupType = null;
 
@@ -31,9 +30,7 @@ namespace Orleans.Runtime.Startup
                     usingCustomServiceProvider = true;
                 }
             }
-
-            registerSystemTypes(serviceCollection, usingCustomServiceProvider);
-
+            
             if (usingCustomServiceProvider)
             {
                 var instance = Activator.CreateInstance(startupType);

--- a/src/OrleansRuntime/Utilities/ServiceCollectionExtensions.cs
+++ b/src/OrleansRuntime/Utilities/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Orleans.Runtime
 {
@@ -16,7 +15,7 @@ namespace Orleans.Runtime
         /// <typeparam name="TService">The service type being provided.</typeparam>
         /// <typeparam name="TImplementation">The implementation of <typeparamref name="TService"/>.</typeparam>
         /// <param name="services">The service collection.</param>
-        public static void TryAddExisting<TService, TImplementation>(this IServiceCollection services) where TImplementation : TService
+        public static void AddFromExisting<TService, TImplementation>(this IServiceCollection services) where TImplementation : TService
         {
             var registration = services.FirstOrDefault(service => service.ServiceType == typeof(TImplementation));
             if (registration != null)
@@ -25,7 +24,7 @@ namespace Orleans.Runtime
                     typeof(TService),
                     sp => sp.GetRequiredService<TImplementation>(),
                     registration.Lifetime);
-                services.TryAdd(newRegistration);
+                services.Add(newRegistration);
             }
         }
     }


### PR DESCRIPTION
Simple change to pre-construct & add services to the DI container before passing it to the startup builder, rather than passing a lambda to add the services to it.

Since we're constructing the container and passing it to the user, 'TryAdd' was misleading, so we're calling 'Add' now.