### PR TITLE
Enhance ServiceRuntime handling, Fix #2491.

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -21,8 +21,8 @@
       <dependency id="Microsoft.Orleans.Core" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
       <dependency id="Microsoft.Orleans.OrleansProviders" version="$version$" />
-
       <dependency id="WindowsAzure.Storage" version="7.0.0" />
+      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -1068,7 +1068,7 @@ namespace Orleans
         PersistentStreamPullingManager_PeriodicPrint    = PersistentStreamPullingManagerBase + 23,
         
         AzureServiceRuntimeWrapper          = Runtime + 3700,
-        AzureServiceRuntime_NotLoaded       = AzureServiceRuntimeWrapper +1,
+        AzureServiceRuntime_NotLoaded       = AzureServiceRuntimeWrapper + 1,
         AzureServiceRuntime_FailedToLoad    = AzureServiceRuntimeWrapper + 2,
 
         CodeGenBase                         = Runtime + 3800,

--- a/src/OrleansAzureUtils/Hosting/AzureClient.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureClient.cs
@@ -3,7 +3,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Orleans.Runtime.Configuration;
-
+#if !NETSTANDARD
+using Microsoft.Azure;
+#endif
 
 namespace Orleans.Runtime.Host
 {
@@ -148,7 +150,11 @@ namespace Orleans.Runtime.Host
         {
             return GrainClient.TestOnlyNoConnect
                 ? "FakeConnectionString"
+#if !NETSTANDARD
+                : CloudConfigurationManager.GetSetting(AzureConstants.DataConnectionConfigurationSettingName, false, false);
+#else
                 : serviceRuntimeWrapper.GetConfigurationSettingValue(AzureConstants.DataConnectionConfigurationSettingName);
+#endif
         }
 
         private static void InitializeImpl_FromConfig(ClientConfiguration config)

--- a/src/OrleansAzureUtils/Hosting/NativeMethods.cs
+++ b/src/OrleansAzureUtils/Hosting/NativeMethods.cs
@@ -1,0 +1,71 @@
+﻿#if !NETSTANDARD
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Orleans.Runtime.Host
+{
+    // Copied from https://github.com/Azure/azure-sdk-for-net/blob/master/src/Common/Configuration/NativeMethods.cs
+    static internal class NativeMethods
+    {
+        const int AssemblyPathMax = 1024;
+
+        [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("e707dcde-d1cd-11d2-bab9-00c04f8eceae")]
+        private interface IAssemblyCache
+        {
+            void Reserved0();
+
+            [PreserveSig]
+            int QueryAssemblyInfo(int flags, [MarshalAs(UnmanagedType.LPWStr)] string assemblyName, ref AssemblyInfo assemblyInfo);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct AssemblyInfo
+        {
+            public int cbAssemblyInfo;
+
+            public int assemblyFlags;
+
+            public long assemblySizeInKB;
+
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string currentAssemblyPath;
+
+            public int cchBuffer; // size of path buffer.
+        }
+
+        [DllImport("fusion.dll")]
+        private static extern int CreateAssemblyCache(out IAssemblyCache ppAsmCache, int reserved);
+
+        /// <summary>
+        /// Gets an assembly path from the GAC given a partial name.
+        /// </summary>
+        /// <param name="name">An assembly partial name. May not be null.</param>
+        /// <returns>
+        /// The assembly path if found; otherwise null;
+        /// </returns>
+        public static string GetAssemblyPath(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException("name");
+
+            string finalName = name;
+            AssemblyInfo aInfo = new AssemblyInfo();
+            aInfo.cchBuffer = AssemblyPathMax;
+            aInfo.currentAssemblyPath = new String('\0', aInfo.cchBuffer);
+
+            IAssemblyCache ac;
+            int hr = CreateAssemblyCache(out ac, 0);
+            if (hr >= 0)
+            {
+                hr = ac.QueryAssemblyInfo(0, finalName, ref aInfo);
+                if (hr < 0)
+                    return null;
+            }
+
+            return aInfo.currentAssemblyPath;
+        }
+    }
+}
+
+#endif

--- a/src/OrleansAzureUtils/Hosting/ServiceRuntimeWrapper.cs
+++ b/src/OrleansAzureUtils/Hosting/ServiceRuntimeWrapper.cs
@@ -1,9 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Reflection;
 using Orleans.Streams;
+#if !NETSTANDARD
+using Microsoft.Azure;
+#endif
+using System.IO;
 
 namespace Orleans.Runtime.Host
 {
@@ -51,10 +56,13 @@ namespace Orleans.Runtime.Host
         IPEndPoint GetIPEndpoint(string endpointName);
 
         /// <summary>
-        /// Returns value of the given configuration setting
+        /// Returns value of the given configuration setting or null if not found.
         /// </summary>
         /// <param name="configurationSettingName"></param>
         /// <returns></returns>
+#if !NETSTANDARD
+        [Obsolete("Update your calls to Microsoft.Azure.CloudConfigurationManager.GetSetting, it provides automatic fallback to System.Configuration.ConfigurationManager to read from Appsettings.")]
+#endif
         string GetConfigurationSettingValue(string configurationSettingName);
 
         /// <summary>
@@ -86,16 +94,25 @@ namespace Orleans.Runtime.Host
     internal class ServiceRuntimeWrapper : IServiceRuntimeWrapper, IDeploymentConfiguration
     {
         private readonly Logger logger;
-        private Assembly assembly;
-        private Type roleEnvironmentType;
         private EventInfo stoppingEvent;
         private MethodInfo stoppingEventAdd;
         private MethodInfo stoppingEventRemove;
-        private Type roleInstanceType;
+        private Type roleEnvironmentExceptionType;          // Exception thrown for missing settings.
+        private MethodInfo getServiceSettingMethod;         // Method for getting values from the service configuration.
         private dynamic currentRoleInstance;
         private dynamic instanceEndpoints;
         private dynamic role;
 
+        private const string RoleEnvironmentTypeName = "Microsoft.WindowsAzure.ServiceRuntime.RoleEnvironment";
+        private const string RoleEnvironmentExceptionTypeName = "Microsoft.WindowsAzure.ServiceRuntime.RoleEnvironmentException";
+        private const string IsAvailablePropertyName = "IsAvailable";
+        private const string GetSettingValueMethodName = "GetConfigurationSettingValue";
+
+        // Keep this array sorted by the version in the descendant order.
+        private readonly string[] knownAssemblyNames = new string[]
+        {
+            "Microsoft.WindowsAzure.ServiceRuntime, Culture=neutral, PublicKeyToken=31bf3856ad364e35, ProcessorArchitecture=MSIL"
+        };
 
         public ServiceRuntimeWrapper()
         {
@@ -152,10 +169,18 @@ namespace Orleans.Runtime.Host
             }
         }
 
+#if !NETSTANDARD
+        [Obsolete("Update your calls to Microsoft.Azure.CloudConfigurationManager.GetSetting, it provides automatic fallback to System.Configuration.ConfigurationManager to read from Appsettings.")]
         public string GetConfigurationSettingValue(string configurationSettingName)
         {
-            return (string) roleEnvironmentType.GetMethod("GetConfigurationSettingValue").Invoke(null, new object[] {configurationSettingName});
+            return CloudConfigurationManager.GetSetting(configurationSettingName, false, false);
         }
+#else
+        public string GetConfigurationSettingValue(string configurationSettingName)
+        {
+            return GetServiceRuntimeSetting(configurationSettingName);
+        }
+#endif
 
         public void SubscribeForStoppingNotification(object handlerObject, EventHandler<object> handler)
         {
@@ -173,8 +198,16 @@ namespace Orleans.Runtime.Host
 
         private void Initialize()
         {
-            assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(
+            var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(
                 a => a.FullName.StartsWith("Microsoft.WindowsAzure.ServiceRuntime"));
+
+#if !NETSTANDARD
+            // Try to load from GAC, took from Azure .Net SDK: https://github.com/Azure/azure-sdk-for-net/blob/master/src/Common/Configuration/AzureApplicationSettings.cs
+            if (assembly == null)
+            {
+                assembly = GetServiceRuntimeAssembly();
+            }
+#endif
 
             // If we are runing within a worker role Microsoft.WindowsAzure.ServiceRuntime should already be loaded
             if (assembly == null)
@@ -184,8 +217,9 @@ namespace Orleans.Runtime.Host
 
                 // Microsoft.WindowsAzure.ServiceRuntime isn't loaded. We may be running within a web role or not in Azure.
 #pragma warning disable 618
-                assembly = Assembly.Load(new AssemblyName("Microsoft.WindowsAzure.ServiceRuntime, Version = 2.7.0.0, Culture = neutral, PublicKeyToken = 31bf3856ad364e35"));
+                assembly = Assembly.Load(new AssemblyName("Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"));
 #pragma warning restore 618
+
                 if (assembly == null)
                 {
                     const string msg2 = "Failed to find or load Microsoft.WindowsAzure.ServiceRuntime.";
@@ -194,27 +228,65 @@ namespace Orleans.Runtime.Host
                 }
             }
 
-            roleEnvironmentType = assembly.GetType("Microsoft.WindowsAzure.ServiceRuntime.RoleEnvironment");
-            stoppingEvent = roleEnvironmentType.GetEvent("Stopping");
-            stoppingEventAdd = stoppingEvent.GetAddMethod();
-            stoppingEventRemove = stoppingEvent.GetRemoveMethod();
+            var roleEnvironmentType = assembly.GetType(RoleEnvironmentTypeName);
 
-            roleInstanceType = assembly.GetType("Microsoft.WindowsAzure.ServiceRuntime.RoleInstance");
+            roleEnvironmentExceptionType = assembly.GetType(RoleEnvironmentExceptionTypeName);
 
-            DeploymentId = (string) roleEnvironmentType.GetProperty("DeploymentId").GetValue(null);
-            if (string.IsNullOrWhiteSpace(DeploymentId))
-                throw new OrleansException("DeploymentId is null or whitespace.");
+            var isAvailable = false;
 
-            currentRoleInstance = roleEnvironmentType.GetProperty("CurrentRoleInstance").GetValue(null);
-            if (currentRoleInstance == null)
-                throw new OrleansException("CurrentRoleInstance is null.");
+            if (roleEnvironmentType != null)
+            {
+                var isAvailableProperty = roleEnvironmentType.GetProperty(IsAvailablePropertyName);
 
-            InstanceId = currentRoleInstance.Id;
-            UpdateDomain = currentRoleInstance.UpdateDomain;
-            FaultDomain = currentRoleInstance.FaultDomain;
-            instanceEndpoints = currentRoleInstance.InstanceEndpoints;
-            role = currentRoleInstance.Role;
-            RoleName = role.Name;
+                try
+                {
+                    isAvailable = isAvailableProperty != null && (bool)isAvailableProperty.GetValue(null, new object[] { });
+                }
+                catch (TargetInvocationException e)
+                {
+                    // Running service runtime code from an application targeting .Net 4.0 results
+                    // in a type initialization exception unless application's configuration file
+                    // explicitly enables v2 runtime activation policy. In this case we should fall
+                    // back to the web.config/app.config file.
+                    if (!(e.InnerException is TypeInitializationException))
+                    {
+                        throw;
+                    }
+
+                    isAvailable = false;
+                }
+            }
+            else
+            {
+                const string msg3 = "Failed to get type RoleEnvironment from ServiceRuntime assembly.";
+                logger.Error(ErrorCode.AzureServiceRuntime_FailedToLoad, msg3);
+                throw new OrleansException(msg3);
+            }
+
+            if (isAvailable)
+            {
+                stoppingEvent = roleEnvironmentType.GetEvent("Stopping");
+                stoppingEventAdd = stoppingEvent.GetAddMethod();
+                stoppingEventRemove = stoppingEvent.GetRemoveMethod();
+
+                DeploymentId = (string)roleEnvironmentType.GetProperty("DeploymentId").GetValue(null);
+                if (string.IsNullOrWhiteSpace(DeploymentId))
+                    throw new OrleansException("DeploymentId is null or whitespace.");
+
+                getServiceSettingMethod = roleEnvironmentType.GetMethod(GetSettingValueMethodName, 
+                    BindingFlags.Public | BindingFlags.Static | BindingFlags.InvokeMethod);
+
+                currentRoleInstance = roleEnvironmentType.GetProperty("CurrentRoleInstance").GetValue(null);
+                if (currentRoleInstance == null)
+                    throw new OrleansException("CurrentRoleInstance is null.");
+
+                InstanceId = currentRoleInstance.Id;
+                UpdateDomain = currentRoleInstance.UpdateDomain;
+                FaultDomain = currentRoleInstance.FaultDomain;
+                instanceEndpoints = currentRoleInstance.InstanceEndpoints;
+                role = currentRoleInstance.Role;
+                RoleName = role.Name;
+            }
         }
 
         private static string ExtractInstanceName(string instanceId, string deploymentId)
@@ -223,5 +295,75 @@ namespace Orleans.Runtime.Host
                 ? instanceId.Substring(deploymentId.Length + 1)
                 : instanceId;
         }
+
+#if !NETSTANDARD
+        private Assembly GetServiceRuntimeAssembly()
+        {
+            Assembly assembly = null;
+
+            foreach (string assemblyName in knownAssemblyNames)
+            {
+                string assemblyPath = NativeMethods.GetAssemblyPath(assemblyName);
+
+                try
+                {
+                    if (!string.IsNullOrEmpty(assemblyPath))
+                    {
+                        assembly = Assembly.LoadFrom(assemblyPath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // The following exceptions are ignored for enabling configuration manager to proceed
+                    // and load the configuration from application settings instead of using ServiceRuntime.
+                    if (!(ex is FileNotFoundException ||
+                          ex is FileLoadException ||
+                          ex is BadImageFormatException))
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            return assembly;
+        }
+#endif
+
+#if NETSTANDARD
+        private bool IsMissingSettingException(Exception e)
+        {
+            if (e == null)
+            {
+                return false;
+            }
+            Type type = e.GetType();
+
+            return object.ReferenceEquals(type, roleEnvironmentExceptionType)
+                || type.GetTypeInfo().IsSubclassOf(roleEnvironmentExceptionType);
+        }
+
+        private string GetServiceRuntimeSetting(string name)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(name));
+
+            string value = null;
+
+            if (getServiceSettingMethod != null)
+            {
+                try
+                {
+                    value = (string)getServiceSettingMethod.Invoke(null, new object[] { name });
+                }
+                catch (TargetInvocationException e)
+                {
+                    if (!IsMissingSettingException(e.InnerException))
+                    {
+                        throw;
+                    }
+                }
+            }
+            return value;
+        }
+#endif
     }
 }

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Hosting\NativeMethods.cs" />
     <Compile Include="MultiClusterNetwork\AzureTableBasedGossipChannel.cs" />
     <Compile Include="MultiClusterNetwork\GossipTableInstanceManager.cs" />
     <Compile Include="Providers\AzureConfigurationExtensions.cs" />

--- a/src/OrleansAzureUtils/project.json
+++ b/src/OrleansAzureUtils/project.json
@@ -1,5 +1,6 @@
-{
+﻿{
   "dependencies": {
+    "Microsoft.WindowsAzure.ConfigurationManager": "3.2.3",
     "WindowsAzure.Storage": "7.0.0"
   },
   "frameworks": {

--- a/src/OrleansServiceBus/project.json
+++ b/src/OrleansServiceBus/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.WindowsAzure.ConfigurationManager": "3.1.0",
+    "Microsoft.WindowsAzure.ConfigurationManager": "3.2.3",
     "WindowsAzure.ServiceBus": "3.3.2",
     "WindowsAzure.Storage": "7.0.0"
   },

--- a/vNext/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
+++ b/vNext/src/NuGet/Microsoft.Orleans.OrleansAzureUtils.nuspec
@@ -20,8 +20,8 @@
     <dependencies>
       <group targetFramework=".NETStandard1.5">
         <dependency id="Microsoft.Orleans.Core" version="$version$" />
-        <dependency id="WindowsAzure.Storage" version="7.2.1" />
         <dependency id="System.Net.Requests" version="4.3.0" />
+        <dependency id="WindowsAzure.Storage" version="7.2.1" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
- Modify AzureUtils classes to leverage CloudConfigurationManager instead of depending RoleEnvironment.
- Add additional GAC loading method for ServiceRuntime in netfx (took from Azure SDK).
- Fix #2491, AzureClient.DefaultConfiguration works outside of Azure Cloud Service environment and fallback to AppSettings if no ServiceRuntime available.