### PR TITLE
Allow null MultiClusterRegistrationStrategy in GrainTypeData

### DIFF
--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeData.cs
@@ -39,7 +39,7 @@ namespace Orleans.Runtime
             RemoteInterfaceTypes = GetRemoteInterfaces(type); ;
             StateObjectType = stateObjectType;
             MayInterleave = GetMayInterleavePredicate(typeInfo) ?? (_ => false);
-            MultiClusterRegistrationStrategy = registrationManager.GetMultiClusterRegistrationStrategy(type);
+            MultiClusterRegistrationStrategy = registrationManager?.GetMultiClusterRegistrationStrategy(type);
         }
 
         /// <summary>


### PR DESCRIPTION
Some usages of `GrainTypeData` are from outside of the silo, where a sensible `MultiClusterRegistrationStrategy` is not available.

For example, it's used in CounterControl.