### PR TITLE
GrainExtensions: remove RuntimeClient.Current usage

### DIFF
--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime
         
         private bool HasGenericArgument { get { return !String.IsNullOrEmpty(genericArguments); } }
 
-        private IRuntimeClient RuntimeClient
+        internal IRuntimeClient RuntimeClient
         {
             get
             {


### PR DESCRIPTION
Removed `RuntimeClient.Current` in favour of using `grainRef.RuntimeClient`.

`Cast<T>` & `AsReference<T>` were almost identical. Now `Cast` simply calls `AsReference`.

Note that calling `GrainFactory.Cast(gref)` already calls the `AsWeaklyTypedReference()` extension method from the IL, so the bodies of these methods were already functionally equivalent.

Should we deprecate one of them? Is there supposed to be a difference between them?