### PR TITLE
GrainReferences hold a reference to a RuntimeClient instance

### DIFF
--- a/src/Orleans/Core/Exceptions.cs
+++ b/src/Orleans/Core/Exceptions.cs
@@ -219,7 +219,7 @@ namespace Orleans.Runtime
         private static string CreateMessage(GrainReference grainReference)
         {
             return $"Attempted to use a GrainReference which has not been bound to the runtime: {grainReference.ToDetailedString()}." +
-                   " Use the Bind method to bind this reference to the runtime.";
+                   $" Use the {nameof(IGrainFactory)}.{nameof(IGrainFactory.BindGrainReference)} method to bind this reference to the runtime.";
         }
 
         internal GrainReferenceNotBoundException(string msg) : base(msg) { }

--- a/src/Orleans/Core/Exceptions.cs
+++ b/src/Orleans/Core/Exceptions.cs
@@ -207,5 +207,29 @@ namespace Orleans.Runtime
         { }
 #endif
     }
+
+    /// <summary>
+    /// Indicates that a <see cref="GrainReference"/> was not bound to the runtime before being used.
+    /// </summary>
+    [Serializable]
+    public class GrainReferenceNotBoundException : OrleansException
+    {
+        internal GrainReferenceNotBoundException(GrainReference grainReference) : base(CreateMessage(grainReference)) { }
+
+        private static string CreateMessage(GrainReference grainReference)
+        {
+            return $"Attempted to use a GrainReference which has not been bound to the runtime: {grainReference.ToDetailedString()}." +
+                   " Use the Bind method to bind this reference to the runtime.";
+        }
+
+        internal GrainReferenceNotBoundException(string msg) : base(msg) { }
+        internal GrainReferenceNotBoundException(string message, Exception innerException) : base(message, innerException) { }
+
+#if !NETSTANDARD
+        protected GrainReferenceNotBoundException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        { }
+#endif
+    }
 }
 

--- a/src/Orleans/Core/GrainExtensions.cs
+++ b/src/Orleans/Core/GrainExtensions.cs
@@ -29,7 +29,7 @@ namespace Orleans
             }
 
             var systemTarget = grain as ISystemTargetBase;
-            if (systemTarget != null) return GrainReference.FromGrainId(systemTarget.GrainId, null, systemTarget.Silo);
+            if (systemTarget != null) return GrainReference.FromGrainId(systemTarget.GrainId, systemTarget.RuntimeClient, null, systemTarget.Silo);
 
             throw new ArgumentException(
                 $"AsWeaklyTypedReference has been called on an unexpected type: {grain.GetType().FullName}.",
@@ -60,6 +60,16 @@ namespace Orleans
         public static TGrainInterface Cast<TGrainInterface>(this IAddressable grain)
         {
             return RuntimeClient.Current.InternalGrainFactory.Cast<TGrainInterface>(grain);
+        }
+
+        /// <summary>
+        /// Binds the grain reference to the provided <see cref="IGrainFactory"/>.
+        /// </summary>
+        /// <param name="grain">The grain reference.</param>
+        /// <param name="grainFactory">The grain factory.</param>
+        public static void BindGrainReference(this IAddressable grain, IGrainFactory grainFactory)
+        {
+            grainFactory.BindGrainReference(grain);
         }
 
         internal static GrainId GetGrainId(IAddressable grain)

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -141,7 +141,16 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        public GrainReference GetGrainFromKeyString(string key) => GrainReference.FromKeyString(key);
+        public void BindGrainReference(IAddressable grain)
+        {
+            if (grain == null) throw new ArgumentNullException(nameof(grain));
+            var reference = grain as GrainReference;
+            if (reference == null) throw new ArgumentException("Provided grain must be a GrainReference.", nameof(grain));
+            reference.Bind(this.runtimeClient);
+        }
+
+        /// <inheritdoc />
+        public GrainReference GetGrainFromKeyString(string key) => GrainReference.FromKeyString(key, this.runtimeClient);
 
         /// <summary>
         /// Creates a reference to the provided <paramref name="obj"/>.
@@ -209,6 +218,7 @@ namespace Orleans
             var typeInfo = interfaceType.GetTypeInfo();
             return GrainReference.FromGrainId(
                 grainId,
+                this.runtimeClient,
                 typeInfo.IsGenericType ? TypeUtils.GenericTypeArgsString(typeInfo.UnderlyingSystemType.FullName) : null);
         }
 
@@ -325,13 +335,23 @@ namespace Orleans
                 }
                 else
                 {
-                    reference = this.Cast<TGrainInterface>(GrainReference.FromGrainId(grainId, null, destination));
+                    reference = this.Cast<TGrainInterface>(GrainReference.FromGrainId(grainId, this.runtimeClient, null, destination));
                     cache[destination] = reference; // Store for next time
                 }
             }
 
             return (TGrainInterface)reference;
         }
+
+        /// <inheritdoc />
+        public TGrainInterface GetGrain<TGrainInterface>(GrainId grainId)
+        {
+            return this.Cast<TGrainInterface>(GrainReference.FromGrainId(grainId, this.runtimeClient));
+        }
+
+        /// <inheritdoc />
+        public GrainReference GetGrain(GrainId grainId, string genericArguments)
+            => GrainReference.FromGrainId(grainId, this.runtimeClient, genericArguments);
 
         #endregion
     }

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -344,7 +344,7 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        public TGrainInterface GetGrain<TGrainInterface>(GrainId grainId)
+        public TGrainInterface GetGrain<TGrainInterface>(GrainId grainId) where TGrainInterface : IAddressable
         {
             return this.Cast<TGrainInterface>(GrainReference.FromGrainId(grainId, this.runtimeClient));
         }

--- a/src/Orleans/Core/IGrainFactory.cs
+++ b/src/Orleans/Core/IGrainFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Orleans.Runtime;
 
 namespace Orleans
 {
@@ -18,5 +19,11 @@ namespace Orleans
         Task<TGrainObserverInterface> CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
 
         Task DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver;
+
+        /// <summary>
+        /// Binds the provided grain reference to this instance.
+        /// </summary>
+        /// <param name="grain">The grain reference.</param>
+        void BindGrainReference(IAddressable grain);
     }
 }

--- a/src/Orleans/Core/IInternalGrainFactory.cs
+++ b/src/Orleans/Core/IInternalGrainFactory.cs
@@ -47,5 +47,21 @@ namespace Orleans
         /// A reference to <paramref name="grain"/> which implements <paramref name="interfaceType"/>.
         /// </returns>
         object Cast(IAddressable grain, Type interfaceType);
+
+        /// <summary>
+        /// Gets a reference to the grain with the provided id.
+        /// </summary>
+        /// <typeparam name="TGrainInterface">The grain reference interface type.</typeparam>
+        /// <param name="grainId">The grain id.</param>
+        /// <returns>A reference to the grain with the provided id.</returns>
+        TGrainInterface GetGrain<TGrainInterface>(GrainId grainId);
+
+        /// <summary>
+        /// Gets a reference to the grain with the provided id.
+        /// </summary>
+        /// <param name="grainId">The grain id.</param>
+        /// <param name="genericArguments">The generic type arguments.</param>
+        /// <returns>A reference to the grain with the provided id.</returns>
+        GrainReference GetGrain(GrainId grainId, string genericArguments = null);
     }
 }

--- a/src/Orleans/Core/IInternalGrainFactory.cs
+++ b/src/Orleans/Core/IInternalGrainFactory.cs
@@ -54,7 +54,7 @@ namespace Orleans
         /// <typeparam name="TGrainInterface">The grain reference interface type.</typeparam>
         /// <param name="grainId">The grain id.</param>
         /// <returns>A reference to the grain with the provided id.</returns>
