### PR TITLE
Extract MessageFactory from Message class.

### DIFF
--- a/src/Orleans/Messaging/MessageFactory.cs
+++ b/src/Orleans/Messaging/MessageFactory.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using Orleans.CodeGeneration;
+
+namespace Orleans.Runtime
+{
+    internal class MessageFactory
+    {
+        private readonly Logger logger;
+
+        public MessageFactory()
+        {
+            this.logger = LogManager.GetLogger(nameof(MessageFactory), LoggerType.Runtime);
+        }
+
+        public Message CreateMessage(InvokeMethodRequest request, InvokeMethodOptions options)
+        {
+            var direction = (options & InvokeMethodOptions.OneWay) != 0 ? Message.Directions.OneWay : Message.Directions.Request;
+            var message = new Message
+            {
+                Category = Message.Categories.Application,
+                Direction = direction,
+                Id = CorrelationId.GetNext(),
+                IsReadOnly = (options & InvokeMethodOptions.ReadOnly) != 0,
+                IsUnordered = (options & InvokeMethodOptions.Unordered) != 0,
+                BodyObject = request
+            };
+
+            if ((options & InvokeMethodOptions.AlwaysInterleave) != 0)
+                message.IsAlwaysInterleave = true;
+
+            message.RequestContextData = RequestContext.Export();
+            return message;
+        }
+
+        public Message CreateResponseMessage(Message request)
+        {
+            var response = new Message
+            {
+                Category = request.Category,
+                Direction = Message.Directions.Response,
+                Id = request.Id,
+                IsReadOnly = request.IsReadOnly,
+                IsAlwaysInterleave = request.IsAlwaysInterleave,
+                TargetSilo = request.SendingSilo
+            };
+
+            if (request.SendingGrain != null)
+            {
+                response.TargetGrain = request.SendingGrain;
+                if (request.SendingActivation != null)
+                {
+                    response.TargetActivation = request.SendingActivation;
+                }
+            }
+
+            response.SendingSilo = request.TargetSilo;
+            if (request.TargetGrain != null)
+            {
+                response.SendingGrain = request.TargetGrain;
+                if (request.TargetActivation != null)
+                {
+                    response.SendingActivation = request.TargetActivation;
+                }
+                else if (request.TargetGrain.IsSystemTarget)
+                {
+                    response.SendingActivation = ActivationId.GetSystemActivation(request.TargetGrain, request.TargetSilo);
+                }
+            }
+
+            if (request.DebugContext != null)
+            {
+                response.DebugContext = request.DebugContext;
+            }
+
+            response.CacheInvalidationHeader = request.CacheInvalidationHeader;
+            response.Expiration = request.Expiration;
+
+            var contextData = RequestContext.Export();
+            if (contextData != null)
+            {
+                response.RequestContextData = contextData;
+            }
+
+            return response;
+        }
+
+        public Message CreateRejectionResponse(Message request, Message.RejectionTypes type, string info, OrleansException ex = null)
+        {
+            var response = this.CreateResponseMessage(request);
+            response.Result = Message.ResponseTypes.Rejection;
+            response.RejectionType = type;
+            response.RejectionInfo = info;
+            response.BodyObject = ex;
+            if (this.logger.IsVerbose) this.logger.Verbose("Creating {0} rejection with info '{1}' for {2} at:" + Environment.NewLine + "{3}", type, info, this, Utils.GetStackTrace());
+            return response;
+        }
+    }
+}

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Logging\LogManager.cs" />
     <Compile Include="LogConsistency\ConnectionIssues.cs" />
     <Compile Include="LogConsistency\IConnectionIssueListener.cs" />
+    <Compile Include="Messaging\MessageFactory.cs" />
     <Compile Include="MultiCluster\IMultiClusterGatewayInfo.cs" />
     <Compile Include="CodeGeneration\CodeGeneratorManager.cs" />
     <Compile Include="CodeGeneration\GrainState.cs" />
@@ -277,6 +278,7 @@
     <Compile Include="Streams\Core\StreamSubscriptionHandle.cs" />
     <Compile Include="Timers\AsyncTaskSafeTimer.cs" />
     <Compile Include="Timers\TimerRegistry.cs" />
+    <Compile Include="Utils\ServiceCollectionExtensions.cs" />
     <Compile Include="Utils\SetExtensions.cs" />
     <Compile Include="Placement\ActivationCountBasedPlacement.cs" />
     <Compile Include="Placement\StatelessWorkerPlacement.cs" />

--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -27,6 +27,11 @@ namespace Orleans.Runtime
         string CurrentActivationIdentity { get; }
 
         /// <summary>
