### PR TITLE
improve JournaledGrain API, add better tests/examples

### DIFF
--- a/src/Orleans/LogConsistency/ILogViewAdaptor.cs
+++ b/src/Orleans/LogConsistency/ILogViewAdaptor.cs
@@ -64,6 +64,15 @@ namespace Orleans.LogConsistency
         /// </summary>
         IEnumerable<TLogEntry> UnconfirmedSuffix { get; }
 
+        /// <summary>
+        /// Attempt to retrieve a segment of the log, possibly from storage. Throws <see cref="NotSupportedException"/> if
+        /// the log cannot be read, which depends on the providers used and how they are configured.
+        /// </summary>
+        /// <param name="fromVersion">the start position </param>
+        /// <param name="toVersion">the end position</param>
+        /// <returns>a </returns>
+        Task<IReadOnlyList<TLogEntry>> RetrieveLogSegment(int fromVersion, int toVersion);
+
     }
 
     /// <summary>

--- a/src/OrleansEventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
+++ b/src/OrleansEventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
@@ -87,6 +87,11 @@ namespace Orleans.EventSourcing.Common
             throw new NotImplementedException();
         }
 
+        public virtual Task<IReadOnlyList<TLogEntry>> RetrieveLogSegment(int fromVersion, int length)
+        {
+            throw new NotSupportedException();
+        }
+
         /// <summary>
         /// Handle notification messages. Override this to handle notification subtypes.
         /// </summary>

--- a/src/OrleansEventSourcing/CustomStorage/ICustomStorageInterface.cs
+++ b/src/OrleansEventSourcing/CustomStorage/ICustomStorageInterface.cs
@@ -18,14 +18,14 @@ namespace Orleans.EventSourcing.CustomStorage
         /// (note that the state object may be mutated by the provider, so it must not be shared).
         /// </summary>
         /// <returns>the version number and a  state object.</returns>
-        Task<KeyValuePair<int,TState>> ReadStateFromStorageAsync();
+        Task<KeyValuePair<int,TState>> ReadStateFromStorage();
 
         /// <summary>
         /// Applies the given array of deltas to storage, and returns true, if the version in storage matches the expected version. 
         /// Otherwise, does nothing and returns false. If successful, the version of storage must be increased by the number of deltas.
         /// </summary>
         /// <returns>true if the deltas were applied, false otherwise</returns>
-        Task<bool> ApplyUpdatesToStorageAsync(IReadOnlyList<TDelta> updates, int expectedversion);
+        Task<bool> ApplyUpdatesToStorage(IReadOnlyList<TDelta> updates, int expectedversion);
     }
 
 }

--- a/src/OrleansEventSourcing/CustomStorage/LogViewAdaptor.cs
+++ b/src/OrleansEventSourcing/CustomStorage/LogViewAdaptor.cs
@@ -126,7 +126,7 @@ namespace Orleans.EventSourcing.CustomStorage
                     if (MayAccessStorage())
                     {
                         // read from storage
-                        var result = await ((ICustomStorageInterface<TLogView, TLogEntry>)Host).ReadStateFromStorageAsync();
+                        var result = await ((ICustomStorageInterface<TLogView, TLogEntry>)Host).ReadStateFromStorage();
                         version = result.Key;
                         cached = result.Value;
                     }
@@ -178,7 +178,7 @@ namespace Orleans.EventSourcing.CustomStorage
 
             try
             {
-                writesuccessful = await ((ICustomStorageInterface<TLogView,TLogEntry>) Host).ApplyUpdatesToStorageAsync(updates, version);
+                writesuccessful = await ((ICustomStorageInterface<TLogView,TLogEntry>) Host).ApplyUpdatesToStorage(updates, version);
 
                 LastPrimaryIssue.Resolve(Host, Services);
             }
@@ -223,7 +223,7 @@ namespace Orleans.EventSourcing.CustomStorage
 
                     try
                     {
-                        var result = await ((ICustomStorageInterface<TLogView, TLogEntry>)Host).ReadStateFromStorageAsync();
+                        var result = await ((ICustomStorageInterface<TLogView, TLogEntry>)Host).ReadStateFromStorage();
                         version = result.Key;
                         cached = result.Value;
 

--- a/src/OrleansEventSourcing/JournaledGrain.cs
+++ b/src/OrleansEventSourcing/JournaledGrain.cs
@@ -178,9 +178,9 @@ namespace Orleans.EventSourcing
         protected Task<IReadOnlyList<TEventBase>> RetrieveConfirmedEvents(int fromVersion, int toVersion)
         {
             if (fromVersion < 0)
-                throw new ArgumentException("fromVersion");
+                throw new ArgumentException("invalid range", nameof(fromVersion));
             if (toVersion < fromVersion || toVersion > LogViewAdaptor.ConfirmedVersion)
-                throw new ArgumentException("toVersion");
+                throw new ArgumentException("invalid range", nameof(toVersion));
 
             return LogViewAdaptor.RetrieveLogSegment(fromVersion, toVersion);
         }

--- a/src/OrleansEventSourcing/JournaledGrain.cs
+++ b/src/OrleansEventSourcing/JournaledGrain.cs
@@ -91,54 +91,45 @@ namespace Orleans.EventSourcing
         }
 
         /// <summary>
-        /// The current state (includes both confirmed and unconfirmed events).
+        /// The current confirmed state. 
+        /// Includes only confirmed events.
         /// </summary>
         protected TGrainState State
-        {
-            get { return this.LogViewAdaptor.TentativeView; }
-        }
-
-        /// <summary>
-        /// The version of the state.
-        /// Always equal to the confirmed version plus the number of unconfirmed events.
-        /// </summary>
-        protected int Version
-        {
-            get { return this.LogViewAdaptor.ConfirmedVersion + this.LogViewAdaptor.UnconfirmedSuffix.Count(); }
-        }
-
-        /// <summary>
-        /// Called whenever the current state may have changed due to local or remote events.
-        /// <para>Override this to react to changes of the state.</para>
-        /// </summary>
-        protected virtual void OnStateChanged()
-        {
-        }
-
-        /// <summary>
-        /// The current confirmed state (includes only confirmed events).
-        /// </summary>
-        protected TGrainState ConfirmedState
         {
             get { return this.LogViewAdaptor.ConfirmedView; }
         }
 
         /// <summary>
-        /// The version of the confirmed state.
-        /// Always equal to the number of confirmed events.
+        /// The version of the current confirmed state. 
+        /// Equals the total number of confirmed events.
         /// </summary>
-        protected int ConfirmedVersion
+        protected int Version
         {
             get { return this.LogViewAdaptor.ConfirmedVersion; }
         }
 
+        /// <summary>
+        /// Called whenever the tentative state may have changed due to local or remote events.
+        /// <para>Override this to react to changes of the state.</para>
+        /// </summary>
+        protected virtual void OnTentativeStateChanged()
+        {
+        }
 
+        /// <summary>
+        /// The current tentative state.
+        /// Includes both confirmed and unconfirmed events.
+        /// </summary>
+        protected TGrainState TentativeState
+        {
+            get { return this.LogViewAdaptor.TentativeView; }
+        }
 
         /// <summary>
         /// Called after the confirmed state may have changed (i.e. the confirmed version number is larger).
         /// <para>Override this to react to changes of the confirmed state.</para>
         /// </summary>
-        protected virtual void OnConfirmedStateChanged()
+        protected virtual void OnStateChanged()
         {
             // overridden by journaled grains that want to react to state changes
         }
@@ -348,9 +339,9 @@ namespace Orleans.EventSourcing
         void ILogViewAdaptorHost<TGrainState, TEventBase>.OnViewChanged(bool tentative, bool confirmed)
         {
             if (tentative)
-                OnStateChanged();
+                OnTentativeStateChanged();
             if (confirmed)
-                OnConfirmedStateChanged();
+                OnStateChanged();
         }
 
         /// <summary>

--- a/src/OrleansEventSourcing/JournaledGrain.cs
+++ b/src/OrleansEventSourcing/JournaledGrain.cs
@@ -177,6 +177,24 @@ namespace Orleans.EventSourcing
 
 
         /// <summary>
+        /// Retrieves a segment of the confirmed event sequence, possibly from storage. 
+        /// Throws <see cref="NotSupportedException"/> if the events are not available to read.
+        /// Whether events are available, and for how long, depends on the providers used and how they are configured.
+        /// </summary>
+        /// <param name="fromVersion">the position of the event sequence from which to start</param>
+        /// <param name="toVersion">the position of the event sequence on which to end</param>
+        /// <returns>a task which returns the sequence of events between the two versions</returns>
+        protected Task<IReadOnlyList<TEventBase>> RetrieveConfirmedEvents(int fromVersion, int toVersion)
+        {
+            if (fromVersion < 0)
+                throw new ArgumentException("fromVersion");
+            if (toVersion < fromVersion || toVersion > LogViewAdaptor.ConfirmedVersion)
+                throw new ArgumentException("toVersion");
+
+            return LogViewAdaptor.RetrieveLogSegment(fromVersion, toVersion);
+        }
+
+        /// <summary>
         /// Called when the underlying persistence or replication protocol is running into some sort of connection trouble.
         /// <para>Override this to monitor the health of the log-consistency protocol and/or
         /// to customize retry delays.

--- a/src/OrleansEventSourcing/LogConsistencyConfigurationExtensions.cs
+++ b/src/OrleansEventSourcing/LogConsistencyConfigurationExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.Configuration
+{ 
+
+    /// <summary>
+    /// Extension methods for configuration classes specific to OrleansEventSourcing.dll 
+    /// </summary>
+    public static class LogConsistencyConfigurationExtensions
+    {
+        /// <summary>
+        /// Adds a log consistency provider of type <see cref="Orleans.EventSourcing.LogStorage.LogConsistencyProvider"/>
+        /// </summary>
+        /// <param name="config">The cluster configuration object to add provider to.</param>
+        /// <param name="providerName">The provider name.</param>
+        public static void AddLogStorageBasedLogConsistencyProvider(
+            this ClusterConfiguration config,
+            string providerName = "LogStorage")
+        {
+            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
+
+            config.Globals.RegisterLogConsistencyProvider<EventSourcing.LogStorage.LogConsistencyProvider>(providerName);
+        }
+
+        /// <summary>
+        /// Adds a log consistency provider of type <see cref="Orleans.EventSourcing.StateStorage.LogConsistencyProvider"/>
+        /// </summary>
+        /// <param name="config">The cluster configuration object to add provider to.</param>
+        /// <param name="providerName">The provider name.</param>
+        public static void AddStateStorageBasedLogConsistencyProvider(
+            this ClusterConfiguration config,
+            string providerName = "StateStorage")
+        {
+            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
+
+            config.Globals.RegisterLogConsistencyProvider<EventSourcing.StateStorage.LogConsistencyProvider>(providerName);
+        }
+
+        /// <summary>
+        /// Adds a log consistency provider of type <see cref="Orleans.EventSourcing.CustomStorage.LogConsistencyProvider"/>
+        /// </summary>
+        /// <param name="config">The cluster configuration object to add provider to.</param>
+        /// <param name="providerName">The provider name.</param>
+        /// <param name="numStorageGrains">The number of storage grains to use.</param>
+        public static void AddCustomStorageInterfaceBasedLogConsistencyProvider(
+            this ClusterConfiguration config,
+            string providerName = "LogStorage",
+            string primaryCluster = null)
+        {
+            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
+
+            var properties = new Dictionary<string, string>();
+
+            if (primaryCluster != null)
+                properties.Add("PrimaryCluster", primaryCluster);
+
+            config.Globals.RegisterLogConsistencyProvider<EventSourcing.CustomStorage.LogConsistencyProvider>(providerName, properties);
+        }
+    }
+}

--- a/src/OrleansEventSourcing/LogStorage/LogViewAdaptor.cs
+++ b/src/OrleansEventSourcing/LogStorage/LogViewAdaptor.cs
@@ -84,6 +84,17 @@ namespace Orleans.EventSourcing.LogStorage
             ConfirmedVersionInternal = GlobalLog.StateAndMetaData.GlobalVersion;
         }
 
+
+        /// <inheritdoc/>
+        public override Task<IReadOnlyList<TLogEntry>> RetrieveLogSegment(int fromVersion, int toVersion)
+        {
+
+            // make a copy of the entries in the range asked for
+            IReadOnlyList<TLogEntry> segment = GlobalLog.StateAndMetaData.Log.GetRange(fromVersion, (toVersion - fromVersion));
+
+            return Task.FromResult(segment);
+        }
+
         // no special tagging is required, thus we create a plain submission entry
         /// <inheritdoc/>
         protected override SubmissionEntry<TLogEntry> MakeSubmissionEntry(TLogEntry entry)

--- a/src/OrleansEventSourcing/OrleansEventSourcing.csproj
+++ b/src/OrleansEventSourcing/OrleansEventSourcing.csproj
@@ -45,6 +45,7 @@
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="LogConsistencyConfigurationExtensions.cs" />
     <Compile Include="CustomStorage\LogViewAdaptor.cs" />
     <Compile Include="CustomStorage\LogConsistencyProvider.cs" />
     <Compile Include="CustomStorage\ICustomStorageInterface.cs" />

--- a/src/OrleansTestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
+++ b/src/OrleansTestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
@@ -32,6 +32,11 @@ namespace Orleans.TestingHost
             realStorageProvider = new TStorage();
         }
 
