### PR TITLE
EventHubs Stream provider ported to netstandard

### DIFF
--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Providers\Streams\EventHub\EventHubAdapterFactory.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubAdapterReceiver.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubBatchContainer.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubConstants.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubDataAdapter.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubCheckpointer.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubPartitionCheckpointEntity.cs" />

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
@@ -2,7 +2,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+#if NETSTANDARD
+using Microsoft.Azure.EventHubs;
+#else
 using Microsoft.ServiceBus.Messaging;
+#endif
 using Orleans.Serialization;
 
 namespace Orleans.ServiceBus.Providers

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -1,12 +1,14 @@
-﻿
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+#if NETSTANDARD
+using Microsoft.Azure.EventHubs;
+#else
 using Microsoft.ServiceBus.Messaging;
+#endif
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -32,7 +34,11 @@ namespace Orleans.ServiceBus.Providers
         private readonly IEventHubReceiverMonitor monitor;
 
         private IEventHubQueueCache cache;
+#if NETSTANDARD
+        private PartitionReceiver receiver;
+#else
         private EventHubReceiver receiver;
+#endif
         private IStreamQueueCheckpointer<string> checkpointer;
         private AggregatedQueueFlowController flowController;
 
@@ -121,11 +127,11 @@ namespace Orleans.ServiceBus.Providers
             try
             {
                 var watch = Stopwatch.StartNew();
-                messages = (await receiver.ReceiveAsync(maxCount, ReceiveTimeout)).ToList();
+                messages = (await receiver.ReceiveAsync(maxCount, ReceiveTimeout))?.ToList();
                 watch.Stop();
-
+                
                 monitor.TrackRead(true);
-                monitor.TrackMessagesRecieved(messages.Count, watch.Elapsed);
+                monitor.TrackMessagesRecieved(messages != null ? messages.Count : 0, watch.Elapsed);
             }
             catch (Exception ex)
             {
@@ -137,15 +143,20 @@ namespace Orleans.ServiceBus.Providers
             }
 
             var batches = new List<IBatchContainer>();
-            if (messages.Count == 0)
+            if (messages == null || messages.Count == 0)
             {
                 return batches;
             }
 
             // monitor message age
             var dequeueTimeUtc = DateTime.UtcNow;
+#if NETSTANDARD
+            TimeSpan oldest = dequeueTimeUtc - messages[0].SystemProperties.EnqueuedTimeUtc;
+            TimeSpan newest = dequeueTimeUtc - messages[messages.Count - 1].SystemProperties.EnqueuedTimeUtc;
+#else
             TimeSpan oldest = dequeueTimeUtc - messages[0].EnqueuedTimeUtc;
-            TimeSpan newest = dequeueTimeUtc - messages[messages.Count - 1].EnqueuedTimeUtc;
+            TimeSpan newest = dequeueTimeUtc - messages[messages.Count - 1].EnqueuedTimeUtc; 
+#endif
             monitor.TrackAgeOfMessagesRead(oldest, newest);
 
             foreach (EventData message in messages)
@@ -157,7 +168,13 @@ namespace Orleans.ServiceBus.Providers
 
             if (!checkpointer.CheckpointExists)
             {
-                checkpointer.Update(messages[0].Offset, DateTime.UtcNow);
+                checkpointer.Update(
+#if NETSTANDARD
+                    messages[0].SystemProperties.Offset,
+#else
+                    messages[0].Offset,  
+#endif
+                    DateTime.UtcNow);
             }
             return batches;
         }
@@ -202,7 +219,12 @@ namespace Orleans.ServiceBus.Providers
 
                 // clear cache and receiver
                 IEventHubQueueCache localCache = Interlocked.Exchange(ref cache, null);
-                EventHubReceiver localReceiver = Interlocked.Exchange(ref receiver, null);
+#if NETSTANDARD
+                PartitionReceiver
+#else
+                EventHubReceiver  
+#endif
+                    localReceiver = Interlocked.Exchange(ref receiver, null);
                 // start closing receiver
                 Task closeTask = TaskDone.Done;
                 if (localReceiver != null)