-        TGrainInterface GetGrain<TGrainInterface>(GrainId grainId);
+        TGrainInterface GetGrain<TGrainInterface>(GrainId grainId) where TGrainInterface : IAddressable;
 
         /// <summary>
         /// Gets a reference to the grain with the provided id.

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -433,7 +433,7 @@ namespace Orleans.Runtime
         // Caller must clean up bytes
         public Message(List<ArraySegment<byte>> header)
         {
-            var context = new DeserializationContext
+            var context = new DeserializationContext(RuntimeClient.Current.InternalGrainFactory)
             {
                 StreamReader = new BinaryTokenStreamReader(header)
             };
@@ -501,7 +501,7 @@ namespace Orleans.Runtime
 
         private List<ArraySegment<byte>> Serialize_Impl(out int headerLengthOut, out int bodyLengthOut)
         {
-            var context = new SerializationContext
+            var context = new SerializationContext(RuntimeClient.Current.InternalGrainFactory)
             {
                 StreamWriter = new BinaryTokenStreamWriter()
             };

--- a/src/Orleans/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans/Providers/ClientProviderRuntime.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 using Orleans.Streams;
 
@@ -15,19 +16,21 @@ namespace Orleans.Providers
         private readonly Dictionary<Type, Tuple<IGrainExtension, IAddressable>> caoTable;
         private readonly AsyncLock lockable;
         private InvokeInterceptor invokeInterceptor;
+        private readonly IInternalGrainFactory grainFactory;
         private readonly IRuntimeClient runtimeClient;
 
-        public ClientProviderRuntime(IGrainFactory grainFactory, IServiceProvider serviceProvider) 
+        public ClientProviderRuntime(IInternalGrainFactory grainFactory, IServiceProvider serviceProvider) 
         {
-            this.runtimeClient = RuntimeClient.Current;
+            this.grainFactory = grainFactory;
+            this.ServiceProvider = serviceProvider;
+            this.runtimeClient = serviceProvider.GetService<IRuntimeClient>();
             caoTable = new Dictionary<Type, Tuple<IGrainExtension, IAddressable>>();
             lockable = new AsyncLock();
-            GrainFactory = grainFactory;
-            ServiceProvider = serviceProvider;
         }
 
-        public IGrainFactory GrainFactory { get; private set; }
-        public IServiceProvider ServiceProvider { get; private set; }
+        public IGrainFactory GrainFactory => this.grainFactory;
+        public IServiceProvider ServiceProvider { get; }
+
         public void SetInvokeInterceptor(InvokeInterceptor interceptor)
         {
             this.invokeInterceptor = interceptor;
@@ -42,10 +45,10 @@ namespace Orleans.Providers
         {
             if (null == implicitStreamSubscriberTable)
             {
-                throw new ArgumentNullException("implicitStreamSubscriberTable");
+                throw new ArgumentNullException(nameof(implicitStreamSubscriberTable));
             }
             grainBasedPubSub = new GrainBasedPubSubRuntime(GrainFactory);
-            var tmp = new ImplicitStreamPubSub(implicitStreamSubscriberTable);
+            var tmp = new ImplicitStreamPubSub(this.grainFactory, implicitStreamSubscriberTable);
             implictPubSub = tmp;
             combinedGrainBasedAndImplicitPubSub = new StreamPubSubImpl(grainBasedPubSub, tmp);
             streamDirectory = new StreamDirectory();

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -54,6 +54,7 @@ namespace Orleans.Runtime
         /// </summary>
         protected internal readonly SiloAddress SystemTargetSilo;
 
+        [NonSerialized]
         private IRuntimeClient runtimeClient;
 
         /// <summary>

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,8 +14,6 @@ namespace Orleans.Runtime
     [Serializable]
     public class GrainReference : IAddressable, IEquatable<GrainReference>, ISerializable
     {
-        private static readonly Action<Message, TaskCompletionSource<object>> ResponseCallbackDelegate = ResponseCallback;
-
         private readonly string genericArguments;
         private readonly GuidId observerId;
         
@@ -41,12 +38,23 @@ namespace Orleans.Runtime
         
         private bool HasGenericArgument { get { return !String.IsNullOrEmpty(genericArguments); } }
 
+        private IRuntimeClient RuntimeClient
+        {
+            get
+            {
+                if (this.runtimeClient == null) throw new GrainReferenceNotBoundException(this);
+                return this.runtimeClient;
+            }
+        }
+
         internal GrainId GrainId { get; private set; }
 
         /// <summary>
         /// Called from generated code.
         /// </summary>
         protected internal readonly SiloAddress SystemTargetSilo;
+
+        private IRuntimeClient runtimeClient;
 
         /// <summary>
         /// Whether the runtime environment for system targets has been initialized yet.
@@ -63,12 +71,14 @@ namespace Orleans.Runtime
         /// <param name="genericArgument">Type arguments in case of a generic grain.</param>
         /// <param name="systemTargetSilo">Target silo in case of a system target reference.</param>
         /// <param name="observerId">Observer ID in case of an observer reference.</param>
-        private GrainReference(GrainId grainId, string genericArgument, SiloAddress systemTargetSilo, GuidId observerId)
+        /// <param name="runtimeClient">The runtime which this grain reference is bound to.</param>
+        private GrainReference(GrainId grainId, string genericArgument, SiloAddress systemTargetSilo, GuidId observerId, IRuntimeClient runtimeClient)
         {
             GrainId = grainId;
             genericArguments = genericArgument;
             SystemTargetSilo = systemTargetSilo;
             this.observerId = observerId;
+            this.runtimeClient = runtimeClient;
             if (String.IsNullOrEmpty(genericArgument))
             {
                 genericArguments = null; // always keep it null instead of empty.
@@ -118,7 +128,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="other">The reference to copy.</param>
         protected GrainReference(GrainReference other)
-            : this(other.GrainId, other.genericArguments, other.SystemTargetSilo, other.ObserverId) { }
+            : this(other.GrainId, other.genericArguments, other.SystemTargetSilo, other.ObserverId, other.RuntimeClient) { }
 
         #endregion
 
@@ -126,19 +136,29 @@ namespace Orleans.Runtime
 
         /// <summary>Constructs a reference to the grain with the specified ID.</summary>
         /// <param name="grainId">The ID of the grain to refer to.</param>
+        /// <param name="runtimeClient">The runtime client</param>
         /// <param name="genericArguments">Type arguments in case of a generic grain.</param>
         /// <param name="systemTargetSilo">Target silo in case of a system target reference.</param>
-        internal static GrainReference FromGrainId(GrainId grainId, string genericArguments = null, SiloAddress systemTargetSilo = null)
+        internal static GrainReference FromGrainId(GrainId grainId, IRuntimeClient runtimeClient, string genericArguments = null, SiloAddress systemTargetSilo = null)
         {
-            return new GrainReference(grainId, genericArguments, systemTargetSilo, null);
+            return new GrainReference(grainId, genericArguments, systemTargetSilo, null, runtimeClient);
         }
 
-        internal static GrainReference NewObserverGrainReference(GrainId grainId, GuidId observerId)
+        internal static GrainReference NewObserverGrainReference(GrainId grainId, GuidId observerId, IRuntimeClient runtimeClient)
         {
-            return new GrainReference(grainId, null, null, observerId);
+            return new GrainReference(grainId, null, null, observerId, runtimeClient);
         }
 
         #endregion
+        
+        /// <summary>
+        /// Binds this instance to a runtime.
+        /// </summary>
+        /// <param name="runtime">The runtime.</param>
+        internal void Bind(IRuntimeClient runtime)
+        {
+            this.runtimeClient = runtime;
+        }
 
         /// <summary>
         /// Tests this reference for equality to another object.
@@ -349,7 +369,7 @@ namespace Orleans.Runtime
             bool isOneWayCall = ((options & InvokeMethodOptions.OneWay) != 0);
 
             var resolver = isOneWayCall ? null : new TaskCompletionSource<object>();
-            RuntimeClient.Current.SendRequest(this, request, resolver, ResponseCallbackDelegate, debugContext, options, genericArguments);
+            this.RuntimeClient.SendRequest(this, request, resolver, ResponseCallback, debugContext, options, genericArguments);
             return isOneWayCall ? null : resolver.Task;
         }
 
@@ -378,7 +398,7 @@ namespace Orleans.Runtime
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        private static void ResponseCallback(Message message, TaskCompletionSource<object> context)
+        private void ResponseCallback(Message message, TaskCompletionSource<object> context)
         {
             Response response;
             if (message.Result != Message.ResponseTypes.Rejection)
@@ -431,9 +451,9 @@ namespace Orleans.Runtime
 
         private bool GetUnordered()
         {
-            if (RuntimeClient.Current == null) return false;
+            if (this.runtimeClient == null) return false;
 
-            return RuntimeClient.Current.GrainTypeResolver != null && RuntimeClient.Current.GrainTypeResolver.IsUnordered(GrainId.GetTypeCode());
+            return this.runtimeClient.GrainTypeResolver != null && this.runtimeClient.GrainTypeResolver.IsUnordered(GrainId.GetTypeCode());
         }
 
         #endregion
@@ -504,7 +524,7 @@ namespace Orleans.Runtime
             }
 
             // store as null, serialize as empty.
-            var genericArg = String.Empty;
+            var genericArg = string.Empty;
             if (input.HasGenericArgument)
                 genericArg = input.genericArguments;
             writer.Write(genericArg);
@@ -531,14 +551,21 @@ namespace Orleans.Runtime
             }
             // store as null, serialize as empty.
             var genericArg = reader.ReadString();
-            if (String.IsNullOrEmpty(genericArg))
+            if (string.IsNullOrEmpty(genericArg))
                 genericArg = null;
 
+            GrainReference result;
             if (expectObserverId)
             {
-                return NewObserverGrainReference(id, observerId);
+                result = NewObserverGrainReference(id, observerId, null);
             }
-            return FromGrainId(id, genericArg, silo);
+            else
+            {
+                result = FromGrainId(id, null, genericArg, silo);
+            }
+
+            context.GrainFactory?.BindGrainReference(result);
+            return result;
         }
 
         /// <summary> Copier function for grain reference. </summary>
@@ -601,8 +628,8 @@ namespace Orleans.Runtime
             }
             return String.Format("{0}={1}", GRAIN_REFERENCE_STR, GrainId.ToParsableString());
         }
-
-        public static GrainReference FromKeyString(string key)
+        
+        internal static GrainReference FromKeyString(string key, IRuntimeClient runtimeClient)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentNullException("key", "GrainReference.FromKeyString cannot parse null key");
             
@@ -622,26 +649,26 @@ namespace Orleans.Runtime
                 {
                     genericStr = null;
                 }
-                return FromGrainId(GrainId.FromParsableString(grainIdStr), genericStr);
+                return FromGrainId(GrainId.FromParsableString(grainIdStr), runtimeClient, genericStr);
             }
             else if (observerIndex >= 0)
             {
                 grainIdStr = trimmed.Substring(grainIdIndex, observerIndex - grainIdIndex).Trim();
                 string observerIdStr = trimmed.Substring(observerIndex + (OBSERVER_ID_STR + "=").Length);
                 GuidId observerId = GuidId.FromParsableString(observerIdStr);
-                return NewObserverGrainReference(GrainId.FromParsableString(grainIdStr), observerId);
+                return NewObserverGrainReference(GrainId.FromParsableString(grainIdStr), observerId, runtimeClient);
             }
             else if (systemTargetIndex >= 0)
             {
                 grainIdStr = trimmed.Substring(grainIdIndex, systemTargetIndex - grainIdIndex).Trim();
                 string systemTargetStr = trimmed.Substring(systemTargetIndex + (SYSTEM_TARGET_STR + "=").Length);
                 SiloAddress siloAddress = SiloAddress.FromParsableString(systemTargetStr);
-                return FromGrainId(GrainId.FromParsableString(grainIdStr), null, siloAddress);
+                return FromGrainId(GrainId.FromParsableString(grainIdStr), runtimeClient, null, siloAddress);
             }
             else
             {
                 grainIdStr = trimmed.Substring(grainIdIndex);
-                return FromGrainId(GrainId.FromParsableString(grainIdStr));
+                return FromGrainId(GrainId.FromParsableString(grainIdStr), runtimeClient);
             }
             //return FromGrainId(GrainId.FromParsableString(grainIdStr), generic);
         }
