### PR TITLE
Azure table storage throws InconsistentStateException

### DIFF
--- a/src/Orleans/Core/GrainStateStorageBridge.cs
+++ b/src/Orleans/Core/GrainStateStorageBridge.cs
@@ -92,7 +92,7 @@ namespace Orleans.Core
                 string errMsgToLog = MakeErrorMsg(what, errorOccurred);
                 store.Log.Error((int) ErrorCode.StorageProvider_WriteFailed, errMsgToLog, errorOccurred);
                 // If error is not specialization of OrleansException, wrap it
-                if (!errorOccurred.GetType().IsInstanceOfType(typeof(OrleansException)))
+                if (!(errorOccurred is OrleansException))
                 {
                     errorOccurred = new OrleansException(errMsgToLog, errorOccurred);
                 }

--- a/src/Orleans/Core/GrainStateStorageBridge.cs
+++ b/src/Orleans/Core/GrainStateStorageBridge.cs
@@ -91,7 +91,11 @@ namespace Orleans.Core
 
                 string errMsgToLog = MakeErrorMsg(what, errorOccurred);
                 store.Log.Error((int) ErrorCode.StorageProvider_WriteFailed, errMsgToLog, errorOccurred);
-                errorOccurred = new OrleansException(errMsgToLog, errorOccurred);
+                // If error is not specialization of OrleansException, wrap it
+                if (!errorOccurred.GetType().IsInstanceOfType(typeof(OrleansException)))
+                {
+                    errorOccurred = new OrleansException(errMsgToLog, errorOccurred);
+                }
 
 #if REREAD_STATE_AFTER_WRITE_FAILED
                 // Force rollback to previously stored state

--- a/src/Orleans/Providers/IStorageProvider.cs
+++ b/src/Orleans/Providers/IStorageProvider.cs
@@ -99,7 +99,10 @@ namespace Orleans.Storage
 #if !NETSTANDARD
         protected InconsistentStateException(SerializationInfo info, StreamingContext context)
             : base(info, context)
-        { }
+        {
+            this.StoredEtag = info.GetString("StoredEtag");
+            this.CurrentEtag = info.GetString("CurrentEtag");
+        }
 #endif
 
         public InconsistentStateException(
@@ -134,6 +137,10 @@ namespace Orleans.Storage
 #if !NETSTANDARD
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+
+            info.AddValue("StoredEtag", this.StoredEtag);
+            info.AddValue("CurrentEtag", this.CurrentEtag);
             base.GetObjectData(info, context);
         }
 #endif

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\RemindersTableManager.cs" />
     <Compile Include="Hosting\ServiceRuntimeWrapper.cs" />
+    <Compile Include="Storage\StorageExceptionExtensions.cs" />
     <Compile Include="Storage\TableQueryFilterBuilder.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Storage\AzureTableDataManager.cs" />
     <Compile Include="Storage\AzureTableDefaultPolicies.cs" />
     <Compile Include="Storage\ClientMetricsTableDataManager.cs" />
+    <Compile Include="Storage\Exceptions.cs" />
     <Compile Include="Storage\OrleansSiloInstanceManager.cs" />
     <Compile Include="Storage\SiloMetricsTableDataManager.cs" />
     <Compile Include="Storage\StatsTableDataManager.cs" />

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -183,7 +183,7 @@ namespace Orleans.Storage
                     $"Error Writing: GrainType={grainType} Grainid={grainReference} ETag={grainState.ETag} to Table={tableName} Exception={exc.Message}", exc);
                 if (exc.IsUpdateConditionNotSatisfiedError())
                 {
-                    throw new InconsistentStateException("Conditions not satisfied", exc);
+                    throw new TableStorageUpdateConditionNotSatisfiedException(grainType, grainReference, tableName, "Unknown", grainState.ETag, exc);
                 }
                 throw;
             }

