### PR TITLE
Change CodeGen classes to be non-static

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -14,7 +14,7 @@ namespace Orleans.CodeGeneration
     /// </summary>
     public class GrainClientGenerator : MarshalByRefObject
     {
-        private static readonly RoslynCodeGenerator CodeGenerator = new RoslynCodeGenerator();
+        private readonly RoslynCodeGenerator codeGenerator = new RoslynCodeGenerator();
 
         [Serializable]
         internal class CodeGenOptions
@@ -113,7 +113,7 @@ namespace Orleans.CodeGeneration
             {
                 sourceWriter.WriteLine("#if !EXCLUDE_CODEGEN");
                 DisableWarnings(sourceWriter, suppressCompilerWarnings);
-                sourceWriter.WriteLine(CodeGenerator.GenerateSourceForAssembly(grainAssembly));
+                sourceWriter.WriteLine(codeGenerator.GenerateSourceForAssembly(grainAssembly));
                 RestoreWarnings(sourceWriter, suppressCompilerWarnings);
                 sourceWriter.WriteLine("#endif");
             }

--- a/src/Orleans/AssemblyLoader/TypeMetadataCache.cs
+++ b/src/Orleans/AssemblyLoader/TypeMetadataCache.cs
@@ -11,6 +11,8 @@ namespace Orleans.Runtime
     /// </summary>
     internal class TypeMetadataCache
     {
+        private readonly CodeGeneratorManager codeGeneratorManager;
+
         /// <summary>
         /// The mapping between grain types and the corresponding type for the <see cref="IGrainMethodInvoker"/> implementation.
         /// </summary>
@@ -20,6 +22,11 @@ namespace Orleans.Runtime
         /// The mapping between grain types and the corresponding type for the <see cref="GrainReference"/> implementation.
         /// </summary>
         private readonly ConcurrentDictionary<Type, Type> grainToReferenceMapping = new ConcurrentDictionary<Type, Type>();
+
+        public TypeMetadataCache(CodeGeneratorManager codeGeneratorManager)
+        {
+            this.codeGeneratorManager = codeGeneratorManager;
+        }
 
         public void FindSupportClasses(Type type)
         {
@@ -40,7 +47,7 @@ namespace Orleans.Runtime
         public Type GetGrainReferenceType(Type interfaceType)
         {
             var typeInfo = interfaceType.GetTypeInfo();
-            CodeGeneratorManager.GenerateAndCacheCodeForAssembly(typeInfo.Assembly);
+            codeGeneratorManager.GenerateAndCacheCodeForAssembly(typeInfo.Assembly);
             var genericInterfaceType = interfaceType.IsConstructedGenericType
                                            ? typeInfo.GetGenericTypeDefinition()
                                            : interfaceType;
@@ -77,7 +84,7 @@ namespace Orleans.Runtime
         public Type GetGrainMethodInvokerType(Type interfaceType)
         {
             var typeInfo = interfaceType.GetTypeInfo();
-            CodeGeneratorManager.GenerateAndCacheCodeForAssembly(typeInfo.Assembly);
+            codeGeneratorManager.GenerateAndCacheCodeForAssembly(typeInfo.Assembly);
             var genericInterfaceType = interfaceType.IsConstructedGenericType
                                            ? typeInfo.GetGenericTypeDefinition()
                                            : interfaceType;

--- a/src/Orleans/CodeGeneration/CodeGeneratorManager.cs
+++ b/src/Orleans/CodeGeneration/CodeGeneratorManager.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Orleans.CodeGeneration
 {
     using System;
@@ -9,7 +11,7 @@ namespace Orleans.CodeGeneration
     /// <summary>
     /// Methods for invoking code generation.
     /// </summary>
-    internal static class CodeGeneratorManager
+    internal class CodeGeneratorManager
     {
         /// <summary>
         /// The name of the code generator assembly.
@@ -30,20 +32,27 @@ namespace Orleans.CodeGeneration
         /// <summary>
         /// The runtime code generator.
         /// </summary>
-        private static IRuntimeCodeGenerator codeGeneratorInstance;
+        private IRuntimeCodeGenerator codeGeneratorInstance;
 
         /// <summary>
         /// The code generator cache.
         /// </summary>
         private static ICodeGeneratorCache codeGeneratorCacheInstance;
 
+        private readonly IServiceProvider serviceProvider;
+
+        public CodeGeneratorManager(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
         /// <summary>
         /// Loads the code generator on demand
         /// </summary>
-        public static void Initialize()
+        public void Initialize()
         {
-            codeGeneratorInstance = LoadCodeGenerator();
-            codeGeneratorCacheInstance = codeGeneratorInstance as ICodeGeneratorCache;
+            this.codeGeneratorInstance = this.serviceProvider.GetService<IRuntimeCodeGenerator>() ?? this.LoadCodeGenerator();
+            codeGeneratorCacheInstance = this.codeGeneratorInstance as ICodeGeneratorCache;
         }
 
         /// <summary>
@@ -52,7 +61,7 @@ namespace Orleans.CodeGeneration
         /// <param name="input">
         /// The input assembly.
         /// </param>
-        public static GeneratedAssembly GenerateAndCacheCodeForAssembly(Assembly input)
+        public GeneratedAssembly GenerateAndCacheCodeForAssembly(Assembly input)
         {
             return codeGeneratorInstance?.GenerateAndLoadForAssembly(input);
         }
@@ -61,7 +70,7 @@ namespace Orleans.CodeGeneration
         /// Ensures code for all currently loaded assemblies has been generated and loaded.
         /// </summary>
         /// <param name="inputs">The assemblies to generate code for.</param>
-        public static IReadOnlyList<GeneratedAssembly> GenerateAndLoadForAssemblies(Assembly[] inputs)
+        public IReadOnlyList<GeneratedAssembly> GenerateAndLoadForAssemblies(Assembly[] inputs)
         {
             return codeGeneratorInstance?.GenerateAndLoadForAssemblies(inputs);
         }
@@ -107,9 +116,9 @@ namespace Orleans.CodeGeneration
         /// Loads the code generator.
         /// </summary>
         /// <returns>The code generator.</returns>
-        private static IRuntimeCodeGenerator LoadCodeGenerator()
+        private IRuntimeCodeGenerator LoadCodeGenerator()
         {
-            IRuntimeCodeGenerator result = AssemblyLoader.TryLoadAndCreateInstance<IRuntimeCodeGenerator>(CodeGenAssemblyName, Log);
+            IRuntimeCodeGenerator result = AssemblyLoader.TryLoadAndCreateInstance<IRuntimeCodeGenerator>(CodeGenAssemblyName, Log, this.serviceProvider);
             if (result == null)
             {
                 Log.Warn(

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -119,6 +119,7 @@ namespace Orleans
             services.AddSingleton<MessageFactory>();
             services.AddSingleton<Func<string, Logger>>(LogManager.GetLogger);
             services.AddSingleton<ClientStatisticsManager>();
+            services.AddSingleton<CodeGeneratorManager>();
             this.ServiceProvider = services.BuildServiceProvider();
             this.InternalGrainFactory = this.ServiceProvider.GetRequiredService<IInternalGrainFactory>();
             this.messageFactory = this.ServiceProvider.GetService<MessageFactory>();

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -25,7 +25,7 @@ namespace Orleans.CodeGenerator
         /// <summary>
         /// The compiled assemblies.
         /// </summary>
-        private static readonly ConcurrentDictionary<string, CachedAssembly> CompiledAssemblies =
+        private readonly ConcurrentDictionary<string, CachedAssembly> CompiledAssemblies =
             new ConcurrentDictionary<string, CachedAssembly>();
 
         /// <summary>
@@ -36,8 +36,16 @@ namespace Orleans.CodeGenerator
         /// <summary>
         /// The serializer generation manager.
         /// </summary>
-        private static readonly SerializerGenerationManager SerializerGenerationManager = new SerializerGenerationManager();
-        
+        private readonly SerializerGenerationManager serializerGenerationManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoslynCodeGenerator"/> class.
+        /// </summary>
+        public RoslynCodeGenerator()
+        {
+            this.serializerGenerationManager = new SerializerGenerationManager();
+        }
+
         /// <summary>
         /// Adds a pre-generated assembly.
         /// </summary>
@@ -243,7 +251,7 @@ namespace Orleans.CodeGenerator
         /// <param name="targetAssembly">
         /// The target assembly which the cached counterpart is generated for.
         /// </param>
-        private static CachedAssembly TryLoadGeneratedAssemblyFromCache(Assembly targetAssembly)
+        private CachedAssembly TryLoadGeneratedAssemblyFromCache(Assembly targetAssembly)
         {
             CachedAssembly cached;
             if (!CompiledAssemblies.TryGetValue(targetAssembly.GetName().FullName, out cached)
@@ -310,7 +318,7 @@ namespace Orleans.CodeGenerator
         /// <param name="assemblies">The assemblies to generate code for.</param>
         /// <param name="runtime">Whether or not runtime code generation is being performed.</param>
         /// <returns>The generated syntax tree.</returns>
-        private static GeneratedSyntax GenerateForAssemblies(List<Assembly> assemblies, bool runtime)
+        private GeneratedSyntax GenerateForAssemblies(List<Assembly> assemblies, bool runtime)
         {
             if (Logger.IsVerbose)
             {
@@ -358,7 +366,7 @@ namespace Orleans.CodeGenerator
                 foreach (var attribute in assembly.GetCustomAttributes<ConsiderForCodeGenerationAttribute>())
                 {
                     ConsiderType(attribute.Type, runtime, targetAssembly, includedTypes, considerForSerialization: true);
-                    if (attribute.ThrowOnFailure && !SerializerGenerationManager.IsTypeRecorded(attribute.Type))
+                    if (attribute.ThrowOnFailure && !serializerGenerationManager.IsTypeRecorded(attribute.Type))
                     {
                         throw new CodeGenerationException(
                             $"Found {attribute.GetType().Name} for type {attribute.Type.GetParseableName()}, but code"
@@ -391,7 +399,7 @@ namespace Orleans.CodeGenerator
                     Action<Type> onEncounteredType = encounteredType =>
                     {
                         // If a type was encountered which can be accessed, process it for serialization.
-                        SerializerGenerationManager.RecordTypeToGenerate(encounteredType, module, targetAssembly);
+                        serializerGenerationManager.RecordTypeToGenerate(encounteredType, module, targetAssembly);
                     };
 
                     if (Logger.IsVerbose2)
@@ -417,7 +425,7 @@ namespace Orleans.CodeGenerator
                     // Generate serializers.
                     var first = true;
                     Type toGen;
-                    while (SerializerGenerationManager.GetNextTypeToProcess(out toGen))
+                    while (serializerGenerationManager.GetNextTypeToProcess(out toGen))
                     {
                         if (!runtime)
                         {
@@ -469,7 +477,7 @@ namespace Orleans.CodeGenerator
             };
         }
 
-        private static void ConsiderType(
+        private void ConsiderType(
             Type type,
             bool runtime,
             Assembly targetAssembly,
@@ -503,15 +511,15 @@ namespace Orleans.CodeGenerator
             }
         }
 
-        private static void RecordType(Type type, Module module, Assembly targetAssembly, ISet<Type> includedTypes)
+        private void RecordType(Type type, Module module, Assembly targetAssembly, ISet<Type> includedTypes)
         {
-            if (SerializerGenerationManager.RecordTypeToGenerate(type, module, targetAssembly))
+            if (serializerGenerationManager.RecordTypeToGenerate(type, module, targetAssembly))
             {
                 includedTypes.Add(type);
             }
         }
 
-        private static void ConsiderGenericBaseTypeArguments(
+        private void ConsiderGenericBaseTypeArguments(
             TypeInfo typeInfo,
             Module module,
             Assembly targetAssembly,
@@ -526,7 +534,7 @@ namespace Orleans.CodeGenerator
             }
         }
 
-        private static void ConsiderGenericInterfacesArguments(
+        private void ConsiderGenericInterfacesArguments(
             TypeInfo typeInfo,
             Module module,
             Assembly targetAssembly,
@@ -570,7 +578,7 @@ namespace Orleans.CodeGenerator
         /// </summary>
         /// <param name="assembly">The assembly.</param>
         /// <returns>A value indicating whether or not code should be generated for the provided assembly.</returns>
-        private static bool ShouldGenerateCodeForAssembly(Assembly assembly)
+        private bool ShouldGenerateCodeForAssembly(Assembly assembly)
         {
             return !assembly.IsDynamic && !CompiledAssemblies.ContainsKey(assembly.GetName().FullName)
                    && TypeUtils.IsOrleansOrReferencesOrleans(assembly)
@@ -582,7 +590,7 @@ namespace Orleans.CodeGenerator
         /// Registers the input assembly with this class.
         /// </summary>
         /// <param name="input">The assembly to register.</param>
-        private static void RegisterGeneratedCodeTargets(Assembly input)
+        private void RegisterGeneratedCodeTargets(Assembly input)
         {
             var targets = input.GetCustomAttributes<OrleansCodeGenerationTargetAttribute>();
             foreach (var target in targets)

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -262,6 +262,7 @@ namespace Orleans.Runtime
             services.AddSingleton<ImplicitStreamSubscriberTable>();
             services.AddSingleton<MessageFactory>();
             services.AddSingleton<Func<string, Logger>>(LogManager.GetLogger);
+            services.AddSingleton<CodeGeneratorManager>();
 
             // Placement
             services.AddSingleton<PlacementDirectorsManager>();


### PR DESCRIPTION
In preparation for non-static grain clients and non-static SerializationManager, we need to also make this class non-static.

Simple change, functionals pass.