### PR TITLE
Reduce allocations in usages of ClosureWorkItem

### DIFF
--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -173,7 +173,7 @@ namespace Orleans.Runtime
                                             nonExistentActivation), exc);
                                 }
                             },
-                            () => "LocalGrainDirectory.UnregisterAfterNonexistingActivation"),
+                            "LocalGrainDirectory.UnregisterAfterNonexistingActivation"),
                             catalog.SchedulingContext);
 
                         ProcessRequestToInvalidActivation(message, nonExistentActivation, null, "Non-existent activation");

--- a/src/Orleans.Runtime/Messaging/IncomingMessageAgent.cs
+++ b/src/Orleans.Runtime/Messaging/IncomingMessageAgent.cs
@@ -164,7 +164,7 @@ namespace Orleans.Runtime.Messaging
                     if (targetActivation != null) targetActivation.DecrementEnqueuedOnDispatcherCount();
                 }
             },
-            () => "Dispatcher.ReceiveMessage"), context);
+            "Dispatcher.ReceiveMessage"), context);
         }
     }
 }

--- a/src/Orleans.Runtime/Scheduler/ClosureWorkItem.cs
+++ b/src/Orleans.Runtime/Scheduler/ClosureWorkItem.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace Orleans.Runtime.Scheduler
 {
     internal class ClosureWorkItem : WorkItemBase
     {
         private readonly Action continuation;
-        private readonly Func<string> nameGetter;
+        private readonly string name;
 
-        public override string Name { get { return nameGetter==null ? "" : nameGetter(); } }
+        public override string Name => this.name ?? GetMethodName(this.continuation);
 
         public ClosureWorkItem(Action closure)
         {
@@ -21,10 +22,10 @@ namespace Orleans.Runtime.Scheduler
 #endif
         }
 
-        public ClosureWorkItem(Action closure, Func<string> getName)
+        public ClosureWorkItem(Action closure, string name)
         {
             continuation = closure;
-            nameGetter = getName;
+            this.name = name;
 #if TRACK_DETAILED_STATS
             if (StatisticsCollector.CollectGlobalShedulerStats)
             {
@@ -46,23 +47,107 @@ namespace Orleans.Runtime.Scheduler
             continuation();
         }
 
-        public override WorkItemType ItemType { get { return WorkItemType.Closure; } }
+        public override WorkItemType ItemType => WorkItemType.Closure;
 
         #endregion
 
-        public override string ToString()
+        internal static string GetMethodName(Delegate action)
         {
-            var detailedName = string.Empty; 
-            if (nameGetter == null) // if NameGetter != null, base.ToString() will print its name.
-            {
-                var continuationMethodInfo = continuation.GetMethodInfo();
-                detailedName = string.Format(": {0}->{1}",
-                   (continuation.Target == null) ? "" : continuation.Target.ToString(),
-                   (continuationMethodInfo == null) ? "" : continuationMethodInfo.ToString());
-            }
-               
-
-            return string.Format("{0}{1}", base.ToString(), detailedName);
+            var continuationMethodInfo = action.GetMethodInfo();
+            return string.Format(
+                "{0}->{1}",
+                action.Target?.ToString() ?? string.Empty,
+                continuationMethodInfo == null ? string.Empty : continuationMethodInfo.ToString());
         }
+    }
+
+    internal class AsyncClosureWorkItem : WorkItemBase
+    {
+        private readonly TaskCompletionSource<bool> completion = new TaskCompletionSource<bool>();
+        private readonly Func<Task> continuation;
+        private readonly string name;
+
+        public override string Name => this.name ?? ClosureWorkItem.GetMethodName(this.continuation);
+        public Task Task => this.completion.Task;
+
+        public AsyncClosureWorkItem(Func<Task> closure, string name = null)
+        {
+            this.continuation = closure;
+            this.name = name;
+#if TRACK_DETAILED_STATS
+            if (StatisticsCollector.CollectGlobalShedulerStats)
+            {
+                SchedulerStatisticsGroup.OnClosureWorkItemsCreated();
+            }
+#endif
+        }
+
+        public override async void Execute()
+        {
+#if TRACK_DETAILED_STATS
+            if (StatisticsCollector.CollectGlobalShedulerStats)
+            {
+                SchedulerStatisticsGroup.OnClosureWorkItemsExecuted();
+            }
+#endif
+
+            try
+            {
+                RequestContext.Clear();
+                await this.continuation();
+                this.completion.TrySetResult(true);
+            }
+            catch (Exception exception)
+            {
+                this.completion.TrySetException(exception);
+            }
+        }
+
+        public override WorkItemType ItemType => WorkItemType.Closure;
+    }
+
+    internal class AsyncClosureWorkItem<T> : WorkItemBase
+    {
+        private readonly TaskCompletionSource<T> completion = new TaskCompletionSource<T>();
+        private readonly Func<Task<T>> continuation;
+        private readonly string name;
+
+        public override string Name => this.name ?? ClosureWorkItem.GetMethodName(this.continuation);
+        public Task<T> Task => this.completion.Task;
+        
+        public AsyncClosureWorkItem(Func<Task<T>> closure, string name = null)
+        {
+            this.continuation = closure;
+            this.name = name;
+#if TRACK_DETAILED_STATS
+            if (StatisticsCollector.CollectGlobalShedulerStats)
+            {
+                SchedulerStatisticsGroup.OnClosureWorkItemsCreated();
+            }
+#endif
+        }
+
+        public override async void Execute()
+        {
+#if TRACK_DETAILED_STATS
+            if (StatisticsCollector.CollectGlobalShedulerStats)
+            {
+                SchedulerStatisticsGroup.OnClosureWorkItemsExecuted();
+            }
+#endif
+
+            try
+            {
+                RequestContext.Clear();
+                var result = await this.continuation();
+                this.completion.TrySetResult(result);
+            }
+            catch (Exception exception)
+            {
+                this.completion.TrySetException(exception);
+            }
+        }
+
+        public override WorkItemType ItemType => WorkItemType.Closure;
     }
 }

--- a/src/Orleans.Runtime/Scheduler/WorkItemBase.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemBase.cs
@@ -30,10 +30,10 @@ namespace Orleans.Runtime.Scheduler
 
         public override string ToString()
         {
-            return String.Format("[{0} WorkItem Name={1}, Ctx={2}]", 
+            return string.Format("[{0} WorkItem Name={1}, Ctx={2}]", 
                 ItemType, 
-                Name ?? "",
-                (SchedulingContext == null) ? "null" : SchedulingContext.ToString()
+                Name ?? string.Empty,
+                SchedulingContext?.ToString() ?? "null"
             );
         }
     }


### PR DESCRIPTION
By creating a couple of specialised versions of `ClosureWorkItem` to handle specific usages, we can reduce allocations by around 1 or 2 per invocation.

* Change the name property from a `Func<string>` to a `string` to avoid allocating a closure.
* Introduce `AsyncClosureWorkItem` for simple `Func<Task>` cases.
* Introduce `AsyncClosureWorkItem<T>` for `Func<Task<T>>` cases.