### PR TITLE
Add a NuGet package for OrleansGoogleUtils.dll

### DIFF
--- a/src/NuGet/Microsoft.Orleans.OrleansGoogleUtils.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansGoogleUtils.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Orleans.OrleansGoogleUtils</id>
+    <version>$version$</version>
+    <title>Microsoft Orleans Google Utilities</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,Orleans</owners>
+    <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
+    <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
+    <summary>
+      Protocol Buffers serialization support for Microsoft Orleans.
+    </summary>
+    <description>
+      Library of utility types for Google of Microsoft Orleans.
+    </description>
+    <copyright>Copyright Microsoft 2017</copyright>
+    <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
+    <dependencies>
+      <dependency id="Microsoft.Orleans.Core" version="$version$" />
+      <dependency id="Google.Protobuf" version="3.0.0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="OrleansConsulUtils.dll" target="lib\net451" />
+    <file src="OrleansConsulUtils.pdb" target="lib\net451" />
+    <file src="$SRC_DIR$OrleansConsulUtils\**\*.cs" target="src" />
+  </files>
+</package>

--- a/src/OrleansGoogleUtils/OrleansGoogleUtils.csproj
+++ b/src/OrleansGoogleUtils/OrleansGoogleUtils.csproj
@@ -58,10 +58,6 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj">
-      <Project>{6ff2004c-cdf8-479c-bf27-c6bfe8ef93e0}</Project>
-      <Name>OrleansRuntime</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Orleans\Orleans.csproj">
       <Project>{bc1bd60c-e7d8-4452-a21c-290aec8e2e74}</Project>
       <Name>Orleans</Name>

--- a/vNext/src/OrleansGoogleUtils/OrleansGoogleUtils.csproj
+++ b/vNext/src/OrleansGoogleUtils/OrleansGoogleUtils.csproj
@@ -32,6 +32,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Orleans\Orleans.csproj" />
-    <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add a NuGet package for OrleansGoogleUtils.dll.
Remove unnecessary reference to OrleansRuntime.dll.