### PR TITLE
Rename IRuntimeClient.Identity to CurrentActivationIdentity

### DIFF
--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -15,9 +15,11 @@ namespace Orleans.Providers
         private readonly Dictionary<Type, Tuple<IGrainExtension, IAddressable>> caoTable;
         private readonly AsyncLock lockable;
         private InvokeInterceptor invokeInterceptor;
+        private readonly IRuntimeClient runtimeClient;
 
         public ClientProviderRuntime(IGrainFactory grainFactory, IServiceProvider serviceProvider) 
         {
+            this.runtimeClient = RuntimeClient.Current;
             caoTable = new Dictionary<Type, Tuple<IGrainExtension, IAddressable>>();
             lockable = new AsyncLock();
             GrainFactory = grainFactory;
@@ -95,7 +97,7 @@ namespace Orleans.Providers
 
         public string ExecutingEntityIdentity()
         {
-            return RuntimeClient.Current.Identity;
+            return this.runtimeClient.CurrentActivationIdentity;
         }
 
         public SiloAddress ExecutingSiloAddress

--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -24,7 +24,7 @@ namespace Orleans.Runtime
         /// A unique identifier for the current client.
         /// There is no semantic content to this string, but it may be useful for logging.
         /// </summary>
-        string Identity { get; }
+        string CurrentActivationIdentity { get; }
 
         /// <summary>
         /// Get the current response timeout setting for this client.

--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -49,9 +49,7 @@ namespace Orleans.Runtime
         GrainReference CreateObjectReference(IAddressable obj, IGrainMethodInvoker invoker);
 
         void DeleteObjectReference(IAddressable obj);
-
-        SiloAddress CurrentSilo { get; }
-
+        
         Streams.IStreamProviderManager CurrentStreamProviderManager { get; }
 
         Streams.IStreamProviderRuntime CurrentStreamProviderRuntime { get; }

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -85,7 +85,7 @@ namespace Orleans
             get { return CurrentActivationAddress.Silo; }
         }
 
-        public string Identity
+        public string CurrentActivationIdentity
         {
             get { return CurrentActivationAddress.ToString(); }
         }

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -79,12 +79,7 @@ namespace Orleans
             get;
             private set;
         }
-
-        public SiloAddress CurrentSilo
-        {
-            get { return CurrentActivationAddress.Silo; }
-        }
-
+        
         public string CurrentActivationIdentity
         {
             get { return CurrentActivationAddress.ToString(); }

--- a/src/OrleansRuntime/Core/ISiloRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/ISiloRuntimeClient.cs
@@ -14,12 +14,6 @@ namespace Orleans.Runtime
         /// </summary>
         /// <returns>The stream directory.</returns>
         StreamDirectory GetStreamDirectory();
-
-        /// <summary>
-        /// Retrieves the opaque identity of currently executing grain or client object. 
-        /// </summary>
-        /// <remarks>Exposed for logging purposes.</remarks>
-        string ExecutingEntityIdentity();
         
         /// <summary>
         /// Attempts to add the provided extension handler to the currently executing grain.

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -602,9 +602,14 @@ namespace Orleans.Runtime
         {
             get { return appLogger; }
         }
+
         public string CurrentActivationIdentity
         {
-            get { return MySilo.ToLongString(); }
+            get
+            {
+                var currentActivation = this.GetCurrentActivationData();
+                return currentActivation.Address.ToString();
+            }
         }
 
         public IActivationData CurrentActivationData
@@ -732,12 +737,6 @@ namespace Orleans.Runtime
         {
             var currentActivation = GetCurrentActivationData();
             return currentActivation.GetStreamDirectory();
-        }
-
-        public string ExecutingEntityIdentity()
-        {
-            var currentActivation = GetCurrentActivationData();
-            return currentActivation.Address.ToString();
         }
 
         public Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -602,7 +602,7 @@ namespace Orleans.Runtime
         {
             get { return appLogger; }
         }
-        public string Identity
+        public string CurrentActivationIdentity
         {
             get { return MySilo.ToLongString(); }
         }

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -130,7 +130,7 @@ namespace Orleans.Runtime.Providers
         }
 
         /// <inheritdoc />
-        public string ExecutingEntityIdentity() => runtimeClient.ExecutingEntityIdentity();
+        public string ExecutingEntityIdentity() => runtimeClient.CurrentActivationIdentity;
 
         /// <inheritdoc />
         public StreamDirectory GetStreamDirectory() => runtimeClient.GetStreamDirectory();


### PR DESCRIPTION
`IRuntimeClient.Identity` is a confusing property, since the name implies it's the identity of the runtime client (which might be interpreted as client/silo id).