### PR TITLE
Avoid a NullReferenceException in SerializationManager.Register(...)

### DIFF
--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -891,6 +891,7 @@ namespace Orleans
         SerMgr_TypeRegistrationFailureIgnore    = SerializationManagerBase + 9,
         SerMgr_ArtifactReport                   = SerializationManagerBase + 10,
         SerMgr_UnavailableSerializer            = SerializationManagerBase + 11,
+        SerMgr_SerializationMethodsMissing      = SerializationManagerBase + 12,
 
         WatchdogBase                            = Runtime + 2600,
         Watchdog_ParticipantThrownException     = WatchdogBase + 1,

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -539,12 +539,22 @@ namespace Orleans.Serialization
                     MethodInfo serializer;
                     MethodInfo deserializer;
                     GetSerializationMethods(serializerType, out copier, out serializer, out deserializer);
-                    Register(
-                        type,
-                        (DeepCopier)copier.CreateDelegate(typeof(DeepCopier)),
-                        (Serializer)serializer.CreateDelegate(typeof(Serializer)),
-                        (Deserializer)deserializer.CreateDelegate(typeof(Deserializer)),
-                        true);
+                    if (serializer != null && deserializer != null && copier != null)
+                    {
+                        Register(
+                            type,
+                            (DeepCopier) copier.CreateDelegate(typeof(DeepCopier)),
+                            (Serializer) serializer.CreateDelegate(typeof(Serializer)),
+                            (Deserializer) deserializer.CreateDelegate(typeof(Deserializer)),
+                            true);
+                    }
+                    else
+                    {
+                        logger.Warn(
+                            ErrorCode.SerMgr_SerializationMethodsMissing,
+                            "Serialization methods not found on type {0}.",
+                            serializerType.GetParseableName());
+                    }
                 }
             }
             catch (ArgumentException)
@@ -552,7 +562,7 @@ namespace Orleans.Serialization
                 logger.Warn(
                     ErrorCode.SerMgr_ErrorBindingMethods,
                     "Error binding serialization methods for type {0}",
-                    type.OrleansTypeName());
+                    type.GetParseableName());
                 throw;
             }
         }


### PR DESCRIPTION
Currently, a NullReferenceException will be thrown in `SerializationManager.Register(Type, Type)` for custom serializers which are missing the serialization attributes/methods.

Reported by @kogir [in chat](https://gitter.im/dotnet/orleans?at=58ae6727de504908220331d0).

This will log a warning instead.

We ought to fix this by using Roslyn Analyzers instead of runtime errors.