### PR TITLE
Minor test fixes for non-static client.

### DIFF
--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -566,6 +566,7 @@ namespace Orleans.TestingHost
                 }
                 catch
                 {
+                    this.InternalClient?.Abort();
                     this.InternalClient = null;
                     throw;
                 }

--- a/test/NonSilo.Tests/ConfigTests.cs
+++ b/test/NonSilo.Tests/ConfigTests.cs
@@ -767,17 +767,23 @@ namespace UnitTests
             const string filename = "ClientConfig_NewAzure.xml";
 
             var client = new ClientBuilder().LoadConfiguration(filename).Build();
+            try
+            {
+                ClientConfiguration config = client.Configuration;
 
-            ClientConfiguration config = client.Configuration;
+                output.WriteLine(config);
 
-            output.WriteLine(config);
+                Assert.NotNull(config); // Client.CurrentConfig
 
-            Assert.NotNull(config); // Client.CurrentConfig
+                Assert.Equal(filename, Path.GetFileName(config.SourceFile)); // ClientConfig.SourceFile
 
-            Assert.Equal(filename, Path.GetFileName(config.SourceFile)); // ClientConfig.SourceFile
-
-            // GatewayProviderType
-            Assert.Equal(ClientConfiguration.GatewayProviderType.AzureTable, config.GatewayProvider);
+                // GatewayProviderType
+                Assert.Equal(ClientConfiguration.GatewayProviderType.AzureTable, config.GatewayProvider);
+            }
+            finally
+            {
+                client.Dispose();
+            }
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Config"), TestCategory("Azure")]

--- a/test/TesterInternal/GatewaySelectionTest.cs
+++ b/test/TesterInternal/GatewaySelectionTest.cs
@@ -44,6 +44,7 @@ namespace UnitTests.MessageCenterTests
             var cfg = new ClientConfiguration();
             cfg.Gateways = null;
             bool failed = false;
+            IDisposable client = null;
             try
             {
                 new ClientBuilder().UseConfiguration(cfg).Build();
@@ -52,6 +53,10 @@ namespace UnitTests.MessageCenterTests
             {
                 output.WriteLine(exc.ToString());
                 failed = true;
+            }
+            finally
+            {
+                client?.Dispose();
             }
             Assert.True(failed, "GatewaySelection_EmptyList failed as GatewayManager did not throw on empty Gateway list.");
 


### PR DESCRIPTION
Dispose `IClusterClient`