+        /// <summary>  Name of the property that controls the inserted delay. </summary>
+        public const string DelayMillisecondsPropertyName = "DelayMilliseconds";
+
+        private int delayMilliseconds;
+
         /// <summary>
         /// Initializes the decorated storage provider.
         /// </summary>
@@ -45,6 +50,10 @@ namespace Orleans.TestingHost
             await realStorageProvider.Init(name, providerRuntime, config);
             Log = realStorageProvider.Log.GetSubLogger("FaultInjection");
             Log.Info($"Initialized fault injection for storage provider {Name}");
+
+            string value;
+            if (config.Properties.TryGetValue(DelayMillisecondsPropertyName, out value))
+                delayMilliseconds = int.Parse(value);
         }
 
         /// <summary>Close function for this provider instance.</summary>
@@ -64,6 +73,8 @@ namespace Orleans.TestingHost
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
             {
+                if (delayMilliseconds > 0)
+                    await Task.Delay(delayMilliseconds);
                 await faultGrain.OnRead(grainReference);
             }
             catch (Exception)
@@ -85,6 +96,8 @@ namespace Orleans.TestingHost
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
             {
+                if (delayMilliseconds > 0)
+                    await Task.Delay(delayMilliseconds);
                 await faultGrain.OnWrite(grainReference);
             }
             catch (Exception)
@@ -106,6 +119,8 @@ namespace Orleans.TestingHost
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
             {
+                if (delayMilliseconds > 0)
+                    await Task.Delay(delayMilliseconds);
                 await faultGrain.OnClear(grainReference);
             }
             catch (Exception)

--- a/src/OrleansTestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
+++ b/src/OrleansTestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
@@ -63,6 +63,14 @@ namespace Orleans.TestingHost
                 await realStorageProvider.Close();
         }
 
+        private Task InsertDelay()
+        {
+            if (delayMilliseconds > 0)
+                return Task.Delay(delayMilliseconds);
+            else
+                return TaskDone.Done;
+        }
+           
         /// <summary>Faults if exception is provided, otherwise calls through to  decorated storage provider.</summary>
         /// <param name="grainType">Type of this grain [fully qualified class name]</param>
         /// <param name="grainReference">Grain reference object for this grain.</param>
@@ -73,8 +81,7 @@ namespace Orleans.TestingHost
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
             {
-                if (delayMilliseconds > 0)
-                    await Task.Delay(delayMilliseconds);
+                await InsertDelay();
                 await faultGrain.OnRead(grainReference);
             }
             catch (Exception)
@@ -96,8 +103,7 @@ namespace Orleans.TestingHost
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
             {
-                if (delayMilliseconds > 0)
-                    await Task.Delay(delayMilliseconds);
+                await InsertDelay();
                 await faultGrain.OnWrite(grainReference);
             }
             catch (Exception)
@@ -119,8 +125,7 @@ namespace Orleans.TestingHost
             IStorageFaultGrain faultGrain = grainFactory.GetGrain<IStorageFaultGrain>(grainType);
             try
             {
-                if (delayMilliseconds > 0)
-                    await Task.Delay(delayMilliseconds);
+                await InsertDelay();
                 await faultGrain.OnClear(grainReference);
             }
             catch (Exception)

--- a/src/OrleansTestingHost/TestStorageProviders/FaultyMemoryStorage.cs
+++ b/src/OrleansTestingHost/TestStorageProviders/FaultyMemoryStorage.cs
@@ -24,10 +24,12 @@ namespace Orleans.TestingHost
         /// <param name="config">The cluster configuration object to add provider to.</param>
         /// <param name="providerName">The provider name.</param>
         /// <param name="numStorageGrains">The number of storage grains to use.</param>
+        /// <param name="delayMilliseconds">A delay to add to each access, in milliseconds</param>
         public static void AddFaultyMemoryStorageProvider(
             this ClusterConfiguration config,
             string providerName = "FaultyMemoryStore",
-            int numStorageGrains = MemoryStorage.NumStorageGrainsDefaultValue)
+            int numStorageGrains = MemoryStorage.NumStorageGrainsDefaultValue,
+            int delayMilliseconds = 0)
         {
             //TODO: find a way to share the provider configuration setup so we don't have duplicate code.
 
@@ -36,6 +38,7 @@ namespace Orleans.TestingHost
             var properties = new Dictionary<string, string>
             {
                 { MemoryStorage.NumStorageGrainsPropertyName, numStorageGrains.ToString() },
+                { FaultyMemoryStorage.DelayMillisecondsPropertyName, delayMilliseconds.ToString() },
             };
 
             config.Globals.RegisterStorageProvider<FaultyMemoryStorage>(providerName, properties);

--- a/test/TestGrainInterfaces/EventSourcing/IAccountGrain.cs
+++ b/test/TestGrainInterfaces/EventSourcing/IAccountGrain.cs
@@ -1,0 +1,54 @@
+﻿using Orleans;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestGrainInterfaces
+{
+    /// <summary>
+    /// A grain that models a bank account
+    /// </summary>
+    public interface IAccountGrain : IGrainWithStringKey
+    {
+        Task<uint> Balance();
+
+        Task Deposit(uint amount, Guid guid, string desc);
+
+        Task<bool> Withdraw(uint amount, Guid guid, string desc);
+
+        Task<IReadOnlyList<Transaction>> GetTransactionLog();
+    }
+
+    // the classes below represent events/transactions on the account
+    // all fields are user-defined (none have a special meaning),
+    // so these can be any type of object you like, as long as they are serializable
+    // (so they can be sent over the wire and persisted in a log).
+
+    [Serializable]
+    public abstract class Transaction
+    {
+        /// <summary> A unique identifier for this transaction  </summary>
+        public Guid Guid { get; set; }
+
+        /// <summary> A description for this transaction  </summary>
+        public String Description { get; set; }
+
+        /// <summary> time on which the request entered the system  </summary>
+        public DateTime IssueTime { get; set; }
+    }
+
+    [Serializable]
+    public class DepositTransaction : Transaction
+    {
+        public uint DepositAmount { get; set; }
+    }
+
+    [Serializable]
+    public class WithdrawalTransaction : Transaction
+    {
+        public uint WithdrawalAmount { get; set; }
+    }
+
+}

--- a/test/TestGrainInterfaces/EventSourcing/IChatGrain.cs
+++ b/test/TestGrainInterfaces/EventSourcing/IChatGrain.cs
@@ -1,0 +1,64 @@
+﻿using Orleans;
+using Orleans.CodeGeneration;
+using Orleans.Serialization;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace TestGrainInterfaces
+{
+    /// <summary>
+    /// The grain interface for the chat grain.
+    /// </summary>
+    public interface IChatGrain : IGrainWithStringKey
+    {
+        /// <summary> Return the current content of the chat room. </summary>
+        Task<XDocument> GetChat();
+
+        /// <summary> Add a new post. </summary>
+        Task Post(Guid guid, string user, string text);
+
+        /// <summary> Delete a specific post. </summary>
+        Task Delete(Guid guid);
+
+        /// <summary> Edit a specific post. </summary>
+        Task Edit(Guid guid, string text);
+
+    }
+
+
+    /// <summary>
+    /// Since XDocument does not seem to serialize automatically, we provide the necessary methods
+    /// </summary>
+    [Serializer(typeof(XDocument))]
+    public class XDocumentSerialization
+    {
+        [CopierMethod]
+        public static object DeepCopier(object original, ICopyContext context)
+        {
+            return new XDocument((XDocument)original);
+        }
+
+        [SerializerMethod]
+        public static void Serialize(object untypedInput, ISerializationContext context, Type expected)
+        {
+            var document = (XDocument)untypedInput;
+            var stream = context.StreamWriter;
+            stream.Write(document.ToString());
+        }
+
+        [DeserializerMethod]
+        public static object Deserialize(Type expected, IDeserializationContext context)
+        {
+            var stream = context.StreamReader;
+            var text = stream.ReadString();
+            return XDocument.Load(new StringReader(text));
+        }
+
+    }
+
+}

--- a/test/TestGrainInterfaces/EventSourcing/ICountersGrain.cs
+++ b/test/TestGrainInterfaces/EventSourcing/ICountersGrain.cs
@@ -11,16 +11,22 @@ namespace TestGrainInterfaces
     public interface ICountersGrain : Orleans.IGrainWithIntegerKey
     {
         /// <summary> Updates the counter for the given key by the given amount </summary>
-        Task Add(string key, int amount, bool wait_till_persisted);
+        Task Add(string key, int amount, bool wait_for_confirmation);
 
         /// <summary> Resets all counters to zero </summary>
-        Task Reset(bool wait_till_persisted);
+        Task Reset(bool wait_for_confirmation);
 
-        /// <summary> Retrieves the counter for the given key </summary>
-        Task<int> Get(string key);
+        /// <summary> Retrieves the tentative value of the counter for the given key </summary>
+        Task<int> GetTentativeCount(string key);
 
-        /// <summary> Retrieves the value of all counters </summary>
-        Task<IReadOnlyDictionary<string, int>> GetAll();
+        /// <summary> Retrieves the tentative value of all counters </summary>
+        Task<IReadOnlyDictionary<string, int>> GetTentativeState();
+
+        /// <summary> Retrieves the confirmed value of all counters </summary>
+        Task<IReadOnlyDictionary<string, int>> GetConfirmedState();
+
+        /// <summary> Confirm all events </summary>
+        Task ConfirmAllPreviouslyRaisedEvents();
 
     }
 }

--- a/test/TestGrainInterfaces/EventSourcing/ICountersGrain.cs
+++ b/test/TestGrainInterfaces/EventSourcing/ICountersGrain.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace TestGrainInterfaces
+{
+   
+    /// <summary>
+    /// A grain that maintains a number of counters, indexed by a string key
+    /// </summary>
+    public interface ICountersGrain : Orleans.IGrainWithIntegerKey
+    {
+        /// <summary> Updates the counter for the given key by the given amount </summary>
+        Task Add(string key, int amount, bool wait_till_persisted);
+
+        /// <summary> Resets all counters to zero </summary>
+        Task Reset(bool wait_till_persisted);
+
+        /// <summary> Retrieves the counter for the given key </summary>
+        Task<int> Get(string key);
+
+        /// <summary> Retrieves the value of all counters </summary>
+        Task<IReadOnlyDictionary<string, int>> GetAll();
+
+    }
+}

--- a/test/TestGrainInterfaces/EventSourcing/IPersonGrain.cs
+++ b/test/TestGrainInterfaces/EventSourcing/IPersonGrain.cs
@@ -20,10 +20,10 @@ namespace TestGrainInterfaces
     /// <summary>
     /// Orleans grain communication interface IPerson
     /// </summary>
