### PR TITLE
Serialization/CodeGen: Avoid generating Register methods

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -573,9 +573,15 @@ namespace Orleans.Serialization
 
             try
             {
+                var attr = typeInfo.GetCustomAttribute<SerializerAttribute>();
                 if (typeInfo.IsEnum)
                 {
                     Register(type);
+                }
+                else if (attr != null)
+                {
+                    // This type is the serializer for another type.
+                    Register(attr.TargetType, type);
                 }
                 else if (!systemAssembly)
                 {

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -439,7 +439,7 @@ namespace Orleans.CodeGenerator
                                 toGen.GetParseableName());
                         }
 
-                        namespaceMembers.AddRange(SerializerGenerator.GenerateClass(toGen, onEncounteredType));
+                        namespaceMembers.Add(SerializerGenerator.GenerateClass(toGen, onEncounteredType));
                     }
                 }
 

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -34,11 +34,6 @@ namespace Orleans.CodeGenerator
         /// The suffix appended to the name of generated classes.
         /// </summary>
         private const string ClassSuffix = "Serializer";
-        
-        /// <summary>
-        /// The suffix appended to the name of the generic serializer registration class.
-        /// </summary>
-        private const string RegistererClassSuffix = "Registerer";
 
         /// <summary>
         /// Generates the class for the provided grain types.
@@ -50,7 +45,7 @@ namespace Orleans.CodeGenerator
         /// <returns>
         /// The generated class.
         /// </returns>
-        internal static IEnumerable<TypeDeclarationSyntax> GenerateClass(Type type, Action<Type> onEncounteredType)
+        internal static TypeDeclarationSyntax GenerateClass(Type type, Action<Type> onEncounteredType)
         {
             var typeInfo = type.GetTypeInfo();
             var genericTypes = typeInfo.IsGenericTypeDefinition
@@ -84,14 +79,7 @@ namespace Orleans.CodeGenerator
                 GenerateSerializerMethod(type, fields),
                 GenerateDeserializerMethod(type, fields),
             };
-
-            if (typeInfo.IsConstructedGenericType() || !typeInfo.IsGenericTypeDefinition)
-            {
-                members.Add(GenerateRegisterMethod(type));
-                members.Add(GenerateConstructor(className));
-                attributes.Add(SF.Attribute(typeof(RegisterSerializerAttribute).GetNameSyntax()));
-            }
-
+            
             var classDeclaration =
                 SF.ClassDeclaration(className)
                     .AddModifiers(SF.Token(SyntaxKind.InternalKeyword))
@@ -103,41 +91,7 @@ namespace Orleans.CodeGenerator
                 classDeclaration = classDeclaration.AddTypeParameterListParameters(genericTypes);
             }
 
-            var classes = new List<TypeDeclarationSyntax> { classDeclaration };
-
-            if (typeInfo.IsGenericTypeDefinition)
-            {
-                // Create a generic representation of the serializer type.
-                var serializerType =
-                    SF.GenericName(classDeclaration.Identifier)
-                        .WithTypeArgumentList(
-                            SF.TypeArgumentList()
-                                .AddArguments(
-                                    type.GetTypeInfo().GetGenericArguments()
-                                        .Select(_ => SF.OmittedTypeArgument())
-                                        .Cast<TypeSyntax>()
-                                        .ToArray()));
-                var registererClassName = className + "_" +
-                                          string.Join("_",
-                                              type.GetTypeInfo().GenericTypeParameters.Select(_ => _.Name)) + "_" +
-                                          RegistererClassSuffix;
-                classes.Add(
-                    SF.ClassDeclaration(registererClassName)
-                        .AddModifiers(SF.Token(SyntaxKind.InternalKeyword))
-                        .AddAttributeLists(
-                            SF.AttributeList()
-                                .AddAttributes(
-                                    CodeGeneratorCommon.GetGeneratedCodeAttributeSyntax(),
-#if !NETSTANDARD
-                                    SF.Attribute(typeof(ExcludeFromCodeCoverageAttribute).GetNameSyntax()),
-#endif
-                                    SF.Attribute(typeof(RegisterSerializerAttribute).GetNameSyntax())))
-                        .AddMembers(
-                            GenerateMasterRegisterMethod(type, serializerType),
-                            GenerateConstructor(registererClassName)));
-            }
-
-            return classes;
+            return classDeclaration;
         }
 
         /// <summary>
@@ -470,72 +424,6 @@ namespace Orleans.CodeGenerator
             }
 
             return result;
