### PR TITLE
Client cluster disconnection

### DIFF
--- a/src/Orleans/Core/GrainClient.cs
+++ b/src/Orleans/Core/GrainClient.cs
@@ -381,6 +381,15 @@ namespace Orleans
             return RuntimeClient.Current.CurrentStreamProviderManager.GetProvider(name) as Streams.IStreamProvider;
         }
 
+        public delegate void ConnectionToClusterLostHandler(object sender, EventArgs e);
+
+        public static event ConnectionToClusterLostHandler ClusterConnectionLost;
+
+        internal static void NotifyClusterConnectionLost()
+        {
+            ClusterConnectionLost?.Invoke(null, null);
+        }
+
         internal static IList<Uri> Gateways
         {
             get

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -373,7 +373,10 @@ namespace Orleans.Messaging
         /// </summary>
         public void Disconnect()
         {
-            throw new NotImplementedException("Disconnect");
+            foreach (var connection in gatewayConnections.Values)
+            {
+                connection.Stop();
+            }
         }
 
         /// <summary>

--- a/test/Tester/ClientConnectionTests/ClientDisconnectionEventTests.cs
+++ b/test/Tester/ClientConnectionTests/ClientDisconnectionEventTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace Tester.ClientConnectionTests
+{
+    public class ClientDisconnectionEventTests : TestClusterPerTest
+    {
+        public override TestCluster CreateTestCluster()
+        {
+            return new TestCluster(new TestClusterOptions(2));
+        }
+
+        [Fact, TestCategory("BVT")]
+        public async Task EventSendWhenDisconnectedFromCluster()
+        {
+            var runtime = (OutsideRuntimeClient) RuntimeClient.Current;
+
+            var semaphore = new SemaphoreSlim(0, 1);
+            GrainClient.ClusterConnectionLost += (sender, args) => semaphore.Release();
+
+            // Burst lot of call, to be sure that we are connected to all silos
+            for (int i = 0; i < 100; i++)
+            {
+                var grain = GrainFactory.GetGrain<ITestGrain>(i);
+                await grain.SetLabel(i.ToString());
+            }
+
+            runtime.Disconnect();
+
+            Assert.True(await semaphore.WaitAsync(TimeSpan.FromSeconds(10)));
+        }
+    }
+}

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CancellationTests\GrainCancellationTokenTests.cs" />
+    <Compile Include="ClientConnectionTests\ClientDisconnectionEventTests.cs" />
     <Compile Include="CollectionFixtures.cs" />
     <Compile Include="EventSourcingTests\JournaledGrainTests.cs" />
     <Compile Include="FakeSerializer.cs" />


### PR DESCRIPTION
Fix for "Access to grain client connection status" #2551 

Now `ProxiedMessageCenter` keeps a counter of opened gateway connection. When this counter reach 0, we send an event to the client to notify that the client might have been disconnected from the cluster.

I think we still can have race condition like this:
- Client connected to GW1 (counter set to 1)
- GW1 connection lost (but no update to the counter yet)
- GW2 connection established (but no update to the counter yet)
- GW2 updates the opened connection counter (counter set to 2)
- GW1 updates the opened connection counter (counter set to 1)

But the windows seems small enough for me, so this fix seems still useful for now
