### PR TITLE
Add IGrainReferenceConverter for converting 'key strings' to GrainReference

### DIFF
--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -11,7 +11,7 @@ namespace Orleans
     /// <summary>
     /// Factory for accessing grains.
     /// </summary>
-    internal class GrainFactory : IInternalGrainFactory
+    internal class GrainFactory : IInternalGrainFactory, IGrainReferenceConverter
     {
         /// <summary>
         /// The mapping between concrete grain interface types and delegate
@@ -139,6 +139,9 @@ namespace Orleans
             var grainId = GrainId.GetGrainId(implementation.GetTypeCode(interfaceType), primaryKey, keyExtension);
             return this.Cast<TGrainInterface>(this.MakeGrainReferenceFromType(interfaceType, grainId));
         }
+
+        /// <inheritdoc />
+        public GrainReference GetGrainFromKeyString(string key) => GrainReference.FromKeyString(key);
 
         /// <summary>
         /// Creates a reference to the provided <paramref name="obj"/>.

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -111,6 +111,7 @@
     <Compile Include="GrainDirectory\MultiClusterStatus.cs" />
     <Compile Include="LogConsistency\ILogViewAdaptorHost.cs" />
     <Compile Include="Providers\ProviderStateManager.cs" />
+    <Compile Include="Runtime\IGrainReferenceConverter.cs" />
     <Compile Include="Runtime\IGrainTimer.cs" />
     <Compile Include="Runtime\ILocalSiloDetails.cs" />
     <Compile Include="Runtime\RingRange.cs" />

--- a/src/Orleans/Runtime/IGrainReferenceConverter.cs
+++ b/src/Orleans/Runtime/IGrainReferenceConverter.cs
@@ -1,0 +1,12 @@
+namespace Orleans.Runtime
+{
+    public interface IGrainReferenceConverter
+    {
+        /// <summary>
+        /// Creates a grain reference from a storage key string.
+        /// </summary>
+        /// <param name="key">The key string.</param>
+        /// <returns>The newly created grain reference.</returns>
+        GrainReference GetGrainFromKeyString(string key);
+    }
+}

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -114,6 +114,7 @@ namespace Orleans
             services.AddSingleton<GrainFactory>();
             services.AddFromExisting<IGrainFactory, GrainFactory>();
             services.AddFromExisting<IInternalGrainFactory, GrainFactory>();
+            services.AddFromExisting<IGrainReferenceConverter, GrainFactory>();
             services.AddSingleton<MessageFactory>();
             this.ServiceProvider = services.BuildServiceProvider();
             this.InternalGrainFactory = this.ServiceProvider.GetRequiredService<IInternalGrainFactory>();

--- a/src/OrleansAWSUtils/Reminders/DynamoDBReminderTable.cs
+++ b/src/OrleansAWSUtils/Reminders/DynamoDBReminderTable.cs
@@ -11,10 +11,11 @@ using Amazon.DynamoDBv2;
 namespace OrleansAWSUtils.Reminders
 {
     /// <summary>
-    /// Implementation for IRemiderTable using DynamoDB as underlying  strorage 
+    /// Implementation for IReminderTable using DynamoDB as underlying storage.
     /// </summary>
     public class DynamoDBReminderTable : IReminderTable
     {
+        private readonly IGrainReferenceConverter grainReferenceConverter;
         private const string DEPLOYMENT_ID_PROPERTY_NAME = "DeploymentId";
         private const string GRAIN_REFERENCE_PROPERTY_NAME = "GrainReference";
         private const string REMINDER_NAME_PROPERTY_NAME = "ReminderName";
@@ -33,6 +34,15 @@ namespace OrleansAWSUtils.Reminders
         private DynamoDBStorage storage;
         private string deploymentId;
         private Guid serviceId;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamoDBReminderTable"/> class.
+        /// </summary>
+        /// <param name="grainReferenceConverter">The grain factory.</param>
+        public DynamoDBReminderTable(IGrainReferenceConverter grainReferenceConverter)
+        {
+            this.grainReferenceConverter = grainReferenceConverter;
+        }
 
         /// <summary>
         /// Initialize current instance with specific global configuration and logger
@@ -172,12 +182,12 @@ namespace OrleansAWSUtils.Reminders
             }
         }
 
