### PR TITLE
Support messages over the max CloudQueueMessage size

### DIFF
--- a/src/Orleans/Serialization/BinaryTokenStreamWriter.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamWriter.cs
@@ -97,6 +97,8 @@ namespace Orleans.Serialization
             writers[typeof(CorrelationId).TypeHandle] = (stream, obj) => { stream.Write(SerializationTokenType.CorrelationId); stream.Write((CorrelationId) obj); };
         }
 
+        internal ByteArrayBuilder ByteArrayBuilder => ab;
+
         /// <summary> Default constructor. </summary>
         public BinaryTokenStreamWriter()
         {

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Providers\AzureConfigurationExtensions.cs" />
     <Compile Include="Providers\Storage\AzureBlobStorage.cs" />
     <Compile Include="Providers\Streams\AzureQueue\AzureQueueBatchContainerV2.cs" />
+    <Compile Include="Providers\Streams\AzureQueue\MessageSegment.cs" />
     <Compile Include="Providers\Streams\PersistentStreams\AzureTableStorageStreamFailureHandler.cs" />
     <Compile Include="Providers\Streams\PersistentStreams\StreamDeliveryFailureEntity.cs" />
     <Compile Include="Storage\AzureBasedMembershipTable.cs" />

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/MessageSegment.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/MessageSegment.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Orleans.Serialization;
+
+namespace Orleans.Runtime.Host.Providers.Streams.AzureQueue
+{
+    internal class MessageSegment
+    {
+        internal Guid Guid { get; set; }
+
+        internal byte Index { get; set; }
+
+        internal byte Count { get; set; }
+
+        internal ushort Size { get; set; }
+
+        internal CloudQueueMessage CloudQueueMessage { get; set; }
+
+        internal byte[] Segment { get; set; }
+
+        internal static IEnumerable<MessageSegment> CreateRange(BinaryTokenStreamWriter writer)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            if (writer.CurrentOffset == 0)
+            {
+                throw new ArgumentException("The data length was 0", nameof(writer));
+            }
+
+            var list = ResizeByteArrayBuilder(writer.ByteArrayBuilder);
+            var guid = Guid.NewGuid();
+
+            return list.Select((t, i) => new MessageSegment
+            {
+                Count = (byte)list.Count,
+                Guid = guid,
+                Index = (byte)i,
+                Segment = t.ToArray(),
+                Size = (ushort) t.Count
+            });
+        }
+
+        internal static MessageSegment FromCloudQueueMessage(CloudQueueMessage message)
+        {
+            ushort size;
+            var reader = new BinaryTokenStreamReader(message.AsBytes);
+            return new MessageSegment
+            {
+                Guid = reader.ReadGuid(),
+                Index = reader.ReadByte(),
+                Count = reader.ReadByte(),
+                Size = size = reader.ReadUShort(),
+                Segment = reader.ReadBytes(size),
+                CloudQueueMessage = message
+            };
+        }
+
+        internal byte[] ToByteArray()
+        {
+            var writer = new BinaryTokenStreamWriter();
+            writer.Write(this.Guid);
+            writer.Write(this.Index);
+            writer.Write(this.Count);
+            writer.Write(this.Size);
+            writer.Write(this.Segment);
+            return writer.ToByteArray();
+        }
+
+        private static List<ArraySegment<byte>> ResizeByteArrayBuilder(ByteArrayBuilder byteArrayBuilder)
+        {
+            // resize the arrays in the byte array builder so that they are all under the max cloud queue message size
+            // Doing it this way will prevent allocations on the large object heap.
+            const int reservedSpace = 1024 * 20;  
+            var maxBufferSize = (int)(CloudQueueMessage.MaxMessageSize - reservedSpace);
+            var list = byteArrayBuilder.ToBytes();
+            var returnValue = new List<ArraySegment<byte>>();
+
+            if (list.Count == 0)
+            {
+                return list;
+            }
+
+            if (byteArrayBuilder.Length <= maxBufferSize)
+            {
+                return list;
+            }
+
+            if (!list.Any(l => l.Count > maxBufferSize))
+            {
+                return list;
+            }
+
+            ArraySegment<byte>? segmentTemp = null;
+            foreach (var segment in list)
+            {
+                if (!segmentTemp.HasValue || segmentTemp.Value.Count == 0)
+                {
+                    segmentTemp = segment;
+                }
+                else
+                {
+                    // create a buffer for the remaining portion of the previous segment and the first part of the next segment
+                    var bufferSize = Math.Min(maxBufferSize, segmentTemp.Value.Count + segment.Count);
+                    var countFromNewSegment = bufferSize - segmentTemp.Value.Count;
+                    var buffer = new byte[bufferSize];
+
+                    // copy rest of previous segment
+                    Array.Copy(segmentTemp.Value.Array, segmentTemp.Value.Offset, buffer, 0, segmentTemp.Value.Count);
+                    
+                    // copy beginning of currentSegment;
+                    Array.Copy(segment.Array, segment.Offset, buffer, segmentTemp.Value.Count, countFromNewSegment);
+
+                    returnValue.Add(new ArraySegment<byte>(buffer));
+                    segmentTemp = new ArraySegment<byte>(segment.Array, segment.Offset + countFromNewSegment, segment.Count - countFromNewSegment);
+                }
+
+                while (segmentTemp.Value.Count >= maxBufferSize)
+                {
+                    returnValue.Add(new ArraySegment<byte>(segmentTemp.Value.Array, segmentTemp.Value.Offset, maxBufferSize));
+                    segmentTemp = new ArraySegment<byte>(segmentTemp.Value.Array, segmentTemp.Value.Offset + maxBufferSize, segmentTemp.Value.Count - maxBufferSize);
+                }
+            }
+
+            if (segmentTemp.HasValue && segmentTemp.Value.Count > 0)
+            {
+                returnValue.Add(segmentTemp.Value);
+            } 
+
+            return returnValue;
+        }
+    }
+}

