### PR TITLE
GrainServices are now Started by the Silo on Startup

### DIFF
--- a/src/OrleansRuntime/Services/GrainService.cs
+++ b/src/OrleansRuntime/Services/GrainService.cs
@@ -58,8 +58,9 @@ namespace Orleans.Runtime
         }
 
         /// <summary>Invoked upon initialization of the service</summary>
-        protected virtual void Init(IServiceProvider serviceProvider)
+        public virtual Task Init(IServiceProvider serviceProvider)
         {
+            return TaskDone.Done;
         }
 
         private void OnStatusChange(GrainServiceStatus oldStatus, GrainServiceStatus newStatus)

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -665,6 +665,7 @@ namespace Orleans.Runtime
                 var grainService = (GrainService)ActivatorUtilities.CreateInstance(this.Services, serviceType, grainId, serviceConfig.Value);
                 RegisterSystemTarget(grainService);
 
+                this.scheduler.QueueTask(() => grainService.Init(Services), grainService.SchedulingContext).WaitWithThrow(this.initTimeout);
                 this.scheduler.QueueTask(grainService.Start, grainService.SchedulingContext).WaitWithThrow(this.initTimeout);
                 if (this.logger.IsVerbose)
                 {

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -662,8 +662,14 @@ namespace Orleans.Runtime
 
                 var typeCode = GrainInterfaceUtils.GetGrainClassTypeCode(grainServiceInterfaceType);
                 var grainId = (IGrainIdentity)GrainId.GetGrainServiceGrainId(0, typeCode);
-                var grainService = (SystemTarget) ActivatorUtilities.CreateInstance(this.Services, serviceType, grainId, serviceConfig.Value);
+                var grainService = (GrainService)ActivatorUtilities.CreateInstance(this.Services, serviceType, grainId, serviceConfig.Value);
                 RegisterSystemTarget(grainService);
+
+                this.scheduler.QueueTask(grainService.Start, grainService.SchedulingContext).WaitWithThrow(this.initTimeout);
+                if (this.logger.IsVerbose)
+                {
+                    this.logger.Verbose(String.Format("{0} Grain Service started successfully.", serviceConfig.Value.Name));
+                }
             }
         }
 

--- a/test/TestGrainInterfaces/IGrainServiceTestGrain.cs
+++ b/test/TestGrainInterfaces/IGrainServiceTestGrain.cs
@@ -7,5 +7,7 @@ namespace UnitTests.GrainInterfaces
     {
         Task<string> GetHelloWorldUsingCustomService();
         Task<string> GetServiceConfigProperty(string propertyName);
+        Task<bool> CallHasStarted();
+        Task<bool> CallHasStartedInBackground();
     }
 }

--- a/test/TestGrainInterfaces/IGrainServiceTestGrain.cs
+++ b/test/TestGrainInterfaces/IGrainServiceTestGrain.cs
@@ -9,5 +9,6 @@ namespace UnitTests.GrainInterfaces
         Task<string> GetServiceConfigProperty(string propertyName);
         Task<bool> CallHasStarted();
         Task<bool> CallHasStartedInBackground();
+        Task<bool> CallHasInit();
     }
 }

--- a/test/TestGrains/GrainService/CustomGrainService.cs
+++ b/test/TestGrains/GrainService/CustomGrainService.cs
@@ -8,11 +8,16 @@ namespace Tester
     {
         Task<string> GetHelloWorldUsingCustomService();
         Task<string> GetServiceConfigProperty(string propertyName);
+        Task<bool> HasStarted();
+        Task<bool> HasStartedInBackground();
     }
 
     public interface ICustomGrainService : IGrainService
     {
         Task<string> GetHelloWorldUsingCustomService(GrainReference reference);
         Task<string> GetServiceConfigProperty(string propertyName);
+
+        Task<bool> HasStarted();
+        Task<bool> HasStartedInBackground();
     }
 }

--- a/test/TestGrains/GrainService/CustomGrainService.cs
+++ b/test/TestGrains/GrainService/CustomGrainService.cs
@@ -10,6 +10,7 @@ namespace Tester
         Task<string> GetServiceConfigProperty(string propertyName);
         Task<bool> HasStarted();
         Task<bool> HasStartedInBackground();