-        }
-
-        /// <summary>
-        /// Returns syntax for the serializer registration method.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>Syntax for the serializer registration method.</returns>
-        private static MemberDeclarationSyntax GenerateRegisterMethod(Type type)
-        {
-            Expression<Action> register =
-                () =>
-                SerializationManager.Register(
-                    default(Type),
-                    default(SerializationManager.DeepCopier),
-                    default(SerializationManager.Serializer),
-                    default(SerializationManager.Deserializer));
-            return
-                SF.MethodDeclaration(typeof(void).GetTypeSyntax(), "Register")
-                    .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.StaticKeyword))
-                    .AddParameterListParameters()
-                    .AddBodyStatements(
-                        SF.ExpressionStatement(
-                            register.Invoke()
-                                .AddArgumentListArguments(
-                                    SF.Argument(SF.TypeOfExpression(type.GetTypeSyntax())),
-                                    SF.Argument(SF.IdentifierName("DeepCopier")),
-                                    SF.Argument(SF.IdentifierName("Serializer")),
-                                    SF.Argument(SF.IdentifierName("Deserializer")))));
-        }
-
-        /// <summary>
-        /// Returns syntax for the constructor.
-        /// </summary>
-        /// <param name="className">The name of the class.</param>
-        /// <returns>Syntax for the constructor.</returns>
-        private static ConstructorDeclarationSyntax GenerateConstructor(string className)
-        {
-            return
-                SF.ConstructorDeclaration(className)
-                    .AddModifiers(SF.Token(SyntaxKind.StaticKeyword))
-                    .AddParameterListParameters()
-                    .AddBodyStatements(
-                        SF.ExpressionStatement(
-                            SF.InvocationExpression(SF.IdentifierName("Register")).AddArgumentListArguments()));
-        }
-
-        /// <summary>
-        /// Returns syntax for the generic serializer registration method for the provided type..
-        /// </summary>
-        /// <param name="type">The type which is supported by this serializer.</param>
-        /// <param name="serializerType">The type of the serializer.</param>
-        /// <returns>Syntax for the generic serializer registration method for the provided type..</returns>
-        private static MemberDeclarationSyntax GenerateMasterRegisterMethod(Type type, TypeSyntax serializerType)
-        {
-            Expression<Action> register = () => SerializationManager.Register(default(Type), default(Type));
-            return
-                SF.MethodDeclaration(typeof(void).GetTypeSyntax(), "Register")
-                    .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.StaticKeyword))
-                    .AddParameterListParameters()
-                    .AddBodyStatements(
-                        SF.ExpressionStatement(
-                            register.Invoke()
-                                .AddArgumentListArguments(
-                                    SF.Argument(
-                                        SF.TypeOfExpression(type.GetTypeSyntax(includeGenericParameters: false))),
-                                    SF.Argument(SF.TypeOfExpression(serializerType)))));
         }
 
         /// <summary>

--- a/test/DefaultCluster.Tests/JsonGrainTests.cs
+++ b/test/DefaultCluster.Tests/JsonGrainTests.cs
@@ -44,14 +44,10 @@ namespace DefaultCluster.Tests.General
             Assert.Equal(input.ToString(), output.ToString());
         }
 
-        [RegisterSerializer]
+        [Serializer(typeof(JObject))]
         public class JObjectSerializationExample1
         {
-            static JObjectSerializationExample1()
-            {
-                Register();
-            }
-
+            [CopierMethod]
             public static object DeepCopier(object original, ICopyContext context)
             {
                 // I assume JObject is immutable, so no need to deep copy.
@@ -59,6 +55,7 @@ namespace DefaultCluster.Tests.General
                 return original;
             }
 
+            [SerializerMethod]
             public static void Serializer(object untypedInput, ISerializationContext context, Type expected)
             {
                 var input = (JObject)untypedInput;
@@ -66,15 +63,11 @@ namespace DefaultCluster.Tests.General
                 SerializationManager.Serialize(str, context.StreamWriter);
             }
 
+            [DeserializerMethod]
             public static object Deserializer(Type expected, IDeserializationContext context)
             {
                 var str = (string)SerializationManager.Deserialize(typeof(string), context.StreamReader);
                 return JObject.Parse(str);
-            }
-
-            public static void Register()
-            {
-                SerializationManager.Register(typeof(JObject), DeepCopier, Serializer, Deserializer);
             }
         }
     }


### PR DESCRIPTION
* When we encounter a type, eg `SerializerType`, with a `[Serializer(typeof(TargetType))]` attribute, we register the type as the serializer for `TargetType`. I.e, `SerializationManager.Register(typeof(TargetType), typeof(SerializerType))`
* Avoid generating `Register` methods
* Avoid adding `[RegisterSerializer]` attribute
* Avoid generating non-generic "master registerer" class for generic types

This code was extracted from #2592

This is a non-breaking change