### PR TITLE
Fix null reference exception in simple queue cache.

### DIFF
--- a/src/Orleans/Streams/QueueAdapters/DataNotAvailableException.cs
+++ b/src/Orleans/Streams/QueueAdapters/DataNotAvailableException.cs
@@ -21,4 +21,19 @@ namespace Orleans.Streams
         }
 #endif
     }
+
+    [Serializable]
+    public class CacheFullException : OrleansException
+    {
+        public CacheFullException() : this("Queue message cache is full") { }
+        public CacheFullException(string message) : base(message) { }
+        public CacheFullException(string message, Exception inner) : base(message, inner) { }
+
+#if !NETSTANDARD
+        public CacheFullException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
 }


### PR DESCRIPTION
Simple queue cache was not rate limiting correctly, leading to messages being removed outside the expected cache purge behavior.  This led to null references in cache cursors under load.

Rate limiting fixed..
Code block which removed messages from cache outside the context of the expected purge behavior was removed.