### PR TITLE
migrate off AppDomainTestHook

### DIFF
--- a/src/OrleansRuntime/Silo/TestHooks/ITestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/ITestHooksSystemTarget.cs
@@ -13,6 +13,9 @@ namespace Orleans.Runtime.TestHooks
         Task<ICollection<string>> GetStorageProviderNames();
         Task<ICollection<string>> GetStreamProviderNames();
         Task<ICollection<string>> GetAllSiloProviderNames();
+        Task<bool> CanGetStorageProvider(string providerName);
+        Task<bool> CanGetStreamProvider(string providerName);
+        Task<bool> CanGetBoostraperProvider(string providerName);
         Task<int> UnregisterGrainForTesting(GrainId grain);
         Task LatchIsOverloaded(bool overloaded, TimeSpan latchPeriod);
     }

--- a/src/OrleansRuntime/Silo/TestHooks/ITestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/ITestHooksSystemTarget.cs
@@ -13,9 +13,9 @@ namespace Orleans.Runtime.TestHooks
         Task<ICollection<string>> GetStorageProviderNames();
         Task<ICollection<string>> GetStreamProviderNames();
         Task<ICollection<string>> GetAllSiloProviderNames();
-        Task<bool> CanGetStorageProvider(string providerName);
-        Task<bool> CanGetStreamProvider(string providerName);
-        Task<bool> CanGetBoostraperProvider(string providerName);
+        Task<bool> HasStorageProvider(string providerName);
+        Task<bool> HasStreamProvider(string providerName);
+        Task<bool> HasBoostraperProvider(string providerName);
         Task<int> UnregisterGrainForTesting(GrainId grain);
         Task LatchIsOverloaded(bool overloaded, TimeSpan latchPeriod);
     }

--- a/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -40,13 +40,13 @@ namespace Orleans.Runtime.TestHooks
 
         public Task<Guid> GetServiceId() => Task.FromResult(silo.GlobalConfig.ServiceId);
 
-        public Task<bool> CanGetStorageProvider(string providerName)
+        public Task<bool> HasStorageProvider(string providerName)
         {
             IStorageProvider tmp;
             return Task.FromResult(silo.StorageProviderManager.TryGetProvider(providerName, out tmp));
         }
 
-        public Task<bool> CanGetStreamProvider(string providerName)
+        public Task<bool> HasStreamProvider(string providerName)
         {
             try
             {
@@ -59,7 +59,7 @@ namespace Orleans.Runtime.TestHooks
             }
         }
 
-        public Task<bool> CanGetBoostraperProvider(string providerName)
+        public Task<bool> HasBoostraperProvider(string providerName)
         {
             foreach (var provider in silo.BootstrapProviders)
             {

--- a/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
 using Orleans.Providers;
 using Orleans.Runtime.ConsistentRing;
+using Orleans.Storage;
+using Orleans.Streams;
 
 namespace Orleans.Runtime.TestHooks
 {
@@ -36,6 +39,37 @@ namespace Orleans.Runtime.TestHooks
         public Task<bool> HasStatisticsProvider() => Task.FromResult(silo.StatisticsProviderManager != null);
 
         public Task<Guid> GetServiceId() => Task.FromResult(silo.GlobalConfig.ServiceId);
+
+        public Task<bool> CanGetStorageProvider(string providerName)
+        {
+            IStorageProvider tmp;
+            return Task.FromResult(silo.StorageProviderManager.TryGetProvider(providerName, out tmp));
+        }
+
+        public Task<bool> CanGetStreamProvider(string providerName)
+        {
+            try
+            {
+                silo.StreamProviderManager.GetStreamProvider(providerName);
+                return Task.FromResult(true);
+            }
+            catch (KeyNotFoundException)
+            {
+                return Task.FromResult(false);
+            }
+        }
+
+        public Task<bool> CanGetBoostraperProvider(string providerName)
+        {
+            foreach (var provider in silo.BootstrapProviders)
+            {
+                if (String.Equals(providerName, provider.Name))
+                {
+                    return Task.FromResult(true);
+                }
+            }
+            return Task.FromResult(false);
+        }
 
         public Task<ICollection<string>> GetStorageProviderNames() => Task.FromResult<ICollection<string>>(silo.StorageProviderManager.GetProviderNames().ToList());
 

--- a/test/TestExtensions/MockStorageProvider.cs
+++ b/test/TestExtensions/MockStorageProvider.cs
@@ -239,7 +239,7 @@ namespace UnitTests.StorageTests
         /// </summary>
         /// <param name="command">A serial number of the command.</param>
         /// <param name="arg">An opaque command argument</param>
-        public Task<object> ExecuteCommand(int command, object arg)
+        public virtual Task<object> ExecuteCommand(int command, object arg)
         {
             switch ((Commands)command)
             {

--- a/test/TestExtensions/MockStorageProvider.cs
+++ b/test/TestExtensions/MockStorageProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
@@ -13,8 +14,27 @@ using Orleans.Storage;
 namespace UnitTests.StorageTests
 {
     [DebuggerDisplay("MockStorageProvider:{Name}")]
-    public class MockStorageProvider : MarshalByRefObject, IStorageProvider
+    public class MockStorageProvider : IControllable, IStorageProvider
     {
+        public enum Commands
+        {
+            InitCount,
+            SetValue,
+            GetProvideState,
+            SetErrorInjection,
+            GetLastState,
+            ResetHistory
+        }
+        [Serializable]
+        public class StateForTest 
+        {
+            public int InitCount { get; set; }
+            public int CloseCount { get; set; }
+            public int ReadCount { get; set; }
+            public int WriteCount { get; set; }
+            public int DeleteCount { get; set; }
+        }
+
         private static int _instanceNum;
         private readonly int _id;
 
@@ -45,7 +65,34 @@ namespace UnitTests.StorageTests
             this.numKeys = numKeys;
         }
 
-        public virtual void SetValue<TState>(string grainType, GrainReference grainReference, string name, object val)
+        public StateForTest GetProviderState()
+        {
+            var state = new StateForTest();
+            state.InitCount = initCount;
+            state.CloseCount = closeCount;
+            state.DeleteCount = deleteCount;
+            state.ReadCount = readCount;
+            state.WriteCount = writeCount;
+            return state;
+        }
+
+        [Serializable]
+        public class SetValueArgs
+        {
+            public Type StateType { get; set; }
+            public string GrainType { get; set; }
+            public GrainReference GrainReference { get; set; }
+            public string Name { get; set; }
+            public object Val { get; set; }
+
+        }
+
+        public virtual void SetValue(SetValueArgs args)
+        {
+            SetValue(args.StateType, args.GrainType, args.GrainReference, args.Name, args.Val);
+        }
+
+        private void SetValue(Type stateType, string grainType, GrainReference grainReference, string name, object val)
         {
             lock (StateStore)
             {
@@ -54,7 +101,7 @@ namespace UnitTests.StorageTests
                 var storedDict = StateStore.ReadRow(keys);
                 if (!storedDict.ContainsKey(stateStoreKey))
                 {
-                    storedDict[stateStoreKey] = Activator.CreateInstance<TState>();
+                    storedDict[stateStoreKey] = Activator.CreateInstance(stateType);
                 } 
 
                 var storedState = storedDict[stateStoreKey];
@@ -63,6 +110,11 @@ namespace UnitTests.StorageTests
                 LastId = GetId(grainReference);
                 LastState = storedState;
             }
+        }
+
+        public object GetLastState()
+        {
+            return LastState;
         }
 
         public T GetLastState<T>()
@@ -186,5 +238,33 @@ namespace UnitTests.StorageTests
             LastId = null;
             LastState = null;
         }
+
+        #region IControllable interface methods
+        /// <summary>
+        /// A function to execute a control command.
+        /// </summary>
+        /// <param name="command">A serial number of the command.</param>
+        /// <param name="arg">An opaque command argument</param>
+        public Task<object> ExecuteCommand(int command, object arg)
+        {
+            switch ((Commands)command)
+            {
+                case Commands.InitCount:
+                    return Task.FromResult<object>(initCount);
+                case Commands.SetValue:
+                    SetValue((SetValueArgs) arg);
+                    return Task.FromResult<object>(true); 
+                case Commands.GetProvideState:
+                    return Task.FromResult<object>(GetProviderState());
+                case Commands.GetLastState:
+                    return Task.FromResult(GetLastState());
+                case Commands.ResetHistory:
+                    ResetHistory();
+                    return Task.FromResult<object>(true);
+                default:
+                    return Task.FromResult<object>(true); 
+            }
+        }
+        #endregion
     }
 }

--- a/test/TestExtensions/MockStorageProvider.cs
+++ b/test/TestExtensions/MockStorageProvider.cs
@@ -40,12 +40,6 @@ namespace UnitTests.StorageTests
 
         private int initCount, closeCount, readCount, writeCount, deleteCount;
 
-        public int InitCount { get { return initCount; } }
-        public int CloseCount { get { return closeCount; } }
-        public int ReadCount { get { return readCount; } }
-        public int WriteCount { get { return writeCount; } }
-        public int DeleteCount { get { return deleteCount; } }
-
         private readonly int numKeys;
         private ILocalDataStore StateStore;
         private const string stateStoreKey = "State";
@@ -87,7 +81,7 @@ namespace UnitTests.StorageTests
 
         }
 
-        public virtual void SetValue(SetValueArgs args)
+        public void SetValue(SetValueArgs args)
         {
             SetValue(args.StateType, args.GrainType, args.GrainReference, args.Name, args.Val);
         }

--- a/test/TesterInternal/ErrorInjectionStorageProvider.cs
+++ b/test/TesterInternal/ErrorInjectionStorageProvider.cs
@@ -128,7 +128,7 @@ namespace UnitTests.StorageTests
         /// </summary>
         /// <param name="command">A serial number of the command.</param>
         /// <param name="arg">An opaque command argument</param>
-        public new Task<object> ExecuteCommand(int command, object arg)
+        public override Task<object> ExecuteCommand(int command, object arg)
         { 
             switch ((Commands)command)
             {

--- a/test/TesterInternal/ErrorInjectionStorageProvider.cs
+++ b/test/TesterInternal/ErrorInjectionStorageProvider.cs
@@ -47,7 +47,7 @@ namespace UnitTests.StorageTests
         }
     }
 
-    public class ErrorInjectionStorageProvider : MockStorageProvider
+    public class ErrorInjectionStorageProvider : MockStorageProvider, IControllable
     {
         public ErrorInjectionPoint ErrorInjection { get; private set; }
 
@@ -121,5 +121,24 @@ namespace UnitTests.StorageTests
                 throw;
             }
         }
+
+        #region IControllable interface methods
+        /// <summary>
+        /// A function to execute a control command.
+        /// </summary>
+        /// <param name="command">A serial number of the command.</param>
+        /// <param name="arg">An opaque command argument</param>
+        public new Task<object> ExecuteCommand(int command, object arg)
+        { 
+            switch ((Commands)command)
+            {
+                case Commands.SetErrorInjection:
+                    SetErrorInjection((ErrorInjectionPoint)arg);
+                    return Task.FromResult<object>(true);
+                default:
+                    return base.ExecuteCommand(command, arg);
+            }
+        }
+        #endregion
     }
 }

