### PR TITLE
Fix [NonSerialized] on .NET Core

### DIFF
--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -372,6 +372,18 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Returns <see langword="true"/> if <paramref name="field"/> is marked as
+        /// <see cref="FieldAttributes.NotSerialized"/>, <see langword="false"/> otherwise.
+        /// </summary>
+        /// <param name="field">The field.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="field"/> is marked as
+        /// <see cref="FieldAttributes.NotSerialized"/>, <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool IsNotSerialized(this FieldInfo field)
+            => (field.Attributes & FieldAttributes.NotSerialized) == FieldAttributes.NotSerialized;
+
+        /// <summary>
         /// decide whether the class is derived from Grain
         /// </summary>
         public static bool IsGrainClass(Type type)

--- a/src/Orleans/Serialization/ILSerializerGenerator.cs
+++ b/src/Orleans/Serialization/ILSerializerGenerator.cs
@@ -313,7 +313,8 @@ namespace Orleans.Serialization
                 type.GetAllFields()
                     .Where(
                         field =>
-                            field.GetCustomAttribute<NonSerializedAttribute>() == null && !field.IsStatic
+                            !field.IsNotSerialized()
+                            && !field.IsStatic
                             && IsSupportedFieldType(field.FieldType.GetTypeInfo())
                             && (fieldFilter == null || fieldFilter(field)))
                     .ToList();

--- a/src/OrleansCodeGenerator/SerializerGenerationManager.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerationManager.cs
@@ -122,7 +122,11 @@ namespace Orleans.CodeGenerator
 
         private bool IsFieldInaccessibleForSerialization(Module module, Assembly targetAssembly, FieldInfo field)
         {
-            return field.GetCustomAttributes().All(attr => attr.GetType().Name != "NonSerializedAttribute")
+            // A field is inaccessible for serialization if:
+            // * It needs to be serialized,
+            // * There is not already a serializer available for it, and
+            // * The field type is not accessible for the purpose of serialization.
+            return !field.IsNotSerialized()
                    && !this.serializationManager.HasSerializer(field.FieldType)
                    && TypeUtilities.IsTypeIsInaccessibleForSerialization(field.FieldType, module, targetAssembly);
         }

--- a/src/OrleansCodeGenerator/SerializerGenerator.cs
+++ b/src/OrleansCodeGenerator/SerializerGenerator.cs
@@ -446,7 +446,7 @@ namespace Orleans.CodeGenerator
         {
             var result =
                 type.GetAllFields()
-                    .Where(field => field.GetCustomAttribute<NonSerializedAttribute>() == null)
+                    .Where(field => !field.IsNotSerialized())
                     .Select((info, i) => new FieldInfoMember { FieldInfo = info, FieldNumber = i })
                     .ToList();
             result.Sort(FieldInfoMember.Comparer.Instance);


### PR DESCRIPTION
Our implementation which made our NonSerializedAttribute check build on .NET Core was not correct.

This fix is quite simple - and I'm silly for not knowing it earlier. Instead of looking for the `[NonSerialized]` attribute on fields, we check for the `FieldAttributes.NotSerialized` flag on the `FieldInfo.Attributes` property.

Our tests don't run on .NET Core, but I tested this method manually using a .NET Core project.

This should fix #2597 

cc @galvesribeiro. You ran into this issue when porting ClientGenerator to .NET Core - we saw some fields in the generated code which should not have been there.