### PR TITLE
in XML config, if SystemStoreType set to Custom but no ReminderTableAssembly are specified, assume that ReminderServiceProviderType is set to Disabled

### DIFF
--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -797,7 +797,10 @@ namespace Orleans.Runtime.Configuration
                         if (LivenessType == LivenessProviderType.Custom && string.IsNullOrEmpty(MembershipTableAssembly))
                             throw new FormatException("MembershipTableAssembly should be set when SystemStoreType is \"Custom\"");
                         if (ReminderServiceType == ReminderServiceProviderType.Custom && String.IsNullOrEmpty(ReminderTableAssembly))
-                            throw new FormatException("ReminderTableAssembly should be set when ReminderServiceType is \"Custom\"");
+                        { 
+                            logger.Info("No ReminderTableAssembly specified with SystemStoreType set to Custom: ReminderService will be disabled");
+                            SetReminderServiceType(ReminderServiceProviderType.Disabled);
+                        }
 
                         if (child.HasAttribute("ServiceId"))
                         {

--- a/test/NonSiloTests/ConfigTests.cs
+++ b/test/NonSiloTests/ConfigTests.cs
@@ -1008,6 +1008,20 @@ namespace UnitTests
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Config")]
+        public void Config_Custom_Membership_No_Reminders()
+        {
+            const string filename = "Config_Custom_Membership_No_Reminders.xml";
+
+            var config = new ClusterConfiguration();
+            config.LoadFromFile(filename);
+            Assert.True(config.Globals.MembershipTableAssembly == "MembershipTableDLL");
+            Assert.True(config.Globals.ReminderServiceType == GlobalConfiguration.ReminderServiceProviderType.Disabled);
+            Assert.True(config.Globals.AdoInvariant == "AdoInvariantValue");
+            Assert.True(config.Globals.AdoInvariantForReminders == "AdoInvariantForReminders");
+            Assert.True(config.Globals.DataConnectionString == "MembershipConnectionString");
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Config")]
         public void Config_Different_Membership_And_Reminders()
         {
             const string filename = "Config_Different_Membership_Reminders.xml";

--- a/test/NonSiloTests/Config_Custom_Membership_No_Reminders.xml
+++ b/test/NonSiloTests/Config_Custom_Membership_No_Reminders.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <StorageProviders>
+      <Provider Type="Orleans.Storage.MemoryStorage" Name="MemoryStore" />
+    </StorageProviders>
+    <SeedNode Address="localhost" Port="11111" />
+    <SystemStore SystemStoreType="Custom" DataConnectionString="MembershipConnectionString"
+                 MembershipTableAssembly="MembershipTableDLL"
+                 AdoInvariant="AdoInvariantValue"
+                 AdoInvariantForReminders="AdoInvariantForReminders" />
+  </Globals>
+  <Defaults>
+    <Networking Address="localhost" Port="11111" />
+    <ProxyingGateway Address="localhost" Port="30000" />
+    <Tracing DefaultTraceLevel="Info" TraceToConsole="false" TraceToFile="{0}-{1}.log">
+      <TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />
+    </Tracing>
+    <Statistics MetricsTableWriteInterval="30s" PerfCounterWriteInterval="30s" LogWriteInterval="300s"
+                WriteLogStatisticsToTable="true" />
+  </Defaults>
+  <Override Node="Primary">
+    <Networking Address="localhost" Port="11111" />
+    <ProxyingGateway Address="localhost" Port="30000" />
+  </Override>
+</OrleansConfiguration>

--- a/test/NonSiloTests/Orleans.NonSiloTests.csproj
+++ b/test/NonSiloTests/Orleans.NonSiloTests.csproj
@@ -102,6 +102,9 @@
     <Content Include="Config_BootstrapProviders.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Config_Custom_Membership_No_Reminders.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Config_Different_Membership_Reminders.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Fix for #2527 

In XML config we only have one setting `SystemStoreType` that set both `LivenessType` and `ReminderServiceType`, so we cannot set `LivenessType` to Custom and `ReminderServiceType` to disabled.

To work around this, now if `SystemStoreType` is set to Custom and that no `ReminderTableAssembly` are provided, we set `ReminderServiceType` to disabled