-    public interface IJournaledPersonGrain : Orleans.IGrainWithGuidKey
+    public interface IPersonGrain : Orleans.IGrainWithGuidKey
     {
         Task RegisterBirth(PersonAttributes person);
-        Task Marry(IJournaledPersonGrain spouse);
+        Task Marry(IPersonGrain spouse);
 
         Task<PersonAttributes> GetPersonalAttributes();
 

--- a/test/TestGrainInterfaces/EventSourcing/IPersonGrain.cs
+++ b/test/TestGrainInterfaces/EventSourcing/IPersonGrain.cs
@@ -25,7 +25,7 @@ namespace TestGrainInterfaces
         Task RegisterBirth(PersonAttributes person);
         Task Marry(IPersonGrain spouse);
 
-        Task<PersonAttributes> GetPersonalAttributes();
+        Task<PersonAttributes> GetTentativePersonalAttributes();
 
         // Tests
 

--- a/test/TestGrainInterfaces/EventSourcing/ISeatReservationGrain.cs
+++ b/test/TestGrainInterfaces/EventSourcing/ISeatReservationGrain.cs
@@ -1,0 +1,19 @@
+﻿using Orleans;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestGrainInterfaces
+{
+    // The grain supports an operation to reserve a seat
+    public interface ISeatReservationGrain : IGrainWithIntegerKey
+    {
+        // returns a boolean if reservation was successful
+        Task<bool> Reserve(int seatnumber, string userid);
+    }
+
+
+
+}

--- a/test/TestGrainInterfaces/ILogConsistentGrain.cs
+++ b/test/TestGrainInterfaces/ILogConsistentGrain.cs
@@ -8,6 +8,9 @@ namespace UnitTests.GrainInterfaces
 {
     /// <summary>
     /// A grain used for testing log-consistency providers.
+    /// The content of this class is pretty arbitrary and messy;
+    /// (don't use this as an introduction on how to use JournaledGrain)
+    /// it started from SimpleGrain, but a lot of stuff got added over time 
     /// </summary>
     public interface ILogConsistentGrain: IGrainWithIntegerKey
     {
@@ -71,11 +74,14 @@ namespace UnitTests.GrainInterfaces
         Task<KeyValuePair<int, object>> Read();
         Task<bool> Update(IReadOnlyList<object> updates, int expectedversion);
 
-        #region Other
+        Task<IReadOnlyList<object>> GetEventLog();
 
-        // other operations
 
-        Task SynchronizeGlobalState();
+            #region Other
+
+            // other operations
+
+            Task SynchronizeGlobalState();
         Task Deactivate();
 
         #endregion

--- a/test/TestGrainInterfaces/ILogTestGrain.cs
+++ b/test/TestGrainInterfaces/ILogTestGrain.cs
@@ -12,7 +12,7 @@ namespace UnitTests.GrainInterfaces
     /// (don't use this as an introduction on how to use JournaledGrain)
     /// it started from SimpleGrain, but a lot of stuff got added over time 
     /// </summary>
-    public interface ILogConsistentGrain: IGrainWithIntegerKey
+    public interface ILogTestGrain: IGrainWithIntegerKey
     {
         #region Queries
 

--- a/test/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/test/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -39,11 +39,17 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="EventSourcing\IAccountGrain.cs" />
+    <Compile Include="EventSourcing\IChatGrain.cs" />
+    <Compile Include="EventSourcing\ICountersGrain.cs" />
+    <Compile Include="EventSourcing\ISeatReservationGrain.cs" />
     <Compile Include="GetGrainInterfaces.cs" />
     <Compile Include="IActivateDeactivateTestGrain.cs" />
     <Compile Include="IChainedGrain.cs" />
@@ -71,7 +77,7 @@
     <Compile Include="IGeneratorTestGrain.cs" />
     <Compile Include="IGrainServiceTestGrain.cs" />
     <Compile Include="IMethodInterceptionGrain.cs" />
-    <Compile Include="IJournaledPersonGrain.cs" />
+    <Compile Include="EventSourcing\IPersonGrain.cs" />
     <Compile Include="IGeneratedEventCollectorGrain.cs" />
     <Compile Include="IGeneratedEventReporterGrain.cs" />
     <Compile Include="IGenericInterfaces.cs" />

--- a/test/TestGrainInterfaces/TestGrainInterfaces.csproj
+++ b/test/TestGrainInterfaces/TestGrainInterfaces.csproj
@@ -112,7 +112,7 @@
     <Compile Include="ISimpleGrain.cs" />
     <Compile Include="ISimplePersistentGrain.cs" />
     <Compile Include="ILivenessTestGrain.cs" />
-    <Compile Include="ILogConsistentGrain.cs" />
+    <Compile Include="ILogTestGrain.cs" />
     <Compile Include="IStatsCollectorGrain.cs" />
     <Compile Include="IStreamingGrain.cs" />
     <Compile Include="IStreamingImmutabilityTestGrain.cs" />

--- a/test/TestGrains/EventSourcing/AccountGrain.cs
+++ b/test/TestGrains/EventSourcing/AccountGrain.cs
@@ -93,7 +93,7 @@ namespace TestGrains
 
         public Task<IReadOnlyList<Transaction>> GetTransactionLog()
         {
-            return RetrieveConfirmedEvents(0, ConfirmedVersion);
+            return RetrieveConfirmedEvents(0, Version);
         }
     }
 

--- a/test/TestGrains/EventSourcing/AccountGrain.cs
+++ b/test/TestGrains/EventSourcing/AccountGrain.cs
@@ -1,0 +1,120 @@
+﻿using Orleans.Concurrency;
+using Orleans.EventSourcing;
+using Orleans.MultiCluster;
+using Orleans.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TestGrainInterfaces;
+
+namespace TestGrains
+{
+    /// <summary>
+    /// An example of a journaled grain that models a bank account.
+    /// 
+    /// Configured to use the default storage provider.
+    /// Configured to use the LogStorage consistency provider.
+    /// 
+    /// This provider persists all events, and allows us to retrieve them all.
+    /// </summary>
+
+    [StorageProvider(ProviderName = "Default")]
+    [LogConsistencyProvider(ProviderName = "LogStorage")]
+
+    public class AccountGrain : JournaledGrain<AccountGrain.GrainState, Transaction>, IAccountGrain
+    {
+        /// <summary>
+        /// The state of this grain is just the current balance.
+        /// </summary>
+        [Serializable]
+        public class GrainState
+        {
+            public uint Balance { get; set; }
+
+            public void Apply(DepositTransaction d)
+            {
+                Balance = Balance + d.DepositAmount;
+            }
+
+            public void Apply(WithdrawalTransaction d)
+            {
+                if (d.WithdrawalAmount > Balance)
+                    throw new InvalidOperationException("we make sure this never happens");
+
+                Balance = Balance - d.WithdrawalAmount;
+            }
+        }
+
+        /// <summary> On activation, ensure we are fully caught up with the latest version</summary>
+        public override Task OnActivateAsync()
+        {
+            return RefreshNow();
+        }
+
+        public Task<uint> Balance()
+        {
+            return Task.FromResult(State.Balance);
+        }
+
+        public Task Deposit(uint amount, Guid guid, string description)
+        {
+            RaiseEvent(new DepositTransaction() {
+                Guid = guid,
+                IssueTime = DateTime.UtcNow,
+                DepositAmount = amount,
+                Description = description
+            });
+
+            // we wait for storage ack
+            return ConfirmEvents();
+        }
+
+        public Task<bool> Withdraw(uint amount, Guid guid, string description)
+        {
+            // if the balance is too low, can't withdraw
+            // reject it immediately
+            if (State.Balance < amount)
+                return Task.FromResult(false);
+
+            // use a conditional event for withdrawal
+            // (conditional events commit only if the version hasn't already changed in the meantime)
+            // this is important so we can guarantee that we never overdraw
+            // even if racing with other clusters, of in transient duplicate grain situations
+            return RaiseConditionalEvent(new WithdrawalTransaction()
+            {
+                Guid = guid,
+                IssueTime = DateTime.UtcNow,
+                WithdrawalAmount = amount,
+                Description = description
+            });
+        }
+
+        public Task<IReadOnlyList<Transaction>> GetTransactionLog()
+        {
+            return RetrieveConfirmedEvents(0, ConfirmedVersion);
+        }
+    }
+
+    
+    /// A variant of the same grain that does not persist the log, but only the latest grain state
+    /// (so it does not do true event sourcing). 
+    [LogConsistencyProvider(ProviderName = "StateStorage")]
+    public class AccountGrain_PersistStateOnly : AccountGrain
+    {
+    }
+
+
+    /// A variant of the account grain that uses one instance per cluster
+    [OneInstancePerCluster]
+    public class AccountGrain_OneInstancePerCluster : AccountGrain
+    {
+    }
+
+    /// A variant of the account grain that uses a single global instance
+    [GlobalSingleInstance]
+    public class AccountGrain_SingleGlobalInstance : AccountGrain
+    {
+    }
+}

--- a/test/TestGrains/EventSourcing/ChatEvents.cs
+++ b/test/TestGrains/EventSourcing/ChatEvents.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using TestGrainInterfaces;
+
+namespace TestGrains
+{
+    /// <summary>
+    /// all chat events implement this interface, to define how each event changes the XML document
+    /// </summary>
+    public interface IChatEvent
+    {
+        void Update(XDocument document);
+    }
+
+    [Serializable]
+    public class CreatedEvent : IChatEvent
+    {
+        public DateTime Timestamp { get; set; }
+        public string Origin { get; set; }
+
+        public void Update(XDocument document)
+        {
+            document.Initialize(Timestamp, Origin);
+        }
+    }
+
+
+    [Serializable]
+    public class PostedEvent : IChatEvent
+    {
+        public Guid Guid { get; set; }
+        public string User { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string Text { get; set; }
+
+        public void Update(XDocument document)
+        {
+            var container = document.GetPostsContainer();
+            container.Add(ChatFormat.MakePost(Guid, User, Timestamp, Text));
+            document.EnforceLimit();
+        }
+    }
+
+    [Serializable]
+    public class DeletedEvent : IChatEvent
+    {
+        public Guid Guid { get; set; }
+
+        public void Update(XDocument document)
+        {
+            document.FindPost(Guid.ToString())?.Remove();
+        }
+    }
+
+    [Serializable]
+    public class EditedEvent : IChatEvent
+    {
+        public Guid Guid { get; set; }
+        public string Text { get; set; }
+
+        public void Update(XDocument document)
+        {
+            document.FindPost(Guid.ToString())?.ReplaceText(Text);
+        }
+    }
+}
+   

--- a/test/TestGrains/EventSourcing/ChatFormat.cs
+++ b/test/TestGrains/EventSourcing/ChatFormat.cs
@@ -1,0 +1,68 @@
+﻿using Orleans.Serialization;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace TestGrains
+{
+    /// <summary>
+    /// Encapsulate choices about how to format the chat XML document (schema).
+    /// Since a grain replays the event log whenever it is loaded,
+    /// it is possible to change this schema, without having to write an XML transformation
+    /// </summary>
+    public static class ChatFormat
+    {
+        public static void Initialize(this XDocument document, DateTime timestamp, string origin)
+        {
+            if (document.Nodes().Count() == 0)
+            {
+                document.Add(new XComment($"This chat room was created by {origin}"));
+                document.Add(new XElement("root",
+                    new XElement("created", timestamp.ToString("s", System.Globalization.CultureInfo.InvariantCulture)),
+                    new XElement("posts")));
+            }
+        }
+
+        public static XElement GetPostsContainer(this XDocument document)
+        {
+            return document.Element("root").Element("posts");
+        }
+
+        public static XElement MakePost(Guid guid, string user, DateTime timestamp, string text)
+        {
+            return new XElement("post", new XAttribute("id", guid.ToString()),
+                 new XElement("user", user),
+                 new XElement("timestamp", timestamp.ToString("s", System.Globalization.CultureInfo.InvariantCulture)),
+                 new XElement("text", text)
+            );
+        }
+
+        public static XElement FindPost(this XDocument document, string guid)
+        {
+            return document.GetPostsContainer()
+                       .Elements("post")
+                       .Where(x => x.Attribute("id").Value == guid)
+                       .FirstOrDefault();
+        }
+
+        public static void ReplaceText(this XElement post, string text)
+        {
+            post.Element("text").ReplaceAll(text);
+        }
+
+        public static void EnforceLimit(this XDocument document)
+        {
+            var container = document.GetPostsContainer();
+            if (container.Nodes().Count() > ChatFormat.MaxNumPosts)
+                container.Nodes().First().Remove();
+        }
+
+        public const int MaxNumPosts = 100;
+    }
+
+
+}

--- a/test/TestGrains/EventSourcing/ChatGrain.cs
+++ b/test/TestGrains/EventSourcing/ChatGrain.cs
@@ -63,7 +63,7 @@ namespace TestGrains
 
         public Task<XDocument> GetChat()
         {
-            return Task.FromResult(State);
+            return Task.FromResult(TentativeState);
         }
  
         public Task Post(Guid guid, string user, string text)

--- a/test/TestGrains/EventSourcing/ChatGrain.cs
+++ b/test/TestGrains/EventSourcing/ChatGrain.cs
@@ -1,0 +1,88 @@
+﻿using Orleans;
+using Orleans.EventSourcing;
+using Orleans.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using TestGrainInterfaces;
+
+namespace TestGrains
+{
+
+
+    /// <summary>
+    /// An example of a journaled grain implementing a chat.
+    /// The state of the grain is an XML document (System.Xml.Linq.XDocument).
+    /// 
+    /// Configured to use the default storage provider.
+    /// Configured to use the LogStorage consistency provider.
+    /// 
+    /// This means we persist all events; since events are replayed when a grain is loaded 
+    /// we can change the XML schema later
+    /// 
+    /// </summary>
+
+    [StorageProvider(ProviderName = "Default")]
+    [LogConsistencyProvider(ProviderName = "LogStorage")]
+    public class ChatGrain : JournaledGrain<XDocument, IChatEvent>, IChatGrain
+    {
+
+        // we want to ensure chats are correctly initialized when first used
+        // so we override the default activation, to insert a creation event if needed
+        public override async Task OnActivateAsync()
+        {
+            // first, wait for all events to be loaded from storage so we are caught up with the latest version
+            await RefreshNow();
+
+            // if the chat has not been initialized, do that now
+            if (Version == 0)
+            {
+                // we are using a conditional event (in case creation is racing with other clusters)
+                // (conditional events commit only if the version hasn't already changed in the meantime)
+                await RaiseConditionalEvent(new CreatedEvent()
+                {
+                    Timestamp = DateTime.UtcNow,
+                    Origin = typeof(ChatGrain).FullName
+                });
+            }
+        }
+
+        /// <summary>
+        /// in order to apply events correctly to the grain state, we 
+        /// must override the transition function
+        /// (because an XDocument object does not have an Apply function)
+        /// </summary>
+        protected override void TransitionState(XDocument state, IChatEvent @event)
+        {
+            @event.Update(state);
+        }
+
+
+        public Task<XDocument> GetChat()
+        {
+            return Task.FromResult(State);
+        }
+ 
+        public Task Post(Guid guid, string user, string text)
+        {
+            RaiseEvent(new PostedEvent() { Guid = guid, User = user, Text = text, Timestamp = DateTime.UtcNow });
+            return TaskDone.Done;
+        }
+
+        public Task Delete(Guid guid)
+        {
+            RaiseEvent(new DeletedEvent() { Guid = guid });
+            return TaskDone.Done;
+        }
+
+        public Task Edit(Guid guid, string text)
+        {
+            RaiseEvent(new EditedEvent() { Guid = guid, Text = text});
+            return TaskDone.Done;
+        }
+    }
+}
+

--- a/test/TestGrains/EventSourcing/CountersGrain.cs
+++ b/test/TestGrains/EventSourcing/CountersGrain.cs
@@ -1,0 +1,102 @@
+﻿using Orleans.Concurrency;
+using Orleans.EventSourcing;
+using Orleans.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TestGrainInterfaces;
+
+namespace TestGrains
+{
+    /// <summary>
+    /// An example of a journaled grain that counts statistics.
+    /// 
+    /// For configuration options, see derived classes in CountersGrainVariations.cs
+    /// </summary>
+    public class CountersGrain : JournaledGrain<CountersGrain.GrainState>, ICountersGrain
+    {
+        /// <summary>
+        /// The state of this grain is a dictionary that keeps a count for each key.
+        /// We define this as a nested class, just for scoping convenience.
+        /// </summary>
+        [Serializable]
+        public class GrainState
+        {
+            /// <summary>  the current count </summary>
+            public Dictionary<string, int> Counts { get; set; }
+
+            public GrainState()
+            {
+                Counts = new Dictionary<string, int>();
+            }
+
+            public void Apply(CountersGrain.UpdatedEvent e)
+            {
+                if (Counts.ContainsKey(e.Key))
+                    Counts[e.Key] += e.Amount;
+                else
+                    Counts.Add(e.Key, e.Amount);
+            }
+
+            public void Apply(CountersGrain.ResetAllEvent e)
+            {
+                Counts.Clear();
+            }
+        }
+
+        /// <summary>
+        /// An event representing a counter update
+        /// </summary>
+        [Serializable]
+        public class UpdatedEvent
+        {
+            public string Key { get; set; }
+            public int Amount { get; set; }
+        }
+
+        /// <summary>
+        /// An event representing a reset of all counters
+        /// </summary>
+        [Serializable]
+        public class ResetAllEvent
+        {
+        }
+
+        public async Task Add(string key, int amount, bool wait_till_persisted)
+        {
+            RaiseEvent(new UpdatedEvent() { Key = key, Amount = amount });
+
+            // optionally, wait until the event has been persisted to storage
+            if (wait_till_persisted)
+                await ConfirmEvents();
+        }
+
+        public async Task Reset(bool wait_till_persisted)
+        {
+            RaiseEvent(new ResetAllEvent());
+
+            // optionally, wait until the event has been persisted to storage
+            if (wait_till_persisted)
+                await ConfirmEvents();
+        }
+
+        public Task<int> Get(string key)
+        {
+            return Task.FromResult(State.Counts[key]);
+        }
+
+        public Task<IReadOnlyDictionary<string, int>> GetAll()
+        {
+            return Task.FromResult((IReadOnlyDictionary<string, int>)State.Counts);
+        }
+
+
+        // some providers allow you to look at the log of events
+        public Task<IReadOnlyList<object>> GetAllEvents()
+        {
+            return RetrieveConfirmedEvents(0, ConfirmedVersion);
+        }
+    }
+}

--- a/test/TestGrains/EventSourcing/CountersGrain.cs
+++ b/test/TestGrains/EventSourcing/CountersGrain.cs
@@ -84,19 +84,19 @@ namespace TestGrains
 
         public Task<int> Get(string key)
         {
-            return Task.FromResult(State.Counts[key]);
+            return Task.FromResult(TentativeState.Counts[key]);
         }
 
         public Task<IReadOnlyDictionary<string, int>> GetAll()
         {
-            return Task.FromResult((IReadOnlyDictionary<string, int>)State.Counts);
+            return Task.FromResult((IReadOnlyDictionary<string, int>)TentativeState.Counts);
         }
 
 
         // some providers allow you to look at the log of events
         public Task<IReadOnlyList<object>> GetAllEvents()
         {
-            return RetrieveConfirmedEvents(0, ConfirmedVersion);
+            return RetrieveConfirmedEvents(0, Version);
         }
     }
 }

--- a/test/TestGrains/EventSourcing/CountersGrain.cs
+++ b/test/TestGrains/EventSourcing/CountersGrain.cs
@@ -64,32 +64,43 @@ namespace TestGrains
         {
         }
 
-        public async Task Add(string key, int amount, bool wait_till_persisted)
+        public async Task Add(string key, int amount, bool wait_for_confirmation)
         {
             RaiseEvent(new UpdatedEvent() { Key = key, Amount = amount });
 
             // optionally, wait until the event has been persisted to storage
-            if (wait_till_persisted)
+            if (wait_for_confirmation)
                 await ConfirmEvents();
         }
 
-        public async Task Reset(bool wait_till_persisted)
+        public async Task Reset(bool wait_for_confirmation)
         {
             RaiseEvent(new ResetAllEvent());
 
             // optionally, wait until the event has been persisted to storage
-            if (wait_till_persisted)
+            if (wait_for_confirmation)
                 await ConfirmEvents();
         }
 
-        public Task<int> Get(string key)
+        public Task ConfirmAllPreviouslyRaisedEvents()
         {
-            return Task.FromResult(TentativeState.Counts[key]);
+            return ConfirmEvents();
+        }
+            
+
+        public Task<int> GetTentativeCount(string key)
+        {
+            return Task.FromResult(State.Counts[key]);
         }
 
-        public Task<IReadOnlyDictionary<string, int>> GetAll()
+        public Task<IReadOnlyDictionary<string, int>> GetTentativeState()
         {
             return Task.FromResult((IReadOnlyDictionary<string, int>)TentativeState.Counts);
+        }
+
+        public Task<IReadOnlyDictionary<string, int>> GetConfirmedState()
+        {
+            return Task.FromResult((IReadOnlyDictionary<string, int>)State.Counts);
         }
 
 

--- a/test/TestGrains/EventSourcing/CountersGrainVariations.cs
+++ b/test/TestGrains/EventSourcing/CountersGrainVariations.cs
@@ -1,0 +1,56 @@
+﻿using Orleans.Concurrency;
+using Orleans.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestGrains
+{
+    // we define four variants of the CountersGrain that have different configurations.
+    //
+    // all variants use the SlowMemoryStore storage provider; it delays all storage accesses by 10ms
+    // to simulate cloud storage latency
+    //
+    // the other configurations pick all four combinations of:
+    // state vs. log storage
+    // reentrant vs. non-reentrant
+
+    /// When using the StateStorage consistency provider, we persist the latest state only ... we are 
+    /// not truly "event sourcing", as we do not want to persist 
+    /// the events, but only state snapshots.
+    /// 
+    /// When using the LogStorage consistency provider, we persist the log,
+    /// i.e. the complete sequence of all events
+ 
+    [LogConsistencyProvider(ProviderName = "StateStorage")]
+    [StorageProvider(ProviderName = "SlowMemoryStore")]
+    public class CountersGrain_StateStore_NonReentrant : CountersGrain
+    {
+    }
+
+    [LogConsistencyProvider(ProviderName = "StateStorage")]
+    [StorageProvider(ProviderName = "SlowMemoryStore")]
+    [Reentrant]
+    public class CountersGrain_StateStore_Reentrant : CountersGrain
+    {
+    }
+    
+    [LogConsistencyProvider(ProviderName = "LogStorage")]
+    [StorageProvider(ProviderName = "SlowMemoryStore")]
+    public class CountersGrain_LogStore_NonReentrant : CountersGrain
+    {
+    }
+
+    [LogConsistencyProvider(ProviderName = "LogStorage")]
+    [StorageProvider(ProviderName = "SlowMemoryStore")]
+    [Reentrant]
+    public class CountersGrain_LogStore_Reentrant : CountersGrain
+    {
+    }
+
+ 
+
+
+}

--- a/test/TestGrains/EventSourcing/PersonEvents.cs
+++ b/test/TestGrains/EventSourcing/PersonEvents.cs
@@ -3,7 +3,10 @@ using TestGrainInterfaces;
 
 namespace TestGrains
 {
-    // we use a marker interface, so we get a bit more typechecking than with plain objects
+    // We list all the events supported by the JournaledPersonGrain 
+
+    // we chose to have all these events implement the following marker interface
+    // (this is optional, but gives us a bit more typechecking)
     public interface IPersonEvent { } 
 
     [Serializable]

--- a/test/TestGrains/EventSourcing/PersonGrain.cs
+++ b/test/TestGrains/EventSourcing/PersonGrain.cs
@@ -9,7 +9,7 @@ using Orleans.Runtime;
 
 namespace TestGrains
 {
-    public class JournaledPersonGrain : JournaledGrain<PersonState,IPersonEvent>, IJournaledPersonGrain
+    public class PersonGrain : JournaledGrain<PersonState,IPersonEvent>, IPersonGrain
     {
 
         public Task RegisterBirth(PersonAttributes props)
@@ -24,7 +24,7 @@ namespace TestGrains
             return TaskDone.Done;
         }
 
-        public async Task Marry(IJournaledPersonGrain spouse)
+        public async Task Marry(IPersonGrain spouse)
         {
             if (State.IsMarried)
                 throw new NotSupportedException(string.Format("{0} is already married.", State.LastName));
@@ -87,11 +87,17 @@ namespace TestGrains
             return Task.FromResult(Version);
         }
 
+
+
+        // below is a unit test; ideally this code would be in the Tester project,
+        // but this test has to run on the grain, not the client, so we had to add it here
+
         private static void AssertEqual<T>(T a, T b)
         {
             if (!Object.Equals(a, b))
                 throw new OrleansException($"Test failed. Expected = {a}. Actual = {b}.");
         }
+
 
         public async Task RunTentativeConfirmedStateTest()
         {
@@ -129,6 +135,7 @@ namespace TestGrains
             AssertEqual("Solo", State.LastName);
 
             // this time, we wait for (what should be) enough time to commit to MemoryStorage.
+            // we would never use such timing assumptions in real code. But this is a unit test.
             await Task.Delay(20);
 
             // now the two versions should be the same again

--- a/test/TestGrains/EventSourcing/PersonGrain.cs
+++ b/test/TestGrains/EventSourcing/PersonGrain.cs
@@ -6,6 +6,7 @@ using Orleans.Providers;
 using TestGrainInterfaces;
 using System.Collections.Generic;
 using Orleans.Runtime;
+using System.Linq;
 
 namespace TestGrains
 {
@@ -29,7 +30,7 @@ namespace TestGrains
             if (State.IsMarried)
                 throw new NotSupportedException(string.Format("{0} is already married.", State.LastName));
 
-            var spouseData = await spouse.GetPersonalAttributes();
+            var spouseData = await spouse.GetTentativePersonalAttributes();
 
             var events = new List<IPersonEvent>();
 
@@ -40,14 +41,17 @@ namespace TestGrains
                 events.Add(new PersonLastNameChanged(spouseData.LastName));
             }
 
+            // issue all events atomically
             RaiseEvents(events);
-
             await ConfirmEvents();
         }
 
         public Task ChangeLastName(string lastName)
         {
             RaiseEvent(new PersonLastNameChanged(lastName));
+
+            // we are not confirming this event here!
+            // therefore, the tentative state and the confirmed state can differ for some time
 
             return TaskDone.Done;
         }
@@ -57,7 +61,17 @@ namespace TestGrains
             return ConfirmEvents();
         }
 
-        public Task<PersonAttributes> GetPersonalAttributes()
+        public Task<PersonAttributes> GetTentativePersonalAttributes()
+        {
+            return Task.FromResult(new PersonAttributes
+            {
+                FirstName = TentativeState.FirstName,
+                LastName = TentativeState.LastName,
+                Gender = TentativeState.Gender
+            });
+        }
+
+        public Task<PersonAttributes> GetConfirmedPersonalAttributes()
         {
             return Task.FromResult(new PersonAttributes
             {
@@ -67,27 +81,23 @@ namespace TestGrains
             });
         }
 
-        public Task<PersonAttributes> GetConfirmedPersonalAttributes()
-        {
-            return Task.FromResult(new PersonAttributes
-            {
-                FirstName = ConfirmedState.FirstName,
-                LastName = ConfirmedState.LastName,
-                Gender = ConfirmedState.Gender
-            });
-        }
-
         public Task<int> GetConfirmedVersion()
-        {
-            return Task.FromResult(ConfirmedVersion);
-        }
-
-        public Task<int> GetVersion()
         {
             return Task.FromResult(Version);
         }
 
+        public Task<int> GetTentativeVersion()
+        {
+            return Task.FromResult(TentativeVersion);
+        }
 
+        private int TentativeVersion
+        {
+            get
+            {
+                return Version + UnconfirmedEvents.Count();
+            }
+        }
 
         // below is a unit test; ideally this code would be in the Tester project,
         // but this test has to run on the grain, not the client, so we had to add it here
@@ -102,47 +112,47 @@ namespace TestGrains
         public async Task RunTentativeConfirmedStateTest()
         {
             // initially both the confirmed version and the tentative version are the same: version 0
-            AssertEqual(0, ConfirmedVersion);
             AssertEqual(0, Version);
-            AssertEqual(null, ConfirmedState.LastName);
+            AssertEqual(0, TentativeVersion);
             AssertEqual(null, State.LastName);
+            AssertEqual(null, TentativeState.LastName);
 
             // now we change the last name
             await ChangeLastName("Organa");
 
             // while the udpate is pending, the confirmed version and the tentative version are different
-            AssertEqual(0, ConfirmedVersion);
-            AssertEqual(1, Version);
-            AssertEqual(null, ConfirmedState.LastName);
-            AssertEqual("Organa", State.LastName);
+            AssertEqual(0, Version);
+            AssertEqual(1, TentativeVersion);
+            AssertEqual(null, State.LastName);
+            AssertEqual("Organa", TentativeState.LastName);
 
             // let's wait until the update has been confirmed.
             await ConfirmChanges();
 
             // now the two versions are the same again
-            AssertEqual(1, ConfirmedVersion);
             AssertEqual(1, Version);
-            AssertEqual("Organa", ConfirmedState.LastName);
+            AssertEqual(1, TentativeVersion);
             AssertEqual("Organa", State.LastName);
+            AssertEqual("Organa", TentativeState.LastName);
 
             // issue another change
             await ChangeLastName("Solo");
 
             // again, the confirmed and the tentative versions are different
-            AssertEqual(1, ConfirmedVersion);
-            AssertEqual(2, Version);
-            AssertEqual("Organa", ConfirmedState.LastName);
-            AssertEqual("Solo", State.LastName);
+            AssertEqual(1, Version);
+            AssertEqual(2, TentativeVersion);
+            AssertEqual("Organa", State.LastName);
+            AssertEqual("Solo", TentativeState.LastName);
 
             // this time, we wait for (what should be) enough time to commit to MemoryStorage.
             // we would never use such timing assumptions in real code. But this is a unit test.
             await Task.Delay(20);
 
             // now the two versions should be the same again
-            AssertEqual(2, ConfirmedVersion);
             AssertEqual(2, Version);
-            AssertEqual("Solo", ConfirmedState.LastName);
+            AssertEqual(2, TentativeVersion);
             AssertEqual("Solo", State.LastName);
+            AssertEqual("Solo", TentativeState.LastName);
         }
     }
 }

--- a/test/TestGrains/EventSourcing/SeatReservationGrain.cs
+++ b/test/TestGrains/EventSourcing/SeatReservationGrain.cs
@@ -41,8 +41,8 @@ namespace TestGrains
 
             // we can determine if the reservation went through
             // by re-reading it - if it is not there, it means a different user won
-            var success = (ConfirmedState.Reservations.ContainsKey(seatnumber)
-                                 && ConfirmedState.Reservations[seatnumber].UserId == userid);
+            var success = (State.Reservations.ContainsKey(seatnumber)
+                                 && State.Reservations[seatnumber].UserId == userid);
             return success;
         }
     }

