### PR TITLE
Fix build on VS 2017

### DIFF
--- a/src/OrleansEventSourcing/OrleansEventSourcing.csproj
+++ b/src/OrleansEventSourcing/OrleansEventSourcing.csproj
@@ -72,7 +72,9 @@
       <Name>Orleans</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/OrleansEventSourcing/project.json
+++ b/src/OrleansEventSourcing/project.json
@@ -1,0 +1,10 @@
+﻿{
+  "dependencies": {},
+  "frameworks": {
+    "net451": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}

--- a/src/OrleansTelemetryConsumers.Counters/OrleansTelemetryConsumers.Counters.csproj
+++ b/src/OrleansTelemetryConsumers.Counters/OrleansTelemetryConsumers.Counters.csproj
@@ -63,6 +63,9 @@
       <Name>Orleans</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/OrleansTelemetryConsumers.Counters/project.json
+++ b/src/OrleansTelemetryConsumers.Counters/project.json
@@ -1,0 +1,10 @@
+﻿{
+  "dependencies": {},
+  "frameworks": {
+    "net451": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}


### PR DESCRIPTION
VS 2017 complains that no platform is specified in the project.json file for these two projects and fails to build.