### PR TITLE
Remove more references to global RuntimeClient.Current

### DIFF
--- a/src/Orleans/Core/GrainClient.cs
+++ b/src/Orleans/Core/GrainClient.cs
@@ -337,7 +337,7 @@ namespace Orleans
             get
             {
                 CheckInitialized();
-                return RuntimeClient.Current.AppLogger;
+                return ((IRuntimeClient)outsideRuntimeClient).AppLogger;
             }
         }
 
@@ -349,7 +349,7 @@ namespace Orleans
         public static void SetResponseTimeout(TimeSpan timeout)
         {
             CheckInitialized();
-            RuntimeClient.Current.SetResponseTimeout(timeout);
+            outsideRuntimeClient.SetResponseTimeout(timeout);
         }
 
         /// <summary>
@@ -360,7 +360,7 @@ namespace Orleans
         public static TimeSpan GetResponseTimeout()
         {
             CheckInitialized();
-            return RuntimeClient.Current.GetResponseTimeout();
+            return outsideRuntimeClient.GetResponseTimeout();
         }
 
         /// <summary>
@@ -376,19 +376,19 @@ namespace Orleans
 
         public static IEnumerable<Streams.IStreamProvider> GetStreamProviders()
         {
-            return RuntimeClient.Current.CurrentStreamProviderManager.GetStreamProviders();
+            return outsideRuntimeClient.CurrentStreamProviderManager.GetStreamProviders();
         }
 
         internal static IStreamProviderRuntime CurrentStreamProviderRuntime
         {
-            get { return RuntimeClient.Current.CurrentStreamProviderRuntime; }
+            get { return outsideRuntimeClient.CurrentStreamProviderRuntime; }
         }
 
         public static Streams.IStreamProvider GetStreamProvider(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentNullException("name");
-            return RuntimeClient.Current.CurrentStreamProviderManager.GetProvider(name) as Streams.IStreamProvider;
+            return outsideRuntimeClient.CurrentStreamProviderManager.GetProvider(name) as Streams.IStreamProvider;
         }
         public delegate void ConnectionToClusterLostHandler(object sender, EventArgs e);
 

--- a/src/Orleans/Core/GrainClient.cs
+++ b/src/Orleans/Core/GrainClient.cs
@@ -53,16 +53,18 @@ namespace Orleans
             {
                 // just in case, make sure we don't get NullRefExc when checking RuntimeContext.
                 bool runningInsideGrain = RuntimeContext.Current != null && RuntimeContext.CurrentActivationContext != null
-                    && RuntimeContext.CurrentActivationContext.ContextType == SchedulingContextType.Activation;
+                                          && RuntimeContext.CurrentActivationContext.ContextType == SchedulingContextType.Activation;
                 if (runningInsideGrain)
                 {
-                    throw new OrleansException("You are running inside a grain. GrainClient.GrainFactory should only be used on the client side. " +
-                             "Inside a grain use GrainFactory property of the Grain base class (use this.GrainFactory).");
+                    throw new OrleansException(
+                        "You are running inside a grain. GrainClient.GrainFactory should only be used on the client side. " +
+                        "Inside a grain use GrainFactory property of the Grain base class (use this.GrainFactory).");
                 }
                 else // running inside provider or else where
                 {
-                    throw new OrleansException("You are running inside the provider code, on the silo. GrainClient.GrainFactory should only be used on the client side. " +
-                            "Inside the provider code use GrainFactory that is passed via IProviderRuntime (use providerRuntime.GrainFactory).");
+                    throw new OrleansException(
+                        "You are running inside the provider code, on the silo. GrainClient.GrainFactory should only be used on the client side. " +
+                        "Inside the provider code use GrainFactory that is passed via IProviderRuntime (use providerRuntime.GrainFactory).");
                 }
             }
 
@@ -71,7 +73,7 @@ namespace Orleans
                 throw new OrleansException("You must initialize the Grain Client before accessing the GrainFactory");
             }
 
-                return outsideRuntimeClient.InternalGrainFactory;
+            return outsideRuntimeClient.InternalGrainFactory;
         }
 
         internal static IInternalGrainFactory InternalGrainFactory
