### PR TITLE
Allow overriding MethodId using [MethodId(id)] on interface methods

### DIFF
--- a/src/Orleans/CodeGeneration/GrainInterfaceUtils.cs
+++ b/src/Orleans/CodeGeneration/GrainInterfaceUtils.cs
@@ -126,6 +126,9 @@ namespace Orleans.CodeGeneration
         
         public static int ComputeMethodId(MethodInfo methodInfo)
         {
+            var attr = methodInfo.GetCustomAttribute<MethodIdAttribute>(true);
+            if (attr != null) return attr.MethodId;
+
             var strMethodId = new StringBuilder(methodInfo.Name + "(");
             ParameterInfo[] parameters = methodInfo.GetParameters();
             bool bFirstTime = true;

--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -226,7 +226,36 @@ namespace Orleans
             {
                 TypeCode = typeCode;
             }
-    }
+        }
+
+        /// <summary>
+        /// Specifies the method id for the interface method which this attribute is declared on.
+        /// </summary>
+        /// <remarks>
+        /// Method ids must be unique for all methods in a given interface.
+        /// This attribute is only applicable for interface method declarations, not for method definitions on classes.
+        /// </remarks>
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class MethodIdAttribute : Attribute
+        {
+            /// <summary>
+            /// Gets the method id for the interface method this attribute is declared on.
+            /// </summary>
+            public int MethodId { get; }
+
+            /// <summary>
+            /// Specifies the method id for the interface method which this attribute is declared on.
+            /// </summary>
+            /// <remarks>
+            /// Method ids must be unique for all methods in a given interface.
+            /// This attribute is only valid only on interface method declarations, not on method definitions.
+            /// </remarks>
+            /// <param name="methodId">The method id.</param>
+            public MethodIdAttribute(int methodId)
+            {
+                this.MethodId = methodId;
+            }
+        }
 
     /// <summary>
     /// Used to mark a method as providing a copier function for that type.

--- a/test/TestGrainInterfaces/IMethodInterceptionGrain.cs
+++ b/test/TestGrainInterfaces/IMethodInterceptionGrain.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Orleans.CodeGeneration;
 
 namespace UnitTests.GrainInterfaces
 {
     using Orleans;
     public interface IMethodInterceptionGrain : IGrainWithIntegerKey, IMethodFromAnotherInterface
     {
+        [MethodId(14142)]
         Task<string> One();
         Task<string> Echo(string someArg);
         Task<string> NotIntercepted();

--- a/test/TestGrains/MethodInterceptionGrain.cs
+++ b/test/TestGrains/MethodInterceptionGrain.cs
@@ -15,6 +15,7 @@ namespace UnitTests.Grains
         {
             if (methodInfo.Name == nameof(One) && methodInfo.GetParameters().Length == 0)
             {
+                if (request.MethodId != 14142) throw new Exception($"Method id of 'One' must be 14142, not {request.MethodId}.");
                 return "intercepted one with no args";
             }
 


### PR DESCRIPTION
Implements #2659.

This slightly improves the upgrade story by removing the restriction that method names and method parameter type names cannot be changed without breaking existing clients/silos.

Users can add the `[MethodId(x)]` attribute to methods to override the default algorithm for generating ids.