--- a/test/TesterInternal/General/BootstrapProviderTests.cs
+++ b/test/TesterInternal/General/BootstrapProviderTests.cs
@@ -132,7 +132,7 @@ namespace UnitTests.General
             List<SiloHandle> silos = HostedCluster.GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                bool re = await siloHandle.TestHook.CanGetBoostraperProvider(providerName);
+                bool re = await siloHandle.TestHook.HasBoostraperProvider(providerName);
                 if (re)
                 {
                     return true;

--- a/test/TesterInternal/General/BootstrapProviderTests.cs
+++ b/test/TesterInternal/General/BootstrapProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,13 +23,14 @@ namespace UnitTests.General
 
         public class Fixture : BaseTestClusterFixture
         {
+            
             protected override TestCluster CreateTestCluster()
             {
                 var options = new TestClusterOptions();
-                options.ClusterConfiguration.Globals.RegisterBootstrapProvider<UnitTests.General.MockBootstrapProvider>("bootstrap1");
-                options.ClusterConfiguration.Globals.RegisterBootstrapProvider<UnitTests.General.GrainCallBootstrapper>("bootstrap2");
-                options.ClusterConfiguration.Globals.RegisterBootstrapProvider<UnitTests.General.LocalGrainInitBootstrapper>("bootstrap3");
-                options.ClusterConfiguration.Globals.RegisterBootstrapProvider<UnitTests.General.ControllableBootstrapProvider>("bootstrap4");
+                options.ClusterConfiguration.Globals.RegisterBootstrapProvider<UnitTests.General.MockBootstrapProvider>(BootstrapProviderName1);
+                options.ClusterConfiguration.Globals.RegisterBootstrapProvider<UnitTests.General.GrainCallBootstrapper>(BootstrapProviderName2);
+                options.ClusterConfiguration.Globals.RegisterBootstrapProvider<UnitTests.General.LocalGrainInitBootstrapper>(BootstrapProviderName3);
+                options.ClusterConfiguration.Globals.RegisterBootstrapProvider<UnitTests.General.ControllableBootstrapProvider>(BootstrapProviderName4);
 
                 options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
                 options.ClusterConfiguration.AddMemoryStorageProvider("Default", numStorageGrains: 1);
@@ -36,7 +38,10 @@ namespace UnitTests.General
                 return new TestCluster(options);
             }
         }
-
+        const string BootstrapProviderName1 = "bootstrap1";
+        const string BootstrapProviderName2 = "bootstrap2";
+        const string BootstrapProviderName3 = "bootstrap3";
+        const string BootstrapProviderName4 = "bootstrap4";
         protected TestCluster HostedCluster => this.fixture.HostedCluster;
         protected IGrainFactory GrainFactory => this.fixture.GrainFactory;
 
@@ -47,22 +52,23 @@ namespace UnitTests.General
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Providers"), TestCategory("Bootstrap")]
-        public void BootstrapProvider_SiloStartsOk()
+        public async void BootstrapProvider_SiloStartsOk()
         {
-            string providerName = "bootstrap1";
-            MockBootstrapProvider bootstrapProvider = FindBootstrapProvider(providerName);
-            Assert.NotNull(bootstrapProvider);
-            Assert.Equal(1, bootstrapProvider.InitCount); // Init count
+            string providerName = BootstrapProviderName1;
+            bool canGetBootstrapProvider = await CanFindBootstrapProviderInUse(providerName);
+            Assert.True(canGetBootstrapProvider);
+            int initCount = await GetInitCountForBootstrapProviderInUse(providerName);
+            Assert.Equal(1, initCount); // Init count
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Providers"), TestCategory("Bootstrap")]
         public async Task BootstrapProvider_GrainCall()
         {
-            string providerName = "bootstrap2";
-            GrainCallBootstrapper bootstrapProvider = (GrainCallBootstrapper) FindBootstrapProvider(providerName);
-            Assert.NotNull(bootstrapProvider);
-            Assert.Equal(1, bootstrapProvider.InitCount); // Init count
-
+            string providerName = BootstrapProviderName2;
+            bool canGetBootstrapProvider = await CanFindBootstrapProviderInUse(providerName);
+            Assert.True(canGetBootstrapProvider);
+            int initCount = await GetInitCountForBootstrapProviderInUse(providerName);
+            Assert.Equal(1, initCount); // Init count
             long grainId = GrainCallBootstrapTestConstants.GrainId;
             int a = GrainCallBootstrapTestConstants.A;
             int b = GrainCallBootstrapTestConstants.B;
@@ -89,54 +95,64 @@ namespace UnitTests.General
         {
             SiloHandle[] silos = HostedCluster.GetActiveSilos().ToArray();
             int numSilos = silos.Length;
-
             string controllerType = typeof(ControllableBootstrapProvider).FullName;
-            string controllerName = "bootstrap4";
-
-            int command = 1;
-            string args = "CommandArgs";
-
+            string controllerName = BootstrapProviderName4;
+            // check all providers are registered correctly
             foreach (SiloHandle silo in silos)
             {
                 var providers = await silo.TestHook.GetAllSiloProviderNames();
 
-                Assert.Contains("bootstrap1", providers);
-                Assert.Contains("bootstrap2", providers);
-                Assert.Contains("bootstrap3", providers);
-                Assert.Contains("bootstrap4", providers);
+                Assert.Contains(BootstrapProviderName1, providers);
+                Assert.Contains(BootstrapProviderName2, providers);
+                Assert.Contains(BootstrapProviderName3, providers);
+                Assert.Contains(BootstrapProviderName4, providers);
             }
 
+            string args = "OneSetOfArgs";
             IManagementGrain mgmtGrain = GrainFactory.GetGrain<IManagementGrain>(0);
 
-            object[] replies = await mgmtGrain.SendControlCommandToProvider(controllerType, controllerName, command, args);
+            object[] replies = await mgmtGrain.SendControlCommandToProvider(controllerType, 
+               controllerName, (int)ControllableBootstrapProvider.Commands.EchoArg, args);
 
             output.WriteLine("Got {0} replies {1}", replies.Length, Utils.EnumerableToString(replies));
             Assert.Equal(numSilos, replies.Length);  //  "Expected to get {0} replies to command {1}", numSilos, command
-            Assert.True(replies.All(reply => reply.ToString().Equals(command.ToString())), $"Got command {command}");
+            Assert.True(replies.All(reply => reply.ToString().Equals(args)), $"Got args {args}");
 
-            command += 1;
-            replies = await mgmtGrain.SendControlCommandToProvider(controllerType, controllerName, command, args);
+            args = "DifferentSetOfArgs";
+            replies = await mgmtGrain.SendControlCommandToProvider(controllerType,
+                controllerName, (int)ControllableBootstrapProvider.Commands.EchoArg, args);
 
             output.WriteLine("Got {0} replies {1}", replies.Length, Utils.EnumerableToString(replies));
             Assert.Equal(numSilos, replies.Length);  //  "Expected to get {0} replies to command {1}", numSilos, command
-            Assert.True(replies.All(reply => reply.ToString().Equals(command.ToString())), $"Got command {command}");
+            Assert.True(replies.All(reply => reply.ToString().Equals(args)), $"Got args {args}");
         }
 
-        private MockBootstrapProvider FindBootstrapProvider(string providerName)
+        private async Task<bool> CanFindBootstrapProviderInUse(string providerName)
         {
-            MockBootstrapProvider providerInUse = null;
             List<SiloHandle> silos = HostedCluster.GetActiveSilos().ToList();
             foreach (var siloHandle in silos)
             {
-                MockBootstrapProvider provider = (MockBootstrapProvider)siloHandle.AppDomainTestHook.GetBootstrapProvider(providerName);
-                Assert.NotNull(provider);
-                providerInUse = provider;
+                bool re = await siloHandle.TestHook.CanGetBoostraperProvider(providerName);
+                if (re)
+                {
+                    return true;
+                }
             }
-            if (providerInUse == null)
+            return false;
+        }
+
+        private async Task<int> GetInitCountForBootstrapProviderInUse(string providerName)
+        {
+            var mgmt = this.fixture.GrainFactory.GetGrain<IManagementGrain>(0);
+            // request provider InitCount on all silos in this cluster
+            object[] results = await mgmt.SendControlCommandToProvider(typeof(GrainCallBootstrapper).FullName, BootstrapProviderName2, (int)MockBootstrapProvider.Commands.InitCount, null);
+            foreach (var re in results)
             {
-                Assert.True(false, $"Cannot find active storage provider currently in use, Name={providerName}");
+                int initCountOnThisProviderInThisSilo = (int) re;
+                if ((int)initCountOnThisProviderInThisSilo > 0)
+                    return initCountOnThisProviderInThisSilo;
             }
-            return providerInUse;
+            return -1;
         }
     }
 }

--- a/test/TesterInternal/General/TestingBootstrapProviders.cs
+++ b/test/TesterInternal/General/TestingBootstrapProviders.cs
@@ -16,8 +16,13 @@ namespace UnitTests.General
         public const long GrainId = 12345;
     }
 
