### PR TITLE
Fix building in VS2017 RC2.

### DIFF
--- a/vNext/src/ClientGenerator/BootstrapCodegen.proj
+++ b/vNext/src/ClientGenerator/BootstrapCodegen.proj
@@ -1,39 +1,79 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
-    <PropertyGroup>
-      <ExcludeCodegenConstants>$(DefineConstants);EXCLUDE_CODEGEN;ORLEANS_BOOTSTRAP;NETSTANDARD;NETSTANDARD_TODO</ExcludeCodegenConstants>
-      <BootstrapOutputPath Condition="'$(BootstrapOutputPath)' == ''">$(MSBuildProjectDirectory)\bin\$(Configuration)\Bootstrap\</BootstrapOutputPath>
-      <TargetFramework />
-      <TargetFrameworks />
-      <RuntimeIdentifier />
-      <MsBuildProperties>
-        Configuration=$(Configuration);
-        Bootstrap=true;
-        OutputPath=$(BootstrapOutputPath);
-        IntermediateOutputPath=$(BootstrapOutputPath)obj\;
-        DefineConstants=$(ExcludeCodegenConstants)
-      </MsBuildProperties>
-    </PropertyGroup>
-    <Target Name="Build">
-      <Message Text="[OrleansDllBootstrapUsingCodeGen] - Compiling code generators for bootstrap" Importance="high" />
-      <MSBuild
-        Projects="ClientGenerator.csproj"
-        Properties="$(MsBuildProperties);TargetFramework=net462"
-        Targets="Build"
-        UnloadProjectsOnCompletion="true"
-        UseResultsCache="false"
-        BuildInParallel="true"
-        ToolsVersion="15.0" />
-    </Target>
-    <Target Name="Clean">
-      <Message Text="[OrleansDllBootstrapUsingCodeGen] - Compiling code generators for bootstrap" Importance="high" />
-      <MSBuild
-        Projects="ClientGenerator.csproj"
-        Properties="$(MsBuildProperties);TargetFramework=net462"
-        Targets="Clean"
-        UnloadProjectsOnCompletion="true"
-        UseResultsCache="false"
-        BuildInParallel="true"
-        ToolsVersion="15.0" />
-    </Target>
+  <PropertyGroup>
+    <ExcludeCodegenConstants>$(DefineConstants);EXCLUDE_CODEGEN;ORLEANS_BOOTSTRAP;NETSTANDARD;NETSTANDARD_TODO</ExcludeCodegenConstants>
+    <BootstrapOutputPath Condition="'$(BootstrapOutputPath)' == ''">$(MSBuildProjectDirectory)\bin\$(Configuration)\Bootstrap\</BootstrapOutputPath>
+    <TargetFramework />
+    <TargetFrameworks />
+    <RuntimeIdentifier />
+    <MsBuildProperties>
+      Configuration=$(Configuration);
+      Bootstrap=true;
+      OutputPath=$(BootstrapOutputPath);
+      IntermediateOutputPath=$(BootstrapOutputPath)obj\;
+      DefineConstants=$(ExcludeCodegenConstants)
+    </MsBuildProperties>
+  </PropertyGroup>
+  <Target Name="Build">
+    <Message Text="[OrleansDllBootstrapUsingCodeGen] - Compiling code generators for bootstrap" Importance="high" />
+    <MSBuild
+      Projects="..\Orleans.PlatformServices\Orleans.PlatformServices.csproj"
+      Properties="$(MsBuildProperties);TargetFramework=net462"
+      Targets="Build"
+      UnloadProjectsOnCompletion="true"
+      UseResultsCache="false"
+      BuildInParallel="false" />
+    <MSBuild
+      Projects="..\Orleans\Orleans.csproj"
+      Properties="$(MsBuildProperties);TargetFramework=netstandard1.5"
+      Targets="Build"
+      UnloadProjectsOnCompletion="true"
+      UseResultsCache="false"
+      BuildInParallel="false" />
+    <MSBuild
+      Projects="..\OrleansCodeGenerator\OrleansCodeGenerator.csproj"
+      Properties="$(MsBuildProperties);TargetFramework=netstandard1.5"
+      Targets="Build"
+      UnloadProjectsOnCompletion="true"
+      UseResultsCache="false"
+      BuildInParallel="false" />
+    <MSBuild
+      Projects="ClientGenerator.csproj"
+      Properties="$(MsBuildProperties);TargetFramework=net462"
+      Targets="Build"
+      UnloadProjectsOnCompletion="true"
+      UseResultsCache="false"
+      BuildInParallel="false" />
+  </Target>
+  <Target Name="Clean">
+    <Message Text="[OrleansDllBootstrapUsingCodeGen] - Cleaning code generators for bootstrap" Importance="high" />
+    <MSBuild
+      Projects="..\Orleans.PlatformServices\Orleans.PlatformServices.csproj"
+      Properties="$(MsBuildProperties);TargetFramework=net462"
+      Targets="Clean"
+      UnloadProjectsOnCompletion="true"
+      UseResultsCache="false"
+      BuildInParallel="false" />
+    <MSBuild
+      Projects="..\Orleans\Orleans.csproj"
+      Properties="$(MsBuildProperties);TargetFramework=netstandard1.5"
+      Targets="Clean"
+      UnloadProjectsOnCompletion="true"
+      UseResultsCache="false"
+      BuildInParallel="false" />
+    <MSBuild
+      Projects="..\OrleansCodeGenerator\OrleansCodeGenerator.csproj"
+      Properties="$(MsBuildProperties);TargetFramework=netstandard1.5"
+      Targets="Clean"
+      UnloadProjectsOnCompletion="true"
+      UseResultsCache="false"
+      BuildInParallel="false" />
+    <MSBuild
+      Projects="ClientGenerator.csproj"
+      Properties="$(MsBuildProperties);TargetFramework=net462"
+      Targets="Clean"
+      UnloadProjectsOnCompletion="true"
+      UseResultsCache="false"
+      BuildInParallel="false" />
+  </Target>
 </Project>


### PR DESCRIPTION
Apparently when building in VS things are still different, so building the projects one-by-one was re-added to proj file.