### PR TITLE
Move more tests

### DIFF
--- a/vNext/test/TesterInternal/TesterInternal.csproj
+++ b/vNext/test/TesterInternal/TesterInternal.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\..\test\TesterInternal\**\*.cs" Exclude="..\..\..\test\TesterInternal\obj\**\*.cs;..\..\..\test\TesterInternal\bin\**\*.cs;..\..\..\test\TesterInternal\Properties\*.cs;..\..\..\test\TesterInternal\CounterControlProgTests.cs;..\..\..\test\TesterInternal\GeoClusterTests\*.cs;..\..\..\test\TesterInternal\HostedTestClusterBase.cs;..\..\..\test\TesterInternal\OrleansHostProgTests.cs;..\..\..\test\TesterInternal\General\BootstrapProviderTests.cs;..\..\..\test\TesterInternal\StorageTests\PersistenceGrainTests.cs;..\..\..\test\TesterInternal\StreamingTests\StreamPubSubReliabilityTests.cs" />
+    <Compile Include="..\..\..\test\TesterInternal\**\*.cs" Exclude="..\..\..\test\TesterInternal\obj\**\*.cs;..\..\..\test\TesterInternal\bin\**\*.cs;..\..\..\test\TesterInternal\Properties\*.cs;..\..\..\test\TesterInternal\CounterControlProgTests.cs;..\..\..\test\TesterInternal\GeoClusterTests\*.cs;..\..\..\test\TesterInternal\HostedTestClusterBase.cs;..\..\..\test\TesterInternal\OrleansHostProgTests.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Can move BootstrapProviderTests, PersistenceGrainTests and StreamPubSubReliabilityTests to vNext now since they already moved away AppDomainTeskHook in #2743, which doesn't work in netstandard 