### PR TITLE
fix bug in TestGrains.CountersGrain 

### DIFF
--- a/test/TestGrains/EventSourcing/CountersGrain.cs
+++ b/test/TestGrains/EventSourcing/CountersGrain.cs
@@ -90,7 +90,7 @@ namespace TestGrains
 
         public Task<int> GetTentativeCount(string key)
         {
-            return Task.FromResult(State.Counts[key]);
+            return Task.FromResult(TentativeState.Counts[key]);
         }
 
         public Task<IReadOnlyDictionary<string, int>> GetTentativeState()


### PR DESCRIPTION
I introduced this bug accidentally (forgot to rename State to TentativeState). This bug made two of the CountersGrain testcases fail frequently.