@@ -376,16 +378,22 @@ namespace Orleans
 
         public static IEnumerable<Streams.IStreamProvider> GetStreamProviders()
         {
+            CheckInitialized();
             return outsideRuntimeClient.CurrentStreamProviderManager.GetStreamProviders();
         }
 
         internal static IStreamProviderRuntime CurrentStreamProviderRuntime
         {
-            get { return outsideRuntimeClient.CurrentStreamProviderRuntime; }
+            get
+            {
+                CheckInitialized();
+                return outsideRuntimeClient.CurrentStreamProviderRuntime;
+            }
         }
 
         public static Streams.IStreamProvider GetStreamProvider(string name)
         {
+            CheckInitialized();
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentNullException("name");
             return outsideRuntimeClient.CurrentStreamProviderManager.GetProvider(name) as Streams.IStreamProvider;
@@ -406,6 +414,5 @@ namespace Orleans
                 Logger.Error(ErrorCode.ClientError, "Error when sending cluster disconnection notification", ex);
             }
         }
-
     }
 }

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime
         
         private bool HasGenericArgument { get { return !String.IsNullOrEmpty(genericArguments); } }
 
-        private IRuntimeClient RuntimeClient
+        internal IRuntimeClient RuntimeClient
         {
             get
             {

--- a/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
+++ b/src/Orleans/Statistics/RuntimeStatisticsGroup.cs
@@ -240,20 +240,20 @@ namespace Orleans.Runtime
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "cpuUsageTimer")]
         public void Dispose()
         {
-            cpuCounterPF.Dispose();
-            availableMemoryCounterPF.Dispose();
+            cpuCounterPF?.Dispose();
+            availableMemoryCounterPF?.Dispose();
 
-            timeInGCPF.Dispose();
+            timeInGCPF?.Dispose();
             if (genSizesPF != null)
                 foreach (var item in genSizesPF)
                 {
                     item?.Dispose();
                 }
-            allocatedBytesPerSecPF.Dispose();
-            promotedMemoryFromGen1PF.Dispose();
-            numberOfInducedGCsPF.Dispose();
-            largeObjectHeapSizePF.Dispose();
-            promotedFinalizationMemoryFromGen0PF.Dispose();
+            allocatedBytesPerSecPF?.Dispose();
+            promotedMemoryFromGen1PF?.Dispose();
+            numberOfInducedGCsPF?.Dispose();
+            largeObjectHeapSizePF?.Dispose();
+            promotedFinalizationMemoryFromGen0PF?.Dispose();
             cpuUsageTimer?.Dispose();
         }
     }

--- a/src/Orleans/SystemTargetInterfaces/IRemoteGrainDirectory.cs
+++ b/src/Orleans/SystemTargetInterfaces/IRemoteGrainDirectory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
 
@@ -22,7 +23,14 @@ namespace Orleans.Runtime
         bool AddActivation(ActivationId act, SiloAddress silo);
         ActivationAddress AddSingleActivation(GrainId grain, ActivationId act, SiloAddress silo, GrainDirectoryEntryStatus registrationStatus);
         bool RemoveActivation(ActivationId act, UnregistrationCause cause, out IActivationInfo entry, out bool wasRemoved);
-        bool Merge(GrainId grain, IGrainInfo other, IInternalGrainFactory grainFactory);
+
+        /// <summary>
+        /// Merges two grain directory infos, returning a map of activations which must be deactivated, grouped by silo.
+        /// </summary>
+        /// <param name="grain"></param>
+        /// <param name="other"></param>
+        /// <returns>A map of activations which must be deactivated, grouped by silo.</returns>
+        Dictionary<SiloAddress, List<ActivationAddress>> Merge(GrainId grain, IGrainInfo other);
         void CacheOrUpdateRemoteClusterRegistration(GrainId grain, ActivationId oldActivation, ActivationId activation, SiloAddress silo);
         bool UpdateClusterRegistrationStatus(ActivationId activationId, GrainDirectoryEntryStatus registrationStatus, GrainDirectoryEntryStatus? compareWith = null);
     }

--- a/src/Orleans/SystemTargetInterfaces/IRemoteGrainDirectory.cs
+++ b/src/Orleans/SystemTargetInterfaces/IRemoteGrainDirectory.cs
@@ -22,7 +22,7 @@ namespace Orleans.Runtime
         bool AddActivation(ActivationId act, SiloAddress silo);
         ActivationAddress AddSingleActivation(GrainId grain, ActivationId act, SiloAddress silo, GrainDirectoryEntryStatus registrationStatus);
         bool RemoveActivation(ActivationId act, UnregistrationCause cause, out IActivationInfo entry, out bool wasRemoved);
