### PR TITLE
Add RequestContextUtil (prep for non-static SerializationManager)

### DIFF
--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -1,6 +1,5 @@
 using System;
 using Orleans.GrainDirectory;
-using Orleans.Runtime;
 
 namespace Orleans
 {
@@ -285,7 +284,7 @@ namespace Orleans
     /// Used to make a class for auto-registration as a serialization helper.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    [Obsolete("[RegisterSerializer] is obsolete, please use [Serializer(typeof(TargetType))] instead.")]
+    [Obsolete("[RegisterSerializer] is obsolete, please use [Serializer(typeof(TargetType))] instead. Note that the signature of Register has changed to 'void Register(SerializationManager sm)'.")]
     public sealed class RegisterSerializerAttribute : Attribute
     {
     }

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -169,6 +169,7 @@ namespace Orleans
             return TaskDone.Done;
         }
 
+        /// <inheritdoc />
         public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IAddressable obj)
                 where TGrainObserverInterface : IAddressable
         {

--- a/src/Orleans/Core/Immutable.cs
+++ b/src/Orleans/Core/Immutable.cs
@@ -1,5 +1,3 @@
-using Orleans.Serialization;
-
 namespace Orleans.Concurrency
 {
     /// <summary>
@@ -28,15 +26,6 @@ namespace Orleans.Concurrency
         public Immutable(T value)
         {
             this.value = value;
-        }
-
-        /// <summary>
-        /// Create a deep copy of the original value stored in this Immutable wrapper.
-        /// </summary>
-        /// <returns></returns>
-        public T GetCopy()
-        {
-            return (T)SerializationManager.DeepCopy(Value);
         }
     }
 

--- a/src/Orleans/Messaging/GatewayProviderFactory.cs
+++ b/src/Orleans/Messaging/GatewayProviderFactory.cs
@@ -9,13 +9,20 @@ namespace Orleans.Messaging
 {
     internal class GatewayProviderFactory
     {
-        private static readonly Logger logger = LogManager.GetLogger(typeof(GatewayProviderFactory).Name, LoggerType.Runtime);
+        private readonly ClientConfiguration cfg;
+        private readonly Logger logger;
 
-        internal static async Task<IGatewayListProvider> CreateGatewayListProvider(ClientConfiguration cfg)
+        public GatewayProviderFactory(ClientConfiguration cfg)
         {
-            IGatewayListProvider listProvider = null;
-            ClientConfiguration.GatewayProviderType gatewayProviderToUse = cfg.GatewayProviderToUse;
+            this.cfg = cfg;
+            this.logger = LogManager.GetLogger(typeof(GatewayProviderFactory).Name, LoggerType.Runtime);
+        }
 
+        internal IGatewayListProvider CreateGatewayListProvider()
+        {
+            IGatewayListProvider listProvider;
+            ClientConfiguration.GatewayProviderType gatewayProviderToUse = cfg.GatewayProviderToUse;
+            
             switch (gatewayProviderToUse)
             {
                 case ClientConfiguration.GatewayProviderType.AzureTable:
@@ -42,7 +49,6 @@ namespace Orleans.Messaging
                     throw new NotImplementedException(gatewayProviderToUse.ToString());
             }
 
-            await listProvider.InitializeGatewayListProvider(cfg, LogManager.GetLogger(listProvider.GetType().Name));
             return listProvider;
         }
     }

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -276,13 +276,13 @@ namespace Orleans.Messaging
             }
         }
 
-        public Task<IGrainTypeResolver> GetTypeCodeMap(GrainFactory grainFactory)
+        public Task<IGrainTypeResolver> GetTypeCodeMap(IInternalGrainFactory grainFactory)
         {
             var silo = GetLiveGatewaySiloAddress();
             return GetTypeManager(silo, grainFactory).GetClusterTypeCodeMap();
         }
 
