### PR TITLE
DynamoDB silo identity fix

### DIFF
--- a/src/OrleansAWSUtils/Membership/SiloInstanceRecord.cs
+++ b/src/OrleansAWSUtils/Membership/SiloInstanceRecord.cs
@@ -149,7 +149,7 @@ namespace Orleans.Runtime.MembershipService
         {
             var keys = new Dictionary<string, AttributeValue>();
             keys.Add(DEPLOYMENT_ID_PROPERTY_NAME, new AttributeValue(DeploymentId));
-            keys.Add(SILO_IDENTITY_PROPERTY_NAME, new AttributeValue($"{Address}-{Port}-{Generation}"));
+            keys.Add(SILO_IDENTITY_PROPERTY_NAME, new AttributeValue(SiloIdentity));
             return keys;
         }
 
@@ -160,7 +160,7 @@ namespace Orleans.Runtime.MembershipService
             if (includeKeys)
             {
                 fields.Add(DEPLOYMENT_ID_PROPERTY_NAME, new AttributeValue(DeploymentId));
-                fields.Add(SILO_IDENTITY_PROPERTY_NAME, new AttributeValue($"{Address}-{Port}-{Generation}")); 
+                fields.Add(SILO_IDENTITY_PROPERTY_NAME, new AttributeValue(SiloIdentity)); 
             }
             
             if (!string.IsNullOrWhiteSpace(Address))

--- a/test/AWSUtils.Tests/AWSUtils.Tests.csproj
+++ b/test/AWSUtils.Tests/AWSUtils.Tests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="CollectionFixtures.cs" />
     <Compile Include="LivenessTests.cs" />
     <Compile Include="MembershipTests\DynamoDBMembershipTableTest.cs" />
+    <Compile Include="MembershipTests\SiloInstanceRecordTests.cs" />
     <Compile Include="Reminder\DynamoDBRemindersTableTests.cs" />
     <Compile Include="StorageTests\AWSTestConstants.cs" />
     <Compile Include="StorageTests\Base_PersistenceGrainTests_AWSStore.cs" />

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -82,5 +82,11 @@ namespace AWSUtils.Tests.MembershipTests
         {
             await MembershipTable_UpdateRowInParallel(false);
         }
+
+        [SkippableFact]
+        public async Task MembershipTable_DynamoDB_UpdateIAmAlive()
+        {
+            await MembershipTable_UpdateIAmAlive(false);
+        }
     }
 }

--- a/test/AWSUtils.Tests/MembershipTests/SiloInstanceRecordTests.cs
+++ b/test/AWSUtils.Tests/MembershipTests/SiloInstanceRecordTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using Amazon.DynamoDBv2.Model;
+using Orleans.Runtime;
+using Orleans.Runtime.MembershipService;
+using Xunit;
+
+namespace AWSUtils.Tests.MembershipTests
+{
+    [TestCategory("Membership"), TestCategory("AWS"), TestCategory("DynamoDb")]
+    public class SiloInstanceRecordTests
+    {
+        [Fact]
+        public void GetKeysTest()
+        {
+            SiloAddress address = SiloAddress.New(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 12345), 67890); 
+            var instanceRecord = new SiloInstanceRecord
+            {
+                DeploymentId = "deploymentID",
+                SiloIdentity = SiloInstanceRecord.ConstructSiloIdentity(address)
+            };
+
+            Dictionary<string, AttributeValue> keys = instanceRecord.GetKeys();
+
+            Assert.Equal(2, keys.Count);
+            Assert.Equal(instanceRecord.DeploymentId, keys[SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME].S);
+            Assert.Equal(instanceRecord.SiloIdentity, keys[SiloInstanceRecord.SILO_IDENTITY_PROPERTY_NAME].S);
+        }
+    }
+}

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -42,43 +42,43 @@ namespace Consul.Tests
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public async Task MembershipTable_DynamoDB_GetGateways()
+        public async Task MembershipTable_Consul_GetGateways()
         {
             await MembershipTable_GetGateways();
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public async Task MembershipTable_DynamoDB_ReadAll_EmptyTable()
+        public async Task MembershipTable_Consul_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public async Task MembershipTable_DynamoDB_InsertRow()
+        public async Task MembershipTable_Consul_InsertRow()
         {
             await MembershipTable_InsertRow(false);
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public async Task MembershipTable_DynamoDB_ReadRow_Insert_Read()
+        public async Task MembershipTable_Consul_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read(false);
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public async Task MembershipTable_DynamoDB_ReadAll_Insert_ReadAll()
+        public async Task MembershipTable_Consul_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll(false);
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public async Task MembershipTable_DynamoDB_UpdateRow()
+        public async Task MembershipTable_Consul_UpdateRow()
         {
             await MembershipTable_UpdateRow(false);
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public async Task MembershipTable_DynamoDB_UpdateRowInParallel()
+        public async Task MembershipTable_Consul_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel(false);
         }

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -82,6 +82,12 @@ namespace Consul.Tests
         {
             await MembershipTable_UpdateRowInParallel(false);
         }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task MembershipTable_Consul_UpdateIAmAlive()
+        {
+            await MembershipTable_UpdateIAmAlive(false);
+        }
     }
 }
 

