### PR TITLE
Follow up on "Client cluster disconnection #2628"

### DIFF
--- a/src/Orleans/Core/GrainClient.cs
+++ b/src/Orleans/Core/GrainClient.cs
@@ -387,7 +387,15 @@ namespace Orleans
 
         internal static void NotifyClusterConnectionLost()
         {
-            ClusterConnectionLost?.Invoke(null, null);
+            try
+            {
+                // TODO: first argument should be 'this' when this class will no longer be static
+                ClusterConnectionLost?.Invoke(null, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ErrorCode.ClientError, "Error when sending cluster disconnection notification", ex);
+            }
         }
 
         internal static IList<Uri> Gateways

--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -321,7 +321,7 @@ namespace Orleans
         Runtime_Error_100312 = Runtime + 312,
         ClientInitializing   = Runtime + 313,
         ClientStarting       = Runtime + 314,
-        Runtime_Error_100315 = Runtime + 315,
+        ClientError          = Runtime + 315,
         Runtime_Error_100316 = Runtime + 316,
         Runtime_Error_100317 = Runtime + 317,
         Runtime_Error_100318 = Runtime + 318,


### PR DESCRIPTION
Following up on #2628

Safer implementation of GrainClient.NotifyClusterConnectionLost and add logging in case of failure when calling event subscriber