### PR TITLE
Add flag for test to assume that all silos in the cluster share the same set of grain types at startup

### DIFF
--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -436,7 +436,7 @@ namespace Orleans.Runtime.Configuration
 
         public int ActivationCountBasedPlacementChooseOutOf { get; set; }
 
-        public bool AssumeAllSilosEqualsForTesting { get; set; }
+        public bool AssumeHomogenousSilosForTesting { get; set; }
 
         /// <summary>
         /// Determines if ADO should be used for storage of Membership and Reminders info.
@@ -572,7 +572,7 @@ namespace Orleans.Runtime.Configuration
             NumVirtualBucketsConsistentRing = DEFAULT_NUM_VIRTUAL_RING_BUCKETS;
             UseMockReminderTable = false;
             MockReminderTableTimeout = DEFAULT_MOCK_REMINDER_TABLE_TIMEOUT;
-            AssumeAllSilosEqualsForTesting = false;
+            AssumeHomogenousSilosForTesting = false;
 
             ProviderConfigurations = new Dictionary<string, ProviderCategoryConfiguration>();
             GrainServiceConfigurations = new GrainServiceConfigurations();

--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -436,6 +436,7 @@ namespace Orleans.Runtime.Configuration
 
         public int ActivationCountBasedPlacementChooseOutOf { get; set; }
 
+        public bool AssumeAllSilosEqualsForTesting { get; set; }
 
         /// <summary>
         /// Determines if ADO should be used for storage of Membership and Reminders info.
@@ -571,6 +572,7 @@ namespace Orleans.Runtime.Configuration
             NumVirtualBucketsConsistentRing = DEFAULT_NUM_VIRTUAL_RING_BUCKETS;
             UseMockReminderTable = false;
             MockReminderTableTimeout = DEFAULT_MOCK_REMINDER_TABLE_TIMEOUT;
+            AssumeAllSilosEqualsForTesting = false;
 
             ProviderConfigurations = new Dictionary<string, ProviderCategoryConfiguration>();
             GrainServiceConfigurations = new GrainServiceConfigurations();

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -212,7 +212,7 @@ namespace Orleans.Runtime
 
             // For test only: if we have silos taht are not yet in the CLuster TypeMap, we assume that they are compatible
             // with the current silo
-            if (this.config.AssumeAllSilosEqualsForTesting)
+            if (this.config.AssumeHomogenousSilosForTesting)
             {
                 var silosInTypeManager = GrainTypeManager.GrainInterfaceMapsBySilo.Keys;
                 var ignoredSilos = AllActiveSilos.Where(s => !silosInTypeManager.Contains(s)).ToList();

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -209,6 +209,19 @@ namespace Orleans.Runtime
             var compatibleSilos = GrainTypeManager.GetSupportedSilos(typeCode).Intersect(AllActiveSilos).ToList();
             if (compatibleSilos.Count == 0)
                 throw new OrleansException($"TypeCode ${typeCode} not supported in the cluster");
+
+            // For test only: if we have silos taht are not yet in the CLuster TypeMap, we assume that they are compatible
+            // with the current silo
+            if (this.config.AssumeAllSilosEqualsForTesting)
+            {
+                var silosInTypeManager = GrainTypeManager.GrainInterfaceMapsBySilo.Keys;
+                var ignoredSilos = AllActiveSilos.Where(s => !silosInTypeManager.Contains(s)).ToList();
+                if (ignoredSilos.Any() && GrainTypeManager.GetTypeCodeMap().ContainsGrainImplementation(typeCode))
+                {
+                    compatibleSilos.AddRange(ignoredSilos);
+                }
+            }
+
             return compatibleSilos;
         }
 

--- a/src/OrleansTestingHost/TestClusterOptions.cs
+++ b/src/OrleansTestingHost/TestClusterOptions.cs
@@ -174,6 +174,7 @@ namespace Orleans.TestingHost
             }
 
             config.Globals.ExpectedClusterSize = silosCount;
+            config.Globals.AssumeAllSilosEqualsForTesting = true;
 
             config.AdjustForTestEnvironment(extendedOptions.DataConnectionString);
             return config;

--- a/src/OrleansTestingHost/TestClusterOptions.cs
+++ b/src/OrleansTestingHost/TestClusterOptions.cs
@@ -174,7 +174,7 @@ namespace Orleans.TestingHost
             }
 
             config.Globals.ExpectedClusterSize = silosCount;
-            config.Globals.AssumeAllSilosEqualsForTesting = true;
+            config.Globals.AssumeHomogenousSilosForTesting = true;
 
             config.AdjustForTestEnvironment(extendedOptions.DataConnectionString);
             return config;

--- a/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
@@ -23,7 +23,7 @@ namespace Tester.HeterogeneousSilosTests
             cluster?.StopAllSilos();
             var typesName = blackListedTypes.Select(t => t.FullName).ToList();
             var options = new TestClusterOptions(1);
-            options.ClusterConfiguration.Globals.AssumeAllSilosEqualsForTesting = false;
+            options.ClusterConfiguration.Globals.AssumeHomogenousSilosForTesting = false;
             options.ClusterConfiguration.Globals.TypeMapRefreshInterval = refreshInterval;
             options.ClusterConfiguration.Globals.DefaultPlacementStrategy = defaultPlacementStrategy;
             options.ClusterConfiguration.Overrides[Silo.PrimarySiloName].ExcludedGrainTypes = typesName;

--- a/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
@@ -23,6 +23,7 @@ namespace Tester.HeterogeneousSilosTests
             cluster?.StopAllSilos();
             var typesName = blackListedTypes.Select(t => t.FullName).ToList();
             var options = new TestClusterOptions(1);
+            options.ClusterConfiguration.Globals.AssumeAllSilosEqualsForTesting = false;
             options.ClusterConfiguration.Globals.TypeMapRefreshInterval = refreshInterval;
             options.ClusterConfiguration.Globals.DefaultPlacementStrategy = defaultPlacementStrategy;
             options.ClusterConfiguration.Overrides[Silo.PrimarySiloName].ExcludedGrainTypes = typesName;


### PR DESCRIPTION
Add flag for test to assume that all silos in the cluster share the same set of grain types at startup

Some tests are failing because all silos didn't refreshed the cluster interface map in time before the test started. 

To avoid introducing delay in the test startup, we assume that all silos not in the cluster type map support the same set of types as the local one.