### PR TITLE
Removed SimpleQueueCache dependecy on EventSequenceToken

### DIFF
--- a/src/Orleans/Streams/QueueAdapters/IQueueCacheCursor.cs
+++ b/src/Orleans/Streams/QueueAdapters/IQueueCacheCursor.cs
@@ -31,7 +31,7 @@ namespace Orleans.Streams
         /// Refresh that cache cursor. Called when new data is added into a cache.
         /// </summary>
         /// <returns></returns>
-        void Refresh();
+        void Refresh(StreamSequenceToken token);
 
         /// <summary>
         /// Record that delivery of the current event has failed

--- a/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
@@ -42,15 +42,6 @@ namespace Orleans.Providers.Streams.Common
         }
 
         /// <summary>
-        /// Sequence number of next event batch in the stream
-        /// </summary>
-        /// <returns></returns>
-        public EventSequenceToken NextSequenceNumber()
-        {
-            return new EventSequenceToken(SequenceNumber + 1, EventIndex);
-        }
-
-        /// <summary>
         /// Creates a sequence token for a specific event in the current batch
         /// </summary>
         /// <param name="eventInd"></param>

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCache.cs
@@ -8,7 +8,7 @@ namespace Orleans.Providers.Streams.Common
     internal class CacheBucket
     {
         // For backpressure detection we maintain a histogram of 10 buckets.
-        // Every buckets recors how many items are in the cache in that bucket
+        // Every bucket records how many items are in the cache in that bucket
         // and how many cursors are poinmting to an item in that bucket.
         // We update the NumCurrentItems when we add and remove cache item (potentially opening or removing a bucket)
         // We update NumCurrentCursors every time we move a cursor
@@ -40,7 +40,6 @@ namespace Orleans.Providers.Streams.Common
     public class SimpleQueueCache : IQueueCache
     {
         private readonly LinkedList<SimpleQueueCacheItem> cachedMessages;
-        private StreamSequenceToken lastSequenceTokenAddedToCache;
         private readonly int maxCacheSize;
         private readonly Logger logger;
         private readonly List<CacheBucket> cacheCursorHistogram; // for backpressure detection
@@ -109,6 +108,7 @@ namespace Orleans.Providers.Streams.Common
                 cacheCursorHistogram.RemoveAt(0); // remove the last bucket
             }
             purgedItems = allItems;
+            Log(logger, "TryPurgeFromCache: purged {0} items from cache.", purgedItems.Count);
             return true;
         }
 
@@ -144,13 +144,12 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="msgs"></param>
         public virtual void AddToCache(IList<IBatchContainer> msgs)
         {
-            if (msgs == null) throw new ArgumentNullException("msgs");
+            if (msgs == null) throw new ArgumentNullException(nameof(msgs));
 
             Log(logger, "AddToCache: added {0} items to cache.", msgs.Count);
             foreach (var message in msgs)
             {
                 Add(message, message.SequenceToken);
-                lastSequenceTokenAddedToCache = message.SequenceToken;
             }
         }
 
@@ -163,39 +162,33 @@ namespace Orleans.Providers.Streams.Common
         /// <returns></returns>
         public virtual IQueueCacheCursor GetCacheCursor(IStreamIdentity streamIdentity, StreamSequenceToken token)
         {
-            if (token != null && !(token is EventSequenceToken))
-            {
-                // Null token can come from a stream subscriber that is just interested to start consuming from latest (the most recent event added to the cache).
-                throw new ArgumentOutOfRangeException("token", "token must be of type EventSequenceToken");
-            }
-
             var cursor = new SimpleQueueCacheCursor(this, streamIdentity, logger);
-            InitializeCursor(cursor, token, true);
+            InitializeCursor(cursor, token);
             return cursor;
         }
 