-    public class MockBootstrapProvider : MarshalByRefObject, IBootstrapProvider
+    public class MockBootstrapProvider : IControllable, IBootstrapProvider
     {
+        public enum Commands
+        {
+            InitCount = 1
+        }
+
         private int initCount;
 
         public string Name { get; private set; }
@@ -49,6 +54,17 @@ namespace UnitTests.General
         {
             logger.Info("Close Name={0}", Name);
             return TaskDone.Done;
+        }
+
+        public Task<object> ExecuteCommand(int command, object arg)
+        {
+            switch ((Commands) command)
+            {
+                case Commands.InitCount:
+                    return Task.FromResult<object>(this.InitCount);
+                default:
+                    return Task.FromResult<object>(true);
+            }
         }
     }
 
@@ -124,6 +140,11 @@ namespace UnitTests.General
 
     public class ControllableBootstrapProvider : MockBootstrapProvider, IControllable
     {
+        public new enum Commands
+        {
+            EchoArg = 2
+        }
+
         private Guid serviceId;
         private string siloId;
 
@@ -147,18 +168,28 @@ namespace UnitTests.General
             logger.Info("Finished Init instance id {0} on silo {1} in service {2}", myId, siloId, serviceId);
         }
 
+        private object EchoArg(object arg)
+        {
+            logger.Info("ExecuteCommand {0} for instance id {1} on silo {2} with arg={3}", "EchoArg", myId, siloId, arg);
+            logger.Info("Finished ExecuteCommand {0} for instance id {1} on silo {2}", "EchoArg", myId, siloId);
+            return arg;
+        }
+
         #region IControllable interface methods
         /// <summary>
         /// A function to execute a control command.
         /// </summary>
         /// <param name="command">A serial number of the command.</param>
         /// <param name="arg">An opaque command argument</param>
-        public async Task<object> ExecuteCommand(int command, object arg)
+        public new Task<object> ExecuteCommand(int command, object arg)
         {
-            logger.Info("ExecuteCommand {0} for instance id {1} on silo {2} with arg={3}", command, myId, siloId, arg);
-            await Task.Delay(1);
-            logger.Info("Finished ExecuteCommand {0} for instance id {1} on silo {2}", command, myId, siloId);
-            return command;
+            switch ((Commands) command)
+            {
+                case Commands.EchoArg:
+                    return Task.FromResult(EchoArg(arg));
+                default:
+                    return base.ExecuteCommand(command, arg);
+            }
         }
         #endregion
     }

