### PR TITLE
Simplify instructions for running HelloWorld.NetCore

### DIFF
--- a/Samples/HelloWorld.NetCore/BuildAndRun.ps1
+++ b/Samples/HelloWorld.NetCore/BuildAndRun.ps1
@@ -1,0 +1,22 @@
+# First build the Orleans vNext nuget packages locally
+if((Test-Path "..\..\vNext\Binaries\Debug\") -eq $false) { 
+     # this will only work in Windows. 
+     # Alternatively build the nuget packages and place them in the <root>/vNext/Binaries/Debug folder 
+     # (or make sure there is a package source available with the Orleans 2.0 TP nugets)
+    ..\..\Build.cmd netstandard
+}
+
+# Uncomment the following to clear the nuget cache if rebuilding the packages doesn't seem to take effect.
+#dotnet nuget locals all --clear
+
+dotnet restore
+dotnet build
+
+# Run the 2 console apps in different windows
+
+$siloPath = (Get-Item -Path ".\src\SiloHost\" -Verbose).FullName;
+$clientPath = (Get-Item -Path ".\src\OrleansClient\" -Verbose).FullName;
+
+Start-Process "dotnet" -ArgumentList "run" -WorkingDirectory $siloPath
+Start-Sleep 10
+Start-Process "dotnet" -ArgumentList "run" -WorkingDirectory $clientPath

--- a/Samples/HelloWorld.NetCore/BuildAndRun.sh
+++ b/Samples/HelloWorld.NetCore/BuildAndRun.sh
@@ -1,0 +1,10 @@
+#/bin/bash
+
+dotnet restore
+dotnet build
+
+# Run the 2 console apps in different windows
+
+dotnet run --project ./src/SiloHost &
+sleep 10
+dotnet run --project ./src/OrleansClient &

--- a/Samples/HelloWorld.NetCore/NuGet.Config
+++ b/Samples/HelloWorld.NetCore/NuGet.Config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
-    <add key="Orleans-local-vNext" value="..\..\vNext\Binaries\Debug\" />
-    <remove key="Orleans-local" />
+    <add key="Orleans-local" value="..\..\vNext\Binaries\Debug\" />
   </packageSources>
 </configuration>

--- a/Samples/HelloWorld.NetCore/Readme.md
+++ b/Samples/HelloWorld.NetCore/Readme.md
@@ -4,27 +4,23 @@ Orleans HelloWorld sample targeting .NET Core
 ## Building the Sample
 If you are trying to use a version of Orleans that is not yet released, first run `Build.cmd netstandard` from the root directory of the repository.
 
-Note: If you need to reinstall packages (for example, after making changes to the Orleans runtime and rebuilding the packages), just manually delete all Orleans packages from `(rootfolder)/Samples/{specific-sample}/packages/` and re-run `Build.cmd netstandard`. You might sometimes also need to clean up the NuGet cache folder.
+Note: If you need to reinstall packages (for example, after making changes to the Orleans runtime and rebuilding the packages), just manually delete all Orleans packages from `(rootfolder)/Samples/{specific-sample}/packages/` and re-run `Build.cmd netstandard`. You might sometimes also need to clean up the NuGet cache folder. In order to do that, run `dotnet nuget locals all --clear`.
 
 You can then compile as usual, build solution.
 
 ```
 dotnet restore
 dotnet build
-dotnet publish
 ```
 
 ## Running the Sample
-It's important to publish the apps before running them, as Orleans loads several assemblies via reflection and they need to be colocated.
-In order to do this, from 2 different command prompts, you can run:
-
 To start the silo
 ```
-dotnet src\SiloHost\bin\Debug\netcoreapp1.1\publish\SiloHost.dll
+dotnet src\SiloHost\bin\Debug\netcoreapp1.1\SiloHost.dll
 ```
 
 
 To start the client
 ```
-dotnet bin\Debug\netcoreapp1.1\publish\OrleansClient.dll
+dotnet src\OrleansClient\bin\Debug\netcoreapp1.1\OrleansClient.dll
 ```

--- a/Samples/HelloWorld.NetCore/Readme.md
+++ b/Samples/HelloWorld.NetCore/Readme.md
@@ -1,7 +1,18 @@
 # HelloWorld.NetCore
 Orleans HelloWorld sample targeting .NET Core
 
-## Building the Sample
+## Build and run the sample in Windows
+The easiest way to build and run the sample in Windows is to execute the `BuildAndRun.ps1` PowerShell script.
+
+## Build and run the sample in non-Windows platforms
+On other platforms you will have to either first build the NuGet packages in a Windows machine (calling `Build.cmd netstandard`) and then make them available in the target platform, 
+or use the pre-release packages published in MyGet (see https://dotnet.myget.org/gallery/orleans-prerelease for more information on how to add the feed).
+Then just execute the `BuildAndRun.sh` bash script.
+
+## Alternative steps to build and run the sample
+Alternatively, you can use the following steps, to understand what is going on:
+
+#### Building the sample
 If you are trying to use a version of Orleans that is not yet released, first run `Build.cmd netstandard` from the root directory of the repository.
 
 Note: If you need to reinstall packages (for example, after making changes to the Orleans runtime and rebuilding the packages), just manually delete all Orleans packages from `(rootfolder)/Samples/{specific-sample}/packages/` and re-run `Build.cmd netstandard`. You might sometimes also need to clean up the NuGet cache folder. In order to do that, run `dotnet nuget locals all --clear`.
@@ -13,14 +24,14 @@ dotnet restore
 dotnet build
 ```
 
-## Running the Sample
+#### Running the sample
 To start the silo
 ```
 dotnet src\SiloHost\bin\Debug\netcoreapp1.1\SiloHost.dll
 ```
 
 
-To start the client
+To start the client (you will have to use a different command window)
 ```
 dotnet src\OrleansClient\bin\Debug\netcoreapp1.1\OrleansClient.dll
 ```


### PR DESCRIPTION
Removed `publish` instructions, since #2772 fixed an issue with serialization that caused the need for that side effect.
Also fixed cascading NuGet.config inconsistencies, to pick up the right nuget packages from the local build.
Created build scripts for PowerShell and Bash to simplify the process even more, for people new to .NET Core.