-        internal void InitializeCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken sequenceToken, bool enforceSequenceToken)
+        internal void InitializeCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken sequenceToken)
         {
             Log(logger, "InitializeCursor: {0} to sequenceToken {1}", cursor, sequenceToken);
-           
-            if (cachedMessages.Count == 0) // nothing in cache
+
+            // Nothing in cache, unset token, and wait for more data.
+            if (cachedMessages.Count == 0)
             {
-                StreamSequenceToken tokenToReset = sequenceToken ?? ((EventSequenceToken) lastSequenceTokenAddedToCache)?.NextSequenceNumber();
-                ResetCursor(cursor, tokenToReset);
+                UnsetCursor(cursor, sequenceToken);
                 return;
             }
 
-            // if offset is not set, iterate from newest (first) message in cache, but not including the irst message itself
+            // if no token is provided, set cursor to idle at end of cache
             if (sequenceToken == null)
             {
-                StreamSequenceToken tokenToReset = ((EventSequenceToken) lastSequenceTokenAddedToCache)?.NextSequenceNumber();
-                ResetCursor(cursor, tokenToReset);
+                UnsetCursor(cursor, cachedMessages.First?.Value?.SequenceToken);
                 return;
             }
 
-            if (sequenceToken.Newer(cachedMessages.First.Value.SequenceToken)) // sequenceId is too new to be in cache
+            // If sequenceToken is too new to be in cache, unset token, and wait for more data.
+            if (sequenceToken.Newer(cachedMessages.First.Value.SequenceToken))
             {
-                ResetCursor(cursor, sequenceToken);
+                UnsetCursor(cursor, sequenceToken);
                 return;
             }
 
@@ -203,12 +196,7 @@ namespace Orleans.Providers.Streams.Common
             // Check to see if offset is too old to be in cache
             if (sequenceToken.Older(lastMessage.Value.SequenceToken))
             {
-                if (enforceSequenceToken)
-                {
-                    // throw cache miss exception
-                    throw new QueueCacheMissException(sequenceToken, cachedMessages.Last.Value.SequenceToken, cachedMessages.First.Value.SequenceToken);
-                }
-                sequenceToken = lastMessage.Value.SequenceToken;
+                throw new QueueCacheMissException(sequenceToken, cachedMessages.Last.Value.SequenceToken, cachedMessages.First.Value.SequenceToken);
             }
 
             // Now the requested sequenceToken is set and is also within the limits of the cache.
@@ -221,16 +209,27 @@ namespace Orleans.Providers.Streams.Common
                 // did we get to the end?
                 if (node.Next == null) // node is the last message
                     break;
-                
+
                 // if sequenceId is between the two, take the higher
                 if (node.Next.Value.SequenceToken.Older(sequenceToken))
                     break;
-                
+
                 node = node.Next;
             }
 
             // return cursor from start.
             SetCursor(cursor, node);
+        }
+
+        internal void RefreshCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken sequenceToken)
+        {
+            Log(logger, "RefreshCursor: {0} to sequenceToken {1}", cursor, sequenceToken);
+
+            // set if unset
+            if (!cursor.IsSet)
+            {
+                InitializeCursor(cursor, cursor.SequenceToken ?? sequenceToken);
+            }
         }
 
         /// <summary>
@@ -244,40 +243,24 @@ namespace Orleans.Providers.Streams.Common
             Log(logger, "TryGetNextMessage: {0}", cursor);
 
             batch = null;
+            if (!cursor.IsSet) return false;
 
-            if (cursor == null) throw new ArgumentNullException("cursor");
-            
-            //if not set, try to set and then get next
-            if (!cursor.IsSet)
-            {
-                InitializeCursor(cursor, cursor.SequenceToken, false);
-                return cursor.IsSet && TryGetNextMessage(cursor, out batch);
-            }
-
-            // has this message been purged
-            if (cursor.SequenceToken.Older(cachedMessages.Last.Value.SequenceToken))
-            {
-                throw new QueueCacheMissException(cursor.SequenceToken, cachedMessages.Last.Value.SequenceToken, cachedMessages.First.Value.SequenceToken);
-            }
-
-            // Cursor now points to a valid message in the cache. Get it!
             // Capture the current element and advance to the next one.
             batch = cursor.Element.Value.Batch;
-            
-            // Advance to next:
+
+            // If we are at the end of the cache unset cursor and move offset one forward
             if (cursor.Element == cachedMessages.First)
             {
-                // If we are at the end of the cache unset cursor and move offset one forward
-                ResetCursor(cursor, ((EventSequenceToken)cursor.SequenceToken).NextSequenceNumber());
+                UnsetCursor(cursor, null);
             }
-            else // move to next
+            else // Advance to next:
             {
-                UpdateCursor(cursor, cursor.Element.Previous);
+                AdvanceCursor(cursor, cursor.Element.Previous);
             }
             return true;
         }
 
-        private void UpdateCursor(SimpleQueueCacheCursor cursor, LinkedListNode<SimpleQueueCacheItem> item)
+        private void AdvanceCursor(SimpleQueueCacheCursor cursor, LinkedListNode<SimpleQueueCacheItem> item)
         {
             Log(logger, "UpdateCursor: {0} to item {1}", cursor, item.Value.Batch);
 
@@ -294,20 +277,20 @@ namespace Orleans.Providers.Streams.Common
             cursor.Element.Value.CacheBucket.UpdateNumCursors(1);  // add to next bucket
         }
 
