### PR TITLE
Support for grains with generic methods

### DIFF
--- a/src/Orleans/CodeGeneration/GenericMethodInvoker.cs
+++ b/src/Orleans/CodeGeneration/GenericMethodInvoker.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+using Orleans.Serialization;
+
+namespace Orleans.CodeGeneration
+{
+    public class GenericMethodInvoker : IEqualityComparer<object[]>
+    {
+        private static readonly ConcurrentDictionary<Type, MethodInfo> BoxMethods = new ConcurrentDictionary<Type, MethodInfo>();
+        private static readonly Func<Type, MethodInfo> CreateBoxMethod = GetBoxMethod;
+        private static readonly MethodInfo GenericMethodInvokerDelegateMethodInfo =
+            TypeUtils.Method((GenericMethodInvokerDelegate del) => del.Invoke(null, null));
+        private static readonly ILFieldBuilder FieldBuilder = new ILFieldBuilder();
+
+        private readonly MethodInfo genericMethodInfo;
+        private readonly Type grainInterfaceType;
+        private readonly int typeParameterCount;
+
+        private readonly ConcurrentDictionary<object[], GenericMethodInvokerDelegate> invokers;
+        private readonly Func<object[], GenericMethodInvokerDelegate> createInvoker;
+
+        delegate Task<object> GenericMethodInvokerDelegate(IAddressable grain, object[] arguments);
+
+        public GenericMethodInvoker(Type grainInterfaceType, string methodName, int typeParameterCount)
+        {
+            this.grainInterfaceType = grainInterfaceType;
+            this.typeParameterCount = typeParameterCount;
+            this.invokers = new ConcurrentDictionary<object[], GenericMethodInvokerDelegate>(this);
+            this.genericMethodInfo = GetMethod(grainInterfaceType, methodName, typeParameterCount);
+            this.createInvoker = this.CreateInvoker;
+        }
+        
+        public Task<object> Invoke(IAddressable grain, object[] arguments)
+        {
+            var invoker = this.invokers.GetOrAdd(arguments, this.createInvoker);
+            return invoker(grain, arguments);
+        }
+
+        private GenericMethodInvokerDelegate CreateInvoker(object[] arguments)
+        {
+            // First, create the concrete method which will be called.
+            var typeParameters = arguments.Take(this.typeParameterCount).Cast<Type>().ToArray();
+            var concreteMethod = this.genericMethodInfo.MakeGenericMethod(typeParameters);
+
+            // Next, create a delegate which will call the method on the grain, pushing each of the arguments,
+            var il = new ILDelegateBuilder<GenericMethodInvokerDelegate>(
+                FieldBuilder,
+                $"GenericMethodInvoker_{this.grainInterfaceType}_{concreteMethod.Name}",
+                GenericMethodInvokerDelegateMethodInfo);
+
+            // Load the grain and cast it into the appropriate type.
+            il.LoadArgument(0);
+            il.CastOrUnbox(this.grainInterfaceType);
+
+            // Load every argument from the argument array.
+            var methodParameters = concreteMethod.GetParameters();
+            for (var i = 0; i < methodParameters.Length; i++)
+            {
+                il.LoadArgument(1); // Load the argument array.
+
+                // The argument is offset by the type parameter count, since type parameters come first.
+                il.LoadConstant(i + this.typeParameterCount); 
+                il.LoadReferenceElement();
+                il.CastOrUnbox(methodParameters[i].ParameterType);
+            }
+
+            // Call the target method.
+            il.Call(concreteMethod);
+
+            // If the result type is Task or Task<T>, convert it to Task<object>.
+            var returnType = concreteMethod.ReturnType;
+            if (returnType != typeof(Task<object>))
+            {
+                var boxMethod = BoxMethods.GetOrAdd(returnType, CreateBoxMethod);
+                il.Call(boxMethod);
+            }
+
+            il.Return();
+            return il.CreateDelegate();
+        }
+
+        private static MethodInfo GetBoxMethod(Type returnType)
+        {
+            if (returnType == typeof(Task)) return TypeUtils.Method((Task task) => task.Box());
+            if (returnType == typeof(void)) return TypeUtils.Property(() => TaskDone.Done).GetMethod;
+
+            if (returnType.GetGenericTypeDefinition() != typeof(Task<>))
+                throw new ArgumentException($"Unsupported return type {returnType}.");
+            var innerType = returnType.GenericTypeArguments[0];
+            var methods = typeof(PublicOrleansTaskExtensions).GetMethods(BindingFlags.Static | BindingFlags.Public);
+            foreach (var method in methods)
+            {
+                if (method.Name != "Box" || !method.ContainsGenericParameters) continue;
+                return method.MakeGenericMethod(innerType);
+            }
+
+            throw new ArgumentException($"Could not find Box method for type {returnType}");
+        }
+
+        bool IEqualityComparer<object[]>.Equals(object[] x, object[] y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(null, y)) return false;
+
+            if (x.Length < this.typeParameterCount || y.Length < this.typeParameterCount) return false;
+
+            for (var i = 0; i < this.typeParameterCount; i++)
+            {
+                if (!CompareAsTypes(x[i] as Type, y[i] as Type)) return false;
+            }
+
+            return true;
+        }
+
+        int IEqualityComparer<object[]>.GetHashCode(object[] obj)
+        {
+            if (obj == null || obj.Length == 0) return 0;
+            unchecked
+            {
+                // Only consider the type parameters.
+                var result = 0;
+                for (var i = 0; i < this.typeParameterCount && i < obj.Length; i++)
+                {
+                    var type = obj[i] as Type;
+                    if (type == null) break;
+
+                    result = (result * 367) ^ type.GetHashCode();
+                }
+
+                return result;
+            }
+        }
+
+        private static bool CompareAsTypes(Type x, Type y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(null, y)) return false;
+            return x == y;
+        }
+
+        private static MethodInfo GetMethod(Type grainInterfaceType, string methodName, int typeParameterCount)
+        {
+            var methods = grainInterfaceType.GetMethods(BindingFlags.Instance | BindingFlags.Public);
+            foreach (var method in methods)
+            {
+                if (!method.ContainsGenericParameters) continue;
+                if (!string.Equals(method.Name, methodName, StringComparison.Ordinal)) continue;
+                if (method.GetGenericArguments().Length != typeParameterCount) continue;
+
+                return method;
+            }
+
+            throw new ArgumentException(
+                $"Could not find generic method {methodName} on type {grainInterfaceType} with {typeParameterCount} type parameters.");
+        }
+    }
+}