+        /// Gets the service provider.
+        /// </summary>
+        IServiceProvider ServiceProvider { get; }
+
+        /// <summary>
         /// Get the current response timeout setting for this client.
         /// </summary>
         /// <returns>Response timeout value</returns>

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProducer.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProducer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.Runtime;
+using Orleans.Serialization;
 
 namespace Orleans.Streams
 {
@@ -24,12 +25,12 @@ namespace Orleans.Streams
 
         public Task OnNextAsync(T item, StreamSequenceToken token)
         {
-            return queueAdapter.QueueMessageAsync(stream.StreamId.Guid, stream.StreamId.Namespace, item, token, Runtime.RequestContext.Export());
+            return this.queueAdapter.QueueMessageAsync(this.stream.StreamId.Guid, this.stream.StreamId.Namespace, item, token, RequestContext.Export());
         }
 
         public Task OnNextBatchAsync(IEnumerable<T> batch, StreamSequenceToken token)
         {
-            return queueAdapter.QueueMessageBatchAsync(stream.StreamId.Guid, stream.StreamId.Namespace, batch, token, Runtime.RequestContext.Export());
+            return this.queueAdapter.QueueMessageBatchAsync(this.stream.StreamId.Guid, this.stream.StreamId.Namespace, batch, token, RequestContext.Export());
         }
 
         public Task OnCompletedAsync()

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
+using Orleans.Serialization;
 using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.Common
@@ -44,7 +46,7 @@ namespace Orleans.Providers.Streams.Common
         internal const string StartupStatePropertyName = "StartupState";
         internal const PersistentStreamProviderState StartupStateDefaultValue = PersistentStreamProviderState.AgentsStarted;
         private PersistentStreamProviderState startupState;
-        private ProviderStateManager stateManager = new ProviderStateManager();
+        private readonly ProviderStateManager stateManager = new ProviderStateManager();
 
         public string Name { get; private set; }
 
@@ -53,7 +55,7 @@ namespace Orleans.Providers.Streams.Common
         // this is a workaround until an IServiceProvider instance is used in the Orleans client
         private class GrainFactoryServiceProvider : IServiceProvider
         {
-            private IStreamProviderRuntime providerRuntime;
+            private readonly IStreamProviderRuntime providerRuntime;
             public GrainFactoryServiceProvider(IStreamProviderRuntime providerRuntime)
             {
                 this.providerRuntime = providerRuntime;

--- a/src/Orleans/Utils/ServiceCollectionExtensions.cs
+++ b/src/Orleans/Utils/ServiceCollectionExtensions.cs
@@ -2,7 +2,7 @@ using System.Linq;
 
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans.Runtime
+namespace Orleans
 {
     /// <summary>
     /// Extension methods for <see cref="IServiceCollection"/>.

--- a/src/Orleans/project.json
+++ b/src/Orleans/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Newtonsoft.Json": "7.0.1",
     "System.Collections.Immutable": "1.1.37"
   },

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -158,7 +158,8 @@ namespace Orleans.Runtime
             GrainCreator grainCreator,
             NodeConfiguration nodeConfig,
             ISiloMessageCenter messageCenter,
-            PlacementDirectorsManager placementDirectorsManager)
+            PlacementDirectorsManager placementDirectorsManager,
+            MessageFactory messageFactory)
             : base(Constants.CatalogId, messageCenter.MyAddress)
         {
             LocalSilo = siloInitializationParameters.SiloAddress;
@@ -175,7 +176,7 @@ namespace Orleans.Runtime
             logger = LogManager.GetLogger("Catalog", Runtime.LoggerType.Runtime);
             this.config = config.Globals;
             ActivationCollector = new ActivationCollector(config);
-            this.Dispatcher = new Dispatcher(scheduler, messageCenter, this, config, placementDirectorsManager, grainDirectory);
+            this.Dispatcher = new Dispatcher(scheduler, messageCenter, this, config, placementDirectorsManager, grainDirectory, messageFactory);
             GC.GetTotalMemory(true); // need to call once w/true to ensure false returns OK value
 
             config.OnConfigChange("Globals/Activation", () => scheduler.RunOrQueueAction(Start, SchedulingContext), false);

--- a/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
@@ -10,9 +10,10 @@ namespace Orleans.Runtime.Messaging
         private readonly ActivationDirectory directory;
         private readonly OrleansTaskScheduler scheduler;
         private readonly Dispatcher dispatcher;
+        private readonly MessageFactory messageFactory;
         private readonly Message.Categories category;
 
-        internal IncomingMessageAgent(Message.Categories cat, IMessageCenter mc, ActivationDirectory ad, OrleansTaskScheduler sched, Dispatcher dispatcher) :
+        internal IncomingMessageAgent(Message.Categories cat, IMessageCenter mc, ActivationDirectory ad, OrleansTaskScheduler sched, Dispatcher dispatcher, MessageFactory messageFactory) :
             base(cat.ToString())
         {
             category = cat;
@@ -20,6 +21,7 @@ namespace Orleans.Runtime.Messaging
             directory = ad;
             scheduler = sched;
             this.dispatcher = dispatcher;
+            this.messageFactory = messageFactory;
             OnFault = FaultBehavior.RestartOnFault;
         }
 
@@ -90,7 +92,7 @@ namespace Orleans.Runtime.Messaging
                 if (target == null)
                 {
                     MessagingStatisticsGroup.OnRejectedMessage(msg);
-                    Message response = msg.CreateRejectionResponse(Message.RejectionTypes.Unrecoverable,
+                    Message response = this.messageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable,
                         String.Format("SystemTarget {0} not active on this silo. Msg={1}", msg.TargetGrain, msg));
                     messageCenter.SendMessage(response);
                     Log.Warn(ErrorCode.MessagingMessageFromUnknownActivation, "Received a message {0} for an unknown SystemTarget: {1}", msg, msg.TargetAddress);

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -201,7 +201,6 @@
     <Compile Include="Streams\QueueBalancer\DeploymentBasedQueueBalancer.cs" />
     <Compile Include="Streams\QueueBalancer\StreamQueueBalancerFactory.cs" />
     <Compile Include="Streams\StreamProviderManagerAgent.cs" />
-    <Compile Include="Utilities\ServiceCollectionExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orleans\Orleans.csproj">

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -259,6 +259,7 @@ namespace Orleans.Runtime
             services.AddSingleton<SiloProviderRuntime>();
             services.AddFromExisting<IStreamProviderRuntime, SiloProviderRuntime>();
             services.AddSingleton<ImplicitStreamSubscriberTable>();
+            services.AddSingleton<MessageFactory>();
 
             // Placement
             services.AddSingleton<PlacementDirectorsManager>();
@@ -344,12 +345,13 @@ namespace Orleans.Runtime
             siloStatistics.MetricsTable.ActivationDirectory = activationDirectory;
             siloStatistics.MetricsTable.ActivationCollector = catalog.ActivationCollector;
             siloStatistics.MetricsTable.MessageCenter = messageCenter;
-            
+
             // Now the incoming message agents
-            incomingSystemAgent = new IncomingMessageAgent(Message.Categories.System, messageCenter, activationDirectory, scheduler, catalog.Dispatcher);
-            incomingPingAgent = new IncomingMessageAgent(Message.Categories.Ping, messageCenter, activationDirectory, scheduler, catalog.Dispatcher);
-            incomingAgent = new IncomingMessageAgent(Message.Categories.Application, messageCenter, activationDirectory, scheduler, catalog.Dispatcher);
-            
+            var messageFactory = this.Services.GetRequiredService<MessageFactory>();
+            incomingSystemAgent = new IncomingMessageAgent(Message.Categories.System, messageCenter, activationDirectory, scheduler, catalog.Dispatcher, messageFactory);
+            incomingPingAgent = new IncomingMessageAgent(Message.Categories.Ping, messageCenter, activationDirectory, scheduler, catalog.Dispatcher, messageFactory);
+            incomingAgent = new IncomingMessageAgent(Message.Categories.Application, messageCenter, activationDirectory, scheduler, catalog.Dispatcher, messageFactory);
+
             membershipOracle = Services.GetRequiredService<IMembershipOracle>();
 
             if (!this.GlobalConfig.HasMultiClusterNetwork)

--- a/test/NonSiloTests/General/RequestContextTestsNonSiloRequired.cs
+++ b/test/NonSiloTests/General/RequestContextTestsNonSiloRequired.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Runtime.Remoting.Messaging;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Serialization;

--- a/test/NonSiloTests/SerializerTests/MessageSerializerTests.cs
+++ b/test/NonSiloTests/SerializerTests/MessageSerializerTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.CodeGeneration;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
@@ -17,11 +18,13 @@ namespace NonSiloTests.UnitTests.SerializerTests
     {
         private readonly ITestOutputHelper output;
         private readonly TestEnvironmentFixture fixture;
+        private readonly MessageFactory messageFactory;
 
         public MessageSerializerTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
         {
             this.output = output;
             this.fixture = fixture;
+            this.messageFactory = this.fixture.Services.GetRequiredService<MessageFactory>();
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
@@ -33,7 +36,7 @@ namespace NonSiloTests.UnitTests.SerializerTests
         private void RunTest(int numItems)
         {
             InvokeMethodRequest request = new InvokeMethodRequest(0, 0, null);
-            Message resp = Message.CreateMessage(request, InvokeMethodOptions.None);
+            Message resp = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None);
             resp.Id = new CorrelationId();
             resp.SendingSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 200), 0);
             resp.TargetSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 300), 0);

--- a/test/TestExtensions/SerializationTestEnvironment.cs
+++ b/test/TestExtensions/SerializationTestEnvironment.cs
@@ -53,6 +53,8 @@ namespace TestExtensions
 
         internal IInternalGrainFactory InternalGrainFactory => this.RuntimeClient.InternalGrainFactory;
 
+        internal IServiceProvider Services => this.RuntimeClient.ServiceProvider;
+
         public void Dispose()
         {
             this.RuntimeClient?.Dispose();


### PR DESCRIPTION
Prep for non-static SerializationManager.

Purpose is to give ourselves a way to inject `SerializationManager`/`RequestContextUtil` when creating messages. We could add an extra field to `Message`, but I believe it's best to keep POCOs as data-only (no services), since that makes serialization/deserialization obvious.

Only the last commit is unique to this PR: the others have their own PRs.