### PR TITLE
Failsafe Exception serialization (#2310)

### DIFF
--- a/src/Orleans/Messaging/ByteArrayBuilder.cs
+++ b/src/Orleans/Messaging/ByteArrayBuilder.cs
@@ -192,7 +192,7 @@ namespace Orleans.Runtime
             }
 
             completedBuffers.AddRange(b);
-            completedLength += b.Select(buff => buff.Count).Sum();
+            completedLength += b.Sum(buff => buff.Count);
 
             currentBuffer = null;
             currentOffset = 0;

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -599,14 +599,14 @@ namespace Orleans.Runtime
                 // being sent off-box. In this case, the likelihood of needed to re-serialize is very low, and the cost of capturing the
                 // serialized bytes from the steam -- where they're a list of ArraySegment objects -- into an array of bytes is actually
                 // pretty high (an array allocation plus a bunch of copying).
-                bodyBytes = bodyStream.ToBytes() as List<ArraySegment<byte>>;
+                bodyBytes = bodyStream.ToBytes();
             }
 
             if (headerBytes != null)
             {
                 BufferPool.GlobalPool.Release(headerBytes);
             }
-            headerBytes = context.StreamWriter.ToBytes() as List<ArraySegment<byte>>;
+            headerBytes = context.StreamWriter.ToBytes();
             int headerLength = context.StreamWriter.CurrentOffset;
             int bodyLength = BufferLength(bodyBytes);
 

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Runtime\IGrainTimer.cs" />
     <Compile Include="Runtime\ILocalSiloDetails.cs" />
     <Compile Include="Runtime\RingRange.cs" />
+    <Compile Include="Serialization\ILBasedExceptionSerializer.cs" />
     <Compile Include="Serialization\IExternalSerializer.cs" />
     <Compile Include="Configuration\LimitNames.cs" />
     <Compile Include="Configuration\LimitValue.cs" />
@@ -156,6 +157,8 @@
     <Compile Include="Serialization\BinaryFormatterSerializer.cs" />
     <Compile Include="Services\IGrainServiceClient.cs" />
     <Compile Include="Services\IGrainService.cs" />
+    <Compile Include="Serialization\RemoteNonDeserializableException.cs" />
+    <Compile Include="Serialization\TypeSerializer.cs" />
     <Compile Include="Streams\Providers\StreamProviderManagerExtensions.cs" />
     <Compile Include="Utils\ReferenceEqualsComparer.cs" />
     <Compile Include="Serialization\ReflectedSerializationMethodInfo.cs" />

--- a/src/Orleans/Serialization/BinaryTokenStreamWriter.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamWriter.cs
@@ -106,7 +106,7 @@ namespace Orleans.Serialization
 
         /// <summary> Return the output stream as a set of <c>ArraySegment</c>. </summary>
         /// <returns>Data from this stream, converted to output type.</returns>
-        public IList<ArraySegment<byte>> ToBytes()
+        public List<ArraySegment<byte>> ToBytes()
         {
             return ab.ToBytes();
         }
@@ -310,6 +310,12 @@ namespace Orleans.Serialization
         {
             Trace("--Wrote byte array of length {0}", b.Length);
             ab.Append(b);
+        }
+
+        /// <summary> Write a list of byte array segments to the stream. </summary>
+        public void Write(List<ArraySegment<byte>> bytes)
+        {
+            ab.Append(bytes);
         }
 
         /// <summary> Write the specified number of bytes to the stream, starting at the specified offset in the input <c>byte[]</c>. </summary>

--- a/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
+++ b/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
@@ -1,4 +1,6 @@
-﻿namespace Orleans.Serialization
+﻿using System.Runtime.Serialization;
+
+namespace Orleans.Serialization
 {
     using System;
     using System.Collections.Concurrent;
@@ -145,7 +147,16 @@
                 {
                     exception.AdditionalData = innerContext.StreamReader.ReadBytes(additionalDataLength);
                 }
-                
+
+                // If a particular type is expected, but the actual type is not available, throw an exception to avoid 
+                if (expectedType != null && !expectedType.IsAssignableFrom(typeof(RemoteNonDeserializableException)))
+                {
+                    throw new SerializationException(
+                        $"Unable to deserialize exception of unavailable type {exception.OriginalTypeName} into expected type {expectedType}. " +
+                        $" See {nameof(Exception.InnerException)} for recovered information.",
+                        exception);
+                }
+
                 result = exception;
             }
             

