### PR TITLE
Fix "*.exe.config" file usage in nuspec files. Fixes #2616.

### DIFF
--- a/src/NuGet/Microsoft.Orleans.Core.nuspec
+++ b/src/NuGet/Microsoft.Orleans.Core.nuspec
@@ -25,7 +25,7 @@
   <files>
     <file src="Orleans.dll" target="lib\net451" />
     <file src="Orleans.pdb" target="lib\net451" />
-	  <file src="Orleans.xml" target="lib\net451" />
+    <file src="Orleans.xml" target="lib\net451" />
     <file src="$SRC_DIR$Orleans\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
+++ b/src/NuGet/Microsoft.Orleans.CounterControl.nuspec
@@ -28,7 +28,8 @@
   <files>
     <file src="OrleansCounterControl.exe" target="lib\net451" />
     <file src="OrleansCounterControl.pdb" target="lib\net451" />
-    <file src="OrleansCounterControl.exe.config" target="lib\net451" />
+    <file src="OrleansCounterControl.exe.config" target="tools" />
     <file src="$SRC_DIR$OrleansCounterControl\**\*.cs" target="src" />
+    <file src="Microsoft.Orleans.CounterControl.targets" target="build" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.nuspec
@@ -23,8 +23,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansCodeGenerator.XML" target="lib\net451" />
     <file src="OrleansCodeGenerator.dll" target="lib\net451" />
+    <file src="OrleansCodeGenerator.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansCodeGenerator\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansHost.nuspec
@@ -25,7 +25,8 @@
   <files>
     <file src="OrleansHost.exe" target="lib\net451" />
     <file src="OrleansHost.pdb" target="lib\net451" />
-    <file src="OrleansHost.exe.config" target="lib\net451" />
+    <file src="OrleansHost.exe.config" target="tools" />
     <file src="$SRC_DIR$OrleansHost\**\*.cs" target="src" />
+    <file src="Microsoft.Orleans.OrleansHost.targets" target="build" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansManager.nuspec
@@ -24,8 +24,9 @@
   <files>
     <file src="OrleansManager.exe" target="lib\net451" />
     <file src="OrleansManager.pdb" target="lib\net451" />
-    <file src="OrleansManager.exe.config" target="lib\net451" />
-    <file src="ClientConfiguration.xml" target="lib\net451" />
+    <file src="OrleansManager.exe.config" target="tools" />
+    <file src="ClientConfiguration.xml" target="tools" />
     <file src="$SRC_DIR$OrleansManager\**\*.cs" target="src" />
+    <file src="Microsoft.Orleans.OrleansManager.targets" target="build" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansProviders.nuspec
@@ -22,9 +22,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansProviders.XML" target="lib\net451" />
     <file src="OrleansProviders.dll" target="lib\net451" />
     <file src="OrleansProviders.pdb" target="lib\net451" />    
+    <file src="OrleansProviders.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansProviders\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansRuntime.nuspec
@@ -24,9 +24,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansRuntime.XML" target="lib\net451" />
     <file src="OrleansRuntime.dll" target="lib\net451" />
     <file src="OrleansRuntime.pdb" target="lib\net451" />
+    <file src="OrleansRuntime.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansRuntime\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
@@ -26,9 +26,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansServiceBus.XML" target="lib\net451" />
     <file src="OrleansServiceBus.dll" target="lib\net451" />
     <file src="OrleansServiceBus.pdb" target="lib\net451" />
+    <file src="OrleansServiceBus.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansServiceBus\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansTelemetryConsumers.Counters.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansTelemetryConsumers.Counters.nuspec
@@ -24,8 +24,8 @@
   </metadata>
   <files>
     <file src="OrleansTelemetryConsumers.Counters.dll" target="lib\net451" />
-    <file src="OrleansTelemetryConsumers.Counters.XML" target="lib\net451" />
     <file src="OrleansTelemetryConsumers.Counters.pdb" target="lib\net451" />
+    <file src="OrleansTelemetryConsumers.Counters.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansTelemetryConsumers.Counters\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -24,9 +24,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansZooKeeperUtils.XML" target="lib\net451" />
     <file src="OrleansZooKeeperUtils.dll" target="lib\net451" />
     <file src="OrleansZooKeeperUtils.pdb" target="lib\net451" />
+    <file src="OrleansZooKeeperUtils.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansZooKeeperUtils\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
+++ b/src/NuGet/Microsoft.Orleans.TestingHost.nuspec
@@ -25,10 +25,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="OrleansTestingHost.XML" target="lib\net451" />
     <file src="OrleansTestingHost.dll" target="lib\net451" />
     <file src="OrleansTestingHost.pdb" target="lib\net451" />
