### PR TITLE
Reduce SchedulingContext allocs for grain activations

### DIFF
--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Orleans.CodeGeneration;
 using Orleans.GrainDirectory;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Scheduler;
 using Orleans.Storage;
 
 namespace Orleans.Runtime
@@ -191,6 +192,7 @@ namespace Orleans.Runtime
 
 
             GrainReference = GrainReference.FromGrainId(addr.Grain, genericArguments, Grain.IsSystemTarget ? addr.Silo : null);
+            this.SchedulingContext = new SchedulingContext(this);
         }
 
         #region Method invocation
@@ -242,6 +244,8 @@ namespace Orleans.Runtime
         }
 
         #endregion
+
+        public ISchedulingContext SchedulingContext { get; }
 
         public string GrainTypeName
         {

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -380,8 +380,7 @@ namespace Orleans.Runtime
         /// <param name="activation"></param>
         public void RegisterMessageTarget(ActivationData activation)
         {
-            var context = new SchedulingContext(activation);
-            scheduler.RegisterWorkContext(context);
+            scheduler.RegisterWorkContext(activation.SchedulingContext);
             activations.RecordNewTarget(activation);
             activationsCreated.Increment();
         }

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -398,7 +398,7 @@ namespace Orleans.Runtime
             ActivationCollector.TryCancelCollection(activation);
             activationsDestroyed.Increment();
 
-            scheduler.UnregisterWorkContext(new SchedulingContext(activation));
+            scheduler.UnregisterWorkContext(activation.SchedulingContext);
 
             if (activation.GrainInstance == null) return;
 
@@ -877,7 +877,7 @@ namespace Orleans.Runtime
 
                     await scheduler.RunOrQueueTask(() =>
                         result.StorageProvider.ReadStateAsync(grainType, grainRef, state),
-                        new SchedulingContext(result));
+                        result.SchedulingContext);
                     
                     sw.Stop();
                     StorageStatisticsGroup.OnStorageActivate(result.StorageProvider, grainType, result.GrainReference, sw.Elapsed);
@@ -1135,7 +1135,7 @@ namespace Orleans.Runtime
                 foreach (var activation in list)
                 {
                     var activationData = activation; // Capture loop variable
-                    var task = scheduler.RunOrQueueTask(() => CallGrainDeactivateAndCleanupStreams(activationData), new SchedulingContext(activationData));
+                    var task = scheduler.RunOrQueueTask(() => CallGrainDeactivateAndCleanupStreams(activationData), activationData.SchedulingContext);
                     tasks2.Add(new Tuple<Task, ActivationData>(task, activationData));
                 }
                 var asyncQueue = new AsyncBatchedContinuationQueue<ActivationData>();
@@ -1379,7 +1379,7 @@ namespace Orleans.Runtime
             {
                 activation.SetState(ActivationState.Activating);
             }
-            return scheduler.QueueTask(() => CallGrainActivate(activation, requestContextData), new SchedulingContext(activation)); // Target grain's scheduler context);
+            return scheduler.QueueTask(() => CallGrainActivate(activation, requestContextData), activation.SchedulingContext); // Target grain's scheduler context);
             // ActivationData will transition out of ActivationState.Activating via Dispatcher.OnActivationCompletedRequest
         }
 #endregion

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -378,10 +378,9 @@ namespace Orleans.Runtime
 
                 // Now we can actually scheduler processing of this request
                 targetActivation.RecordRunning(message);
-                var context = new SchedulingContext(targetActivation);
 
                 MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedOk(message);
-                scheduler.QueueWorkItem(new InvokeWorkItem(targetActivation, message, context, this), context);
+                scheduler.QueueWorkItem(new InvokeWorkItem(targetActivation, message, this), targetActivation.SchedulingContext);
             }
         }
 

--- a/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
+++ b/src/OrleansRuntime/Messaging/IncomingMessageAgent.cs
@@ -136,7 +136,7 @@ namespace Orleans.Runtime.Messaging
                             }
 
                             // Run ReceiveMessage in context of target activation
-                            context = new SchedulingContext(target);
+                            context = target.SchedulingContext;
                         }
                         else
                         {

--- a/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
+++ b/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
@@ -10,18 +10,19 @@ namespace Orleans.Runtime.Scheduler
         private readonly Message message;
         private readonly Dispatcher dispatcher;
 
-        public InvokeWorkItem(ActivationData activation, Message message, ISchedulingContext context, Dispatcher dispatcher)
+        public InvokeWorkItem(ActivationData activation, Message message, Dispatcher dispatcher)
         {
-            this.activation = activation;
-            this.message = message;
-            this.dispatcher = dispatcher;
-            SchedulingContext = context;
-            if (activation == null || activation.GrainInstance==null)
+            if (activation?.GrainInstance == null)
             {
-                var str = String.Format("Creating InvokeWorkItem with bad activation: {0}. Message: {1}", activation, message);
+                var str = string.Format("Creating InvokeWorkItem with bad activation: {0}. Message: {1}", activation, message);
                 logger.Warn(ErrorCode.SchedulerNullActivation, str);
                 throw new ArgumentException(str);
             }
+
+            this.activation = activation;
+            this.message = message;
+            this.dispatcher = dispatcher;
+            this.SchedulingContext = activation.SchedulingContext;
             activation.IncrementInFlightCount();
         }
 

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -1007,7 +1007,7 @@ namespace Orleans.Runtime
                 Utils.SafeExecute(() =>
                 {
                     var activationData = enumerator.Current.Value;
-                    var workItemGroup = scheduler.GetWorkItemGroup(new SchedulingContext(activationData));
+                    var workItemGroup = scheduler.GetWorkItemGroup(activationData.SchedulingContext);
                     if (workItemGroup == null)
                     {
                         sb.AppendFormat("Activation with no work item group!! Grain {0}, activation {1}.",


### PR DESCRIPTION
By implementing `ISchedulingContext` in `ActivationData` we can remove at least one allocation per call.

I did not perform the same optimization for `SystemTarget` at this stage because there are comparatively very few `SystemTarget`s and we already allocate just one `SchedulingContext` per `SystemTarget` (i.e, not per-call).

I chose to implement this explicitly in `ActivationData` rather than adding a `SchedulingContext` member because it's simple and results in less GC pressure without adding any fields.

Fixes #2677.