### PR TITLE
Add missing entries to app.config for OrleansHost.exe. Fixes #2795

### DIFF
--- a/src/OrleansHost/app.config
+++ b/src/OrleansHost/app.config
@@ -29,6 +29,14 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Add missing entries to app.config. This fix makes it possible to run OrleansHost.exe without manual modifications when added from ```Microsoft.Orleans.Server``` nuget package to a project.
Fixes #2795.