+        Task<bool> HasInit();
     }
 
     public interface ICustomGrainService : IGrainService
@@ -19,5 +20,6 @@ namespace Tester
 
         Task<bool> HasStarted();
         Task<bool> HasStartedInBackground();
+        Task<bool> HasInit();
     }
 }

--- a/test/TestGrains/GrainService/GrainServiceTestGrain.cs
+++ b/test/TestGrains/GrainService/GrainServiceTestGrain.cs
@@ -23,6 +23,16 @@ namespace UnitTests.Grains
         {
             this.customGrainServiceClient = customGrainServiceClient;
         }
+
+        public Task<bool> CallHasStarted()
+        {
+            return this.customGrainServiceClient.HasStarted();
+        }
+
+        public Task<bool> CallHasStartedInBackground()
+        {
+            return this.customGrainServiceClient.HasStartedInBackground();
+        }
     }
 
 }

--- a/test/TestGrains/GrainService/GrainServiceTestGrain.cs
+++ b/test/TestGrains/GrainService/GrainServiceTestGrain.cs
@@ -33,6 +33,11 @@ namespace UnitTests.Grains
         {
             return this.customGrainServiceClient.HasStartedInBackground();
         }
+
+        public Task<bool> CallHasInit()
+        {
+            return this.customGrainServiceClient.HasInit();
+        }
     }
 
 }

--- a/test/Tester/GrainServiceTests/CustomGrainService.cs
+++ b/test/Tester/GrainServiceTests/CustomGrainService.cs
@@ -47,19 +47,19 @@ namespace Tester
             
         }
 
-        private bool m_Started = false;
-        private bool m_StartedInBackground = false;
-        private bool m_Init = false;
+        private bool started = false;
+        private bool startedInBackground = false;
+        private bool init = false;
 
         public override Task Init(IServiceProvider serviceProvider)
         {
-            m_Init = true;
+            init = true;
             return base.Init(serviceProvider);
         }
 
         public override Task Start()
         {
-            m_Started = true;
+            started = true;
             return base.Start();
         }
 
@@ -75,23 +75,23 @@ namespace Tester
 
         protected override Task StartInBackground()
         {
-            m_StartedInBackground = true;
+            startedInBackground = true;
             return TaskDone.Done;
         }
 
         public Task<bool> HasStarted()
         {
-            return Task.FromResult(m_Started);
+            return Task.FromResult(started);
         }
 
         public Task<bool> HasStartedInBackground()
         {
-            return Task.FromResult(m_StartedInBackground);
+            return Task.FromResult(startedInBackground);
         }
 
         public Task<bool> HasInit()
         {
-            return Task.FromResult(m_Init);
+            return Task.FromResult(init);
         }
     }
 }

--- a/test/Tester/GrainServiceTests/CustomGrainService.cs
+++ b/test/Tester/GrainServiceTests/CustomGrainService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Remoting.Channels;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Core;
@@ -24,6 +23,16 @@ namespace Tester
         {
             return GrainService.GetServiceConfigProperty(propertyName);
         }
+
+        public Task<bool> HasStarted()
+        {
+            return GrainService.HasStarted();
+        }
+
+        public Task<bool> HasStartedInBackground()
+        {
+            return GrainService.HasStartedInBackground();
+        }
     }
 
     public class CustomGrainService : GrainService, ICustomGrainService
@@ -31,6 +40,15 @@ namespace Tester
         public CustomGrainService(IGrainIdentity id, Silo silo, IGrainServiceConfiguration config) : base(id, silo, config)
         {
             
+        }
+
+        private bool m_Started = false;
+        private bool m_StartedInBackground = false;
+
+        public override Task Start()
+        {
+            m_Started = true;
+            return base.Start();
         }
 
         public Task<string> GetHelloWorldUsingCustomService(GrainReference reference)