-        bool Merge(GrainId grain, IGrainInfo other);
+        bool Merge(GrainId grain, IGrainInfo other, IInternalGrainFactory grainFactory);
         void CacheOrUpdateRemoteClusterRegistration(GrainId grain, ActivationId oldActivation, ActivationId activation, SiloAddress silo);
         bool UpdateClusterRegistrationStatus(ActivationId activationId, GrainDirectoryEntryStatus registrationStatus, GrainDirectoryEntryStatus? compareWith = null);
     }

--- a/src/OrleansRuntime/Counters/SiloStatisticsManager.cs
+++ b/src/OrleansRuntime/Counters/SiloStatisticsManager.cs
@@ -7,16 +7,14 @@ namespace Orleans.Runtime.Counters
 {
     internal class SiloStatisticsManager
     {
-        private readonly IServiceProvider serviceProvider;
         private LogStatistics logStatistics;
         private RuntimeStatisticsGroup runtimeStats;
         private CountersStatistics countersPublisher;
         internal SiloPerformanceMetrics MetricsTable;
         private readonly Logger logger = LogManager.GetLogger("SiloStatisticsManager");
 
-        public SiloStatisticsManager(SiloInitializationParameters initializationParams, SerializationManager serializationManager, IServiceProvider serviceProvider)
+        public SiloStatisticsManager(SiloInitializationParameters initializationParams, SerializationManager serializationManager)
         {
-            this.serviceProvider = serviceProvider;
             MessagingStatisticsGroup.Init(true);
             MessagingProcessingStatisticsGroup.Init();
             NetworkingStatisticsGroup.Init(true);

--- a/src/OrleansRuntime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/OrleansRuntime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -25,11 +25,12 @@ namespace Orleans.Runtime.GrainDirectory
         internal static AsynchAgent CreateGrainDirectoryCacheMaintainer(
             LocalGrainDirectory router,
             IGrainDirectoryCache<TValue> cache,
-            Func<List<ActivationAddress>, TValue> updateFunc)
+            Func<List<ActivationAddress>, TValue> updateFunc,
+            IInternalGrainFactory grainFactory)
         {
             var adaptiveCache = cache as AdaptiveGrainDirectoryCache<TValue>;
             return adaptiveCache != null
-                ? new AdaptiveDirectoryCacheMaintainer<TValue>(router, adaptiveCache, updateFunc)
+                ? new AdaptiveDirectoryCacheMaintainer<TValue>(router, adaptiveCache, updateFunc, grainFactory)
                 : null;
         }
     }

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/RegistrarManager.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/RegistrarManager.cs
@@ -12,7 +12,7 @@ namespace Orleans.Runtime.GrainDirectory
     {
         private readonly Dictionary<Type, IGrainRegistrar> registrars = new Dictionary<Type, IGrainRegistrar>();
         
-        public RegistrarManager(GrainDirectoryPartition directoryPartition, GlobalSingleInstanceActivationMaintainer gsiActivationMaintainer, GlobalConfiguration globalConfig, Logger logger)
+        public RegistrarManager(GrainDirectoryPartition directoryPartition, GlobalSingleInstanceActivationMaintainer gsiActivationMaintainer, GlobalConfiguration globalConfig, Logger logger, IInternalGrainFactory grainFactory)
         {
             this.Register<ClusterLocalRegistration>(new ClusterLocalRegistrar(directoryPartition));
             this.Register<GlobalSingleInstanceRegistration>(
@@ -20,7 +20,8 @@ namespace Orleans.Runtime.GrainDirectory
                     directoryPartition,
                     logger,
                     gsiActivationMaintainer,
-                    globalConfig.GlobalSingleInstanceNumberRetries));
+                    globalConfig.GlobalSingleInstanceNumberRetries,
+                    grainFactory));
         }
 
         private void Register<TStrategy>(IGrainRegistrar directory)

--- a/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
@@ -105,24 +105,5 @@ namespace Orleans.Runtime.GrainDirectory
             router.HandoffManager.RemoveHandoffPartition(source);
             return TaskDone.Done;
         }
