### PR TITLE
event-sourcing documentation

### DIFF
--- a/src/Documentation/Event-Sourcing/Configuration.md
+++ b/src/Documentation/Event-Sourcing/Configuration.md
@@ -1,0 +1,69 @@
+---
+layout: page
+title: Configuration
+---
+
+# Configuration
+
+## Configuring Project References
+
+### Grain Interfaces
+
+As before, interfaces depend only on the `Microsoft.Orleans.Core` package, because the grain interface is independent of the implementation. 
+
+### Grain Implementations
+
+JournaledGrains need to derive from `JournaledGrain<S,E>` or `JournaledGrain<S>`, which is defined in the `Microsoft.Orleans.EventSourcing` package. 
+
+### Log-Consistency Providers
+
+We currently include three log-consistency providers (for state storage, log storage, and custom storage). All three are contained in the `Microsoft.Orleans.EventSourcing` package as well. Therefore, all Journaled Grains already have access to those. For a description of what these providers do and how they differ, see [Included Log-Consistency Providers](LogConsistencyProviders.md).
+
+## Cluster Configuration
+
+Log-consistency providers are configured just like any other Orleans providers.
+For example, to include all three providers (of course, you probably won't need all three), add this to the `<Globals>` element of the configuration file:
+
+```xml
+<LogConsistencyProviders>
+  <Provider Type="Orleans.EventSourcing.StateStorage.LogConsistencyProvider" Name="StateStorage" />
+  <Provider Type="Orleans.EventSourcing.LogStorage.LogConsistencyProvider" Name="LogStorage" />
+  <Provider Type="Orleans.EventSourcing.CustomStorage.LogConsistencyProvider" Name="CustomStorage" />
+</LogConsistencyProviders>
+```
+
+The same can be achieved programmatically. Assuming the project contains the `Microsoft.Orleans.EventSourcing` package, and `config` is a `ClusterConfiguration` object:
+
+```csharp
+using Orleans.Runtime.Configuration; \\ pick up the necessary extension methods
+
+config.AddLogStorageBasedLogConsistencyProvider("LogStorage");
+config.AddStateStorageBasedLogConsistencyProvider("StateStorage");
+config.AddCustomStorageBasedLogConsistencyProvider("CustomStorage");
+```
+
+## Grain Class Attributes
+
+Each journaled grain class can be configured to use a log-consistency provider, and a storage provider of choice. These choices are independent.
+
+
+### LogConsistencyProvider Attributes
+
+By default, a journaled grain uses the built-in `StateStorage` provider. This provider persists the latest state snapshot, but not the events themselves. We can choose a different provider by adding a `[LogConsistencyProvider(ProviderName=...)]` attribute to the grain class, and give the name of the provider as configured by the Cluster Configuration. For example, the following attribute means that for `ChatGrain` instances, we use the `LogStorage` provider, which was configured to use `Orleans.EventSourcing.LogStorage.LogConsistencyProvider`. This provider always persists the entire event sequence (log).
+
+```csharp
+[LogConsistencyProvider(ProviderName = "LogStorage")]
+public class ChatGrain : JournaledGrain<XDocument, IChatEvent>, IChatGrain { ... }
+```
+
+### StorageProvider Attributes
+
+Some consistency providers (including both the LogStorage and StateStorage providers) in turn rely on a StorageProvider to communicate with storage. As usual, a default storage provider is used if none is explicitly specified. But we can add one. For example, we could specify
+
+```csharp
+[LogConsistencyProvider(ProviderName = "LogStorage")]
+[StorageProvider(ProviderName = "AzureBlobStorage")]
+public class ChatGrain : JournaledGrain<XDocument, IChatEvent>, IChatGrain { ... }
+```
+
+

--- a/src/Documentation/Event-Sourcing/Configuration.md
+++ b/src/Documentation/Event-Sourcing/Configuration.md
@@ -31,11 +31,10 @@ For example, to include all three providers (of course, you probably won't need 
   <Provider Type="Orleans.EventSourcing.CustomStorage.LogConsistencyProvider" Name="CustomStorage" />
 </LogConsistencyProviders>
 ```
-
 The same can be achieved programmatically. Assuming the project contains the `Microsoft.Orleans.EventSourcing` package, and `config` is a `ClusterConfiguration` object:
 
 ```csharp
-using Orleans.Runtime.Configuration; \\ pick up the necessary extension methods
+using Orleans.Runtime.Configuration; // pick up the necessary extension methods
 
 config.AddLogStorageBasedLogConsistencyProvider("LogStorage");
 config.AddStateStorageBasedLogConsistencyProvider("StateStorage");
@@ -44,21 +43,21 @@ config.AddCustomStorageBasedLogConsistencyProvider("CustomStorage");
 
 ## Grain Class Attributes
 
-Each journaled grain class can be configured to use a log-consistency provider, and a storage provider of choice. These choices are independent.
+Each journaled grain class must have a `LogConsistencyProvider` attribute to specify the log-consistency provider. Some providers additionally require a `StorageProvider` attribute.
 
 
 ### LogConsistencyProvider Attributes
 
-By default, a journaled grain uses the built-in `StateStorage` provider. This provider persists the latest state snapshot, but not the events themselves. We can choose a different provider by adding a `[LogConsistencyProvider(ProviderName=...)]` attribute to the grain class, and give the name of the provider as configured by the Cluster Configuration. For example, the following attribute means that for `ChatGrain` instances, we use the `LogStorage` provider, which was configured to use `Orleans.EventSourcing.LogStorage.LogConsistencyProvider`. This provider always persists the entire event sequence (log).
+To specify the log-consistency provider, add a `[LogConsistencyProvider(ProviderName=...)]` attribute to the grain class, and give the name of the provider as configured by the Cluster Configuration. For example:
 
 ```csharp
-[LogConsistencyProvider(ProviderName = "LogStorage")]
-public class ChatGrain : JournaledGrain<XDocument, IChatEvent>, IChatGrain { ... }
+[LogConsistencyProvider(ProviderName = "CustomStorage")]
+public class ChatGrain : JournaledGrain<XDocument, IChatEvent>, IChatGrain, ICustomStorage { ... }
 ```
 
 ### StorageProvider Attributes
 
-Some consistency providers (including both the LogStorage and StateStorage providers) in turn rely on a StorageProvider to communicate with storage. As usual, a default storage provider is used if none is explicitly specified. But we can add one. For example, we could specify
+Some log-consistency providers (including `LogStorage` and `StateStorage`) use a standard StorageProvider to communicate with storage. This provider is specified using a separate `StorageProvider` attribute, as follows:
 
 ```csharp
 [LogConsistencyProvider(ProviderName = "LogStorage")]
@@ -66,4 +65,14 @@ Some consistency providers (including both the LogStorage and StateStorage provi
 public class ChatGrain : JournaledGrain<XDocument, IChatEvent>, IChatGrain { ... }
 ```
 
+## Default Providers
 
+It is possible to omit the `LogConsistencyProvider` and/or the `StorageProvider` attributes, if a default is specified in the configuration. This is done by using the special name `Default` for the respective provider. For example:
+```xml
+<LogConsistencyProviders>
+  <Provider Type="Orleans.EventSourcing.LogStorage.LogConsistencyProvider" Name="Default" />
+</LogConsistencyProviders>
+<StorageProviders>
+  <Provider Type="Orleans.Storage.MemoryStorage" Name="Default" />
+</StorageProviders>
+```

--- a/src/Documentation/Event-Sourcing/Diagnostics.md
+++ b/src/Documentation/Event-Sourcing/Diagnostics.md
@@ -1,0 +1,44 @@
+---
+layout: page
+title: JournaledGrain Diagnostics
+---
+
+# JournaledGrain Diagnostics
+
+
+## Monitoring Connection Errors
+
+By design, log consistency providers are resilient under connection errors (including both connections to storage, and connections between clusters). But just tolerating errors is not enough, as applications usually need to monitor any such issues, and bring them to the attention of an operator if they are serious.
+
+JournaledGrain subclasses can override the following methods to receive notifiations when there are connection errors observed, and when those errors are resolved:
+
+```csharp
+protected override void OnConnectionIssue(ConnectionIssue issue) 
+{
+    /// handle the observed error described by issue             
+}
+protected override void OnConnectionIssueResolved(ConnectionIssue issue) 
+{
+    /// handle the resolution of a previously reported issue             
+}
+```
+    
+`ConnectionIssue` is an abstract class, with several common fields describing the issue, including how many times it has been observed since the last time connection was successful. The actual type of connection issue is defined by subclasses. Connection issues are categorized into types, such as `PrimaryOperationFailed` or `NotificationFailed`, and sometimes have extra keys (such as `RemoteCluster`) that further narrow the category.
+
+If the same category of issue happens several times (for example, we keep getting a `NotificationFailed` that targets the same `RemoteCluster`), it is reported each time by `OnConnectionIssue`. Once this category of issue is resolved (for example, we are finally successful with sending a notification to this `RemoteCluster`), then `OnConnectionIssueResolved` is called once, with the same `issue` object that was last reported by `OnConnectionIssue`. Connection issues, and their resolution, for independent categories, are reported independently.
+
+## Simple Statistics
+
+We currently offer a simple support for basic statistics (in the future, we will probably replace this with a more standard telemetry mechanism).
+Statistics collection can be enabled or disabled for a JournaledGrain by calling
+
+```csharp
+void EnableStatsCollection()
+void DisableStatsCollection()
+```
+
+The statistics can be retrieved by calling
+
+ ```csharp
+LogConsistencyStatistics GetStats()
+```

--- a/src/Documentation/Event-Sourcing/GrainStateAPI.md
+++ b/src/Documentation/Event-Sourcing/GrainStateAPI.md
@@ -99,7 +99,7 @@ This guarantees that the given sequence of events is written to storage atomical
 
 ## Retrieving the Event Sequence
 
-The following method allows the application to retrieve a specified segment of the sequence of all confirmed events:
+The following method from the base `JournaledGrain` class allows the application to retrieve a specified segment of the sequence of all confirmed events:
 
 ```csharp
 Task<IReadOnlyList<EventType>> RetrieveConfirmedEvents(int fromVersion, int toVersion)
@@ -107,6 +107,15 @@ Task<IReadOnlyList<EventType>> RetrieveConfirmedEvents(int fromVersion, int toVe
 
 However, it is not supported by all log consistency providers. If not supported, or if the specified segment of the sequence is no longer available, a `NotSupportedException` is thrown. 
 
+To retrieve all events up to the latest confirmed version, one would call 
+```csharp
+await RetrieveConfirmedEvents(0, Version);
+```
+
+Only confirmed events can be retrieved: an exception is thrown if `toVersion` is larger than the current value of the property `Version`.
+
+Since confirmed events never change, there are no races to worry about, even in the presence of [multiple instances](MultiInstance.md) or [delayed confirmation](MultiVersion.md). However, in such situations, it is possible that the value of the property `Version` is larger by the time the `await` resumes than at the time `RetrieveConfirmedEvents` is called, so it may be advisable to save its value in a variable. See also the section on [Concurrency Guarantees](MultiVersion.md).
+ 
 
 
 

--- a/src/Documentation/Event-Sourcing/GrainStateAPI.md
+++ b/src/Documentation/Event-Sourcing/GrainStateAPI.md
@@ -1,0 +1,112 @@
+---
+layout: page
+title: JournaledGrain API
+---
+
+# JournaledGrain Basics
+
+Journaled grains derive from `<JournaledGrain<StateType,EventType>`, with the following type parameters:
+
+* The `StateType` represents the state of the grain. It must be a class with a public default constructor.  
+* `EventType` is a common supertype for all the events that can be raised for this grain, and can be any class or interface. 
+
+All state and event objects should be serializable (because the log-consistency providers may need to persist them, and/or send them in notification messages). 
+
+For grains whose events are POCOs (plain old C# objects),  `JournaledGrain<StateType>` can be used as a shorthand for `JournaledGrain<StateType,Object>`.
+
+## Reading the Grain State
+
+To read the current grain state, and determine its version number, the JournaledGrain has properties
+
+```csharp
+GrainState State { get; }
+int Version { get; }
+```
+
+The version number is always equal to the total number of confirmed events, and the state is the result of applying all the confirmed events to the initial state. The initial state, which has version 0 (because no events have been applied to it), is determined by the default constructor of the GrainState class.
+
+_Important:_ The application should never directly modify the object returned by `State`. It is meant for reading only. Rather, when the application wants to modify the state, it must do so indirectly by raising events.
+
+## Raising Events
+
+Raising events is accomplished by calling the `RaiseEvent` function. For example, a grain representing a chat can raise a `PostedEvent` to indicate that a user submitted a post:
+
+```csharp
+RaiseEvent(new PostedEvent() { Guid = guid, User = user, Text = text, Timestamp = DateTime.UtcNow });
+```
+
+Note that `RaiseEvent` kicks off a write to storage access, but does not wait for the write to complete. For many applications, it is important to wait until we have confirmation that the event has been persisted. In that case, we always follow up by waiting for `ConfirmEvents`:
+
+```csharp
+RaiseEvent(new DepositTransaction() { DepositAmount = amount, Description = description });
+await ConfirmEvents();
+```
+
+Note that even if you don't explicitly call `ConfirmEvents`, the events will eventually be confirmed - it happens automatically in the background. For more discussion on this topic, see [Immediate vs. Delayed Confirmation](MultiVersion.md).
+
+## State Transition Methods
+
+The runtime updates the grain state _automatically_ whenever events are raised. There is no need for the application to explicitly update the state after raising an event. However, the application still has to provide the code that specifies _how_ to update the state in response to an event. This can be done in two ways.
+
+**(a)** The GrainState class can implement one or more `Apply` methods on the `StateType`. Typically, one would create multiple overloads, and the closest match is chosen for the runtime type of the event:
+```csharp
+class GrainState {
+   
+   Apply(E1 @event)  
+   {
+     // code that updates the state
+   }
+   Apply(E2 @event)  
+   {
+     // code that updates the state
+   }
+}
+```
+
+**(b)** The grain can override the TransitionState function:
+```csharp
+protected override void TransitionState(State state, EventType @event)
+{
+   // code that updates the state
+}
+```
+
+The transition methods are assumed to have no side effects other than modifying the state object, and should be deterministic (otherwise, the effects are unpredictable).  If the transition code throws an exception, that exception is caught and included in a warning in the Orleans log, issued by the log-consistency provider.  
+
+When, exactly, the runtime calls the transition methods depends on the chosen log consistency provider and its configuration. It is best for applications not to rely on a particular timing, except when specifically guaranteed by the log consistency provider. 
+
+Some providers, such as the `LogStorage` log-consistency provider, replay the event sequence every time the grain is loaded. Therefore, as long as the event objects can still be properly deserialized from storage, it is possibly to radically modify the GrainState class and the transition methods. But for other providers, such as the `StateStorage` log-consistency provider, only the `GrainState` object is persisted, so developers must ensure that it can be deserialized correctly when read from storage. 
+
+
+## Raising Multiple Events
+
+It is possible to make multiple calls to RaiseEvent before calling ConfirmEvents:
+
+```csharp
+RaiseEvent(e1);
+RaiseEvent(e2);
+await ConfirmEvents();
+```
+
+However, this is likely to cause two successive storage accesses, and it incurs a risk that the grain fails after writing only the first event. Thus, it is usually better to raise multiple events at once, using
+
+```csharp
+RaiseEvents(IEnumerable<EventType> events)
+```
+
+This guarantees that the given sequence of events is written to storage atomically. Note that since the version number always matches the length of the event sequence, raising multiple events increases the version number by more than one at a time.
+
+
+## Retrieving the Event Sequence
+
+The following method allows the application to retrieve a specified segment of the sequence of all confirmed events:
+
+```csharp
+Task<IReadOnlyList<EventType>> RetrieveConfirmedEvents(int fromVersion, int toVersion)
+```
+
+However, it is not supported by all log consistency providers. If not supported, or if the specified segment of the sequence is no longer available, a `NotSupportedException` is thrown. 
+
+
+
+

--- a/src/Documentation/Event-Sourcing/LogConsistencyProviders.md
+++ b/src/Documentation/Event-Sourcing/LogConsistencyProviders.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: Included Log-Consistency Providers
+---
+
+# Built-In Log-Consistency Providers
+
+The `Microsoft.Orleans.EventSourcing` package includes several log-consistency providers that cover basic scenarios suitable to get started, and allow some extensibility.
+
+
+### Orleans.EventSourcing.**StateStorage**.LogConsistencyProvider
+
+This provider stores *grain state snapshots*, using a standard storage provider that can be configured independently. 
+
+The data that is kept in storage is an object that contains both the grain state (as specified by the first type parameter to `JournaledGrain`) and some meta-data (the version number, amd a special tag that is used to avoid duplication of events when storage accesses fail).
+
+Since the entire grain state is read/written every time we access storage, this provider is not suitable for objects whose grain state is very large. 
+
+This provider does not support `RetrieveConfirmedEvents`: it cannot retrieve the events from storage because the events are not persisted.
+
+### Orleans.EventSourcing.**LogStorage**.LogConsistencyProvider
+
+This provider stores *the complete event sequence as a single object*, using a standard storage provider that can be configured independently.
+
+The data that is kept in storage is an object that contains a `List<EventType> object`, and some meta-data (a special tag that is used to avoid duplication of events when storage accesses fail).
+
+This provider does support `RetrieveConfirmedEvents`. All events are always available and kept in memory.
+
+Since the whole event sequence is read/written every time we access storage, this provider is _not suitable for use in production_, unless the event sequences are guaranteed to remain pretty short. The main purpose of this provider is to illustrate the semantics of the event sourcing, and for samples/testing environments.
+
+### Orleans.EventSourcing.**CustomStorage**.LogConsistencyProvider
+
+This provider allows the developer to plug in their own storage interface, which is then called by the conistency protocol at appropriate times. This provider does not make specific assumptions about whether what is stored are state snapshots or events - the programmer assumes control over that choice (and may store either or both).
+
+To use this provider, a grain must derive from `JournaledGrain<StateType,EventType>`, as before, but additionally must also implement the following interface:
+
+```csharp
+public interface ICustomStorageInterface<StateType, EventType>
+{
+   Task<KeyValuePair<int,StateType>> ReadStateFromStorage();
+
+   Task<bool> ApplyUpdatesToStorage(IReadOnlyList<EventType> updates, int expectedversion);
+}
+```
+The consistency provider expects these to behave a certain way. Programmers should be aware that:
+
+* The first method, `ReadStateFromStorage`, is expected to return both the version, and the state read. If there is nothing stored yet, it should return zero for the version and a state that matches corresponds to the default constructor for `StateType`.
+
+* `ApplyUpdatesToStorage` must return false if the expected version does not match the actual version (this is analogous to an e-tag check). 
+
+* If `ApplyUpdatesToStorageFails` fails with an exception, the consistency provider retries. This means some events could be duplicated if such an exception is thrown, but the event was actually persisted. The developer is responsible to make sure this is safe: e.g. either avoid this case by not throwing an exception, or ensure duplicated events are harmless for the application logic, or add some extra mechanism to filter duplicates.  
+
+This provider does not support `RetrieveConfirmedEvents`. Of course, since the developer controls the storage interface anyway, they don't need to call this in the first place, but can implement their own event retrieval.
+

--- a/src/Documentation/Event-Sourcing/LogConsistencyProviders.md
+++ b/src/Documentation/Event-Sourcing/LogConsistencyProviders.md
@@ -12,9 +12,9 @@ The `Microsoft.Orleans.EventSourcing` package includes several log-consistency p
 
 This provider stores *grain state snapshots*, using a standard storage provider that can be configured independently. 
 
-The data that is kept in storage is an object that contains both the grain state (as specified by the first type parameter to `JournaledGrain`) and some meta-data (the version number, amd a special tag that is used to avoid duplication of events when storage accesses fail).
+The data that is kept in storage is an object that contains both the grain state (as specified by the first type parameter to `JournaledGrain`) and some meta-data (the version number, and a special tag that is used to avoid duplication of events when storage accesses fail).
 
-Since the entire grain state is read/written every time we access storage, this provider is not suitable for objects whose grain state is very large. 
+Since the entire grain state is read/written every time we access storage, this provider is not suitable for objects whose grain state is very large.
 
 This provider does not support `RetrieveConfirmedEvents`: it cannot retrieve the events from storage because the events are not persisted.
 
@@ -48,7 +48,7 @@ The consistency provider expects these to behave a certain way. Programmers shou
 
 * `ApplyUpdatesToStorage` must return false if the expected version does not match the actual version (this is analogous to an e-tag check). 
 
-* If `ApplyUpdatesToStorageFails` fails with an exception, the consistency provider retries. This means some events could be duplicated if such an exception is thrown, but the event was actually persisted. The developer is responsible to make sure this is safe: e.g. either avoid this case by not throwing an exception, or ensure duplicated events are harmless for the application logic, or add some extra mechanism to filter duplicates.  
+* If `ApplyUpdatesToStorage` fails with an exception, the consistency provider retries. This means some events could be duplicated if such an exception is thrown, but the event was actually persisted. The developer is responsible to make sure this is safe: e.g. either avoid this case by not throwing an exception, or ensure duplicated events are harmless for the application logic, or add some extra mechanism to filter duplicates.  
 
 This provider does not support `RetrieveConfirmedEvents`. Of course, since the developer controls the storage interface anyway, they don't need to call this in the first place, but can implement their own event retrieval.
 

--- a/src/Documentation/Event-Sourcing/MultiInstance.md
+++ b/src/Documentation/Event-Sourcing/MultiInstance.md
@@ -1,0 +1,64 @@
+---
+layout: page
+title: Replicated Grains
+---
+
+## Replicated Grains
+
+Sometimes, there can be multiple instances of the same grain active, such as when operating a multi-cluster, and using the `[OneInstancePerCluster]` attribute. The JournaledGrain is designed to support replicated instances with minimal friction. It relies on *log-consistency providers* to run the necessary protocols to ensure all instances agree on the same sequence of events. In particular, it takes care of the following aspects: 
+
+* **Consistent Versions**: All versions of the grain state (except for tentative versions) are based on the same global sequence of events. In particular, if two instances see the same version number, then they see the same state.
+
+* **Racing Events**: Multiple instances can simultaneously raise an event. The consistency provider resolves this race and ensures everyone agrees on the same sequence.
+
+* **Notifications/Reactivity**: After an event is raised at one grain instance, the consistency provider not only updates storage, but also notifies all the other grain instances.
+
+For a general discussion of the consistency model see our [TechReport](https://www.microsoft.com/en-us/research/publication/geo-distribution-actor-based-services/) and the [GSP paper](https://www.microsoft.com/en-us/research/publication/global-sequence-protocol-a-robust-abstraction-for-replicated-shared-state-extended-version/) (Global Sequence Protocol).
+
+## Conditional Events
+
+Racing events can be problematic if they have a conflict, i.e. should not both commit for some reason. For example, when withdrawing money from a bank account, two instances may independently determine that there are sufficient funds for a withdrawal, and issue a withdrawal event. But the combination of both events could overdraw. To avoid this, the JournaledGrain API supports a `RaiseConditionalEvent` method. 
+
+```csharp
+bool success = await RaiseConditionalEvent(new WithdrawalEvent()  { ... });
+```
+
+Conditional events double-check if the local version matches the version in storage. If not, it means the event sequence has grown in the meantime, which means this event has lost a race against some other event. In that case, the conditional event is *not* appended to the log, and `RaiseConditionalEvent` returns false.
+
+This is the analogue of using e-tags with conditional storage updates, and likewise provides a simple mechanism to avoid committing conflicting events. 
+
+It is possible and sensible to use both conditional and unconditional events for the same grain, such as a `DepositEvent` and a `WithdrawalEvent`. Deposits need not be conditional: even if a `DepositEvent` loses a race, it does not have to be cancelled, but can still be appended to the global event sequence. 
+
+Awaiting the task returned by `RaiseConditionalEvent` is sufficient to confirm the event, i.e. it is not necessary to also call `ConfirmEvents`.
+
+## Explicit Synchronization
+
+Sometimes, it is desirable to ensure that a grain is fully caught up with the latest version. This can be enforced by calling
+
+```csharp
+await RefreshNow();
+```
+
+which both (1) confirms all unconfirmed events, and (2) loads the latest version from storage.
+
+## Subscribing to Changes
+
+It is often convenient to have the ability to react to state changes. To this end, `JournaledGrain` subclasses can override this method:
+
+
+```csharp
+protected override void OnStateChanged()
+{
+   // read state and/or event log and take appropriate action
+}
+```
+
+`OnStateChanged` is called whenever the confirmed state is updated, i.e. the version number increases. This can happen when
+
+1. A newer version of the state was loaded from storage. 
+2. An event that was raised by this instance has been successfully written to storage.
+3. A notification message was received from some other instance.
+
+Note that since all grains initially have version zero, until the initial load from storage completes, this means that `OnStateChanged` is called whenever the initial load completes with a version larger than zero.
+
+

--- a/src/Documentation/Event-Sourcing/MultiInstance.md
+++ b/src/Documentation/Event-Sourcing/MultiInstance.md
@@ -41,24 +41,3 @@ await RefreshNow();
 
 which both (1) confirms all unconfirmed events, and (2) loads the latest version from storage.
 
-## Subscribing to Changes
-
-It is often convenient to have the ability to react to state changes. To this end, `JournaledGrain` subclasses can override this method:
-
-
-```csharp
-protected override void OnStateChanged()
-{
-   // read state and/or event log and take appropriate action
-}
-```
-
-`OnStateChanged` is called whenever the confirmed state is updated, i.e. the version number increases. This can happen when
-
-1. A newer version of the state was loaded from storage. 
-2. An event that was raised by this instance has been successfully written to storage.
-3. A notification message was received from some other instance.
-
-Note that since all grains initially have version zero, until the initial load from storage completes, this means that `OnStateChanged` is called whenever the initial load completes with a version larger than zero.
-
-

--- a/src/Documentation/Event-Sourcing/MultiVersion.md
+++ b/src/Documentation/Event-Sourcing/MultiVersion.md
@@ -1,0 +1,60 @@
+---
+layout: page
+title: Immediate vs. Delayed Confirmation
+---
+
+# Immediate Confirmation
+
+For many applications, we want to ensure that events are confirmed immediately, so that the persisted version does not lag behind the current version in memory, and we do not risk losing the latest state if the grain should fail. We can guarantee this by following these rules:
+
+1. Confirm all `RaiseEvent` calls using `ConfirmEvents` before the grain method returns.
+
+1. Make sure tasks returned by `RaiseConditionalEvent` complete before the grain method returns.
+
+1. Avoid  `[Reentrant]` or `[AlwaysInterleave]` attributes, so only one grain call can be processed at a time.
+
+If we follow these rules, it means that after an event is raised, no other grain code can execute until the event has been written to storage. Therefore, it is impossible to observe inconsistencies between the version in memory and the version in storage. While this is often exactly what we want, it also has some decided disadvantages.
+
+* if the connection to a remote cluster or to storage is temporarily interrupted, then the grain becomes unavailable: effectively, the grain cannot execute any code while it is stuck waiting to confirm the events, which can take an indefinite amount of time (the confirmation protocol never times out).
+
+* when handling a lot of of updates, confirming them one at a time can be very inefficient. 
+
+
+# Delayed Confirmation
+
+To improve availability and throughput, grains can choose to do one or both of the following:
+
+* allow grain methods to raise events without waiting for confirmation. 
+
+* allow reentrancy, so the grain can keep processing new calls even if previous calls get stuck waiting for confirmation.
+
+This means it is possible for grain code to execute while some events are still in the process of being confirmed. The `JournaledGrain` API has some specific provisions to give developers precise control over how to deal with unconfirmed events that are currently "in flight".
+
+The following property can be examined to find out what events are currently unconfirmed:
+
+```csharp
+IEnumerable<EventType> UnconfirmedEvents { get; }
+```
+Also, since the state returned by the `State` property does not include the effect of unconfirmed events, there is an alternative property 
+
+```csharp
+StateType TentativeState { get; }
+```
+
+which returns a "tentative" state, obtained from "State" by applying all the unconfirmed events. The tentative state is essentially a "best guess" at what will likely become the next confirmed state, after all unconfirmed events are confirmed. However, there is no guarantee that it actually will, because the grain may fail, or because the events may race against other events and lose, causing them to be canceled (if they are conditional) or appear at a later position in the sequence than anticipated (if they are unconditional). 
+
+Just like reacting to state changes via `OnStateChanged`, grains can react to changes in the tentative state:
+
+```csharp
+protected override void OnTentativeStateChanged()
+{
+   // read state and/or events and take appropriate action
+}
+```
+
+`OnTentativeStateChanged` is called whenever the tentative state changes, i.e. if the combined sequence  (ConfirmedEvents + UnconfirmedEvents) changes.
+
+## Concurrency
+
+Note that even with delayed confirmation, Orleans turn-based scheduling (cooperative concurrency) always applies: several grain methods may be in progress, but only one can be actively executing, i.e. not stuck at an await. In particular, even though the variables `State`, `TentativeState`, `Version`, and `UnconfirmedEvents` can change during the execution of a grain method, this can only happen while stuck at an await.
+

--- a/src/Documentation/Event-Sourcing/Overview.md
+++ b/src/Documentation/Event-Sourcing/Overview.md
@@ -1,0 +1,27 @@
+---
+layout: page
+title: Event Sourcing
+---
+
+# Event Sourcing
+
+Event sourcing provides a flexible way to manage and persist grain state. An event-sourced grain has many potential advantages over a standard grain. For one, it can be used with many different storage provider configurations, and supports geo-replication across multiple clusters. Moreover, it cleanly separates the grain class from definitions of the grain state (represented by a grain state object) and grain updates (represented by event objects). 
+
+
+The documentation is structured as follows:
+
+* [JournaledGrain Basics](GrainStateAPI.md) explains how to define an event-sourced grains by deriving from `JournaledGrain`, how to access the current state, and how to raise events that update the state.
+
+* [Replicated Instances](MultiInstance.md) explains how the event-sourcing mechanism handles replicated grain instances and ensures consistency. It discusses the possibility of racing events and conflicts, and how to address them.
+
+* [Immediate/Delayed Confirmation](MultiVersion.md) explains how delayed confirmation of events, and reentrancy, can improve availability and throughput.
+
+* [Configuration](Configuration.md) explains how to configure projects, clusters, and log-consistency providers.
+
+* [Built-In Log-Consistency Providers](LogConsistencyProviders.md) explains how the three currently included log-consistency providers work.
+
+* [Diagnostics](Diagnostics.md) explains how to monitor for connection errors, and get simple statistics.
+
+
+The behavior documented above is reasonably stable, as far as the JournaledGrain API is concerned. However, we expect to extend or change the list of log consistency providers soon, to more easily allow developers to plug in  standard event storage systems.
+

--- a/src/Documentation/Event-Sourcing/Overview.md
+++ b/src/Documentation/Event-Sourcing/Overview.md
@@ -16,6 +16,8 @@ The documentation is structured as follows:
 
 * [Immediate/Delayed Confirmation](MultiVersion.md) explains how delayed confirmation of events, and reentrancy, can improve availability and throughput.
 
+* [Notifications](Subscribe.md) explains how to subscribe to notifications, allowing grains to react to new events.
+
 * [Configuration](Configuration.md) explains how to configure projects, clusters, and log-consistency providers.
 
 * [Built-In Log-Consistency Providers](LogConsistencyProviders.md) explains how the three currently included log-consistency providers work.

--- a/src/Documentation/Event-Sourcing/Subscribe.md
+++ b/src/Documentation/Event-Sourcing/Subscribe.md
@@ -1,0 +1,37 @@
+# Notifications
+
+It is often convenient to have the ability to react to state changes. 
+All callbacks are subject to Orleans' turn-based guarantees; see also the section on [Concurrency Guarantees](MultiInstance.md).
+
+## Tracking Confirmed State
+
+To be notified of any changes to the confirmed state, `JournaledGrain` subclasses can override this method:
+
+```csharp
+protected override void OnStateChanged()
+{
+   // read state and/or event log and take appropriate action
+}
+```
+
+`OnStateChanged` is called whenever the confirmed state is updated, i.e. the version number increases. This can happen when
+
+1. A newer version of the state was loaded from storage. 
+2. An event that was raised by this instance has been successfully written to storage.
+3. A notification message was received from some other instance.
+
+Note that since all grains initially have version zero, until the initial load from storage completes, this means that `OnStateChanged` is called whenever the initial load completes with a version larger than zero.
+
+## Tracking Tentative State
+
+To be notified of any changes to the tentative state, `JournaledGrain` subclasses can override this method:
+
+```csharp
+protected override void OnTentativeStateChanged()
+{
+   // read state and/or events and take appropriate action
+}
+```
+
+`OnTentativeStateChanged` is called whenever the tentative state changes, i.e. if the combined sequence  (ConfirmedEvents + UnconfirmedEvents) changes. In particular, a callback to `OnTentativeStateChanged()` always happens during `RaiseEvent`.
+

--- a/src/Documentation/toc.yml
+++ b/src/Documentation/toc.yml
@@ -129,6 +129,23 @@
     - name: Global-Single-Instance Grains
       href: Multi-Cluster/GlobalSingleInstance.md
 
+- name: Event Sourcing
+  href: Event-Sourcing/Overview.md
+  homepage: Event-Sourcing/Overview.md
+  items:
+    - name: JournaledGrain Basics
+      href: Event-Sourcing/GrainStateAPI.md
+    - name: Replicated Instances
+      href: Event-Sourcing/MultiInstance.md
+    - name: Immediate/Delayed Confirmation
+      href: Event-Sourcing/MultiVersion.md
+    - name: Configuration
+      href: Event-Sourcing/Configuration.md
+    - name: Built-In Log-Consistency Providers
+      href: Event-Sourcing/LogConsistencyProviders.md
+    - name: Diagnostics
+      href: Event-Sourcing/Diagnostics.md
+ 
 - name: Configuration Guide
   homepage: Orleans-Configuration-Guide/index.md
   href: Orleans-Configuration-Guide/index.md

--- a/src/Documentation/toc.yml
+++ b/src/Documentation/toc.yml
@@ -139,6 +139,8 @@
       href: Event-Sourcing/MultiInstance.md
     - name: Immediate/Delayed Confirmation
       href: Event-Sourcing/MultiVersion.md
+    - name: Notifications
+      href: Event-Sourcing/Subscribe.md
     - name: Configuration
       href: Event-Sourcing/Configuration.md
     - name: Built-In Log-Consistency Providers


### PR DESCRIPTION
A first draft of the documentation as promised in #2598.

This is not yet complete, as it does not yet discuss the samples which I will add soon.

Also, we most likely want to not merge this until #2651 is completed in case there are more changes to the API.

However, I thought it may be good to at least start this PR as it may be quite helpful to everyone involved to have some coherent documentation.
