### PR TITLE
Improve support for generic grains with generic state

### DIFF
--- a/test/DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/DefaultCluster.Tests/GenericGrainTests.cs
@@ -743,9 +743,20 @@ namespace DefaultCluster.Tests.General
 
             Assert.Equal(result, "Hello!");
         }
+        
+        /// <summary>
+        /// Tests that generic grains can have generic state and that the parameters to the Grain{TState}
+        /// class do not have to match the parameters to the grain class itself.
+        /// </summary>
+        /// <returns></returns>
+        [Fact, TestCategory("BVT"), TestCategory("Generics")]
+        public async Task GenericGrainStateParameterMismatchTest()
+        {
+            var grain = this.GrainFactory.GetGrain<IGenericGrainWithGenericState<int, List<Guid>, string>>(Guid.NewGuid());
+            var result = await grain.GetStateType();
+            Assert.Equal(typeof(List<Guid>), result);
+        }
     }
-
-
 
     namespace Generic.EdgeCases
     {

--- a/test/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/TestGrainInterfaces/IGenericInterfaces.cs
@@ -5,6 +5,17 @@ using Orleans;
 
 namespace UnitTests.GrainInterfaces
 {
+    public interface IGenericGrainWithGenericState<TFirstTypeParam, TStateType, TLastTypeParam> : IGrainWithGuidKey
+    {
+        Task<Type> GetStateType();
+    }
+
+    public class GenericGrainWithGenericState<TFirstTypeParam, TStateType, TLastTypeParam> : Grain<TStateType>,
+        IGenericGrainWithGenericState<TFirstTypeParam, TStateType, TLastTypeParam> where TStateType : new()
+    {
+        public Task<Type> GetStateType() => Task.FromResult(this.State.GetType());
+    }
+
     public interface IGenericGrain<T, U> : IGrainWithIntegerKey
     {
         Task SetT(T a);


### PR DESCRIPTION
Current support for generic grains with generic state assumes that the type parameter to the grain is also the type parameter of the state class.

This PR relaxes that assumption by navigating the concrete grain type's hierarchy until it reaches the `Grain<TState>` level and extracting the concrete value of `TState`.

/cc @lwansbrough who [reported this issue on Gitter](https://gitter.im/dotnet/orleans?at=589d05abaa800ee52c75e6de) - thank you, Loch!