-        
-        /// <summary>
-        /// This method is called before retrying to access the current owner of a grain, following
-        /// a request that was sent to us, while we are not the owner of the given grain.
-        /// This may happen if during the time the request was on its way, a ring has changed 
-        /// (new servers came up / failed down).
-        /// Here we might take some actions before the actual retrial is done.
-        /// For example, we might back-off for some random time.
-        /// </summary>
-        /// <param name="retries"></param>
-        protected void PrepareForRetry(int retries)
-        {
-            // For now, we do not do anything special ...
-        }
-
-        private IRemoteGrainDirectory GetDirectoryReference(SiloAddress target)
-        {
-            return InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceId, target);
-        }
     }
 }

--- a/src/OrleansRuntime/LogConsistency/ProtocolServices.cs
+++ b/src/OrleansRuntime/LogConsistency/ProtocolServices.cs
@@ -25,6 +25,7 @@ namespace Orleans.Runtime.LogConsistency
         public GrainReference GrainReference { get { return grain.GrainReference; } }
 
         private Logger log;
+        private readonly IInternalGrainFactory grainFactory;
 
         public IMultiClusterRegistrationStrategy RegistrationStrategy { get; private set; }
 
@@ -33,10 +34,11 @@ namespace Orleans.Runtime.LogConsistency
         // pseudo-configuration to use if there is no actual multicluster network
         private static MultiClusterConfiguration PseudoMultiClusterConfiguration;
 
-        internal ProtocolServices(Grain gr, Logger log, IMultiClusterRegistrationStrategy strategy, SerializationManager serializationManager)
+        internal ProtocolServices(Grain gr, Logger log, IMultiClusterRegistrationStrategy strategy, SerializationManager serializationManager, IInternalGrainFactory grainFactory)
         {
             this.grain = gr;
             this.log = log;
+            this.grainFactory = grainFactory;
             this.RegistrationStrategy = strategy;
             this.SerializationManager = serializationManager;
 
@@ -84,7 +86,7 @@ namespace Orleans.Runtime.LogConsistency
             if (clusterGateway == null)
                 throw new ProtocolTransportException("no active gateways found for cluster");
 
-            var repAgent = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<ILogConsistencyProtocolGateway>(Constants.ProtocolGatewayId, clusterGateway);
+            var repAgent = this.grainFactory.GetSystemTarget<ILogConsistencyProtocolGateway>(Constants.ProtocolGatewayId, clusterGateway);
 
             // test hook
             var filter = (oracle as MultiClusterNetwork.MultiClusterOracle).ProtocolMessageFilterForTesting;

--- a/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -27,18 +27,20 @@ namespace Orleans.Runtime.MultiClusterNetwork
         private List<IGossipChannel> gossipChannels;
         private IGrainTimer timer;
         private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly IInternalGrainFactory grainFactory;
         private MultiClusterConfiguration injectedConfig;
 
-        public MultiClusterOracle(SiloInitializationParameters siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle)
+        public MultiClusterOracle(SiloInitializationParameters siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle, IInternalGrainFactory grainFactory)
             : base(Constants.MultiClusterOracleId, siloDetails.SiloAddress)
         {
             this.channelFactory = channelFactory;
             this.siloStatusOracle = siloStatusOracle;
+            this.grainFactory = grainFactory;
             if (siloDetails == null) throw new ArgumentNullException(nameof(siloDetails));
 
             var config = siloDetails.GlobalConfig;
             logger = LogManager.GetLogger("MultiClusterOracle");
-            localData = new MultiClusterOracleData(logger);
+            localData = new MultiClusterOracleData(logger, grainFactory);
             clusterId = config.ClusterId;
             defaultMultiCluster = config.DefaultMultiCluster;
             random = new SafeRandom();
@@ -398,7 +400,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
                     var silo = GetRandomClusterGateway(cluster);
                     if (silo == null)
                         throw new OrleansException("no gateway for cluster " + cluster);
-                    var remoteOracle = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IMultiClusterGossipService>(Constants.MultiClusterOracleId, silo);
+                    var remoteOracle = this.grainFactory.GetSystemTarget<IMultiClusterGossipService>(Constants.MultiClusterOracleId, silo);
                     tasks.Add(remoteOracle.FindLaggingSilos(expected, true));
                 }
             }
@@ -431,7 +433,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
 
                 foreach (var activeSilo in this.GetApproximateOtherActiveSilos())
                 {
-                    var remoteOracle = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IMultiClusterGossipService>(Constants.MultiClusterOracleId, activeSilo);
+                    var remoteOracle = this.grainFactory.GetSystemTarget<IMultiClusterGossipService>(Constants.MultiClusterOracleId, activeSilo);
                     tasks.Add(remoteOracle.FindLaggingSilos(expected, false));
                 }
 
