### PR TITLE
Added a data adapter to azure queue stream provider

### DIFF
--- a/src/OrleansAWSUtils/Streams/SQSBatchContainer.cs
+++ b/src/OrleansAWSUtils/Streams/SQSBatchContainer.cs
@@ -17,7 +17,7 @@ namespace OrleansAWSUtils.Streams
     internal class SQSBatchContainer : IBatchContainer
     {
         [JsonProperty]
-        private EventSequenceToken sequenceToken;
+        private EventSequenceTokenV2 sequenceToken;
 
         [JsonProperty]
         private readonly List<object> events;
@@ -45,7 +45,7 @@ namespace OrleansAWSUtils.Streams
             String streamNamespace,
             List<object> events,
             Dictionary<string, object> requestContext,
-            EventSequenceToken sequenceToken)
+            EventSequenceTokenV2 sequenceToken)
             : this(streamGuid, streamNamespace, events, requestContext)
         {
             this.sequenceToken = sequenceToken;

--- a/src/OrleansAzureUtils/OrleansAzureUtils.csproj
+++ b/src/OrleansAzureUtils/OrleansAzureUtils.csproj
@@ -57,7 +57,9 @@
     <Compile Include="MultiClusterNetwork\GossipTableInstanceManager.cs" />
     <Compile Include="Providers\AzureConfigurationExtensions.cs" />
     <Compile Include="Providers\Storage\AzureBlobStorage.cs" />
+    <Compile Include="Providers\Streams\AzureQueue\AzureQueueAdapterConstants.cs" />
     <Compile Include="Providers\Streams\AzureQueue\AzureQueueBatchContainerV2.cs" />
+    <Compile Include="Providers\Streams\AzureQueue\IAzureQueueDataAdapter.cs" />
     <Compile Include="Providers\Streams\PersistentStreams\AzureTableStorageStreamFailureHandler.cs" />
     <Compile Include="Providers\Streams\PersistentStreams\StreamDeliveryFailureEntity.cs" />
     <Compile Include="Storage\AzureBasedMembershipTable.cs" />
@@ -112,11 +114,25 @@
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <!-- Begin Orleans: Without these lines the project won't build properly -->
+  <PropertyGroup>
+    <OrleansProjectType>Server</OrleansProjectType>
+  </PropertyGroup>
+  <!-- Set path to ClientGenerator.exe -->
+  <Choose>
+    <When Condition="'$(builduri)' != ''">
+      <PropertyGroup>
+        <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
+  <!--End Orleans -->
 </Project>

--- a/src/OrleansAzureUtils/Properties/AssemblyInfo.cs
+++ b/src/OrleansAzureUtils/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Orleans.CodeGeneration;
+using Orleans.Providers.Streams.AzureQueue;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -23,4 +24,5 @@ using Orleans.CodeGeneration;
 [assembly: InternalsVisibleTo("UnitTestGrains")]
 [assembly: InternalsVisibleTo("Orleans.NonSiloTests")]
 [assembly: InternalsVisibleTo("Tester.AzureUtils")]
-[assembly: SkipCodeGeneration]
+[assembly: GenerateSerializer(typeof(AzureQueueBatchContainerV2))]
+

--- a/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
+++ b/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
@@ -100,9 +100,9 @@ namespace Orleans.Runtime.Configuration
             this ClusterConfiguration config,
             string providerName,
             string connectionString = null,
-            int numberOfQueues = AzureQueueAdapterFactory.NumQueuesDefaultValue,
+            int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
             string deploymentId = null,
-            int cacheSize = AzureQueueAdapterFactory.CacheSizeDefaultValue,
+            int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
@@ -110,6 +110,33 @@ namespace Orleans.Runtime.Configuration
             deploymentId = deploymentId ?? config.Globals.DeploymentId;
             var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
             config.Globals.RegisterStreamProvider<AzureQueueStreamProvider>(providerName, properties);
+        }
+
+        /// <summary>
+        /// Adds a stream provider of type <see cref="AzureQueueStreamProviderV2"/>.
+        /// </summary>
+        /// <param name="config">The cluster configuration object to add provider to.</param>
+        /// <param name="providerName">The provider name</param>
+        /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
+        /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
+        /// <param name="deploymentId">The deployment ID used for partitioning. If none is specified, the provider will use the same DeploymentId as the Cluster.</param>
+        /// <param name="cacheSize">The cache size.</param>
+        /// <param name="startupState">The startup state of the persistent stream provider.</param>
+        /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>
+        public static void AddAzureQueueStreamProviderV2(
+            this ClusterConfiguration config,
+            string providerName,
+            string connectionString = null,
+            int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
+            string deploymentId = null,
+            int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
+            PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
+            PersistentStreamProviderConfig persistentStreamProviderConfig = null)
+        {
+            connectionString = GetConnectionString(connectionString, config);
+            deploymentId = deploymentId ?? config.Globals.DeploymentId;
+            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
+            config.Globals.RegisterStreamProvider<AzureQueueStreamProviderV2>(providerName, properties);
         }
 
         /// <summary>
@@ -127,9 +154,9 @@ namespace Orleans.Runtime.Configuration
             this ClientConfiguration config,
             string providerName,
             string connectionString = null,
-            int numberOfQueues = AzureQueueAdapterFactory.NumQueuesDefaultValue,
+            int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
             string deploymentId = null,
-            int cacheSize = AzureQueueAdapterFactory.CacheSizeDefaultValue,
+            int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
@@ -139,6 +166,33 @@ namespace Orleans.Runtime.Configuration
             config.RegisterStreamProvider<AzureQueueStreamProvider>(providerName, properties);
         }
 
