### PR TITLE
fix missing check for empty deployment id

### DIFF
--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -130,8 +130,13 @@ namespace Orleans.Runtime
         /// <summary> Get the id of the cluster this silo is part of. </summary>
         public string ClusterId
         {
-            get { return GlobalConfig.HasMultiClusterNetwork ? GlobalConfig.ClusterId : GlobalConfig.DeploymentId; } 
+            get {
+                var configuredId = GlobalConfig.HasMultiClusterNetwork ? GlobalConfig.ClusterId : GlobalConfig.DeploymentId;
+                return string.IsNullOrEmpty(configuredId) ? CLUSTER_ID_DEFAULT : configuredId; 
+            } 
         }
+
+        private const string CLUSTER_ID_DEFAULT = "A"; // if no id is configured, we pick a nonempty default.
 
         /// <summary> SiloAddress for this silo. </summary>
         public SiloAddress SiloAddress => this.initializationParams.SiloAddress;

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -136,7 +136,7 @@ namespace Orleans.Runtime
             } 
         }
 
-        private const string CLUSTER_ID_DEFAULT = "A"; // if no id is configured, we pick a nonempty default.
+        private const string CLUSTER_ID_DEFAULT = "DefaultClusterID"; // if no id is configured, we pick a nonempty default.
 
         /// <summary> SiloAddress for this silo. </summary>
         public SiloAddress SiloAddress => this.initializationParams.SiloAddress;


### PR DESCRIPTION
This is a fix for the bug observed in #2774.

The problem was that cluster-id was picking deployment-id as a default, but deployment-id can be null or empty. This PR adds a check to catch this and use an appropriate default in all cases.