### PR TITLE
Checkpointer tests wrong checkpointer connection string - bugfix

### DIFF
--- a/test/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -38,7 +38,7 @@ namespace ServiceBus.Tests.StreamingTests
                 EHConsumerGroup, EHPath));
 
         private static readonly EventHubCheckpointerSettings CheckpointerSettings =
-            new EventHubCheckpointerSettings(TestDefaultConfiguration.EventHubConnectionString,
+            new EventHubCheckpointerSettings(TestDefaultConfiguration.DataConnectionString,
                 EHCheckpointTable, CheckpointNamespace, TimeSpan.FromSeconds(1));
 
         private static readonly EventHubStreamProviderSettings ProviderSettings =


### PR DESCRIPTION
Somewhere along the line the azure storage connection string used in the checkpointer was changed to the eventhub connection string.
This change sets it back.