### PR TITLE
When adding a concrete implementation of a generic interface, add also the generic version in the GrainInterfaceMap

### DIFF
--- a/src/Orleans/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans/Runtime/GrainInterfaceMap.cs
@@ -133,10 +133,9 @@ namespace Orleans.Runtime
             lock (this)
             {
                 var interfaceId = GrainInterfaceUtils.GetGrainInterfaceId(iface);
-                var ifaceCompleteName = TypeUtils.GetFullName(iface);
-                var grainInterface = TypeUtils.GetRawClassName(ifaceCompleteName);
+                var interfaceName = TypeUtils.GetRawClassName(TypeUtils.GetFullName(iface));
                 var grainTypeInfo = grain.GetTypeInfo();
-                var grainClass = TypeUtils.GetFullName(grainTypeInfo);
+                var grainName = TypeUtils.GetFullName(grainTypeInfo);
                 var isGenericGrainClass = grainTypeInfo.ContainsGenericParameters;
                 var grainTypeCode = GrainInterfaceUtils.GetGrainClassTypeCode(grain);
 
@@ -148,26 +147,26 @@ namespace Orleans.Runtime
                 }
                 else
                 {
-                    grainInterfaceData = new GrainInterfaceData(interfaceId, iface, grainInterface);
+                    grainInterfaceData = new GrainInterfaceData(interfaceId, iface, interfaceName);
 
                     table[interfaceId] = grainInterfaceData;
                     var interfaceTypeKey = GetTypeKey(iface, isGenericGrainClass);
                     typeToInterfaceData[interfaceTypeKey] = grainInterfaceData;
                 }
 
-                var implementation = new GrainClassData(grainTypeCode, grainClass, isGenericGrainClass, grainInterfaceData, placement, registrationStrategy);
+                var implementation = new GrainClassData(grainTypeCode, grainName, isGenericGrainClass, grainInterfaceData, placement, registrationStrategy);
                 if (!implementationIndex.ContainsKey(grainTypeCode))
                     implementationIndex.Add(grainTypeCode, implementation);
 
                 grainInterfaceData.AddImplementation(implementation, primaryImplementation);
                 if (primaryImplementation)
                 {
-                    primaryImplementations[grainInterface] = grainClass;
+                    primaryImplementations[interfaceName] = grainName;
                 }
                 else
                 {
-                    if (!primaryImplementations.ContainsKey(grainInterface))
-                        primaryImplementations.Add(grainInterface, grainClass);
+                    if (!primaryImplementations.ContainsKey(interfaceName))
+                        primaryImplementations.Add(interfaceName, grainName);
                 }
 
                 if (localTestMode)

--- a/src/Orleans/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans/Runtime/GrainInterfaceMap.cs
@@ -181,6 +181,12 @@ namespace Orleans.Runtime
             var interfaceTypeKey = GetTypeKey(iface, isGenericGrainClass);
             typeToInterfaceData[interfaceTypeKey] = grainInterfaceData;
 
+            // If we are adding a concrete implementation of a generic interface
+            // add also the latter to the map: GrainReference and InvokeMethodRequest 
+            // always use the id of the generic one
+            if (iface.IsConstructedGenericType)
+                AddOrGetGrainInterfaceData(iface.GetGenericTypeDefinition(), true);
+
             return grainInterfaceData;
         }
 

--- a/src/Orleans/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans/Runtime/GrainInterfaceMap.cs
@@ -156,7 +156,7 @@ namespace Orleans.Runtime
 
                 if (localTestMode)
                 {
-                    var assembly = grain.Assembly.CodeBase;
+                    var assembly = grainTypeInfo.Assembly.CodeBase;
                     if (!loadedGrainAsemblies.Contains(assembly))
                         loadedGrainAsemblies.Add(assembly);
                 }

--- a/src/Orleans/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans/Runtime/GrainInterfaceMap.cs
@@ -137,7 +137,7 @@ namespace Orleans.Runtime
                 var isGenericGrainClass = grainTypeInfo.ContainsGenericParameters;
                 var grainTypeCode = GrainInterfaceUtils.GetGrainClassTypeCode(grain);
 
-                var grainInterfaceData = AddOrGetGrainInterfaceData(iface, isGenericGrainClass);
+                var grainInterfaceData = GetOrAddGrainInterfaceData(iface, isGenericGrainClass);
 
                 var implementation = new GrainClassData(grainTypeCode, grainName, isGenericGrainClass, grainInterfaceData, placement, registrationStrategy);
                 if (!implementationIndex.ContainsKey(grainTypeCode))
@@ -163,7 +163,7 @@ namespace Orleans.Runtime
             }
         }
 
-        private GrainInterfaceData AddOrGetGrainInterfaceData(Type iface, bool isGenericGrainClass)
+        private GrainInterfaceData GetOrAddGrainInterfaceData(Type iface, bool isGenericGrainClass)
         {
             var interfaceId = GrainInterfaceUtils.GetGrainInterfaceId(iface);
 
@@ -185,7 +185,7 @@ namespace Orleans.Runtime
             // add also the latter to the map: GrainReference and InvokeMethodRequest 
             // always use the id of the generic one
             if (iface.IsConstructedGenericType)
-                AddOrGetGrainInterfaceData(iface.GetGenericTypeDefinition(), true);
+                GetOrAddGrainInterfaceData(iface.GetGenericTypeDefinition(), true);
 
             return grainInterfaceData;
         }

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -173,25 +173,17 @@ namespace Orleans.Runtime
 
         private void AddToGrainInterfaceToClassMap(Type grainClass, IEnumerable<Type> grainInterfaces, bool isUnordered)
         {
-            var grainTypeInfo = grainClass.GetTypeInfo();
-            var grainClassCompleteName = TypeUtils.GetFullName(grainTypeInfo);
-            var isGenericGrainClass = grainTypeInfo.ContainsGenericParameters;
-            var grainClassTypeCode = GrainInterfaceUtils.GetGrainClassTypeCode(grainClass);
             var placement = GrainTypeData.GetPlacementStrategy(grainClass, this.defaultPlacementStrategy);
             var registrationStrategy = this.multiClusterRegistrationStrategyManager.GetMultiClusterRegistrationStrategy(grainClass);
 
             foreach (var iface in grainInterfaces)
             {
-                var ifaceCompleteName = TypeUtils.GetFullName(iface);
-                var ifaceName = TypeUtils.GetRawClassName(ifaceCompleteName);
                 var isPrimaryImplementor = IsPrimaryImplementor(grainClass, iface);
-                var ifaceId = GrainInterfaceUtils.GetGrainInterfaceId(iface);
-                grainInterfaceMap.AddEntry(ifaceId, iface, grainClassTypeCode, ifaceName, grainClassCompleteName,
-                    grainTypeInfo.Assembly.CodeBase, isGenericGrainClass, placement, registrationStrategy, isPrimaryImplementor);
+                grainInterfaceMap.AddEntry(iface, grainClass, placement, registrationStrategy, isPrimaryImplementor);
             }
 
             if (isUnordered)
-                grainInterfaceMap.AddToUnorderedList(grainClassTypeCode);
+                grainInterfaceMap.AddToUnorderedList(grainClass);
         }
 
 


### PR DESCRIPTION
See #2808 for more explanations.

The fix is simple: add the "open generic" version of the interface in the `GrainInterfaceMap` so we can lookup information with the value returned by the `GrainReference` and the `InvokeMethodRequest` that are used by this implementation.