@@ -224,30 +246,56 @@ namespace Orleans.ServiceBus.Providers
             }
         }
 
-        private static async Task<EventHubReceiver> CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, Logger logger)
+#if NETSTANDARD
+        private static async Task<PartitionReceiver> CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, Logger logger)
+#else
+        private static async Task<EventHubReceiver> CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, Logger logger) 
+#endif
         {
             bool offsetInclusive = true;
-            EventHubClient client = EventHubClient.CreateFromConnectionString(partitionSettings.Hub.ConnectionString, partitionSettings.Hub.Path);
+#if NETSTANDARD
+            var connectionStringBuilder = new EventHubsConnectionStringBuilder(partitionSettings.Hub.ConnectionString)
+            {
+                EntityPath = partitionSettings.Hub.Path
+            };
+            EventHubClient client = EventHubClient.CreateFromConnectionString(connectionStringBuilder.ToString());
+#else
+            EventHubClient client = EventHubClient.CreateFromConnectionString(partitionSettings.Hub.ConnectionString, partitionSettings.Hub.Path); 
+
             EventHubConsumerGroup consumerGroup = client.GetConsumerGroup(partitionSettings.Hub.ConsumerGroup);
             if (partitionSettings.Hub.PrefetchCount.HasValue)
             {
                 consumerGroup.PrefetchCount = partitionSettings.Hub.PrefetchCount.Value;
             }
+#endif
             // if we have a starting offset or if we're not configured to start reading from utc now, read from offset
-            if (!partitionSettings.Hub.StartFromNow || offset != EventHubConsumerGroup.StartOfStream)
+            if (!partitionSettings.Hub.StartFromNow ||
+#if NETSTANDARD
+                offset != PartitionReceiver.StartOfStream)
+#else
+                offset != EventHubConsumerGroup.StartOfStream) 
+#endif
             {
                 logger.Info("Starting to read from EventHub partition {0}-{1} at offset {2}", partitionSettings.Hub.Path, partitionSettings.Partition, offset);
             }
             else
             {
                 // to start reading from most recent data, we get the latest offset from the partition.
-                PartitionRuntimeInformation patitionInfo =
-                    await client.GetPartitionRuntimeInformationAsync(partitionSettings.Partition);
-                offset = patitionInfo.LastEnqueuedOffset;
+#if NETSTANDARD
+                EventHubPartitionRuntimeInformation partitionInfo =
+#else
+                PartitionRuntimeInformation partitionInfo = 
+#endif
+                await client.GetPartitionRuntimeInformationAsync(partitionSettings.Partition);
+                offset = partitionInfo.LastEnqueuedOffset;
                 offsetInclusive = false;
                 logger.Info("Starting to read latest messages from EventHub partition {0}-{1} at offset {2}", partitionSettings.Hub.Path, partitionSettings.Partition, offset);
             }
-            return await consumerGroup.CreateReceiverAsync(partitionSettings.Partition, offset, offsetInclusive);
+#if NETSTANDARD
+            return client.CreateReceiver(partitionSettings.Hub.ConsumerGroup, partitionSettings.Partition, offset, offsetInclusive);
+#else
+            return await consumerGroup.CreateReceiverAsync(partitionSettings.Partition, offset, offsetInclusive); 
+#endif
         }
 
         private class StreamActivityNotificationBatch : IBatchContainer

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -2,7 +2,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+#if NETSTANDARD
+using Microsoft.Azure.EventHubs;
+#else
 using Microsoft.ServiceBus.Messaging;
+#endif
 using Newtonsoft.Json;
 using Orleans.Runtime;
 using Orleans.Serialization;
@@ -101,7 +105,12 @@ namespace Orleans.ServiceBus.Providers
                 RequestContext = requestContext
             };
             var bytes = SerializationManager.SerializeToByteArray(payload);