--- a/src/OrleansAzureUtils/Storage/Exceptions.cs
+++ b/src/OrleansAzureUtils/Storage/Exceptions.cs
@@ -1,0 +1,120 @@
+﻿
+using System;
+using System.Runtime.Serialization;
+using Orleans.Runtime;
+
+namespace Orleans.Storage
+{
+    /// <summary>
+    /// Exception thrown when a storage provider detects an Etag inconsistency when attemptiong to perform a WriteStateAsync operation.
+    /// </summary>
+    [Serializable]
+    public class TableStorageUpdateConditionNotSatisfiedException : InconsistentStateException
+    {
+        private const string DefaultMessageFormat = "Table storage condition not Satisfied.  GrainType: {0}, GrainId: {1}, TableName: {2}, StoredETag: {3}, CurrentETag: {4}";
+
+        /// <summary>
+        /// Exception thrown when an azure table storage exception is thrown due to update conditions not being satisfied.
+        /// </summary>
+        public TableStorageUpdateConditionNotSatisfiedException(
+            string errorMsg,
+            string grainType,
+            GrainReference grainId, 
+            string tableName,
+            string storedEtag,
+            string currentEtag,
+            Exception storageException)
+            : base(errorMsg, storedEtag, currentEtag, storageException)
+        {
+            this.GrainType = grainType;
+            this.GrainId = grainId;
+            this.TableName = tableName;
+        }
+
+        /// <summary>
+        /// Exception thrown when an azure table storage exception is thrown due to update conditions not being satisfied.
+        /// </summary>
+        public TableStorageUpdateConditionNotSatisfiedException(
+            string grainType,
+            GrainReference grainId,
+            string tableName,
+            string storedEtag,
+            string currentEtag,
+            Exception storageException)
+            : this(CreateDefaultMessage(grainType, grainId, tableName, storedEtag, currentEtag), grainType, grainId, tableName, storedEtag, currentEtag, storageException)
+        {
+        }
+        
+        /// <summary>
+        /// Id of grain
+        /// </summary>
+        public GrainReference GrainId { get; }
+
+        /// <summary>
+        /// Type of grain that throw this exception
+        /// </summary>
+        public string GrainType { get; }
+
+        /// <summary>
+        /// Azure table name
+        /// </summary>
+        public string TableName { get; }
+
+        /// <summary>
+        /// Exception thrown when an azure table storage exception is thrown due to update conditions not being satisfied.
+        /// </summary>
+        public TableStorageUpdateConditionNotSatisfiedException()
+        {
+        }
+
+        /// <summary>
+        /// Exception thrown when an azure table storage exception is thrown due to update conditions not being satisfied.
+        /// </summary>
+        public TableStorageUpdateConditionNotSatisfiedException(string msg)
+            : base(msg)
+        {
+        }
+
+        /// <summary>
+        /// Exception thrown when an azure table storage exception is thrown due to update conditions not being satisfied.
+        /// </summary>
+        public TableStorageUpdateConditionNotSatisfiedException(string msg, Exception exc)
+            : base(msg, exc)
+        {
+        }
+
+        private static string CreateDefaultMessage(
+            string grainType,
+            GrainReference grainId,
+            string tableName,
+            string storedEtag,
+            string currentEtag)
+        {
+            return string.Format(DefaultMessageFormat, grainType, grainId, tableName, storedEtag, currentEtag);
+        }
+
+#if !NETSTANDARD
+        /// <summary>
+        /// Exception thrown when an azure table storage exception is thrown due to update conditions not being satisfied.
+        /// </summary>
+        protected TableStorageUpdateConditionNotSatisfiedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            this.GrainType = info.GetString("GrainType");
+            this.GrainId = GrainReference.FromKeyString(info.GetString("GrainId"));
+            this.TableName = info.GetString("TableName");
+        }
+
+        /// <inheritdoc />
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+
+            info.AddValue("GrainType", this.GrainType);
+            info.AddValue("GrainId", this.GrainId.ToKeyString());
+            info.AddValue("TableName", this.TableName);
+            base.GetObjectData(info, context);
+        }
+#endif
+    }
+}

--- a/src/OrleansAzureUtils/Storage/StorageExceptionExtensions.cs
+++ b/src/OrleansAzureUtils/Storage/StorageExceptionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Net;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table.Protocol;
+
+namespace Orleans.Storage
+{
+    internal static class StorageExceptionExtensions
+    {
+        /// <summary>
+        /// See https://msdn.microsoft.com/en-us/library/azure/dd179438.aspx
+        /// </summary>
+        internal static bool IsUpdateConditionNotSatisfiedError(this StorageException storageException)
+        {
+            return storageException?.RequestInformation != null &&
+                   storageException.RequestInformation.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed &&
+                   (storageException.RequestInformation.ExtendedErrorInformation == null ||
+                    storageException.RequestInformation.ExtendedErrorInformation.ErrorCode.Equals(TableErrorCodeStrings.UpdateConditionNotSatisfied));
+        }
+    }
+}


### PR DESCRIPTION
Azure table storage throws InconsistentStateException upon a write conflict.

See issue "Storage providers have to throw an InconsistentStateException upon a write conflict #1609"