### PR TITLE
Fix test issue that created client configuration prematurely

### DIFF
--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableStore.cs
@@ -44,7 +44,6 @@ namespace Tester.AzureUtils.Persistence
 
                 Guid serviceId = Guid.NewGuid();
                 var options = new TestClusterOptions(initialSilosCount: 4);
-                options.ClientConfiguration.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
                 options.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
                 options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
 


### PR DESCRIPTION
When using TestClusterOptions it is best to first fully initialize the cluster configuration and then client one, because it will copy stuff from the former on first access.
In this case, the connection string is one of the things it copies, so it is unnecessary. But because of it is was failing to copy the membership config, and the tests were sometimes getting `No gateway available`