-        private static ReminderEntry Resolve(Dictionary<string, AttributeValue> item)
+        private ReminderEntry Resolve(Dictionary<string, AttributeValue> item)
         {
             return new ReminderEntry
             {
                 ETag = item[ETAG_PROPERTY_NAME].N,
-                GrainRef = GrainReference.FromKeyString(item[GRAIN_REFERENCE_PROPERTY_NAME].S),
+                GrainRef = this.grainReferenceConverter.GetGrainFromKeyString(item[GRAIN_REFERENCE_PROPERTY_NAME].S),
                 Period = TimeSpan.Parse(item[PERIOD_PROPERTY_NAME].S),
                 ReminderName = item[REMINDER_NAME_PROPERTY_NAME].S,
                 StartAt = DateTime.Parse(item[START_TIME_PROPERTY_NAME].S)

--- a/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
+++ b/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
@@ -8,9 +8,14 @@ namespace Orleans.Runtime.ReminderService
 {
     internal class AzureBasedReminderTable : IReminderTable
     {
+        private readonly IGrainReferenceConverter grainReferenceConverter;
         private Logger logger;
         private RemindersTableManager remTableManager;
 
+        public AzureBasedReminderTable(IGrainReferenceConverter grainReferenceConverter)
+        {
+            this.grainReferenceConverter = grainReferenceConverter;
+        }
 
         public async Task Init(GlobalConfiguration config, Logger logger)
         {
@@ -44,7 +49,7 @@ namespace Orleans.Runtime.ReminderService
             {
                 return new ReminderEntry
                 {
-                    GrainRef = GrainReference.FromKeyString(tableEntry.GrainReference),
+                    GrainRef = this.grainReferenceConverter.GetGrainFromKeyString(tableEntry.GrainReference),
                     ReminderName = tableEntry.ReminderName,
                     StartAt = LogFormatter.ParseDate(tableEntry.StartAt),
                     Period = TimeSpan.Parse(tableEntry.Period),

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -228,6 +228,7 @@ namespace Orleans.Runtime
             services.AddSingleton<GrainFactory>(sp => sp.GetService<InsideRuntimeClient>().ConcreteGrainFactory);
             services.AddFromExisting<IGrainFactory, GrainFactory>();
             services.AddFromExisting<IInternalGrainFactory, GrainFactory>();
+            services.AddFromExisting<IGrainReferenceConverter, GrainFactory>();
             services.AddSingleton<TypeMetadataCache>();
             services.AddSingleton<AssemblyProcessor>();
             services.AddSingleton<ActivationDirectory>();

--- a/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
+++ b/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
@@ -10,10 +10,16 @@ namespace Orleans.Runtime.MembershipService
 {
     internal class SqlMembershipTable: IMembershipTable, IGatewayListProvider
     {
+        private readonly IGrainReferenceConverter grainReferenceConverter;
         private string deploymentId;        
         private TimeSpan maxStaleness;
         private Logger logger;
         private RelationalOrleansQueries orleansQueries;
+
+        public SqlMembershipTable(IGrainReferenceConverter grainReferenceConverter)
+        {
+            this.grainReferenceConverter = grainReferenceConverter;
+        }
 
         public async Task InitializeMembershipTable(GlobalConfiguration config, bool tryInitTableVersion, Logger traceLogger)
         {
@@ -23,8 +29,8 @@ namespace Orleans.Runtime.MembershipService
             if (logger.IsVerbose3) logger.Verbose3("SqlMembershipTable.InitializeMembershipTable called.");
 
             //This initializes all of Orleans operational queries from the database using a well known view
-            //and assumes the database with appropriate defintions exists already.
-            orleansQueries = await RelationalOrleansQueries.CreateInstance(config.AdoInvariant, config.DataConnectionString);
+            //and assumes the database with appropriate definitions exists already.
+            orleansQueries = await RelationalOrleansQueries.CreateInstance(config.AdoInvariant, config.DataConnectionString, this.grainReferenceConverter);
             
             // even if I am not the one who created the table, 
             // try to insert an initial table version if it is not already there,
@@ -47,7 +53,7 @@ namespace Orleans.Runtime.MembershipService
 
             deploymentId = config.DeploymentId;            
             maxStaleness = config.GatewayListRefreshPeriod;
-            orleansQueries = await RelationalOrleansQueries.CreateInstance(config.AdoInvariant, config.DataConnectionString);
+            orleansQueries = await RelationalOrleansQueries.CreateInstance(config.AdoInvariant, config.DataConnectionString, this.grainReferenceConverter);
         }
 
 

--- a/src/OrleansSQLUtils/ReminderService/SqlReminderTable.cs
+++ b/src/OrleansSQLUtils/ReminderService/SqlReminderTable.cs
@@ -2,18 +2,23 @@ using System.Threading.Tasks;
 using Orleans.Runtime.Configuration;
 using Orleans.SqlUtils;
 
-
 namespace Orleans.Runtime.ReminderService
 {
     internal class SqlReminderTable: IReminderTable
     {
+        private readonly IGrainReferenceConverter grainReferenceConverter;
         private string serviceId;
         private RelationalOrleansQueries orleansQueries;
+
+        public SqlReminderTable(IGrainReferenceConverter grainReferenceConverter)
+        {
+            this.grainReferenceConverter = grainReferenceConverter;
+        }
 
         public async Task Init(GlobalConfiguration config, Logger logger)
         {
             serviceId = config.ServiceId.ToString();
-            orleansQueries = await RelationalOrleansQueries.CreateInstance(config.AdoInvariantForReminders, config.DataConnectionStringForReminders);
+            orleansQueries = await RelationalOrleansQueries.CreateInstance(config.AdoInvariantForReminders, config.DataConnectionStringForReminders, this.grainReferenceConverter);
         }
 
         public Task<ReminderTableData> ReadRows(GrainReference grainRef)

--- a/src/OrleansSQLUtils/Storage/DbStoredQueries.cs
+++ b/src/OrleansSQLUtils/Storage/DbStoredQueries.cs
@@ -134,7 +134,7 @@ namespace OrleansSQLUtils.Storage
                     record.GetValue<string>("QueryText"));
             }
 
-            internal static ReminderEntry GetReminderEntry(IDataRecord record)
+            internal static ReminderEntry GetReminderEntry(IDataRecord record, IGrainReferenceConverter grainReferenceConverter)
             {
                 //Having non-null field, GrainId, means with the query filter options, an entry was found.
                 string grainId = record.GetValueOrDefault<string>(nameof(Columns.GrainId));
@@ -142,7 +142,7 @@ namespace OrleansSQLUtils.Storage
                 {
                     return new ReminderEntry
                     {
-                        GrainRef = GrainReference.FromKeyString(grainId),
+                        GrainRef = grainReferenceConverter.GetGrainFromKeyString(grainId),
                         ReminderName = record.GetValue<string>(nameof(Columns.ReminderName)),
                         StartAt = record.GetValue<DateTime>(nameof(Columns.StartTime)),
                         Period = TimeSpan.FromMilliseconds(record.GetValue<int>(nameof(Columns.Period))),

--- a/test/AWSUtils.Tests/Reminder/DynamoDBRemindersTableTests.cs
+++ b/test/AWSUtils.Tests/Reminder/DynamoDBRemindersTableTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
 using AWSUtils.Tests.StorageTests;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
+using Orleans.Runtime;
 using OrleansAWSUtils.Reminders;
 using TestExtensions;
 using UnitTests;
@@ -22,7 +24,7 @@ namespace AWSUtils.Tests.RemindersTest
             if (!AWSTestConstants.IsDynamoDbAvailable)
                 throw new SkipException("Unable to connect to AWS DynamoDB simulator");
 
-            return new DynamoDBReminderTable();
+            return new DynamoDBReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>());
         }
 
         protected override string GetConnectionString()

--- a/test/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
+++ b/test/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
@@ -26,8 +26,8 @@ namespace AWSUtils.Tests.StorageTests
 
             DefaultProviderRuntime = new StorageProviderManager(
                 fixture.GrainFactory,
-                null,
-                new ClientProviderRuntime(fixture.InternalGrainFactory, null));
+                fixture.Services,
+                new ClientProviderRuntime(fixture.InternalGrainFactory, fixture.Services));
             ((StorageProviderManager) DefaultProviderRuntime).LoadEmptyStorageProviders().WaitWithThrow(TestConstants.InitTimeout);
 
             var properties = new Dictionary<string, string>();

--- a/test/NonSiloTests/General/Identifiertests.cs
+++ b/test/NonSiloTests/General/Identifiertests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Net;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
@@ -456,7 +457,7 @@ namespace UnitTests.General
         private GrainReference RoundTripGrainReferenceToKey(GrainReference input)
         {
             string str = input.ToKeyString();
-            GrainReference output = GrainReference.FromKeyString(str);
+            GrainReference output = this.environment.Services.GetRequiredService<IGrainReferenceConverter>().GetGrainFromKeyString(str);
             return output;
         }
     }

--- a/test/TesterAzureUtils/AzureRemindersTableTests.cs
+++ b/test/TesterAzureUtils/AzureRemindersTableTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.AzureUtils;
 using Orleans.Runtime;
@@ -33,7 +34,7 @@ namespace UnitTests.RemindersTest
 
         protected override IReminderTable CreateRemindersTable()
         {
-            return new AzureBasedReminderTable();
+            return new AzureBasedReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>());
         }
 
         protected override string GetConnectionString()

--- a/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
@@ -44,7 +45,7 @@ namespace UnitTests.TimerTests
         [Fact, TestCategory("ReminderService"), TestCategory("Azure"), TestCategory("Performance")]
         public async Task Reminders_AzureTable_InsertRate()
         {
-            IReminderTable table = new AzureBasedReminderTable();
+            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>());
             var config = new GlobalConfiguration()
             {
                 ServiceId = ServiceId,
@@ -61,7 +62,7 @@ namespace UnitTests.TimerTests
         public async Task Reminders_AzureTable_InsertNewRowAndReadBack()
         {
             string deploymentId = NewDeploymentId();
-            IReminderTable table = new AzureBasedReminderTable();
+            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>());
             var config = new GlobalConfiguration()
             {
                 ServiceId = ServiceId,

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Messaging;
 using Orleans.Runtime;
@@ -73,6 +74,10 @@ namespace UnitTests.MembershipTests
         }
 
         public IGrainFactory GrainFactory => this.environment.GrainFactory;
+
+        public IGrainReferenceConverter GrainReferenceConverter => this.environment.Services.GetRequiredService<IGrainReferenceConverter>();
+
+        public IServiceProvider Services => this.environment.Services;
 
         public void Dispose()
         {

--- a/test/TesterSQLUtils/MySqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/MySqlMembershipTableTests.cs
@@ -22,12 +22,12 @@ namespace UnitTests.MembershipTests
 
         protected override IMembershipTable CreateMembershipTable(Logger logger)
         {
-            return new SqlMembershipTable();
+            return new SqlMembershipTable(this.GrainReferenceConverter);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)
         {
-            return new SqlMembershipTable();
+            return new SqlMembershipTable(this.GrainReferenceConverter);
         }
 
         protected override string GetAdoInvariant()
@@ -41,7 +41,6 @@ namespace UnitTests.MembershipTests
                 RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName)
                     .Result.CurrentConnectionString;
         }
-
 
         [Fact, TestCategory("Membership"), TestCategory("MySql")]
         public void MembershipTable_MySql_Init()

--- a/test/TesterSQLUtils/MySqlRemindersTableTests.cs
+++ b/test/TesterSQLUtils/MySqlRemindersTableTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.ReminderService;
@@ -21,7 +22,7 @@ namespace UnitTests.RemindersTest
 
         protected override IReminderTable CreateRemindersTable()
         {
-            return new SqlReminderTable();
+            return new SqlReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>());
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
@@ -19,12 +19,12 @@ namespace UnitTests.MembershipTests
 
         protected override IMembershipTable CreateMembershipTable(Logger logger)
         {
-            return new SqlMembershipTable();
+            return new SqlMembershipTable(this.GrainReferenceConverter);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)
         {
-            return new SqlMembershipTable();
+            return new SqlMembershipTable(this.GrainReferenceConverter);
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterSQLUtils/PostgreSqlRemindersTableTests.cs
+++ b/test/TesterSQLUtils/PostgreSqlRemindersTableTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.ReminderService;
@@ -18,7 +19,7 @@ namespace UnitTests.RemindersTest
 
         protected override IReminderTable CreateRemindersTable()
         {
-            return new SqlReminderTable();
+            return new SqlReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>());
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
+++ b/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
@@ -22,12 +22,12 @@ namespace UnitTests.MembershipTests
 
         protected override IMembershipTable CreateMembershipTable(Logger logger)
         {
-            return new SqlMembershipTable();
+            return new SqlMembershipTable(this.GrainReferenceConverter);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)
         {
-            return new SqlMembershipTable();
+            return new SqlMembershipTable(this.GrainReferenceConverter);
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterSQLUtils/SqlServerRemindersTableTests.cs
+++ b/test/TesterSQLUtils/SqlServerRemindersTableTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.ReminderService;
@@ -21,7 +22,7 @@ namespace UnitTests.RemindersTest
 
         protected override IReminderTable CreateRemindersTable()
         {
-            return new SqlReminderTable();
+            return new SqlReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>());
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
+++ b/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Providers.SqlServer;
 using Orleans.Runtime;
@@ -72,7 +73,7 @@ namespace UnitTests.SqlStatisticsPublisherTests
                 DataConnectionString = ConnectionString
             };
 
-            IMembershipTable mbr = new SqlMembershipTable();
+            IMembershipTable mbr = new SqlMembershipTable(this.environment.Services.GetRequiredService<IGrainReferenceConverter>());
             await mbr.InitializeMembershipTable(config, true, logger).WithTimeout(TimeSpan.FromMinutes(1));
             StatisticsPublisher.AddConfiguration("statisticsDeployment", true, "statisticsSiloId", SiloAddress.NewLocalAddress(0), new IPEndPoint(IPAddress.Loopback, 12345), "statisticsHostName");
             await RunParallel(10, () => StatisticsPublisher.ReportMetrics((ISiloPerformanceMetrics)new DummyPerformanceMetrics()));

--- a/test/TesterSQLUtils/StorageTests/Relational/CommonFixture.cs
+++ b/test/TesterSQLUtils/StorageTests/Relational/CommonFixture.cs
@@ -56,8 +56,8 @@ namespace UnitTests.StorageTests.Relational
         {
             DefaultProviderRuntime = new StorageProviderManager(
                 this.GrainFactory,
-                null,
-                new ClientProviderRuntime(this.InternalGrainFactory, null));
+                this.Services,
+                new ClientProviderRuntime(this.InternalGrainFactory, this.Services));
             ((StorageProviderManager) DefaultProviderRuntime).LoadEmptyStorageProviders().WaitWithThrow(TestConstants.InitTimeout);
         }
 

--- a/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -2,8 +2,6 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Messaging;
 using Orleans.Runtime;
-using Orleans.TestingHost;
-using Tester;
 using TestExtensions;
 using Xunit;
 


### PR DESCRIPTION
Prep for non-static SerialziationManager.

Purpose: adds a non-static point for us to inject `IRuntimeClient` into `GrainReferences` as they're deserialzied from the 'key strings' used with various storage providers.

Check the last commit. The previous commits are from other pending PRs