--- a/src/Orleans/CodeGeneration/GenericMethodInvoker.cs
+++ b/src/Orleans/CodeGeneration/GenericMethodInvoker.cs
@@ -9,10 +9,16 @@ using Orleans.Serialization;
 
 namespace Orleans.CodeGeneration
 {
+    /// <summary>
+    /// Functionality for invoking calls on a generic instance method.
+    /// </summary>
+    /// <remarks>
+    /// Each instance of this class can invoke calls on one generic method.
+    /// </remarks>
     public class GenericMethodInvoker : IEqualityComparer<object[]>
     {
         private static readonly ConcurrentDictionary<Type, MethodInfo> BoxMethods = new ConcurrentDictionary<Type, MethodInfo>();
-        private static readonly Func<Type, MethodInfo> CreateBoxMethod = GetBoxMethod;
+        private static readonly Func<Type, MethodInfo> CreateBoxMethod = GetTaskConversionMethod;
         private static readonly MethodInfo GenericMethodInvokerDelegateMethodInfo =
             TypeUtils.Method((GenericMethodInvokerDelegate del) => del.Invoke(null, null));
         private static readonly ILFieldBuilder FieldBuilder = new ILFieldBuilder();
@@ -20,12 +26,23 @@ namespace Orleans.CodeGeneration
         private readonly MethodInfo genericMethodInfo;
         private readonly Type grainInterfaceType;
         private readonly int typeParameterCount;
-
         private readonly ConcurrentDictionary<object[], GenericMethodInvokerDelegate> invokers;
         private readonly Func<object[], GenericMethodInvokerDelegate> createInvoker;
 
-        delegate Task<object> GenericMethodInvokerDelegate(IAddressable grain, object[] arguments);
+        /// <summary>
+        ///  Invoke the generic method described by this instance on the provided <paramref name="grain"/>.
+        /// </summary>
+        /// <param name="grain">The grain.</param>
+        /// <param name="arguments">The arguments, including the method's type parameters.</param>
+        /// <returns>The method result.</returns>
+        private delegate Task<object> GenericMethodInvokerDelegate(IAddressable grain, object[] arguments);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenericMethodInvoker"/> class.
+        /// </summary>
+        /// <param name="grainInterfaceType">The grain interface type which the method exists on.</param>
+        /// <param name="methodName">The name of the method.</param>
+        /// <param name="typeParameterCount">The number of type parameters which the method has.</param>
         public GenericMethodInvoker(Type grainInterfaceType, string methodName, int typeParameterCount)
         {
             this.grainInterfaceType = grainInterfaceType;
@@ -35,12 +52,23 @@ namespace Orleans.CodeGeneration
             this.createInvoker = this.CreateInvoker;
         }
         
+        /// <summary>
+        /// Invoke the defined method on the provided <paramref name="grain"/> instance with the given <paramref name="arguments"/>.
+        /// </summary>
+        /// <param name="grain">The grain.</param>
+        /// <param name="arguments">The arguments to the method with the type parameters first, followed by the method parameters.</param>
+        /// <returns>The invocation result.</returns>
         public Task<object> Invoke(IAddressable grain, object[] arguments)
         {
             var invoker = this.invokers.GetOrAdd(arguments, this.createInvoker);
             return invoker(grain, arguments);
         }
 
+        /// <summary>
+        /// Creates an invoker delegate for the type arguments specified in <paramref name="arguments"/>.
+        /// </summary>
+        /// <param name="arguments">The arguments.</param>
+        /// <returns>A new invoker delegate.</returns>
         private GenericMethodInvokerDelegate CreateInvoker(object[] arguments)
         {
             // First, create the concrete method which will be called.
@@ -80,44 +108,65 @@ namespace Orleans.CodeGeneration
                 il.Call(boxMethod);
             }
 
+            // Return the resulting Task<object>.
             il.Return();
             return il.CreateDelegate();
         }
 
-        private static MethodInfo GetBoxMethod(Type returnType)
+        /// <summary>
+        /// Returns a suitable <see cref="MethodInfo"/> for a method which will convert an argument of type <paramref name="taskType"/>
+        /// into <see cref="Task{Object}"/>.
+        /// </summary>
+        /// <param name="taskType">The type to convert.</param>
+        /// <returns>A suitable conversion method.</returns>
+        private static MethodInfo GetTaskConversionMethod(Type taskType)
         {
-            if (returnType == typeof(Task)) return TypeUtils.Method((Task task) => task.Box());
-            if (returnType == typeof(void)) return TypeUtils.Property(() => TaskDone.Done).GetMethod;
+            if (taskType == typeof(Task)) return TypeUtils.Method((Task task) => task.Box());
+            if (taskType == typeof(void)) return TypeUtils.Property(() => TaskDone.Done).GetMethod;
 
-            if (returnType.GetGenericTypeDefinition() != typeof(Task<>))
-                throw new ArgumentException($"Unsupported return type {returnType}.");
-            var innerType = returnType.GenericTypeArguments[0];
+            if (taskType.GetGenericTypeDefinition() != typeof(Task<>))
+                throw new ArgumentException($"Unsupported return type {taskType}.");
+            var innerType = taskType.GenericTypeArguments[0];
             var methods = typeof(PublicOrleansTaskExtensions).GetMethods(BindingFlags.Static | BindingFlags.Public);
             foreach (var method in methods)
             {
-                if (method.Name != "Box" || !method.ContainsGenericParameters) continue;
+                if (method.Name != nameof(PublicOrleansTaskExtensions.Box) || !method.ContainsGenericParameters) continue;
                 return method.MakeGenericMethod(innerType);
             }
 
-            throw new ArgumentException($"Could not find Box method for type {returnType}");
+            throw new ArgumentException($"Could not find conversion method for type {taskType}");
         }
 
+        /// <summary>
+        /// Performs equality comparison for the purpose of comparing type parameters only.
+        /// </summary>
+        /// <param name="x">One argument list.</param>
+        /// <param name="y">The other argument list.</param>
+        /// <returns><see langword="true"/> if the type parameters in the respective arguments are equal, <see langword="false"/> otherwise.</returns>
         bool IEqualityComparer<object[]>.Equals(object[] x, object[] y)
         {
             if (ReferenceEquals(x, y)) return true;
             if (ReferenceEquals(x, null)) return false;
             if (ReferenceEquals(null, y)) return false;
 
+            // Since this equality compararer only compares type parameters, ignore any elements after
+            // the defined type parameter count.
             if (x.Length < this.typeParameterCount || y.Length < this.typeParameterCount) return false;
 
+            // Compare each type parameter.
             for (var i = 0; i < this.typeParameterCount; i++)
             {
-                if (!CompareAsTypes(x[i] as Type, y[i] as Type)) return false;
+                if (x[i] as Type != y[i] as Type) return false;
             }
 
             return true;
         }
 
+        /// <summary>
+        /// Returns a hash code for the type parameters in the provided argument list.
+        /// </summary>
+        /// <param name="obj">The argument list.</param>
+        /// <returns>A hash code.</returns>
         int IEqualityComparer<object[]>.GetHashCode(object[] obj)
         {
             if (obj == null || obj.Length == 0) return 0;
@@ -136,21 +185,21 @@ namespace Orleans.CodeGeneration
                 return result;
             }
         }