+        /// <summary>
+        /// Adds a stream provider of type <see cref="AzureQueueStreamProviderV2"/>.
+        /// </summary>
+        /// <param name="config">The cluster configuration object to add provider to.</param>
+        /// <param name="providerName">The provider name</param>
+        /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
+        /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
+        /// <param name="deploymentId">The deployment ID used for partitioning. If none is specified, the provider will use the same DeploymentId as the Cluster.</param>
+        /// <param name="cacheSize">The cache size.</param>
+        /// <param name="startupState">The startup state of the persistent stream provider.</param>
+        /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>
+        public static void AddAzureQueueStreamProviderV2(
+            this ClientConfiguration config,
+            string providerName,
+            string connectionString = null,
+            int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
+            string deploymentId = null,
+            int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
+            PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
+            PersistentStreamProviderConfig persistentStreamProviderConfig = null)
+        {
+            connectionString = GetConnectionString(connectionString, config);
+            deploymentId = deploymentId ?? config.DeploymentId;
+            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
+            config.RegisterStreamProvider<AzureQueueStreamProviderV2>(providerName, properties);
+        }
+
         private static Dictionary<string, string> GetAzureQueueStreamProviderProperties(string providerName, string connectionString, int numberOfQueues, string deploymentId, int cacheSize, PersistentStreamProviderState startupState, PersistentStreamProviderConfig persistentStreamProviderConfig)
         {
             if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
@@ -146,9 +200,9 @@ namespace Orleans.Runtime.Configuration
 
             var properties = new Dictionary<string, string>
             {
-                { AzureQueueAdapterFactory.DataConnectionStringPropertyName, connectionString },
-                { AzureQueueAdapterFactory.NumQueuesPropertyName, numberOfQueues.ToString() },
-                { AzureQueueAdapterFactory.DeploymentIdPropertyName, deploymentId },
+                { AzureQueueAdapterConstants.DataConnectionStringPropertyName, connectionString },
+                { AzureQueueAdapterConstants.NumQueuesPropertyName, numberOfQueues.ToString() },
+                { AzureQueueAdapterConstants.DeploymentIdPropertyName, deploymentId },
                 { SimpleQueueAdapterCache.CacheSizePropertyName, cacheSize.ToString() },
                 { AzureQueueStreamProvider.StartupStatePropertyName, startupState.ToString() },
             };

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapter.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapter.cs
@@ -1,3 +1,4 @@
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -7,42 +8,42 @@ using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.AzureQueue
 {
-    internal class AzureQueueAdapter : IQueueAdapter
+    internal class AzureQueueAdapter<TDataAdapter> : IQueueAdapter
+        where TDataAdapter : IAzureQueueDataAdapter, new()
     {
         protected readonly string DeploymentId;
         protected readonly string DataConnectionString;
         protected readonly TimeSpan? MessageVisibilityTimeout;
         private readonly HashRingBasedStreamQueueMapper streamQueueMapper;
         protected readonly ConcurrentDictionary<QueueId, AzureQueueDataManager> Queues = new ConcurrentDictionary<QueueId, AzureQueueDataManager>();
+        protected readonly IAzureQueueDataAdapter dataAdapter;
 
-        public string Name { get ; private set; }
-        public bool IsRewindable { get { return false; } }
+        public string Name { get ; }
+        public bool IsRewindable => false;
 
-        public StreamProviderDirection Direction { get { return StreamProviderDirection.ReadWrite; } }
+        public StreamProviderDirection Direction => StreamProviderDirection.ReadWrite;
 
         public AzureQueueAdapter(HashRingBasedStreamQueueMapper streamQueueMapper, string dataConnectionString, string deploymentId, string providerName, TimeSpan? messageVisibilityTimeout = null)
         {
-            if (String.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
-            if (String.IsNullOrEmpty(deploymentId)) throw new ArgumentNullException("deploymentId");
+            if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException(nameof(dataConnectionString));
+            if (string.IsNullOrEmpty(deploymentId)) throw new ArgumentNullException(nameof(deploymentId));
             
             DataConnectionString = dataConnectionString;
             DeploymentId = deploymentId;
             Name = providerName;
             MessageVisibilityTimeout = messageVisibilityTimeout;
             this.streamQueueMapper = streamQueueMapper;
+            this.dataAdapter = new TDataAdapter();
         }
 
         public IQueueAdapterReceiver CreateReceiver(QueueId queueId)
         {
-            return AzureQueueAdapterReceiver.Create(queueId, DataConnectionString, DeploymentId, MessageVisibilityTimeout);
+            return AzureQueueAdapterReceiver.Create(queueId, DataConnectionString, DeploymentId, this.dataAdapter, MessageVisibilityTimeout);
         }
 
-        public async Task QueueMessageBatchAsync<T>(Guid streamGuid, String streamNamespace, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext)
+        public async Task QueueMessageBatchAsync<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext)
         {
-            if(token != null)
-            {
-                throw new ArgumentException("AzureQueue stream provider currently does not support non-null StreamSequenceToken.", "token");
-            }
+            if(token != null) throw new ArgumentException("AzureQueue stream provider currently does not support non-null StreamSequenceToken.", nameof(token));
             var queueId = streamQueueMapper.GetQueueForStream(streamGuid, streamNamespace);
             AzureQueueDataManager queue;
             if (!Queues.TryGetValue(queueId, out queue))
@@ -51,7 +52,7 @@ namespace Orleans.Providers.Streams.AzureQueue
                 await tmpQueue.InitQueueAsync();
                 queue = Queues.GetOrAdd(queueId, tmpQueue);
             }
-            var cloudMsg = AzureQueueBatchContainer.ToCloudQueueMessage(streamGuid, streamNamespace, events, requestContext);
+            var cloudMsg = this.dataAdapter.ToCloudQueueMessage(streamGuid, streamNamespace, events, requestContext);
             await queue.AddQueueMessage(cloudMsg);
         }
     }

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterConstants.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterConstants.cs
@@ -1,0 +1,23 @@
+﻿
+namespace Orleans.Providers.Streams.AzureQueue
+{
+    /// <summary>
+    /// Azure queue stream provider constants.
+    /// </summary>
+    public static class AzureQueueAdapterConstants
+    {
+        internal const int CacheSizeDefaultValue = 4096;
+
+        /// <summary>"DataConnectionString".</summary>
+        public const string DataConnectionStringPropertyName = "DataConnectionString";
+        /// <summary>"DeploymentId".</summary>
+        public const string DeploymentIdPropertyName = "DeploymentId";
+        /// <summary>"MessageVisibilityTimeout".</summary>
+        public const string MessageVisibilityTimeoutPropertyName = "VisibilityTimeout";
+
+        /// <summary>"NumQueues".</summary>
+        public const string NumQueuesPropertyName = "NumQueues";
+        /// <summary> Default number of Azure Queue used in this stream provider.</summary>
+        public const int NumQueuesDefaultValue = 8; // keep as power of 2.
+    }
+}

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueBatchContainerV2.cs
@@ -1,135 +1,89 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Orleans.CodeGeneration;
 using Orleans.Providers.Streams.Common;
-using Orleans.Serialization;
+using Orleans.Runtime;
+using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.AzureQueue
 {
-    internal class AzureQueueBatchContainerV2 : AzureQueueBatchContainer
+    /// <summary>
+    /// Second version of AzureQueueBatchContainer.  This version supports external serializers (like json)
+    /// </summary>
+    internal class AzureQueueBatchContainerV2 : IBatchContainer
     {
+        [JsonProperty]
+        private EventSequenceTokenV2 sequenceToken;
+
+        [JsonProperty]
+        private readonly List<object> events;
+
+        [JsonProperty]
+        private readonly Dictionary<string, object> requestContext;
+
+        public Guid StreamGuid { get; }
+
+        public String StreamNamespace { get; }
+
+        public StreamSequenceToken SequenceToken => sequenceToken;
+
+        internal EventSequenceTokenV2 RealSequenceToken
+        {
+            set { sequenceToken = value; }
+        }
+
         [JsonConstructor]
-        internal AzureQueueBatchContainerV2(
-            Guid streamGuid, 
-            string streamNamespace,
-            List<object> events,
-            Dictionary<string, object> requestContext, 
-            EventSequenceTokenV2 sequenceToken)
-            : base(streamGuid, streamNamespace, events, requestContext, sequenceToken)
-        {
-        }
-
-        internal AzureQueueBatchContainerV2(
+        public AzureQueueBatchContainerV2(
             Guid streamGuid,
-            string streamNamespace,
+            String streamNamespace,
             List<object> events,
-            Dictionary<string, object> requestContext)
-            : base(streamGuid, streamNamespace, events, requestContext)
+            Dictionary<string, object> requestContext,
+            EventSequenceTokenV2 sequenceToken)
+            : this(streamGuid, streamNamespace, events, requestContext)
         {
+            this.sequenceToken = sequenceToken;
         }
 
-        private AzureQueueBatchContainerV2() : base()
+        public AzureQueueBatchContainerV2(Guid streamGuid, String streamNamespace, List<object> events, Dictionary<string, object> requestContext)
         {
-        }
+            if (events == null) throw new ArgumentNullException(nameof(events), "Message contains no events");
 
-        /// <summary>
-        /// Creates a deep copy of an object
-        /// </summary>
-        /// <param name="original">The object to create a copy of</param>
-        /// <param name="context">The copy context.</param>
-        /// <returns>The copy.</returns>
-        [CopierMethod]
-        public static object DeepCopy(object original, ICopyContext context)
-        {
-            var source = original as AzureQueueBatchContainerV2;
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(original));
-            }
-
-            var copy = new AzureQueueBatchContainerV2();
-            context.RecordCopy(original, copy);
-            var token = source.sequenceToken == null ? null : new EventSequenceTokenV2(source.sequenceToken.SequenceNumber, source.sequenceToken.EventIndex);
-            List<object> events = null;
-            if (source.events != null)
-            {
-                events = new List<object>(source.events.Count);
-                foreach (var item in source.events)
-                {
-                    events.Add(SerializationManager.DeepCopyInner(item, context));
-                }
-            }
-            
-            var ctx = source.requestContext?.ToDictionary(kv => kv.Key, kv => SerializationManager.DeepCopyInner(kv.Value, context));
-            copy.SetValues(source.StreamGuid, source.StreamNamespace, events, ctx, token);
-            return copy;
-        }
-
-        /// <summary>
-        /// Serializes the container to the binary stream.
-        /// </summary>
-        /// <param name="untypedInput">The object to serialize</param>
-        /// <param name="context">The serialization context.</param>
-        /// <param name="expected">The expected type</param>
-        [SerializerMethod]
-        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
-        {
-            var typed = untypedInput as AzureQueueBatchContainerV2;
-            if (typed == null)
-            {
-                throw new SerializationException();
-            }
-
-            context.StreamWriter.Write(typed.StreamGuid);
-            context.StreamWriter.Write(typed.StreamNamespace);
-            WriteOrSerializeInner(typed.sequenceToken, context);
-            WriteOrSerializeInner(typed.events, context);
-            WriteOrSerializeInner(typed.requestContext, context);
-        }
-
-        /// <summary>
-        /// Deserializes the container from the data stream.
-        /// </summary>
-        /// <param name="expected">The expected type</param>
-        /// <param name="context">The deserialization context.</param>
-        /// <returns>The deserialized value</returns>
-        [DeserializerMethod]
-        public static object Deserialize(Type expected, IDeserializationContext context)
-        {
-            var reader = context.StreamReader;
-            var deserialized = new AzureQueueBatchContainerV2();
-            context.RecordObject(deserialized);
-            var guid = reader.ReadGuid();
-            var ns = reader.ReadString();
-            var eventToken = SerializationManager.DeserializeInner<EventSequenceTokenV2>(context);
-            var events = SerializationManager.DeserializeInner<List<object>>(context);
-            var ctx = SerializationManager.DeserializeInner<Dictionary<string, object>>(context);
-            deserialized.SetValues(guid, ns, events, ctx, eventToken);
-            return deserialized;
-        }
-
-        private static void WriteOrSerializeInner<T>(T val, ISerializationContext context) where T : class
-        {
-            if (val == null)
-            {
-                context.StreamWriter.WriteNull();
-            }
-            else
-            {
-                SerializationManager.SerializeInner(val, context, val.GetType());
-            }
-        }
-
-        private void SetValues(Guid streamGuid, string streamNamespace, List<object> events, Dictionary<string, object> requestContext, EventSequenceTokenV2 sequenceToken)
-        {
-            this.StreamGuid = streamGuid;
-            this.StreamNamespace = streamNamespace;
+            StreamGuid = streamGuid;
+            StreamNamespace = streamNamespace;
             this.events = events;
             this.requestContext = requestContext;
-            this.sequenceToken = sequenceToken;
+        }
+
+        public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
+        {
+            return events.OfType<T>().Select((e, i) => Tuple.Create<T, StreamSequenceToken>(e, sequenceToken.CreateSequenceTokenForEvent(i)));
+        }
+
+        public bool ShouldDeliver(IStreamIdentity stream, object filterData, StreamFilterPredicate shouldReceiveFunc)
+        {
+            foreach (object item in events)
+            {
+                if (shouldReceiveFunc(stream, filterData, item))
+                    return true; // There is something in this batch that the consumer is intereted in, so we should send it.
+            }
+            return false; // Consumer is not interested in any of these events, so don't send.
+        }
+
+        public bool ImportRequestContext()
+        {
+            if (requestContext != null)
+            {
+                RequestContext.Import(requestContext);
+                return true;
+            }
+            return false;
+        }
+
+        public override string ToString()
+        {
+            return $"[AzureQueueBatchContainerV2:Stream={StreamGuid},#Items={events.Count}]";
         }
     }
 }

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueStreamProvider.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueStreamProvider.cs
@@ -4,8 +4,16 @@ namespace Orleans.Providers.Streams.AzureQueue
 {
     /// <summary>
     /// Persistent stream provider that uses azure queue for persistence
+    /// WARNING: This version is maintained for compatability purposes.  New services should use AzureQueueStreamProviderV2 as it supports external serializers.
     /// </summary>
-    public class AzureQueueStreamProvider : PersistentStreamProvider<AzureQueueAdapterFactory>
+    public class AzureQueueStreamProvider : PersistentStreamProvider<AzureQueueAdapterFactory<AzureQueueDataAdapterV1>>
+    {
+    }
+
+    /// <summary>
+    /// Persistent stream provider that uses azure queue for persistence
+    /// </summary>
+    public class AzureQueueStreamProviderV2 : PersistentStreamProvider<AzureQueueAdapterFactory<AzureQueueDataAdapterV2>>
     {
     }
 }

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
@@ -21,7 +21,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         {
             if (deploymentId != null)
             {
-                var queueMapper = new HashRingBasedStreamQueueMapper(AzureQueueAdapterFactory.NumQueuesDefaultValue, providerName);
+                var queueMapper = new HashRingBasedStreamQueueMapper(AzureQueueAdapterConstants.NumQueuesDefaultValue, providerName);
                 List<QueueId> allQueues = queueMapper.GetAllQueues().ToList();
 
                 var deleteTasks = new List<Task>();
@@ -45,7 +45,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         {
             if (deploymentId != null)
             {
-                var queueMapper = new HashRingBasedStreamQueueMapper(AzureQueueAdapterFactory.NumQueuesDefaultValue, providerName);
+                var queueMapper = new HashRingBasedStreamQueueMapper(AzureQueueAdapterConstants.NumQueuesDefaultValue, providerName);
                 List<QueueId> allQueues = queueMapper.GetAllQueues().ToList();
 
                 var deleteTasks = new List<Task>();

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -1,0 +1,87 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Orleans.Providers.Streams.Common;
+using Orleans.Serialization;
+using Orleans.Streams;
+
+namespace Orleans.Providers.Streams.AzureQueue
+{
+    /// <summary>
+    /// Converts event data to and from cloud queue message
+    /// </summary>
+    public interface IAzureQueueDataAdapter
+    {
+        /// <summary>
+        /// Creates a cloud queue message from stream event data.
+        /// </summary>
+        CloudQueueMessage ToCloudQueueMessage<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, Dictionary<string, object> requestContext);
+
+        /// <summary>
+        /// Creates a batch container from a cloud queue message
+        /// </summary>
+        IBatchContainer FromCloudQueueMessage(CloudQueueMessage cloudMsg, long sequenceId);
+    }
+
+    /// <summary>
+    /// Original data adapter.  Here to maintain backwards compatablity, but does not support json and other custom serializers
+    /// </summary>
+    public class AzureQueueDataAdapterV1 : IAzureQueueDataAdapter
+    {
+        /// <summary>
+        /// Creates a cloud queue message from stream event data.
+        /// </summary>
+        public CloudQueueMessage ToCloudQueueMessage<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, Dictionary<string, object> requestContext)
+        {
+            var azureQueueBatchMessage = new AzureQueueBatchContainer(streamGuid, streamNamespace, events.Cast<object>().ToList(), requestContext);
+            var rawBytes = SerializationManager.SerializeToByteArray(azureQueueBatchMessage);
+
+            //new CloudQueueMessage(byte[]) not supported in netstandard, taking a detour to set it
+            var cloudQueueMessage = new CloudQueueMessage(null as string);
+            cloudQueueMessage.SetMessageContent(rawBytes);
+            return cloudQueueMessage;
+        }
+
+        /// <summary>
+        /// Creates a batch container from a cloud queue message
+        /// </summary>
+        public IBatchContainer FromCloudQueueMessage(CloudQueueMessage cloudMsg, long sequenceId)
+        {
+            var azureQueueBatch = SerializationManager.DeserializeFromByteArray<AzureQueueBatchContainer>(cloudMsg.AsBytes);
+            azureQueueBatch.RealSequenceToken = new EventSequenceToken(sequenceId);
+            return azureQueueBatch;
+        }
+    }
+
+    /// <summary>
+    /// Data adapter that uses types that support custom serializers (like json).
+    /// </summary>
+    public class AzureQueueDataAdapterV2 : IAzureQueueDataAdapter
+    {
+        /// <summary>
+        /// Creates a cloud queue message from stream event data.
+        /// </summary>
+        public CloudQueueMessage ToCloudQueueMessage<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, Dictionary<string, object> requestContext)
+        {
+            var azureQueueBatchMessage = new AzureQueueBatchContainerV2(streamGuid, streamNamespace, events.Cast<object>().ToList(), requestContext);
+            var rawBytes = SerializationManager.SerializeToByteArray(azureQueueBatchMessage);
+
+            //new CloudQueueMessage(byte[]) not supported in netstandard, taking a detour to set it
+            var cloudQueueMessage = new CloudQueueMessage(null as string);
+            cloudQueueMessage.SetMessageContent(rawBytes);
+            return cloudQueueMessage;
+        }
+
+        /// <summary>
+        /// Creates a batch container from a cloud queue message
+        /// </summary>
+        public IBatchContainer FromCloudQueueMessage(CloudQueueMessage cloudMsg, long sequenceId)
+        {
+            var azureQueueBatch = SerializationManager.DeserializeFromByteArray<AzureQueueBatchContainerV2>(cloudMsg.AsBytes);
+            azureQueueBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
+            return azureQueueBatch;
+        }
+    }
+}

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/SimpleAzureQueueAdapterFactory.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/SimpleAzureQueueAdapterFactory.cs
@@ -19,8 +19,8 @@ namespace Orleans.Providers.Streams.AzureQueue
         public virtual void Init(IProviderConfiguration config, string providerName, Logger logger, IServiceProvider serviceProvider)
         {
             if (config == null) throw new ArgumentNullException("config");
-            if (!config.Properties.TryGetValue(AzureQueueAdapterFactory.DataConnectionStringPropertyName, out dataConnectionString))
-                throw new ArgumentException(String.Format("{0} property not set", AzureQueueAdapterFactory.DataConnectionStringPropertyName));
+            if (!config.Properties.TryGetValue(AzureQueueAdapterConstants.DataConnectionStringPropertyName, out dataConnectionString))
+                throw new ArgumentException(String.Format("{0} property not set", AzureQueueAdapterConstants.DataConnectionStringPropertyName));
             if (!config.Properties.TryGetValue(QUEUE_NAME_STRING, out queueName))
                 throw new ArgumentException(String.Format("{0} property not set", QUEUE_NAME_STRING));
 

--- a/src/OrleansProviders/Properties/AssemblyInfo.cs
+++ b/src/OrleansProviders/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Orleans.CodeGeneration;
+using Orleans.Providers.Streams.Common;
+using Orleans.Providers.Streams.Generator;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -24,3 +27,6 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("TestExtensions")]
 [assembly: InternalsVisibleTo("Tester.AzureUtils")]
 [assembly: InternalsVisibleTo("Tester.SQLUtils")]
+
+[assembly: GenerateSerializer(typeof(EventSequenceTokenV2))]
+[assembly: GenerateSerializer(typeof(GeneratedBatchContainer))]

--- a/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceToken.cs
@@ -51,11 +51,6 @@ namespace Orleans.Providers.Streams.Common
             return new EventSequenceToken(SequenceNumber, eventInd);
         }
 