-    
+    <file src="OrleansTestingHost.xml" target="lib\net451" />
     <file src="$SRC_DIR$OrleansTestingHost\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/OrleansCounterControl/Microsoft.Orleans.CounterControl.targets
+++ b/src/OrleansCounterControl/Microsoft.Orleans.CounterControl.targets
@@ -1,0 +1,19 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="CopyOrleansCounterControlTools" BeforeTargets="AfterBuild">
+    <ItemGroup>
+      <FilesToCopy Include="$(MSBuildThisFileDirectory)..\tools\OrleansCounterControl.exe.config" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutDir)" />
+  </Target>
+
+  <Target Name="DeleteOrleansCounterControlTools" BeforeTargets="AfterClean">
+    <ItemGroup>
+      <FilesToClean Include="$(OutDir)OrleansCounterControl.exe.config" />
+    </ItemGroup>
+
+    <Delete Files="@(FilesToClean)" />
+  </Target>
+
+</Project>

--- a/src/OrleansCounterControl/OrleansCounterControl.csproj
+++ b/src/OrleansCounterControl/OrleansCounterControl.csproj
@@ -61,6 +61,9 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="app.manifest" />
+    <None Include="Microsoft.Orleans.CounterControl.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj">

--- a/src/OrleansHost/Microsoft.Orleans.OrleansHost.targets
+++ b/src/OrleansHost/Microsoft.Orleans.OrleansHost.targets
@@ -1,0 +1,19 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="CopyOrleansHostTools" BeforeTargets="AfterBuild">
+    <ItemGroup>
+      <FilesToCopy Include="$(MSBuildThisFileDirectory)..\tools\OrleansHost.exe.config" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutDir)" />
+  </Target>
+
+  <Target Name="DeleteOrleansHostTools" BeforeTargets="AfterClean">
+    <ItemGroup>
+      <FilesToClean Include="$(OutDir)OrleansHost.exe.config" />
+    </ItemGroup>
+
+    <Delete Files="@(FilesToClean)" />
+  </Target>
+
+</Project>

--- a/src/OrleansHost/OrleansHost.csproj
+++ b/src/OrleansHost/OrleansHost.csproj
@@ -74,6 +74,9 @@
     <Content Include="StartOrleans.cmd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="Microsoft.Orleans.OrleansHost.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/OrleansManager/Microsoft.Orleans.OrleansManager.targets
+++ b/src/OrleansManager/Microsoft.Orleans.OrleansManager.targets
@@ -3,7 +3,7 @@
   <Target Name="CopyOrleansManagerTools" BeforeTargets="AfterBuild">
     <ItemGroup>
       <FilesToCopy Include="$(MSBuildThisFileDirectory)..\tools\OrleansManager.exe.config" />
-      <FilesToCopy Include="$(MSBuildThisFileDirectory)..\tools\ClientConfiguration.xml" />
+      <FilesToCopy Include="$(MSBuildThisFileDirectory)..\tools\ClientConfiguration.xml" Condition="!Exists('$(OutDir)ClientConfiguration.xml')" />
     </ItemGroup>
 
     <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutDir)" />

--- a/src/OrleansManager/Microsoft.Orleans.OrleansManager.targets
+++ b/src/OrleansManager/Microsoft.Orleans.OrleansManager.targets
@@ -1,0 +1,21 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="CopyOrleansManagerTools" BeforeTargets="AfterBuild">
+    <ItemGroup>
+      <FilesToCopy Include="$(MSBuildThisFileDirectory)..\tools\OrleansManager.exe.config" />
+      <FilesToCopy Include="$(MSBuildThisFileDirectory)..\tools\ClientConfiguration.xml" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutDir)" />
+  </Target>
+
+  <Target Name="DeleteOrleansManagerTools" BeforeTargets="AfterClean">
+    <ItemGroup>
+      <FilesToClean Include="$(OutDir)OrleansManager.exe.config" />
+      <FilesToClean Include="$(OutDir)ClientConfiguration.xml" />
+    </ItemGroup>
+
+    <Delete Files="@(FilesToClean)" />
+  </Target>
+
+</Project>

--- a/src/OrleansManager/OrleansManager.csproj
+++ b/src/OrleansManager/OrleansManager.csproj
@@ -70,6 +70,9 @@
     <None Include="runOrleansManager.cmd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Microsoft.Orleans.OrleansManager.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
- Modify Nuget packages to copy executable and other tool files to output directory.
- Fix file order in nuspec files (cosmetic).