### PR TITLE
Skip some environment-dependent tests.

### DIFF
--- a/src/OrleansConsulUtils/ConsulBasedMembershipTable.cs
+++ b/src/OrleansConsulUtils/ConsulBasedMembershipTable.cs
@@ -67,7 +67,7 @@ namespace Orleans.Runtime.Host
             _connectionString = dataConnectionString;
 
             _consulClient =
-                new ConsulClient( config => config.Address = new Uri(dataConnectionString));
+                new ConsulClient( config => config.Address = new Uri(_connectionString));
         }
 
         public async Task<MembershipTableData> ReadRow(SiloAddress siloAddress)

--- a/src/Test.cmd
+++ b/src/Test.cmd
@@ -12,7 +12,7 @@ pushd "%CMDHOME%"
 
 SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
-set TESTS=%OutDir%\Tester.dll,%OutDir%\TesterInternal.dll,%OutDir%\NonSilo.Tests.dll,%OutDir%\Tester.AzureUtils.dll,%OutDir%\Tester.SQLUtils.dll,%OutDir%\DefaultCluster.Tests.dll,%OutDir%\AWSUtils.Tests.dll,%OutDir%\BondUtils.Tests.dll,%OutDir%\GoogleUtils.Tests.dll,%OutDir%\PSUtils.Tests.dll,%OutDir%\ServiceBus.Tests.dll,%OutDir%\TestServiceFabric.dll
+set TESTS=%OutDir%\Tester.dll,%OutDir%\TesterInternal.dll,%OutDir%\NonSilo.Tests.dll,%OutDir%\Tester.AzureUtils.dll,%OutDir%\Tester.SQLUtils.dll,%OutDir%\DefaultCluster.Tests.dll,%OutDir%\AWSUtils.Tests.dll,%OutDir%\BondUtils.Tests.dll,%OutDir%\GoogleUtils.Tests.dll,%OutDir%\PSUtils.Tests.dll,%OutDir%\ServiceBus.Tests.dll,%OutDir%\TestServiceFabric.dll,%OutDir%\Consul.Tests.dll,%OutDir%\Tester.ZooKeeperUtils.dll
 if []==[%TEST_FILTERS%] set TEST_FILTERS=-trait 'Category=BVT' -trait 'Category=SlowBVT'
 
 @Echo Test assemblies = %TESTS%

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -37,9 +37,9 @@ namespace AWSUtils.Tests.MembershipTests
             return new DynamoDBGatewayListProvider();
         }
 
-        protected override string GetConnectionString()
+        protected override Task<string> GetConnectionString()
         {
-            return "Service=http://localhost:8000;";
+            return Task.FromResult(AWSTestConstants.IsDynamoDbAvailable ? "Service=http://localhost:8000;" : null);
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/AWSUtils.Tests/Reminder/DynamoDBRemindersTableTests.cs
+++ b/test/AWSUtils.Tests/Reminder/DynamoDBRemindersTableTests.cs
@@ -27,9 +27,9 @@ namespace AWSUtils.Tests.RemindersTest
             return new DynamoDBReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>());
         }
 
-        protected override string GetConnectionString()
+        protected override Task<string> GetConnectionString()
         {
-            return $"Service={AWSTestConstants.Service}";
+            return Task.FromResult(AWSTestConstants.IsDynamoDbAvailable ? $"Service={AWSTestConstants.Service}" : null);
         }
 
         [SkippableFact]

--- a/test/Consul.Tests/CollectionFixtures.cs
+++ b/test/Consul.Tests/CollectionFixtures.cs
@@ -1,0 +1,10 @@
+﻿using TestExtensions;
+using Xunit;
+
+namespace Consul.Tests
+{
+    // Assembly collections must be defined once in each assembly
+
+    [CollectionDefinition(TestEnvironmentFixture.DefaultCollection)]
+    public class TestEnvironmentFixtureCollection : ICollectionFixture<TestEnvironmentFixture> { }
+}

--- a/test/Consul.Tests/Consul.Tests.csproj
+++ b/test/Consul.Tests/Consul.Tests.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CollectionFixtures.cs" />
     <Compile Include="ConsulTestUtils.cs" />
     <Compile Include="LivenessTests.cs" />
     <Compile Include="ConsulMembershipTableTest.cs" />

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -37,9 +37,9 @@ namespace Consul.Tests
             return new ConsulBasedMembershipTable();
         }
 
