### PR TITLE
Split packing into a separate build step to account for build signing

### DIFF
--- a/vNext/Directory.Build.props
+++ b/vNext/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet">
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Can use `Build.cmd Pack` to continue the packing process after signing the binaries