### PR TITLE
Choose more reasonable default when activating JournaledGrain

### DIFF
--- a/src/OrleansEventSourcing/JournaledGrain.cs
+++ b/src/OrleansEventSourcing/JournaledGrain.cs
@@ -168,6 +168,16 @@ namespace Orleans.EventSourcing
 
 
         /// <summary>
+        /// By default, upon activation, the journaled grain waits until it has loaded the latest
+        /// view from storage. Subclasses can override this behavior,
+        /// and skip the wait if desired.
+        /// </summary>
+        public override Task OnActivateAsync()
+        {
+            return LogViewAdaptor.Synchronize();
+        }
+
+        /// <summary>
         /// Retrieves a segment of the confirmed event sequence, possibly from storage. 
         /// Throws <see cref="NotSupportedException"/> if the events are not available to read.
         /// Whether events are available, and for how long, depends on the providers used and how they are configured.

--- a/test/TestGrains/EventSourcing/AccountGrain.cs
+++ b/test/TestGrains/EventSourcing/AccountGrain.cs
@@ -47,12 +47,6 @@ namespace TestGrains
             }
         }
 
-        /// <summary> On activation, ensure we are fully caught up with the latest version</summary>
-        public override Task OnActivateAsync()
-        {
-            return RefreshNow();
-        }
-
         public Task<uint> Balance()
         {
             return Task.FromResult(State.Balance);

--- a/test/TestGrains/EventSourcing/ChatGrain.cs
+++ b/test/TestGrains/EventSourcing/ChatGrain.cs
@@ -35,7 +35,7 @@ namespace TestGrains
         public override async Task OnActivateAsync()
         {
             // first, wait for all events to be loaded from storage so we are caught up with the latest version
-            await RefreshNow();
+            await base.OnActivateAsync();
 
             // if the chat has not been initialized, do that now
             if (Version == 0)

--- a/test/TestGrains/EventSourcing/CountersGrain.cs
+++ b/test/TestGrains/EventSourcing/CountersGrain.cs
@@ -1,4 +1,5 @@
-﻿using Orleans.Concurrency;
+﻿using Orleans;
+using Orleans.Concurrency;
 using Orleans.EventSourcing;
 using Orleans.Providers;
 using System;
@@ -62,6 +63,13 @@ namespace TestGrains
         [Serializable]
         public class ResetAllEvent
         {
+        }
+
+        
+        public override Task OnActivateAsync()
+        {
+            // on activation, we load lazily (do not wait until the current state is loaded).
+            return TaskDone.Done;
         }
 
         public async Task Add(string key, int amount, bool wait_for_confirmation)

--- a/test/TestGrains/LogTestGrain.cs
+++ b/test/TestGrains/LogTestGrain.cs
@@ -63,6 +63,12 @@ namespace TestGrains
     /// </summary>
     public abstract class LogTestGrain : JournaledGrain<MyGrainState,object>, UnitTests.GrainInterfaces.ILogTestGrain
     {
+
+        public override Task OnActivateAsync()
+        {
+            return TaskDone.Done; // do not wait for initial load
+        }
+
         public async Task SetAGlobal(int x)
         {
             RaiseEvent(new UpdateA() { Val = x });


### PR DESCRIPTION
While writing documentation, I noticed another mistake in the JournaledGrain API, which is likely to confuse many users unless fixed.

Previously, the grain did NOT wait until the latest state is loaded on activation. Users had to override OnActivateAsync to make sure the grain has loaded the latest version before it starts executing calls.

*But this is exactly backwards*: the simple, common scenario is that we always wait for the load to complete before the grain starts taking calls; the advanced, uncommon scenario is to skip the wait (there are very few cases where you would want to do this).

**So this PR swaps the default behavior to be more in line with standard expectations.**

 Now, we wait by default during activation; but users can still override OnActivateAsync if they want a different behavior, e.g. do something before waiting, or do something after waiting, or skip the wait completely.