@@ -687,6 +714,11 @@ namespace Orleans.Runtime
             if (String.IsNullOrEmpty(genericArg))
                 genericArg = null;
             genericArguments = genericArg;
+
+#if !NETSTANDARD
+            var deserializationContext = context.Context as IDeserializationContext;
+            deserializationContext?.GrainFactory.BindGrainReference(this);
+#endif
         }
 
         #endregion

--- a/src/Orleans/Serialization/BinaryFormatterSerializer.cs
+++ b/src/Orleans/Serialization/BinaryFormatterSerializer.cs
@@ -30,7 +30,10 @@ namespace Orleans.Serialization
                 return null;
             }
 
-            var formatter = new BinaryFormatter();
+            var formatter = new BinaryFormatter
+            {
+                Context = new StreamingContext(StreamingContextStates.All, context)
+            };
             object ret = null;
             using (var memoryStream = new MemoryStream())
             {
@@ -58,7 +61,10 @@ namespace Orleans.Serialization
                 return;
             }
 
-            var formatter = new BinaryFormatter();
+            var formatter = new BinaryFormatter
+            {
+                Context = new StreamingContext(StreamingContextStates.All, context)
+            };
             byte[] bytes;
             using (var memoryStream = new MemoryStream())
             {
@@ -81,7 +87,11 @@ namespace Orleans.Serialization
 
             var n = reader.ReadInt();
             var bytes = reader.ReadBytes(n);
-            var formatter = new BinaryFormatter();
+            var formatter = new BinaryFormatter
+            {
+                Context = new StreamingContext(StreamingContextStates.All, context)
+            };
+
             object retVal = null;
             using (var memoryStream = new MemoryStream(bytes))
             {

--- a/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
+++ b/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
@@ -93,7 +93,7 @@ namespace Orleans.Serialization
             // Write the concrete type directly.
             this.typeSerializer.WriteNamedType(actualType, outerWriter);
 
-            var innerContext = new SerializationContext
+            var innerContext = new SerializationContext(outerContext.GrainFactory)
             {
                 StreamWriter = new BinaryTokenStreamWriter()
             };
@@ -117,7 +117,7 @@ namespace Orleans.Serialization
             var length = outerReader.ReadInt();
             var innerBytes = outerReader.ReadBytes(length);
             
-            var innerContext = new DeserializationContext
+            var innerContext = new DeserializationContext(outerContext.GrainFactory)
             {
                 StreamReader = new BinaryTokenStreamReader(innerBytes)
             };
@@ -183,7 +183,7 @@ namespace Orleans.Serialization
             TypeSerializer.WriteTypeKey(key, outerWriter);
             
             // Serialize the only accepted fields from the base Exception class.
-            var innerContext = new SerializationContext
+            var innerContext = new SerializationContext(outerContext.GrainFactory)
             {
                 StreamWriter = new BinaryTokenStreamWriter()
             };

--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -102,13 +102,13 @@ namespace Orleans.Serialization
                 return null;
             }
 
-            var serializationContext = new SerializationContext
+            var serializationContext = new SerializationContext(context.GrainFactory)
             {
                 StreamWriter = new BinaryTokenStreamWriter()
             };
             
             Serialize(source, serializationContext, source.GetType());
-            var deserializationContext = new DeserializationContext
+            var deserializationContext = new DeserializationContext(context.GrainFactory)
             {
                 StreamReader = new BinaryTokenStreamReader(serializationContext.StreamWriter.ToBytes())
             };

--- a/src/Orleans/Serialization/SerializationContext.cs
+++ b/src/Orleans/Serialization/SerializationContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Orleans.Runtime;
 
 namespace Orleans.Serialization
 {
@@ -15,6 +16,11 @@ namespace Orleans.Serialization
         void RecordCopy(object original, object copy);
 
         object CheckObjectWhileCopying(object raw);
+
+        /// <summary>
+        /// Gets the <see cref="IGrainFactory"/> associated with this instance.
+        /// </summary>
+        IGrainFactory GrainFactory { get; }
     }
 
     public interface ISerializationContext
@@ -22,6 +28,11 @@ namespace Orleans.Serialization
         BinaryTokenStreamWriter StreamWriter { get; }
         void RecordObject(object original);
         int CheckObjectWhileSerializing(object raw);
+
+        /// <summary>
+        /// Gets the <see cref="IGrainFactory"/> associated with this instance.
+        /// </summary>
+        IGrainFactory GrainFactory { get; }
     }
 
     /// <summary>
