### PR TITLE
Fix xml doc typo

### DIFF
--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -566,7 +566,7 @@ namespace Orleans.Runtime.Configuration
         }
 
         /// <summary>
-        /// Retuurns a ClientConfiguration object for connecting to a local silo (for testing).
+        /// Returns a ClientConfiguration object for connecting to a local silo (for testing).
         /// </summary>
         /// <param name="gatewayPort">Client gateway TCP port</param>
         /// <returns>ClientConfiguration object that can be passed to GrainClient class for initialization</returns>


### PR DESCRIPTION
Spotted this very small typo whilst having a look through the tutorials.