@@ -45,7 +63,18 @@ namespace Tester
 
         protected override Task StartInBackground()
         {
+            m_StartedInBackground = true;
             return TaskDone.Done;
+        }
+
+        public Task<bool> HasStarted()
+        {
+            return Task.FromResult(m_Started);
+        }
+
+        public Task<bool> HasStartedInBackground()
+        {
+            return Task.FromResult(m_StartedInBackground);
         }
     }
 }

--- a/test/Tester/GrainServiceTests/CustomGrainService.cs
+++ b/test/Tester/GrainServiceTests/CustomGrainService.cs
@@ -33,6 +33,11 @@ namespace Tester
         {
             return GrainService.HasStartedInBackground();
         }
+
+        public Task<bool> HasInit()
+        {
+            return GrainService.HasInit();
+        }
     }
 
     public class CustomGrainService : GrainService, ICustomGrainService
@@ -44,6 +49,13 @@ namespace Tester
 
         private bool m_Started = false;
         private bool m_StartedInBackground = false;
+        private bool m_Init = false;
+
+        public override Task Init(IServiceProvider serviceProvider)
+        {
+            m_Init = true;
+            return base.Init(serviceProvider);
+        }
 
         public override Task Start()
         {
@@ -75,6 +87,11 @@ namespace Tester
         public Task<bool> HasStartedInBackground()
         {
             return Task.FromResult(m_StartedInBackground);
+        }
+
+        public Task<bool> HasInit()
+        {
+            return Task.FromResult(m_Init);
         }
     }
 }

--- a/test/Tester/GrainServiceTests/GrainServiceTests.cs
+++ b/test/Tester/GrainServiceTests/GrainServiceTests.cs
@@ -25,8 +25,6 @@ namespace Tester
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
         public async Task SimpleInvokeGrainService()
         {
-            // We need to get the Silo to create the GrainService instances and register them as SystemTargets.
-
             IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
             var grainId = await grain.GetHelloWorldUsingCustomService();
             Assert.Equal("Hello World from Grain Service", grainId);
@@ -37,11 +35,7 @@ namespace Tester
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
         public async Task GrainServiceWasStarted()
         {
-            // We need to get the Silo to create the GrainService instances and register them as SystemTargets.
-
             IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
-            var grainId = await grain.GetHelloWorldUsingCustomService();
-            Assert.Equal("Hello World from Grain Service", grainId);
             var prop = await grain.CallHasStarted();
             Assert.True(prop);
         }
@@ -49,12 +43,16 @@ namespace Tester
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
         public async Task GrainServiceWasStartedInBackground()
         {
-            // We need to get the Silo to create the GrainService instances and register them as SystemTargets.
-
             IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
-            var grainId = await grain.GetHelloWorldUsingCustomService();
-            Assert.Equal("Hello World from Grain Service", grainId);
             var prop = await grain.CallHasStartedInBackground();
+            Assert.True(prop);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
+        public async Task GrainServiceWasInit()
+        {
+            IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
+            var prop = await grain.CallHasInit();
             Assert.True(prop);
         }
     }

--- a/test/Tester/GrainServiceTests/GrainServiceTests.cs
+++ b/test/Tester/GrainServiceTests/GrainServiceTests.cs
@@ -33,6 +33,30 @@ namespace Tester
             var prop = await grain.GetServiceConfigProperty("test-property");
             Assert.Equal("xyz", prop);
         }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
+        public async Task GrainServiceWasStarted()
+        {
+            // We need to get the Silo to create the GrainService instances and register them as SystemTargets.
+
+            IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
+            var grainId = await grain.GetHelloWorldUsingCustomService();
+            Assert.Equal("Hello World from Grain Service", grainId);
+            var prop = await grain.CallHasStarted();
+            Assert.True(prop);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
+        public async Task GrainServiceWasStartedInBackground()
+        {
+            // We need to get the Silo to create the GrainService instances and register them as SystemTargets.
+
+            IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
+            var grainId = await grain.GetHelloWorldUsingCustomService();
+            Assert.Equal("Hello World from Grain Service", grainId);
+            var prop = await grain.CallHasStartedInBackground();
+            Assert.True(prop);
+        }
     }
 
 


### PR DESCRIPTION
Previously GrainServices which were added never called Startup, Reminder service worked because it is being created and started up discretely.