### PR TITLE
Use ILocalSiloDetails abstraction

### DIFF
--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -153,7 +153,7 @@ namespace Orleans.Runtime
         private readonly MultiClusterRegistrationStrategyManager multiClusterRegistrationStrategyManager;
 
         public Catalog(
-            SiloInitializationParameters siloInitializationParameters,
+            ILocalSiloDetails localSiloDetails,
             ILocalGrainDirectory grainDirectory,
             GrainTypeManager typeManager,
             OrleansTaskScheduler scheduler,
@@ -168,8 +168,8 @@ namespace Orleans.Runtime
             MultiClusterRegistrationStrategyManager multiClusterRegistrationStrategyManager)
             : base(Constants.CatalogId, messageCenter.MyAddress)
         {
-            LocalSilo = siloInitializationParameters.SiloAddress;
-            localSiloName = siloInitializationParameters.Name;
+            LocalSilo = localSiloDetails.SiloAddress;
+            localSiloName = localSiloDetails.Name;
             directory = grainDirectory;
             activations = activationDirectory;
             this.scheduler = scheduler;

--- a/src/OrleansRuntime/GrainDirectory/ClientObserverRegistrar.cs
+++ b/src/OrleansRuntime/GrainDirectory/ClientObserverRegistrar.cs
@@ -24,14 +24,14 @@ namespace Orleans.Runtime
 
 
         public ClientObserverRegistrar(
-            SiloInitializationParameters initializationParameters,
+            ILocalSiloDetails siloDetails,
             ILocalGrainDirectory dir,
             OrleansTaskScheduler scheduler,
             ClusterConfiguration config)
-            : base(Constants.ClientObserverRegistrarId, initializationParameters.SiloAddress)
+            : base(Constants.ClientObserverRegistrarId, siloDetails.SiloAddress)
         {
             grainDirectory = dir;
-            myAddress = initializationParameters.SiloAddress;
+            myAddress = siloDetails.SiloAddress;
             this.scheduler = scheduler;
             orleansConfig = config;
             logger = LogManager.GetLogger(typeof(ClientObserverRegistrar).Name);

--- a/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
@@ -93,7 +93,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public LocalGrainDirectory(
             ClusterConfiguration clusterConfig,
-            SiloInitializationParameters siloInitializationParameters,
+            ILocalSiloDetails siloDetails,
             OrleansTaskScheduler scheduler,
             ISiloStatusOracle siloStatusOracle,
             IMultiClusterOracle multiClusterOracle,
@@ -104,7 +104,7 @@ namespace Orleans.Runtime.GrainDirectory
             var globalConfig = clusterConfig.Globals;
 
             var clusterId = globalConfig.HasMultiClusterNetwork ? globalConfig.ClusterId : null;
-            MyAddress = siloInitializationParameters.SiloAddress;
+            MyAddress = siloDetails.SiloAddress;
 
             Scheduler = scheduler;
             this.siloStatusOracle = siloStatusOracle;

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -34,8 +34,8 @@ namespace Orleans.Runtime
 
         public GrainInterfaceMap ClusterGrainInterfaceMap { get; private set; }
         
-        public GrainTypeManager(SiloInitializationParameters silo, SiloAssemblyLoader loader, DefaultPlacementStrategy defaultPlacementStrategy, SerializationManager serializationManager, MultiClusterRegistrationStrategyManager multiClusterRegistrationStrategyManager)
-            : this(silo.SiloAddress.Endpoint.Address.Equals(IPAddress.Loopback), loader, defaultPlacementStrategy, serializationManager, multiClusterRegistrationStrategyManager)
+        public GrainTypeManager(ILocalSiloDetails siloDetails, SiloAssemblyLoader loader, DefaultPlacementStrategy defaultPlacementStrategy, SerializationManager serializationManager, MultiClusterRegistrationStrategyManager multiClusterRegistrationStrategyManager)
+            : this(siloDetails.SiloAddress.Endpoint.Address.Equals(IPAddress.Loopback), loader, defaultPlacementStrategy, serializationManager, multiClusterRegistrationStrategyManager)
         {
         }
 

--- a/src/OrleansRuntime/Messaging/MessageCenter.cs
+++ b/src/OrleansRuntime/Messaging/MessageCenter.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.Messaging
         public IMessagingConfiguration MessagingConfiguration { get; private set; }
 
         public MessageCenter(
-            SiloInitializationParameters silo,
+            ILocalSiloDetails siloDetails,
             NodeConfiguration nodeConfig,
             IMessagingConfiguration config,
             SerializationManager serializationManager,
@@ -50,7 +50,7 @@ namespace Orleans.Runtime.Messaging
         {
             this.serializationManager = serializationManager;
             this.messageFactory = messageFactory;
-            this.Initialize(silo.SiloAddress.Endpoint, nodeConfig.Generation, config, metrics);
+            this.Initialize(siloDetails.SiloAddress.Endpoint, nodeConfig.Generation, config, metrics);
             if (nodeConfig.IsGatewayNode)
             {
                 this.InstallGateway(nodeConfig.ProxyGatewayEndpoint);

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -222,7 +222,7 @@ namespace Orleans.Runtime
             var services = new ServiceCollection();
             services.AddSingleton(this);
             services.AddSingleton(initializationParams);
-            services.AddSingleton<ILocalSiloDetails>(initializationParams);
+            services.AddFromExisting<ILocalSiloDetails, SiloInitializationParameters>();
             services.AddSingleton(initializationParams.ClusterConfig);
             services.AddSingleton(initializationParams.GlobalConfig);
             services.AddTransient(sp => initializationParams.NodeConfig);


### PR DESCRIPTION
Minor cleanup to use the abstraction (interface) instead of the concrete object when it's not required