--- a/test/TesterAzureUtils/AzureMembershipTableTests.cs
+++ b/test/TesterAzureUtils/AzureMembershipTableTests.cs
@@ -82,10 +82,16 @@ namespace Tester.AzureUtils
             await MembershipTable_UpdateRow();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("Azure")]
+        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
         public async Task MembershipTable_Azure_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel();
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        public async Task MembershipTable_Azure_UpdateIAmAlive()
+        {
+            await MembershipTable_UpdateIAmAlive();
         }
     }
 }

--- a/test/TesterSQLUtils/MySqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/MySqlMembershipTableTests.cs
@@ -88,5 +88,11 @@ namespace UnitTests.MembershipTests
         {
             await MembershipTable_UpdateRowInParallel();
         }
+
+        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        public async Task MembershipTable_MySql_UpdateIAmAlive()
+        {
+            await MembershipTable_UpdateIAmAlive();
+        }
     }
 }

--- a/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
@@ -38,7 +38,6 @@ namespace UnitTests.MembershipTests
                     .Result.CurrentConnectionString;
         }
 
-
         [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
         public void MembershipTable_PostgreSql_Init()
         {
@@ -84,6 +83,12 @@ namespace UnitTests.MembershipTests
         public async Task MembershipTable_PostgreSql_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel();
+        }
+
+        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        public async Task MembershipTable_PostgreSql_UpdateIAmAlive()
+        {
+            await MembershipTable_UpdateIAmAlive();
         }
     }
 }

--- a/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
+++ b/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
@@ -87,5 +87,11 @@ namespace UnitTests.MembershipTests
         {
             await MembershipTable_UpdateRowInParallel();
         }
+
+        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        public async Task MembershipTable_SqlServer_UpdateIAmAlive()
+        {
+            await MembershipTable_UpdateIAmAlive();
+        }
     }
 }

--- a/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -80,5 +80,11 @@ namespace UnitTests.MembershipTests
         {
             await MembershipTable_UpdateRowInParallel();
         }
+
+        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        public async Task MembershipTable_ZooKeeper_UpdateIAmAlive()
+        {
+            await MembershipTable_UpdateIAmAlive();
+        }
     }
 }

--- a/vNext/test/AWSUtils.Tests/AWSUtils.Tests.csproj
+++ b/vNext/test/AWSUtils.Tests/AWSUtils.Tests.csproj
@@ -52,6 +52,9 @@
     <Compile Include="..\..\..\test\AWSUtils.Tests\MembershipTests\DynamoDBMembershipTableTest.cs">
       <Link>MembershipTests\DynamoDBMembershipTableTest.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\test\AWSUtils.Tests\MembershipTests\SiloInstanceRecordTests.cs">
+      <Link>MembershipTests\SiloInstanceRecordTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\test\AWSUtils.Tests\Reminder\DynamoDBRemindersTableTests.cs">
       <Link>Reminder\DynamoDBRemindersTableTests.cs</Link>
     </Compile>


### PR DESCRIPTION
(@galvesribeiro - as per chat on Gitter)

When using DynamoDB for the membership store, I was seeing `ConditionalCheckFailedException` errors when trying to update the `IAmAlive` field in the database. 

This was because the key being used to locate the record always had a value of "-0-0" rather than the expected "_IP-Port-Generation_". This was because it was being built using the `Address`, `Port`, and `Generation` values on the `SiloInstanceRecord` object, but on this code path these values are not assigned. Only the `SiloIdentity` property gets set by the `MembershipOracle` (see `OnIAmAliveUpdateInTableTimer`).

I have added new unit tests for the `GetKeys` call on `SiloInstanceRecord`, and fixed the issue.

I also added integration tests for all the membership stores, to exercise `UpdateIAmAlive`, as it looked like this was not being tested. **Note, I've not been able to run all these tests, as I don't have the various databases set up locally**.