@@ -55,11 +66,16 @@ namespace Orleans.Serialization
         public BinaryTokenStreamWriter StreamWriter { get; set; }
 
         private readonly Dictionary<object, Record> processedObjects;
+        private IGrainFactory grainFactory;
 
-        public SerializationContext()
+        public SerializationContext(IGrainFactory grainFactory)
         {
+            this.grainFactory = grainFactory;
             processedObjects = new Dictionary<object, Record>(ReferenceEqualsComparer.Instance);
         }
+
+        /// <inheritdoc />
+        public IGrainFactory GrainFactory => this.grainFactory ?? (this.grainFactory = RuntimeClient.Current.InternalGrainFactory);
 
         internal void Reset()
         {

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -137,13 +137,13 @@ namespace Orleans.Serialization
         private static SerializationContext serializationContext;
 
         private static SerializationContext CurrentSerializationContext
-            => serializationContext ?? (serializationContext = new SerializationContext());
+            => serializationContext ?? (serializationContext = new SerializationContext(null));
         
         [ThreadStatic]
         private static DeserializationContext deserializationContext;
 
         private static DeserializationContext CurrentDeserializationContext
-            => deserializationContext ?? (deserializationContext = new DeserializationContext());
+            => deserializationContext ?? (deserializationContext = new DeserializationContext(null));
 
         #endregion
 

--- a/src/Orleans/Streams/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans/Streams/PubSub/ImplicitStreamPubSub.cs
@@ -7,15 +7,17 @@ namespace Orleans.Streams
 {
     internal class ImplicitStreamPubSub : IStreamPubSub
     {
+        private readonly IInternalGrainFactory grainFactory;
         private readonly ImplicitStreamSubscriberTable implicitTable;
 
-        public ImplicitStreamPubSub(ImplicitStreamSubscriberTable implicitPubSubTable)
+        public ImplicitStreamPubSub(IInternalGrainFactory grainFactory, ImplicitStreamSubscriberTable implicitPubSubTable)
         {
             if (implicitPubSubTable == null)
             {
                 throw new ArgumentNullException("implicitPubSubTable");
             }
 
+            this.grainFactory = grainFactory;
             this.implicitTable = implicitPubSubTable;
         }
 
@@ -24,7 +26,7 @@ namespace Orleans.Streams
             ISet<PubSubSubscriptionState> result = new HashSet<PubSubSubscriptionState>();
             if (String.IsNullOrWhiteSpace(streamId.Namespace)) return Task.FromResult(result);
 
-            IDictionary<Guid, IStreamConsumerExtension> implicitSubscriptions = implicitTable.GetImplicitSubscribers(streamId);
+            IDictionary<Guid, IStreamConsumerExtension> implicitSubscriptions = implicitTable.GetImplicitSubscribers(streamId, this.grainFactory);
             foreach (var kvp in implicitSubscriptions)
             {
                 GuidId subscriptionId = GuidId.GetGuidId(kvp.Key);

--- a/src/OrleansAzureUtils/Storage/StatsTableDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/StatsTableDataManager.cs
@@ -63,10 +63,12 @@ namespace Orleans.AzureUtils
 
         private static readonly TimeSpan initTimeout = AzureTableDefaultPolicies.TableCreationTimeout;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatsTableDataManager"/> class.
+        /// </summary>
         public StatsTableDataManager()
         {
             logger = LogManager.GetLogger(this.GetType().Name, LoggerType.Runtime);
-            
         }
 
         async Task IStatisticsPublisher.Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName, string hostName)

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -169,7 +169,8 @@ namespace Orleans.Runtime
             TimeSpan ageLimit,
             NodeConfiguration nodeConfiguration,
             TimeSpan maxWarningRequestProcessingTime,
-			TimeSpan maxRequestProcessingTime)
+			TimeSpan maxRequestProcessingTime,
+            IRuntimeClient runtimeClient)
         {
             if (null == addr) throw new ArgumentNullException("addr");
             if (null == placedUsing) throw new ArgumentNullException("placedUsing");
@@ -190,8 +191,7 @@ namespace Orleans.Runtime
             }
             CollectionAgeLimit = ageLimit;
 
-
-            GrainReference = GrainReference.FromGrainId(addr.Grain, genericArguments, Grain.IsSystemTarget ? addr.Silo : null);
+            GrainReference = GrainReference.FromGrainId(addr.Grain, runtimeClient, genericArguments, Grain.IsSystemTarget ? addr.Silo : null);
             this.SchedulingContext = new SchedulingContext(this);
         }
 

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -510,7 +510,8 @@ namespace Orleans.Runtime
                         config.Application.GetCollectionAgeLimit(grainType),
                         this.nodeConfig,
                         this.maxWarningRequestProcessingTime,
-                        this.maxRequestProcessingTime);
+                        this.maxRequestProcessingTime,
+                        this.RuntimeClient);
                     RegisterMessageTarget(result);
                 }
             } // End lock

--- a/src/OrleansRuntime/LogConsistency/ProtocolGateway.cs
+++ b/src/OrleansRuntime/LogConsistency/ProtocolGateway.cs
@@ -22,7 +22,7 @@ namespace Orleans.Runtime.LogConsistency
 
         public async Task<ILogConsistencyProtocolMessage> RelayMessage(GrainId id, ILogConsistencyProtocolMessage payload)
         {
-            var g = InsideRuntimeClient.Current.InternalGrainFactory.Cast<ILogConsistencyProtocolParticipant>(GrainReference.FromGrainId(id));
+            var g = this.RuntimeClient.InternalGrainFactory.GetGrain<ILogConsistencyProtocolParticipant>(id);
             return await g.OnProtocolMessageReceived(payload);
         }
 

--- a/src/OrleansRuntime/MembershipService/MembershipTableFactory.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipTableFactory.cs
@@ -79,7 +79,7 @@ namespace Orleans.Runtime.MembershipService
             }
 
             var grainFactory = this.serviceProvider.GetRequiredService<IInternalGrainFactory>();