-
-        private static bool CompareAsTypes(Type x, Type y)
+        
+        /// <summary>
+        /// Returns the <see cref="MethodInfo"/> for the method on <paramref name="declaringType"/> with the provided name
+        /// and number of generic type parameters.
+        /// </summary>
+        /// <param name="declaringType">The type which the method is declared on.</param>
+        /// <param name="methodName">The method name.</param>
+        /// <param name="typeParameterCount">The number of generic type parameters.</param>
+        /// <returns>The identified method.</returns>
+        private static MethodInfo GetMethod(Type declaringType, string methodName, int typeParameterCount)
         {
-            if (ReferenceEquals(x, y)) return true;
-            if (ReferenceEquals(x, null)) return false;
-            if (ReferenceEquals(null, y)) return false;
-            return x == y;
-        }
-
-        private static MethodInfo GetMethod(Type grainInterfaceType, string methodName, int typeParameterCount)
-        {
-            var methods = grainInterfaceType.GetMethods(BindingFlags.Instance | BindingFlags.Public);
+            var methods = declaringType.GetMethods(BindingFlags.Instance | BindingFlags.Public);
             foreach (var method in methods)
             {
-                if (!method.ContainsGenericParameters) continue;
+                if (!method.IsGenericMethodDefinition) continue;
                 if (!string.Equals(method.Name, methodName, StringComparison.Ordinal)) continue;
                 if (method.GetGenericArguments().Length != typeParameterCount) continue;
 
@@ -158,7 +207,7 @@ namespace Orleans.CodeGeneration
             }
 
             throw new ArgumentException(
-                $"Could not find generic method {methodName} on type {grainInterfaceType} with {typeParameterCount} type parameters.");
+                $"Could not find generic method {declaringType}.{methodName}<{new string(',', typeParameterCount)}>(...).");
         }
     }
 }

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -875,6 +875,29 @@ namespace Orleans.Runtime
 
             throw new ArgumentException("Expression type unsupported.");
         }