--- a/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
+++ b/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
@@ -1,0 +1,231 @@
+﻿namespace Orleans.Serialization
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Reflection;
+
+    /// <summary>
+    /// Methods for serializing instances of <see cref="Exception"/> and its subclasses.
+    /// </summary>
+    internal class ILBasedExceptionSerializer
+    {
+        private static readonly Type ExceptionType = typeof(Exception);
+
+        /// <summary>
+        /// The collection of serializers.
+        /// </summary>
+        private readonly ConcurrentDictionary<Type, SerializationManager.SerializerMethods> serializers =
+            new ConcurrentDictionary<Type, SerializationManager.SerializerMethods>();
+
+        /// <summary>
+        /// The field filter used for generating serializers for subclasses of <see cref="Exception"/>.
+        /// </summary>
+        private readonly Func<FieldInfo, bool> exceptionFieldFilter;
+
+        /// <summary>
+        /// The serializer used as a fallback when the concrete exception type is unavailable.
+        /// </summary>
+        /// <remarks>
+        /// This serializer operates on <see cref="RemoteNonDeserializableException"/> instances, however it 
+        /// includes only fields from <see cref="Exception"/> and no sub-class fields.
+        /// </remarks>
+        private readonly SerializationManager.SerializerMethods fallbackBaseExceptionSerializer;
+        
+        /// <summary>
+        /// The serializer generator.
+        /// </summary>
+        private readonly ILSerializerGenerator generator;
+
+        private readonly TypeSerializer typeSerializer;
+
+        public ILBasedExceptionSerializer(ILSerializerGenerator generator, TypeSerializer typeSerializer)
+        {
+            this.generator = generator;
+            this.typeSerializer = typeSerializer;
+
+            // Exceptions are a special type in .NET because of the way they are handled by the runtime.
+            // Only certain fields can be safely serialized.
+            this.exceptionFieldFilter = field =>
+            {
+                // Any field defined below Exception is acceptable.
+                if (field.DeclaringType != ExceptionType) return true;
+
+                // Certain fields from the Exception base class are acceptable.
+                return field.FieldType == typeof(string) || field.FieldType == ExceptionType;
+            };
+
+            // When serializing the fallback type, only the fields declared on Exception are included.
+            // Other fields are manually serialized.
+            this.fallbackBaseExceptionSerializer = this.generator.GenerateSerializer(
+                typeof(RemoteNonDeserializableException),
+                field =>
+                {
+                    // Only serialize base-class fields.
+                    if (field.DeclaringType != ExceptionType) return false;
+
+                    // Certain fields from the Exception base class are acceptable.
+                    return field.FieldType == typeof(string) || field.FieldType == ExceptionType;
+                },
+                fieldComparer: ExceptionFieldInfoComparer.Instance);
+
+            // Ensure that the fallback serializer only ever has its base exception fields serialized.
+            this.serializers[typeof(RemoteNonDeserializableException)] = this.fallbackBaseExceptionSerializer;
+        }
+
+        public void Serialize(object item, ISerializationContext outerContext, Type expectedType)
+        {
+            var outerWriter = outerContext.StreamWriter;
+            
+            var actualType = item.GetType();
+
+            // To support loss-free serialization where possible, instances of the fallback exception type are serialized in a
+            // semi-manual fashion.
+            var fallbackException = item as RemoteNonDeserializableException;
+            if (fallbackException != null)
+            {
+                this.ReserializeFallback(fallbackException, outerContext);
+                return;
+            }
+            
+            // Write the concrete type directly.
+            this.typeSerializer.WriteNamedType(actualType, outerWriter);
+
+            var innerContext = new SerializationContext
+            {
+                StreamWriter = new BinaryTokenStreamWriter()
+            };
+
+            // Serialize the exception itself.
+            var methods = this.GetSerializerMethods(actualType);
+            methods.Serialize(item, innerContext, null);
+
+            // Write the serialized exception to the output stream.
+            outerContext.StreamWriter.Write(innerContext.StreamWriter.CurrentOffset);
+            outerContext.StreamWriter.Write(innerContext.StreamWriter.ToBytes());
+        }
+
+        public object Deserialize(Type expectedType, IDeserializationContext outerContext)
+        {
+            var outerReader = outerContext.StreamReader;
+
+            var typeKey = TypeSerializer.ReadTypeKey(outerReader);
+            
+            // Read the serialized payload.
+            var length = outerReader.ReadInt();
+            var innerBytes = outerReader.ReadBytes(length);
+            
+            var innerContext = new DeserializationContext
+            {
+                StreamReader = new BinaryTokenStreamReader(innerBytes)
+            };
+            
+            object result;
+
+            // If the concrete type is available and the exception is valid for reconstruction,
+            // reconstruct the original exception type.
+            var actualType = this.typeSerializer.GetTypeFromTypeKey(typeKey, throwOnError: false);
+            if (actualType != null)
+            {
+                // Deserialize into the concrete type.
+                var methods = this.GetSerializerMethods(actualType);
+                result = methods.Deserialize(null, innerContext);
+            }
+            else
+            {
+                // Since the concrete type is unavailable, deserialize into the fallback type.
+
+                // Read the Exception fields.
+                var exception = (RemoteNonDeserializableException)this.fallbackBaseExceptionSerializer.Deserialize(null, innerContext);
+                exception.OriginalTypeName = typeKey.GetTypeName();
+
+                // If there is additional data, store it for later serialization.
+                var additionalDataLength = length - innerContext.StreamReader.CurrentPosition;
+                if (additionalDataLength > 0)
+                {
+                    exception.AdditionalData = innerContext.StreamReader.ReadBytes(additionalDataLength);
+                }
+                
+                result = exception;
+            }
+            
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a copy of the provided instance.
+        /// </summary>
+        /// <param name="original">The object to copy.</param>
+        /// <param name="context">The copy context.</param>
+        /// <returns>A copy of the provided instance.</returns>
+        public object DeepCopy(object original, ICopyContext context)
+        {
+            return original;
+        }
+
+        private void ReserializeFallback(RemoteNonDeserializableException fallbackException, ISerializationContext outerContext)
+        {
+            var outerWriter = outerContext.StreamWriter;
+
+            // Write the type name directly.
+            var key = new TypeSerializer.TypeKey(fallbackException.OriginalTypeName);
+            TypeSerializer.WriteTypeKey(key, outerWriter);
+            
+            // Serialize the only accepted fields from the base Exception class.
+            var innerContext = new SerializationContext
+            {
+                StreamWriter = new BinaryTokenStreamWriter()
+            };
+            this.fallbackBaseExceptionSerializer.Serialize(fallbackException, innerContext, null);
+
+            // Write the length of the serialized exception, then write the serialized bytes.
+            var additionalDataLength = fallbackException.AdditionalData?.Length ?? 0;
+            outerWriter.Write(innerContext.StreamWriter.CurrentOffset + additionalDataLength);
+            outerWriter.Write(innerContext.StreamWriter.ToBytes());
+            
+            if (additionalDataLength > 0)
+            {
+                outerWriter.Write(fallbackException.AdditionalData);
+            }
+        }
+
+        private SerializationManager.SerializerMethods GetSerializerMethods(Type actualType)
+        {
+            SerializationManager.SerializerMethods methods;
+            if (!this.serializers.TryGetValue(actualType, out methods))
+            {
+                methods = this.generator.GenerateSerializer(
+                    actualType,
+                    this.exceptionFieldFilter,
+                    fieldComparer: ExceptionFieldInfoComparer.Instance);
+                this.serializers.TryAdd(actualType, methods);
+            }
+
+            return methods;
+        }
+
+        /// <summary>
+        /// Field comparer which sorts fields on the Exception class higher than fields on sub classes.
+        /// </summary>
+        private class ExceptionFieldInfoComparer : IComparer<FieldInfo>
+        {
+            /// <summary>
+            /// Gets the singleton instance of this class.
+            /// </summary>
+            public static ExceptionFieldInfoComparer Instance { get; } = new ExceptionFieldInfoComparer();
+
+            public int Compare(FieldInfo left, FieldInfo right)
+            {
+                var l = left.DeclaringType == ExceptionType ? 1 : 0;
+                var r = right.DeclaringType == ExceptionType ? 1 : 0;
+
+                // First compare based on whether or not the field is from the Exception base class.
+                var compareBaseClass = r - l;
+                if (compareBaseClass != 0) return compareBaseClass;
+
+                // Secondarily compare the field names.
+                return string.Compare(left.Name, right.Name, StringComparison.Ordinal);
+            }
+        }
+    }
+}