--- a/test/TestGrains/EventSourcing/SeatReservationGrain.cs
+++ b/test/TestGrains/EventSourcing/SeatReservationGrain.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+using TestGrainInterfaces;
+using Orleans.Providers;
+using Orleans.EventSourcing;
+using Orleans.MultiCluster;
+
+namespace TestGrains
+{
+
+
+    /// <summary>
+    /// An example of a journaled grain that records seat reservations.
+    /// 
+    /// Configured to have one instance per cluster.
+    /// Configured to use the default storage provider.
+    /// Configured to use the StateStorage consistency provider.
+    /// 
+    /// This means we persist the latest state only ... we are not truly "event sourcing".
+    /// It is not necessary here to persist all events, as the state already stores all the successful reservations.
+    /// 
+    /// </summary>
+    
+    [OneInstancePerCluster]
+    [StorageProvider(ProviderName = "Default")]
+    [LogConsistencyProvider(ProviderName = "StateStorage")]
+    public class SeatReservationGrain : JournaledGrain<ReservationState,SeatReservation>, ISeatReservationGrain
+    {
+      
+        public async Task<bool> Reserve(int seatnumber, string userid)
+        {
+            // first, enqueue the request
+            RaiseEvent(new SeatReservation() { Seat = seatnumber, UserId = userid });
+
+            // then, wait for the request to propagate
+            await ConfirmEvents();
+
+            // we can determine if the reservation went through
+            // by re-reading it - if it is not there, it means a different user won
+            var success = (ConfirmedState.Reservations.ContainsKey(seatnumber)
+                                 && ConfirmedState.Reservations[seatnumber].UserId == userid);
+            return success;
+        }
+    }
+
+
+    /// <summary>
+    /// The state of the reservation grain
+    /// </summary>
+    [Serializable]
+    public class ReservationState
+    {
+        public Dictionary<int, SeatReservation> Reservations { get; set; }
+
+        public ReservationState()
+        {
+            Reservations = new Dictionary<int, SeatReservation>();
+        }
+
+        void Apply(SeatReservation reservation)
+        {
+            // see if this reservation targets an available seat
+            // otherwise, treat it as a no-op
+            // (this is a "first writer wins" conflict resolution)
+            if (!Reservations.ContainsKey(reservation.Seat))
+                Reservations.Add(reservation.Seat, reservation);
+        }
+    }
+
+    /// <summary>
+    /// The class that defines the update operation when a reservation is requested
+    /// </summary>
+    [Serializable]
+    public class SeatReservation
+    {
+        public int Seat { get; set; }
+        public string UserId { get; set; }
+    }
+
+
+}
+

