### PR TITLE
Remove unnecessary service registration of IServiceProvider to itself

### DIFF
--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -107,7 +107,6 @@ namespace Orleans
             
             var services = new ServiceCollection();
             services.AddSingleton(cfg);
-            services.AddSingleton<IServiceProvider>(sp => sp);
             services.AddSingleton<TypeMetadataCache>();
             services.AddSingleton<AssemblyProcessor>();
             services.AddSingleton(this);

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -212,7 +212,6 @@ namespace Orleans.Runtime
 
             // Register system services.
             var services = new ServiceCollection();
-            services.AddSingleton(sp => sp);
             services.AddSingleton(this);
             services.AddSingleton(initializationParams);
             services.AddSingleton<ILocalSiloDetails>(initializationParams);


### PR DESCRIPTION
This registration causes a "Circular Reference" error when used with Autofac (#2747) and seems unnecessary as the DI framework provides it automatically.