### PR TITLE
DynamoDB Gateway Provider fix: was including non-gateway silos

### DIFF
--- a/src/OrleansAWSUtils/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/OrleansAWSUtils/Membership/DynamoDBGatewayListProvider.cs
@@ -45,9 +45,15 @@ namespace Orleans.Runtime.MembershipService
             var expressionValues = new Dictionary<string, AttributeValue>
             {
                 { $":{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}", new AttributeValue(deploymentId) },
-                { $":{SiloInstanceRecord.STATUS_PROPERTY_NAME}", new AttributeValue { N =  INSTANCE_STATUS_ACTIVE } }
+                { $":{SiloInstanceRecord.STATUS_PROPERTY_NAME}", new AttributeValue { N = INSTANCE_STATUS_ACTIVE } },
+                { $":{SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME}", new AttributeValue { N = "0"} }
             };
-            var expression = $"{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME} = :{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME} AND {SiloInstanceRecord.STATUS_PROPERTY_NAME} = :{SiloInstanceRecord.STATUS_PROPERTY_NAME}";
+
+            var expression =
+                $"{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME} = :{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME} " +
+                $"AND {SiloInstanceRecord.STATUS_PROPERTY_NAME} = :{SiloInstanceRecord.STATUS_PROPERTY_NAME} " + 
+                $"AND {SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME} > :{SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME}";
+
             var records = await storage.ScanAsync<Uri>(TABLE_NAME_DEFAULT_VALUE, expressionValues,
                 expression, gateway =>
                 {

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -108,8 +108,13 @@ namespace UnitTests.MembershipTests
 
             var entries = new List<string>(gateways.Select(g => g.ToString()));
 
+            // only members with a non-zero Gateway port
+            Assert.False(entries.Contains(membershipEntries[3].SiloAddress.ToGatewayUri().ToString()));
+
+            // only Active members
             Assert.True(entries.Contains(membershipEntries[5].SiloAddress.ToGatewayUri().ToString()));
             Assert.True(entries.Contains(membershipEntries[9].SiloAddress.ToGatewayUri().ToString()));
+            Assert.Equal(2, entries.Count);
         }
 
         protected async Task MembershipTable_ReadAll_EmptyTable()
@@ -394,7 +399,6 @@ namespace UnitTests.MembershipTests
         private static MembershipEntry CreateMembershipEntryForTest()
         {
             SiloAddress siloAddress = CreateSiloAddressForTest();
-
 
             var membershipEntry = new MembershipEntry
             {


### PR DESCRIPTION
The DynamoDB gateway provider was not filtering out silos with a proxy-port of 0.

All other providers only consider Active silos, sharing the current DeploymentId, with a non-zero proxy port (e.g. https://github.com/dotnet/orleans/blob/master/src/OrleansAzureUtils/Storage/OrleansSiloInstanceManager.cs#L235)

Added test coverage and fixed using additional predicate on query.

I've not been able to re-run all the membership provider tests for other providers locally, but have examined the code for all of them, and they all appear to include this correct check.