### PR TITLE
fix AzureUtils PersistenceGrainTests

### DIFF
--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
@@ -35,6 +35,8 @@ namespace Tester.AzureUtils.Persistence
 
                 Guid serviceId = Guid.NewGuid();
                 var options = new TestClusterOptions(initialSilosCount: 4);
+                options.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
 
                 options.ClusterConfiguration.Globals.ServiceId = serviceId;
 

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableStore.cs
@@ -39,6 +39,8 @@ namespace Tester.AzureUtils.Persistence
 
                 Guid serviceId = Guid.NewGuid();
                 var options = new TestClusterOptions(initialSilosCount: 4);
+                options.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
 
                 options.ClusterConfiguration.Globals.ServiceId = serviceId;
 


### PR DESCRIPTION
Make AzureUtils PersistenceGrainTests to use AzureTable as membership provider, as a more reliable solution when one test case restarting primary silo. 