### PR TITLE
Add a timeout for socket connection

### DIFF
--- a/src/Orleans/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans/Configuration/MessagingConfiguration.cs
@@ -13,6 +13,10 @@ namespace Orleans.Runtime.Configuration
     public interface IMessagingConfiguration
     {
         /// <summary>
+        /// The OpenConnectionTimeout attribute specifies the timeout before a connection open is assumed to have failed
+        /// </summary>
+        TimeSpan OpenConnectionTimeout { get; set; }
+        /// <summary>
         /// The ResponseTimeout attribute specifies the default timeout before a request is assumed to have failed.
         /// </summary>
         TimeSpan ResponseTimeout { get; set; }
@@ -92,6 +96,7 @@ namespace Orleans.Runtime.Configuration
     [Serializable]
     public class MessagingConfiguration : IMessagingConfiguration
     {
+        public TimeSpan OpenConnectionTimeout { get; set; }
         public TimeSpan ResponseTimeout { get; set; }
         public int MaxResendCount { get; set; }
         public bool ResendOnTimeout { get; set; }
@@ -138,6 +143,7 @@ namespace Orleans.Runtime.Configuration
         {
             isSiloConfig = isSilo;
 
+            OpenConnectionTimeout = Constants.DEFAULT_OPENCONNECTION_TIMEOUT;
             ResponseTimeout = Constants.DEFAULT_RESPONSE_TIMEOUT;
             MaxResendCount = 0;
             ResendOnTimeout = DEFAULT_RESEND_ON_TIMEOUT;

--- a/src/Orleans/Messaging/GatewayConnection.cs
+++ b/src/Orleans/Messaging/GatewayConnection.cs
@@ -160,16 +160,16 @@ namespace Orleans.Messaging
                         }
                         lastConnect = DateTime.UtcNow;
                         Socket = new Socket(Silo.Endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-                        Socket.Connect(Silo.Endpoint);
+                        SocketManager.Connect(Socket, Silo.Endpoint, MsgCenter.MessagingConfiguration.OpenConnectionTimeout);
                         NetworkingStatisticsGroup.OnOpenedGatewayDuplexSocket();
                         MsgCenter.OnGatewayConnectionOpen();
                         SocketManager.WriteConnectionPreamble(Socket, MsgCenter.ClientId);  // Identifies this client
                         Log.Info(ErrorCode.ProxyClient_Connected, "Connected to gateway at address {0} on trial {1}.", Address, i);
                         return;
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
-                        Log.Warn(ErrorCode.ProxyClient_CannotConnect, "Unable to connect to gateway at address {0} on trial {1}.", Address, i);
+                        Log.Warn(ErrorCode.ProxyClient_CannotConnect, $"Unable to connect to gateway at address {Address} on trial {i} (Exception: {ex.Message})");
                         MarkAsDisconnected(Socket);
                     }
                 }

--- a/src/Orleans/Messaging/SocketManager.cs
+++ b/src/Orleans/Messaging/SocketManager.cs
@@ -171,6 +171,23 @@ namespace Orleans.Runtime
             cache.Clear();
         }
 
+        /// <summary>
+        /// Connect the socket to the target endpoint
+        /// </summary>
+        /// <param name="s">The socket</param>
+        /// <param name="endPoint">The target endpoint</param>
+        /// <param name="connectionTimeout">The timeout value to use when opening the connection</param>
+        /// <exception cref="TimeoutException">When the connection could not be established in time</exception>
+        internal static void Connect(Socket s, IPEndPoint endPoint, TimeSpan connectionTimeout)
+        {
+            var ar = s.BeginConnect(endPoint, null, null);
+
+            if (!ar.AsyncWaitHandle.WaitOne(connectionTimeout))
+                throw new TimeoutException($"Connection to {endPoint} could not be established in {connectionTimeout}");
+
+            s.EndConnect(ar);
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         internal static void CloseSocket(Socket s)
         {

--- a/src/Orleans/Runtime/Constants.cs
+++ b/src/Orleans/Runtime/Constants.cs
@@ -52,7 +52,9 @@ namespace Orleans.Runtime
         public static readonly GrainId SiloDirectConnectionId = GrainId.GetSystemGrainId(new Guid("01111111-1111-1111-1111-111111111111"));
 
         internal const long ReminderTableGrainId = 12345;
-         
+
+        public static TimeSpan DEFAULT_OPENCONNECTION_TIMEOUT = TimeSpan.FromSeconds(5);
+
         /// <summary>
         /// The default timeout before a request is assumed to have failed.
         /// </summary>


### PR DESCRIPTION
Fix for #2788 

It seems that the value by default is around 20 seconds.

I added a method in `SocketManager` to be able to specify a timeout from the configuration, and use it for client->gw and silo->silo socket connect.