+        
+        /// <summary>
+        /// Returns the <see cref="PropertyInfo"/> for the simple member access in the provided <paramref name="expression"/>.
+        /// </summary>
+        /// <typeparam name="TResult">
+        /// The return type of the property.
+        /// </typeparam>
+        /// <param name="expression">
+        /// The expression.
+        /// </param>
+        /// <returns>
+        /// The <see cref="PropertyInfo"/> for the simple member access call in the provided <paramref name="expression"/>.
+        /// </returns>
+        public static PropertyInfo Property<TResult>(Expression<Func<TResult>> expression)
+        {
+            var property = expression.Body as MemberExpression;
+            if (property != null)
+            {
+                return property.Member as PropertyInfo;
+            }
+
+            throw new ArgumentException("Expression type unsupported.");
+        }
 
         /// <summary>
         /// Returns the <see cref="MemberInfo"/> for the simple member access in the provided <paramref name="expression"/>.

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Async\UnobservedExceptionsHandlerClass.cs" />
     <Compile Include="Async\TaskExtensions.cs" />
     <Compile Include="CodeGeneration\GeneratedAssembly.cs" />
+    <Compile Include="CodeGeneration\GenericMethodInvoker.cs" />
     <Compile Include="Configuration\GrainServiceConfiguration.cs" />
     <Compile Include="Core\GrainCasterFactory.cs" />
     <Compile Include="Core\IInternalGrainFactory.cs" />

