### PR TITLE
Allow serializers to have multiple [Serializer(...)] attributes

### DIFF
--- a/src/Orleans/CodeGeneration/ActivationAttribute.cs
+++ b/src/Orleans/CodeGeneration/ActivationAttribute.cs
@@ -60,7 +60,7 @@ namespace Orleans.CodeGeneration
     /// <summary>
     /// Identifies a class that contains all the serializer methods for a type.
     /// </summary>
-    [AttributeUsage(System.AttributeTargets.Class)]
+    [AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
     public sealed class SerializerAttribute : GeneratedAttribute
     {
         /// <summary>

--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -256,6 +256,7 @@ namespace Orleans
     /// Used to make a class for auto-registration as a serialization helper.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
+    [Obsolete("[RegisterSerializer] is obsolete, please use [Serializer(typeof(TargetType))] instead.")]
     public sealed class RegisterSerializerAttribute : Attribute
     {
     }

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -573,7 +573,7 @@ namespace Orleans.Serialization
 
             try
             {
-                var serializerAttributes = Attribute.GetCustomAttributes(typeInfo, typeof(SerializerAttribute));
+                var serializerAttributes = typeInfo.GetCustomAttributes<SerializerAttribute>().ToArray();
                 if (typeInfo.IsEnum)
                 {
                     Register(type);
@@ -583,8 +583,7 @@ namespace Orleans.Serialization
                     // This type is the serializer for another type.
                     foreach (var attr in serializerAttributes)
                     {
-                        var serializerAttribute = (SerializerAttribute) attr;
-                        Register(serializerAttribute.TargetType, type);
+                        Register(attr.TargetType, type);
                     }
                 }
                 else if (!systemAssembly)
@@ -594,7 +593,9 @@ namespace Orleans.Serialization
                             || (!typeInfo.Namespace.Equals("System", StringComparison.Ordinal)
                                 && !typeInfo.Namespace.StartsWith("System.", StringComparison.Ordinal))))
                     {
+#pragma warning disable 618
                         if (typeInfo.GetCustomAttributes(typeof(RegisterSerializerAttribute), false).Any())
+#pragma warning restore 618
                         {
                             // Call the static Register method on the type
                             if (logger.IsVerbose3)

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -573,15 +573,19 @@ namespace Orleans.Serialization
 
             try
             {
-                var attr = typeInfo.GetCustomAttribute<SerializerAttribute>();
+                var serializerAttributes = Attribute.GetCustomAttributes(typeInfo, typeof(SerializerAttribute));
                 if (typeInfo.IsEnum)
                 {
                     Register(type);
                 }
-                else if (attr != null)
+                else if (serializerAttributes.Length > 0)
                 {
                     // This type is the serializer for another type.
-                    Register(attr.TargetType, type);
+                    foreach (var attr in serializerAttributes)
+                    {
+                        var serializerAttribute = (SerializerAttribute) attr;
+                        Register(serializerAttribute.TargetType, type);
+                    }
                 }
                 else if (!systemAssembly)
                 {

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
@@ -9,7 +9,6 @@ using Orleans.Serialization;
 
 namespace Orleans.Providers.Streams.AzureQueue
 {
-    [RegisterSerializer]
     internal class AzureQueueBatchContainerV2 : AzureQueueBatchContainer
     {
         [JsonConstructor]
@@ -42,6 +41,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <param name="original">The object to create a copy of</param>
         /// <param name="context">The copy context.</param>
         /// <returns>The copy.</returns>
+        [CopierMethod]
         public static object DeepCopy(object original, ICopyContext context)
         {
             var source = original as AzureQueueBatchContainerV2;
@@ -74,6 +74,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <param name="untypedInput">The object to serialize</param>
         /// <param name="context">The serialization context.</param>
         /// <param name="expected">The expected type</param>
+        [SerializerMethod]
         public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
         {
             var typed = untypedInput as AzureQueueBatchContainerV2;
@@ -95,6 +96,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <param name="expected">The expected type</param>
         /// <param name="context">The deserialization context.</param>
         /// <returns>The deserialized value</returns>
+        [DeserializerMethod]
         public static object Deserialize(Type expected, IDeserializationContext context)
         {
             var reader = context.StreamReader;
@@ -107,14 +109,6 @@ namespace Orleans.Providers.Streams.AzureQueue
             var ctx = SerializationManager.DeserializeInner<Dictionary<string, object>>(context);
             deserialized.SetValues(guid, ns, events, ctx, eventToken);
             return deserialized;
-        }
-
-        /// <summary>
-        /// Register the serializer methods.
-        /// </summary>
-        public static void Register()
-        {
-            SerializationManager.Register(typeof(AzureQueueBatchContainerV2), DeepCopy, Serialize, Deserialize);
         }
 
         private static void WriteOrSerializeInner<T>(T val, ISerializationContext context) where T : class

--- a/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
@@ -5,9 +5,8 @@ using Orleans.Serialization;
 namespace Orleans.Providers.Streams.Common
 {
     /// <summary>
-    /// Stream sequcen token that tracks sequence nubmer and event index
+    /// Stream sequence token that tracks sequence number and event index
     /// </summary>
-    [RegisterSerializer]
     public class EventSequenceTokenV2 : EventSequenceToken
     {
         /// <summary>
@@ -28,19 +27,12 @@ namespace Orleans.Providers.Streams.Common
         }
 
         /// <summary>
-        /// Register the serializers
-        /// </summary>
-        public static void Register()
-        {
-            SerializationManager.Register(typeof(EventSequenceTokenV2), DeepCopy, Serialize, Deserialize);
-        }
-
-        /// <summary>
         /// Create a deep copy of the token.
         /// </summary>
         /// <param name="original">The token to copy</param>
         /// <param name="context">The serialization context.</param>
         /// <returns>A copy</returns>
+        [CopierMethod]
         public static object DeepCopy(object original, ICopyContext context)
         {
             var source = original as EventSequenceTokenV2;
@@ -60,6 +52,7 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="untypedInput">The object to serialize.</param>
         /// <param name="context">The serialization context.</param>
         /// <param name="expected">The expected type.</param>
+        [SerializerMethod]
         public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
         {
             var writer = context.StreamWriter;
@@ -80,6 +73,7 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="expected">The expected type.</param>
         /// <param name="context">The deserialization context.</param>
         /// <returns></returns>
+        [DeserializerMethod]
         public static object Deserialize(Type expected, IDeserializationContext context)
         {
             var reader = context.StreamReader;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
@@ -12,9 +12,8 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
     ///   The SequenceNumber is required for uniqueness and ordering of EventHub messages within a partition.
     /// event Index - Since each EventHub message may contain more than one application layer event, this value
     ///   indicates which application layer event this token is for, within an EventHub message.  It is required for uniqueness
-    ///   and ordering of aplication layer events within an EventHub message.
+    ///   and ordering of application layer events within an EventHub message.
     /// </summary>
-    [RegisterSerializer]
     public class EventHubSequenceTokenV2 : EventHubSequenceToken
     {
         /// <summary>
@@ -27,13 +26,6 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
             : base(eventHubOffset, sequenceNumber, eventIndex)
         {
         }
-        /// <summary>
-        /// Register the serializers
-        /// </summary>
-        public static void Register()
-        {
-            SerializationManager.Register(typeof(EventHubSequenceTokenV2), DeepCopy, Serialize, Deserialize);
-        }
 
         /// <summary>
         /// Create a deep copy of the token.
@@ -41,6 +33,7 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
         /// <param name="original">The token to copy</param>
         /// <param name="context">The serialization context.</param>
         /// <returns>A copy</returns>
+        [CopierMethod]
         public static object DeepCopy(object original, ICopyContext context)
         {
             var source = original as EventHubSequenceTokenV2;
@@ -60,6 +53,7 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
         /// <param name="untypedInput">The object to serialize.</param>
         /// <param name="context">The serialization context.</param>
         /// <param name="expected">The expected type.</param>
+        [SerializerMethod]
         public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
         {
             var typed = untypedInput as EventHubSequenceTokenV2;
@@ -81,6 +75,7 @@ namespace OrleansServiceBus.Providers.Streams.EventHub
         /// <param name="expected">The expected type.</param>
         /// <param name="context">The deserialization context.</param>
         /// <returns></returns>
+        [DeserializerMethod]
         public static object Deserialize(Type expected, IDeserializationContext context)
         {
             var reader = context.StreamReader;

--- a/test/NonSiloTests/SerializationTests/SerializationTests.DifferentTypes.cs
+++ b/test/NonSiloTests/SerializationTests/SerializationTests.DifferentTypes.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Orleans.CodeGeneration;
 using Orleans.Serialization;
 using TestExtensions;
 using Xunit;
@@ -80,20 +81,15 @@ namespace UnitTests.Serialization
         }
 
         [Serializable]
-        internal class TestTypeA
+        private class TestTypeA
         {
             public ICollection<TestTypeA> Collection { get; set; }
         }
 
-        [Orleans.CodeGeneration.RegisterSerializerAttribute()]
+        [Serializer(typeof(TestTypeA))]
         internal class TestTypeASerialization
         {
-
-            static TestTypeASerialization()
-            {
-                Register();
-            }
-
+            [CopierMethod]
             public static object DeepCopier(object original, ICopyContext context)
             {
                 TestTypeA input = (TestTypeA)original;
@@ -103,23 +99,20 @@ namespace UnitTests.Serialization
                 return result;
             }
 
+            [SerializerMethod]
             public static void Serializer(object untypedInput, ISerializationContext context, Type expected)
             {
                 TestTypeA input = (TestTypeA)untypedInput;
                 SerializationManager.SerializeInner(input.Collection, context, typeof(ICollection<TestTypeA>));
             }
 
+            [DeserializerMethod]
             public static object Deserializer(Type expected, IDeserializationContext context)
             {
                 TestTypeA result = new TestTypeA();
                 context.RecordObject(result);
                 result.Collection = (ICollection<TestTypeA>)SerializationManager.DeserializeInner(typeof(ICollection<TestTypeA>), context);
                 return result;
-            }
-
-            public static void Register()
-            {
-                SerializationManager.Register(typeof(TestTypeA), DeepCopier, Serializer, Deserializer);
             }
         }
 

--- a/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
+++ b/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
@@ -10,6 +10,7 @@ using Orleans.ServiceBus.Providers;
 using OrleansServiceBus.Providers.Streams.EventHub;
 using Xunit;
 using Tester.Serialization;
+using TestExtensions;
 
 namespace UnitTests.Serialization
 {
@@ -18,9 +19,7 @@ namespace UnitTests.Serialization
         public StreamTypeSerializationTests()
         {
             // FakeSerializer definied in ExternalSerializerTest.cs
-            SerializationManager.InitializeForTesting(new List<TypeInfo> { typeof(FakeSerializer).GetTypeInfo() });
-            EventSequenceTokenV2.Register();
-            EventHubSequenceTokenV2.Register();
+            SerializationTestEnvironment.Initialize(new List<TypeInfo> { typeof(FakeSerializer).GetTypeInfo() });
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -35,7 +35,9 @@ namespace UnitTests.Serialization
             Assert.Equal(input.ToString(), output.ToString());
         }
 
+#pragma warning disable 618
         [RegisterSerializer]
+#pragma warning restore 618
         public class JObjectSerializationExample1
         {
             public static bool RegisterWasCalled;
@@ -62,6 +64,7 @@ namespace UnitTests.Serialization
 
             public static void Register()
             {
+                RegisterWasCalled = true;
                 SerializationManager.Register(typeof(JObject), DeepCopier, Serializer, Deserializer);
             }
         }

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -35,13 +35,10 @@ namespace UnitTests.Serialization
             Assert.Equal(input.ToString(), output.ToString());
         }
 
-        [RegisterSerializerAttribute]
+        [RegisterSerializer]
         public class JObjectSerializationExample1
         {
-            static JObjectSerializationExample1()
-            {
-                Register();
-            }
+            public static bool RegisterWasCalled;
 
             public static object DeepCopier(object original, ICopyContext context)
             {
@@ -68,7 +65,13 @@ namespace UnitTests.Serialization
                 SerializationManager.Register(typeof(JObject), DeepCopier, Serializer, Deserializer);
             }
         }
-        
+
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
+        public void SerializationTests_RegisterMethod_IsCalled()
+        {
+            Assert.True(JObjectSerializationExample1.RegisterWasCalled);
+        }
+
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
         public void SerializationTests_Json_InnerTypes_TypeNameHandling()
         {
@@ -133,7 +136,12 @@ namespace UnitTests.Serialization
         /// <summary>
         /// A different way to configure Json serializer.
         /// </summary>
-        [RegisterSerializer]
+        [Serializer(typeof(JObject))]
+        [Serializer(typeof(JArray))]
+        [Serializer(typeof(JToken))]
+        [Serializer(typeof(JValue))]
+        [Serializer(typeof(JProperty))]
+        [Serializer(typeof(JConstructor))]
         public class JsonSerializationExample2
         {
             internal static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
@@ -142,11 +150,7 @@ namespace UnitTests.Serialization
                 TypeNameHandling = TypeNameHandling.All
             };
 
-            static JsonSerializationExample2()
-            {
-                Register();
-            }
-
+            [CopierMethod]
             public static object DeepCopier(object original, ICopyContext context)
             {
                 // I assume JObject is immutable, so no need to deep copy.
@@ -154,27 +158,18 @@ namespace UnitTests.Serialization
                 return original;
             }
 
+            [SerializerMethod]
             public static void Serialize(object obj, ISerializationContext context, Type expected)
             {
                 var str = JsonConvert.SerializeObject(obj, Settings);
                 SerializationManager.Serialize(str, context.StreamWriter);
             }
 
+            [DeserializerMethod]
             public static object Deserialize(Type expected, IDeserializationContext context)
             {
                 var str = (string)SerializationManager.Deserialize(typeof(string), context.StreamReader);
                 return JsonConvert.DeserializeObject(str, expected);
-            }
-
-            public static void Register()
-            {
-                foreach (var type in new[]
-                    {
-                        typeof(JObject), typeof(JArray), typeof(JToken), typeof(JValue), typeof(JProperty), typeof(JConstructor), 
-                    })
-                {
-                    SerializationManager.Register(type, DeepCopier, Serialize, Deserialize);
-                }
             }
         }
     }

--- a/test/TesterAzureUtils/StreamTypeSerializationTests.cs
+++ b/test/TesterAzureUtils/StreamTypeSerializationTests.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Providers.Streams.Common;
 using Orleans.Serialization;
@@ -11,6 +8,7 @@ using Xunit;
 using Orleans.Streams;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Tester.Serialization;
+using TestExtensions;
 
 namespace Tester.AzureUtils.Streaming
 {
@@ -19,9 +17,7 @@ namespace Tester.AzureUtils.Streaming
         public StreamTypeSerializationTests()
         {
             // FakeSerializer definied in ExternalSerializerTest.cs
-            SerializationManager.InitializeForTesting(new List<TypeInfo> { typeof(FakeSerializer).GetTypeInfo() });
-            EventSequenceTokenV2.Register();
-            AzureQueueBatchContainerV2.Register();
+            SerializationTestEnvironment.Initialize(new List<TypeInfo> { typeof(FakeSerializer).GetTypeInfo() });
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]


### PR DESCRIPTION
Part of the work to obviate `SerializationManager.Register` methods. See #2610

Simple fix to allow a single static serializer class to support multiple types, as can be seen with the JSON serializer below.

`[RegisterSerializer]` is still available and this PR adds a test to ensure it's still being called, but it's marked as obsolete in order to set expectations.