### PR TITLE
Allow echoing build script commands

### DIFF
--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -1,29 +1,20 @@
-@REM NOTE: This script must be run from a Visual Studio command prompt window
-
-@setlocal
-@ECHO off
+@if not defined _echo @echo off
+setlocal
 
 SET CMDHOME=%~dp0.
-if "%VisualStudioVersion%" == "" (
+if not defined VisualStudioVersion (
     @REM Try to find VS command prompt init script
-    where /Q VsDevCmd.bat
-    if ERRORLEVEL 1 (
-        if exist "%VS150COMNTOOLS%" (
-            call "%VS150COMNTOOLS%VsDevCmd.bat"
-        ) else (
-            if exist "%VS140COMNTOOLS%" (
-                call "%VS140COMNTOOLS%VsDevCmd.bat"
-            )
-        )
-    ) else (
-        @REM VsDevCmd.bat is in PATH, so just exec it.
-        call VsDevCmd.bat
-    )
+	if defined VS150COMNTOOLS (
+		call "%VS150COMNTOOLS%\VsDevCmd.bat"
+	) else if defined VS140COMNTOOLS (
+		call "%VS140COMNTOOLS%\VsDevCmd.bat"
+	)
+	if not defined VisualStudioVersion (
+		echo Could not determine Visual Studio version in the system. Cannot continue.
+		exit /b 1
+	)
 )
-if "%VisualStudioVersion%" == "" (
-    echo Could not determine Visual Studio version in the system. Cannot continue.
-    exit /b 1
-)
+
 @ECHO VisualStudioVersion = %VisualStudioVersion%
 
 @REM Get path to MSBuild Binaries

--- a/src/Test.cmd
+++ b/src/Test.cmd
@@ -1,5 +1,6 @@
-@setlocal
-@ECHO off
+@if not defined _echo @echo off
+setlocal
+ECHO off
 
 SET CONFIGURATION=Release
 
@@ -17,7 +18,7 @@ if []==[%TEST_FILTERS%] set TEST_FILTERS=-trait 'Category=BVT' -trait 'Category=
 
 @Echo Test assemblies = %TESTS%
 @Echo Test filters = %TEST_FILTERS%
-@echo on
+@if not defined _echo @echo on
 call "%CMDHOME%\SetupTestScript.cmd" "%OutDir%"
 
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& ./Parallel-Tests.ps1 -assemblies %TESTS% -testFilter \"%TEST_FILTERS%\" -outDir '%OutDir%'"

--- a/src/Test.cmd
+++ b/src/Test.cmd
@@ -1,6 +1,5 @@
 @if not defined _echo @echo off
 setlocal
-ECHO off
 
 SET CONFIGURATION=Release
 

--- a/vNext/Build.cmd
+++ b/vNext/Build.cmd
@@ -1,4 +1,4 @@
-@if "%_echo%" neq "on" echo off
+@if not defined _echo @echo off
 setlocal
 
 SET CMDHOME=%~dp0.

--- a/vNext/Test.cmd
+++ b/vNext/Test.cmd
@@ -1,5 +1,5 @@
-@setlocal
-@ECHO off
+@if not defined _echo @echo off
+setlocal
 
 SET CONFIGURATION=Release
 
@@ -18,7 +18,7 @@ if []==[%TEST_FILTERS%] set TEST_FILTERS=-trait 'Category=BVT' -trait 'Category=
 
 @Echo Test assemblies = %TESTS%
 @Echo Test filters = %TEST_FILTERS%
-@echo on
+@if not defined _echo @echo on
 REM call "%CMDHOME%\SetupTestScript.cmd" "%OutDir%"
 
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& ./Parallel-Tests.ps1 -assemblies %TESTS% -testFilter \"%TEST_FILTERS%\" -outDir '%OutDir%'"


### PR DESCRIPTION
If the `_echo` environment variable is set (regardless of its value), then echo is not turned off. We were already doing it in some of the scripts, but not all. This is the exact same mechanism that http://github.com/dotnet/corefx uses