-            var result = grainFactory.Cast<IMembershipTableGrain>(GrainReference.FromGrainId(Constants.SystemMembershipTableId));
+            var result = grainFactory.GetGrain<IMembershipTableGrain>(Constants.SystemMembershipTableId);
 
             if (isPrimarySilo)
             {

--- a/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
+++ b/src/OrleansRuntime/Silo/SiloProviderRuntime.cs
@@ -25,7 +25,7 @@ namespace Orleans.Runtime.Providers
         private InvokeInterceptor invokeInterceptor;
 
         public IGrainFactory GrainFactory => this.runtimeClient.InternalGrainFactory;
-        public IServiceProvider ServiceProvider { get; }
+        public IServiceProvider ServiceProvider => this.runtimeClient.ServiceProvider;
 
         public Guid ServiceId { get; }
         public string SiloIdentity { get; }
@@ -38,10 +38,8 @@ namespace Orleans.Runtime.Providers
             ImplicitStreamSubscriberTable implicitStreamSubscriberTable,
             ISiloStatusOracle siloStatusOracle,
             OrleansTaskScheduler scheduler,
-            ActivationDirectory activationDirectory,
-            IServiceProvider serviceProvider)
+            ActivationDirectory activationDirectory)
         {
-            this.ServiceProvider = serviceProvider;
             this.siloDetails = siloDetails;
             this.siloStatusOracle = siloStatusOracle;
             this.scheduler = scheduler;
@@ -52,7 +50,7 @@ namespace Orleans.Runtime.Providers
             this.SiloIdentity = siloDetails.SiloAddress.ToLongString();
 
             this.grainBasedPubSub = new GrainBasedPubSubRuntime(this.GrainFactory);
-            var tmp = new ImplicitStreamPubSub(implicitStreamSubscriberTable);
+            var tmp = new ImplicitStreamPubSub(this.runtimeClient.InternalGrainFactory, implicitStreamSubscriberTable);
             this.implictPubSub = tmp;
             this.combinedGrainBasedAndImplicitPubSub = new StreamPubSubImpl(this.grainBasedPubSub, tmp);
         }

--- a/test/DefaultCluster.Tests/GrainReferenceTest.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceTest.cs
@@ -110,6 +110,8 @@ namespace DefaultCluster.Tests.General
                 // Serialize + Deserialize through .NET serializer
                 other = DotNetSerializeRoundtrip(grain);
             }
+            
+            this.GrainFactory.BindGrainReference(other);
 
             if (!resolveBeforeSerialize)
             {

--- a/test/NonSiloTests/General/Identifiertests.cs
+++ b/test/NonSiloTests/General/Identifiertests.cs
@@ -423,22 +423,22 @@ namespace UnitTests.General
         {
             Guid guid = Guid.NewGuid();
             GrainId regularGrainId = GrainId.GetGrainIdForTesting(guid);
-            GrainReference grainRef = GrainReference.FromGrainId(regularGrainId);
+            GrainReference grainRef = this.environment.InternalGrainFactory.GetGrain(regularGrainId);
             TestGrainReference(grainRef);
 
-            grainRef = GrainReference.FromGrainId(regularGrainId, "generic");
+            grainRef = GrainReference.FromGrainId(regularGrainId, null, "generic");
             TestGrainReference(grainRef);
 
             GrainId systemTragetGrainId = GrainId.NewSystemTargetGrainIdByTypeCode(2);
-            grainRef = GrainReference.FromGrainId(systemTragetGrainId, null, SiloAddress.NewLocalAddress(1));
+            grainRef = GrainReference.FromGrainId(systemTragetGrainId, null, null, SiloAddress.NewLocalAddress(1));
             TestGrainReference(grainRef);
 
             GrainId observerGrainId = GrainId.NewClientId();
-            grainRef = GrainReference.NewObserverGrainReference(observerGrainId, GuidId.GetNewGuidId());
+            grainRef = GrainReference.NewObserverGrainReference(observerGrainId, GuidId.GetNewGuidId(), this.environment.RuntimeClient);
             TestGrainReference(grainRef);
 
             GrainId geoObserverGrainId = GrainId.NewClientId("clusterid");
-            grainRef = GrainReference.NewObserverGrainReference(geoObserverGrainId, GuidId.GetNewGuidId());
+            grainRef = GrainReference.NewObserverGrainReference(geoObserverGrainId, GuidId.GetNewGuidId(), this.environment.RuntimeClient);
             TestGrainReference(grainRef);
         }
 

--- a/test/NonSiloTests/General/InternalSerializationTests.cs
+++ b/test/NonSiloTests/General/InternalSerializationTests.cs
@@ -1,3 +1,4 @@
+using Orleans;
 using TestExtensions;
 
 namespace UnitTests.Serialization
@@ -72,6 +73,7 @@ namespace UnitTests.Serialization
             SerializationManager.Serialize(grainReference, writer);
             var deserialized = SerializationManager.Deserialize(new BinaryTokenStreamReader(writer.ToByteArray()));
             var copy = (GrainReference)SerializationManager.DeepCopy(deserialized);
+            this.fixture.GrainFactory.BindGrainReference(copy);
 
             // Get the final value of the fallback serialization counters.
             var final = counters.Select(_ => _.GetCurrentValue()).ToList();
@@ -131,7 +133,7 @@ namespace UnitTests.Serialization
             }
 
             var regularGrainId = GrainId.GetGrainIdForTesting(Guid.NewGuid());