-        public Task<Streams.ImplicitStreamSubscriberTable> GetImplicitStreamSubscriberTable(GrainFactory grainFactory)
+        public Task<Streams.ImplicitStreamSubscriberTable> GetImplicitStreamSubscriberTable(IInternalGrainFactory grainFactory)
         {
             var silo = GetLiveGatewaySiloAddress();
             return GetTypeManager(silo, grainFactory).GetImplicitStreamSubscriberTable(silo);
@@ -401,7 +401,7 @@ namespace Orleans.Messaging
 
         #endregion
 
-        private IClusterTypeManager GetTypeManager(SiloAddress destination, GrainFactory grainFactory)
+        private IClusterTypeManager GetTypeManager(SiloAddress destination, IInternalGrainFactory grainFactory)
         {
             return grainFactory.GetSystemTarget<IClusterTypeManager>(Constants.TypeManagerId, destination);
         }

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Providers\ProviderStateManager.cs" />
     <Compile Include="Runtime\IGrainTimer.cs" />
     <Compile Include="Runtime\ILocalSiloDetails.cs" />
+    <Compile Include="Runtime\RequestContextUtil.cs" />
     <Compile Include="Runtime\RingRange.cs" />
     <Compile Include="Serialization\ILBasedExceptionSerializer.cs" />
     <Compile Include="Serialization\IExternalSerializer.cs" />
@@ -277,6 +278,7 @@
     <Compile Include="Streams\Core\StreamSubscriptionHandle.cs" />
     <Compile Include="Timers\AsyncTaskSafeTimer.cs" />
     <Compile Include="Timers\TimerRegistry.cs" />
+    <Compile Include="Utils\ServiceCollectionExtensions.cs" />
     <Compile Include="Utils\SetExtensions.cs" />
     <Compile Include="Placement\ActivationCountBasedPlacement.cs" />
     <Compile Include="Placement\StatelessWorkerPlacement.cs" />

--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -27,6 +27,11 @@ namespace Orleans.Runtime
         string CurrentActivationIdentity { get; }
 
         /// <summary>
+        /// Gets the service provider.
+        /// </summary>
+        IServiceProvider ServiceProvider { get; }
+
+        /// <summary>
         /// Get the current response timeout setting for this client.
         /// </summary>
         /// <returns>Response timeout value</returns>

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -175,8 +175,8 @@ namespace Orleans
                 config.CheckGatewayProviderSettings();
 
                 var generation = -SiloAddress.AllocateNewGeneration(); // Client generations are negative
-                var gatewayListProvider = GatewayProviderFactory.CreateGatewayListProvider(config)
-                    .WithTimeout(initTimeout).Result;
+                var gatewayListProvider = new GatewayProviderFactory(this.config).CreateGatewayListProvider();
+                gatewayListProvider.InitializeGatewayListProvider(this.config, LogManager.GetLogger(gatewayListProvider.GetType().Name)).WaitWithThrow(initTimeout);
                 transport = new ProxiedMessageCenter(config, localAddress, generation, handshakeClientId, gatewayListProvider);
 
                 if (StatisticsCollector.CollectThreadTimeTrackingStats)

--- a/src/Orleans/Runtime/RequestContextUtil.cs
+++ b/src/Orleans/Runtime/RequestContextUtil.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Orleans.Runtime
+{
+    public class RequestContextUtil
+    {
+        public Dictionary<string, object> Export()
+        {
+            return RequestContext.Export();
+        }
+    }
+}

--- a/src/Orleans/Serialization/DeserializationContext.cs
+++ b/src/Orleans/Serialization/DeserializationContext.cs
@@ -5,9 +5,27 @@ namespace Orleans.Serialization
 {
     public interface IDeserializationContext
     {
+
+        /// <summary>
+        /// The stream reader.
+        /// </summary>
         BinaryTokenStreamReader StreamReader { get; }
+        
+        /// <summary>
+        /// The offset of the current object in <see cref="StreamReader"/>.
+        /// </summary>
         int CurrentObjectOffset { get; set; }
+        /// <summary>
+        /// Records deserialization of the provided object.
+        /// </summary>
+        /// <param name="obj"></param>
         void RecordObject(object obj);
+
+        /// <summary>
+        /// Returns the object from the specified offset.
+        /// </summary>
+        /// <param name="offset">The offset within <see cref="StreamReader"/>.</param>
+        /// <returns>The object from the specified offset.</returns>
         object FetchReferencedObject(int offset);
     }
 
@@ -20,21 +38,25 @@ namespace Orleans.Serialization
             taggedObjects = new Dictionary<int, object>();
         }
 
-        public BinaryTokenStreamReader StreamReader { get; set; }
 
         internal void Reset()
         {
             taggedObjects.Clear();
             CurrentObjectOffset = 0;
         }
+        /// <inheritdoc />
+        public BinaryTokenStreamReader StreamReader { get; set; }
 
+        /// <inheritdoc />
         public int CurrentObjectOffset { get; set; }
 
+        /// <inheritdoc />
         public void RecordObject(object obj)
         {
             taggedObjects[CurrentObjectOffset] = obj;
         }
 
+        /// <inheritdoc />
         public object FetchReferencedObject(int offset)
         {
             object result;

--- a/src/Orleans/Serialization/ReflectedSerializationMethodInfo.cs
+++ b/src/Orleans/Serialization/ReflectedSerializationMethodInfo.cs
@@ -12,17 +12,17 @@ namespace Orleans.Serialization
     internal class ReflectedSerializationMethodInfo
     {
         /// <summary>
-        /// A reference to the <see cref="SerializationContext.StreamWriter"/> getter.
+        /// A reference to the <see cref="ISerializationContext.StreamWriter"/> getter.
         /// </summary>
         public readonly MethodInfo GetStreamFromSerializationContext;
 
         /// <summary>
-        /// A reference to the getter for <see cref="SerializationManager.CurrentDeserializationContext"/>.
+        /// A reference to the getter for <see cref="IDeserializationContext.StreamReader"/>.
         /// </summary>
         public readonly MethodInfo GetStreamFromDeserializationContext;
 
         /// <summary>
-        /// A reference to the <see cref="SerializationContext.RecordCopy"/> method.
+        /// A reference to the <see cref="ICopyContext.RecordCopy"/> method.
         /// </summary>
         public readonly MethodInfo RecordObjectWhileCopying;
 

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1974,33 +1974,6 @@ namespace Orleans.Serialization
 
 #region Utilities
 
-        private static bool HasOrleansSerialization(Type t)
-        {
-            switch (Type.GetTypeCode(t))
-            {
-                case TypeCode.Boolean:
-                case TypeCode.Byte:
-                case TypeCode.SByte:
-                case TypeCode.Int16:
-                case TypeCode.Int32:
-                case TypeCode.Int64:
-                case TypeCode.UInt16:
-                case TypeCode.UInt32:
-                case TypeCode.UInt64:
-                case TypeCode.Single:
-                case TypeCode.Double:
-                case TypeCode.Decimal:
-                case TypeCode.Char:
-                case TypeCode.DateTime:
-                    return true;
-                default:
-                    if (t.IsArray)
-                        return HasOrleansSerialization(t.GetElementType());
-
-                    return t == typeof(string) || serializers.ContainsKey(t.TypeHandle) || typeToExternalSerializerDictionary.ContainsKey(t);
-            }
-        }
-
         internal static Type ResolveTypeName(string typeName)
         {
             Type t;

--- a/src/Orleans/Statistics/ApplicationRequestsStatisticsGroup.cs
+++ b/src/Orleans/Statistics/ApplicationRequestsStatisticsGroup.cs
@@ -40,14 +40,14 @@ namespace Orleans.Runtime
 
         internal static void OnAppRequestsEnd(TimeSpan timeSpan)
         {
-            appRequestsLatencyHistogram.AddData(timeSpan);
-            appRequestsTotalLatency.IncrementBy(timeSpan.Ticks);
-            totalAppRequests.Increment();
+            appRequestsLatencyHistogram?.AddData(timeSpan);
+            appRequestsTotalLatency?.IncrementBy(timeSpan.Ticks);
+            totalAppRequests?.Increment();
         }
 
         internal static void OnAppRequestsTimedOut()
         {
-            timedOutRequests.Increment();
+            timedOutRequests?.Increment();
         }
     }
 }

--- a/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
+++ b/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
@@ -254,7 +254,8 @@ namespace Orleans.Runtime
             numberOfInducedGCsPF.Dispose();
             largeObjectHeapSizePF.Dispose();
             promotedFinalizationMemoryFromGen0PF.Dispose();
-            cpuUsageTimer.Dispose();
+            IDisposable disposable = this.cpuUsageTimer;
+            if (disposable != null) disposable.Dispose();
         }
     }
 }

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProducer.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProducer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.Runtime;
+using Orleans.Serialization;
 
 namespace Orleans.Streams
 {
@@ -9,13 +10,15 @@ namespace Orleans.Streams
     {
         private readonly StreamImpl<T> stream;
         private readonly IQueueAdapter queueAdapter;
+        private readonly RequestContextUtil requestContext;
 
         internal bool IsRewindable { get; private set; }
 
-        internal PersistentStreamProducer(StreamImpl<T> stream, IStreamProviderRuntime providerUtilities, IQueueAdapter queueAdapter, bool isRewindable)
+        internal PersistentStreamProducer(StreamImpl<T> stream, IStreamProviderRuntime providerUtilities, IQueueAdapter queueAdapter, bool isRewindable, RequestContextUtil requestContext)
         {
             this.stream = stream;
             this.queueAdapter = queueAdapter;
+            this.requestContext = requestContext;
             IsRewindable = isRewindable;
             var logger = providerUtilities.GetLogger(this.GetType().Name);
             if (logger.IsVerbose) logger.Verbose("Created PersistentStreamProducer for stream {0}, of type {1}, and with Adapter: {2}.",
@@ -24,12 +27,12 @@ namespace Orleans.Streams
 
         public Task OnNextAsync(T item, StreamSequenceToken token)
         {
-            return queueAdapter.QueueMessageAsync(stream.StreamId.Guid, stream.StreamId.Namespace, item, token, Runtime.RequestContext.Export());
+            return queueAdapter.QueueMessageAsync(stream.StreamId.Guid, stream.StreamId.Namespace, item, token, this.requestContext.Export());
         }
 
         public Task OnNextBatchAsync(IEnumerable<T> batch, StreamSequenceToken token)
         {
-            return queueAdapter.QueueMessageBatchAsync(stream.StreamId.Guid, stream.StreamId.Namespace, batch, token, Runtime.RequestContext.Export());
+            return queueAdapter.QueueMessageBatchAsync(stream.StreamId.Guid, stream.StreamId.Namespace, batch, token, this.requestContext.Export());
         }
 
         public Task OnCompletedAsync()

--- a/src/Orleans/Utils/ServiceCollectionExtensions.cs
+++ b/src/Orleans/Utils/ServiceCollectionExtensions.cs
@@ -2,7 +2,7 @@ using System.Linq;
 
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans.Runtime
+namespace Orleans
 {
     /// <summary>
     /// Extension methods for <see cref="IServiceCollection"/>.

--- a/src/Orleans/project.json
+++ b/src/Orleans/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Newtonsoft.Json": "7.0.1",
     "System.Collections.Immutable": "1.1.37"
   },

--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -132,7 +132,7 @@ namespace Orleans.Storage
                 }
                 catch (StorageException exception)
                 {
-                    var errorCode = exception.RequestInformation.ExtendedErrorInformation.ErrorCode;
+                    var errorCode = exception.RequestInformation.ExtendedErrorInformation?.ErrorCode;
                     if (errorCode == BlobErrorCodeStrings.BlobNotFound)
                     {
                         if (this.Log.IsVerbose2) this.Log.Verbose2((int)AzureProviderErrorCode.AzureBlobProvider_BlobNotFound, "BlobNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
@@ -199,7 +199,7 @@ namespace Orleans.Storage
                 }
                 catch (StorageException exception)
                 {
-                    var errorCode = exception.RequestInformation.ExtendedErrorInformation.ErrorCode;
+                    var errorCode = exception.RequestInformation.ExtendedErrorInformation?.ErrorCode;
                     containerNotFound = errorCode == BlobErrorCodeStrings.ContainerNotFound;
                 }
                 if (containerNotFound)

--- a/src/OrleansAzureUtils/Storage/Exceptions.cs
+++ b/src/OrleansAzureUtils/Storage/Exceptions.cs
@@ -6,7 +6,7 @@ using Orleans.Runtime;
 namespace Orleans.Storage
 {
     /// <summary>
-    /// Exception thrown when a storage provider detects an Etag inconsistency when attemptiong to perform a WriteStateAsync operation.
+    /// Exception thrown when a storage provider detects an Etag inconsistency when attempting to perform a WriteStateAsync operation.
     /// </summary>
     [Serializable]
     public class TableStorageUpdateConditionNotSatisfiedException : InconsistentStateException
@@ -27,7 +27,7 @@ namespace Orleans.Storage
             : base(errorMsg, storedEtag, currentEtag, storageException)
         {
             this.GrainType = grainType;
-            this.GrainId = grainId;
+            this.GrainId = grainId.ToKeyString();
             this.TableName = tableName;
         }
 
@@ -48,7 +48,7 @@ namespace Orleans.Storage
         /// <summary>
         /// Id of grain
         /// </summary>
-        public GrainReference GrainId { get; }
+        public string GrainId { get; }
 
         /// <summary>
         /// Type of grain that throw this exception
@@ -101,7 +101,7 @@ namespace Orleans.Storage
             : base(info, context)
         {
             this.GrainType = info.GetString("GrainType");
-            this.GrainId = GrainReference.FromKeyString(info.GetString("GrainId"));
+            this.GrainId = info.GetString("GrainId");
             this.TableName = info.GetString("TableName");
         }
 
@@ -111,7 +111,7 @@ namespace Orleans.Storage
             if (info == null) throw new ArgumentNullException(nameof(info));
 
             info.AddValue("GrainType", this.GrainType);
-            info.AddValue("GrainId", this.GrainId.ToKeyString());
+            info.AddValue("GrainId", this.GrainId);
             info.AddValue("TableName", this.TableName);
             base.GetObjectData(info, context);
         }

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -107,7 +107,7 @@ namespace Orleans.CodeGenerator
 
             // This check is here and not within TypeUtilities.IsTypeIsInaccessibleForSerialization() to prevent potential infinite recursions 
             var skipSerializerGeneration =
-                t.GetAllFields().Any(field => IsFieldInaccessibleForSerialization(module, targetAssembly, field));
+                t.GetAllFields().Any(field => this.IsFieldInaccessibleForSerialization(module, targetAssembly, field));
             if (skipSerializerGeneration)
             {
                 return false;
@@ -117,7 +117,7 @@ namespace Orleans.CodeGenerator
             return true;
         }
 
-        private static bool IsFieldInaccessibleForSerialization(Module module, Assembly targetAssembly, FieldInfo field)
+        private bool IsFieldInaccessibleForSerialization(Module module, Assembly targetAssembly, FieldInfo field)
         {
             return field.GetCustomAttributes().All(attr => attr.GetType().Name != "NonSerializedAttribute")
                    && !SerializationManager.HasSerializer(field.FieldType)

--- a/src/OrleansRuntime/Catalog/GrainCreator.cs
+++ b/src/OrleansRuntime/Catalog/GrainCreator.cs
@@ -10,7 +10,7 @@ using Orleans.GrainDirectory;
 namespace Orleans.Runtime
 {
     /// <summary>
-    /// Helper classe used to create local instances of grains.
+    /// Helper class used to create local instances of grains.
     /// </summary>
     public class GrainCreator
     {

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -699,28 +699,6 @@ namespace Orleans.Runtime
 
         public IGrainTypeResolver GrainTypeResolver { get; private set; }
 
-        private void CheckValidReminderServiceType(string doingWhat)
-        {
-            var remType = Config.Globals.ReminderServiceType;
-            if (remType.Equals(GlobalConfiguration.ReminderServiceProviderType.NotSpecified) ||
-                remType.Equals(GlobalConfiguration.ReminderServiceProviderType.Disabled))
-            {
-                throw new InvalidOperationException(
-                    string.Format("Cannot {0} when ReminderServiceProviderType is {1}",
-                    doingWhat, remType));
-            }
-        }
-
-        private SiloAddress MapGrainReferenceToSiloRing(GrainReference grainRef)
-        {
-            var hashCode = grainRef.GetUniformHashCode();
-            return ConsistentRingProvider.GetPrimaryTargetSilo(hashCode);
-        }
-
-        public IGrainMethodInvoker GetInvoker(int interfaceId, string genericGrainType = null)
-        {
-            return typeManager.GetInvoker(interfaceId, genericGrainType);
-        }
 
         public void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo)
         {

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -14,7 +13,6 @@ using Orleans.Runtime.GrainDirectory;
 using Orleans.Runtime.Scheduler;
 using Orleans.Serialization;
 using Orleans.Streams;
-using Orleans.Timers;
 
 namespace Orleans.Runtime
 {
@@ -48,8 +46,10 @@ namespace Orleans.Runtime
             IConsistentRingProvider ring,
             GrainTypeManager typeManager,
             TypeMetadataCache typeMetadataCache,
-            OrleansTaskScheduler scheduler)
+            OrleansTaskScheduler scheduler,
+            IServiceProvider serviceProvider)
         {
+            this.ServiceProvider = serviceProvider;
             this.dispatcher = dispatcher;
             MySilo = catalog.LocalSilo;
             this.directory = directory;
@@ -70,6 +70,8 @@ namespace Orleans.Runtime
 
         public static InsideRuntimeClient Current { get { return (InsideRuntimeClient)RuntimeClient.Current; } }
 
+        public IServiceProvider ServiceProvider { get; }
+
         public IStreamProviderManager CurrentStreamProviderManager { get; internal set; }
 
         public IStreamProviderRuntime CurrentStreamProviderRuntime { get; internal set; }
@@ -81,8 +83,6 @@ namespace Orleans.Runtime
         public ClusterConfiguration Config { get; private set; }
 
         public OrleansTaskScheduler Scheduler { get; }
-
-        public IGrainFactory GrainFactory => this.ConcreteGrainFactory;
 
         public IInternalGrainFactory InternalGrainFactory => this.ConcreteGrainFactory;
 

--- a/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAcceptor.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime.Messaging
 {
     internal class IncomingMessageAcceptor : AsynchAgent
     {
-        private readonly ConcurrentObjectPool<SaeaPoolWrapper> receiveEventArgsPool = new ConcurrentObjectPool<SaeaPoolWrapper>(CreateSocketReceiveAsyncEventArgsPoolWrapper);
+        private readonly ConcurrentObjectPool<SaeaPoolWrapper> receiveEventArgsPool;
         private const int SocketBufferSize = 1024 * 128; // 128 kb
         private readonly IPEndPoint listenAddress;
         private Action<Message> sniffIncomingMessageHandler;
@@ -48,6 +48,7 @@ namespace Orleans.Runtime.Messaging
         {
             MessageCenter = msgCtr;
             listenAddress = here;
+            this.receiveEventArgsPool = new ConcurrentObjectPool<SaeaPoolWrapper>(() => this.CreateSocketReceiveAsyncEventArgsPoolWrapper());
             if (here == null)
                 listenAddress = MessageCenter.MyAddress.Endpoint;
 
@@ -401,7 +402,7 @@ namespace Orleans.Runtime.Messaging
             return saea.SocketAsyncEventArgs;
         }
 
-        private static SaeaPoolWrapper CreateSocketReceiveAsyncEventArgsPoolWrapper()
+        private SaeaPoolWrapper CreateSocketReceiveAsyncEventArgsPoolWrapper()
         {
             SocketAsyncEventArgs readEventArgs = new SocketAsyncEventArgs();
             readEventArgs.Completed += OnReceiveCompleted;
@@ -602,6 +603,7 @@ namespace Orleans.Runtime.Messaging
         {
             private readonly IncomingMessageBuffer _buffer;
             private Socket socket;
+
             public Socket Socket {
                 get { return socket; }
                 internal set

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -201,7 +201,6 @@
     <Compile Include="Streams\QueueBalancer\DeploymentBasedQueueBalancer.cs" />
     <Compile Include="Streams\QueueBalancer\StreamQueueBalancerFactory.cs" />
     <Compile Include="Streams\StreamProviderManagerAgent.cs" />
-    <Compile Include="Utilities\ServiceCollectionExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orleans\Orleans.csproj">

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -259,6 +259,7 @@ namespace Orleans.Runtime
             services.AddSingleton<SiloProviderRuntime>();
             services.AddFromExisting<IStreamProviderRuntime, SiloProviderRuntime>();
             services.AddSingleton<ImplicitStreamSubscriberTable>();
+            services.AddSingleton<RequestContextUtil>();
 
             // Placement
             services.AddSingleton<PlacementDirectorsManager>();

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -24,7 +24,7 @@ namespace Orleans.Runtime.Providers
         
         private InvokeInterceptor invokeInterceptor;
 
-        public IGrainFactory GrainFactory { get; }
+        public IGrainFactory GrainFactory => this.runtimeClient.InternalGrainFactory;
         public IServiceProvider ServiceProvider { get; }
 
         public Guid ServiceId { get; }
@@ -33,15 +33,15 @@ namespace Orleans.Runtime.Providers
         public SiloProviderRuntime(
             SiloInitializationParameters siloDetails,
             GlobalConfiguration config,
-            IGrainFactory grainFactory,
             IConsistentRingProvider consistentRingProvider,
             ISiloRuntimeClient runtimeClient,
-            IServiceProvider serviceProvider,
             ImplicitStreamSubscriberTable implicitStreamSubscriberTable,
             ISiloStatusOracle siloStatusOracle,
             OrleansTaskScheduler scheduler,
-            ActivationDirectory activationDirectory)
+            ActivationDirectory activationDirectory,
+            IServiceProvider serviceProvider)
         {
+            this.ServiceProvider = serviceProvider;
             this.siloDetails = siloDetails;
             this.siloStatusOracle = siloStatusOracle;
             this.scheduler = scheduler;
@@ -50,8 +50,6 @@ namespace Orleans.Runtime.Providers
             this.runtimeClient = runtimeClient;
             this.ServiceId = config.ServiceId;
             this.SiloIdentity = siloDetails.SiloAddress.ToLongString();
-            this.GrainFactory = grainFactory;
-            this.ServiceProvider = serviceProvider;
 
             this.grainBasedPubSub = new GrainBasedPubSubRuntime(this.GrainFactory);
             var tmp = new ImplicitStreamPubSub(implicitStreamSubscriberTable);

--- a/src/OrleansSQLUtils/Storage/Provider/AdoNetStorageProvider.cs
+++ b/src/OrleansSQLUtils/Storage/Provider/AdoNetStorageProvider.cs
@@ -167,7 +167,7 @@ namespace Orleans.Storage
             //NOTE: StorageSerializationPicker should be defined outside and given as a parameter in constructor or via Init in IProviderConfiguration perhaps.
             //Currently this limits one's options to much to the current situation of providing only one serializer for serialization and deserialization
             //with no regard to state update or serializer changes. Maybe have this serialized as a JSON in props and read via a key?
-            StorageSerializationPicker = new DefaultRelationalStoragePicker(ConfigureDeserializers(config), ConfigureSerializers(config));
+            StorageSerializationPicker = new DefaultRelationalStoragePicker(this.ConfigureDeserializers(config), this.ConfigureSerializers(config));
 
             //NOTE: Currently there should be only one pair of providers given. That is, only UseJsonFormatPropertyName, UseXmlFormatPropertyName or UseBinaryFormatPropertyName.
             if(StorageSerializationPicker.Deserializers.Count > 1 || StorageSerializationPicker.Serializers.Count > 1)
@@ -544,7 +544,7 @@ namespace Orleans.Storage
         }
 
 
-        private static ICollection<IStorageDeserializer> ConfigureDeserializers(IProviderConfiguration config)
+        private ICollection<IStorageDeserializer> ConfigureDeserializers(IProviderConfiguration config)
         {
             const string @true = "true";
             var deserializers = new List<IStorageDeserializer>();
@@ -568,7 +568,7 @@ namespace Orleans.Storage
         }
 
 
-        private static ICollection<IStorageSerializer> ConfigureSerializers(IProviderConfiguration config)
+        private ICollection<IStorageSerializer> ConfigureSerializers(IProviderConfiguration config)
         {
             const string @true = "true";
             var serializers = new List<IStorageSerializer>();

--- a/test/AWSUtils.Tests/CollectionFixtures.cs
+++ b/test/AWSUtils.Tests/CollectionFixtures.cs
@@ -1,12 +1,11 @@
 ﻿using TestExtensions;
 using Xunit;
 
-namespace UnitTests
+namespace AWSUtils.Tests
 {
     // Assembly collections must be defined once in each assembly
     [CollectionDefinition("DefaultCluster")]
     public class DefaultClusterTestCollection : ICollectionFixture<DefaultClusterFixture> { }
-    
 
     [CollectionDefinition(TestEnvironmentFixture.DefaultCollection)]
     public class TestEnvironmentFixtureCollection : ICollectionFixture<TestEnvironmentFixture> { }

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -4,6 +4,7 @@ using Orleans;
 using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.Runtime.MembershipService;
+using TestExtensions;
 using UnitTests;
 using UnitTests.MembershipTests;
 using Xunit;
@@ -16,7 +17,7 @@ namespace AWSUtils.Tests.MembershipTests
     [TestCategory("Membership"), TestCategory("AWS"), TestCategory("DynamoDb")] 
     public class DynamoDBMembershipTableTest : MembershipTableTestsBase, IClassFixture<DynamoDBStorageTestsFixture>
     {
-        public DynamoDBMembershipTableTest(ConnectionStringFixture fixture) : base(fixture)
+        public DynamoDBMembershipTableTest(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
             LogManager.AddTraceLevelOverride("DynamoDBDataManager", Severity.Verbose3);
             LogManager.AddTraceLevelOverride("OrleansSiloInstanceManager", Severity.Verbose3);

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -4,6 +4,7 @@ using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.Runtime.Host;
 using System.Threading.Tasks;
+using TestExtensions;
 using UnitTests;
 using UnitTests.MembershipTests;
 using Xunit;
@@ -16,7 +17,7 @@ namespace Consul.Tests
     [TestCategory("Membership"), TestCategory("Consul")]
     public class ConsulMembershipTableTest : MembershipTableTestsBase
     {
-        public ConsulMembershipTableTest(ConnectionStringFixture fixture) : base(fixture)
+        public ConsulMembershipTableTest(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
             LogManager.AddTraceLevelOverride("ConsulBasedMembershipTable", Severity.Verbose3);
             LogManager.AddTraceLevelOverride("Storage", Severity.Verbose3);

--- a/test/DefaultCluster.Tests/GrainReferenceTest.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceTest.cs
@@ -89,17 +89,17 @@ namespace DefaultCluster.Tests.General
             TestGrainReferenceSerialization(id, false, true);
         }
 
-        private static void TestGrainReferenceSerialization(int id, bool resolveBeforeSerialize, bool useJson)
+        private void TestGrainReferenceSerialization(int id, bool resolveBeforeSerialize, bool useJson)
         {
             // Make sure grain references serialize well through .NET serializer.
-            var grain = GrainClient.GrainFactory.GetGrain<ISimpleGrain>(random.Next(), UnitTests.Grains.SimpleGrain.SimpleGrainNamePrefix);
+            var grain = this.GrainFactory.GetGrain<ISimpleGrain>(random.Next(), UnitTests.Grains.SimpleGrain.SimpleGrainNamePrefix);
 
             if (resolveBeforeSerialize)
             {
                 grain.SetA(id).Wait(); //  Resolve GR
             }
 
-            object other;
+            ISimpleGrain other;
             if (useJson)
             {
                 // Serialize + Deserialise through Json serializer
@@ -117,33 +117,32 @@ namespace DefaultCluster.Tests.General
             }
 
             Assert.IsAssignableFrom(grain.GetType(), other);
-            ISimpleGrain otherGrain = other as ISimpleGrain;
-            Assert.NotNull(otherGrain);
-            Assert.Equal(grain,  otherGrain);  // "Deserialized grain reference equality is preserved"
-            int res = otherGrain.GetA().Result;
+            Assert.NotNull(other);
+            Assert.Equal(grain,  other);  // "Deserialized grain reference equality is preserved"
+            int res = other.GetA().Result;
             Assert.Equal(id,  res);  // "Returned values from call to deserialized grain reference"
         }
 
-        private static object DotNetSerialiseRoundtrip(object obj)
+        private static T DotNetSerialiseRoundtrip<T>(T obj)
         {
-            object other;
+            T other;
             using (var memoryStream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
                 formatter.Serialize(memoryStream, obj);
                 memoryStream.Flush();
                 memoryStream.Position = 0; // Reset to start
-                other = formatter.Deserialize(memoryStream);
+                other = (T)formatter.Deserialize(memoryStream);
             }
             return other;
         }
 
-        private static object NewtonsoftJsonSerialiseRoundtrip(object obj)
+        private static T NewtonsoftJsonSerialiseRoundtrip<T>(T obj)
         {
             // http://james.newtonking.com/json/help/index.html?topic=html/T_Newtonsoft_Json_JsonConvert.htm
             string json = Newtonsoft.Json.JsonConvert.SerializeObject(obj);
             object other = Newtonsoft.Json.JsonConvert.DeserializeObject(json, obj.GetType());
-            return other;
+            return (T)other;
         }
     }
 }

--- a/test/NonSiloTests/CollectionFixtures.cs
+++ b/test/NonSiloTests/CollectionFixtures.cs
@@ -1,5 +1,5 @@
-﻿using Orleans.Serialization;
-using TestExtensions;
+﻿using TestExtensions;
+using UnitTests.Serialization;
 using Xunit;
 
 namespace Orleans.NonSiloTests

--- a/test/NonSiloTests/General/Identifiertests.cs
+++ b/test/NonSiloTests/General/Identifiertests.cs
@@ -12,19 +12,20 @@ using Xunit.Abstractions;
 
 namespace UnitTests.General
 {
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class Identifiertests
     {
         private readonly ITestOutputHelper output;
+        private readonly TestEnvironmentFixture environment;
         private static readonly Random random = new Random();
 
         class A { }
         class B : A { }
         
-        public Identifiertests(ITestOutputHelper output)
+        public Identifiertests(ITestOutputHelper output, TestEnvironmentFixture fixture)
         {
             this.output = output;
-            SerializationTestEnvironment.Initialize();
-            BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
+            this.environment = fixture;
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]

--- a/test/NonSiloTests/General/InternalSerializationTests.cs
+++ b/test/NonSiloTests/General/InternalSerializationTests.cs
@@ -15,14 +15,17 @@ namespace UnitTests.Serialization
     /// <summary>
     /// Tests for the serialization system.
     /// </summary>
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class InternalSerializationTests
     {
+        private readonly TestEnvironmentFixture fixture;
+
         /// <summary>
         /// Initializes the system for testing.
         /// </summary>
-        public InternalSerializationTests()
+        public InternalSerializationTests(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         /// <summary>

--- a/test/NonSiloTests/General/RequestContextTestsNonSiloRequired.cs
+++ b/test/NonSiloTests/General/RequestContextTestsNonSiloRequired.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Runtime.Remoting.Messaging;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Serialization;
@@ -22,10 +23,12 @@ namespace UnitTests.General
 
         private static readonly SafeRandom random = new SafeRandom();
         private readonly TestEnvironmentFixture fixture;
+        private readonly RequestContextUtil requestContextUtil;
 
         public RequestContextTests_Local(TestEnvironmentFixture fixture)
         {
             this.fixture = fixture;
+            this.requestContextUtil = this.fixture.Services.GetRequiredService<RequestContextUtil>();
             oldPropagateActivityId = RequestContext.PropagateActivityId;
             RequestContext.PropagateActivityId = true;
             Trace.CorrelationManager.ActivityId = Guid.Empty;
@@ -63,7 +66,7 @@ namespace UnitTests.General
                 promises[i] = Task.Run(() =>
                 {
                     flag.Wait();
-                    msg.RequestContextData = RequestContext.Export();
+                    msg.RequestContextData = this.requestContextUtil.Export();
                 });
                 flag.Set();
                 Thread.Sleep(1);
@@ -80,7 +83,7 @@ namespace UnitTests.General
             Guid nullActivityId = Guid.Empty;
 
             Message msg = new Message();
-            msg.RequestContextData = RequestContext.Export();
+            msg.RequestContextData = this.requestContextUtil.Export();
             if (msg.RequestContextData != null) foreach (var kvp in msg.RequestContextData)
                 {
                     headers.Add(kvp.Key, kvp.Value);
@@ -94,7 +97,7 @@ namespace UnitTests.General
             RequestContext.ActivityId.Value = activityId;
 #endif
             msg = new Message();
-            msg.RequestContextData = RequestContext.Export();
+            msg.RequestContextData = this.requestContextUtil.Export();
             if (msg.RequestContextData != null) foreach (var kvp in msg.RequestContextData)
                 {
                     headers.Add(kvp.Key, kvp.Value);
@@ -116,7 +119,7 @@ namespace UnitTests.General
             RequestContext.ActivityId.Value = nullActivityId;
 #endif
             msg = new Message();
-            msg.RequestContextData = RequestContext.Export();
+            msg.RequestContextData = this.requestContextUtil.Export();
             if (msg.RequestContextData != null) foreach (var kvp in msg.RequestContextData)
                 {
                     headers.Add(kvp.Key, kvp.Value);
@@ -130,7 +133,7 @@ namespace UnitTests.General
             RequestContext.ActivityId.Value = activityId2;
 #endif
             msg = new Message();
-            msg.RequestContextData = RequestContext.Export();
+            msg.RequestContextData = this.requestContextUtil.Export();
             foreach (var kvp in msg.RequestContextData)
             {
                 headers.Add(kvp.Key, kvp.Value);
@@ -155,7 +158,7 @@ namespace UnitTests.General
             Guid nullActivityId = Guid.Empty;
 
             Message msg = new Message();
-            msg.RequestContextData = RequestContext.Export();
+            msg.RequestContextData = this.requestContextUtil.Export();
             RequestContext.Clear();
             RequestContext.Import(msg.RequestContextData);
             var actId = RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER);
@@ -167,7 +170,7 @@ namespace UnitTests.General
             RequestContext.ActivityId.Value = activityId;
 #endif
             msg = new Message();
-            msg.RequestContextData = RequestContext.Export();
+            msg.RequestContextData = this.requestContextUtil.Export();
             RequestContext.Clear();
             RequestContext.Import(msg.RequestContextData);
             actId = RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER);
@@ -192,7 +195,7 @@ namespace UnitTests.General
             RequestContext.ActivityId.Value = nullActivityId;
 #endif
             msg = new Message();
-            msg.RequestContextData = RequestContext.Export();
+            msg.RequestContextData = this.requestContextUtil.Export();
             RequestContext.Clear();
             RequestContext.Import(msg.RequestContextData);
             actId = RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER);
@@ -205,7 +208,7 @@ namespace UnitTests.General
             RequestContext.ActivityId.Value = activityId2;
 #endif
             msg = new Message();
-            msg.RequestContextData = RequestContext.Export();
+            msg.RequestContextData = this.requestContextUtil.Export();
             RequestContext.Clear();
             RequestContext.Import(msg.RequestContextData);
             actId = RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER);

--- a/test/NonSiloTests/General/RequestContextTestsNonSiloRequired.cs
+++ b/test/NonSiloTests/General/RequestContextTestsNonSiloRequired.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace UnitTests.General
 {
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class RequestContextTests_Local : IDisposable
     {
         private readonly Dictionary<string, object> headers = new Dictionary<string, object>();
@@ -20,10 +21,11 @@ namespace UnitTests.General
         private static bool oldPropagateActivityId;
 
         private static readonly SafeRandom random = new SafeRandom();
+        private readonly TestEnvironmentFixture fixture;
 
-        public RequestContextTests_Local()
+        public RequestContextTests_Local(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
             oldPropagateActivityId = RequestContext.PropagateActivityId;
             RequestContext.PropagateActivityId = true;
             Trace.CorrelationManager.ActivityId = Guid.Empty;

--- a/test/NonSiloTests/OrleansRuntime/ExceptionsTests.cs
+++ b/test/NonSiloTests/OrleansRuntime/ExceptionsTests.cs
@@ -3,16 +3,20 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
 using Orleans.TestingHost.Utils;
+using TestExtensions;
 using Xunit;
 
 namespace UnitTests.OrleansRuntime
 {
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class ExceptionsTests
     {
-        public ExceptionsTests()
+        private readonly TestEnvironmentFixture fixture;
+
+        public ExceptionsTests(TestEnvironmentFixture fixture)
         {
+            this.fixture = fixture;
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
-            SerializationManager.Initialize(null);
         }
 
 #if !NETSTANDARD

--- a/test/NonSiloTests/Serialization/ILBasedSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/ILBasedSerializerTests.cs
@@ -9,11 +9,14 @@ namespace UnitTests.Serialization
     using Xunit;
 
     [TestCategory("BVT"), TestCategory("Serialization")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class ILSerializerTests
     {
-        public ILSerializerTests()
+        private readonly TestEnvironmentFixture fixture;
+
+        public ILSerializerTests(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         /// <summary>

--- a/test/NonSiloTests/Serialization/SerializerGenerationTests.cs
+++ b/test/NonSiloTests/Serialization/SerializerGenerationTests.cs
@@ -10,11 +10,14 @@ namespace UnitTests.Serialization
     /// <summary>
     /// Test the built-in serializers
     /// </summary>
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class SerializerGenerationTests
     {
-        public SerializerGenerationTests()
+        private readonly TestEnvironmentFixture fixture;
+
+        public SerializerGenerationTests(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/NonSiloTests/SerializationTests/SerializationTests.DifferentTypes.cs
+++ b/test/NonSiloTests/SerializationTests/SerializationTests.DifferentTypes.cs
@@ -11,11 +11,14 @@ namespace UnitTests.Serialization
     /// <summary>
     /// Summary description for SerializationTests
     /// </summary>
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class SerializationTestsDifferentTypes
     {
-        public SerializationTestsDifferentTypes()
+        private readonly TestEnvironmentFixture fixture;
+
+        public SerializationTestsDifferentTypes(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/NonSiloTests/SerializationTests/SerializationTests.ImmutableCollections.cs
+++ b/test/NonSiloTests/SerializationTests/SerializationTests.ImmutableCollections.cs
@@ -8,11 +8,14 @@ using TestExtensions;
 
 namespace Tester.SerializationTests
 {
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class SerializationTestsImmutableCollections
     {
-        public SerializationTestsImmutableCollections()
+        private readonly TestEnvironmentFixture fixture;
+
+        public SerializationTestsImmutableCollections(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         void RoundTripCollectionSerializationTest<T>(IEnumerable<T> input)

--- a/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
+++ b/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
 using Orleans.Providers.Streams.Common;
+using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
 using Orleans.ServiceBus.Providers;
 using OrleansServiceBus.Providers.Streams.EventHub;
@@ -14,12 +11,25 @@ using TestExtensions;
 
 namespace UnitTests.Serialization
 {
-    public class StreamTypeSerializationTests
+    public class FakeSerializerFixture
     {
-        public StreamTypeSerializationTests()
+        public SerializationTestEnvironment Environment = SerializationTestEnvironment.InitializeWithDefaults(
+            new ClientConfiguration
+            {
+                SerializationProviders =
+                {
+                    typeof(FakeSerializer).GetTypeInfo()
+                }
+            });
+    }
+
+    public class StreamTypeSerializationTests : IClassFixture<FakeSerializerFixture>
+    {
+        private readonly FakeSerializerFixture fixture;
+
+        public StreamTypeSerializationTests(FakeSerializerFixture fixture)
         {
-            // FakeSerializer definied in ExternalSerializerTest.cs
-            SerializationTestEnvironment.Initialize(new List<TypeInfo> { typeof(FakeSerializer).GetTypeInfo() });
+            this.fixture = fixture;
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/NonSiloTests/SerializerTests/CustomSerializerTests.cs
+++ b/test/NonSiloTests/SerializerTests/CustomSerializerTests.cs
@@ -69,12 +69,15 @@ namespace NonSiloTests.UnitTests.SerializerTests
         }
     }
 
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class CustomSerializerTests
     {
-        public CustomSerializerTests()
+        private readonly TestEnvironmentFixture fixture;
+
+        public CustomSerializerTests(TestEnvironmentFixture fixture)
         {
+            this.fixture = fixture;
             LogManager.Initialize(new NodeConfiguration());
-            SerializationTestEnvironment.Initialize();
         }
 
         [Fact, TestCategory("Serialization")]

--- a/test/NonSiloTests/SerializerTests/MessageSerializerTests.cs
+++ b/test/NonSiloTests/SerializerTests/MessageSerializerTests.cs
@@ -12,19 +12,16 @@ using Xunit.Abstractions;
 
 namespace NonSiloTests.UnitTests.SerializerTests
 {
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class MessageSerializerTests
     {
         private readonly ITestOutputHelper output;
+        private readonly TestEnvironmentFixture fixture;
 
-        public MessageSerializerTests(ITestOutputHelper output)
+        public MessageSerializerTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
         {
             this.output = output;
-            MessagingStatisticsGroup.Init(false);
-
-            var orleansConfig = ClusterConfiguration.LocalhostPrimarySilo();
-            BufferPool.InitGlobalBufferPool(orleansConfig.Globals);
-
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/TestExtensions/BaseClusterFixture.cs
+++ b/test/TestExtensions/BaseClusterFixture.cs
@@ -17,9 +17,9 @@ namespace TestExtensions
         {
             GrainClient.Uninitialize();
             var testCluster = CreateTestCluster();
-            if (testCluster.Primary == null)
+            if (testCluster?.Primary == null)
             {
-                testCluster.Deploy();
+                testCluster?.Deploy();
             }
             this.HostedCluster = testCluster;
         }
@@ -32,7 +32,7 @@ namespace TestExtensions
 
         public virtual void Dispose()
         {
-            this.HostedCluster.StopAllSilos();
+            this.HostedCluster?.StopAllSilos();
         }
     }
 }

--- a/test/TestExtensions/SerializationTestEnvironment.cs
+++ b/test/TestExtensions/SerializationTestEnvironment.cs
@@ -53,6 +53,8 @@ namespace TestExtensions
 
         internal IInternalGrainFactory InternalGrainFactory => this.RuntimeClient.InternalGrainFactory;
 
+        internal IServiceProvider Services => this.RuntimeClient.ServiceProvider;
+
         public void Dispose()
         {
             this.RuntimeClient?.Dispose();

--- a/test/TestGrains/MessageSerializationGrain.cs
+++ b/test/TestGrains/MessageSerializationGrain.cs
@@ -42,11 +42,6 @@
     [Serializable]
     public struct SimpleType
     {
-        static SimpleType()
-        {
-            SerializationManager.Register(typeof(SimpleType));
-        }
-
         public SimpleType(int num)
         {
             this.Number = num;

--- a/test/Tester/CollectionFixtures.cs
+++ b/test/Tester/CollectionFixtures.cs
@@ -6,4 +6,7 @@ namespace Tester
     // Assembly collections must be defined once in each assembly
     [CollectionDefinition("DefaultCluster")]
     public class DefaultClusterTestCollection : ICollectionFixture<DefaultClusterFixture> { }
+
+    [CollectionDefinition(TestEnvironmentFixture.DefaultCollection)]
+    public class TestEnvironmentFixtureCollection : ICollectionFixture<TestEnvironmentFixture> { }
 }

--- a/test/Tester/GrainServiceTests/GrainServiceTests.cs
+++ b/test/Tester/GrainServiceTests/GrainServiceTests.cs
@@ -25,7 +25,7 @@ namespace Tester
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("GrainServices")]
         public async Task SimpleInvokeGrainService()
         {
-            IGrainServiceTestGrain grain = GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
+            IGrainServiceTestGrain grain = this.GrainFactory.GetGrain<IGrainServiceTestGrain>(0);
             var grainId = await grain.GetHelloWorldUsingCustomService();
             Assert.Equal("Hello World from Grain Service", grainId);
             var prop = await grain.GetServiceConfigProperty("test-property");

--- a/test/Tester/SerializationTests/ConsiderForCodeGenerationAttributeTests.cs
+++ b/test/Tester/SerializationTests/ConsiderForCodeGenerationAttributeTests.cs
@@ -6,11 +6,14 @@ using Xunit;
 
 namespace Tester.SerializationTests
 {
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class ConsiderForCodeGenerationAttributeTests
     {
-        public ConsiderForCodeGenerationAttributeTests()
+        private readonly TestEnvironmentFixture fixture;
+
+        public ConsiderForCodeGenerationAttributeTests(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Serialization")]

--- a/test/Tester/SerializationTests/DeepCopyTests.cs
+++ b/test/Tester/SerializationTests/DeepCopyTests.cs
@@ -11,11 +11,14 @@ namespace UnitTests.Serialization
     /// <summary>
     /// Test the deep copy of built-in and user-defined types
     /// </summary>
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class DeepCopyTests
     {
-        public DeepCopyTests()
+        private readonly TestEnvironmentFixture fixture;
+
+        public DeepCopyTests(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/Tester/SerializationTests/SerializationTests.FSharpTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.FSharpTypes.cs
@@ -9,11 +9,14 @@ namespace UnitTests.Serialization
     /// <summary>
     /// Summary description for SerializationTests
     /// </summary>
-    public class SerializationTestsFsharpTypes
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
+    public class SerializationTestsFSharpTypes
     {
-        public SerializationTestsFsharpTypes()
+        private readonly TestEnvironmentFixture fixture;
+
+        public SerializationTestsFSharpTypes(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         void RoundtripSerializationTest<T>(T input)

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -12,11 +12,14 @@ namespace UnitTests.Serialization
     /// <summary>
     /// Summary description for SerializationTests
     /// </summary>
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class SerializationTestsJsonTypes
     {
-        public SerializationTestsJsonTypes()
+        private readonly TestEnvironmentFixture fixture;
+
+        public SerializationTestsJsonTypes(TestEnvironmentFixture fixture)
         {
-            SerializationTestEnvironment.Initialize();
+            this.fixture = fixture;
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]

--- a/test/TesterAzureUtils/AzureMembershipTableTests.cs
+++ b/test/TesterAzureUtils/AzureMembershipTableTests.cs
@@ -19,7 +19,7 @@ namespace Tester.AzureUtils
     /// </summary>
     public class AzureMembershipTableTests : MembershipTableTestsBase, IClassFixture<AzureStorageBasicTestFixture>
     {
-        public AzureMembershipTableTests(ConnectionStringFixture fixture):base(fixture)
+        public AzureMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
             LogManager.AddTraceLevelOverride("AzureTableDataManager", Severity.Verbose3);
             LogManager.AddTraceLevelOverride("OrleansSiloInstanceManager", Severity.Verbose3);

--- a/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Tester.AzureUtils.Streaming
 {
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class AzureQueueAdapterTests : IDisposable
     {
         private readonly ITestOutputHelper output;
@@ -29,14 +30,15 @@ namespace Tester.AzureUtils.Streaming
         public static readonly string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AQAdapterTests";
 
         private static readonly SafeRandom Random = new SafeRandom();
-        
-        public AzureQueueAdapterTests(ITestOutputHelper output)
+        private readonly TestEnvironmentFixture fixture;
+
+        public AzureQueueAdapterTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
         {
             this.output = output;
             this.deploymentId = MakeDeploymentId();
             LogManager.Initialize(new NodeConfiguration());
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
-            SerializationManager.InitializeForTesting();
+            this.fixture = fixture;
         }
         
         public void Dispose()

--- a/test/TesterInternal/CollectionFixtures.cs
+++ b/test/TesterInternal/CollectionFixtures.cs
@@ -7,7 +7,6 @@ namespace UnitTests
     [CollectionDefinition("DefaultCluster")]
     public class DefaultClusterTestCollection : ICollectionFixture<DefaultClusterFixture> { }
     
-
     [CollectionDefinition(TestEnvironmentFixture.DefaultCollection)]
     public class TestEnvironmentFixtureCollection : ICollectionFixture<TestEnvironmentFixture> { }
 }

--- a/test/TesterInternal/General/LoggerTest.cs
+++ b/test/TesterInternal/General/LoggerTest.cs
@@ -22,9 +22,11 @@ namespace UnitTests
     {
         private readonly ITestOutputHelper output;
         private double timingFactor;
-                
-        public LoggerTest(ITestOutputHelper output)
+        private DefaultClusterFixture fixture;
+
+        public LoggerTest(ITestOutputHelper output, DefaultClusterFixture fixture)
         {
+            this.fixture = fixture;
             this.output = output;
             LogManager.UnInitialize();
             LogManager.SetRuntimeLogLevel(Severity.Verbose);

--- a/test/TesterInternal/GeoClusterTests/LogConsistencyTestFixture.cs
+++ b/test/TesterInternal/GeoClusterTests/LogConsistencyTestFixture.cs
@@ -31,7 +31,7 @@ namespace Tests.GeoClusterTests
             public ClientWrapper(string name, int gatewayport, string clusterId, Action<ClientConfiguration> customizer)
                : base(name, gatewayport, clusterId, customizer)
             {
-                systemManagement = GrainClient.GrainFactory.GetGrain<IManagementGrain>(0);
+                systemManagement = this.GrainFactory.GetGrain<IManagementGrain>(0);
             }
 
             public string GetGrainRef(string grainclass, int i)

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -8,6 +8,7 @@ using Orleans;
 using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
+using TestExtensions;
 using UnitTests.StorageTests;
 using Xunit;
 
@@ -23,8 +24,11 @@ namespace UnitTests.MembershipTests
         internal static readonly string INSTANCE_STATUS_ACTIVE = SiloStatus.Active.ToString();    //"Active";
         internal static readonly string INSTANCE_STATUS_DEAD = SiloStatus.Dead.ToString();        //"Dead";
     }
+
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public abstract class MembershipTableTestsBase : IDisposable, IClassFixture<ConnectionStringFixture>
     {
+        private readonly TestEnvironmentFixture environment;
         private static readonly string hostName = Dns.GetHostName();
         private readonly Logger logger;
         private readonly IMembershipTable membershipTable;
@@ -33,8 +37,9 @@ namespace UnitTests.MembershipTests
 
         protected const string testDatabaseName = "OrleansMembershipTest";//for relational storage
 
-        protected MembershipTableTestsBase(ConnectionStringFixture fixture)
+        protected MembershipTableTestsBase(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
         {
+            this.environment = environment;
             LogManager.Initialize(new NodeConfiguration());
             logger = LogManager.GetLogger(GetType().Name, LoggerType.Application);
             deploymentId = "test-" + Guid.NewGuid();
@@ -66,6 +71,8 @@ namespace UnitTests.MembershipTests
             gatewayListProvider = CreateGatewayListProvider(logger);
             gatewayListProvider.InitializeGatewayListProvider(clientConfiguration, logger).WithTimeout(TimeSpan.FromMinutes(1)).Wait();
         }
+
+        public IGrainFactory GrainFactory => this.environment.GrainFactory;
 
         public void Dispose()
         {

--- a/test/TesterSQLUtils/MySqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/MySqlMembershipTableTests.cs
@@ -4,6 +4,7 @@ using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.Runtime.MembershipService;
 using Orleans.SqlUtils;
+using TestExtensions;
 using UnitTests.General;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace UnitTests.MembershipTests
     /// </summary>
     public class MySqlMembershipTableTests : MembershipTableTestsBase
     {
-        public MySqlMembershipTableTests(ConnectionStringFixture fixture) : base(fixture)
+        public MySqlMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
             LogManager.AddTraceLevelOverride(typeof (MySqlMembershipTableTests).Name, Severity.Verbose3);
         }

--- a/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
@@ -4,6 +4,7 @@ using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.Runtime.MembershipService;
 using Orleans.SqlUtils;
+using TestExtensions;
 using UnitTests.General;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace UnitTests.MembershipTests
 {
     public class PostgreSqlMembershipTableTests : MembershipTableTestsBase
     {
-        public PostgreSqlMembershipTableTests(ConnectionStringFixture fixture) : base(fixture)
+        public PostgreSqlMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
             LogManager.AddTraceLevelOverride(typeof(PostgreSqlMembershipTableTests).Name, Severity.Verbose3);
         }

--- a/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
+++ b/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
@@ -4,6 +4,7 @@ using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.Runtime.MembershipService;
 using Orleans.SqlUtils;
+using TestExtensions;
 using UnitTests.General;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace UnitTests.MembershipTests
     /// </summary>
     public class SqlServerMembershipTableTests : MembershipTableTestsBase
     {
-        public SqlServerMembershipTableTests(ConnectionStringFixture fixture) : base(fixture)
+        public SqlServerMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
             LogManager.AddTraceLevelOverride(typeof (SqlServerMembershipTableTests).Name, Severity.Verbose3);
         }

--- a/test/TesterSQLUtils/SqlStatisticsPublisherTests/MySqlStatisticsPublisherTests.cs
+++ b/test/TesterSQLUtils/SqlStatisticsPublisherTests/MySqlStatisticsPublisherTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Orleans.SqlUtils;
+using TestExtensions;
 using Xunit;
 
 namespace UnitTests.SqlStatisticsPublisherTests
@@ -9,7 +10,7 @@ namespace UnitTests.SqlStatisticsPublisherTests
     /// </summary>
     public class MySqlStatisticsPublisherTests : SqlStatisticsPublisherTestsBase
     {
-        public MySqlStatisticsPublisherTests(ConnectionStringFixture fixture) : base(fixture)
+        public MySqlStatisticsPublisherTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
         }
         protected override string AdoInvariant

--- a/test/TesterSQLUtils/SqlStatisticsPublisherTests/PostgreSqlStatisticsPublisherTests.cs
+++ b/test/TesterSQLUtils/SqlStatisticsPublisherTests/PostgreSqlStatisticsPublisherTests.cs
@@ -1,12 +1,13 @@
 ﻿using System.Threading.Tasks;
 using Orleans.SqlUtils;
+using TestExtensions;
 using Xunit;
 
 namespace UnitTests.SqlStatisticsPublisherTests
 {
     public class PostgreSqlStatisticsPublisherTests : SqlStatisticsPublisherTestsBase
     {
-        public PostgreSqlStatisticsPublisherTests(ConnectionStringFixture fixture) : base(fixture)
+        public PostgreSqlStatisticsPublisherTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
         }
         protected override string AdoInvariant

--- a/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlServerStatisticsPublisherTests.cs
+++ b/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlServerStatisticsPublisherTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Orleans.SqlUtils;
+using TestExtensions;
 using Xunit;
 
 namespace UnitTests.SqlStatisticsPublisherTests
@@ -9,7 +10,7 @@ namespace UnitTests.SqlStatisticsPublisherTests
     /// </summary>
     public class SqlServerStatisticsPublisherTests : SqlStatisticsPublisherTestsBase
     {
-        public SqlServerStatisticsPublisherTests(ConnectionStringFixture fixture) : base(fixture)
+        public SqlServerStatisticsPublisherTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
         }
         protected override string AdoInvariant

--- a/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
+++ b/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
@@ -8,6 +8,7 @@ using Orleans.Providers.SqlServer;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.MembershipService;
+using TestExtensions;
 using UnitTests.General;
 using Xunit;
 
@@ -16,8 +17,10 @@ namespace UnitTests.SqlStatisticsPublisherTests
     /// <summary>
     /// Tests for operation of Orleans Statistics Publisher using relational storage
     /// </summary>
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public abstract class SqlStatisticsPublisherTestsBase: IClassFixture<ConnectionStringFixture>
     {
+        private readonly TestEnvironmentFixture environment;
         protected abstract string AdoInvariant { get; }
 
         private readonly string ConnectionString;
@@ -28,8 +31,9 @@ namespace UnitTests.SqlStatisticsPublisherTests
 
         private readonly SqlStatisticsPublisher StatisticsPublisher;
         
-        protected SqlStatisticsPublisherTestsBase(ConnectionStringFixture fixture)
+        protected SqlStatisticsPublisherTestsBase(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
         {
+            this.environment = environment;
             LogManager.Initialize(new NodeConfiguration());
             logger = LogManager.GetLogger(GetType().Name, LoggerType.Application);
 

--- a/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -14,7 +14,7 @@ namespace UnitTests.MembershipTests
     /// </summary>
     public class ZookeeperMembershipTableTests : MembershipTableTestsBase
     {
-        public ZookeeperMembershipTableTests(ConnectionStringFixture fixture) : base(fixture)
+        public ZookeeperMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
         {
             LogManager.AddTraceLevelOverride(typeof (ZookeeperMembershipTableTests).Name, Severity.Verbose3);
         }

--- a/vNext/test/NonSiloTests/Orleans.NonSiloTests.csproj
+++ b/vNext/test/NonSiloTests/Orleans.NonSiloTests.csproj
@@ -44,6 +44,9 @@
     <Compile Include="..\..\..\test\NonSiloTests\ConfigTests.cs">
       <Link>ConfigTests.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\test\NonSiloTests\CollectionFixtures.cs">
+      <Link>CollectionFixtures.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\test\NonSiloTests\AsynchAgentRestartTest.cs">
       <Link>AsynchAgentRestartTest.cs</Link>
     </Compile>


### PR DESCRIPTION
Please review the latest commit only and of course avoid merging before the prior commits are merged (#2654 & #2665).

Since `RequestContext` has an implicit dependency on `SerializationManager`, changes will need to be made to support #467.

This PR injects a seemingly useless class, `RequestContextUtil` which will later hold an instance of non-static `SerializationManager` (as can be seen in #2592).

It also adds a client-side dependency on `Microsoft.Extensions.DependencyInjection`. This needs to happen sooner or later. DI is not exposed to consumers by this PR.