### PR TITLE
Suppress noise build warnings

### DIFF
--- a/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
+++ b/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
@@ -233,11 +233,11 @@ namespace Orleans.Runtime
 
         public void Stop()
         {
-            if (cpuUsageTimer != null)
-                cpuUsageTimer.Dispose();
+            cpuUsageTimer?.Dispose();
             cpuUsageTimer = null;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "cpuUsageTimer")]
         public void Dispose()
         {
             cpuCounterPF.Dispose();
@@ -254,7 +254,7 @@ namespace Orleans.Runtime
             numberOfInducedGCsPF.Dispose();
             largeObjectHeapSizePF.Dispose();
             promotedFinalizationMemoryFromGen0PF.Dispose();
-            this.cpuUsageTimer?.Dispose();
+            cpuUsageTimer?.Dispose();
         }
     }
 }

--- a/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
+++ b/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
@@ -103,13 +103,17 @@ namespace Orleans.Runtime.Configuration
             int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
             string deploymentId = null,
             int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
+#pragma warning disable CS0618 // Type or member is obsolete
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
+#pragma warning restore CS0618 // Type or member is obsolete
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
             deploymentId = deploymentId ?? config.Globals.DeploymentId;
             var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
+#pragma warning disable 618
             config.Globals.RegisterStreamProvider<AzureQueueStreamProvider>(providerName, properties);
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -130,7 +134,9 @@ namespace Orleans.Runtime.Configuration
             int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
             string deploymentId = null,
             int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
+#pragma warning disable 618
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
+#pragma warning restore 618
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
@@ -157,13 +163,17 @@ namespace Orleans.Runtime.Configuration
             int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
             string deploymentId = null,
             int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
+#pragma warning disable 618
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
+#pragma warning restore 618
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
             deploymentId = deploymentId ?? config.DeploymentId;
             var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
+#pragma warning disable 618
             config.RegisterStreamProvider<AzureQueueStreamProvider>(providerName, properties);
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -184,7 +194,9 @@ namespace Orleans.Runtime.Configuration
             int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
             string deploymentId = null,
             int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
+#pragma warning disable 618
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
+#pragma warning restore 618
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
@@ -204,7 +216,9 @@ namespace Orleans.Runtime.Configuration
                 { AzureQueueAdapterConstants.NumQueuesPropertyName, numberOfQueues.ToString() },
                 { AzureQueueAdapterConstants.DeploymentIdPropertyName, deploymentId },
                 { SimpleQueueAdapterCache.CacheSizePropertyName, cacheSize.ToString() },
+#pragma warning disable 618
                 { AzureQueueStreamProvider.StartupStatePropertyName, startupState.ToString() },
+#pragma warning restore 618
             };
 
             persistentStreamProviderConfig?.WriteProperties(properties);

--- a/test/Tester/StreamingTests/PullingAgentManagementTests.cs
+++ b/test/Tester/StreamingTests/PullingAgentManagementTests.cs
@@ -35,7 +35,9 @@ namespace UnitTests.StreamingTests
         }
 
         private const string adapterName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
+#pragma warning disable 618
         private readonly string adapterType = typeof(AzureQueueStreamProvider).FullName;
+#pragma warning restore 618
 
         public PullingAgentManagementTests(Fixture fixture)
         {

--- a/test/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
@@ -18,7 +18,9 @@ namespace Tester.AzureUtils.Streaming
     public class DelayedQueueRebalancingTests : TestClusterPerTest
     {
         private const string adapterName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
+#pragma warning disable 618
         private readonly string adapterType = typeof(AzureQueueStreamProvider).FullName;
+#pragma warning restore 618
         private static readonly TimeSpan SILO_IMMATURE_PERIOD = TimeSpan.FromSeconds(40); // matches the config
         private static readonly TimeSpan LEEWAY = TimeSpan.FromSeconds(10);
 


### PR DESCRIPTION
Suppress a set of warnings stemming from us having deprecated `AzureQueueStreamProvider`.
Suppress a false positive warning about not disposing a timer.