--- a/test/TestGrains/LogConsistentGrain.cs
+++ b/test/TestGrains/LogConsistentGrain.cs
@@ -71,7 +71,7 @@ namespace TestGrains
 
         public async Task<Tuple<int, bool>> SetAConditional(int x)
         {
-            int version = this.ConfirmedVersion;
+            int version = this.Version;
             bool success = await RaiseConditionalEvent(new UpdateA() { Val = x });
             return new Tuple<int, bool>(version, success);
         }
@@ -109,23 +109,23 @@ namespace TestGrains
         public async Task<int> GetAGlobal()
         {
             await RefreshNow();
-            return ConfirmedState.A;
+            return State.A;
         }
 
         public Task<int> GetALocal()
         {
-            return Task.FromResult(State.A);
+            return Task.FromResult(TentativeState.A);
         }
 
         public async Task<AB> GetBothGlobal()
         {
             await RefreshNow();
-            return new AB() { A = ConfirmedState.A, B = ConfirmedState.B };
+            return new AB() { A = State.A, B = State.B };
         }
 
         public Task<AB> GetBothLocal()
         {
-            return Task.FromResult(new AB() { A = State.A, B = State.B });
+            return Task.FromResult(new AB() { A = TentativeState.A, B = TentativeState.B });
         }
 
         public Task AddReservationLocal(int val)
@@ -143,7 +143,7 @@ namespace TestGrains
         public async Task<int[]> GetReservationsGlobal()
         {
             await RefreshNow();
-            return ConfirmedState.Reservations.Values.ToArray();
+            return State.Reservations.Values.ToArray();
         }
 
         public Task SynchronizeGlobalState()
@@ -153,7 +153,7 @@ namespace TestGrains
 
         public Task<int> GetConfirmedVersion()
         {
-            return Task.FromResult(this.ConfirmedVersion);
+            return Task.FromResult(this.Version);
         }
 
         public Task<IEnumerable<ConnectionIssue>> GetUnresolvedConnectionIssues()
@@ -164,13 +164,13 @@ namespace TestGrains
         public async Task<KeyValuePair<int, object>> Read()
         {
             await RefreshNow();
-            return new KeyValuePair<int, object>(ConfirmedVersion, ConfirmedState);
+            return new KeyValuePair<int, object>(Version, State);
         }
         public async Task<bool> Update(IReadOnlyList<object> updates, int expectedversion)
         {
-            if (expectedversion > ConfirmedVersion)
+            if (expectedversion > Version)
                 await RefreshNow();
-            if (expectedversion != ConfirmedVersion)
+            if (expectedversion != Version)
                 return false;
             return await RaiseConditionalEvents(updates);
         }
@@ -182,7 +182,7 @@ namespace TestGrains
         }
 
         public Task<IReadOnlyList<object>> GetEventLog() {
-            return this.RetrieveConfirmedEvents(0, ConfirmedVersion);
+            return this.RetrieveConfirmedEvents(0, Version);
         }
 
     }

--- a/test/TestGrains/LogConsistentGrain.cs
+++ b/test/TestGrains/LogConsistentGrain.cs
@@ -7,9 +7,14 @@ using Orleans.LogConsistency;
 using UnitTests.GrainInterfaces;
 using Orleans.EventSourcing;
 
