### PR TITLE
Bugfix - EventHubSequenceToken not used consistently

### DIFF
--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -11,7 +11,6 @@ using Newtonsoft.Json;
 using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Streams;
-using OrleansServiceBus.Providers.Streams.EventHub;
 
 namespace Orleans.ServiceBus.Providers
 {

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -138,9 +138,7 @@ namespace Orleans.ServiceBus.Providers
         public int Compare(CachedEventHubMessage cachedMessage, StreamSequenceToken streamToken)
         {
             var realToken = (EventSequenceToken)streamToken;
-            return cachedMessage.SequenceNumber != realToken.SequenceNumber
-                ? (int)(cachedMessage.SequenceNumber - realToken.SequenceNumber)
-                : 0 - realToken.EventIndex;
+            return (int)(cachedMessage.SequenceNumber - realToken.SequenceNumber);
         }
 
         /// <summary>
@@ -237,7 +235,7 @@ namespace Orleans.ServiceBus.Providers
         /// <returns></returns>
         public virtual StreamSequenceToken GetSequenceToken(ref CachedEventHubMessage cachedMessage)
         {
-            return new EventSequenceTokenV2(cachedMessage.SequenceNumber, 0);
+            return new EventHubSequenceTokenV2("", cachedMessage.SequenceNumber, 0);
         }
 
         /// <summary>
@@ -257,9 +255,9 @@ namespace Orleans.ServiceBus.Providers
             IStreamIdentity stremIdentity = new StreamIdentity(streamGuid, streamNamespace);
             StreamSequenceToken token =
 #if NETSTANDARD
-                new EventSequenceTokenV2(queueMessage.SystemProperties.SequenceNumber, 0);
+                new EventHubSequenceTokenV2(queueMessage.SystemProperties.Offset, queueMessage.SystemProperties.SequenceNumber, 0);
 #else
-                new EventSequenceTokenV2(queueMessage.SequenceNumber, 0); 
+                new EventHubSequenceTokenV2(queueMessage.Offset, queueMessage.SequenceNumber, 0); 
 #endif
             return new StreamPosition(stremIdentity, token);
         }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubSequenceTokenV2.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using Orleans.CodeGeneration;
 using Orleans.Serialization;
-using Orleans.ServiceBus.Providers;
 
-namespace OrleansServiceBus.Providers.Streams.EventHub
+namespace Orleans.ServiceBus.Providers
 {
     /// <summary>
     /// Event Hub messages consist of a batch of application layer events, so EventHub tokens contain three pieces of information.

--- a/test/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
@@ -54,9 +54,9 @@ namespace ServiceBus.Tests.TestStreamProviders.EventHub
                 IStreamIdentity stremIdentity = new StreamIdentity(partitionStreamGuid, null);
                 StreamSequenceToken token =
 #if NETSTANDARD
-                new EventSequenceTokenV2(queueMessage.SystemProperties.SequenceNumber, 0);
+                new EventHubSequenceTokenV2(queueMessage.SystemProperties.Offset, queueMessage.SystemProperties.SequenceNumber, 0);
 #else
-                new EventSequenceTokenV2(queueMessage.SequenceNumber, 0); 
+                new EventHubSequenceTokenV2(queueMessage.Offset, queueMessage.SequenceNumber, 0); 
 #endif
                 return new StreamPosition(stremIdentity, token);
             }


### PR DESCRIPTION
EventSequenceToken was being used instead of EventHubSequenceToken.