-        internal void ResetCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken token)
+        internal void UnsetCursor(SimpleQueueCacheCursor cursor, StreamSequenceToken token)
         {
-            Log(logger, "ResetCursor: {0} to token {1}", cursor, token);
+            Log(logger, "UnsetCursor: {0}", cursor);
 
             if (cursor.IsSet)
             {
                 cursor.Element.Value.CacheBucket.UpdateNumCursors(-1);
             }
-            cursor.Reset(token);
+            cursor.UnSet(token);
         }
 
         private void Add(IBatchContainer batch, StreamSequenceToken sequenceToken)
         {
-            if (batch == null) throw new ArgumentNullException("batch");
+            if (batch == null) throw new ArgumentNullException(nameof(batch));
 
             CacheBucket cacheBucket;
             if (cacheCursorHistogram.Count == 0)

--- a/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCacheCursor.cs
+++ b/src/OrleansProviders/Streams/Common/SimpleCache/SimpleQueueCacheCursor.cs
@@ -24,16 +24,17 @@ namespace Orleans.Providers.Streams.Common
 
         internal bool IsSet => Element != null;
 
-        internal void Reset(StreamSequenceToken token)
+        internal void Set(LinkedListNode<SimpleQueueCacheItem> item)
+        {
+            if (item == null) throw new NullReferenceException(nameof(item));
+            Element = item;
+            SequenceToken = item.Value.SequenceToken;
+        }
+
+        internal void UnSet(StreamSequenceToken token)
         {
             Element = null;
             SequenceToken = token;
-        }
-
-        internal void Set(LinkedListNode<SimpleQueueCacheItem> item)
-        {
-            Element = item;
-            SequenceToken = item.Value.SequenceToken;
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (cache == null)
             {
-                throw new ArgumentNullException("cache");
+                throw new ArgumentNullException(nameof(cache));
             }
             this.cache = cache;
             this.streamIdentity = streamIdentity;
@@ -98,11 +99,11 @@ namespace Orleans.Providers.Streams.Common
         /// Refresh that cache cursor. Called when new data is added into a cache.
         /// </summary>
         /// <returns></returns>
-        public virtual void Refresh()
+        public virtual void Refresh(StreamSequenceToken sequenceToken)
         {
             if (!IsSet)
             {
-                cache.InitializeCursor(this, SequenceToken, false);
+                cache.RefreshCursor(this, sequenceToken);
             }
         }
 
@@ -142,7 +143,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (disposing)
             {
-                cache.ResetCursor(this, null);
+                cache.UnsetCursor(this, null);
             }
         }
 
@@ -154,8 +155,7 @@ namespace Orleans.Providers.Streams.Common
         /// <returns></returns>
         public override string ToString()
         {
-            return
-                $"<SimpleQueueCacheCursor: Element={Element?.Value.Batch.ToString() ?? "null"}, SequenceToken={SequenceToken?.ToString() ?? "null"}>";
+            return $"<SimpleQueueCacheCursor: Element={Element?.Value.Batch.ToString() ?? "null"}, SequenceToken={SequenceToken?.ToString() ?? "null"}>";
         }
     }
 }

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -174,7 +174,7 @@ namespace Orleans.Providers.Streams.Generator
                 return true;
             }
 
-            public void Refresh()
+            public void Refresh(StreamSequenceToken token)
             {
             }
 

--- a/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
@@ -163,7 +163,7 @@ namespace Orleans.Providers
                 return true;
             }
 
-            public void Refresh()
+            public void Refresh(StreamSequenceToken token)
             {
             }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -303,7 +303,7 @@ namespace Orleans.ServiceBus.Providers
                 return true;
             }
 
-            public void Refresh()
+            public void Refresh(StreamSequenceToken token)
             {
             }
 

--- a/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -95,7 +95,7 @@ namespace Tester.AzureUtils.Streaming
                         {
                             continue;
                         }
-                        foreach (AzureQueueBatchContainer message in messages.Cast<AzureQueueBatchContainer>())
+                        foreach (IBatchContainer message in messages)
                         {
                             streamsPerQueue.AddOrUpdate(queueId,
                                 id => new HashSet<IStreamIdentity> { new StreamIdentity(message.StreamGuid, message.StreamGuid.ToString()) },


### PR DESCRIPTION
SimpleQueueCache has a hard dependency on EventSequenceToken.  This is bad, as it's intended to be a generic cache and should not be dependent on specific batch containers or sequence tokens.

The original compromise was made to manage cursor location in the cache, which was originally, unset, set, or idle.  To help manage cursor position for idle cursors, we'd needed to know the sequence token of the next message.  We used the state of the EventSequenceToken to get the next sequence token, which introduced the dependency.

This change treats unset and idle cursors the same, with a special case for cursors set in the future.