### PR TITLE
Minimal disambiguation of service types over DependencyInjection.Abstractions

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Streams\Providers\StreamProviderUtils.cs" />
     <Compile Include="Streams\PubSub\StreamSubscriptionManagerExtensions.cs" />
     <Compile Include="Utils\Factory.cs" />
+    <Compile Include="Utils\IKeyedServiceCollection.cs" />
     <Compile Include="Utils\ReferenceEqualsComparer.cs" />
     <Compile Include="Serialization\ReflectedSerializationMethodInfo.cs" />
     <Compile Include="Streams\Core\StreamIdentity.cs" />

--- a/src/Orleans/Utils/IKeyedServiceCollection.cs
+++ b/src/Orleans/Utils/IKeyedServiceCollection.cs
@@ -1,0 +1,37 @@
+﻿
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Collection of services that can be disambiguated by key
+    /// </summary>
+    public interface IKeyedServiceCollection<in TKey, out TService>
+        where TService : class
+    {
+        TService GetService(TKey key);
+    }
+
+    public static class KeyedServiceExtensions
+    {
+        /// <summary>
+        /// Acquire a service by key.
+        /// </summary>
+        public static TService GetServiceByKey<TKey, TService>(this IServiceProvider services, TKey key)
+            where TService : class
+        {
+            IKeyedServiceCollection<TKey, TService> collection = services.GetService<IKeyedServiceCollection<TKey, TService>>();
+            return collection?.GetService(key);
+        }
+
+        /// <summary>
+        /// Acquire a service by name.
+        /// </summary>
+        public static TService GetServiceByName<TService>(this IServiceProvider services, string name)
+            where TService : class
+        {
+            return services.GetServiceByKey<string,TService>(name);
+        }
+    }
+}

--- a/src/Orleans/Utils/ServiceCollectionExtensions.cs
+++ b/src/Orleans/Utils/ServiceCollectionExtensions.cs
@@ -2,7 +2,7 @@ using System.Linq;
 
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans
+namespace Orleans.Runtime
 {
     /// <summary>
     /// Extension methods for <see cref="IServiceCollection"/>.

--- a/test/Tester/DependencyInjectionDisambiguationTests.cs
+++ b/test/Tester/DependencyInjectionDisambiguationTests.cs
@@ -1,0 +1,63 @@
+﻿
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Orleans.Runtime;
+
+namespace UnitTests.General
+{
+    [TestCategory("DI")]
+    public class DependencyInjectionDisambiguationTests
+    {
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public void DisambiguateByKeyTest()
+        {
+            IServiceProvider services = ConfigureServices();
+            int actual0 = services.GetServiceByKey<int, IValue<int>>(0).Value;
+            Assert.StrictEqual(0, actual0);
+            int actual1 = services.GetServiceByKey<int, IValue<int>>(1).Value;
+            Assert.StrictEqual(1, actual1);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public void DisambiguateByNameTest()
+        {
+            IServiceProvider services = ConfigureServices();
+            string actualThis = services.GetServiceByName<IValue<string>>("this").Value;
+            Assert.StrictEqual("this", actualThis);
+            string actualThat = services.GetServiceByName<IValue<string>>("that").Value;
+            Assert.StrictEqual("that", actualThat);
+        }
+
+        private interface IValue<out TValue>
+        {
+            TValue Value { get; }
+        }
+
+        private class SomeValue<TValue> : IValue<TValue>
+        {
+            public TValue Value { get; set; }
+        }
+
+        private class ValueServiceCollection<TValue> : IKeyedServiceCollection<TValue, IValue<TValue>>
+        {
+            public IValue<TValue> GetService(TValue name)
+            {
+                return new SomeValue<TValue> { Value = name };
+            }
+        }
+
+        private IServiceProvider ConfigureServices()
+        {
+            IServiceCollection services = new ServiceCollection();
+
+            // add services by Key;
+            services.AddSingleton<IKeyedServiceCollection<int, IValue<int>>, ValueServiceCollection<int>>();
+
+            // add named services
+            services.AddTransient<IKeyedServiceCollection<string, IValue<string>>, ValueServiceCollection<string>>();
+
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ClientConnectionTests\ClientDisconnectionEventTests.cs" />
     <Compile Include="ClientConnectionTests\GatewayConnectionTests.cs" />
     <Compile Include="CollectionFixtures.cs" />
+    <Compile Include="DependencyInjectionDisambiguationTests.cs" />
     <Compile Include="EventSourcingTests\AccountGrainTests.cs" />
     <Compile Include="EventSourcingTests\ChatGrainTests.cs" />
     <Compile Include="EventSourcingTests\CountersGrainPerfTests.cs" />


### PR DESCRIPTION
Since we're limited to features provided by Microsoft.Extensions.DependencyInjection.Abstractions, neither we nor our users that don't use more advanced DI, have a means of acquiring a service from a service provider by name or key.  This PR introduces a minimal implementation for this.

To register a keyed or named service in the service collection:

                // add keyed services
                services.AddTransient<Zero>().WithKey<int, IValue<int>, Zero>(0);
                services.AddTransient<One>().WithKey<int, IValue<int>, One>(1);

                // add named services
                services.AddTransient<This>().WithName<IValue<string>, This>("this");
                services.AddTransient<That>().WithName<IValue<string>, That>("that");

To acquire these from a service provider:

                // get by key
                IValue<int> intValue = ServiceProvider.GetServiceByKey<int,IValue<int>>(0);

                // get by name
                IValue<string> stringValue = ServiceProvider.GetServiceByKey<int,IValue<string>>("that");