--- a/src/Orleans/Serialization/ILSerializerGenerator.cs
+++ b/src/Orleans/Serialization/ILSerializerGenerator.cs
@@ -113,7 +113,6 @@ namespace Orleans.Serialization
             var il = new ILDelegateBuilder<SerializationManager.DeepCopier>(
                 FieldBuilder,
                 type.Name + "DeepCopier",
-                SerializationMethodInfos,
                 SerializationMethodInfos.DeepCopierDelegate);
 
             // Declare local variables.
@@ -126,7 +125,7 @@ namespace Orleans.Serialization
             il.StoreLocal(typedInput);
 
             // Construct the result.
-            il.CreateInstance(type, result);
+            il.CreateInstance(type, result, SerializationMethodInfos.GetUninitializedObject);
 
             // Record the object.
             il.LoadArgument(1); // Load 'context' parameter.
@@ -169,7 +168,6 @@ namespace Orleans.Serialization
             var il = new ILDelegateBuilder<SerializationManager.Serializer>(
                 FieldBuilder,
                 type.Name + "Serializer",
-                SerializationMethodInfos,
                 SerializationMethodInfos.SerializerDelegate);
 
             // Declare local variables.
@@ -226,14 +224,13 @@ namespace Orleans.Serialization
             var il = new ILDelegateBuilder<SerializationManager.Deserializer>(
                 FieldBuilder,
                 type.Name + "Deserializer",
-                SerializationMethodInfos,
                 SerializationMethodInfos.DeserializerDelegate);
 
             // Declare local variables.
             var result = il.DeclareLocal(type);
 
             // Construct the result.
-            il.CreateInstance(type, result);
+            il.CreateInstance(type, result, SerializationMethodInfos.GetUninitializedObject);
 
             // Record the object.
             il.LoadArgument(1); // Load the 'context' parameter.

--- a/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainMethodInvokerGenerator.cs
@@ -63,7 +63,7 @@ namespace Orleans.CodeGenerator
 #endif
             };
 
