### PR TITLE
Improve GrainReference deserialization for BinaryFormatter & Json.NET

### DIFF
--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -726,12 +726,24 @@ namespace Orleans.Runtime
                 genericArg = null;
             genericArguments = genericArg;
 
-#if !NETSTANDARD
-            var deserializationContext = context.Context as IDeserializationContext;
-            deserializationContext?.GrainFactory.BindGrainReference(this);
+#if !NETSTANDARD_TODO
+            var grainFactory = context.Context as IGrainFactory;
+            grainFactory?.BindGrainReference(this);
 #endif
         }
 
-        #endregion
+#if !NETSTANDARD_TODO
+        /// <summary>
+        /// Called by BinaryFormatter after deserialization has completed.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext context)
+        {
+            var grainFactory = context.Context as IGrainFactory;
+            grainFactory?.BindGrainReference(this);
+        }
+#endif
+#endregion
     }
 }

--- a/src/Orleans/Serialization/BinaryFormatterSerializer.cs
+++ b/src/Orleans/Serialization/BinaryFormatterSerializer.cs
@@ -32,7 +32,7 @@ namespace Orleans.Serialization
 
             var formatter = new BinaryFormatter
             {
-                Context = new StreamingContext(StreamingContextStates.All, context)
+                Context = new StreamingContext(StreamingContextStates.All, context.GrainFactory)
             };
             object ret = null;
             using (var memoryStream = new MemoryStream())
@@ -63,7 +63,7 @@ namespace Orleans.Serialization
 
             var formatter = new BinaryFormatter
             {
-                Context = new StreamingContext(StreamingContextStates.All, context)
+                Context = new StreamingContext(StreamingContextStates.All, context.GrainFactory)
             };
             byte[] bytes;
             using (var memoryStream = new MemoryStream())
@@ -89,7 +89,7 @@ namespace Orleans.Serialization
             var bytes = reader.ReadBytes(n);
             var formatter = new BinaryFormatter
             {
-                Context = new StreamingContext(StreamingContextStates.All, context)
+                Context = new StreamingContext(StreamingContextStates.All, context.GrainFactory)
             };
 
             object retVal = null;

--- a/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
+++ b/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
@@ -11,6 +11,7 @@ using Amazon.DynamoDBv2.Model;
 using Amazon.DynamoDBv2;
 using OrleansAWSUtils;
 using System.IO;
+using Microsoft.Extensions.DependencyInjection;
 using OrleansAWSUtils.Storage;
 
 namespace Orleans.Storage
@@ -91,7 +92,8 @@ namespace Orleans.Storage
             if (config.Properties.ContainsKey(USE_JSON_FORMAT_PROPERTY_NAME))
                 useJsonFormat = "true".Equals(config.Properties[USE_JSON_FORMAT_PROPERTY_NAME], StringComparison.OrdinalIgnoreCase);
 
-            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
+            var grainFactory = providerRuntime.ServiceProvider.GetRequiredService<IGrainFactory>();
+            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(grainFactory), config);
 
             initMsg = string.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 

--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.Blob.Protocol;
@@ -69,7 +70,8 @@ namespace Orleans.Storage
             try
             {
                 this.Name = name;
-                this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
+                var grainFactory = providerRuntime.ServiceProvider.GetRequiredService<IGrainFactory>();
+                this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(grainFactory), config);
 
                 if (!config.Properties.ContainsKey(DataConnectionStringPropertyName)) throw new BadProviderConfigException($"The {DataConnectionStringPropertyName} setting has not been configured in the cloud role. Please add a {DataConnectionStringPropertyName} setting with a valid Azure Storage connection string.");
 

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using Orleans.AzureUtils;
@@ -111,7 +112,8 @@ namespace Orleans.Storage
             if (config.Properties.ContainsKey(UseJsonFormatPropertyName))
                 useJsonFormat = "true".Equals(config.Properties[UseJsonFormatPropertyName], StringComparison.OrdinalIgnoreCase);
 
