### PR TITLE
Fix a cleanup issue in TestCluster after a failure

### DIFF
--- a/src/OrleansTestingHost/AppDomainSiloHandle.cs
+++ b/src/OrleansTestingHost/AppDomainSiloHandle.cs
@@ -40,54 +40,62 @@ namespace Orleans.TestingHost
 
             var appDomain = AppDomain.CreateDomain(siloName, null, setup);
 
-            // Load each of the additional assemblies.
-            AppDomainSiloHost.CodeGeneratorOptimizer optimizer = null;
-            foreach (var assembly in additionalAssemblies.Where(asm => asm.Value != null))
+            try
             {
-                if (optimizer == null)
+                // Load each of the additional assemblies.
+                AppDomainSiloHost.CodeGeneratorOptimizer optimizer = null;
+                foreach (var assembly in additionalAssemblies.Where(asm => asm.Value != null))
                 {
-                    optimizer =
-                        (AppDomainSiloHost.CodeGeneratorOptimizer)
-                        appDomain.CreateInstanceAndUnwrap(
-                            typeof(AppDomainSiloHost.CodeGeneratorOptimizer).Assembly.FullName, typeof(AppDomainSiloHost.CodeGeneratorOptimizer).FullName, false,
-                            BindingFlags.Default,
-                            null,
-                            null,
-                            CultureInfo.CurrentCulture,
-                            new object[] { });
+                    if (optimizer == null)
+                    {
+                        optimizer =
+                            (AppDomainSiloHost.CodeGeneratorOptimizer)
+                            appDomain.CreateInstanceAndUnwrap(
+                                typeof(AppDomainSiloHost.CodeGeneratorOptimizer).Assembly.FullName, typeof(AppDomainSiloHost.CodeGeneratorOptimizer).FullName, false,
+                                BindingFlags.Default,
+                                null,
+                                null,
+                                CultureInfo.CurrentCulture,
+                                new object[] { });
+                    }
+
+                    optimizer.AddCachedAssembly(assembly.Key, assembly.Value);
                 }
 
-                optimizer.AddCachedAssembly(assembly.Key, assembly.Value);
-            }
+                var args = new object[] { siloName, type, config };
 
-            var args = new object[] { siloName, type, config };
+                var siloHost = (AppDomainSiloHost)appDomain.CreateInstanceAndUnwrap(
+                    typeof(AppDomainSiloHost).Assembly.FullName, typeof(AppDomainSiloHost).FullName, false,
+                    BindingFlags.Default, null, args, CultureInfo.CurrentCulture,
+                    new object[] { });
 
-            var siloHost = (AppDomainSiloHost)appDomain.CreateInstanceAndUnwrap(
-                typeof(AppDomainSiloHost).Assembly.FullName, typeof(AppDomainSiloHost).FullName, false,
-                BindingFlags.Default, null, args, CultureInfo.CurrentCulture,
-                new object[] { });
+                appDomain.UnhandledException += ReportUnobservedException;
 
-            appDomain.UnhandledException += ReportUnobservedException;
+                siloHost.Start();
 
-            siloHost.Start();
-
-            var retValue = new AppDomainSiloHandle
-            {
-                Name = siloName,
-                SiloHost = siloHost,
-                NodeConfiguration = nodeConfiguration,
-                SiloAddress = siloHost.SiloAddress,
-                Type = type,
-                AppDomain = appDomain,
-                additionalAssemblies = additionalAssemblies,
+                var retValue = new AppDomainSiloHandle
+                {
+                    Name = siloName,
+                    SiloHost = siloHost,
+                    NodeConfiguration = nodeConfiguration,
+                    SiloAddress = siloHost.SiloAddress,
+                    Type = type,
+                    AppDomain = appDomain,
+                    additionalAssemblies = additionalAssemblies,
 #if !NETSTANDARD_TODO
-                AppDomainTestHook = siloHost.AppDomainTestHook,
+                    AppDomainTestHook = siloHost.AppDomainTestHook,
 #endif
-            };
+                };
 
-            retValue.ImportGeneratedAssemblies();
+                retValue.ImportGeneratedAssemblies();
 
-            return retValue;
+                return retValue;
+            }
+            catch (Exception)
+            {
+                UnloadAppDomain(appDomain);
+                throw;
+            }
         }
 
 
@@ -162,11 +170,16 @@ namespace Orleans.TestingHost
 
         private void UnloadAppDomain()
         {
-            if (this.AppDomain != null)
+            UnloadAppDomain(this.AppDomain);
+            this.AppDomain = null;
+        }
+
+        private static void UnloadAppDomain(AppDomain appDomain)
+        {
+            if (appDomain != null)
             {
-                this.AppDomain.UnhandledException -= ReportUnobservedException;
-                AppDomain.Unload(this.AppDomain);
-                this.AppDomain = null;
+                appDomain.UnhandledException -= ReportUnobservedException;
+                AppDomain.Unload(appDomain);
             }
         }
 

--- a/src/OrleansTestingHost/TestCluster.cs
+++ b/src/OrleansTestingHost/TestCluster.cs
@@ -455,7 +455,7 @@ namespace Orleans.TestingHost
                 }
                 catch (Exception)
                 {
-                    this.additionalSilos.AddRange(siloStartTasks.Where(t => t.Exception != null).Select(t => t.Result));
+                    this.additionalSilos.AddRange(siloStartTasks.Where(t => t.Exception == null).Select(t => t.Result));
                     throw;
                 }
 


### PR DESCRIPTION
Cleanup logic threw another exception that ended up masquerading the real exception and potentially leaking an initialized silo