-            var members = new List<MemberDeclarationSyntax>
+            var members = new List<MemberDeclarationSyntax>(GenerateGenericInvokerFields(grainType))
             {
                 GenerateInvokeMethod(grainType),
                 GenerateInterfaceIdProperty(grainType)
@@ -75,7 +75,7 @@ namespace Orleans.CodeGenerator
                 baseTypes.Add(SF.SimpleBaseType(typeof(IGrainExtensionMethodInvoker).GetTypeSyntax()));
                 members.Add(GenerateExtensionInvokeMethod(grainType));
             }
-
+            
             var classDeclaration =
                 SF.ClassDeclaration(
                     CodeGeneratorCommon.ClassPrefix + TypeUtils.GetSuitableClassName(grainType) + ClassSuffix)
@@ -169,7 +169,7 @@ namespace Orleans.CodeGenerator
 
             var grainArgument = parameters[0].Name.ToIdentifierName();
             var requestArgument = parameters[1].Name.ToIdentifierName();
-            
+
             // Store the relevant values from the request in local variables.
             var interfaceIdDeclaration =
                 SF.LocalDeclarationStatement(
@@ -227,7 +227,7 @@ namespace Orleans.CodeGenerator
                         grainArgument,
                         SF.LiteralExpression(SyntaxKind.NullLiteralExpression)),
                     SF.ThrowStatement(argumentNullException));
-            
+
             return methodDeclaration.AddBodyStatements(grainArgumentCheck, interfaceIdSwitch);
         }
 
@@ -271,18 +271,32 @@ namespace Orleans.CodeGenerator
                 parameters.Add(arg);
             }
 
+            // If the method is a generic method definition, use the generic method invoker field to invoke the method.
+            if (method.IsGenericMethodDefinition)
+            {
+                return new StatementSyntax[]
+                {
+                    SF.ReturnStatement(
+                        SF.InvocationExpression(
+                              SF.IdentifierName(GetGenericMethodInvokerFieldName(method))
+                                .Member((GenericMethodInvoker invoker) => invoker.Invoke(null, null)))
+                          .AddArgumentListArguments(SF.Argument(grain), SF.Argument(arguments)))
+                };
+            }
+
             // Invoke the method.
             var grainMethodCall =
                 SF.InvocationExpression(castGrain.Member(method.Name))
                     .AddArgumentListArguments(parameters.Select(SF.Argument).ToArray());
-            
+
             // For void methods, invoke the method and return a completed task.
             if (method.ReturnType == typeof(void))
             {
                 var completed = (Expression<Func<Task<object>>>)(() => TaskUtility.Completed());
                 return new StatementSyntax[]
                 {
-                    SF.ExpressionStatement(grainMethodCall), SF.ReturnStatement(completed.Invoke())
+                    SF.ExpressionStatement(grainMethodCall),
+                    SF.ReturnStatement(completed.Invoke())
                 };
             }
 
@@ -298,6 +312,49 @@ namespace Orleans.CodeGenerator
             {
                 SF.ReturnStatement(SF.InvocationExpression(grainMethodCall.Member((Task _) => _.Box())))
             };
