### PR TITLE
SingleRange Begin/End needs to be exposed for GrainServices

### DIFF
--- a/src/Orleans/Runtime/RingRange.cs
+++ b/src/Orleans/Runtime/RingRange.cs
@@ -25,8 +25,20 @@ namespace Orleans.Runtime
         string ToFullString();
     }
 
+    public interface ISingleRange : IRingRange
+    {
+        /// <summary>
+        /// Exclusive
+        /// </summary>
+        uint Begin { get; }
+        /// <summary>
+        /// Inclusive
+        /// </summary>
+        uint End { get; }
+    }
+
     [Serializable]
-    internal class SingleRange : IRingRangeInternal, IEquatable<SingleRange>
+    internal class SingleRange : IRingRangeInternal, IEquatable<SingleRange>, ISingleRange
     {
         private readonly uint begin;
         private readonly uint end;
@@ -121,7 +133,7 @@ namespace Orleans.Runtime
         }
     }
 
-    internal static class RangeFactory
+    public static class RangeFactory
     {
         public const long RING_SIZE = ((long)uint.MaxValue) + 1;
 
@@ -140,12 +152,12 @@ namespace Orleans.Runtime
             return new GeneralMultiRange(inRanges);
         }
 
-        public static EquallyDividedMultiRange CreateEquallyDividedMultiRange(IRingRange range, int numSubRanges)
+        internal static EquallyDividedMultiRange CreateEquallyDividedMultiRange(IRingRange range, int numSubRanges)
         {
             return new EquallyDividedMultiRange(range, numSubRanges);
         }
 
-        public static IEnumerable<SingleRange> GetSubRanges(IRingRange range)
+        public static IEnumerable<ISingleRange> GetSubRanges(IRingRange range)
         {
             if (range is SingleRange)
             {
@@ -352,3 +364,4 @@ namespace Orleans.Runtime
         }
     }
 }
+

--- a/src/OrleansRuntime/ReminderService/LocalReminderService.cs
+++ b/src/OrleansRuntime/ReminderService/LocalReminderService.cs
@@ -175,7 +175,7 @@ namespace Orleans.Runtime.ReminderService
             var rangeSerialNumberCopy = RangeSerialNumber;
             if (Logger.IsVerbose2) Logger.Verbose2($"My range= {RingRange}, RangeSerialNumber {RangeSerialNumber}. Local reminders count {localReminders.Count}");
             var acks = new List<Task>();
-            foreach (SingleRange range in RangeFactory.GetSubRanges(RingRange))
+            foreach (var range in RangeFactory.GetSubRanges(RingRange))
             {
                 acks.Add(ReadTableAndStartTimers(range, rangeSerialNumberCopy));
             }
@@ -289,7 +289,10 @@ namespace Orleans.Runtime.ReminderService
 
             try
             {
-                var srange = (SingleRange)range;
+                var srange = range as ISingleRange;
+                if (srange == null)
+                    throw new InvalidOperationException("LocalReminderService must be dealing with SingleRange");
+
                 ReminderTableData table = await reminderTable.ReadRows(srange.Begin, srange.End); // get all reminders, even the ones we already have
 
                 if (rangeSerialNumberCopy < RangeSerialNumber)


### PR DESCRIPTION
Added ISingleRange interface to be exposed externally. Also exposed helper method NextTimeSpan from StandardExtensions as well as some helper methods in RangeFactory.