-            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(), config);
+            var grainFactory = providerRuntime.ServiceProvider.GetRequiredService<IGrainFactory>();
+            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(grainFactory), config);
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 
             Log.Info((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, initMsg);

--- a/src/OrleansTestingHost/Utils/TestingUtils.cs
+++ b/src/OrleansTestingHost/Utils/TestingUtils.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Serialization;
 
 namespace Orleans.TestingHost.Utils
 {
@@ -90,14 +91,24 @@ namespace Orleans.TestingHost.Utils
         /// <summary> Serialize and deserialize the input </summary>
         /// <typeparam name="T">The type of the input</typeparam>
         /// <param name="input">The input to serialize and deserialize</param>
+        /// <param name="grainFactory">The grain factory.</param>
         /// <returns>Input that have been serialized and then deserialized</returns>
-        public static T RoundTripDotNetSerializer<T>(T input)
+        public static T RoundTripDotNetSerializer<T>(T input, IGrainFactory grainFactory)
         {
             IFormatter formatter = new BinaryFormatter();
             MemoryStream stream = new MemoryStream(new byte[100000], true);
+#if !NETSTANDARD_TODO
+            formatter.Context = new StreamingContext(StreamingContextStates.All, grainFactory);
+#endif
             formatter.Serialize(stream, input);
             stream.Position = 0;
             T output = (T)formatter.Deserialize(stream);
+
+#if NETSTANDARD_TODO
+                // On .NET Standard, currently we need to manually fixup grain references.
+                var outputAsGrainRef = output as Orleans.Runtime.GrainReference;
+                if (outputAsGrainRef != null) grainFactory.BindGrainReference(outputAsGrainRef);
+#endif
             return output;
         }
     }

--- a/test/NonSiloTests/General/Identifiertests.cs
+++ b/test/NonSiloTests/General/Identifiertests.cs
@@ -450,7 +450,7 @@ namespace UnitTests.General
             roundTripped = SerializationManager.RoundTripSerializationForTesting(grainRef);
             Assert.Equal(grainRef, roundTripped); // GrainReference.OrleansSerializer
 
-            roundTripped = TestingUtils.RoundTripDotNetSerializer(grainRef);
+            roundTripped = TestingUtils.RoundTripDotNetSerializer(grainRef, this.environment.GrainFactory);
             Assert.Equal(grainRef, roundTripped); // GrainReference.DotNetSerializer
         }
 

--- a/test/NonSiloTests/General/InternalSerializationTests.cs
+++ b/test/NonSiloTests/General/InternalSerializationTests.cs
@@ -73,7 +73,6 @@ namespace UnitTests.Serialization
             SerializationManager.Serialize(grainReference, writer);
             var deserialized = SerializationManager.Deserialize(new BinaryTokenStreamReader(writer.ToByteArray()));
             var copy = (GrainReference)SerializationManager.DeepCopy(deserialized);
-            this.fixture.GrainFactory.BindGrainReference(copy);
 
             // Get the final value of the fallback serialization counters.
             var final = counters.Select(_ => _.GetCurrentValue()).ToList();

--- a/test/NonSiloTests/OrleansRuntime/ExceptionsTests.cs
+++ b/test/NonSiloTests/OrleansRuntime/ExceptionsTests.cs
@@ -27,7 +27,7 @@ namespace UnitTests.OrleansRuntime
             SiloAddress primaryDirectoryForGrain = SiloAddress.NewLocalAddress(6789);
            
             Catalog.DuplicateActivationException original = new Catalog.DuplicateActivationException(activationAddress, primaryDirectoryForGrain);
-            Catalog.DuplicateActivationException output = TestingUtils.RoundTripDotNetSerializer(original);
+            Catalog.DuplicateActivationException output = TestingUtils.RoundTripDotNetSerializer(original, this.fixture.GrainFactory);
 
             Assert.Equal(original.Message, output.Message);
             Assert.Equal(original.ActivationToUse, output.ActivationToUse);

--- a/test/NonSiloTests/SerializationTests/SerializationTests.DifferentTypes.cs
+++ b/test/NonSiloTests/SerializationTests/SerializationTests.DifferentTypes.cs
@@ -127,7 +127,7 @@ namespace UnitTests.Serialization
             input.Collection = new HashSet<TestTypeA>();
             input.Collection.Add(input);
 
-            TestTypeA output1 = Orleans.TestingHost.Utils.TestingUtils.RoundTripDotNetSerializer(input);
+            TestTypeA output1 = Orleans.TestingHost.Utils.TestingUtils.RoundTripDotNetSerializer(input, this.fixture.GrainFactory);
 
             TestTypeA output2 = SerializationManager.RoundTripSerializationForTesting(input);
         }


### PR DESCRIPTION
BinaryFormatter and Json.NET have a facility to pass context to types being deserialized. This PR plumbs `IGrainFactory` through that context and makes use of it during deserialization of GrainReference.

Originally I was intending to plumb some new `IExternalSerializerContext`, but figured it's best to be lightweight - we can add some new interface later if needed.

Unfortunately, while `StreamingContext` does exist on .NET Core, it's defined as a struct with no members. In other words, it's totally useless and exists only to keep method signatures consistent with Full Fx.

Functionals pass. 