+        }
+
+        private static MemberDeclarationSyntax[] GenerateGenericInvokerFields(Type grainType)
+        {
+            var methods = GrainInterfaceUtils.GetMethods(grainType);
+
+            var result = new List<MemberDeclarationSyntax>();
+            foreach (var method in methods)
+            {
+                if (!method.IsGenericMethodDefinition) continue;
+                result.Add(GenerateGenericInvokerField(method));
+            }
+
+            return result.ToArray();
+        }
+
+        private static MemberDeclarationSyntax GenerateGenericInvokerField(MethodInfo method)
+        {
+            var fieldInfoVariable =
+                SF.VariableDeclarator(GetGenericMethodInvokerFieldName(method))
+                  .WithInitializer(
+                      SF.EqualsValueClause(
+                          SF.ObjectCreationExpression(typeof(GenericMethodInvoker).GetTypeSyntax())
+                            .AddArgumentListArguments(
+                                SF.Argument(SF.TypeOfExpression(method.DeclaringType.GetTypeSyntax())),
+                                SF.Argument(method.Name.GetLiteralExpression()),
+                                SF.Argument(
+                                    SF.LiteralExpression(
+                                        SyntaxKind.NumericLiteralExpression,
+                                        SF.Literal(method.GetGenericArguments().Length))))));
+
+            return
+                SF.FieldDeclaration(
+                      SF.VariableDeclaration(typeof(GenericMethodInvoker).GetTypeSyntax()).AddVariables(fieldInfoVariable))
+                  .AddModifiers(
+                      SF.Token(SyntaxKind.PrivateKeyword),
+                      SF.Token(SyntaxKind.StaticKeyword),
+                      SF.Token(SyntaxKind.ReadOnlyKeyword));
+        }
+
+        private static string GetGenericMethodInvokerFieldName(MethodInfo method)
+        {
+            return method.Name + string.Join("_", method.GetGenericArguments().Select(arg => arg.Name));
         }
     }
 }


### PR DESCRIPTION
This PR adds support for generic methods on grains in a pay-for-what-you-use fashion, so any additional cost is only incurred for generic methods. The cost should be quite low anyway because the invoker stub is generated using (simple) IL.

Supports methods with constraints, overloads, generic methods inside generic grains, upcasting arguments, grain observers, and grain extensions (last one not tested). We can address anything I missed as they come.

This is what a generated `GrainReference` method looks like for a generic method:
```C#
public global::System.Threading.Tasks.Task<global::System.Type[]> @GetTypesInferred<T, U>(T @t, U @u, global::System.Int32 @v)
{
    return base.@InvokeMethodAsync<global::System.Type[]>(-1221167187, new global::System.Object[]{typeof (T), typeof (U), @t, @u, @v});
}
```
Notice that it passes the static types of the arguments in the arguments array before the actual arguments.

The other end is more complicated: in the `IGrainMethodInvoker`, we add a static `GenericMethodInvoker` field for each generic method and use that for invoking the methods using runtime codegen (IL). So a snippet of the generated invoker looks like this:
```C#
switch (interfaceId)
{
    case 447824211:
        switch (methodId)
        {
            case 1337175495:
                return GetTypesExplicitT_U_V.@Invoke(@grain, arguments);
            case -105247224:
                return GetTypesInferredT_U_V.@Invoke(@grain, arguments);
            case -1221167187:
                return GetTypesInferredT_U.@Invoke(@grain, arguments);
```

With the fields declared something like this:
```C#
private static readonly global::Orleans.CodeGeneration.GenericMethodInvoker GetTypesExplicitT_U_V = new global::Orleans.CodeGeneration.GenericMethodInvoker(typeof (global::Tester.CodeGenTests.IGrainWithGenericMethods), "GetTypesExplicit", 3);
```

We use these fields to ensure that everything is as efficient as can be: no additional allocations are made on the hot path (any allocs are made only once).

The generated IL for the invokers looks like this:
```
Ldarg_0 // Load the grain argument
Castclass <grain interface type>

// foreach arg:
Ldarg_1 // Load the arguments array
Ldc_I4 <arg index + number of type params>
Ldelem_Ref // Load the argument as a reference (since it's an object array)
CastClass <argument type> // Or Unbox_Any <type> if it's a value type.

Call <concrete method>

// If return type is void
Call TaskDone.Done
// Else if return type is Task
Call PublicOrleansTaskUtils.Box(Task)
// Else if return type is Task<T>
Call PublicOrleansTaskUtils.Box(Task<T>)

Ret
```

Thanks, @Joshua-Ferguson, for your PR which I took inspiration from to create this :) You led the way. I had figured it was too difficult to implement and just not worth it.

Implements #1352
cc @@marianogenovese & @centur (since you both asked about this functionality recently)