### PR TITLE
Consolidate FluentAssertions version used in test projects

### DIFF
--- a/test/AWSUtils.Tests/project.json
+++ b/test/AWSUtils.Tests/project.json
@@ -1,11 +1,11 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "AWSSDK.DynamoDBv2": "3.1.5.2",
+    "AWSSDK.SQS": "3.1.0.9",
+    "FluentAssertions": "4.18.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14",
-    "AWSSDK.DynamoDBv2": "3.1.5.2",
-    "AWSSDK.SQS": "3.1.0.9"
+    "Xunit.SkippableFact": "1.2.14"
   },
   "frameworks": {
     "net451": {}

--- a/test/BondUtils.Tests/project.json
+++ b/test/BondUtils.Tests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"

--- a/test/Consul.Tests/project.json
+++ b/test/Consul.Tests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"

--- a/test/DefaultCluster.Tests/project.json
+++ b/test/DefaultCluster.Tests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"

--- a/test/GoogleUtils.Tests/project.json
+++ b/test/GoogleUtils.Tests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"

--- a/test/PSUtils.Tests/project.json
+++ b/test/PSUtils.Tests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"

--- a/test/ServiceBus.Tests/project.json
+++ b/test/ServiceBus.Tests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"

--- a/test/Tester/project.json
+++ b/test/Tester/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
     "Microsoft.Extensions.Configuration.Json": "1.0.0",
     "Newtonsoft.Json": "9.0.1",

--- a/test/TesterAzureUtils/project.json
+++ b/test/TesterAzureUtils/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "Newtonsoft.Json": "9.0.1",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",

--- a/test/TesterSQLUtils/project.json
+++ b/test/TesterSQLUtils/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "Microsoft.Data.SQLite": "1.1.0",
     "MySql.Data": "6.9.9",
     "Newtonsoft.Json": "9.0.1",

--- a/test/TesterZooKeeperUtils/project.json
+++ b/test/TesterZooKeeperUtils/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "FluentAssertions": "4.0.0",
+    "FluentAssertions": "4.18.0",
     "Newtonsoft.Json": "9.0.1",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",

--- a/vNext/test/Consul.Tests/Consul.Tests.csproj
+++ b/vNext/test/Consul.Tests/Consul.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup Label="Configuration">
     <DefineConstants>NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
   </PropertyGroup>
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.2.14" />
-    <PackageReference Include="FluentAssertions" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="4.18.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrleansConsulUtils\OrleansConsulUtils.csproj" />

--- a/vNext/test/Tester/Tester.csproj
+++ b/vNext/test/Tester/Tester.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="xunit" Version="2.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.2.14" />
-    <PackageReference Include="FluentAssertions" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="4.18.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/vNext/test/TesterSQLUtils/Tester.SQLUtils.csproj
+++ b/vNext/test/TesterSQLUtils/Tester.SQLUtils.csproj
@@ -1,24 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup Label="Configuration">
     <DefineConstants>NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="**\*.cs" />
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -30,17 +26,15 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.2.14" />
     <PackageReference Include="System.Data.SqlClient" Version="4.3.0" />
-    <PackageReference Include="FluentAssertions" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="4.18.0" />
     <PackageReference Include="Microsoft.Data.SQLite" Version="1.1.0" />
     <PackageReference Include="Npgsql" Version="3.1.9" />
     <PackageReference Include="MySql.Data" Version="7.0.6-IR31" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Orleans.PlatformServices\Orleans.PlatformServices.csproj" />
     <ProjectReference Include="..\..\src\OrleansSQLUtils\OrleansSQLUtils.csproj" />
@@ -57,7 +51,6 @@
     <ProjectReference Include="..\TestInternalGrainInterface\TestInternalGrainInterfaces.csproj" />
     <ProjectReference Include="..\TestInternalGrains\TestInternalGrains.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="..\..\..\test\TesterSQLUtils\CollectionFixtures.cs">
       <Link>CollectionFixtures.cs</Link>
@@ -150,7 +143,6 @@
       <Link>SqlServerRemindersTableTests.cs</Link>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\..\src\OrleansSQLUtils\CreateOrleansTables_MySql.sql">
       <Link>CreateOrleansTables_MySql.sql</Link>
@@ -173,7 +165,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/vNext/test/TesterZooKeeperUtils/Tester.ZooKeeperUtils.csproj
+++ b/vNext/test/TesterZooKeeperUtils/Tester.ZooKeeperUtils.csproj
@@ -1,24 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup Label="Configuration">
     <DefineConstants>NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="**\*.cs" />
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -30,14 +26,12 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.2.14" />
     <PackageReference Include="System.Data.SqlClient" Version="4.3.0" />
-    <PackageReference Include="FluentAssertions" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="4.18.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrleansZooKeeperUtils\OrleansZooKeeperUtils.csproj" />
     <ProjectReference Include="..\..\src\OrleansProviders\OrleansProviders.csproj" />
@@ -48,23 +42,20 @@
     <ProjectReference Include="..\Tester\Tester.csproj" />
     <ProjectReference Include="..\TestExtensions\TestExtensions.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="..\..\..\test\TesterZooKeeperUtils\LivenessTests.cs">
       <Link>LivenessTests.cs</Link>
     </Compile>
-	<Compile Include="..\..\..\test\TesterZooKeeperUtils\ZookeeperMembershipTableTests.cs">
+    <Compile Include="..\..\..\test\TesterZooKeeperUtils\ZookeeperMembershipTableTests.cs">
       <Link>ZookeeperMembershipTableTests.cs</Link>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <None Include="App.config" />
     <None Include="Tester.ZooKeeperUtils.xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>


### PR DESCRIPTION
vNext and mainline projects were using different versions of FluentAssertions.

This just consolidates all versions to the latest. I was seeing some errors during some test runs because of this mismatch.