-        protected override string GetConnectionString()
+        protected override async Task<string> GetConnectionString()
         {
-            return ConsulTestUtils.CONSUL_ENDPOINT;
+            return await ConsulTestUtils.EnsureConsulAsync() ? ConsulTestUtils.CONSUL_ENDPOINT : null;
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/Consul.Tests/ConsulTestUtils.cs
+++ b/test/Consul.Tests/ConsulTestUtils.cs
@@ -1,6 +1,8 @@
 ﻿#if !NETSTANDARD_TODO
+using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Consul.Tests
@@ -8,13 +10,27 @@ namespace Consul.Tests
     public static class ConsulTestUtils
     {
         public const string CONSUL_ENDPOINT = "http://localhost:8500";
+        private static readonly Lazy<bool> EnsureConsulLazy = new Lazy<bool>(() => EnsureConsulAsync().Result);
 
         public static void EnsureConsul()
         {
-            var client = new HttpClient();
-            var response = client.GetAsync($"{CONSUL_ENDPOINT}/v1/health/service/consul?pretty").Result;
-            if (response.StatusCode != HttpStatusCode.OK)
+            if (!EnsureConsulLazy.Value)
                 throw new SkipException("Consul cluster isn't running");
+        }
+
+        public  static async Task<bool> EnsureConsulAsync()
+        {
+            try
+            {
+                var client = new HttpClient();
+                var response = await client.GetAsync($"{CONSUL_ENDPOINT}/v1/health/service/consul?pretty");
+                return response.StatusCode == HttpStatusCode.OK;
+            }
+            catch (HttpRequestException)
+            {
+                return false;
+            }
+
         }
     }
 }

--- a/test/TesterAzureUtils/AzureMembershipTableTests.cs
+++ b/test/TesterAzureUtils/AzureMembershipTableTests.cs
@@ -4,12 +4,9 @@ using Orleans.AzureUtils;
 using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.Runtime.MembershipService;
-using Orleans.TestingHost;
-using Tester;
 using TestExtensions;
 using UnitTests;
 using UnitTests.MembershipTests;
-using UnitTests.StorageTests;
 using Xunit;
 
 namespace Tester.AzureUtils
@@ -17,6 +14,7 @@ namespace Tester.AzureUtils
     /// <summary>
     /// Tests for operation of Orleans Membership Table using AzureStore - Requires access to external Azure storage
     /// </summary>
+    [TestCategory("Membership"), TestCategory("Azure")]
     public class AzureMembershipTableTests : MembershipTableTestsBase, IClassFixture<AzureStorageBasicTestFixture>
     {
         public AzureMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
@@ -36,59 +34,60 @@ namespace Tester.AzureUtils
             return new AzureGatewayListProvider();
         }
 