--- a/src/Orleans/Serialization/ILBasedSerializer.cs
+++ b/src/Orleans/Serialization/ILBasedSerializer.cs
@@ -2,10 +2,7 @@
 {
     using System;
     using System.Collections.Concurrent;
-    using System.Collections.Generic;
     using System.Reflection;
-    using System.Text;
-
     using Orleans.Runtime;
 
     /// <summary>
@@ -13,6 +10,9 @@
     /// </summary>
     public class ILBasedSerializer : IExternalSerializer
     {
+        private static readonly Type ExceptionType = typeof(Exception);
+        private static readonly Type TypeType = typeof(Type);
+
         /// <summary>
         /// The serializer generator.
         /// </summary>
@@ -24,43 +24,52 @@
         private readonly ConcurrentDictionary<Type, SerializerBundle> serializers =
             new ConcurrentDictionary<Type, SerializerBundle>();
 
-        private readonly ConcurrentDictionary<Type, TypeKey> typeCache = new ConcurrentDictionary<Type, TypeKey>();
-
-        private readonly ConcurrentDictionary<TypeKey, Type> typeKeyCache =
-            new ConcurrentDictionary<TypeKey, Type>(new TypeKey.Comparer());
+        private readonly TypeSerializer typeSerializer = new TypeSerializer();
 
         /// <summary>
         /// The serializer used when a concrete type is not known.
         /// </summary>
-        private readonly SerializationManager.SerializerMethods thisSerializer;
+        private readonly SerializerBundle thisSerializer;
 
         /// <summary>
         /// The serializer used for implementations of <see cref="Type"/>.
         /// </summary>
-        private readonly SerializerBundle typeSerializer;
+        private readonly SerializerBundle namedTypeSerializer;
+
+        private readonly SerializerBundle exceptionSerializer;
 
         private readonly Func<Type, SerializerBundle> generateSerializer;
 
-        private readonly Func<FieldInfo, bool> exceptionFieldFilter;
-
         public ILBasedSerializer()
         {
-            this.exceptionFieldFilter = ExceptionFieldFilter;
-
+            var fallbackExceptionSerializer = new ILBasedExceptionSerializer(this.generator, this.typeSerializer);
+            this.exceptionSerializer = new SerializerBundle(
+                new SerializationManager.SerializerMethods(
+                    fallbackExceptionSerializer.DeepCopy,
+                    fallbackExceptionSerializer.Serialize,
+                    fallbackExceptionSerializer.Deserialize));
+            
             // Configure the serializer to be used when a concrete type is not known.
             // The serializer will generate and register serializers for concrete types
             // as they are discovered.
-            this.thisSerializer = new SerializationManager.SerializerMethods(
-                this.DeepCopy,
-                this.Serialize,
-                this.Deserialize);
+            this.thisSerializer = new SerializerBundle(
+                new SerializationManager.SerializerMethods(
+                    this.DeepCopy,
+                    this.Serialize,
+                    this.Deserialize));
 
-            this.typeSerializer = new SerializerBundle(
-                typeof(Type),
+            this.namedTypeSerializer = new SerializerBundle(
                 new SerializationManager.SerializerMethods(
                     (original, context) => original,
-                    (original, writer, expected) => { this.WriteNamedType((Type)original, writer); },
-                    (expected, reader) => this.ReadNamedType(reader)));
+                    (original, writer, expected) => {
+                        var writer1 = writer.StreamWriter;
+                        this.typeSerializer.WriteNamedType((Type)original, writer1);
+                    },
+                    (expected, reader) =>
+                    {
+                        var reader1 = reader.StreamReader;
+                        return this.typeSerializer.ReadNamedType(reader1);
+                    }));
             this.generateSerializer = this.GenerateSerializer;
         }
 
@@ -93,7 +102,7 @@
         {
             if (item == null)
             {
-                context.StreamWriter.WriteNull();
+                context.StreamWriter.Write((byte)ILSerializerTypeToken.Null);
                 return;
             }
 
@@ -106,8 +115,8 @@
         public object Deserialize(Type expectedType, IDeserializationContext context)
         {
             var reader = context.StreamReader;
-            var token = reader.ReadToken();
-            if (token == SerializationTokenType.Null) return null;
+            var token = (ILSerializerTypeToken)reader.ReadByte();
+            if (token == ILSerializerTypeToken.Null) return null;
             var actualType = this.ReadType(token, context, expectedType);
             return this.serializers.GetOrAdd(actualType, this.generateSerializer)
                        .Methods.Deserialize(expectedType, context);
@@ -115,143 +124,72 @@
 
         private void WriteType(Type actualType, Type expectedType, ISerializationContext context)
         {
-            if (actualType == expectedType)
+            if (ExceptionType.IsAssignableFrom(actualType))
             {
-                context.StreamWriter.Write((byte)SerializationTokenType.ExpectedType);
+                // Exceptions are always serialized using a special-purpose serializer, even if the actual and expected
+                // types match. That serializer also writes its own type header.
+                context.StreamWriter.Write((byte) ILSerializerTypeToken.Exception);
+            }
+            else if (actualType == expectedType)
+            {
+                context.StreamWriter.Write((byte) ILSerializerTypeToken.ExpectedType);
             }
             else
             {
-                context.StreamWriter.Write((byte)SerializationTokenType.NamedType);
-                this.WriteNamedType(actualType, context);
+                context.StreamWriter.Write((byte) ILSerializerTypeToken.NamedType);
+                this.typeSerializer.WriteNamedType(actualType, context.StreamWriter);
             }
         }
 
-        private Type ReadType(SerializationTokenType token, IDeserializationContext context, Type expectedType)
+        private Type ReadType(ILSerializerTypeToken token, IDeserializationContext context, Type expectedType)
         {
             switch (token)
             {
-                case SerializationTokenType.ExpectedType:
+                case ILSerializerTypeToken.ExpectedType:
                     return expectedType;
-                case SerializationTokenType.NamedType:
-                    return this.ReadNamedType(context);
+                case ILSerializerTypeToken.NamedType:
+                    return this.typeSerializer.ReadNamedType(context.StreamReader);
+                case ILSerializerTypeToken.Exception:
+                    return ExceptionType;
                 default:
-                    throw new NotSupportedException($"{nameof(SerializationTokenType)} of {token} is not supported.");
+                    throw new NotSupportedException($"{nameof(ILSerializerTypeToken)} of {token} is not supported.");
             }
-        }
-
-        private Type ReadNamedType(IDeserializationContext context)
-        {
-            var reader = context.StreamReader;
-            var hashCode = reader.ReadInt();
-            var count = reader.ReadUShort();
-            var typeName = reader.ReadBytes(count);
-            return this.typeKeyCache.GetOrAdd(
-                new TypeKey(hashCode, typeName),
-                k => Type.GetType(Encoding.UTF8.GetString(k.TypeName), throwOnError: true));
-        }
-
-        private void WriteNamedType(Type type, ISerializationContext context)
-        {
-            var writer = context.StreamWriter;
-            var key = this.typeCache.GetOrAdd(type, t => new TypeKey(Encoding.UTF8.GetBytes(t.AssemblyQualifiedName)));
-            writer.Write(key.HashCode);
-            writer.Write((ushort)key.TypeName.Length);
-            writer.Write(key.TypeName);
         }
 
         private SerializerBundle GenerateSerializer(Type type)
         {
-            if (type.GetTypeInfo().IsGenericTypeDefinition) return new SerializerBundle(type, this.thisSerializer);
+            if (type.GetTypeInfo().IsGenericTypeDefinition) return this.thisSerializer;
 
-            if (typeof(Type).IsAssignableFrom(type))
+            if (TypeType.IsAssignableFrom(type))
             {
-                return this.typeSerializer;
+                return this.namedTypeSerializer;
+            }
+            
+            if (ExceptionType.IsAssignableFrom(type))
+            {
+                return this.exceptionSerializer;
             }
 
-            Func<FieldInfo, bool> fieldFilter = null;
-            if (typeof(Exception).IsAssignableFrom(type))
-            {
-                fieldFilter = this.exceptionFieldFilter;
-            }
-
-            return new SerializerBundle(type, this.generator.GenerateSerializer(type, fieldFilter));
+            return new SerializerBundle(this.generator.GenerateSerializer(type));
         }
-
-        private static bool ExceptionFieldFilter(FieldInfo arg)
+        
+        private enum ILSerializerTypeToken : byte
         {
-            // Any field defined below Exception is acceptable.
-            if (arg.DeclaringType != typeof(Exception)) return true;
-
-            // Certain fields from the Exception base class are acceptable.
-            return arg.FieldType == typeof(string) || arg.FieldType == typeof(Exception);
+            Null,
+            ExpectedType,
+            NamedType,
+            Exception,
         }
 
         /// <summary>
-        /// Represents a named type for the purposes of serialization.
+        /// This class primarily exists as a means to hold a reference to a <see cref="SerializationManager.SerializerMethods"/> structure.
         /// </summary>
-        internal struct TypeKey
-        {
-            public readonly int HashCode;
-
-            public readonly byte[] TypeName;
-
-            public TypeKey(int hashCode, byte[] key)
-            {
-                this.HashCode = hashCode;
-                this.TypeName = key;
-            }
-
-            public TypeKey(byte[] key)
-            {
-                this.HashCode = unchecked((int)JenkinsHash.ComputeHash(key));
-                this.TypeName = key;
-            }
-
-            public bool Equals(TypeKey other)
-            {
-                if (this.HashCode != other.HashCode) return false;
-                var a = this.TypeName;
-                var b = other.TypeName;
-                if (ReferenceEquals(a, b)) return true;
-                if (a.Length != b.Length) return false;
-                var length = a.Length;
-                for (var i = 0; i < length; i++) if (a[i] != b[i]) return false;
-                return true;
-            }
-
-            public override bool Equals(object obj)
-            {
-                return obj is TypeKey && this.Equals((TypeKey)obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return this.HashCode;
-            }
-
-            internal class Comparer : IEqualityComparer<TypeKey>
-            {
-                public bool Equals(TypeKey x, TypeKey y)
-                {
-                    return x.Equals(y);
-                }
-
-                public int GetHashCode(TypeKey obj)
-                {
-                    return obj.HashCode;
-                }
-            }
-        }
-
-        public class SerializerBundle
+        private class SerializerBundle
         {
             public readonly SerializationManager.SerializerMethods Methods;
-
-            public readonly Type Type;
-
-            public SerializerBundle(Type type, SerializationManager.SerializerMethods methods)
+            
+            public SerializerBundle(SerializationManager.SerializerMethods methods)
             {
-                this.Type = type;
                 this.Methods = methods;
             }
         }

--- a/src/Orleans/Serialization/ILSerializerGenerator.cs
+++ b/src/Orleans/Serialization/ILSerializerGenerator.cs
@@ -12,21 +12,21 @@ namespace Orleans.Serialization
     {
         private static readonly RuntimeTypeHandle IntPtrTypeHandle = typeof(IntPtr).TypeHandle;
 
-        private static readonly RuntimeTypeHandle UintPtrTypeHandle = typeof(UIntPtr).TypeHandle;
+        private static readonly RuntimeTypeHandle UIntPtrTypeHandle = typeof(UIntPtr).TypeHandle;
 
         private static readonly TypeInfo DelegateTypeInfo = typeof(Delegate).GetTypeInfo();
         
-        private readonly Dictionary<RuntimeTypeHandle, SimpleTypeSerializer> directSerializers;
+        private static readonly Dictionary<RuntimeTypeHandle, SimpleTypeSerializer> DirectSerializers;
 
-        private readonly ReflectedSerializationMethodInfo methods = new ReflectedSerializationMethodInfo();
+        private static readonly ReflectedSerializationMethodInfo SerializationMethodInfos = new ReflectedSerializationMethodInfo();
 
-        private readonly SerializationManager.DeepCopier immutableTypeCopier = (obj, context) => obj;
+        private static readonly SerializationManager.DeepCopier ImmutableTypeCopier = (obj, context) => obj;
 
-        private readonly ILFieldBuilder fieldBuilder = new ILFieldBuilder();
+        private static readonly ILFieldBuilder FieldBuilder = new ILFieldBuilder();
         
-        public ILSerializerGenerator()
+        static ILSerializerGenerator()
         {
-            this.directSerializers = new Dictionary<RuntimeTypeHandle, SimpleTypeSerializer>
+            DirectSerializers = new Dictionary<RuntimeTypeHandle, SimpleTypeSerializer>
             {
                 [typeof(int).TypeHandle] = new SimpleTypeSerializer(w => w.Write(default(int)), r => r.ReadInt()),
                 [typeof(uint).TypeHandle] = new SimpleTypeSerializer(w => w.Write(default(uint)), r => r.ReadUInt()),
@@ -70,15 +70,17 @@ namespace Orleans.Serialization
         /// <param name="copyFieldsFilter">
         /// The predicate used in addition to the default logic to select which fields are included in copying.
         /// </param>
+        /// <param name="fieldComparer">The comparer used to sort fields, or <see langword="null"/> to use the default.</param>
         /// <returns>The generated serializer.</returns>
         public SerializationManager.SerializerMethods GenerateSerializer(
             Type type,
             Func<FieldInfo, bool> serializationFieldsFilter = null,
-            Func<FieldInfo, bool> copyFieldsFilter = null)
+            Func<FieldInfo, bool> copyFieldsFilter = null,
+            IComparer<FieldInfo> fieldComparer = null)
         {
             try
             {
-                var serializationFields = this.GetFields(type, serializationFieldsFilter);
+                var serializationFields = this.GetFields(type, serializationFieldsFilter, fieldComparer);
                 List<FieldInfo> copyFields;
                 if (copyFieldsFilter == serializationFieldsFilter)
                 {
@@ -86,11 +88,11 @@ namespace Orleans.Serialization
                 }
                 else
                 {
-                    copyFields = this.GetFields(type, copyFieldsFilter);
+                    copyFields = this.GetFields(type, copyFieldsFilter, fieldComparer);
                 }
                 
                 SerializationManager.DeepCopier copier;
-                if (type.IsOrleansShallowCopyable()) copier = this.immutableTypeCopier;
+                if (type.IsOrleansShallowCopyable()) copier = ImmutableTypeCopier;
                 else copier = this.EmitCopier(type, copyFields).CreateDelegate();
 
                 var serializer = this.EmitSerializer(type, serializationFields);
@@ -109,10 +111,10 @@ namespace Orleans.Serialization
         private ILDelegateBuilder<SerializationManager.DeepCopier> EmitCopier(Type type, List<FieldInfo> fields)
         {
             var il = new ILDelegateBuilder<SerializationManager.DeepCopier>(
-                this.fieldBuilder,
+                FieldBuilder,
                 type.Name + "DeepCopier",
-                this.methods,
-                this.methods.DeepCopierDelegate);
+                SerializationMethodInfos,
+                SerializationMethodInfos.DeepCopierDelegate);
 
             // Declare local variables.
             var result = il.DeclareLocal(type);
@@ -131,7 +133,7 @@ namespace Orleans.Serialization
             il.LoadArgument(0); // Load 'original' parameter.
             il.LoadLocal(result); // Load 'result' local.
             il.BoxIfValueType(type);
-            il.Call(this.methods.RecordObjectWhileCopying);
+            il.Call(SerializationMethodInfos.RecordObjectWhileCopying);
 
             // Copy each field.
             foreach (var field in fields)
@@ -144,7 +146,7 @@ namespace Orleans.Serialization
                 // Deep-copy the field if needed, otherwise just leave it as-is.
                 if (!field.FieldType.IsOrleansShallowCopyable())
                 {
-                    var copyMethod = this.methods.DeepCopyInner;
+                    var copyMethod = SerializationMethodInfos.DeepCopyInner;
 
                     il.BoxIfValueType(field.FieldType);
                     il.LoadArgument(1);
@@ -165,10 +167,10 @@ namespace Orleans.Serialization
         private ILDelegateBuilder<SerializationManager.Serializer> EmitSerializer(Type type, List<FieldInfo> fields)
         {
             var il = new ILDelegateBuilder<SerializationManager.Serializer>(
-                this.fieldBuilder,
+                FieldBuilder,
                 type.Name + "Serializer",
-                this.methods,
-                this.methods.SerializerDelegate);
+                SerializationMethodInfos,
+                SerializationMethodInfos.SerializerDelegate);
 
             // Declare local variables.
             var typedInput = il.DeclareLocal(type);
@@ -189,10 +191,10 @@ namespace Orleans.Serialization
                     typeHandle = fieldType.GetEnumUnderlyingType().TypeHandle;
                 }
                 
-                if (this.directSerializers.TryGetValue(typeHandle, out serializer))
+                if (DirectSerializers.TryGetValue(typeHandle, out serializer))
                 {
                     il.LoadArgument(1);
-                    il.Call(this.methods.GetStreamFromSerializationContext);
+                    il.Call(SerializationMethodInfos.GetStreamFromSerializationContext);
                     il.LoadLocal(typedInput);
                     il.LoadField(field);
 
@@ -200,7 +202,7 @@ namespace Orleans.Serialization
                 }
                 else
                 {
-                    var serializeMethod = this.methods.SerializeInner;
+                    var serializeMethod = SerializationMethodInfos.SerializeInner;
 
                     // Load the field.
                     il.LoadLocal(typedInput);
@@ -222,10 +224,10 @@ namespace Orleans.Serialization
         private ILDelegateBuilder<SerializationManager.Deserializer> EmitDeserializer(Type type, List<FieldInfo> fields)
         {
             var il = new ILDelegateBuilder<SerializationManager.Deserializer>(
-                this.fieldBuilder,
+                FieldBuilder,
                 type.Name + "Deserializer",
-                this.methods,
-                this.methods.DeserializerDelegate);
+                SerializationMethodInfos,
+                SerializationMethodInfos.DeserializerDelegate);
 
             // Declare local variables.
             var result = il.DeclareLocal(type);
@@ -237,7 +239,7 @@ namespace Orleans.Serialization
             il.LoadArgument(1); // Load the 'context' parameter.
             il.LoadLocal(result);
             il.BoxIfValueType(type);
-            il.Call(this.methods.RecordObjectWhileDeserializing);
+            il.Call(SerializationMethodInfos.RecordObjectWhileDeserializing);
 
             // Deserialize each field.
             foreach (var field in fields)
@@ -251,22 +253,22 @@ namespace Orleans.Serialization
                     il.LoadLocalAsReference(type, result);
                     
                     il.LoadArgument(1);
-                    il.Call(this.methods.GetStreamFromDeserializationContext);
-                    il.Call(this.directSerializers[typeHandle].ReadMethod);
+                    il.Call(SerializationMethodInfos.GetStreamFromDeserializationContext);
+                    il.Call(DirectSerializers[typeHandle].ReadMethod);
                     il.StoreField(field);
                 }
-                else if (this.directSerializers.TryGetValue(field.FieldType.TypeHandle, out serializer))
+                else if (DirectSerializers.TryGetValue(field.FieldType.TypeHandle, out serializer))
                 {
                     il.LoadLocalAsReference(type, result);
                     il.LoadArgument(1);
-                    il.Call(this.methods.GetStreamFromDeserializationContext);
+                    il.Call(SerializationMethodInfos.GetStreamFromDeserializationContext);
                     il.Call(serializer.ReadMethod);
 
                     il.StoreField(field);
                 }
                 else
                 {
-                    var deserializeMethod = this.methods.DeserializeInner;
+                    var deserializeMethod = SerializationMethodInfos.DeserializeInner;
 
                     il.LoadLocalAsReference(type, result);
                     il.LoadType(field.FieldType);
@@ -290,18 +292,22 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="type">The type.</param>
         /// <param name="fieldFilter">The predicate used in addition to the default logic to select which fields are included.</param>
+        /// <param name="fieldInfoComparer">The comparer used to sort fields, or <see langword="null"/> to use the default.</param>
         /// <returns>A sorted list of the fields of the provided type.</returns>
-        private List<FieldInfo> GetFields(Type type, Func<FieldInfo, bool> fieldFilter = null)
+        private List<FieldInfo> GetFields(
+            Type type,
+            Func<FieldInfo, bool> fieldFilter = null,
+            IComparer<FieldInfo> fieldInfoComparer = null)
         {
             var result =
                 type.GetAllFields()
                     .Where(
                         field =>
-                        field.GetCustomAttribute<NonSerializedAttribute>() == null && !field.IsStatic
-                        && IsSupportedFieldType(field.FieldType.GetTypeInfo())
-                        && (fieldFilter == null || fieldFilter(field)))
+                            field.GetCustomAttribute<NonSerializedAttribute>() == null && !field.IsStatic
+                            && IsSupportedFieldType(field.FieldType.GetTypeInfo())
+                            && (fieldFilter == null || fieldFilter(field)))
                     .ToList();
-            result.Sort(FieldInfoComparer.Instance);
+            result.Sort(fieldInfoComparer ?? FieldInfoComparer.Instance);
             return result;
         }
 
@@ -316,7 +322,7 @@ namespace Orleans.Serialization
 
             var handle = type.AsType().TypeHandle;
             if (handle.Equals(IntPtrTypeHandle)) return false;
-            if (handle.Equals(UintPtrTypeHandle)) return false;
+            if (handle.Equals(UIntPtrTypeHandle)) return false;
             if (DelegateTypeInfo.IsAssignableFrom(type)) return false;
 
             return true;

--- a/src/Orleans/Serialization/RemoteNonDeserializableException.cs
+++ b/src/Orleans/Serialization/RemoteNonDeserializableException.cs
@@ -1,0 +1,77 @@
+﻿using System.Runtime.Serialization;
+
+namespace Orleans.Serialization
+{
+    using System;
+    using System.Text;
+
+    /// <summary>
+    /// Represents an exception which cannot be fully deserialized.
+    /// </summary>
+    [Serializable]
+    public class RemoteNonDeserializableException : Exception
+    {
+        public RemoteNonDeserializableException() { }
+
+        /// <summary>
+        /// Gets the type name of the original <see cref="Exception"/> represented by this instance.
+        /// </summary>
+        public string OriginalTypeName { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the original type of this exception can be reconstructed during
+        /// deserialization.
+        /// </summary>
+        internal bool CanAttemptReconstruction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional data deserialized alongside this 
+        /// </summary>
+        internal byte[] AdditionalData { get; set; }
+
+        /// <summary>
+        /// Returns a <see cref="string"/> representation of this instance.
+        /// </summary>
+        /// <returns>A <see cref="string"/> representation of this instance.</returns>
+        public override string ToString()
+        {
+            if (string.IsNullOrWhiteSpace(this.OriginalTypeName)) return base.ToString();
+
+            var builder = new StringBuilder();
+            builder.Append(this.OriginalTypeName);
+            if (!string.IsNullOrWhiteSpace(this.Message))
+            {
+                builder.Append(": ").Append(this.Message);
+            }
+
+            if (this.InnerException != null)
+            {
+                builder.Append(" ---> ")
+                       .AppendLine(this.InnerException.ToString())
+                       .Append("   --- End of inner exception stack trace ---");
+            }
+
+            builder.AppendLine();
+            builder.Append(this.StackTrace);
+            return builder.ToString();
+        }
+        
+#if !NETSTANDARD
+        protected RemoteNonDeserializableException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            this.OriginalTypeName = info.GetString(nameof(this.OriginalTypeName));
+            this.AdditionalData = (byte[]) info.GetValue(nameof(this.AdditionalData), typeof(byte[]));
+        }
+
+        /// <inheritdoc />
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(this.OriginalTypeName), this.OriginalTypeName);
+            info.AddValue(nameof(this.AdditionalData), this.AdditionalData);
+
+            base.GetObjectData(info, context);
+        }
+#endif
+    }
+}

--- a/src/Orleans/Serialization/RemoteNonDeserializableException.cs
+++ b/src/Orleans/Serialization/RemoteNonDeserializableException.cs
@@ -18,17 +18,11 @@ namespace Orleans.Serialization
         /// Gets the type name of the original <see cref="Exception"/> represented by this instance.
         /// </summary>
         public string OriginalTypeName { get; internal set; }
-
+        
         /// <summary>
-        /// Gets or sets a value indicating whether the original type of this exception can be reconstructed during
-        /// deserialization.
+        /// Gets or sets the additional data deserialized alongside this instance, for example, exception subclass fields.
         /// </summary>
-        internal bool CanAttemptReconstruction { get; set; }
-
-        /// <summary>
-        /// Gets or sets the additional data deserialized alongside this 
-        /// </summary>
-        internal byte[] AdditionalData { get; set; }
+        public byte[] AdditionalData { get; internal set; }
 
         /// <summary>
         /// Returns a <see cref="string"/> representation of this instance.
@@ -58,7 +52,7 @@ namespace Orleans.Serialization
         }
         
 #if !NETSTANDARD
-        protected RemoteNonDeserializableException(SerializationInfo info, StreamingContext context)
+        public RemoteNonDeserializableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             this.OriginalTypeName = info.GetString(nameof(this.OriginalTypeName));

--- a/src/Orleans/Serialization/RemoteNonDeserializableException.cs
+++ b/src/Orleans/Serialization/RemoteNonDeserializableException.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Orleans.Runtime;
 
 namespace Orleans.Serialization
 {
@@ -9,7 +10,7 @@ namespace Orleans.Serialization
     /// Represents an exception which cannot be fully deserialized.
     /// </summary>
     [Serializable]
-    public class RemoteNonDeserializableException : Exception
+    public class RemoteNonDeserializableException : OrleansException
     {
         public RemoteNonDeserializableException() { }
 

--- a/src/Orleans/Serialization/TypeSerializer.cs
+++ b/src/Orleans/Serialization/TypeSerializer.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Orleans.Serialization
+{
+    internal class TypeSerializer
+    {
+        private readonly ConcurrentDictionary<Type, TypeKey> typeCache = new ConcurrentDictionary<Type, TypeKey>();
+
+        private readonly ConcurrentDictionary<TypeKey, Type> typeKeyCache =
+            new ConcurrentDictionary<TypeKey, Type>(new TypeKey.Comparer());
+
+        private readonly Func<Type, TypeKey> getTypeKey;
+
+        public TypeSerializer()
+        {
+            this.getTypeKey = type => new TypeKey(Encoding.UTF8.GetBytes(this.GetNameFromType(type)));
+        }
+
+        public static TypeKey ReadTypeKey(BinaryTokenStreamReader reader)
+        {
+            var hashCode = reader.ReadInt();
+            var count = reader.ReadUShort();
+            var typeName = reader.ReadBytes(count);
+            return new TypeKey(hashCode, typeName);
+        }
+
+        public static void WriteTypeKey(TypeKey key, BinaryTokenStreamWriter writer)
+        {
+            writer.Write(key.HashCode);
+            writer.Write((ushort)key.TypeName.Length);
+            writer.Write(key.TypeName);
+        }
+
+        public void WriteType(Type actualType, Type expectedType, BinaryTokenStreamWriter writer)
+        {
+            if (actualType == expectedType)
+            {
+                writer.Write((byte)SerializationTokenType.ExpectedType);
+            }
+            else
+            {
+                writer.Write((byte)SerializationTokenType.NamedType);
+                this.WriteNamedType(actualType, writer);
+            }
+        }
+
+        public Type ReadType(SerializationTokenType token, BinaryTokenStreamReader reader, Type expectedType)
+        {
+            switch (token)
+            {
+                case SerializationTokenType.ExpectedType:
+                    return expectedType;
+                case SerializationTokenType.NamedType:
+                    return this.ReadNamedType(reader);
+                default:
+                    throw new NotSupportedException($"{nameof(SerializationTokenType)} of {token} is not supported.");
+            }
+        }
+
+        public Type ReadNamedType(BinaryTokenStreamReader reader)
+        {
+            var key = ReadTypeKey(reader);
+            return this.GetTypeFromTypeKey(key, throwOnError: true);
+        }
+
+        public Type GetTypeFromTypeKey(TypeKey key, bool throwOnError = true)
+        {
+            Type result;
+            if (!this.typeKeyCache.TryGetValue(key, out result))
+            {
+                result = this.GetTypeFromName(Encoding.UTF8.GetString(key.TypeName), throwOnError: throwOnError);
+                if (result != null)
+                {
+                    this.typeKeyCache[key] = result;
+                }
+            }
+
+            return result;
+        }
+
+        public void WriteNamedType(Type type, BinaryTokenStreamWriter writer)
+        {
+            var key = this.typeCache.GetOrAdd(type, this.getTypeKey);
+            WriteTypeKey(key, writer);
+        }
+
+        /// <summary>
+        /// The method used by this instance to retrieve a type from an assembly-qualified name.
+        /// </summary>
+        /// <param name="assemblyQualifiedTypeName">The type name.</param>
+        /// <param name="throwOnError">Whether or not to throw if the type could not be loaded.</param>
+        /// <returns>The type, or <see langword="null"/> if the type could not be loaded.</returns>
+        internal virtual Type GetTypeFromName(string assemblyQualifiedTypeName, bool throwOnError)
+            => Type.GetType(assemblyQualifiedTypeName, throwOnError: throwOnError);
+
+        /// <summary>
+        /// The method used by this instance to retrieve an assembly-qualified name from a type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>The assembly-qualified name of <paramref name="type"/>.</returns>
+        internal virtual string GetNameFromType(Type type) => type.AssemblyQualifiedName;
+
+        /// <summary>
+        /// Represents a named type for the purposes of serialization.
+        /// </summary>
+        internal struct TypeKey
+        {
+            public readonly int HashCode;
+
+            public readonly byte[] TypeName;
+
+            public TypeKey(int hashCode, byte[] key)
+            {
+                this.HashCode = hashCode;
+                this.TypeName = key;
+            }
+
+            public TypeKey(byte[] key)
+            {
+                this.HashCode = unchecked((int)JenkinsHash.ComputeHash(key));
+                this.TypeName = key;
+            }
+
+            public TypeKey(string typeName) : this(Encoding.UTF8.GetBytes(typeName)) { }
+
+            public string GetTypeName() => Encoding.UTF8.GetString(this.TypeName);
+
+            public bool Equals(TypeKey other)
+            {
+                if (this.HashCode != other.HashCode) return false;
+                var a = this.TypeName;
+                var b = other.TypeName;
+                if (ReferenceEquals(a, b)) return true;
+                if (a.Length != b.Length) return false;
+                var length = a.Length;
+                for (var i = 0; i < length; i++) if (a[i] != b[i]) return false;
+                return true;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is TypeKey && this.Equals((TypeKey)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return this.HashCode;
+            }
+
+            internal class Comparer : IEqualityComparer<TypeKey>
+            {
+                public bool Equals(TypeKey x, TypeKey y)
+                {
+                    return x.Equals(y);
+                }
+
+                public int GetHashCode(TypeKey obj)
+                {
+                    return obj.HashCode;
+                }
+            }
+        }
+    }
+}

--- a/test/NonSiloTests/Orleans.NonSiloTests.csproj
+++ b/test/NonSiloTests/Orleans.NonSiloTests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="SerializationTests\SerializationTests.ImmutableCollections.cs" />
     <Compile Include="SerializationTests\StreamTypeSerializationTests.cs" />
     <Compile Include="Serialization\BuiltInSerializerTests.cs" />
+    <Compile Include="Serialization\ILBasedExceptionSerializerTests.cs" />
     <Compile Include="Serialization\ILBasedSerializerTests.cs" />
     <Compile Include="Serialization\SerializerGenerationTests.cs" />
     <Compile Include="SerializerTests\CustomSerializerTests.cs" />

--- a/test/NonSiloTests/Serialization/ILBasedExceptionSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/ILBasedExceptionSerializerTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Orleans;
+using TestExtensions;
+
+namespace UnitTests.Serialization
+{
+    using Orleans.Serialization;
+
+    using Xunit;
+
+    [TestCategory("BVT"), TestCategory("Serialization")]
+    public class ILBasedExceptionSerializerTests
+    {
+        private readonly ILSerializerGenerator serializerGenerator = new ILSerializerGenerator();
+        private readonly SerializationTestEnvironment environment;
+
+        public ILBasedExceptionSerializerTests()
+        {
+            this.environment = SerializationTestEnvironment.Initialize(null, typeof(ILBasedSerializer).GetTypeInfo());
+        }
+
+        /// <summary>
+        /// Tests that <see cref="ILBasedExceptionSerializer"/> supports distinct field selection for serialization
+        /// versus copy operations.
+        /// </summary>
+        [Fact]
+        public void ExceptionSerializer_SimpleException()
+        {
+            // Throw an exception so that is has a stack trace.
+            var expected = GetNewException();
+
+            var writer = new SerializationContext
+            {
+                StreamWriter = new BinaryTokenStreamWriter()
+            };
+
+            // Deep copies should be reference-equal.
+            Assert.Equal(expected, SerializationManager.DeepCopyInner(expected, new SerializationContext()), ReferenceEqualsComparer.Instance);
+
+            SerializationManager.Serialize(expected, writer.StreamWriter);
+            var reader = new DeserializationContext
+            {
+                StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
+            };
+
+            var actual = (ILExceptionSerializerTestException)SerializationManager.Deserialize(null, reader.StreamReader);
+            Assert.Equal(expected.BaseField.Value, actual.BaseField.Value, StringComparer.Ordinal);
+            Assert.Equal(expected.SubClassField, actual.SubClassField, StringComparer.Ordinal);
+            Assert.Equal(expected.OtherField.Value, actual.OtherField.Value, StringComparer.Ordinal);
+
+            // Check for referential equality in the two fields which happened to be reference-equals.
+            Assert.Equal(actual.BaseField, actual.OtherField, ReferenceEqualsComparer.Instance);
+        }
+
+        private static ILExceptionSerializerTestException GetNewException()
+        {
+            ILExceptionSerializerTestException expected;
+            try
+            {
+                var baseField = new SomeFunObject
+                {
+                    Value = Guid.NewGuid().ToString()
+                };
+                var res = new ILExceptionSerializerTestException
+                {
+                    BaseField = baseField,
+                    SubClassField = Guid.NewGuid().ToString(),
+                    OtherField = baseField,
+                };
+                throw res;
+            }
+            catch (ILExceptionSerializerTestException exception)
+            {
+                expected = exception;
+            }
+            return expected;
+        }
+
+        /// <summary>
+        /// Tests that <see cref="ILBasedExceptionSerializer"/> supports distinct field selection for serialization
+        /// versus copy operations.
+        /// </summary>
+        [Fact]
+        public void ExceptionSerializer_UnknownException()
+        {
+            var expected = GetNewException();
+
+            var knowsException = new ILBasedExceptionSerializer(this.serializerGenerator, new TypeSerializer());
+            
+            var writer = new SerializationContext
+            {
+                StreamWriter = new BinaryTokenStreamWriter()
+            };
+            knowsException.Serialize(expected, writer, null);
+
+            // Deep copies should be reference-equal.
+            Assert.Equal(expected, knowsException.DeepCopy(expected, new SerializationContext()), ReferenceEqualsComparer.Instance);
+
+            // Create a deserializer which doesn't know about the expected exception type.
+            var reader = new DeserializationContext
+            {
+                StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
+            };
+
+            // Ensure that the deserialized object has the fallback type.
+            var doesNotKnowException = new ILBasedExceptionSerializer(this.serializerGenerator, new TestTypeSerializer());
+            var untypedActual = doesNotKnowException.Deserialize(null, reader);
+            Assert.IsType<RemoteNonDeserializableException>(untypedActual);
+
+            // Ensure that the original type name is preserved correctly.
+            var actualDeserialized = (RemoteNonDeserializableException) untypedActual;
+            Assert.Equal(typeof(ILExceptionSerializerTestException).AssemblyQualifiedName, actualDeserialized.OriginalTypeName);
+
+            // Re-serialize the deserialized object using the serializer which does not have access to the original type.
+            writer = new SerializationContext
+            {
+                StreamWriter = new BinaryTokenStreamWriter()
+            };
+            doesNotKnowException.Serialize(untypedActual, writer, null);
+
+            reader = new DeserializationContext
+            {
+                StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
+            };
+
+            // Deserialize the round-tripped object and verify that it has the original type and all properties are
+            // correctly.
+            untypedActual = knowsException.Deserialize(null, reader);
+            Assert.IsType<ILExceptionSerializerTestException>(untypedActual);
+
+            var actual = (ILExceptionSerializerTestException) untypedActual;
+            Assert.Equal(expected.BaseField.Value, actual.BaseField.Value, StringComparer.Ordinal);
+            Assert.Equal(expected.SubClassField, actual.SubClassField, StringComparer.Ordinal);
+            Assert.Equal(expected.OtherField.Value, actual.OtherField.Value, StringComparer.Ordinal);
+
+            // Check for referential equality in the two fields which happened to be reference-equals.
+            Assert.Equal(actual.BaseField, actual.OtherField, ReferenceEqualsComparer.Instance);
+        }
+
+        private class SomeFunObject
+        {
+            public string Value { get; set; }
+        }
+
+        private class BaseException : Exception
+        {
+            public SomeFunObject BaseField { get; set; }
+        }
+
+        private class ILExceptionSerializerTestException : BaseException
+        {
+            public string SubClassField { get; set; }
+            public SomeFunObject OtherField { get; set; }
+        }
+
+        private class TestTypeSerializer : TypeSerializer
+        {
+            internal override Type GetTypeFromName(string assemblyQualifiedTypeName, bool throwOnError)
+            {
+                if (throwOnError) throw new TypeLoadException($"Type {assemblyQualifiedTypeName} could not be loaded");
+                return null;
+            }
+        }
+    }
+}

--- a/vNext/test/NonSiloTests/Orleans.NonSiloTests.csproj
+++ b/vNext/test/NonSiloTests/Orleans.NonSiloTests.csproj
@@ -106,6 +106,9 @@
     <Compile Include="..\..\..\test\NonSiloTests\Serialization\BuiltInSerializerTests.cs">
       <Link>Serialization\BuiltInSerializerTests.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\test\NonSiloTests\Serialization\ILBasedExceptionSerializerTests.cs">
+      <Link>Serialization\ILBasedExceptionSerializerTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\test\NonSiloTests\Serialization\ILBasedSerializerTests.cs">
       <Link>Serialization\ILBasedSerializerTests.cs</Link>
     </Compile>


### PR DESCRIPTION
This is an implementation of failsafe Exception serialization.

Features:
* Serializes Exceptions so that they can be deserialized even if the original exception type is not available.
* A fallback type, `RemoteNonDeserializableException`, is used in place of the original exception type when the original is not available. In this case, the message and stack trace are preserved, but any additional fields on sub-classes of `Exception` cannot be inspected.
* Exceptions are round-tripped without any loss of fidelity, regardless of whether or not one of the parties does not have access to the original exception type.

Caveats:
* Currently it does not support referential transparency for the exception itself.
* This is an extension to `ILBasedSerializer` and therefore will only be enabled if that is the configured `FallbackSerializationProvider`. This it the default on .NET Core, but not Full .NET.

Let me know if I missed something.

xref #2528