--- a/test/TesterAzureUtils/Streaming/MessageSegmentTests.cs
+++ b/test/TesterAzureUtils/Streaming/MessageSegmentTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime.Host.Providers.Streams.AzureQueue;
+using Orleans.Serialization;
+using Xunit;
+
+namespace Tester.AzureUtils.Streaming
+{
+    public class MessageSegmentTests
+    {
+        [Fact, TestCategory("Functional"), TestCategory("Azure"), TestCategory("Streaming"), TestCategory("Serialization")]
+        public void Test_MessageSegment_SerializationAndDeserialization()
+        {
+            SerializationManager.InitializeForTesting();
+            EventSequenceTokenV2.Register();
+            AzureQueueBatchContainerV2.Register();
+            var size = CloudQueueMessage.MaxMessageSize * 13;
+            var buffer = new byte[size];
+            var random = new Random();
+            random.NextBytes(buffer);
+            var container = new AzureQueueBatchContainerV2(Guid.NewGuid(), "namespace", new List<object> {buffer}, new Dictionary<string, object> {{"key", "value"}}, new EventSequenceTokenV2(0, 0));
+            var writer = new BinaryTokenStreamWriter();
+            SerializationManager.Serialize(container, writer);
+            var segments = MessageSegment.CreateRange(writer);
+            var deserialized = AzureQueueBatchContainer.FromMessageSegments(segments, 0, true);
+            
+            Assert.Equal(container.StreamGuid, deserialized.StreamGuid);
+            Assert.Equal(container.StreamNamespace, deserialized.StreamNamespace);
+            Assert.NotNull(deserialized.RequestContext);
+            Assert.Equal(container.RequestContext.Count, deserialized.RequestContext.Count);
+            foreach (var key in deserialized.RequestContext.Keys)
+            {
+                Assert.True(deserialized.RequestContext.ContainsKey(key));
+                Assert.Equal(container.RequestContext[key], deserialized.RequestContext[key]);
+            }
+
+            var list = deserialized.GetEvents<byte[]>().ToList();
+            Assert.Equal(1, list.Count);
+            var outBuffer = list.First().Item1;
+            Assert.True(buffer.SequenceEqual(outBuffer));
+        }
+    }
+}

--- a/test/TesterAzureUtils/TesterAzureUtils.csproj
+++ b/test/TesterAzureUtils/TesterAzureUtils.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Streaming\AQStreamingTests.cs" />
     <Compile Include="Streaming\AQSubscriptionMultiplicityTests.cs" />
     <Compile Include="Streaming\AzureQueueAdapterTests.cs" />
+    <Compile Include="Streaming\MessageSegmentTests.cs" />
     <Compile Include="Streaming\DelayedQueueRebalancingTests.cs" />
     <Compile Include="Streaming\HaloStreamSubscribeTests.cs" />
     <Compile Include="Streaming\SampleAzureQueueStreamingTests.cs" />


### PR DESCRIPTION
when sending a large number of events or events of sufficient size, the max size of an azure queue message is exceeded.  This commit does the following

1. Adds a config paramto the azure queue adapter to support large messages
2. Splits messages into chunks that can be sent as cloud queue messages
3. Reassembles the chunks in azure queue batch containers