-namespace UnitTests.Grains
+namespace TestGrains
 {
-
+    /// <summary>
+    /// A class used by many different unit tests for the various log consistency providers.
+    /// The content of this class is pretty arbitrary and messy;
+    /// (don't use this as an introduction on how to use JournaledGrain)
+    /// it started from SimpleGrain, but a lot of stuff got added over time 
+    /// </summary>
     [Serializable]
     public class MyGrainState
     {
@@ -56,7 +61,7 @@ namespace UnitTests.Grains
     /// and a dictionary of reservations thatcan be aded and removed
     /// We subclass this to create variations for all storage providers
     /// </summary>
-    public abstract class LogConsistentGrain : JournaledGrain<MyGrainState,object>, GrainInterfaces.ILogConsistentGrain
+    public abstract class LogConsistentGrain : JournaledGrain<MyGrainState,object>, UnitTests.GrainInterfaces.ILogConsistentGrain
     {
         public async Task SetAGlobal(int x)
         {
@@ -174,6 +179,10 @@ namespace UnitTests.Grains
         {
             DeactivateOnIdle();
             return TaskDone.Done;
+        }
+
+        public Task<IReadOnlyList<object>> GetEventLog() {
+            return this.RetrieveConfirmedEvents(0, ConfirmedVersion);
         }
 
     }

--- a/test/TestGrains/LogConsistentGrainVariations.cs
+++ b/test/TestGrains/LogConsistentGrainVariations.cs
@@ -70,12 +70,12 @@ namespace TestGrains
         }
  
 
-        public Task<bool> ApplyUpdatesToStorageAsync(IReadOnlyList<object> updates, int expectedversion)
+        public Task<bool> ApplyUpdatesToStorage(IReadOnlyList<object> updates, int expectedversion)
         {
             return GetStorageGrain().Update(updates, expectedversion);
         }
 
-        public async Task<KeyValuePair<int, MyGrainState>> ReadStateFromStorageAsync()
+        public async Task<KeyValuePair<int, MyGrainState>> ReadStateFromStorage()
         {
             var kvp = await GetStorageGrain().Read();
             return new KeyValuePair<int, MyGrainState>(kvp.Key, (MyGrainState)kvp.Value);
@@ -104,7 +104,7 @@ namespace TestGrains
         }
 
 
-        public Task<bool> ApplyUpdatesToStorageAsync(IReadOnlyList<object> updates, int expectedversion)
+        public Task<bool> ApplyUpdatesToStorage(IReadOnlyList<object> updates, int expectedversion)
         {
             if (state == null)
             {
@@ -124,7 +124,7 @@ namespace TestGrains
             return Task.FromResult(true);
         }
 
-        public Task<KeyValuePair<int, MyGrainState>> ReadStateFromStorageAsync()
+        public Task<KeyValuePair<int, MyGrainState>> ReadStateFromStorage()
         {
             if (state == null)
             {

--- a/test/TestGrains/LogConsistentGrainVariations.cs
+++ b/test/TestGrains/LogConsistentGrainVariations.cs
@@ -9,8 +9,9 @@ using System.Text;
 using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
 
-namespace UnitTests.Grains
+namespace TestGrains
 {
+    // variations of the log consistent grain are used to test a variety of provider and configurations
 
     // use azure storage and a explicitly configured consistency provider
     [OneInstancePerCluster]

--- a/test/TestGrains/LogTestGrain.cs
+++ b/test/TestGrains/LogTestGrain.cs
@@ -61,7 +61,7 @@ namespace TestGrains
     /// and a dictionary of reservations thatcan be aded and removed
     /// We subclass this to create variations for all storage providers
     /// </summary>
-    public abstract class LogConsistentGrain : JournaledGrain<MyGrainState,object>, UnitTests.GrainInterfaces.ILogConsistentGrain
+    public abstract class LogTestGrain : JournaledGrain<MyGrainState,object>, UnitTests.GrainInterfaces.ILogTestGrain
     {
         public async Task SetAGlobal(int x)
         {

--- a/test/TestGrains/LogTestGrainVariations.cs
+++ b/test/TestGrains/LogTestGrainVariations.cs
@@ -17,7 +17,7 @@ namespace TestGrains
     [OneInstancePerCluster]
     [StorageProvider(ProviderName = "AzureStore")]
     [LogConsistencyProvider(ProviderName = "StateStorage")]
-    public class LogConsistentGrainSharedStateStorage : LogConsistentGrain
+    public class LogTestGrainSharedStateStorage : LogTestGrain
     {
     }
 
@@ -25,13 +25,13 @@ namespace TestGrains
     [OneInstancePerCluster]
     [StorageProvider(ProviderName = "AzureStore")]
     [LogConsistencyProvider(ProviderName = "LogStorage")]
-    public class LogConsistentGrainSharedLogStorage : LogConsistentGrain
+    public class LogTestGrainSharedLogStorage : LogTestGrain
     {
     }
 
     // use the default storage provider as the shared storage
     [OneInstancePerCluster]
-    public class LogConsistentGrainDefaultStorage : LogConsistentGrain
+    public class LogTestGrainDefaultStorage : LogTestGrain
     {
     }
 
@@ -39,32 +39,32 @@ namespace TestGrains
     [GlobalSingleInstance]
     [StorageProvider(ProviderName = "AzureStore")]
     [LogConsistencyProvider(ProviderName = "StateStorage")]
-    public class GsiLogConsistentGrain : LogConsistentGrain
+    public class GsiLogTestGrain : LogTestGrain
     {
     }
 
     // use MemoryStore (which uses GSI grain)
     [OneInstancePerCluster]
     [StorageProvider(ProviderName = "MemoryStore")]
-    public class LogConsistentGrainMemoryStorage : LogConsistentGrain
+    public class LogTestGrainMemoryStorage : LogTestGrain
     {
     }
 
     // use the explictly specified "CustomStorage" log-consistency provider with symmetric access from all clusters
     [OneInstancePerCluster]
     [LogConsistencyProvider(ProviderName = "CustomStorage")]
-    public class LogConsistentGrainCustomStorage : LogConsistentGrain,
+    public class LogTestGrainCustomStorage : LogTestGrain,
         Orleans.EventSourcing.CustomStorage.ICustomStorageInterface<MyGrainState, object>
     {
 
         // we use another impl of this grain as the primary.
-        private ILogConsistentGrain storagegrain;
+        private ILogTestGrain storagegrain;
 
-        private ILogConsistentGrain GetStorageGrain()
+        private ILogTestGrain GetStorageGrain()
         {
             if (storagegrain == null)
             {
-                storagegrain = GrainFactory.GetGrain<ILogConsistentGrain>(this.GetPrimaryKeyLong(), "UnitTests.Grains.LogConsistentGrainSharedStateStorage");
+                storagegrain = GrainFactory.GetGrain<ILogTestGrain>(this.GetPrimaryKeyLong(), "TestGrains.LogTestGrainSharedStateStorage");
             }
             return storagegrain;
         }
@@ -85,7 +85,7 @@ namespace TestGrains
     // use the explictly specified "CustomStorage" log-consistency provider with access from primary cluster only
     [OneInstancePerCluster]
     [LogConsistencyProvider(ProviderName = "CustomStoragePrimaryCluster")]
-    public class LogConsistentGrainCustomStoragePrimaryCluster : LogConsistentGrain,
+    public class LogTestGrainCustomStoragePrimaryCluster : LogTestGrain,
         Orleans.EventSourcing.CustomStorage.ICustomStorageInterface<MyGrainState, object>
     {
 

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.XML" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs">
@@ -61,6 +62,13 @@
     <Compile Include="ConsumerEventCountingGrain.cs" />
     <Compile Include="DeadlockGrain.cs" />
     <Compile Include="DerivedServiceType.cs" />
+    <Compile Include="EventSourcing\AccountGrain.cs" />
+    <Compile Include="EventSourcing\ChatFormat.cs" />
+    <Compile Include="EventSourcing\ChatEvents.cs" />
+    <Compile Include="EventSourcing\ChatGrain.cs" />
+    <Compile Include="EventSourcing\CountersGrain.cs" />
+    <Compile Include="EventSourcing\CountersGrainVariations.cs" />
+    <Compile Include="EventSourcing\SeatReservationGrain.cs" />
     <Compile Include="GrainService\CustomGrainService.cs" />
     <Compile Include="GrainService\GrainServiceTestGrain.cs" />
     <Compile Include="RoundtripSerializationGrain.cs" />
@@ -87,8 +95,8 @@
     <Compile Include="KeyExtensionTestGrain.cs" />
     <Compile Include="JsonEchoGrain.cs" />
     <Compile Include="MultipleImplicitSubscriptionGrain.cs" />
-    <Compile Include="EventSourcing\JournaledPersonGrain.cs" />
-    <Compile Include="EventSourcing\JournaledPerson_Events.cs" />
+    <Compile Include="EventSourcing\PersonGrain.cs" />
+    <Compile Include="EventSourcing\PersonEvents.cs" />
     <Compile Include="MyObserverSubscriptionManager.cs" />
     <Compile Include="PolymorphicTestGrain.cs" />
     <Compile Include="ProducerEventCountingGrain.cs" />

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -123,11 +123,11 @@
     <Compile Include="ObserverGrain.cs" />
     <Compile Include="SimpleGrain.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="LogConsistentGrain.cs" />
+    <Compile Include="LogTestGrain.cs" />
     <Compile Include="SimplePersistentGrain.cs" />
     <Compile Include="GrainInterfaceHierarchyGrains.cs" />
     <Compile Include="LivenessTestGrain.cs" />
-    <Compile Include="LogConsistentGrainVariations.cs" />
+    <Compile Include="LogTestGrainVariations.cs" />
     <Compile Include="SpecializedSimpleGenericGrain.cs" />
     <Compile Include="StatsCollectorGrain.cs" />
     <Compile Include="StreamCheckpoint.cs" />

--- a/test/Tester/EventSourcingTests/AccountGrainTests.cs
+++ b/test/Tester/EventSourcingTests/AccountGrainTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Linq;
+using Orleans;
+using TestGrainInterfaces;
+using Xunit;
+using Assert = Xunit.Assert;
+using TestExtensions;
+using Xunit.Abstractions;
+using Orleans.Runtime;
+
+namespace Tester.EventSourcingTests
+{
+    public class AccountGrainTests : IClassFixture<EventSourcingClusterFixture>
+    {
+
+        public async Task TestSequence(IAccountGrain account, bool hasLogStored)
+        {
+            Assert.Equal(0u, await account.Balance());
+
+            var initialdepositguid = Guid.NewGuid();
+            await account.Deposit(100, initialdepositguid, "initial deposit");
+
+            Assert.Equal(100u, await account.Balance());
+
+            var firstwithdrawalguid = Guid.NewGuid();
+            var success = await account.Withdraw(70, firstwithdrawalguid, "first withdrawal");
+
+            Assert.True(success);
+            Assert.Equal(30u, await account.Balance());
+
+            var secondwithdrawalguid = Guid.NewGuid();
+            success = await account.Withdraw(70, secondwithdrawalguid, "second withdrawal");
+
+            Assert.False(success);
+            Assert.Equal(30u, await account.Balance());
+
+            if (hasLogStored)
+            {
+                // check the transaction log
+                var log = await account.GetTransactionLog();
+
+                Assert.Equal(2, log.Count());
+                Assert.Equal(initialdepositguid, log[0].Guid);
+                Assert.Equal("initial deposit", log[0].Description);
+                Assert.Equal(firstwithdrawalguid, log[1].Guid);
+                Assert.Equal("first withdrawal", log[1].Description);
+                Assert.True(log[0].IssueTime < log[1].IssueTime);
+            }
+            else
+            {
+                await Assert.ThrowsAsync(typeof(NotSupportedException), 
+                    async () => await account.GetTransactionLog());
+            }
+        }
+
+        [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
+        public async Task AccountWithLog()
+        {
+            var account = GrainClient.GrainFactory.GetGrain<IAccountGrain>($"Account-{Guid.NewGuid()}", "TestGrains.AccountGrain");
+            await TestSequence(account, true);
+        }
+
+
+        [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
+        public async Task AccountWithoutLog()
+        {
+            var account = GrainClient.GrainFactory.GetGrain<IAccountGrain>($"Account-{Guid.NewGuid()}", "TestGrains.AccountGrain_PersistStateOnly");
+            await TestSequence(account, false);
+        }
+
+    }
+}

--- a/test/Tester/EventSourcingTests/ChatGrainTests.cs
+++ b/test/Tester/EventSourcingTests/ChatGrainTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Linq;
+using Orleans;
+using TestGrainInterfaces;
+using Xunit;
+using Assert = Xunit.Assert;
+using TestExtensions;
+using Xunit.Abstractions;
+using Orleans.Runtime;
+using System.Xml.Linq;
+using System.IO;
+using TestGrains;
+
+namespace Tester.EventSourcingTests
+{
+    public class ChatGrainTests : IClassFixture<EventSourcingClusterFixture>
+    {
+        [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
+        public async Task Init()
+        {
+            var chat = GrainClient.GrainFactory.GetGrain<IChatGrain>($"Chatroom-{Guid.NewGuid()}");
+
+            var content = (await chat.GetChat()).ToString();
+
+            var expectedprefix = "<!--This chat room was created by TestGrains.ChatGrain-->\r\n<root>\r\n  <created>";
+            var expectedsuffix = "</created>\r\n  <posts />\r\n</root>";
+ 
+            Assert.True(content.StartsWith(expectedprefix));
+            Assert.True(content.EndsWith(expectedsuffix));
+        }
+
+        [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
+        public async Task PostThenDelete()
+        {
+            var chat = GrainClient.GrainFactory.GetGrain<IChatGrain>($"Chatroom-{Guid.NewGuid()}");
+            var guid = Guid.NewGuid();
+
+            await chat.Post(guid, "Famous Athlete", "I am retiring");
+
+            {
+                var content = (await chat.GetChat()).ToString();
+                var doc = XDocument.Load(new StringReader(content));
+                var container = doc.GetPostsContainer();
+                Assert.Equal(1, container.Elements("post").Count());
+            }
+
+            await chat.Delete(guid);
+
+            {
+                var content = (await chat.GetChat()).ToString();
+                var doc = XDocument.Load(new StringReader(content));
+                var container = doc.GetPostsContainer();
+                Assert.Equal(0, container.Elements("post").Count());
+            }
+        }
+
+        [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
+        public async Task PostThenEdit()
+        {
+            var chat = GrainClient.GrainFactory.GetGrain<IChatGrain>($"Chatroom-{Guid.NewGuid()}");
+            var guid = Guid.NewGuid();
+
+            await chat.Post(Guid.NewGuid(), "asdf", "asdf");
+            await chat.Post(guid, "Famous Athlete", "I am retiring");
+            await chat.Post(Guid.NewGuid(), "456", "456");
+
+            {
+                var content = (await chat.GetChat()).ToString();
+                var doc = XDocument.Load(new StringReader(content));
+                var container = doc.GetPostsContainer();
+                Assert.Equal(3, container.Elements("post").Count());
+            }
+
+            await chat.Edit(guid, "I am not retiring");
+
+            {
+                var content = (await chat.GetChat()).ToString();
+                var doc = XDocument.Load(new StringReader(content));
+                var container = doc.GetPostsContainer();
+                Assert.Equal(3, container.Elements("post").Count());
+                var post = doc.FindPost(guid.ToString());
+                Assert.Equal("I am not retiring", post.Element("text").Value);
+            }
+        }
+
+        [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
+        public async Task Truncate()
+        {
+            var chat = GrainClient.GrainFactory.GetGrain<IChatGrain>($"Chatroom-{Guid.NewGuid()}");
+
+            for (int i = 0; i < ChatFormat.MaxNumPosts + 10; i++)
+                await chat.Post(Guid.NewGuid(), i.ToString(), i.ToString());
+
+            {
+                var content = (await chat.GetChat()).ToString();
+                var doc = XDocument.Load(new StringReader(content));
+                var container = doc.GetPostsContainer();
+                Assert.Equal(ChatFormat.MaxNumPosts, container.Elements("post").Count());
+            }
+        }
+
+    }
+}

--- a/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
+++ b/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
@@ -14,13 +14,24 @@ using Xunit.Sdk;
 
 namespace Tester.EventSourcingTests
 {
-    [TestCaseOrderer("SimplePriorityOrderer", "Tester")]
+    [TestCaseOrderer("Tester.EventSourcingTests.SimplePriorityOrderer", "Tester")]
     public partial class CountersGrainTests
     {
 
         // you can look at the time taken by each of the tests below
         // to get a rough idea on how the synchronization choices, and the configuration parameters,
         // and the consistency provider, affect throughput
+
+        // To run these perf tests from within visual studio, first type
+        // "CountersGrainTests.Perf" in the search box, and then "Run All"
+        // This will run the warmup and then all tests, in the same test cluster. Afterwards it reports
+        // approximate time taken for each. It's not really a test, just an
+        // illustration of how JournaledGrain performance can vary with the choices made.
+
+        // what you should see is:
+        // - the conservative approach (confirm each update, disallow reentrancy) is slow.
+        // - confirming at end only, instead of after each update, is fast.
+        // - allowing reentrancy, while still confirming after each update, is also fast. 
 
         private int iterations = 800;
 

--- a/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
+++ b/test/Tester/EventSourcingTests/CountersGrainPerfTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using System.Linq;
+using Orleans;
+using TestGrainInterfaces;
+using Xunit;
+using Assert = Xunit.Assert;
+using TestExtensions;
+using Xunit.Abstractions;
+using Orleans.Runtime;
+using System.Collections.Generic;
+using Xunit.Sdk;
+
+namespace Tester.EventSourcingTests
+{
+    [TestCaseOrderer("SimplePriorityOrderer", "Tester")]
+    public partial class CountersGrainTests
+    {
+
+        // you can look at the time taken by each of the tests below
+        // to get a rough idea on how the synchronization choices, and the configuration parameters,
+        // and the consistency provider, affect throughput
+
+        private int iterations = 800;
+
+        [Fact, RunThisFirst, TestCategory("EventSourcing")]
+        public Task Perf_Warmup()
+        {
+            // call reset on each grain to ensure everything is loaded and primed
+            return Task.WhenAll(
+                GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_StateStore_NonReentrant").Reset(true),
+                GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_StateStore_Reentrant").Reset(true),
+                GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_LogStore_NonReentrant").Reset(true),
+                GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_LogStore_Reentrant").Reset(true)
+            );
+        }
+
+        [Fact, TestCategory("EventSourcing")]
+        public async Task Perf_ConfirmEachUpdate_MemoryStateStore_NonReentrant()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_StateStore_NonReentrant");
+            await ConcurrentIncrements(grain, iterations, true);
+        }
+        [Fact, TestCategory("EventSourcing")]
+        public async Task Perf_ConfirmAtEndOnly_MemoryStateStore_NonReentrant()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_StateStore_NonReentrant");
+            await ConcurrentIncrements(grain, iterations, false);
+        }
+        [Fact, TestCategory("EventSourcing")]
+        public async Task Perf_ConfirmEachUpdate_MemoryLogStore_NonReentrant()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_LogStore_NonReentrant");
+            await ConcurrentIncrements(grain, iterations, true);
+        }
+        [Fact, TestCategory("EventSourcing")]
+        public async Task Perf_ConfirmAtEndOnly_MemoryLogStore_NonReentrant()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_LogStore_NonReentrant");
+            await ConcurrentIncrements(grain, iterations, false);
+        }
+        [Fact, TestCategory("EventSourcing")]
+        public async Task Perf_ConfirmEachUpdate_MemoryStateStore_Reentrant()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_StateStore_Reentrant");
+            await ConcurrentIncrements(grain, iterations, true);
+        }
+        [Fact, TestCategory("EventSourcing")]
+        public async Task Perf_ConfirmAtEndOnly_MemoryStateStore_Reentrant()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_StateStore_Reentrant");
+            await ConcurrentIncrements(grain, iterations, false);
+        }
+        [Fact, TestCategory("EventSourcing")]
+        public async Task Perf_ConfirmEachUpdate_MemoryLogStore_Reentrant()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_LogStore_Reentrant");
+            await ConcurrentIncrements(grain, iterations, true);
+        }
+        [Fact, TestCategory("EventSourcing")]
+        public async Task Perf_ConfirmAtEndOnly_MemoryLogStore_Reentrant()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain_LogStore_Reentrant");
+            await ConcurrentIncrements(grain, iterations, false);
+        }
+
+
+    }
+
+    class RunThisFirstAttribute : Attribute
+    {
+    }
+
+    public class SimplePriorityOrderer : ITestCaseOrderer
+    {
+        private string attrname = typeof(RunThisFirstAttribute).AssemblyQualifiedName;
+
+        private bool HasRunThisFirstAttribute(ITestCase testcase)
+        {
+            return testcase.TestMethod.Method.GetCustomAttributes(attrname).Count() > 0;
+        }
+
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+        {
+            // return all tests with RunThisFirst attribute
+            foreach (var tc in testCases.Where(tc => HasRunThisFirstAttribute(tc)))
+                yield return tc;
+
+            // return all other tests
+            foreach (var tc in testCases.Where(tc => !HasRunThisFirstAttribute(tc)))
+                yield return tc;
+        }
+    }
+
+}

--- a/test/Tester/EventSourcingTests/CountersGrainTests.cs
+++ b/test/Tester/EventSourcingTests/CountersGrainTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using System.Linq;
+using Orleans;
+using TestGrainInterfaces;
+using Xunit;
+using Assert = Xunit.Assert;
+using TestExtensions;
+using Xunit.Abstractions;
+using Orleans.Runtime;
+using System.Collections.Generic;
+
+namespace Tester.EventSourcingTests
+{
+    public partial class CountersGrainTests : IClassFixture<EventSourcingClusterFixture>
+    {
+
+        [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
+        public async Task Record()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain");
+
+            var currentstate = await grain.GetAll();
+            Assert.NotNull(currentstate);
+            Assert.Equal(0, currentstate.Count());
+
+            await grain.Add("Alice", 1, false);
+            await grain.Add("Alice", 1, false);
+            await grain.Add("Alice", 1, false);
+
+            // all three updates should be visible (even if not persisted to storage yet)
+            Assert.Equal(3, await grain.Get("Alice"));
+
+            await grain.Reset(true);
+
+            Assert.Equal(0, (await grain.GetAll()).Count());
+        }
+
+        [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
+        public async Task ConcurrentIncrements()
+        {
+            var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain");
+            await ConcurrentIncrements(grain, 50, false);
+        }
+
+
+        private static string[] keys = { "a", "b", "c", "d", "e", "f", "g", "h" };
+        private static readonly SafeRandom random = new SafeRandom();
+        private string RandomKey() { return keys[random.Next(keys.Length)]; }
+
+
+        private async Task ConcurrentIncrements(ICountersGrain grain, int count, bool wait_till_persisted_on_each)
+        {
+            // increment (count) times, on random keys, in parallel
+            var tasks = new List<Task>();
+            for (int i = 0; i < count; i++)
+                tasks.Add(grain.Add(RandomKey(), 1, wait_till_persisted_on_each));
+            await Task.WhenAll(tasks);
+
+            // check that the sum of all the counters is correct
+            Assert.Equal(count, (await grain.GetAll()).Aggregate(0, (c, kvp) => c + kvp.Value));
+
+            // reset all counters
+            await grain.Reset(true);
+        }
+    }
+}

--- a/test/Tester/EventSourcingTests/CountersGrainTests.cs
+++ b/test/Tester/EventSourcingTests/CountersGrainTests.cs
@@ -21,7 +21,7 @@ namespace Tester.EventSourcingTests
         {
             var grain = GrainClient.GrainFactory.GetGrain<ICountersGrain>(0, "TestGrains.CountersGrain");
 
-            var currentstate = await grain.GetAll();
+            var currentstate = await grain.GetTentativeState();
             Assert.NotNull(currentstate);
             Assert.Equal(0, currentstate.Count());
 
@@ -29,12 +29,13 @@ namespace Tester.EventSourcingTests
             await grain.Add("Alice", 1, false);
             await grain.Add("Alice", 1, false);
 
-            // all three updates should be visible (even if not persisted to storage yet)
-            Assert.Equal(3, await grain.Get("Alice"));
+            // all three updates should be visible in the tentative count (even if not confirmed yet)
+            Assert.Equal(3, await grain.GetTentativeCount("Alice"));
 
+            // reset all counters to zero, and wait for confirmation
             await grain.Reset(true);
 
-            Assert.Equal(0, (await grain.GetAll()).Count());
+            Assert.Equal(0, (await grain.GetTentativeState()).Count());
         }
 
         [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
@@ -50,16 +51,23 @@ namespace Tester.EventSourcingTests
         private string RandomKey() { return keys[random.Next(keys.Length)]; }
 
 
-        private async Task ConcurrentIncrements(ICountersGrain grain, int count, bool wait_till_persisted_on_each)
+        private async Task ConcurrentIncrements(ICountersGrain grain, int count, bool wait_for_confirmation_on_each)
         {
-            // increment (count) times, on random keys, in parallel
+            // increment (count) times, on random keys, concurrently
             var tasks = new List<Task>();
             for (int i = 0; i < count; i++)
-                tasks.Add(grain.Add(RandomKey(), 1, wait_till_persisted_on_each));
+                tasks.Add(grain.Add(RandomKey(), 1, wait_for_confirmation_on_each));
             await Task.WhenAll(tasks);
 
-            // check that the sum of all the counters is correct
-            Assert.Equal(count, (await grain.GetAll()).Aggregate(0, (c, kvp) => c + kvp.Value));
+            // check that the tentative state shows all increments
+            Assert.Equal(count, (await grain.GetTentativeState()).Aggregate(0, (c, kvp) => c + kvp.Value));
+
+            // if we did not wait for confirmation on each event, wait now
+            if (!wait_for_confirmation_on_each)
+                await grain.ConfirmAllPreviouslyRaisedEvents();
+
+            // check that the confirmed state shows all the increments
+            Assert.Equal(count, (await grain.GetConfirmedState()).Aggregate(0, (c, kvp) => c + kvp.Value));
 
             // reset all counters
             await grain.Reset(true);

--- a/test/Tester/EventSourcingTests/EventSourcingClusterFixture.cs
+++ b/test/Tester/EventSourcingTests/EventSourcingClusterFixture.cs
@@ -1,0 +1,44 @@
+﻿using Orleans.TestingHost;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TestExtensions;
+using Orleans.Runtime.Configuration;
+using Orleans.Runtime;
+
+namespace Tester.EventSourcingTests
+{
+    /// <summary>
+    /// We use a special fixture for event sourcing tests 
+    /// so we can add the required log consistency providers, and 
+    /// do more tracing
+    /// </summary>
+    public class EventSourcingClusterFixture : BaseTestClusterFixture
+    {
+        protected override TestCluster CreateTestCluster()
+        {
+            var options = new TestClusterOptions();
+
+            // we use a slowed-down memory storage provider
+            options.ClusterConfiguration.AddMemoryStorageProvider("Default");
+            options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore");
+
+            options.ClusterConfiguration.AddFaultyMemoryStorageProvider("SlowMemoryStore", 10, 15);
+
+            // log consistency providers are used to configure journaled grains
+            options.ClusterConfiguration.AddLogStorageBasedLogConsistencyProvider("LogStorage");
+            options.ClusterConfiguration.AddStateStorageBasedLogConsistencyProvider("StateStorage");
+
+            // we turn on extra logging  to see more tracing from the log consistency providers
+            foreach (var o in options.ClusterConfiguration.Overrides)
+            {
+                o.Value.TraceLevelOverrides.Add(new Tuple<string, Severity>("Storage.MemoryStorage", Severity.Verbose));
+                o.Value.TraceLevelOverrides.Add(new Tuple<string, Severity>("LogViews", Severity.Verbose));
+            }
+
+            return new TestCluster(options);
+        }
+    }
+}

--- a/test/Tester/EventSourcingTests/PersonGrainTests.cs
+++ b/test/Tester/EventSourcingTests/PersonGrainTests.cs
@@ -18,7 +18,7 @@ namespace Tester.EventSourcingTests
         {
             var grainWithState = GrainClient.GrainFactory.GetGrain<IPersonGrain>(Guid.Empty);
 
-            Assert.NotNull(await grainWithState.GetPersonalAttributes());
+            Assert.NotNull(await grainWithState.GetTentativePersonalAttributes());
         }
 
         [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
@@ -28,7 +28,7 @@ namespace Tester.EventSourcingTests
 
             await grainWithState.RegisterBirth(new PersonAttributes { FirstName = "Luke", LastName = "Skywalker", Gender = GenderType.Male });
 
-            var attributes = await grainWithState.GetPersonalAttributes();
+            var attributes = await grainWithState.GetTentativePersonalAttributes();
 
             Assert.NotNull(attributes);
             Assert.Equal("Luke", attributes.FirstName);
@@ -45,7 +45,7 @@ namespace Tester.EventSourcingTests
 
             await leia.Marry(han);
 
-            var attributes = await leia.GetPersonalAttributes();
+            var attributes = await leia.GetTentativePersonalAttributes();
             Assert.NotNull(attributes);
             Assert.Equal("Leia", attributes.FirstName);
             Assert.Equal("Solo", attributes.LastName);

--- a/test/Tester/EventSourcingTests/PersonGrainTests.cs
+++ b/test/Tester/EventSourcingTests/PersonGrainTests.cs
@@ -9,31 +9,14 @@ using TestExtensions;
 using Xunit.Abstractions;
 using Orleans.Runtime;
 
-namespace UnitTests.EventSourcingTests
+namespace Tester.EventSourcingTests
 {
-    public class JournaledGrainTests : HostedTestClusterEnsureDefaultStarted, IDisposable
+    public class PersonGrainTests : IClassFixture<EventSourcingClusterFixture>
     {
-        private const string LoggerPrefix = "Storage.MemoryStorage.1";
-
-        public JournaledGrainTests(DefaultClusterFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            var mgmt = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
-            var hosts = mgmt.GetHosts().Result.Select(kvp => kvp.Key).ToArray();
-            mgmt.SetLogLevel(hosts, LoggerPrefix, (int)Severity.Verbose2);
-        }
-
-        public void Dispose()
-        {
-            var mgmt = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
-            var hosts = mgmt.GetHosts().Result.Select(kvp => kvp.Key).ToArray();
-            mgmt.SetLogLevel(hosts, LoggerPrefix, (int)Severity.Info);
-        }
-
-
         [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
         public async Task JournaledGrainTests_Activate()
         {
-            var grainWithState = GrainClient.GrainFactory.GetGrain<IJournaledPersonGrain>(Guid.Empty);
+            var grainWithState = GrainClient.GrainFactory.GetGrain<IPersonGrain>(Guid.Empty);
 
             Assert.NotNull(await grainWithState.GetPersonalAttributes());
         }
@@ -41,7 +24,7 @@ namespace UnitTests.EventSourcingTests
         [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
         public async Task JournaledGrainTests_Persist()
         {
-            var grainWithState = GrainClient.GrainFactory.GetGrain<IJournaledPersonGrain>(Guid.Empty);
+            var grainWithState = GrainClient.GrainFactory.GetGrain<IPersonGrain>(Guid.Empty);
 
             await grainWithState.RegisterBirth(new PersonAttributes { FirstName = "Luke", LastName = "Skywalker", Gender = GenderType.Male });
 
@@ -54,10 +37,10 @@ namespace UnitTests.EventSourcingTests
         [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
         public async Task JournaledGrainTests_AppendMoreEvents()
         {
-            var leia = GrainClient.GrainFactory.GetGrain<IJournaledPersonGrain>(Guid.NewGuid());
+            var leia = GrainClient.GrainFactory.GetGrain<IPersonGrain>(Guid.NewGuid());
             await leia.RegisterBirth(new PersonAttributes { FirstName = "Leia", LastName = "Organa", Gender = GenderType.Female });
 
-            var han = GrainClient.GrainFactory.GetGrain<IJournaledPersonGrain>(Guid.NewGuid());
+            var han = GrainClient.GrainFactory.GetGrain<IPersonGrain>(Guid.NewGuid());
             await han.RegisterBirth(new PersonAttributes { FirstName = "Han", LastName = "Solo", Gender = GenderType.Male });
 
             await leia.Marry(han);
@@ -71,7 +54,7 @@ namespace UnitTests.EventSourcingTests
         [Fact, TestCategory("EventSourcing"), TestCategory("Functional")]
         public async Task JournaledGrainTests_TentativeConfirmedState()
         {
-            var leia = GrainClient.GrainFactory.GetGrain<IJournaledPersonGrain>(Guid.NewGuid());
+            var leia = GrainClient.GrainFactory.GetGrain<IPersonGrain>(Guid.NewGuid());
 
             // the whole test has to run inside the grain, otherwise the interleaving of 
             // the individual steps is nondeterministic

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -47,7 +47,12 @@
     <Compile Include="CancellationTests\GrainCancellationTokenTests.cs" />
     <Compile Include="ClientConnectionTests\ClientDisconnectionEventTests.cs" />
     <Compile Include="CollectionFixtures.cs" />
-    <Compile Include="EventSourcingTests\JournaledGrainTests.cs" />
+    <Compile Include="EventSourcingTests\AccountGrainTests.cs" />
+    <Compile Include="EventSourcingTests\ChatGrainTests.cs" />
+    <Compile Include="EventSourcingTests\CountersGrainPerfTests.cs" />
+    <Compile Include="EventSourcingTests\CountersGrainTests.cs" />
+    <Compile Include="EventSourcingTests\EventSourcingClusterFixture.cs" />
+    <Compile Include="EventSourcingTests\PersonGrainTests.cs" />
     <Compile Include="FakeSerializer.cs" />
     <Compile Include="Forwarding\ShutdownSiloTests.cs" />
     <Compile Include="HeterogeneousSilosTests\HeterogeneousTests.cs" />
@@ -136,6 +141,10 @@
     <ProjectReference Include="..\..\src\OrleansCodeGenerator\OrleansCodeGenerator.csproj">
       <Project>{8d937706-f6da-4d33-b0a9-24a260bd3080}</Project>
       <Name>OrleansCodeGenerator</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\OrleansEventSourcing\OrleansEventSourcing.csproj">
+      <Project>{cf7ee78b-39e1-4660-beaf-0e2606098f8c}</Project>
+      <Name>OrleansEventSourcing</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\OrleansProviders\OrleansProviders.csproj">
       <Project>{0054db14-2a92-4cc0-959e-a2c51f5e65d4}</Project>

--- a/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
@@ -10,11 +10,11 @@ using TestExtensions;
 
 namespace Tests.GeoClusterTests
 {
-    public class BasicLogConsistentGrainTests : TestingSiloHost
+    public class BasicLogTestGrainTests : TestingSiloHost
     {
 
 
-        public BasicLogConsistentGrainTests() :
+        public BasicLogTestGrainTests() :
             base(
                 new TestingSiloOptions
                 {
@@ -35,32 +35,32 @@ namespace Tests.GeoClusterTests
         [Fact, TestCategory("GeoCluster")]
         public async Task DefaultStorage()
         {
-            await DoBasicLogConsistentGrainTest("UnitTests.Grains.LogConsistentGrainDefaultStorage");
+            await DoBasicLogTestGrainTest("TestGrains.LogTestGrainDefaultStorage");
         }
         [Fact, TestCategory("GeoCluster")]
         public async Task MemoryStorage()
         {
-            await DoBasicLogConsistentGrainTest("UnitTests.Grains.LogConsistentGrainMemoryStorage");
+            await DoBasicLogTestGrainTest("TestGrains.LogTestGrainMemoryStorage");
         }
         [Fact, TestCategory("GeoCluster")]
         public async Task SharedStorage()
         {
-            await DoBasicLogConsistentGrainTest("UnitTests.Grains.LogConsistentGrainSharedStateStorage");
+            await DoBasicLogTestGrainTest("TestGrains.LogTestGrainSharedStateStorage");
         }
         [Fact, TestCategory("GeoCluster")]
         public async Task SharedLogStorage()
         {
-            await DoBasicLogConsistentGrainTest("UnitTests.Grains.LogConsistentGrainSharedLogStorage");
+            await DoBasicLogTestGrainTest("TestGrains.LogTestGrainSharedLogStorage");
         }
         [Fact, TestCategory("GeoCluster")]
         public async Task CustomStorage()
         {
-            await DoBasicLogConsistentGrainTest("UnitTests.Grains.LogConsistentGrainCustomStorage");
+            await DoBasicLogTestGrainTest("TestGrains.LogTestGrainCustomStorage");
         }
         [Fact, TestCategory("GeoCluster")]
         public async Task GsiStorage()
         {
-            await DoBasicLogConsistentGrainTest("UnitTests.Grains.GsiLogConsistentGrain");
+            await DoBasicLogTestGrainTest("TestGrains.GsiLogTestGrain");
         }
 
         private int GetRandom()
@@ -70,7 +70,7 @@ namespace Tests.GeoClusterTests
         }
 
 
-        private async Task DoBasicLogConsistentGrainTest(string grainClass, int phases = 100)
+        private async Task DoBasicLogTestGrainTest(string grainClass, int phases = 100)
         {
             await ThreeCheckers(grainClass, phases);
         }
@@ -81,7 +81,7 @@ namespace Tests.GeoClusterTests
             Func<Task> checker1 = async () =>
             {
                 int x = GetRandom();
-                var grain = GrainFactory.GetGrain<ILogConsistentGrain>(x, grainClass);
+                var grain = GrainFactory.GetGrain<ILogTestGrain>(x, grainClass);
                 await grain.SetAGlobal(x);
                 int a = await grain.GetAGlobal();
                 Assert.Equal(x, a); // value of A survive grain call
@@ -92,7 +92,7 @@ namespace Tests.GeoClusterTests
             Func<Task> checker2 = async () =>
             {
                 int x = GetRandom();
-                var grain = GrainFactory.GetGrain<ILogConsistentGrain>(x, grainClass);
+                var grain = GrainFactory.GetGrain<ILogTestGrain>(x, grainClass);
                 Assert.Equal(0, await grain.GetConfirmedVersion());
                 await grain.SetALocal(x);
                 int a = await grain.GetALocal();
@@ -104,7 +104,7 @@ namespace Tests.GeoClusterTests
             {
                 // Local then Global
                 int x = GetRandom();
-                var grain = GrainFactory.GetGrain<ILogConsistentGrain>(x, grainClass);
+                var grain = GrainFactory.GetGrain<ILogTestGrain>(x, grainClass);
                 await grain.SetALocal(x);
                 int a = await grain.GetAGlobal();
                 Assert.Equal(x, a);

--- a/test/TesterInternal/GeoClusterTests/LogConsistencyTestFixture.cs
+++ b/test/TesterInternal/GeoClusterTests/LogConsistencyTestFixture.cs
@@ -36,72 +36,72 @@ namespace Tests.GeoClusterTests
 
             public string GetGrainRef(string grainclass, int i)
             {
-                return GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass).ToString();
+                return GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass).ToString();
             }
 
             public void SetALocal(string grainclass, int i, int a)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 grainRef.SetALocal(a).GetResult();
             }
 
             public void SetAGlobal(string grainclass, int i, int a)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 grainRef.SetAGlobal(a).GetResult();
             }
 
             public Tuple<int, bool> SetAConditional(string grainclass, int i, int a)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 return grainRef.SetAConditional(a).GetResult();
             }
 
             public void IncrementAGlobal(string grainclass, int i)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 grainRef.IncrementAGlobal().GetResult();
             }
 
             public void IncrementALocal(string grainclass, int i)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 grainRef.IncrementALocal().GetResult();
             }
 
             public int GetAGlobal(string grainclass, int i)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 return grainRef.GetAGlobal().GetResult();
             }
 
             public int GetALocal(string grainclass, int i)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 return grainRef.GetALocal().GetResult();
             }    
 
             public void AddReservationLocal(string grainclass, int i, int x)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 grainRef.AddReservationLocal(x).GetResult();
             }
 
             public void RemoveReservationLocal(string grainclass, int i, int x)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 grainRef.RemoveReservationLocal(x).GetResult();
             }
 
             public int[] GetReservationsGlobal(string grainclass, int i)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 return grainRef.GetReservationsGlobal().GetResult();
             }
 
             public void Synchronize(string grainclass, int i)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 grainRef.SynchronizeGlobalState().GetResult();
             }
 
@@ -113,13 +113,13 @@ namespace Tests.GeoClusterTests
 
             public long GetConfirmedVersion(string grainclass, int i)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 return grainRef.GetConfirmedVersion().GetResult();
             }
 
             public IEnumerable<ConnectionIssue> GetUnresolvedConnectionIssues(string grainclass, int i)
             {
-                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogConsistentGrain>(i, grainclass);
+                var grainRef = GrainClient.GrainFactory.GetGrain<UnitTests.GrainInterfaces.ILogTestGrain>(i, grainclass);
                 return grainRef.GetUnresolvedConnectionIssues().GetResult();
             }
 

--- a/test/TesterInternal/GeoClusterTests/LogConsistencyTestsFourClusters.cs
+++ b/test/TesterInternal/GeoClusterTests/LogConsistencyTestsFourClusters.cs
@@ -33,37 +33,37 @@ namespace Tests.GeoClusterTests
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_SharedStateStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainSharedStateStorage", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainSharedStateStorage", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_SharedLogStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainSharedLogStorage", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainSharedLogStorage", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_GsiDefaultStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.GsiLogConsistentGrain", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.GsiLogTestGrain", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_MemoryStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainMemoryStorage", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainMemoryStorage", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_CustomStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainCustomStorage", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainCustomStorage", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_CustomStorageProvider_PrimaryCluster()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainCustomStoragePrimaryCluster", false, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainCustomStoragePrimaryCluster", false, phases);
         }
 
     }

--- a/test/TesterInternal/GeoClusterTests/LogConsistencyTestsTwoClusters.cs
+++ b/test/TesterInternal/GeoClusterTests/LogConsistencyTestsTwoClusters.cs
@@ -32,37 +32,37 @@ namespace Tests.GeoClusterTests
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_SharedStateStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainSharedStateStorage", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainSharedStateStorage", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_SharedLogStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainSharedLogStorage", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainSharedLogStorage", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_GsiDefaultStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.GsiLogConsistentGrain", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.GsiLogTestGrain", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_MemoryStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainMemoryStorage", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainMemoryStorage", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_CustomStorageProvider()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainCustomStorage", true, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainCustomStorage", true, phases);
         }
 
         [Fact, TestCategory("GeoCluster")]
         public async Task TestBattery_CustomStorageProvider_PrimaryCluster()
         {
-            await fixture.RunChecksOnGrainClass("UnitTests.Grains.LogConsistentGrainCustomStoragePrimaryCluster", false, phases);
+            await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainCustomStoragePrimaryCluster", false, phases);
         }
 
 

--- a/test/TesterInternal/TesterInternal.csproj
+++ b/test/TesterInternal/TesterInternal.csproj
@@ -80,7 +80,7 @@
     <Compile Include="General\LoggerTest.cs" />
     <Compile Include="General\RequestContextTest.cs" />
     <Compile Include="General\TestingBootstrapProviders.cs" />
-    <Compile Include="GeoClusterTests\BasicLogConsistentGrainTests.cs" />
+    <Compile Include="GeoClusterTests\BasicLogTestGrainTests.cs" />
     <Compile Include="GeoClusterTests\BasicMultiClusterTest.cs" />
     <Compile Include="GeoClusterTests\GatewaySelectionTest.cs" />
     <Compile Include="GeoClusterTests\GlobalSingleInstanceClusterTests.cs" />

--- a/vNext/test/Tester/Tester.csproj
+++ b/vNext/test/Tester/Tester.csproj
@@ -84,9 +84,7 @@
     <Compile Include="..\..\..\test\Tester\SerializationTests\SerializationTestsUtils.cs">
       <Link>SerializationTests\SerializationTestsUtils.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\test\Tester\EventSourcingTests\JournaledGrainTests.cs">
-      <Link>EventSourcingTests\JournaledGrainTests.cs</Link>
-    </Compile>
+    <Compile Include="..\..\..\test\Tester\EventSourcingTests\*.cs"/>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/vNext/test/Tester/Tester.csproj
+++ b/vNext/test/Tester/Tester.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\..\src\Orleans\Orleans.csproj" />
     <ProjectReference Include="..\..\src\OrleansTestingHost\OrleansTestingHost.csproj" />
     <ProjectReference Include="..\..\src\OrleansCodeGenerator\OrleansCodeGenerator.csproj" />
+    <ProjectReference Include="..\..\src\OrleansEventSourcing\OrleansEventSourcing.csproj" />
     <ProjectReference Include="..\TestExtensions\TestExtensions.csproj" />
     <ProjectReference Include="..\TestGrainInterfaces\TestGrainInterfaces.csproj" />
     <ProjectReference Include="..\TestGrains\TestGrains.csproj" />


### PR DESCRIPTION
Based on discussion in #2598.

Added `RetrieveConfirmedEvents` method to JournaledGrain, which can read a desired segment of the event log.

Added many more tests/examples as the first step to better documentation. These demonstrate a diverse collection of scenarios, including several configuration options. 

They are located in folders:
- Tester.EventSourcing
- TestGrains.EventSourcing 
- TestGrainInterfaces.EventSourcing