-        internal static long Distance(EventSequenceToken first, EventSequenceToken second)
-        {
-            return first.SequenceNumber - second.SequenceNumber;
-        }
-
         /// <summary>
         /// Determines whether the specified object is equal to the current object.
         /// </summary>

--- a/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
+++ b/src/OrleansProviders/Streams/Common/EventSequenceTokenV2.cs
@@ -1,20 +1,32 @@
 ﻿using System;
-using Orleans.CodeGeneration;
-using Orleans.Serialization;
+using System.Globalization;
+using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.Common
 {
     /// <summary>
     /// Stream sequence token that tracks sequence number and event index
     /// </summary>
-    public class EventSequenceTokenV2 : EventSequenceToken
+    public class EventSequenceTokenV2 : StreamSequenceToken
     {
+        /// <summary>
+        /// Number of event batches in stream prior to this event batch
+        /// </summary>
+        public long SequenceNumber { get;  }
+
+        /// <summary>
+        /// Number of events in batch prior to this event
+        /// </summary>
+        public int EventIndex { get;  }
+
         /// <summary>
         /// Sequence token constructor
         /// </summary>
         /// <param name="seqNumber"></param>
-        public EventSequenceTokenV2(long seqNumber) : base(seqNumber)
+        public EventSequenceTokenV2(long seqNumber)
         {
+            SequenceNumber = seqNumber;
+            EventIndex = 0;
         }
 
         /// <summary>
@@ -22,64 +34,85 @@ namespace Orleans.Providers.Streams.Common
         /// </summary>
         /// <param name="seqNumber"></param>
         /// <param name="eventInd"></param>
-        public EventSequenceTokenV2(long seqNumber, int eventInd) : base(seqNumber, eventInd)
+        public EventSequenceTokenV2(long seqNumber, int eventInd)
         {
+            SequenceNumber = seqNumber;
+            EventIndex = eventInd;
         }
 
         /// <summary>
-        /// Create a deep copy of the token.
+        /// Creates a sequence token for a specific event in the current batch
         /// </summary>
-        /// <param name="original">The token to copy</param>
-        /// <param name="context">The serialization context.</param>
-        /// <returns>A copy</returns>
-        [CopierMethod]
-        public static object DeepCopy(object original, ICopyContext context)
-        {
-            var source = original as EventSequenceTokenV2;
-            if (source == null)
-            {
-                return null;
-            }
-
-            var copy = new EventSequenceTokenV2(source.SequenceNumber, source.EventIndex);
-            context.RecordCopy(original, copy);
-            return copy;
-        }
-
-        /// <summary>
-        /// Serialize the event sequence token.
-        /// </summary>
-        /// <param name="untypedInput">The object to serialize.</param>
-        /// <param name="context">The serialization context.</param>
-        /// <param name="expected">The expected type.</param>
-        [SerializerMethod]
-        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
-        {
-            var writer = context.StreamWriter;
-            var typed = untypedInput as EventSequenceTokenV2;
-            if (typed == null)
-            {
-                writer.WriteNull();
-                return;
-            }
-
-            writer.Write(typed.SequenceNumber);
-            writer.Write(typed.EventIndex);
-        }
-
-        /// <summary>
-        /// Deserializes an event sequence token
-        /// </summary>
-        /// <param name="expected">The expected type.</param>
-        /// <param name="context">The deserialization context.</param>
+        /// <param name="eventInd"></param>
         /// <returns></returns>
-        [DeserializerMethod]
-        public static object Deserialize(Type expected, IDeserializationContext context)
+        public EventSequenceTokenV2 CreateSequenceTokenForEvent(int eventInd)
         {
-            var reader = context.StreamReader;
-            var result = new EventSequenceTokenV2(reader.ReadLong(), reader.ReadInt());
-            context.RecordObject(result);
-            return result;
+            return new EventSequenceTokenV2(SequenceNumber, eventInd);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object. </param><filterpriority>2</filterpriority>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as EventSequenceTokenV2);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other"/> parameter; otherwise, false.
+        /// </returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public override bool Equals(StreamSequenceToken other)
+        {
+            var token = other as EventSequenceTokenV2;
+            return token != null && (token.SequenceNumber == SequenceNumber &&
+                                     token.EventIndex == EventIndex);
+        }
+
+        /// <summary>
+        /// Compares the current object with another object of the same type.
+        /// </summary>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared. The return value has the following meanings: Value Meaning Less than zero This object is less than the <paramref name="other"/> parameter.Zero This object is equal to <paramref name="other"/>. Greater than zero This object is greater than <paramref name="other"/>. 
+        /// </returns>
+        /// <param name="other">An object to compare with this object.</param>
+        public override int CompareTo(StreamSequenceToken other)
+        {
+            if (other == null)
+                return 1;
+
+            var token = other as EventSequenceTokenV2;
+            if (token == null)
+                throw new ArgumentOutOfRangeException(nameof(other));
+
+            int difference = SequenceNumber.CompareTo(token.SequenceNumber);
+            return difference != 0 ? difference : EventIndex.CompareTo(token.EventIndex);
+        }
+
+        /// <summary>
+        /// GetHashCode method for current EventSequenceToken
+        /// </summary>
+        /// <returns> Hash code for current EventSequenceToken object </returns>
+        public override int GetHashCode()
+        {
+            // why 397?
+            return (EventIndex * 397) ^ SequenceNumber.GetHashCode();
+        }
+
+        /// <summary>
+        /// ToString method
+        /// </summary>
+        /// <returns> A string which represent current EventSequenceToken object </returns>
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "[EventSequenceTokenV2: SeqNum={0}, EventIndex={1}]", SequenceNumber, EventIndex);
         }
     }
 }

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -44,7 +44,7 @@ namespace Orleans.Providers.Streams.Generator
 
             public int Compare(CachedMessage cachedMessage, StreamSequenceToken token)
             {
-                var realToken = (EventSequenceToken)token;
+                var realToken = (EventSequenceTokenV2)token;
                 return cachedMessage.SequenceNumber != realToken.SequenceNumber
                     ? (int)(cachedMessage.SequenceNumber - realToken.SequenceNumber)
                     : 0 - realToken.EventIndex;
@@ -68,7 +68,7 @@ namespace Orleans.Providers.Streams.Generator
             {
                 if (bufferPool == null)
                 {
-                    throw new ArgumentNullException("bufferPool");
+                    throw new ArgumentNullException(nameof(bufferPool));
                 }
                 this.bufferPool = bufferPool;
             }
@@ -102,7 +102,7 @@ namespace Orleans.Providers.Streams.Generator
                     {
                         string errmsg = Format(CultureInfo.InvariantCulture,
                             "Message size is to big. MessageSize: {0}", size);
-                        throw new ArgumentOutOfRangeException("queueMessage", errmsg);
+                        throw new ArgumentOutOfRangeException(nameof(queueMessage), errmsg);
                     }
                 }
                 Buffer.BlockCopy(serializedPayload, 0, segment.Array, segment.Offset, size);