-            var eventData = new EventData(bytes) { PartitionKey = streamGuid.ToString() };
+#if NETSTANDARD
+            var eventData = new EventData(bytes);
+#else
+            var eventData = new EventData(bytes) { PartitionKey = streamGuid.ToString() }; 
+#endif
+
             if (!string.IsNullOrWhiteSpace(streamNamespace))
             {
                 eventData.SetStreamNamespaceProperty(streamNamespace);

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -1,7 +1,11 @@
 ﻿
 using System;
 using System.Threading.Tasks;
+#if NETSTANDARD
+using Microsoft.Azure.EventHubs;
+#else
 using Microsoft.ServiceBus.Messaging;
+#endif
 using Orleans.AzureUtils;
 using Orleans.Streams;
 
@@ -22,7 +26,12 @@ namespace Orleans.ServiceBus.Providers
         /// <summary>
         /// Indicates if a checkpoint exists
         /// </summary>
-        public bool CheckpointExists => entity != null && entity.Offset != EventHubConsumerGroup.StartOfStream;
+        public bool CheckpointExists => entity != null && entity.Offset !=
+#if NETSTANDARD
+            PartitionReceiver.StartOfStream;
+#else
+            EventHubConsumerGroup.StartOfStream; 
+#endif
 
         /// <summary>
         /// Factory function that creates and initializes the checkpointer
@@ -85,7 +94,11 @@ namespace Orleans.ServiceBus.Providers
         public void Update(string offset, DateTime utcNow)
         {
             // if offset has not changed, do nothing
-            if (string.Compare(entity.Offset, offset, StringComparison.InvariantCulture)==0)
+#if NETSTANDARD
+            if (string.Compare(entity.Offset, offset, StringComparison.Ordinal) == 0)
+#else
+            if (string.Compare(entity.Offset, offset, StringComparison.InvariantCulture) == 0) 
+#endif
             {
                 return;
             }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -1,11 +1,6 @@
 ﻿
 using System;
 using System.Threading.Tasks;
-#if NETSTANDARD
-using Microsoft.Azure.EventHubs;
-#else
-using Microsoft.ServiceBus.Messaging;
-#endif
 using Orleans.AzureUtils;
 using Orleans.Streams;
 
@@ -26,12 +21,7 @@ namespace Orleans.ServiceBus.Providers
         /// <summary>
         /// Indicates if a checkpoint exists
         /// </summary>
-        public bool CheckpointExists => entity != null && entity.Offset !=
-#if NETSTANDARD
-            PartitionReceiver.StartOfStream;
-#else
-            EventHubConsumerGroup.StartOfStream; 
-#endif
+        public bool CheckpointExists => entity != null && entity.Offset != EventHubConstants.StartOfStream;
 
         /// <summary>
         /// Factory function that creates and initializes the checkpointer
@@ -94,11 +84,7 @@ namespace Orleans.ServiceBus.Providers
         public void Update(string offset, DateTime utcNow)
         {
             // if offset has not changed, do nothing
-#if NETSTANDARD
             if (string.Compare(entity.Offset, offset, StringComparison.Ordinal) == 0)
-#else
-            if (string.Compare(entity.Offset, offset, StringComparison.InvariantCulture) == 0) 
-#endif
             {
                 return;
             }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubConstants.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubConstants.cs
@@ -1,0 +1,12 @@
+namespace Orleans.ServiceBus.Providers
+{
+    internal class EventHubConstants
+    {
+        public readonly static string StartOfStream =
+#if NETSTANDARD
+            Microsoft.Azure.EventHubs.PartitionReceiver.StartOfStream;
+#else
+            Microsoft.ServiceBus.Messaging.EventHubConsumerGroup.StartOfStream;
+#endif
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
@@ -1,9 +1,4 @@
-﻿#if NETSTANDARD
-using Microsoft.Azure.EventHubs;
-#else
-using Microsoft.ServiceBus.Messaging;
-#endif
-using Microsoft.WindowsAzure.Storage.Table;
+﻿using Microsoft.WindowsAzure.Storage.Table;
 using Orleans.AzureUtils;
 
 namespace Orleans.ServiceBus.Providers
@@ -14,11 +9,7 @@ namespace Orleans.ServiceBus.Providers
 
         public EventHubPartitionCheckpointEntity()
         {
-#if NETSTANDARD
-            Offset = PartitionReceiver.StartOfStream;
-#else
-            Offset = EventHubConsumerGroup.StartOfStream; 
-#endif
+            Offset = EventHubConstants.StartOfStream;
         }
 
         public static EventHubPartitionCheckpointEntity Create(string streamProviderName, string checkpointNamespace, string partition)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubPartitionCheckpointEntity.cs
@@ -1,5 +1,8 @@
-﻿
+﻿#if NETSTANDARD
+using Microsoft.Azure.EventHubs;
+#else
 using Microsoft.ServiceBus.Messaging;
+#endif
 using Microsoft.WindowsAzure.Storage.Table;
 using Orleans.AzureUtils;
 
@@ -11,7 +14,11 @@ namespace Orleans.ServiceBus.Providers
 
         public EventHubPartitionCheckpointEntity()
         {
-            Offset = EventHubConsumerGroup.StartOfStream;
+#if NETSTANDARD
+            Offset = PartitionReceiver.StartOfStream;
+#else
+            Offset = EventHubConsumerGroup.StartOfStream; 
+#endif
         }
 
         public static EventHubPartitionCheckpointEntity Create(string streamProviderName, string checkpointNamespace, string partition)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -1,6 +1,10 @@
 ﻿
 using System;
+#if NETSTANDARD
+using Microsoft.Azure.EventHubs;
+#else
 using Microsoft.ServiceBus.Messaging;
+#endif
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -1,6 +1,10 @@
 ﻿
 using System;
+#if NETSTANDARD
+using Microsoft.Azure.EventHubs;
+#else
 using Microsoft.ServiceBus.Messaging;
+#endif
 using Orleans.Providers.Streams.Common;
 using Orleans.Streams;
 

--- a/test/ServiceBus.Tests/CollectionFixtures.cs
+++ b/test/ServiceBus.Tests/CollectionFixtures.cs
@@ -1,0 +1,13 @@
+﻿using TestExtensions;
+using Xunit;
+
+namespace UnitTests
+{
+    // Assembly collections must be defined once in each assembly
+    [CollectionDefinition("DefaultCluster")]
+    public class DefaultClusterTestCollection : ICollectionFixture<DefaultClusterFixture> { }
+    
+
+    [CollectionDefinition(TestEnvironmentFixture.DefaultCollection)]
+    public class TestEnvironmentFixtureCollection : ICollectionFixture<TestEnvironmentFixture> { }
+}

--- a/test/ServiceBus.Tests/ServiceBus.Tests.csproj
+++ b/test/ServiceBus.Tests/ServiceBus.Tests.csproj
@@ -126,6 +126,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CollectionFixtures.cs" />
     <Compile Include="Streaming\EHClientStreamTests.cs" />
     <Compile Include="Streaming\EHImplicitSubscriptionStreamRecoveryTests.cs" />
     <Compile Include="Streaming\EHStreamPerPartitionTests.cs" />

--- a/test/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -22,6 +22,7 @@ using Xunit;
 namespace ServiceBus.Tests.StreamingTests
 {
     [TestCategory("EventHub"), TestCategory("Streaming")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class EHImplicitSubscriptionStreamRecoveryTests : OrleansTestingBase, IClassFixture<EHImplicitSubscriptionStreamRecoveryTests.Fixture>
     {
         private readonly Fixture fixture;

--- a/test/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -21,6 +21,7 @@ using Xunit;
 namespace ServiceBus.Tests.StreamingTests
 {
     [TestCategory("EventHub"), TestCategory("Streaming")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class EHStreamPerPartitionTests : OrleansTestingBase, IClassFixture<EHStreamPerPartitionTests.Fixture>
     {
         private readonly Fixture fixture;

--- a/test/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -23,6 +23,7 @@ using Xunit;
 namespace ServiceBus.Tests.StreamingTests
 {
     [TestCategory("EventHub"), TestCategory("Streaming")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class EHStreamProviderCheckpointTests : TestClusterPerTest
     {
         private static readonly string StreamProviderTypeName = typeof(EventHubStreamProvider).FullName;

--- a/test/ServiceBus.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace ServiceBus.Tests.StreamingTests
 {
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class EHSubscriptionMultiplicityTests : OrleansTestingBase, IClassFixture<EHSubscriptionMultiplicityTests.Fixture>
     {
         private const string StreamProviderName = "EventHubStreamProvider";

--- a/test/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
@@ -1,14 +1,21 @@
 ﻿
 using System;
 using System.Text;
+#if NETSTANDARD
+using Microsoft.Azure.EventHubs;
+#else
 using Microsoft.ServiceBus.Messaging;
+#endif
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
+using TestExtensions;
+using Xunit;
 
 namespace ServiceBus.Tests.TestStreamProviders.EventHub
 {
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class StreamPerPartitionEventHubStreamProvider : PersistentStreamProvider<StreamPerPartitionEventHubStreamProvider.AdapterFactory>
     {
         public class AdapterFactory : EventHubAdapterFactory
@@ -45,7 +52,12 @@ namespace ServiceBus.Tests.TestStreamProviders.EventHub
             public override StreamPosition GetStreamPosition(EventData queueMessage)
             {
                 IStreamIdentity stremIdentity = new StreamIdentity(partitionStreamGuid, null);
-                StreamSequenceToken token = new EventSequenceTokenV2(queueMessage.SequenceNumber, 0);
+                StreamSequenceToken token =
+#if NETSTANDARD
+                new EventSequenceTokenV2(queueMessage.SystemProperties.SequenceNumber, 0);
+#else
+                new EventSequenceTokenV2(queueMessage.SequenceNumber, 0); 
+#endif
                 return new StreamPosition(stremIdentity, token);
             }
         }

--- a/vNext/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
+++ b/vNext/src/NuGet/Microsoft.Orleans.OrleansServiceBus.nuspec
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Orleans.OrleansServiceBus</id>
+    <version>$version$</version>
+    <title>Microsoft Orleans ServiceBus Utilities</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,Orleans</owners>
+    <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
+    <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
+    <summary>
+      ServiceBus Utilities Library of Microsoft Orleans - OrleansServiceBus.dll
+    </summary>
+    <description>
+      Library of utility types for Microsoft Azure ServiceBus of Microsoft Orleans.
+    </description>
+    <copyright>Copyright Microsoft 2016</copyright>
+    <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
+    <dependencies>
+      <group targetFramework=".NETStandard1.5">
+        <dependency id="Microsoft.Orleans.Core" version="$version$" />
+		<dependency id="Microsoft.Orleans.OrleansRuntime" version="$version$" />
+		<dependency id="Microsoft.Orleans.OrleansProviders" version="$version$" />
+		<dependency id="Microsoft.Orleans.OrleansServiceBus" version="$version$" />
+        <dependency id="Microsoft.Azure.EventHubs" version="1.0.0" />
+        <dependency id="Microsoft.Azure.EventHubs.Processor" version="1.0.0" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="netstandard1.5\OrleansServiceBus.dll" target="lib\netstandard1.5" />
+    <file src="netstandard1.5\OrleansServiceBus.pdb" target="lib\netstandard1.5" />
+    <file src="netstandard1.5\OrleansServiceBus.xml" target="lib\netstandard1.5" />
+    <file src="$SRC_DIR$OrleansServiceBus\**\*.cs" exclude="$SRC_DIR$OrleansServiceBus\obj\**\*.*;$SRC_DIR$OrleansServiceBus\bin\**\*.*" target="src" />
+  </files>
+</package>

--- a/vNext/src/Orleans.vNext.sln
+++ b/vNext/src/Orleans.vNext.sln
@@ -55,6 +55,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{146C4184
 		NuGet\Microsoft.Orleans.OrleansGoogleUtils.nuspec = NuGet\Microsoft.Orleans.OrleansGoogleUtils.nuspec
 		NuGet\Microsoft.Orleans.OrleansProviders.nuspec = NuGet\Microsoft.Orleans.OrleansProviders.nuspec
 		NuGet\Microsoft.Orleans.OrleansRuntime.nuspec = NuGet\Microsoft.Orleans.OrleansRuntime.nuspec
+		NuGet\Microsoft.Orleans.OrleansServiceBus.nuspec = NuGet\Microsoft.Orleans.OrleansServiceBus.nuspec
 		NuGet\Microsoft.Orleans.OrleansSqlUtils.nuspec = NuGet\Microsoft.Orleans.OrleansSqlUtils.nuspec
 		NuGet\Microsoft.Orleans.OrleansTelemetryConsumers.AI.nuspec = NuGet\Microsoft.Orleans.OrleansTelemetryConsumers.AI.nuspec
 		NuGet\Microsoft.Orleans.OrleansZooKeeperUtils.nuspec = NuGet\Microsoft.Orleans.OrleansZooKeeperUtils.nuspec
@@ -116,6 +117,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrleansCodeGeneratorBuildMetaPackage", "OrleansCodeGeneratorBuildMetaPackage\OrleansCodeGeneratorBuildMetaPackage.csproj", "{35501066-738F-4DA1-9BBF-4D863FA55BBC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrleansServerMetaPackage", "OrleansServerMetaPackage\OrleansServerMetaPackage.csproj", "{4345AFF3-8B57-472B-8934-EDE375D4DC1A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrleansServiceBus", "OrleansServiceBus\OrleansServiceBus.csproj", "{69C6C088-4485-440D-B2A6-183F610CBF0A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceBus.Tests", "..\test\ServiceBus.Tests\ServiceBus.Tests.csproj", "{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -571,6 +576,30 @@ Global
 		{4345AFF3-8B57-472B-8934-EDE375D4DC1A}.Release|x64.Build.0 = Release|x64
 		{4345AFF3-8B57-472B-8934-EDE375D4DC1A}.Release|x86.ActiveCfg = Release|x86
 		{4345AFF3-8B57-472B-8934-EDE375D4DC1A}.Release|x86.Build.0 = Release|x86
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Debug|x64.ActiveCfg = Debug|x64
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Debug|x64.Build.0 = Debug|x64
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Debug|x86.ActiveCfg = Debug|x86
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Debug|x86.Build.0 = Debug|x86
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Release|x64.ActiveCfg = Release|x64
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Release|x64.Build.0 = Release|x64
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Release|x86.ActiveCfg = Release|x86
+		{69C6C088-4485-440D-B2A6-183F610CBF0A}.Release|x86.Build.0 = Release|x86
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Debug|x64.ActiveCfg = Debug|x64
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Debug|x64.Build.0 = Debug|x64
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Debug|x86.ActiveCfg = Debug|x86
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Debug|x86.Build.0 = Debug|x86
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Release|x64.ActiveCfg = Release|x64
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Release|x64.Build.0 = Release|x64
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Release|x86.ActiveCfg = Release|x86
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -614,5 +643,7 @@ Global
 		{C2722CE8-7101-4E29-8123-20010FFBE83E} = {8ED4353E-6B58-4B2D-86D2-D96AD3A7EE6D}
 		{35501066-738F-4DA1-9BBF-4D863FA55BBC} = {8ED4353E-6B58-4B2D-86D2-D96AD3A7EE6D}
 		{4345AFF3-8B57-472B-8934-EDE375D4DC1A} = {8ED4353E-6B58-4B2D-86D2-D96AD3A7EE6D}
+		{69C6C088-4485-440D-B2A6-183F610CBF0A} = {7B982A96-66A1-4E08-AA68-8A56905A53CA}
+		{5D2FB41F-806F-4769-BC15-7BF08C1BD1D2} = {224EAB7B-DBF8-4652-AC71-6C6ABBAB22AD}
 	EndGlobalSection
 EndGlobal

--- a/vNext/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/vNext/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Label="NuGet">
+    <IsPackable>true</IsPackable>
+    <PackageId>Microsoft.Orleans.OrleansServiceBus</PackageId>
+    <Title>Microsoft Orleans ServiceBus Utilities</Title>
+    <Description>
+      Library of utility types for Microsoft Azure ServiceBus of Microsoft Orleans.
+    </Description>
+    <PackageTags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</PackageTags>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <DefineConstants>NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard1.5</TargetFramework>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wpa81+wp8</PackageTargetFallback>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Build\GlobalAssemblyInfo.cs" />
+    <Compile Include="..\..\..\src\OrleansServiceBus\**\*.cs" Exclude="..\..\..\src\OrleansServiceBus\Properties\*.cs;..\..\..\src\OrleansServiceBus\obj\**\*.cs;..\..\..\src\OrleansServiceBus\bin\**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Orleans\Orleans.csproj" />
+    <ProjectReference Include="..\OrleansAzureUtils\OrleansAzureUtils.csproj" />
+    <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj" />
+    <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
+  </ItemGroup>
+</Project>

--- a/vNext/src/OrleansServiceBus/Properties/AssemblyInfo.cs
+++ b/vNext/src/OrleansServiceBus/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("OrleansServiceBus")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("60c5eab4-80ac-4c12-a231-37a7f10db25a")]

--- a/vNext/src/OrleansServiceBus/app.config
+++ b/vNext/src/OrleansServiceBus/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/vNext/src/Test.cmd
+++ b/vNext/src/Test.cmd
@@ -13,7 +13,7 @@ pushd "%CMDHOME%"
 SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
 REM set TESTS=%OutDir%\Tester.dll,%OutDir%\TesterInternal.dll,%OutDir%\Orleans.NonSiloTests.dll,%OutDir%\Tester.AzureUtils.dll
-set TESTS=%OutDir%\net462\Tester.dll,%OutDir%\net462\Orleans.NonSiloTests.dll,%OutDir%\net462\Tester.AzureUtils.dll,%OutDir%\net462\TesterInternal.dll,%OutDir%\net462\Tester.SQLUtils.dll,%OutDir%\net462\DefaultCluster.Tests.dll,%OutDir%\net462\Consul.Tests.dll,%OutDir%\net462\BondUtils.Tests.dll,%OutDir%\net462\AWSUtils.Tests.dll,%OutDir%\net462\GoogleUtils.Tests.dll
+set TESTS=%OutDir%\net462\Tester.dll,%OutDir%\net462\Orleans.NonSiloTests.dll,%OutDir%\net462\Tester.AzureUtils.dll,%OutDir%\net462\TesterInternal.dll,%OutDir%\net462\Tester.SQLUtils.dll,%OutDir%\net462\DefaultCluster.Tests.dll,%OutDir%\net462\Consul.Tests.dll,%OutDir%\net462\BondUtils.Tests.dll,%OutDir%\net462\AWSUtils.Tests.dll,%OutDir%\net462\GoogleUtils.Tests.dll,%OutDir%\net462\ServiceBus.Tests.dll
 if []==[%TEST_FILTERS%] set TEST_FILTERS=-trait 'Category=BVT' -trait 'Category=SlowBVT'
 
 @Echo Test assemblies = %TESTS%

--- a/vNext/test/ServiceBus.Tests/App.config
+++ b/vNext/test/ServiceBus.Tests/App.config
@@ -1,0 +1,250 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <ThrowUnobservedTaskExceptions enabled="false" />
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="false" />
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.1.0" newVersion="1.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.1.0" newVersion="1.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Json" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Win32.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.AppContext" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.NonGeneric" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ComponentModel.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ComponentModel.TypeConverter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.FileVersionInfo" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Process" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.TraceSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Globalization.Calendars" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression.ZipFile" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.NameResolution" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.NetworkInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Sockets" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.TypeExtensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Serialization.Formatters" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.X509Certificates" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.ThreadPool" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XmlDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath.XmlDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/vNext/test/ServiceBus.Tests/ServiceBus.Tests.csproj
+++ b/vNext/test/ServiceBus.Tests/ServiceBus.Tests.csproj
@@ -1,0 +1,83 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Label="Configuration">
+    <DefineConstants>NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="4.0.0" />
+    <PackageReference Include="xunit" Version="2.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.2.14" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Orleans.PlatformServices\Orleans.PlatformServices.csproj" />
+    <ProjectReference Include="..\..\src\OrleansServiceBus\OrleansServiceBus.csproj" />
+    <ProjectReference Include="..\..\src\OrleansProviders\OrleansProviders.csproj" />
+    <ProjectReference Include="..\..\src\OrleansRuntime\OrleansRuntime.csproj" />
+    <ProjectReference Include="..\..\src\OrleansAzureUtils\OrleansAzureUtils.csproj" />
+    <ProjectReference Include="..\..\src\OrleansCodeGenerator\OrleansCodeGenerator.csproj" />
+    <ProjectReference Include="..\..\src\OrleansTestingHost\OrleansTestingHost.csproj" />
+    <ProjectReference Include="..\..\src\Orleans\Orleans.csproj" />
+    <ProjectReference Include="..\TesterInternal\TesterInternal.csproj" />
+    <ProjectReference Include="..\Tester\Tester.csproj" />
+    <ProjectReference Include="..\TestExtensions\TestExtensions.csproj" />
+    <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj" />
+    <ProjectReference Include="..\TestGrains\TestGrains.csproj" />
+    <ProjectReference Include="..\TestInternalGrains\TestInternalGrains.csproj" />
+    <ProjectReference Include="..\TestInterfaces\TestInterfaces.csproj" />
+    <ProjectReference Include="..\TestInternalDtosRefOrleans\TestInternalDtosRefOrleans.csproj" />
+    <ProjectReference Include="..\TestInternalGrainInterface\TestInternalGrainInterfaces.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHClientStreamTests.cs">
+      <Link>Streaming\EHClientStreamTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHImplicitSubscriptionStreamRecoveryTests.cs">
+      <Link>Streaming\EHImplicitSubscriptionStreamRecoveryTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHStreamPerPartitionTests.cs">
+      <Link>Streaming\EHStreamPerPartitionTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHStreamProviderCheckpointTests.cs">
+      <Link>Streaming\EHStreamProviderCheckpointTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHSubscriptionMultiplicityTests.cs">
+      <Link>Streaming\EHSubscriptionMultiplicityTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\TimePurgePredicateTests.cs">
+      <Link>Streaming\TimePurgePredicateTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\ServiceBus.Tests\TestStreamProviders\StreamPerPartitionEventHubStreamProvider.cs">
+      <Link>TestStreamProviders\StreamPerPartitionEventHubStreamProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\ServiceBus.Tests\TestStreamProviders\TestEventHubStreamProvider.cs">
+      <Link>TestStreamProviders\TestEventHubStreamProvider.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="ServiceBus.Tests.xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/vNext/test/ServiceBus.Tests/ServiceBus.Tests.xunit.runner.json
+++ b/vNext/test/ServiceBus.Tests/ServiceBus.Tests.xunit.runner.json
@@ -1,0 +1,8 @@
+﻿{
+  "appDomain": "ifAvailable",
+  "diagnosticMessages": true,
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false,
+  "methodDisplay": "classAndMethod",
+  "shadowCopy": false
+}

--- a/vNext/test/Tester/Tester.csproj
+++ b/vNext/test/Tester/Tester.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Configuration">
     <DefineConstants>NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
   </PropertyGroup>
@@ -67,6 +67,9 @@
     </Compile>
     <Compile Include="..\..\..\test\Tester\StreamingTests\SubscriptionMultiplicityTestRunner.cs">
       <Link>StreamingTests\SubscriptionMultiplicityTestRunner.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\test\Tester\StreamingTests\ImplicitSubscritionRecoverableStreamTestRunner.cs">
+      <Link>StreamingTests\ImplicitSubscritionRecoverableStreamTestRunner.cs</Link>
     </Compile>
     <Compile Include="..\..\..\test\Tester\TestStreamProviders\FailureInjectionStreamProvider.cs">
       <Link>TestStreamProviders\FailureInjectionStreamProvider.cs</Link>


### PR DESCRIPTION
As part of #2145 this PR add EventHub stream provider support to vNext solution supporting `netstandard1.5`.

The new `netstandard1.5` project rely on the new nugets [Microsoft.Azure.EventHubs](https://www.nuget.org/packages/Microsoft.Azure.EventHubs/0.0.4-preview) and [Microsoft.Azure.EventHubs.Processor](https://www.nuget.org/packages/Microsoft.Azure.EventHubs.Processor/0.0.4-preview) which will deprecate the old ones once they are released. There were namespace changes and a bit of API changes on those nugets and they were addressed with some `#if`s among other small changes. 

For now those nugets were only used at vNext and should only be updated on master when we merge the solutions.

cc: @jason-bragg 