-            var grainRef = GrainReference.FromGrainId(regularGrainId);
+            var grainRef = this.fixture.InternalGrainFactory.GetGrain(regularGrainId);
             return
                 (GrainReference)
                 type.GetConstructor(

--- a/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
@@ -748,10 +748,11 @@ namespace UnitTests.Serialization
             var environment = InitializeSerializer(serializerToUse);
             GrainId grainId = GrainId.NewId();
             GrainReference input = environment.InternalGrainFactory.GetGrain(grainId);
+            Assert.True(input.IsBound);
 
             object deserialized = DotNetSerializationLoop(input);
-
             var grainRef = Assert.IsAssignableFrom<GrainReference>(deserialized); //GrainReference copied as wrong type
+            Assert.True(grainRef.IsBound);
             Assert.Equal(grainId, grainRef.GrainId); //GrainId different after copy
             Assert.Equal(grainId.GetPrimaryKey(), grainRef.GrainId.GetPrimaryKey()); //PK different after copy
             Assert.Equal(input, grainRef); //Wrong contents after round-trip of input

--- a/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/BuiltInSerializerTests.cs
@@ -34,6 +34,7 @@ namespace UnitTests.Serialization
     public class BuiltInSerializerTests
     {
         private readonly ITestOutputHelper output;
+        private readonly TestEnvironmentFixture defaultFixture;
 
         public enum SerializerToUse
         {
@@ -52,7 +53,7 @@ namespace UnitTests.Serialization
             new object[] { SerializerToUse.IlBasedFallbackSerializer }
         };
 
-        private void InitializeSerializer(SerializerToUse serializerToUse)
+        private SerializationTestEnvironment InitializeSerializer(SerializerToUse serializerToUse)
         {
             List<TypeInfo> serializationProviders = null;
             TypeInfo fallback = null;
@@ -75,8 +76,9 @@ namespace UnitTests.Serialization
                     throw new InvalidOperationException("Invalid Serializer was selected");
             }
 
-            SerializationTestEnvironment.Initialize(serializationProviders, fallback);
+            var result = SerializationTestEnvironment.Initialize(serializationProviders, fallback);
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
+            return result;
         }
 
         public BuiltInSerializerTests(ITestOutputHelper output)
@@ -435,7 +437,7 @@ namespace UnitTests.Serialization
         [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_ArrayOfArrays(SerializerToUse serializerToUse)
         {
-            InitializeSerializer(serializerToUse);
+            var environment = InitializeSerializer(serializerToUse);
 
             var source1 = new[] { new[] { 1, 3, 5 }, new[] { 10, 20, 30 }, new[] { 17, 13, 11, 7, 5, 3, 2 } };
             object deserialized = OrleansSerializationLoop(source1);
@@ -474,12 +476,12 @@ namespace UnitTests.Serialization
             source4[0] = new GrainReference[2];
             source4[1] = new GrainReference[3];
             source4[2] = new GrainReference[1];
-            source4[0][0] = GrainReference.FromGrainId(GrainId.NewId());
-            source4[0][1] = GrainReference.FromGrainId(GrainId.NewId());
-            source4[1][0] = GrainReference.FromGrainId(GrainId.NewId());
-            source4[1][1] = GrainReference.FromGrainId(GrainId.NewId());
-            source4[1][2] = GrainReference.FromGrainId(GrainId.NewId());
-            source4[2][0] = GrainReference.FromGrainId(GrainId.NewId());
+            source4[0][0] = environment.InternalGrainFactory.GetGrain(GrainId.NewId());
+            source4[0][1] = environment.InternalGrainFactory.GetGrain(GrainId.NewId());
+            source4[1][0] = environment.InternalGrainFactory.GetGrain(GrainId.NewId());
+            source4[1][1] = environment.InternalGrainFactory.GetGrain(GrainId.NewId());
+            source4[1][2] = environment.InternalGrainFactory.GetGrain(GrainId.NewId());
+            source4[2][0] = environment.InternalGrainFactory.GetGrain(GrainId.NewId());
             deserialized = OrleansSerializationLoop(source4);
             ValidateArrayOfArrays(source4, deserialized, "grain reference");
 
@@ -489,7 +491,7 @@ namespace UnitTests.Serialization
                 source5[i] = new GrainReference[64];
                 for (int j = 0; j < source5[i].Length; j++)
                 {
-                    source5[i][j] = GrainReference.FromGrainId(GrainId.NewId());
+                    source5[i][j] = environment.InternalGrainFactory.GetGrain(GrainId.NewId());
                 }
             }
             deserialized = OrleansSerializationLoop(source5);
@@ -727,9 +729,9 @@ namespace UnitTests.Serialization
         [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_GrainReference(SerializerToUse serializerToUse)
         {
-            InitializeSerializer(serializerToUse);
+            var environment = InitializeSerializer(serializerToUse);
             GrainId grainId = GrainId.NewId();
-            GrainReference input = GrainReference.FromGrainId(grainId);
+            GrainReference input = environment.InternalGrainFactory.GetGrain(grainId);
 
             object deserialized = OrleansSerializationLoop(input);
 
@@ -743,9 +745,9 @@ namespace UnitTests.Serialization
         [InlineData(SerializerToUse.NoFallback)]
         public void Serialize_GrainReference_ViaStandardSerializer(SerializerToUse serializerToUse)
         {
-            InitializeSerializer(serializerToUse);
+            var environment = InitializeSerializer(serializerToUse);
             GrainId grainId = GrainId.NewId();
-            GrainReference input = GrainReference.FromGrainId(grainId);
+            GrainReference input = environment.InternalGrainFactory.GetGrain(grainId);
 
             object deserialized = DotNetSerializationLoop(input);
 

--- a/test/NonSiloTests/Serialization/ILBasedExceptionSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/ILBasedExceptionSerializerTests.cs
@@ -32,16 +32,19 @@ namespace UnitTests.Serialization
             // Throw an exception so that is has a stack trace.
             var expected = GetNewException();
 
-            var writer = new SerializationContext
+            var writer = new SerializationContext(this.environment.GrainFactory)
             {
                 StreamWriter = new BinaryTokenStreamWriter()
             };
 
             // Deep copies should be reference-equal.
-            Assert.Equal(expected, SerializationManager.DeepCopyInner(expected, new SerializationContext()), ReferenceEqualsComparer.Instance);
+            Assert.Equal(
+                expected,
+                SerializationManager.DeepCopyInner(expected, new SerializationContext(this.environment.GrainFactory)),
+                ReferenceEqualsComparer.Instance);
 
             SerializationManager.Serialize(expected, writer.StreamWriter);
-            var reader = new DeserializationContext
+            var reader = new DeserializationContext(this.environment.GrainFactory)
             {
                 StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
             };
@@ -90,17 +93,17 @@ namespace UnitTests.Serialization
 
             var knowsException = new ILBasedExceptionSerializer(this.serializerGenerator, new TypeSerializer());
             
-            var writer = new SerializationContext
+            var writer = new SerializationContext(this.environment.GrainFactory)
             {
                 StreamWriter = new BinaryTokenStreamWriter()
             };
             knowsException.Serialize(expected, writer, null);
 
             // Deep copies should be reference-equal.
-            Assert.Equal(expected, knowsException.DeepCopy(expected, new SerializationContext()), ReferenceEqualsComparer.Instance);
+            Assert.Equal(expected, knowsException.DeepCopy(expected, new SerializationContext(this.environment.GrainFactory)), ReferenceEqualsComparer.Instance);
 
             // Create a deserializer which doesn't know about the expected exception type.
-            var reader = new DeserializationContext
+            var reader = new DeserializationContext(this.environment.GrainFactory)
             {
                 StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
             };
@@ -115,13 +118,13 @@ namespace UnitTests.Serialization
             Assert.Equal(typeof(ILExceptionSerializerTestException).AssemblyQualifiedName, actualDeserialized.OriginalTypeName);
 
             // Re-serialize the deserialized object using the serializer which does not have access to the original type.
-            writer = new SerializationContext
+            writer = new SerializationContext(this.environment.GrainFactory)
             {
                 StreamWriter = new BinaryTokenStreamWriter()
             };
             doesNotKnowException.Serialize(untypedActual, writer, null);
 
-            reader = new DeserializationContext
+            reader = new DeserializationContext(this.environment.GrainFactory)
             {
                 StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
             };

--- a/test/NonSiloTests/Serialization/ILBasedSerializerTests.cs
+++ b/test/NonSiloTests/Serialization/ILBasedSerializerTests.cs
@@ -35,7 +35,7 @@ namespace UnitTests.Serialization
 
             var generator = new ILSerializerGenerator();
             var serializers = generator.GenerateSerializer(input.GetType(), f => f.Name != "One", f => f.Name != "Three");
-            var writer = new SerializationContext
+            var writer = new SerializationContext(this.fixture.GrainFactory)
             {
                 StreamWriter = new BinaryTokenStreamWriter()
             };
@@ -45,7 +45,7 @@ namespace UnitTests.Serialization
             Assert.Equal(0, copy.Three);
             
             serializers.Serialize(input, writer, input.GetType());
-            var reader = new DeserializationContext
+            var reader = new DeserializationContext(this.fixture.GrainFactory)
             {
                 StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
             };

--- a/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
+++ b/test/NonSiloTests/SerializationTests/StreamTypeSerializationTests.cs
@@ -36,7 +36,7 @@ namespace UnitTests.Serialization
         public void EventSequenceToken_VerifyStillUsingFallbackSerializer()
         {
             var token = new EventSequenceToken(long.MaxValue, int.MaxValue);
-            Tester.SerializationTests.SerializationTestsUtils.VerifyUsingFallbackSerializer(token);
+            Tester.SerializationTests.SerializationTestsUtils.VerifyUsingFallbackSerializer(token, this.fixture.Environment.GrainFactory);
 
         }
 
@@ -44,7 +44,7 @@ namespace UnitTests.Serialization
         public void EventHubSequenceToken_VerifyStillUsingFallbackSerializer()
         {
             var token = new EventHubSequenceToken("some offset", long.MaxValue, int.MaxValue);
-            Tester.SerializationTests.SerializationTestsUtils.VerifyUsingFallbackSerializer(token);
+            Tester.SerializationTests.SerializationTestsUtils.VerifyUsingFallbackSerializer(token, this.fixture.Environment.GrainFactory);
         }
 
         #region EventSequenceToken2

--- a/test/TestExtensions/SerializationTestEnvironment.cs
+++ b/test/TestExtensions/SerializationTestEnvironment.cs
@@ -12,7 +12,7 @@ namespace TestExtensions
         public SerializationTestEnvironment(ClientConfiguration config = null)
         {
             if (config == null) config = this.DefaultConfig();
-            this.RuntimeClient = new OutsideRuntimeClient(config, true);
+            Orleans.Runtime.RuntimeClient.Current = this.RuntimeClient = new OutsideRuntimeClient(config, true);
         }
 
         private ClientConfiguration DefaultConfig()

--- a/test/Tester/SerializationTests/SerializationTestsUtils.cs
+++ b/test/Tester/SerializationTests/SerializationTestsUtils.cs
@@ -1,13 +1,14 @@
-﻿using Orleans.Serialization;
+﻿using Orleans;
+using Orleans.Serialization;
 using Xunit;
 
 namespace Tester.SerializationTests
 {
     public class SerializationTestsUtils
     {
-        public static void VerifyUsingFallbackSerializer(object ob)
+        public static void VerifyUsingFallbackSerializer(object ob, IGrainFactory grainFactory)
         {
-            var writer = new SerializationContext
+            var writer = new SerializationContext(grainFactory)
             {
                 StreamWriter = new BinaryTokenStreamWriter()
             };

--- a/test/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -32,8 +32,8 @@ namespace Tester.AzureUtils.Persistence
             this.fixture = fixture;
             storageProviderManager = new StorageProviderManager(
                 fixture.GrainFactory,
-                null,
-                new ClientProviderRuntime(fixture.InternalGrainFactory, null));
+                fixture.Services,
+                new ClientProviderRuntime(fixture.InternalGrainFactory, fixture.Services));
             storageProviderManager.LoadEmptyStorageProviders().WaitWithThrow(TestConstants.InitTimeout);
             providerCfgProps.Clear();
             LocalDataStoreInstance.LocalDataStore = null;
@@ -260,7 +260,7 @@ namespace Tester.AzureUtils.Persistence
             var cfg = new ProviderConfiguration(providerCfgProps, null);
             await store.Init(testName, storageProviderManager, cfg);
 
-            GrainReference reference = GrainReference.FromGrainId(GrainId.NewId());
+            GrainReference reference = this.fixture.InternalGrainFactory.GetGrain(GrainId.NewId());
             var state = TestStoreGrainState.NewRandomState();
             Stopwatch sw = new Stopwatch();
             sw.Start();
@@ -334,7 +334,7 @@ namespace Tester.AzureUtils.Persistence
         private async Task Test_PersistenceProvider_Read(string grainTypeName, IStorageProvider store,
             GrainState<TestStoreGrainState> grainState = null, GrainId grainId = null)
         {
-            var reference = GrainReference.FromGrainId(grainId ?? GrainId.NewId());
+            var reference = this.fixture.InternalGrainFactory.GetGrain(grainId ?? GrainId.NewId());
 
             if (grainState == null)
             {
@@ -359,7 +359,7 @@ namespace Tester.AzureUtils.Persistence
         private async Task<GrainState<TestStoreGrainState>> Test_PersistenceProvider_WriteRead(string grainTypeName,
             IStorageProvider store, GrainState<TestStoreGrainState> grainState = null, GrainId grainId = null)
         {
-            GrainReference reference = GrainReference.FromGrainId(grainId ?? GrainId.NewId());
+            GrainReference reference = this.fixture.InternalGrainFactory.GetGrain(grainId ?? GrainId.NewId());
 
             if (grainState == null)
             {
@@ -391,7 +391,7 @@ namespace Tester.AzureUtils.Persistence
         private async Task<GrainState<TestStoreGrainState>> Test_PersistenceProvider_WriteClearRead(string grainTypeName,
             IStorageProvider store, GrainState<TestStoreGrainState> grainState = null, GrainId grainId = null)
         {
-            GrainReference reference = GrainReference.FromGrainId(grainId ?? GrainId.NewId());
+            GrainReference reference = this.fixture.InternalGrainFactory.GetGrain(grainId ?? GrainId.NewId());
 
             if (grainState == null)
             {

--- a/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -103,7 +103,7 @@ namespace UnitTests.TimerTests
                     var e = new ReminderEntry
                     {
                         //GrainId = GrainId.GetGrainId(new Guid(s)),
-                        GrainRef = GrainReference.FromGrainId(GrainId.NewId()),
+                        GrainRef = this.fixture.InternalGrainFactory.GetGrain(GrainId.NewId()),
                         ReminderName = "MY_REMINDER_" + i,
                         Period = TimeSpan.FromSeconds(5),
                         StartAt = DateTime.UtcNow
@@ -136,7 +136,7 @@ namespace UnitTests.TimerTests
             Guid guid = Guid.NewGuid();
             return new ReminderEntry
                 {
-                    GrainRef = GrainReference.FromGrainId(GrainId.NewId()),
+                    GrainRef = this.fixture.InternalGrainFactory.GetGrain(GrainId.NewId()),
                     ReminderName = string.Format("TestReminder.{0}", guid),
                     Period = TimeSpan.FromSeconds(5),
                     StartAt = DateTime.UtcNow

--- a/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -24,21 +24,21 @@ namespace Tester.AzureUtils.Streaming
     public class AzureQueueAdapterTests : IDisposable
     {
         private readonly ITestOutputHelper output;
+        private readonly TestEnvironmentFixture fixture;
         private const int NumBatches = 20;
         private const int NumMessagesPerBatch = 20;
         private string deploymentId;
         public static readonly string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AQAdapterTests";
 
         private static readonly SafeRandom Random = new SafeRandom();
-        private readonly TestEnvironmentFixture fixture;
 
         public AzureQueueAdapterTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
         {
             this.output = output;
+            this.fixture = fixture;
             this.deploymentId = MakeDeploymentId();
             LogManager.Initialize(new NodeConfiguration());
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
-            this.fixture = fixture;
         }
         
         public void Dispose()
@@ -58,7 +58,7 @@ namespace Tester.AzureUtils.Streaming
             var config = new ProviderConfiguration(properties, "type", "name");
 
             var adapterFactory = new AzureQueueAdapterFactory<AzureQueueDataAdapterV2>();
-            adapterFactory.Init(config, AZURE_QUEUE_STREAM_PROVIDER_NAME, LogManager.GetLogger("AzureQueueAdapter", LoggerType.Application), null);
+            adapterFactory.Init(config, AZURE_QUEUE_STREAM_PROVIDER_NAME, LogManager.GetLogger("AzureQueueAdapter", LoggerType.Application), this.fixture.Services);
             await SendAndReceiveFromQueueAdapter(adapterFactory, config);
         }
 

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -159,7 +159,7 @@ namespace UnitTests.RemindersTest
         private GrainReference MakeTestGrainReference()
         {
             GrainId regularGrainId = GrainId.GetGrainIdForTesting(Guid.NewGuid());
-            GrainReference grainRef = GrainReference.FromGrainId(regularGrainId);
+            GrainReference grainRef = this.ClusterFixture.InternalGrainFactory.GetGrain(regularGrainId);
             return grainRef;
         }
     }

--- a/test/TesterInternal/StorageTests/CommonStorageTests.cs
+++ b/test/TesterInternal/StorageTests/CommonStorageTests.cs
@@ -196,7 +196,7 @@ namespace UnitTests.StorageTests.Relational
         /// <returns>A grain reference and a state pair.</returns>
         internal Tuple<GrainReference, GrainState<TestState1>> GetTestReferenceAndState(long grainId, string version)
         {
-            return Tuple.Create(GrainReference.FromGrainId(GrainId.GetGrainId(UniqueKey.NewKey(grainId, UniqueKey.Category.Grain))), new GrainState<TestState1> { State = new TestState1(), ETag = version });
+            return Tuple.Create(this.grainFactory.GetGrain(GrainId.GetGrainId(UniqueKey.NewKey(grainId, UniqueKey.Category.Grain))), new GrainState<TestState1> { State = new TestState1(), ETag = version });
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace UnitTests.StorageTests.Relational
         /// <returns>A grain reference and a state pair.</returns>
         internal Tuple<GrainReference, GrainState<TestState1>> GetTestReferenceAndState(string grainId, string version)
         {
-            return Tuple.Create(GrainReference.FromGrainId(GrainId.FromParsableString(GrainId.GetGrainId(RandomUtilities.NormalGrainTypeCode, grainId).ToParsableString())), new GrainState<TestState1> { State = new TestState1(), ETag = version });
+            return Tuple.Create(this.grainFactory.GetGrain(GrainId.FromParsableString(GrainId.GetGrainId(RandomUtilities.NormalGrainTypeCode, grainId).ToParsableString())), new GrainState<TestState1> { State = new TestState1(), ETag = version });
         }
     }
 }

--- a/test/TesterInternal/StorageTests/LocalStoreTests.cs
+++ b/test/TesterInternal/StorageTests/LocalStoreTests.cs
@@ -49,7 +49,7 @@ namespace UnitTests.StorageTests
 
             ILocalDataStore store = new HierarchicalKeyStore(2);
 
-            GrainReference reference = GrainReference.FromGrainId(GrainId.NewId());
+            GrainReference reference = this.fixture.InternalGrainFactory.GetGrain(GrainId.NewId());
             TestStoreGrainState state = new TestStoreGrainState();
             var stateProperties = AsDictionary(state);
             var keys = GetKeys(name, reference);
@@ -71,7 +71,7 @@ namespace UnitTests.StorageTests
 
             ILocalDataStore store = new HierarchicalKeyStore(2);
 
-            GrainReference reference = GrainReference.FromGrainId(GrainId.NewId());
+            GrainReference reference = fixture.InternalGrainFactory.GetGrain(GrainId.NewId());
             var state = TestStoreGrainState.NewRandomState();
             Stopwatch sw = new Stopwatch();
             sw.Start();
@@ -95,7 +95,7 @@ namespace UnitTests.StorageTests
 
             ILocalDataStore store = new HierarchicalKeyStore(2);
 
-            GrainReference reference = GrainReference.FromGrainId(GrainId.NewId());
+            GrainReference reference = this.fixture.InternalGrainFactory.GetGrain(GrainId.NewId());
             var data = TestStoreGrainState.NewRandomState();
 
             output.WriteLine("Using store = {0}", store.GetType().FullName);
@@ -181,7 +181,7 @@ namespace UnitTests.StorageTests
 
             ILocalDataStore store = new HierarchicalKeyStore(2);
 
-            GrainReference reference = GrainReference.FromGrainId(GrainId.NewId());
+            GrainReference reference = this.fixture.InternalGrainFactory.GetGrain(GrainId.NewId());
             var grainState = TestStoreGrainState.NewRandomState();
             var state = grainState.State;
             Stopwatch sw = new Stopwatch();

--- a/test/TesterInternal/StorageTests/RandomUtilities.cs
+++ b/test/TesterInternal/StorageTests/RandomUtilities.cs
@@ -48,10 +48,10 @@ namespace UnitTests.StorageTests.Relational
                 Guid grainId = GetRandom<Guid>();
                 if(type != typeof(NotApplicable))
                 {
-                    return GrainReference.FromGrainId(GrainId.GetGrainId(UniqueKey.NewKey(grainId, keyExtension ? UniqueKey.Category.KeyExtGrain : UniqueKey.Category.Grain, keyExtension ? KeyExtensionGrainTypeCode : NormalGrainTypeCode, extension)), type.FullName);
+                    return grainFactory.GetGrain(GrainId.GetGrainId(UniqueKey.NewKey(grainId, keyExtension ? UniqueKey.Category.KeyExtGrain : UniqueKey.Category.Grain, keyExtension ? KeyExtensionGrainTypeCode : NormalGrainTypeCode, extension)), type.FullName);
                 }
 
-                return GrainReference.FromGrainId(GrainId.GetGrainId(UniqueKey.NewKey(grainId, keyExtension ? UniqueKey.Category.KeyExtGrain : UniqueKey.Category.Grain, keyExtension ? KeyExtensionGrainTypeCode : NormalGrainTypeCode, extension)));
+                return grainFactory.GetGrain(GrainId.GetGrainId(UniqueKey.NewKey(grainId, keyExtension ? UniqueKey.Category.KeyExtGrain : UniqueKey.Category.Grain, keyExtension ? KeyExtensionGrainTypeCode : NormalGrainTypeCode, extension)));
             },
             [typeof(long)] = (grainFactory, type, keyExtension, state) =>
             {
@@ -62,10 +62,10 @@ namespace UnitTests.StorageTests.Relational
                 long grainId = GetRandom<long>();
                 if(type != typeof(NotApplicable))
                 {
-                    return GrainReference.FromGrainId(GrainId.GetGrainId(UniqueKey.NewKey(grainId, keyExtension ? UniqueKey.Category.KeyExtGrain : UniqueKey.Category.Grain, keyExtension ? KeyExtensionGrainTypeCode : NormalGrainTypeCode, extension)), type.FullName);
+                    return grainFactory.GetGrain(GrainId.GetGrainId(UniqueKey.NewKey(grainId, keyExtension ? UniqueKey.Category.KeyExtGrain : UniqueKey.Category.Grain, keyExtension ? KeyExtensionGrainTypeCode : NormalGrainTypeCode, extension)), type.FullName);
                 }
 
-                return GrainReference.FromGrainId(GrainId.GetGrainId(UniqueKey.NewKey(grainId, keyExtension ? UniqueKey.Category.KeyExtGrain : UniqueKey.Category.Grain, keyExtension ? KeyExtensionGrainTypeCode : NormalGrainTypeCode, extension)));
+                return grainFactory.GetGrain(GrainId.GetGrainId(UniqueKey.NewKey(grainId, keyExtension ? UniqueKey.Category.KeyExtGrain : UniqueKey.Category.Grain, keyExtension ? KeyExtensionGrainTypeCode : NormalGrainTypeCode, extension)));
             },
             [typeof(string)] = (grainFactory, type, keyExtension, state) =>
             {
@@ -75,10 +75,10 @@ namespace UnitTests.StorageTests.Relational
                 var grainId = GetRandomCharacters(symbolSet, range);
                 if(type != typeof(NotApplicable))
                 {
-                    return GrainReference.FromGrainId(GrainId.FromParsableString(GrainId.GetGrainId(NormalGrainTypeCode, grainId).ToParsableString()));
+                    return grainFactory.GetGrain(GrainId.FromParsableString(GrainId.GetGrainId(NormalGrainTypeCode, grainId).ToParsableString()));
                 }
 
-                return GrainReference.FromGrainId(GrainId.FromParsableString(GrainId.GetGrainId(NormalGrainTypeCode, grainId).ToParsableString()), type.FullName);
+                return grainFactory.GetGrain(GrainId.FromParsableString(GrainId.GetGrainId(NormalGrainTypeCode, grainId).ToParsableString()), type.FullName);
             }
         };
 

--- a/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
@@ -336,7 +336,7 @@ namespace UnitTests.StreamingTests
         {
             var grainIds = targets.Distinct().Where(t => t is GrainReference).Select(t => ((GrainReference)t).GrainId).ToArray();
             IManagementGrain systemManagement = grainFactory.GetGrain<IManagementGrain>(0);
-            var tasks = grainIds.Select(g => systemManagement.GetGrainActivationCount(GrainReference.FromGrainId(g))).ToArray();
+            var tasks = grainIds.Select(g => systemManagement.GetGrainActivationCount(grainFactory.GetGrain(g))).ToArray();
             await Task.WhenAll(tasks);
             return tasks.Sum(t => t.Result);
         }


### PR DESCRIPTION
One of the key pieces for non-static clients. GrainReference instances must hold a reference to the runtime.

There are a few methods needed on `IGrainFactory` and `IInternalGrainFactory` to support these grain references, most important is the ability to bind a `GrainReference` instance to the runtime.