--- a/src/OrleansProviders/Streams/Generator/Generators/GeneratedBatchContainer.cs
+++ b/src/OrleansProviders/Streams/Generator/Generators/GeneratedBatchContainer.cs
@@ -6,16 +6,15 @@ using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.Generator
 {
-    [Serializable]
     internal class GeneratedBatchContainer : IBatchContainer
     {
-        public Guid StreamGuid { get; private set; }
-        public string StreamNamespace { get; private set; }
-        public StreamSequenceToken SequenceToken { get { return RealToken; } }
-        public EventSequenceToken RealToken { get; private set; }
-        public object Payload { get; private set; }
+        public Guid StreamGuid { get; }
+        public string StreamNamespace { get; }
+        public StreamSequenceToken SequenceToken => RealToken;
+        public EventSequenceTokenV2 RealToken { get;  }
+        public object Payload { get; }
 
-        public GeneratedBatchContainer(Guid streamGuid, string streamNamespace, object payload, EventSequenceToken token)
+        public GeneratedBatchContainer(Guid streamGuid, string streamNamespace, object payload, EventSequenceTokenV2 token)
         {
             StreamGuid = streamGuid;
             StreamNamespace = streamNamespace;

--- a/src/OrleansProviders/Streams/Generator/Generators/SimpleGenerator.cs
+++ b/src/OrleansProviders/Streams/Generator/Generators/SimpleGenerator.cs
@@ -21,7 +21,7 @@ namespace Orleans.Providers.Streams.Generator
             var cfg = generatorConfig as SimpleGeneratorConfig;
             if (cfg == null)
             {
-                throw new ArgumentOutOfRangeException("generatorConfig");
+                throw new ArgumentOutOfRangeException(nameof(generatorConfig));
             }
             config = cfg;
             sequenceId = 0;
@@ -55,7 +55,7 @@ namespace Orleans.Providers.Streams.Generator
                 // If this is the last event generated, mark it as such, so test grains know to report results.
                 EventType = (sequenceId != config.EventsInStream)
                         ? GeneratedEvent.GeneratedEventType.Fill
-                        : GeneratedEvent.GeneratedEventType.Report,
+                        : GeneratedEvent.GeneratedEventType.Report
             };
             return new GeneratedBatchContainer(streamGuid, config.StreamNamespace, evt, new EventSequenceTokenV2(sequenceId));
         }

--- a/test/NonSiloTests/Orleans.NonSiloTests.csproj
+++ b/test/NonSiloTests/Orleans.NonSiloTests.csproj
@@ -74,7 +74,6 @@
     <Compile Include="SerializationTests\SerializationOrderTests.cs" />
     <Compile Include="SerializationTests\SerializationTests.DifferentTypes.cs" />
     <Compile Include="SerializationTests\SerializationTests.ImmutableCollections.cs" />
-    <Compile Include="SerializationTests\StreamTypeSerializationTests.cs" />
     <Compile Include="Serialization\BuiltInSerializerTests.cs" />
     <Compile Include="Serialization\ILBasedSerializerTests.cs" />
     <Compile Include="Serialization\SerializerGenerationTests.cs" />

--- a/test/Tester/StreamingTests/PullingAgentManagementTests.cs
+++ b/test/Tester/StreamingTests/PullingAgentManagementTests.cs
@@ -79,7 +79,7 @@ namespace UnitTests.StreamingTests
             int totalNumAgents = numAgents.Select(Convert.ToInt32).Sum();
             if (expectedState == PersistentStreamProviderState.AgentsStarted)
             {
-                Assert.Equal(AzureQueueAdapterFactory.NumQueuesDefaultValue, totalNumAgents);
+                Assert.Equal(AzureQueueAdapterConstants.NumQueuesDefaultValue, totalNumAgents);
             }
             else
             {

--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -2,7 +2,6 @@
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
-using Tester;
 using TestExtensions;
 using UnitTests.Streaming;
 using UnitTests.StreamingTests;
@@ -16,24 +15,22 @@ namespace Tester.AzureUtils.Streaming
         public const string AzureQueueStreamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
         public const string SmsStreamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
 
-        private SingleStreamTestRunner runner;
+        private readonly SingleStreamTestRunner runner;
 
         public override TestCluster CreateTestCluster()
         {
             var options = new TestClusterOptions(initialSilosCount: 2);
 
-            options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore");
+            options.ClusterConfiguration.AddMemoryStorageProvider();
 
             options.ClusterConfiguration.AddAzureTableStorageProvider("AzureStore", deleteOnClear : true);
             options.ClusterConfiguration.AddAzureTableStorageProvider("PubSubStore", deleteOnClear: true, useJsonFormat: false);
 
             options.ClusterConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
-
-            options.ClusterConfiguration.AddAzureQueueStreamProvider(AzureQueueStreamProviderName);
-            options.ClusterConfiguration.AddAzureQueueStreamProvider("AzureQueueProvider2");
-
             options.ClientConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
-            options.ClientConfiguration.AddAzureQueueStreamProvider(AzureQueueStreamProviderName);
+
+            options.ClusterConfiguration.AddAzureQueueStreamProviderV2(AzureQueueStreamProviderName);
+            options.ClientConfiguration.AddAzureQueueStreamProviderV2(AzureQueueStreamProviderName);
 
             return new TestCluster(options);
         }

--- a/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -49,13 +49,13 @@ namespace Tester.AzureUtils.Streaming
         {
             var properties = new Dictionary<string, string>
                 {
-                    {AzureQueueAdapterFactory.DataConnectionStringPropertyName, TestDefaultConfiguration.DataConnectionString},
-                    {AzureQueueAdapterFactory.DeploymentIdPropertyName, deploymentId},
-                    {AzureQueueAdapterFactory.MessageVisibilityTimeoutPropertyName, "00:00:30" }
+                    {AzureQueueAdapterConstants.DataConnectionStringPropertyName, TestDefaultConfiguration.DataConnectionString},
+                    {AzureQueueAdapterConstants.DeploymentIdPropertyName, deploymentId},
+                    {AzureQueueAdapterConstants.MessageVisibilityTimeoutPropertyName, "00:00:30" }
                 };
             var config = new ProviderConfiguration(properties, "type", "name");
 
-            var adapterFactory = new AzureQueueAdapterFactory();
+            var adapterFactory = new AzureQueueAdapterFactory<AzureQueueDataAdapterV2>();
             adapterFactory.Init(config, AZURE_QUEUE_STREAM_PROVIDER_NAME, LogManager.GetLogger("AzureQueueAdapter", LoggerType.Application), null);
             await SendAndReceiveFromQueueAdapter(adapterFactory, config);
         }

--- a/test/TesterAzureUtils/Streaming/TestAzureQueueStreamProvider.cs
+++ b/test/TesterAzureUtils/Streaming/TestAzureQueueStreamProvider.cs
@@ -7,7 +7,7 @@ namespace Tester.AzureUtils.Streaming
 {
     public class TestAzureQueueStreamProvider : PersistentStreamProvider<TestAzureQueueStreamProvider.AdapterFactory>
     {
-        public class AdapterFactory : AzureQueueAdapterFactory
+        public class AdapterFactory : AzureQueueAdapterFactory<AzureQueueDataAdapterV2>
         {
             public AdapterFactory()
             {

--- a/test/TesterAzureUtils/TesterAzureUtils.csproj
+++ b/test/TesterAzureUtils/TesterAzureUtils.csproj
@@ -80,7 +80,6 @@
     <Compile Include="Streaming\StreamLimitTests.cs" />
     <Compile Include="Streaming\StreamReliabilityTests.cs" />
     <Compile Include="Streaming\TestAzureQueueStreamProvider.cs" />
-    <Compile Include="StreamTypeSerializationTests.cs" />
     <Compile Include="UnitTestAzureTableDataManager.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
@@ -15,7 +15,7 @@ namespace UnitTests.OrleansRuntime.Streams
         private class TestQueueMessage
         {
             public Guid StreamGuid { get; set; }
-            public EventSequenceToken SequenceToken { get; set; }
+            public EventSequenceTokenV2 SequenceToken { get; set; }
         }
 
         private struct TestCachedMessage
@@ -213,14 +213,14 @@ namespace UnitTests.OrleansRuntime.Streams
             int streamIndex;
             Assert.True(block.TryFindFirstMessage(streams[0], TestCacheDataComparer.Instance, out streamIndex));
             Assert.Equal(0, streamIndex);
-            Assert.Equal(0, (block.GetSequenceToken(streamIndex, dataAdapter) as EventSequenceToken).SequenceNumber);
+            Assert.Equal(0, (block.GetSequenceToken(streamIndex, dataAdapter) as EventSequenceTokenV2).SequenceNumber);
 
             // find stream1 messages
             int iteration = 1;
             while (block.TryFindNextMessage(streamIndex + 1, streams[0], TestCacheDataComparer.Instance, out streamIndex))
             {
                 Assert.Equal(iteration * 2, streamIndex);
-                Assert.Equal(iteration * 4, (block.GetSequenceToken(streamIndex, dataAdapter) as EventSequenceToken).SequenceNumber);
+                Assert.Equal(iteration * 4, (block.GetSequenceToken(streamIndex, dataAdapter) as EventSequenceTokenV2).SequenceNumber);
                 iteration++;
             }
             Assert.Equal(iteration, TestBlockSize / 2);
@@ -228,14 +228,14 @@ namespace UnitTests.OrleansRuntime.Streams
             // get index of first stream
             Assert.True(block.TryFindFirstMessage(streams[1], TestCacheDataComparer.Instance, out streamIndex));
             Assert.Equal(1, streamIndex);
-            Assert.Equal(2, (block.GetSequenceToken(streamIndex, dataAdapter) as EventSequenceToken).SequenceNumber);
+            Assert.Equal(2, (block.GetSequenceToken(streamIndex, dataAdapter) as EventSequenceTokenV2).SequenceNumber);
 
             // find stream1 messages
             iteration = 1;
             while (block.TryFindNextMessage(streamIndex + 1, streams[1], TestCacheDataComparer.Instance, out streamIndex))
             {
                 Assert.Equal(iteration * 2 + 1, streamIndex);
-                Assert.Equal(iteration * 4 + 2, (block.GetSequenceToken(streamIndex, dataAdapter) as EventSequenceToken).SequenceNumber);
+                Assert.Equal(iteration * 4 + 2, (block.GetSequenceToken(streamIndex, dataAdapter) as EventSequenceTokenV2).SequenceNumber);
                 iteration++;
             }
             Assert.Equal(iteration, TestBlockSize / 2);

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -64,7 +64,7 @@ namespace UnitTests.OrleansRuntime.Streams
 
             public int Compare(TestCachedMessage cachedMessage, StreamSequenceToken token)
             {
-                var realToken = (EventSequenceToken)token;
+                var realToken = (EventSequenceTokenV2)token;
                 return cachedMessage.SequenceNumber != realToken.SequenceNumber
                     ? (int)(cachedMessage.SequenceNumber - realToken.SequenceNumber)
                     : 0 - realToken.EventIndex;
@@ -88,7 +88,7 @@ namespace UnitTests.OrleansRuntime.Streams
             {
                 if (bufferPool == null)
                 {
-                    throw new ArgumentNullException("bufferPool");
+                    throw new ArgumentNullException(nameof(bufferPool));
                 }
                 this.bufferPool = bufferPool;
             }


### PR DESCRIPTION
The data adapter allows users to use the new v2 versions of sequence token and batch container without risking changes to the original versions, which are being used in production services.
The adapter also allows service developers to control how data is structured in azure queues, enabling the streaming of azure queue events of legacy systems or systems integrated with other non-orleans services.

This change addresses "Revisit azure queue serialization. #2456"