--- a/test/TesterInternal/General/TestingBootstrapProviders.cs
+++ b/test/TesterInternal/General/TestingBootstrapProviders.cs
@@ -56,7 +56,7 @@ namespace UnitTests.General
             return TaskDone.Done;
         }
 
-        public Task<object> ExecuteCommand(int command, object arg)
+        public virtual Task<object> ExecuteCommand(int command, object arg)
         {
             switch ((Commands) command)
             {
@@ -181,7 +181,7 @@ namespace UnitTests.General
         /// </summary>
         /// <param name="command">A serial number of the command.</param>
         /// <param name="arg">An opaque command argument</param>
-        public new Task<object> ExecuteCommand(int command, object arg)
+        public override Task<object> ExecuteCommand(int command, object arg)
         {
             switch ((Commands) command)
             {

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -31,38 +31,41 @@ namespace UnitTests.StorageTests
     {
         public class Fixture : BaseTestClusterFixture
         {
+
             protected override TestCluster CreateTestCluster()
             {
                 var options = new TestClusterOptions(initialSilosCount: 1);
-                options.ClusterConfiguration.Globals.RegisterStorageProvider<MockStorageProvider>("test1");
-                options.ClusterConfiguration.Globals.RegisterStorageProvider<MockStorageProvider>("test2", new Dictionary<string, string> { { "Config1", "1" }, { "Config2", "2" } });
-                options.ClusterConfiguration.Globals.RegisterStorageProvider<ErrorInjectionStorageProvider>("ErrorInjector");
-                options.ClusterConfiguration.Globals.RegisterStorageProvider<MockStorageProvider>("lowercase");
+                options.ClusterConfiguration.Globals.RegisterStorageProvider<MockStorageProvider>(MockStorageProviderName1);
+                options.ClusterConfiguration.Globals.RegisterStorageProvider<MockStorageProvider>(MockStorageProviderName2, new Dictionary<string, string> { { "Config1", "1" }, { "Config2", "2" } });
+                options.ClusterConfiguration.Globals.RegisterStorageProvider<ErrorInjectionStorageProvider>(MockStorageProviderNameErrorInjector);
+                options.ClusterConfiguration.Globals.RegisterStorageProvider<MockStorageProvider>(MockStorageProviderNameLowerCase);
                 options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore");
 
                 return new TestCluster(options);
             }
         }
 
-        const string ErrorInjectorStorageProvider = "ErrorInjector";
+        const string MockStorageProviderName1 = "test1";
+        const string MockStorageProviderName2 = "test2";
+        const string MockStorageProviderNameLowerCase = "lowercase";
+        const string MockStorageProviderNameErrorInjector = "ErrorInjector";
         private readonly ITestOutputHelper output;
         protected TestCluster HostedCluster { get; }
-
         public PersistenceGrainTests_Local(ITestOutputHelper output, Fixture fixture)
         {
             this.output = output;
             HostedCluster = fixture.HostedCluster;
-            SetErrorInjection(ErrorInjectorStorageProvider, ErrorInjectionPoint.None);
+            SetErrorInjection(MockStorageProviderNameErrorInjector, ErrorInjectionPoint.None);
             ResetMockStorageProvidersHistory();
         }
 
         public void Dispose()
         {
-            SetErrorInjection(ErrorInjectorStorageProvider, ErrorInjectionPoint.None);
+            SetErrorInjection(MockStorageProviderNameErrorInjector, ErrorInjectionPoint.None);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
-        public async Task Persistence_Silo_StorageProviders()
+        public async Task Persistence_Silo_StorageProvidersLoaded()
         {
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             foreach (var silo in silos)
@@ -70,21 +73,14 @@ namespace UnitTests.StorageTests
                 ICollection<string> providers = await silo.TestHook.GetStorageProviderNames();
                 Assert.NotNull(providers); // Null provider manager
                 Assert.True(providers.Count > 0, "Some providers loaded");
-                const string providerName = "test1";
-                IStorageProvider storageProvider = silo.AppDomainTestHook.GetStorageProvider(providerName);
-                Assert.NotNull(storageProvider);
-            }
-        }
-
-        [Fact, TestCategory("Functional"), TestCategory("Persistence")]
-        public void Persistence_Silo_StorageProvider_Name_LowerCase()
-        {
-            List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
-            foreach (var silo in silos)
-            {
-                const string providerName = "LowerCase";
-                IStorageProvider storageProvider = silo.AppDomainTestHook.GetStorageProvider(providerName);
-                Assert.NotNull(storageProvider);
+                Assert.True(silo.TestHook.CanGetStorageProvider(MockStorageProviderName1).Result,
+                    $"provider {MockStorageProviderName1} on silo {silo.Name} should be registered");
+                Assert.True(silo.TestHook.CanGetStorageProvider(MockStorageProviderName2).Result,
+                    $"provider {MockStorageProviderName2} on silo {silo.Name} should be registered");
+                Assert.True(silo.TestHook.CanGetStorageProvider(MockStorageProviderNameLowerCase).Result,
+                    $"provider {MockStorageProviderNameLowerCase} on silo {silo.Name} should be registered");
+                Assert.True(silo.TestHook.CanGetStorageProvider(MockStorageProviderNameErrorInjector).Result,
+                    $"provider {MockStorageProviderNameErrorInjector} on silo {silo.Name} should be registered");
             }
         }
 
@@ -94,10 +90,8 @@ namespace UnitTests.StorageTests
             List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
             var silo = silos.First();
             const string providerName = "NotPresent";
-            Assert.Throws<KeyNotFoundException>(() =>
-            {
-                IStorageProvider store = silo.AppDomainTestHook.GetStorageProvider(providerName);
-            });
+            Assert.False(silo.TestHook.CanGetStorageProvider(providerName).Result,
+                    $"provider {providerName} on silo {silo.Name} should not be registered");
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
@@ -121,21 +115,22 @@ namespace UnitTests.StorageTests
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Grain_Init()
         {
-            const string providerName = "test1";
             Guid id = Guid.NewGuid();
             IPersistenceTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceTestGrain>(id);
-
             await grain.DoSomething();
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName);
+            //request InitCount on providers on all silos in this cluster
+            IManagementGrain mgmtGrain = this.HostedCluster.GrainFactory.GetGrain<IManagementGrain>(0);
+            object[] replies = await mgmtGrain.SendControlCommandToProvider(typeof(MockStorageProvider).FullName,
+               MockStorageProviderName1, (int)MockStorageProvider.Commands.InitCount, null);
 
-            Assert.Equal(1, storageProvider.InitCount); // StorageProvider #Init
+            Assert.True(replies.Contains(1)); // StorageProvider #Init
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Grain_Activate_StoredValue()
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             string grainType = typeof(PersistenceTestGrain).FullName;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
@@ -144,7 +139,7 @@ namespace UnitTests.StorageTests
 
             // Store initial value in storage
             int initialValue = 567;
-            SetStoredValue<PersistenceTestGrainState>(providerName, grainType, grain, "Field1", initialValue);
+            SetStoredValue(providerName, typeof(MockStorageProvider).FullName, grainType, grain, "Field1", initialValue);
 
             int readValue = await grain.GetValue();
             Assert.Equal(initialValue, readValue); // Read previously stored value
@@ -153,7 +148,7 @@ namespace UnitTests.StorageTests
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Generics")]
         public async Task Persistence_Grain_Activate_StoredValue_Generic() 
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             string grainType = typeof(PersistenceTestGenericGrain<int>).FullName;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
@@ -162,7 +157,7 @@ namespace UnitTests.StorageTests
 
             // Store initial value in storage
             int initialValue = 567;
-            SetStoredValue<PersistenceTestGrainState>(providerName, grainType, grain, "Field1", initialValue);
+            SetStoredValue(providerName, typeof(MockStorageProvider).FullName, grainType, grain, "Field1", initialValue);
 
             int readValue = await grain.GetValue();
             Assert.Equal(initialValue, readValue); // Read previously stored value
@@ -171,7 +166,7 @@ namespace UnitTests.StorageTests
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Grain_Activate_Error()
         {
-            const string providerName = ErrorInjectorStorageProvider;
+            const string providerName = MockStorageProviderNameErrorInjector;
             string grainType = typeof(PersistenceProviderErrorGrain).FullName;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
@@ -180,7 +175,7 @@ namespace UnitTests.StorageTests
 
             // Store initial value in storage
             int initialValue = 567;
-            SetStoredValue<PersistenceTestGrainState>(providerName, grainType, grain, "Field1", initialValue);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", initialValue);
 
             SetErrorInjection(providerName, ErrorInjectionPoint.BeforeRead);
 
@@ -191,46 +186,45 @@ namespace UnitTests.StorageTests
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Grain_Read()
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             Guid id = Guid.NewGuid();
             IPersistenceTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceTestGrain>(id);
 
             await grain.DoSomething();
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName);
-
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(0, storageProvider.WriteCount); // StorageProvider #Writes
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Grain_Write()
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             Guid id = Guid.NewGuid();
             IPersistenceTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceTestGrain>(id);
 
             await grain.DoWrite(1);
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName);
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(1, storageProvider.WriteCount); // StorageProvider #Writes
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(1, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            Assert.Equal(1, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(1, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             await grain.DoWrite(2);
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(2, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(2, storageProvider.WriteCount); // StorageProvider #Writes
-
-            Assert.Equal(2, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(2, providerState.LastStoredGrainState.Field1); // Store-Field1
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Grain_ReRead()
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             string grainType = typeof(PersistenceTestGrain).FullName;
 
             Guid guid = Guid.NewGuid();
@@ -239,19 +233,18 @@ namespace UnitTests.StorageTests
 
             await grain.DoSomething();
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName);
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(0, storageProvider.WriteCount); // StorageProvider #Writes
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", 42); // Update state data behind grain
-
-
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
+            SetStoredValue(providerName, typeof(MockStorageProvider).FullName, grainType, grain, "Field1", 42);
+            
             await grain.DoRead();
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(2, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads-2
+            Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes-2
 
-            Assert.Equal(2, storageProvider.ReadCount); // StorageProvider #Reads-2
-            Assert.Equal(0, storageProvider.WriteCount); // StorageProvider #Writes-2
-
-            Assert.Equal(42, ((PersistenceTestGrainState)storageProvider.LastState).Field1); // Store-Field1
+            Assert.Equal(42, providerState.LastStoredGrainState.Field1); // Store-Field1
         }
         
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("MemoryStore")]
@@ -328,72 +321,73 @@ namespace UnitTests.StorageTests
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Write()
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             Guid id = Guid.NewGuid();
             IPersistenceTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceTestGrain>(id);
 
             await grain.DoWrite(1);
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName);
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(1, storageProvider.WriteCount); // StorageProvider #Writes
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(1, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            Assert.Equal(1, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(1, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             await grain.DoWrite(2);
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(2, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(2, storageProvider.WriteCount); // StorageProvider #Writes
-
-            Assert.Equal(2, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(2, providerState.LastStoredGrainState.Field1); // Store-Field1
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Delete()
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             Guid id = Guid.NewGuid();
             IPersistenceTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceTestGrain>(id);
 
             await grain.DoWrite(1);
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName);
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
-            int initialReadCount = storageProvider.ReadCount;
-            int initialWriteCount = storageProvider.WriteCount;
-            int initialDeleteCount = storageProvider.DeleteCount;
+            int initialReadCount = providerState.ProviderStateForTest.ReadCount;
+            int initialWriteCount = providerState.ProviderStateForTest.WriteCount;
+            int initialDeleteCount = providerState.ProviderStateForTest.DeleteCount;
 
             await grain.DoDelete();
-
-            Assert.Equal(initialDeleteCount + 1, storageProvider.DeleteCount); // StorageProvider #Deletes
-            Assert.Equal(null, storageProvider.LastState); // Store-AfterDelete-Empty
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(initialDeleteCount + 1, providerState.ProviderStateForTest.DeleteCount); // StorageProvider #Deletes
+            Assert.Equal(null, providerState.LastStoredGrainState); // Store-AfterDelete-Empty
 
             int val = await grain.GetValue(); // Returns current in-memory null data without re-read.
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName); // update state
             Assert.Equal(0, val); // Value after Delete
-            Assert.Equal(initialReadCount, storageProvider.ReadCount); // StorageProvider #Reads
+            Assert.Equal(initialReadCount, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
 
             await grain.DoWrite(2);
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName); // update state
+            Assert.Equal(initialReadCount, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(initialWriteCount + 1, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            Assert.Equal(initialReadCount, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(initialWriteCount + 1, storageProvider.WriteCount); // StorageProvider #Writes
-
-            Assert.Equal(2, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(2, providerState.LastStoredGrainState.Field1); // Store-Field1
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Grain_Read_Error()
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             Guid id = Guid.NewGuid();
             IPersistenceErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceErrorGrain>(id);
 
             var val = await grain.GetValue();
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName);
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(0, storageProvider.WriteCount); // StorageProvider #Writes
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
             try
             {
@@ -416,8 +410,9 @@ namespace UnitTests.StorageTests
                 }
             }
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads-2
-            Assert.Equal(0, storageProvider.WriteCount); // StorageProvider #Writes-2
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads-2
+            Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes-2
 
             try
             {
@@ -439,33 +434,33 @@ namespace UnitTests.StorageTests
                     throw e;
                 }
             }
-
-            Assert.Equal(2, storageProvider.ReadCount); // StorageProvider #Reads-2
-            Assert.Equal(0, storageProvider.WriteCount); // StorageProvider #Writes-2
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(2, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads-2
+            Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes-2
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Grain_Write_Error()
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             Guid id = Guid.NewGuid();
             IPersistenceErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceErrorGrain>(id);
 
             await grain.DoWrite(1);
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName);
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(1, storageProvider.WriteCount); // StorageProvider #Writes
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(1, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            Assert.Equal(1, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(1, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             await grain.DoWrite(2);
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(2, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(2, storageProvider.WriteCount); // StorageProvider #Writes
-
-            Assert.Equal(2, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(2, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             try
             {
@@ -486,11 +481,11 @@ namespace UnitTests.StorageTests
                     throw;
                 }
             }
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName); // update provider state
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(2, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(2, storageProvider.WriteCount); // StorageProvider #Writes
-
-            Assert.Equal(2, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(2, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             try
             {
@@ -511,11 +506,11 @@ namespace UnitTests.StorageTests
                     throw;
                 }
             }
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(3, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(3, storageProvider.WriteCount); // StorageProvider #Writes
-
-            Assert.Equal(4, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(4, providerState.LastStoredGrainState.Field1); // Store-Field1
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
@@ -530,26 +525,26 @@ namespace UnitTests.StorageTests
 
             var val = await grain.GetValue();
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName);
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
 
-            Assert.Equal(1, storageProvider.ReadCount); // StorageProvider #Reads
-            Assert.Equal(0, storageProvider.WriteCount); // StorageProvider #Writes
+            Assert.Equal(1, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads
+            Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes
 
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", 42);
+            SetStoredValue(providerName, typeof(MockStorageProvider).FullName, grainType, grain, "Field1", 42);
 
             await grain.DoRead();
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(2, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads-2
+            Assert.Equal(0, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes-2
 
-            Assert.Equal(2, storageProvider.ReadCount); // StorageProvider #Reads-2
-            Assert.Equal(0, storageProvider.WriteCount); // StorageProvider #Writes-2
-
-            Assert.Equal(42, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(42, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             await grain.DoWrite(43);
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(2, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads-2
+            Assert.Equal(1, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes-2
 
-            Assert.Equal(2, storageProvider.ReadCount); // StorageProvider #Reads-2
-            Assert.Equal(1, storageProvider.WriteCount); // StorageProvider #Writes-2
-
-            Assert.Equal(43, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(43, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             try
             {
@@ -570,11 +565,11 @@ namespace UnitTests.StorageTests
                     throw;
                 }
             }
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(2, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads-2
+            Assert.Equal(1, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes-2
 
-            Assert.Equal(2, storageProvider.ReadCount); // StorageProvider #Reads-2
-            Assert.Equal(1, storageProvider.WriteCount); // StorageProvider #Writes-2
-
-            Assert.Equal(43, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(43, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             try
             {
@@ -595,18 +590,18 @@ namespace UnitTests.StorageTests
                     throw;
                 }
             }
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(MockStorageProvider).FullName);
+            Assert.Equal(3, providerState.ProviderStateForTest.ReadCount); // StorageProvider #Reads-2
+            Assert.Equal(1, providerState.ProviderStateForTest.WriteCount); // StorageProvider #Writes-2
 
-            Assert.Equal(3, storageProvider.ReadCount); // StorageProvider #Reads-2
-            Assert.Equal(1, storageProvider.WriteCount); // StorageProvider #Writes-2
-
-            Assert.Equal(43, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            Assert.Equal(43, providerState.LastStoredGrainState.Field1); // Store-Field1
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Provider_Error_BeforeRead()
         {
             string grainType = typeof(PersistenceProviderErrorGrain).FullName;
-
+            string providerName = MockStorageProviderNameErrorInjector;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
             IPersistenceProviderErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorGrain>(guid);
@@ -614,19 +609,16 @@ namespace UnitTests.StorageTests
             var val = await grain.GetValue(); // Activate grain
             int expectedVal = 42;
 
-            ErrorInjectionStorageProvider storageProvider = (ErrorInjectionStorageProvider)FindStorageProviderInUse(ErrorInjectorStorageProvider);
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
-
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", expectedVal);
-
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
             val = await grain.DoRead();
 
             Assert.Equal(expectedVal, val); // Returned value
-
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.BeforeRead);
+            SetErrorInjection(providerName, ErrorInjectionPoint.BeforeRead);
+            
             CheckStorageProviderErrors(grain.DoRead);
 
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
 
             val = await grain.GetValue();
             Assert.Equal(expectedVal, val); // Returned value
@@ -636,7 +628,7 @@ namespace UnitTests.StorageTests
         public async Task Persistence_Provider_Error_AfterRead()
         {
             string grainType = typeof(PersistenceProviderErrorGrain).FullName;
-
+            string providerName = MockStorageProviderNameErrorInjector;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
             IPersistenceProviderErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorGrain>(guid);
@@ -644,25 +636,22 @@ namespace UnitTests.StorageTests
             var val = await grain.GetValue(); // Activate grain
             int expectedVal = 52;
 
-            ErrorInjectionStorageProvider storageProvider = (ErrorInjectionStorageProvider)FindStorageProviderInUse(ErrorInjectorStorageProvider);
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
-
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", expectedVal);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
 
             val = await grain.DoRead();
 
             Assert.Equal(expectedVal, val); // Returned value
 
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.AfterRead);
+            SetErrorInjection(providerName, ErrorInjectionPoint.AfterRead);
             CheckStorageProviderErrors(grain.DoRead);
 
             val = await grain.GetValue();
             Assert.Equal(expectedVal, val); // Returned value
 
             int newVal = 53;
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
-
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", newVal);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", newVal);
 
             val = await grain.GetValue();
             Assert.Equal(expectedVal, val); // Returned value
@@ -678,27 +667,29 @@ namespace UnitTests.StorageTests
         public async Task Persistence_Provider_Error_BeforeWrite()
         {
             Guid id = Guid.NewGuid();
+            string providerName = MockStorageProviderNameErrorInjector;
             IPersistenceProviderErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorGrain>(id);
 
             var val = await grain.GetValue();
 
-            ErrorInjectionStorageProvider storageProvider = (ErrorInjectionStorageProvider)FindStorageProviderInUse(ErrorInjectorStorageProvider);
-
             int expectedVal = 62;
             await grain.DoWrite(expectedVal);
-            Assert.Equal(expectedVal, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(ErrorInjectionStorageProvider).FullName);
+            Assert.Equal(expectedVal, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             const int attemptedVal3 = 63;
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.BeforeWrite);
+            SetErrorInjection(providerName, ErrorInjectionPoint.BeforeWrite);
             CheckStorageProviderErrors(() => grain.DoWrite(attemptedVal3));
 
             // Stored value unchanged
-            Assert.Equal(expectedVal, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(ErrorInjectionStorageProvider).FullName);
+            Assert.Equal(expectedVal, providerState.LastStoredGrainState.Field1); // Store-Field1
 
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
             val = await grain.GetValue();
             // Stored value unchanged
-            Assert.Equal(expectedVal, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(ErrorInjectionStorageProvider).FullName);
+            Assert.Equal(expectedVal, providerState.LastStoredGrainState.Field1); // Store-Field1
 #if REREAD_STATE_AFTER_WRITE_FAILED
             Assert.Equal(expectedVal, val); // Last value written successfully
 #else
@@ -710,24 +701,25 @@ namespace UnitTests.StorageTests
         public async Task Persistence_Provider_Error_AfterWrite()
         {
             Guid id = Guid.NewGuid();
+            string providerName = MockStorageProviderNameErrorInjector;
             IPersistenceProviderErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorGrain>(id);
 
             var val = await grain.GetValue();
 
-            ErrorInjectionStorageProvider storageProvider = (ErrorInjectionStorageProvider)FindStorageProviderInUse(ErrorInjectorStorageProvider);
-
             int expectedVal = 82;
             await grain.DoWrite(expectedVal);
-            Assert.Equal(expectedVal, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(ErrorInjectionStorageProvider).FullName);
+            Assert.Equal(expectedVal, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             const int attemptedVal4 = 83;
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.AfterWrite);
+            SetErrorInjection(providerName, ErrorInjectionPoint.AfterWrite);
             CheckStorageProviderErrors(() => grain.DoWrite(attemptedVal4));
 
             // Stored value has changed
             expectedVal = attemptedVal4;
-            Assert.Equal(expectedVal, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
+            providerState = GetStateForStorageProviderInUse(providerName, typeof(ErrorInjectionStorageProvider).FullName);
+            Assert.Equal(expectedVal, providerState.LastStoredGrainState.Field1); // Store-Field1
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
             val = await grain.GetValue();
             Assert.Equal(expectedVal, val); // Returned value
         }
@@ -736,29 +728,26 @@ namespace UnitTests.StorageTests
         public async Task Persistence_Provider_Error_BeforeReRead()
         {
             string grainType = typeof(PersistenceProviderErrorGrain).FullName;
-
+            string providerName = MockStorageProviderNameErrorInjector;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
             IPersistenceProviderErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorGrain>(guid);
 
             var val = await grain.GetValue();
-
-            ErrorInjectionStorageProvider storageProvider = (ErrorInjectionStorageProvider)FindStorageProviderInUse(ErrorInjectorStorageProvider);
-
             int expectedVal = 72;
-
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", expectedVal);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
             val = await grain.DoRead();
             Assert.Equal(expectedVal, val); // Returned value
 
             expectedVal = 73;
             await grain.DoWrite(expectedVal);
-            Assert.Equal(expectedVal, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(ErrorInjectionStorageProvider).FullName);
+            Assert.Equal(expectedVal, providerState.LastStoredGrainState.Field1); // Store-Field1
 
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.BeforeRead);
+            SetErrorInjection(providerName, ErrorInjectionPoint.BeforeRead);
             CheckStorageProviderErrors(grain.DoRead);
 
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
             val = await grain.GetValue();
             Assert.Equal(expectedVal, val); // Returned value
         }
@@ -767,32 +756,29 @@ namespace UnitTests.StorageTests
         public async Task Persistence_Provider_Error_AfterReRead()
         {
             string grainType = typeof(PersistenceProviderErrorGrain).FullName;
-
+            string providerName = MockStorageProviderNameErrorInjector;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
             IPersistenceProviderErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceProviderErrorGrain>(guid);
 
             var val = await grain.GetValue();
 
-            ErrorInjectionStorageProvider storageProvider = (ErrorInjectionStorageProvider)FindStorageProviderInUse(ErrorInjectorStorageProvider);
-
             int expectedVal = 92;
-
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", expectedVal);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
             val = await grain.DoRead();
             Assert.Equal(expectedVal, val); // Returned value
 
             expectedVal = 93;
             await grain.DoWrite(expectedVal);
-            Assert.Equal(expectedVal, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(ErrorInjectionStorageProvider).FullName);
+            Assert.Equal(expectedVal, providerState.LastStoredGrainState.Field1); // Store-Field1
 
             expectedVal = 94;
-
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", expectedVal);
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.AfterRead);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
+            SetErrorInjection(providerName, ErrorInjectionPoint.AfterRead);
             CheckStorageProviderErrors(grain.DoRead);
 
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
             val = await grain.GetValue();
             Assert.Equal(expectedVal, val); // Returned value
         }
@@ -801,7 +787,7 @@ namespace UnitTests.StorageTests
         public async Task Persistence_Error_Handled_Read()
         {
             string grainType = typeof(PersistenceUserHandledErrorGrain).FullName;
-
+            string providerName = MockStorageProviderNameErrorInjector;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
             IPersistenceUserHandledErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceUserHandledErrorGrain>(guid);
@@ -809,10 +795,8 @@ namespace UnitTests.StorageTests
             var val = await grain.GetValue(); // Activate grain
             int expectedVal = 42;
 
-            ErrorInjectionStorageProvider storageProvider = (ErrorInjectionStorageProvider)FindStorageProviderInUse(ErrorInjectorStorageProvider);
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
-
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", expectedVal);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
 
             val = await grain.DoRead(false);
 
@@ -820,16 +804,14 @@ namespace UnitTests.StorageTests
 
             int newVal = expectedVal + 1;
 
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", newVal);
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.BeforeRead);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", newVal);
+            SetErrorInjection(providerName, ErrorInjectionPoint.BeforeRead);
             val = await grain.DoRead(true);
             Assert.Equal(expectedVal, val); // Returned value
-
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
-
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
             expectedVal = newVal;
 
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", newVal);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", newVal);
             val = await grain.DoRead(false);
             Assert.Equal(expectedVal, val); // Returned value
         }
@@ -838,7 +820,7 @@ namespace UnitTests.StorageTests
         public async Task Persistence_Error_Handled_Write()
         {
             string grainType = typeof(PersistenceUserHandledErrorGrain).FullName;
-
+            string providerName = MockStorageProviderNameErrorInjector;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
             IPersistenceUserHandledErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceUserHandledErrorGrain>(guid);
@@ -846,22 +828,20 @@ namespace UnitTests.StorageTests
             var val = await grain.GetValue(); // Activate grain
             int expectedVal = 42;
 
-            ErrorInjectionStorageProvider storageProvider = (ErrorInjectionStorageProvider)FindStorageProviderInUse(ErrorInjectorStorageProvider);
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
-
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", expectedVal);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
 
             val = await grain.DoRead(false);
 
             Assert.Equal(expectedVal, val); // Returned value
 
             int newVal = expectedVal + 1;
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.BeforeWrite);
+            SetErrorInjection(providerName, ErrorInjectionPoint.BeforeWrite);
             await grain.DoWrite(newVal, true);
             val = await grain.GetValue();
             Assert.Equal(expectedVal, val); // Returned value
 
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
 
             expectedVal = newVal;
             await grain.DoWrite(newVal, false);
@@ -873,7 +853,7 @@ namespace UnitTests.StorageTests
         public async Task Persistence_Error_NotHandled_Write()
         {
             string grainType = typeof(PersistenceUserHandledErrorGrain).FullName;
-
+            string providerName = MockStorageProviderNameErrorInjector;
             Guid guid = Guid.NewGuid();
             string id = guid.ToString("N");
             IPersistenceUserHandledErrorGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceUserHandledErrorGrain>(guid);
@@ -881,28 +861,26 @@ namespace UnitTests.StorageTests
             var val = await grain.GetValue(); // Activate grain
             int expectedVal = 42;
 
-            ErrorInjectionStorageProvider storageProvider = (ErrorInjectionStorageProvider)FindStorageProviderInUse(ErrorInjectorStorageProvider);
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
-            storageProvider.SetValue<PersistenceTestGrainState>(grainType, (GrainReference)grain, "Field1", expectedVal);
-
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
+            SetStoredValue(providerName, typeof(ErrorInjectionStorageProvider).FullName, grainType, grain, "Field1", expectedVal);
             val = await grain.DoRead(false);
 
             Assert.Equal(expectedVal, val); // Returned value after read
 
             int newVal = expectedVal + 1;
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.BeforeWrite);
+            SetErrorInjection(providerName, ErrorInjectionPoint.BeforeWrite);
             CheckStorageProviderErrors(() => grain.DoWrite(newVal, false));
 
             val = await grain.GetValue();
             // Stored value unchanged
-            Assert.Equal(expectedVal, storageProvider.GetLastState<PersistenceTestGrainState>().Field1); // Store-Field1
+            var providerState = GetStateForStorageProviderInUse(providerName, typeof(ErrorInjectionStorageProvider).FullName);
+            Assert.Equal(expectedVal, providerState.LastStoredGrainState.Field1); // Store-Field1
 #if REREAD_STATE_AFTER_WRITE_FAILED
             Assert.Equal(expectedVal, val); // After failed write: Last value written successfully
 #else
             Assert.Equal(newVal, val); // After failed write: Last value attempted to be written is still in memory
 #endif
-
-            storageProvider.SetErrorInjection(ErrorInjectionPoint.None);
+            SetErrorInjection(providerName, ErrorInjectionPoint.None);
 
             expectedVal = newVal;
             await grain.DoWrite(newVal, false);
@@ -925,7 +903,7 @@ namespace UnitTests.StorageTests
                 Guid guid = grain.GetPrimaryKey();
                 string id = guid.ToString("N");
 
-                this.SetStoredValue<PersistenceTestGrainState>("test1", grainType, grain, "Field1", expectedVal); // Update state data behind grain
+                SetStoredValue(MockStorageProviderName1, typeof(MockStorageProvider).FullName, grainType, grain, "Field1", expectedVal); // Update state data behind grain
                 promises[i] = grain.DoRead();
             }
             await Task.WhenAll(promises);
@@ -1012,15 +990,13 @@ namespace UnitTests.StorageTests
         [Fact, TestCategory("Functional"), TestCategory("Persistence")]
         public async Task Persistence_Grain_NoState()
         {
-            const string providerName = "test1";
+            const string providerName = MockStorageProviderName1;
             Guid id = Guid.NewGuid();
             IPersistenceNoStateTestGrain grain = this.HostedCluster.GrainFactory.GetGrain<IPersistenceNoStateTestGrain>(id);
 
             await grain.DoSomething();
 
-            MockStorageProvider storageProvider = FindStorageProviderInUse(providerName, true);
-
-            Assert.Equal(null, storageProvider); // StorageProvider found
+            Assert.True(CanGetStorageProviderInUse(providerName));
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Persistence"), TestCategory("Serialization")]
@@ -1143,24 +1119,25 @@ namespace UnitTests.StorageTests
         
         #region Utility functions
         // ---------- Utility functions ----------
-        private void SetStoredValue<TState>(string providerName, string grainType, IGrain grain, string fieldName, int newValue)
+        private void SetStoredValue(string providerName, string providerTypeFullName, string grainType, IGrain grain, string fieldName, int newValue)
         {
-            List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
-            foreach (var siloHandle in silos)
-            {
-                MockStorageProvider provider = (MockStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
-                provider.SetValue<TState>(grainType, (GrainReference)grain, "Field1", newValue);
-            }
+            IManagementGrain mgmtGrain = this.HostedCluster.GrainFactory.GetGrain<IManagementGrain>(0);
+            // set up SetVal func args
+            var args = new MockStorageProvider.SetValueArgs();
+            args.Val = newValue;
+            args.Name = "Field1";
+            args.GrainType = grainType;
+            args.GrainReference = (GrainReference)grain;
+            args.StateType = typeof(PersistenceTestGrainState);
+            mgmtGrain.SendControlCommandToProvider(providerTypeFullName,
+                providerName, (int)MockStorageProvider.Commands.SetValue, args).Wait();
         }
 
         private void SetErrorInjection(string providerName, ErrorInjectionPoint errorInjectionPoint)
         {
-            List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
-            foreach (var siloHandle in silos)
-            {
-                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
-                provider.SetErrorInjection(errorInjectionPoint);
-            }
+            IManagementGrain mgmtGrain = this.HostedCluster.GrainFactory.GetGrain<IManagementGrain>(0);
+            mgmtGrain.SendControlCommandToProvider(typeof(ErrorInjectionStorageProvider).FullName,
+                providerName, (int)MockStorageProvider.Commands.SetErrorInjection, errorInjectionPoint).Wait();
         }
 
         private void CheckStorageProviderErrors(
@@ -1200,45 +1177,58 @@ namespace UnitTests.StorageTests
                 //}
             }
         }
-
-        private MockStorageProvider FindStorageProviderInUse(string providerName, bool okNull = false)
+        private bool CanGetStorageProviderInUse(string providerName)
         {
-            MockStorageProvider providerInUse = null;
-            SiloHandle siloInUse = null;
-            List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
-            foreach (var siloHandle in silos)
+            foreach (var siloHandle in this.HostedCluster.GetActiveSilos())
             {
-                MockStorageProvider provider = (MockStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
-                Assert.NotNull(provider);
-                if (provider.ReadCount > 0)
+                if (siloHandle.TestHook.CanGetStorageProvider(providerName).Result)
                 {
-                    Assert.Null(providerInUse);
-                   
-                    providerInUse = provider;
-                    siloInUse = siloHandle;
+                    return true;
                 }
             }
+            return false;
+        }
 
-            if (!okNull && providerInUse == null)
+        private ProviderState GetStateForStorageProviderInUse(string providerName, string providerTypeFullName, bool okNull = false)
+        {
+            ProviderState providerState = new ProviderState();
+            IManagementGrain mgmtGrain = this.HostedCluster.GrainFactory.GetGrain<IManagementGrain>(0);
+            object[] replies = mgmtGrain.SendControlCommandToProvider(providerTypeFullName,
+               providerName, (int)MockStorageProvider.Commands.GetProvideState, null).Result;
+            object[] replies2 = mgmtGrain.SendControlCommandToProvider(providerTypeFullName,
+                              providerName, (int)MockStorageProvider.Commands.GetLastState, null).Result;
+            for(int i = 0; i < replies.Length; i++)
             {
-                Assert.True(false, $"Cannot find active storage provider currently in use, Name={providerName}");
+                MockStorageProvider.StateForTest state = (MockStorageProvider.StateForTest)replies[i];
+                PersistenceTestGrainState grainState = (PersistenceTestGrainState)replies2[i];
+                if (state.ReadCount > 0)
+                {
+                    providerState.ProviderStateForTest = state;
+                    providerState.LastStoredGrainState = grainState;
+                    return providerState;
+                }
             }
+            
+            return providerState;
+        }
 
-            return providerInUse;
+        class ProviderState
+        {
+            public MockStorageProvider.StateForTest ProviderStateForTest { get; set; }
+            public PersistenceTestGrainState LastStoredGrainState { get; set; }
         }
 
         private void ResetMockStorageProvidersHistory()
         {
-            var mockStorageProviders = new[] { "test1", "test2", "lowercase" };
+            var mockStorageProviders = new[] { MockStorageProviderName1, MockStorageProviderName2, MockStorageProviderNameLowerCase };
             foreach (var siloHandle in this.HostedCluster.GetActiveSilos().ToList())
             {
                 foreach (var providerName in mockStorageProviders)
                 {
-                    MockStorageProvider provider = (MockStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
-                    if (provider != null)
-                    {
-                        provider.ResetHistory();
-                    }
+                    if (!siloHandle.TestHook.CanGetStorageProvider(providerName).Result) continue;
+                    IManagementGrain mgmtGrain = this.HostedCluster.GrainFactory.GetGrain<IManagementGrain>(0);
+                    object[] replies = mgmtGrain.SendControlCommandToProvider(typeof(MockStorageProvider).FullName,
+                       providerName, (int)MockStorageProvider.Commands.ResetHistory, null).Result;
                 }
             }
         }

--- a/test/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
+++ b/test/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
@@ -125,12 +125,9 @@ namespace UnitTests.StreamingTests
 
         private void SetErrorInjection(string providerName, ErrorInjectionPoint errorInjectionPoint)
         {
-            List<SiloHandle> silos = this.HostedCluster.GetActiveSilos().ToList();
-            foreach (var siloHandle in silos)
-            {
-                ErrorInjectionStorageProvider provider = (ErrorInjectionStorageProvider)siloHandle.AppDomainTestHook.GetStorageProvider(providerName);
-                provider.SetErrorInjection(errorInjectionPoint);
-            }
+            IManagementGrain mgmtGrain = this.HostedCluster.GrainFactory.GetGrain<IManagementGrain>(0);
+            mgmtGrain.SendControlCommandToProvider(typeof(ErrorInjectionStorageProvider).FullName,
+                providerName, (int)MockStorageProvider.Commands.SetErrorInjection, errorInjectionPoint).Wait();
         }
     }
 }


### PR DESCRIPTION
Remove usage of AppDomainTestHook on BootstrapProviderTests.cs , PersistenceGrainTests.cs, and StreamPubSubReliabilityTests. 

leaving GeoClusterTests the only tests using AppDomainTestHook