-        protected override string GetConnectionString()
+        protected override Task<string> GetConnectionString()
         {
-            return TestDefaultConfiguration.DataConnectionString;
+            TestUtils.CheckForAzureStorage();
+            return Task.FromResult(TestDefaultConfiguration.DataConnectionString);
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public void MembershipTable_Azure_Init()
         {
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_Azure_GetGateways()
         {
             await MembershipTable_GetGateways();
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_Azure_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_Azure_InsertRow()
         {
             await MembershipTable_InsertRow();
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_Azure_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read();
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_Azure_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll();
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_Azure_UpdateRow()
         {
             await MembershipTable_UpdateRow();
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_Azure_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel();
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Membership"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_Azure_UpdateIAmAlive()
         {
             await MembershipTable_UpdateIAmAlive();

--- a/test/TesterAzureUtils/AzureRemindersTableTests.cs
+++ b/test/TesterAzureUtils/AzureRemindersTableTests.cs
@@ -7,8 +7,6 @@ using Orleans.Runtime.ReminderService;
 using Tester;
 using Tester.AzureUtils;
 using TestExtensions;
-using UnitTests.MembershipTests;
-using UnitTests.StorageTests;
 using Xunit;
 
 namespace UnitTests.RemindersTest
@@ -16,6 +14,7 @@ namespace UnitTests.RemindersTest
     /// <summary>
     /// Tests for operation of Orleans Reminders Table using Azure
     /// </summary>
+    [TestCategory("Reminders"), TestCategory("Azure")]
     public class AzureRemindersTableTests : ReminderTableTestsBase, IClassFixture<AzureStorageBasicTestFixture>
     {
         public AzureRemindersTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
@@ -37,29 +36,30 @@ namespace UnitTests.RemindersTest
             return new AzureBasedReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>());
         }
 
-        protected override string GetConnectionString()
+        protected override Task<string> GetConnectionString()
         {
-            return TestDefaultConfiguration.DataConnectionString;
+            TestUtils.CheckForAzureStorage();
+            return Task.FromResult(TestDefaultConfiguration.DataConnectionString);
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("Azure")]
+        [SkippableFact]
         public void RemindersTable_Azure_Init()
         {
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task RemindersTable_Azure_RemindersRange()
         {
             await RemindersRange(50);
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task RemindersTable_Azure_RemindersParallelUpsert()
         {
             await RemindersParallelUpsert();
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("Azure")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task RemindersTable_Azure_ReminderSimple()
         {
             await ReminderSimple();

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -47,11 +47,8 @@ namespace UnitTests.MembershipTests
 
             logger.Info("DeploymentId={0}", deploymentId);
 
-            lock (fixture.SyncRoot)
-            {
-                if (fixture.ConnectionString == null)
-                    fixture.ConnectionString = GetConnectionString();
-            }
+            fixture.InitializeConnectionStringAccessor(GetConnectionString);
+
             var globalConfiguration = new GlobalConfiguration
             {
                 DeploymentId = deploymentId,
@@ -89,7 +86,7 @@ namespace UnitTests.MembershipTests
 
         protected abstract IGatewayListProvider CreateGatewayListProvider(Logger logger);
         protected abstract IMembershipTable CreateMembershipTable(Logger logger);
-        protected abstract string GetConnectionString();
+        protected abstract Task<string> GetConnectionString();
 
         protected virtual string GetAdoInvariant()
         {

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Orleans;
@@ -33,11 +34,7 @@ namespace UnitTests.RemindersTest
 
             logger.Info("DeploymentId={0}", deploymentId);
 
-            lock (fixture.SyncRoot)
-            {
-                if (fixture.ConnectionString == null)
-                    fixture.ConnectionString = GetConnectionString();
-            }
+            fixture.InitializeConnectionStringAccessor(GetConnectionString);
 
             var globalConfiguration = new GlobalConfiguration
             {
@@ -61,7 +58,7 @@ namespace UnitTests.RemindersTest
         }
 
         protected abstract IReminderTable CreateRemindersTable();
-        protected abstract string GetConnectionString();
+        protected abstract Task<string> GetConnectionString();
 
         protected virtual string GetAdoInvariant()
         {

--- a/test/TesterSQLUtils/MySqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/MySqlMembershipTableTests.cs
@@ -13,6 +13,7 @@ namespace UnitTests.MembershipTests
     /// <summary>
     /// Tests for operation of Orleans Membership Table using MySQL
     /// </summary>
+    [TestCategory("Membership"), TestCategory("MySql")]
     public class MySqlMembershipTableTests : MembershipTableTestsBase
     {
         public MySqlMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
@@ -35,61 +36,60 @@ namespace UnitTests.MembershipTests
             return AdoNetInvariants.InvariantNameMySql;
         }
 
-        protected override string GetConnectionString()
+        protected override async Task<string> GetConnectionString()
         {
-            return
-                RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName)
-                    .Result.CurrentConnectionString;
+            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            return instance.CurrentConnectionString;
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        [SkippableFact]
         public void MembershipTable_MySql_Init()
         {
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task MembershipTable_MySql_GetGateways()
         {
             await MembershipTable_GetGateways();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task MembershipTable_MySql_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task MembershipTable_MySql_InsertRow()
         {
             await MembershipTable_InsertRow();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task MembershipTable_MySql_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task MembershipTable_MySql_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task MembershipTable_MySql_UpdateRow()
         {
             await MembershipTable_UpdateRow();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task MembershipTable_MySql_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task MembershipTable_MySql_UpdateIAmAlive()
         {
             await MembershipTable_UpdateIAmAlive();

--- a/test/TesterSQLUtils/MySqlRemindersTableTests.cs
+++ b/test/TesterSQLUtils/MySqlRemindersTableTests.cs
@@ -13,6 +13,7 @@ namespace UnitTests.RemindersTest
     /// <summary>
     /// Tests for operation of Orleans Reminders Table using MySQL
     /// </summary>
+    [TestCategory("Reminders"), TestCategory("MySql")]
     public class MySqlRemindersTableTests : ReminderTableTestsBase
     {
         public MySqlRemindersTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
@@ -30,32 +31,31 @@ namespace UnitTests.RemindersTest
             return AdoNetInvariants.InvariantNameMySql;
         }
 
-        protected override string GetConnectionString()
+        protected override async Task<string> GetConnectionString()
         {
-            return RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName)
-                    .Result.CurrentConnectionString;
+            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            return instance.CurrentConnectionString;
         }
 
-
-        [Fact, TestCategory("Reminders"), TestCategory("MySql")]
+        [SkippableFact]
         public void RemindersTable_MySql_Init()
         {
         }
 
 
-        [Fact, TestCategory("Reminders"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task RemindersTable_MySql_RemindersRange()
         {
             await RemindersRange();
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task RemindersTable_MySql_RemindersParallelUpsert()
         {
             await RemindersParallelUpsert();
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("MySql")]
+        [SkippableFact]
         public async Task RemindersTable_MySql_ReminderSimple()
         {
             await ReminderSimple();

--- a/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace UnitTests.MembershipTests
 {
+    [TestCategory("Membership"), TestCategory("PostgreSql")]
     public class PostgreSqlMembershipTableTests : MembershipTableTestsBase
     {
         public PostgreSqlMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
@@ -32,61 +33,60 @@ namespace UnitTests.MembershipTests
             return AdoNetInvariants.InvariantNamePostgreSql;
         }
 
-        protected override string GetConnectionString()
+        protected override async Task<string> GetConnectionString()
         {
-            return
-                RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName)
-                    .Result.CurrentConnectionString;
+            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            return instance.CurrentConnectionString;
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public void MembershipTable_PostgreSql_Init()
         {
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task MembershipTable_PostgreSql_GetGateways()
         {
             await MembershipTable_GetGateways();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task MembershipTable_PostgreSql_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task MembershipTable_PostgreSql_InsertRow()
         {
             await MembershipTable_InsertRow();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task MembershipTable_PostgreSql_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task MembershipTable_PostgreSql_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task MembershipTable_PostgreSql_UpdateRow()
         {
             await MembershipTable_UpdateRow();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task MembershipTable_PostgreSql_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task MembershipTable_PostgreSql_UpdateIAmAlive()
         {
             await MembershipTable_UpdateIAmAlive();

--- a/test/TesterSQLUtils/PostgreSqlRemindersTableTests.cs
+++ b/test/TesterSQLUtils/PostgreSqlRemindersTableTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace UnitTests.RemindersTest
 {
+    [TestCategory("Reminders"), TestCategory("PostgreSql")]
     public class PostgreSqlRemindersTableTests : ReminderTableTestsBase
     {
         public PostgreSqlRemindersTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
@@ -27,32 +28,31 @@ namespace UnitTests.RemindersTest
             return AdoNetInvariants.InvariantNamePostgreSql;
         }
 
-        protected override string GetConnectionString()
+        protected override async Task<string> GetConnectionString()
         {
-            return RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName)
-                    .Result.CurrentConnectionString;
+            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            return instance.CurrentConnectionString;
         }
 
-
-        [Fact, TestCategory("Reminders"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public void RemindersTable_PostgreSql_Init()
         {
         }
 
 
-        [Fact, TestCategory("Reminders"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task RemindersTable_PostgreSql_RemindersRange()
         {
             await RemindersRange();
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task RemindersTable_PostgreSql_RemindersParallelUpsert()
         {
             await RemindersParallelUpsert();
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("PostgreSql")]
+        [SkippableFact]
         public async Task RemindersTable_PostgreSql_ReminderSimple()
         {
             await ReminderSimple();

--- a/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
+++ b/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
@@ -13,6 +13,7 @@ namespace UnitTests.MembershipTests
     /// <summary>
     /// Tests for operation of Orleans Membership Table using SQL Server
     /// </summary>
+    [TestCategory("Membership"), TestCategory("SqlServer")]
     public class SqlServerMembershipTableTests : MembershipTableTestsBase
     {
         public SqlServerMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
@@ -35,61 +36,60 @@ namespace UnitTests.MembershipTests
             return AdoNetInvariants.InvariantNameSqlServer;
         }
 
-        protected override string GetConnectionString()
+        protected override async Task<string> GetConnectionString()
         {
-            return
-                RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName)
-                    .Result.CurrentConnectionString;
+            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            return instance.CurrentConnectionString;
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        [SkippableFact]
         public void MembershipTable_SqlServer_Init()
         {
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_SqlServer_GetGateways()
         {
             await MembershipTable_GetGateways();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_SqlServer_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_SqlServer_InsertRow()
         {
             await MembershipTable_InsertRow();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_SqlServer_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_SqlServer_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_SqlServer_UpdateRow()
         {
             await MembershipTable_UpdateRow();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_SqlServer_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task MembershipTable_SqlServer_UpdateIAmAlive()
         {
             await MembershipTable_UpdateIAmAlive();

--- a/test/TesterSQLUtils/SqlServerRemindersTableTests.cs
+++ b/test/TesterSQLUtils/SqlServerRemindersTableTests.cs
@@ -13,6 +13,7 @@ namespace UnitTests.RemindersTest
     /// <summary>
     /// Tests for operation of Orleans Reminders Table using SQL Server
     /// </summary>
+    [TestCategory("Reminders"), TestCategory("SqlServer")]
     public class SqlServerRemindersTableTests : ReminderTableTestsBase
     {
         public SqlServerRemindersTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
@@ -30,31 +31,30 @@ namespace UnitTests.RemindersTest
             return AdoNetInvariants.InvariantNameSqlServer;
         }
 
-        protected override string GetConnectionString()
+        protected override async Task<string> GetConnectionString()
         {
-            return RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName)
-                .Result.CurrentConnectionString;
+            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            return instance.CurrentConnectionString;
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("SqlServer")]
+        [SkippableFact]
         public void RemindersTable_SqlServer_Init()
         {
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task RemindersTable_SqlServer_RemindersRange()
         {
             await RemindersRange();
         }
 
-
-        [Fact, TestCategory("Reminders"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task RemindersTable_SqlServer_RemindersParallelUpsert()
         {
             await RemindersParallelUpsert();
         }
 
-        [Fact, TestCategory("Reminders"), TestCategory("SqlServer")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task RemindersTable_SqlServer_ReminderSimple()
         {
             await ReminderSimple();

--- a/test/TesterZooKeeperUtils/CollectionFixtures.cs
+++ b/test/TesterZooKeeperUtils/CollectionFixtures.cs
@@ -1,0 +1,10 @@
+﻿using TestExtensions;
+using Xunit;
+
+namespace Tester.ZooKeeperUtils
+{
+    // Assembly collections must be defined once in each assembly
+
+    [CollectionDefinition(TestEnvironmentFixture.DefaultCollection)]
+    public class TestEnvironmentFixtureCollection : ICollectionFixture<TestEnvironmentFixture> { }
+}

--- a/test/TesterZooKeeperUtils/TesterZooKeeperUtils.csproj
+++ b/test/TesterZooKeeperUtils/TesterZooKeeperUtils.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CollectionFixtures.cs" />
     <Compile Include="LivenessTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ZookeeperMembershipTableTests.cs" />

--- a/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using org.apache.zookeeper;
 using Orleans;
 using Orleans.Messaging;
 using Orleans.Runtime;
@@ -10,76 +11,96 @@ namespace UnitTests.MembershipTests
     /// <summary>
     /// Tests for operation of Orleans SiloInstanceManager using ZookeeperStore - Requires access to external Zookeeper storage
     /// </summary>
+    [TestCategory("Membership"), TestCategory("ZooKeeper")]
     public class ZookeeperMembershipTableTests : MembershipTableTestsBase
     {
-        public ZookeeperMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment) : base(fixture, environment)
+        public ZookeeperMembershipTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
+            : base(fixture, environment)
         {
-            LogManager.AddTraceLevelOverride(typeof (ZookeeperMembershipTableTests).Name, Severity.Verbose3);
+            LogManager.AddTraceLevelOverride(typeof(ZookeeperMembershipTableTests).Name, Severity.Verbose3);
         }
 
         protected override IMembershipTable CreateMembershipTable(Logger logger)
         {
-            return AssemblyLoader.LoadAndCreateInstance<IMembershipTable>(Constants.ORLEANS_ZOOKEEPER_UTILS_DLL, logger, this.Services);
+            return AssemblyLoader.LoadAndCreateInstance<IMembershipTable>(Constants.ORLEANS_ZOOKEEPER_UTILS_DLL, logger,
+                this.Services);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)
         {
-            return AssemblyLoader.LoadAndCreateInstance<IGatewayListProvider>(Constants.ORLEANS_ZOOKEEPER_UTILS_DLL, logger, this.Services);
+            return AssemblyLoader.LoadAndCreateInstance<IGatewayListProvider>(Constants.ORLEANS_ZOOKEEPER_UTILS_DLL,
+                logger, this.Services);
         }
 
-        protected override string GetConnectionString()
+        protected override async Task<string> GetConnectionString()
         {
-            return TestDefaultConfiguration.ZooKeeperConnectionString;
+            var connectionString = TestDefaultConfiguration.ZooKeeperConnectionString;
+            if (string.IsNullOrWhiteSpace(connectionString)) return null;
+
+            bool isReachable = false;
+            await ZooKeeper.Using(connectionString, 2000, null, async zk =>
+            {
+                try
+                {
+                    await zk.existsAsync("/test", false);
+                    isReachable = true;
+                }
+                catch (KeeperException.ConnectionLossException)
+                {
+                }
+            });
+
+            return isReachable ? connectionString : null;
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact]
         public void MembershipTable_ZooKeeper_Init()
         {
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact]
         public async Task MembershipTable_ZooKeeper_GetGateways()
         {
             await MembershipTable_GetGateways();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact]
         public async Task MembershipTable_ZooKeeper_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact]
         public async Task MembershipTable_ZooKeeper_InsertRow()
         {
             await MembershipTable_InsertRow();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact]
         public async Task MembershipTable_ZooKeeper_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact]
         public async Task MembershipTable_ZooKeeper_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact]
         public async Task MembershipTable_ZooKeeper_UpdateRow()
         {
             await MembershipTable_UpdateRow();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact]
         public async Task MembershipTable_ZooKeeper_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact]
         public async Task MembershipTable_ZooKeeper_UpdateIAmAlive()
         {
             await MembershipTable_UpdateIAmAlive();

--- a/vNext/Test.cmd
+++ b/vNext/Test.cmd
@@ -13,7 +13,7 @@ pushd "%CMDHOME%"
 SET OutDir=%CMDHOME%\Binaries\%CONFIGURATION%
 
 REM set TESTS=%OutDir%\Tester.dll,%OutDir%\TesterInternal.dll,%OutDir%\NonSilo.Tests.dll,%OutDir%\Tester.AzureUtils.dll
-set TESTS=%OutDir%\net462\Tester.dll,%OutDir%\net462\NonSilo.Tests.dll,%OutDir%\net462\Tester.AzureUtils.dll,%OutDir%\net462\TesterInternal.dll,%OutDir%\net462\Tester.SQLUtils.dll,%OutDir%\net462\DefaultCluster.Tests.dll,%OutDir%\net462\Consul.Tests.dll,%OutDir%\net462\BondUtils.Tests.dll,%OutDir%\net462\AWSUtils.Tests.dll,%OutDir%\net462\GoogleUtils.Tests.dll,%OutDir%\net462\ServiceBus.Tests.dll
+set TESTS=%OutDir%\net462\Tester.dll,%OutDir%\net462\NonSilo.Tests.dll,%OutDir%\net462\Tester.AzureUtils.dll,%OutDir%\net462\TesterInternal.dll,%OutDir%\net462\Tester.SQLUtils.dll,%OutDir%\net462\DefaultCluster.Tests.dll,%OutDir%\net462\Consul.Tests.dll,%OutDir%\net462\BondUtils.Tests.dll,%OutDir%\net462\AWSUtils.Tests.dll,%OutDir%\net462\GoogleUtils.Tests.dll,%OutDir%\net462\ServiceBus.Tests.dll,%OutDir%\net462\Tester.ZooKeeperUtils.dll
 if []==[%TEST_FILTERS%] set TEST_FILTERS=-trait 'Category=BVT' -trait 'Category=SlowBVT'
 
 @Echo Test assemblies = %TESTS%


### PR DESCRIPTION
Add missing fixture in Consul and ZooKeeper tests, and skip them if environment is not set up.
Make GetConnectionString allowed to fail and skip its tests (for several providers).