@@ -486,7 +488,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
             if (silo == null) throw new ArgumentNullException("silo");
             SiloGossipWorker worker;
             if (!this.siloWorkers.TryGetValue(silo, out worker))
-                this.siloWorkers[silo] = worker = new SiloGossipWorker(this, silo);
+                this.siloWorkers[silo] = worker = new SiloGossipWorker(this, silo, this.grainFactory);
             return worker;
         }
         private SiloGossipWorker GetClusterWorker(string cluster)
@@ -576,17 +578,19 @@ namespace Orleans.Runtime.MultiClusterNetwork
         private class SiloGossipWorker : GossipWorker
         {
             public SiloAddress Silo;
+            private readonly IInternalGrainFactory grainFactory;
             public string Cluster;
 
             public bool TargetsRemoteCluster { get { return Cluster != null; } }
 
             public bool KnowsMe; // used for optimizing pushes
 
-            public SiloGossipWorker(MultiClusterOracle oracle, SiloAddress Silo)
+            public SiloGossipWorker(MultiClusterOracle oracle, SiloAddress Silo, IInternalGrainFactory grainFactory)
                 : base(oracle)
             {
                 this.Cluster = null; // only local cluster
                 this.Silo = Silo;
+                this.grainFactory = grainFactory;
             }
 
             public SiloGossipWorker(MultiClusterOracle oracle, string cluster)
@@ -622,7 +626,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
                 try
                 {
                     // publish to the remote system target
-                    var remoteOracle = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IMultiClusterGossipService>(Constants.MultiClusterOracleId, Silo);
+                    var remoteOracle = this.grainFactory.GetSystemTarget<IMultiClusterGossipService>(Constants.MultiClusterOracleId, Silo);
                     await remoteOracle.Publish(data, TargetsRemoteCluster);
 
                     LastException = null;
@@ -650,7 +654,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
                 oracle.logger.Verbose("-{0} Synchronize with silo {1} ({2})", id, Silo, Cluster ?? "local");
                 try
                 {
-                    var remoteOracle = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IMultiClusterGossipService>(Constants.MultiClusterOracleId, Silo);
+                    var remoteOracle = this.grainFactory.GetSystemTarget<IMultiClusterGossipService>(Constants.MultiClusterOracleId, Silo);
                     var data = oracle.localData.Current;
                     var answer = (MultiClusterData)await remoteOracle.Synchronize(oracle.localData.Current);
 

--- a/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -496,7 +496,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
             if (cluster == null) throw new ArgumentNullException("cluster");
             SiloGossipWorker worker;
             if (!this.clusterWorkers.TryGetValue(cluster, out worker))
-                this.clusterWorkers[cluster] = worker = new SiloGossipWorker(this, cluster);
+                this.clusterWorkers[cluster] = worker = new SiloGossipWorker(this, cluster, this.grainFactory);
             return worker;
         }
         private ChannelGossipWorker GetChannelWorker(IGossipChannel channel)
@@ -593,12 +593,13 @@ namespace Orleans.Runtime.MultiClusterNetwork
                 this.grainFactory = grainFactory;
             }
 
-            public SiloGossipWorker(MultiClusterOracle oracle, string cluster)
+            public SiloGossipWorker(MultiClusterOracle oracle, string cluster, IInternalGrainFactory grainFactory)
                : base(oracle)
             {
 
                 this.Cluster = cluster;
                 this.Silo = null;
+                this.grainFactory = grainFactory;
             }
 
             protected override void LogQueuedPublish(MultiClusterData data)

--- a/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracleData.cs
+++ b/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracleData.cs
@@ -19,12 +19,14 @@ namespace Orleans.Runtime.MultiClusterNetwork
         private readonly HashSet<GrainReference> confListeners;
 
         private readonly Logger logger;
+        private readonly IInternalGrainFactory grainFactory;
 
         internal MultiClusterData Current { get { return localData; } }
 
-        internal MultiClusterOracleData(Logger log)
+        internal MultiClusterOracleData(Logger log, IInternalGrainFactory grainFactory)
         {
             logger = log;
+            this.grainFactory = grainFactory;
             localData = new MultiClusterData();
             activeGatewaysByCluster = new Dictionary<string, List<SiloAddress>>();
             confListeners = new HashSet<GrainReference>();
@@ -114,7 +116,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
                             logger.Verbose2("-NotificationWork: notify IProtocolParticipant {0} of configuration {1}", listener, delta.Configuration);
 
                         // enqueue conf change event as grain call
-                        var g = InsideRuntimeClient.Current.InternalGrainFactory.Cast<ILogConsistencyProtocolParticipant>(listener);
+                        var g = this.grainFactory.Cast<ILogConsistencyProtocolParticipant>(listener);
                         g.OnMultiClusterConfigurationChange(delta.Configuration).Ignore();
                     }
                     catch (Exception exc)

--- a/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
+++ b/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
@@ -16,6 +16,7 @@ namespace Orleans.Runtime
     {
         private readonly Silo silo;
         private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly IInternalGrainFactory grainFactory;
         private readonly ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics> periodicStats;
         private readonly TimeSpan statisticsRefreshTime;
         private readonly IList<ISiloStatisticsChangeListener> siloStatisticsChangeListeners;
@@ -26,11 +27,13 @@ namespace Orleans.Runtime
         public DeploymentLoadPublisher(
             Silo silo,
             ISiloStatusOracle siloStatusOracle,
-            GlobalConfiguration config)
+            GlobalConfiguration config,
+            IInternalGrainFactory grainFactory)
             : base(Constants.DeploymentLoadPublisherSystemTargetId, silo.SiloAddress)
         {
             this.silo = silo;
             this.siloStatusOracle = siloStatusOracle;
+            this.grainFactory = grainFactory;
             statisticsRefreshTime = config.DeploymentLoadPublisherRefreshTime;
             periodicStats = new ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics>();
             siloStatisticsChangeListeners = new List<ISiloStatisticsChangeListener>();
@@ -64,7 +67,7 @@ namespace Orleans.Runtime
                 {
                     try
                     {
-                        tasks.Add(InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IDeploymentLoadPublisher>(
+                        tasks.Add(this.grainFactory.GetSystemTarget<IDeploymentLoadPublisher>(
                             Constants.DeploymentLoadPublisherSystemTargetId, siloAddress)
                             .UpdateRuntimeStatistics(silo.SiloAddress, myStats));
                     }
@@ -110,7 +113,7 @@ namespace Orleans.Runtime
                     foreach (var siloAddress in members)
                     {
                         var capture = siloAddress;
-                        Task task = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, capture)
+                        Task task = this.grainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, capture)
                                 .GetRuntimeStatistics()
                                 .ContinueWith((Task<SiloRuntimeStatistics> statsTask) =>
                                     {

--- a/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
+++ b/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
@@ -42,8 +42,9 @@ namespace Orleans.Runtime.Scheduler
         {
             try
             {
-                IAddressable grain = activation.GrainInstance;
-                Task task = InsideRuntimeClient.Current.Invoke(grain, activation, message);
+                var grain = activation.GrainInstance;
+                var runtimeClient = (ISiloRuntimeClient)grain.GrainReference.RuntimeClient;
+                Task task = runtimeClient.Invoke(grain, this.activation, this.message);
                 task.ContinueWith(t =>
                 {
                     // Note: This runs for all outcomes of resultPromiseTask - both Success or Fault

--- a/test/Benchmarks/Benchmarks/project.json
+++ b/test/Benchmarks/Benchmarks/project.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "BenchmarkDotNet": "0.9.9",
     "BenchmarkDotNet.Diagnostics.Windows": "0.9.9",
-    "BenchmarkDotNet.Toolchains.Roslyn": "0.9.9"
+    "BenchmarkDotNet.Toolchains.Roslyn": "0.9.9",
+    "xunit.extensibility.core": "2.1.0"
   },
   "frameworks": {
     "net451": {}

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -836,7 +836,7 @@ namespace UnitTests.Serialization
         public void Serialize_GrainBase_ViaStandardSerializer(SerializerToUse serializerToUse)
         {
             var environment = InitializeSerializer(serializerToUse);
-            Grain input = new EchoTaskGrain();
+            Grain input = new EchoTaskGrain(null);
 
             // Expected exception:
             // System.Runtime.Serialization.SerializationException: Type 'Echo.Grains.EchoTaskGrain' in Assembly 'UnitTestGrains, Version=1.0.0.0, Culture=neutral, PublicKeyToken=070f47935e3ed133' is not marked as serializable.

--- a/test/TestGrains/ClusterTestGrains.cs
+++ b/test/TestGrains/ClusterTestGrains.cs
@@ -95,7 +95,7 @@ namespace UnitTests.Grains
 
         public Task EnableStreamNotifications()
         {
-            IStreamProvider streamProvider = GrainClient.GetStreamProvider("SMSProvider");
+            IStreamProvider streamProvider = this.GetStreamProvider("SMSProvider");
             Guid guid = new Guid((int) this.GetPrimaryKeyLong(), 0, 0, new byte[8]);
             stream = streamProvider.GetStream<int>(guid, "notificationtest");
             return TaskDone.Done;

--- a/test/TestInternalGrains/ActivationGCTestGrains.cs
+++ b/test/TestInternalGrains/ActivationGCTestGrains.cs
@@ -23,9 +23,15 @@ namespace UnitTests.Grains
         }
     }
 
-    public class BusyActivationGcTestGrain1: Grain, IBusyActivationGcTestGrain1
+    internal class BusyActivationGcTestGrain1: Grain, IBusyActivationGcTestGrain1
     {
+        private readonly Catalog catalog;
         private int burstCount = 0;
+
+        public BusyActivationGcTestGrain1(Catalog catalog)
+        {
+            this.catalog = catalog;
+        }
 
         public Task Nop()
         {
@@ -50,7 +56,7 @@ namespace UnitTests.Grains
             }
 
             burstCount = count;
-            InsideRuntimeClient.Current.Catalog.ActivationCollector.Debug_OnDecideToCollectActivation = OnCollectActivation;
+            this.catalog.ActivationCollector.Debug_OnDecideToCollectActivation = OnCollectActivation;
             return TaskDone.Done;
         }
 

--- a/test/TestInternalGrains/EchoTaskGrain.cs
+++ b/test/TestInternalGrains/EchoTaskGrain.cs
@@ -51,9 +51,15 @@ namespace UnitTests.Grains
     }
 
     [StorageProvider(ProviderName = "MemoryStore")]
-    public class EchoTaskGrain : Grain<EchoTaskGrainState>, IEchoTaskGrain
+    internal class EchoTaskGrain : Grain<EchoTaskGrainState>, IEchoTaskGrain
     {
-        private  Logger logger;
+        private readonly IInternalGrainFactory internalGrainFactory;
+        private Logger logger;
+
+        public EchoTaskGrain(IInternalGrainFactory internalGrainFactory)
+        {
+            this.internalGrainFactory = internalGrainFactory;
+        }
 
         public Task<int> GetMyIdAsync() { return Task.FromResult(State.MyId); } 
         public Task<string> GetLastEchoAsync() { return Task.FromResult(State.LastEcho); }
@@ -160,7 +166,7 @@ namespace UnitTests.Grains
             SiloAddress siloAddress = silos.Where(pair => !pair.Key.Equals(mySilo)).Select(pair => pair.Key).First();
             logger.Info("Sending Ping to remote silo {0}", siloAddress);
 
-            var oracle = InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<IMembershipService>(Constants.MembershipOracleId, siloAddress);
+            var oracle = this.internalGrainFactory.GetSystemTarget<IMembershipService>(Constants.MembershipOracleId, siloAddress);
 
             await oracle.Ping(1);
             logger.Info("Ping reply received for {0}", siloAddress);
@@ -168,7 +174,7 @@ namespace UnitTests.Grains
 
         private ISiloControl GetSiloControlReference(SiloAddress silo)
         {
-            return InsideRuntimeClient.Current.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, silo);
+            return this.internalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, silo);
         }
     }
 

--- a/vNext/test/TestInternalGrains/Properties/AssemblyInfo.cs
+++ b/vNext/test/TestInternalGrains/Properties/AssemblyInfo.cs
@@ -16,3 +16,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("775ed7b7-caa7-4267-aa62-d555c74451b2")]
 [assembly: InternalsVisibleTo("NonSilo.Tests")]
 [assembly: InternalsVisibleTo("Tester.AzureUtils")]
+[assembly: InternalsVisibleTo("TesterInternal")]


### PR DESCRIPTION
Completely removed `InsideRuntimeClient.Current and removed most usages of `RuntimeClient.Current`.

In order to have everthing continue working, I needed to make some of the dependencies in `InsideRuntimeClient` lazy.

Note that this depends on #2592