### PR TITLE
Re-categorize some BVTs as slow

### DIFF
--- a/test/DefaultCluster.Tests/BasicActivationTests.cs
+++ b/test/DefaultCluster.Tests/BasicActivationTests.cs
@@ -185,7 +185,7 @@ namespace DefaultCluster.Tests.General
             this.Logger.Info("GetMultipleGrainInterfaces_Array() worked");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"),
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"),
          TestCategory("Reentrancy")]
         public void BasicActivation_Reentrant_RecoveryAfterExpiredMessage()
         {

--- a/test/DefaultCluster.Tests/EchoTaskGrainTests.cs
+++ b/test/DefaultCluster.Tests/EchoTaskGrainTests.cs
@@ -69,7 +69,7 @@ namespace DefaultCluster.Tests.General
             }).WithTimeout(timeout);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Echo"), TestCategory("Timeout")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Echo"), TestCategory("Timeout")]
         public async Task EchoGrain_Timeout_Wait()
         {
             grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
@@ -94,7 +94,7 @@ namespace DefaultCluster.Tests.General
             Assert.True(TimeIsShorter(sw.Elapsed, delay60), $"Elapsed time out of range: {sw.Elapsed}");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Echo")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Echo")]
         public async Task EchoGrain_Timeout_Await()
         {
             grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
@@ -118,7 +118,7 @@ namespace DefaultCluster.Tests.General
             Assert.True(TimeIsShorter(sw.Elapsed, delay60), $"Elapsed time out of range: {sw.Elapsed}");
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Echo"), TestCategory("Timeout")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Echo"), TestCategory("Timeout")]
         public async Task EchoGrain_Timeout_Result()
         {
             grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());

--- a/test/DefaultCluster.Tests/StatelessWorkerTests.cs
+++ b/test/DefaultCluster.Tests/StatelessWorkerTests.cs
@@ -24,7 +24,7 @@ namespace DefaultCluster.Tests.General
             this.output = output;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("StatelessWorker")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("StatelessWorker")]
         public async Task StatelessWorkerActivationsPerSiloDoNotExceedMaxLocalWorkersCount()
         {
             var gatewaysCount = HostedCluster.ClientConfiguration.Gateways.Count;

--- a/test/DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/DefaultCluster.Tests/TimerOrleansTest.cs
@@ -20,7 +20,7 @@ namespace DefaultCluster.Tests.TimerTests
             this.output = output;
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Timers")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Timers")]
         public async Task TimerOrleansTest_Basic()
         {
             for (int i = 0; i < 10; i++)
@@ -134,7 +134,7 @@ namespace DefaultCluster.Tests.TimerTests
                 ". Actual ticks = " + last);
         }
 
-        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Timers")]
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Timers")]
         public async Task AsyncTimerTest_GrainCall()
         {
             const string testName = "AsyncTimerTest_GrainCall";

--- a/test/Tester/ClientConnectionTests/ClientDisconnectionEventTests.cs
+++ b/test/Tester/ClientConnectionTests/ClientDisconnectionEventTests.cs
@@ -24,7 +24,7 @@ namespace Tester.ClientConnectionTests
             this.runtimeClient = this.HostedCluster.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();
         }
 
-        [Fact, TestCategory("BVT")]
+        [Fact, TestCategory("SlowBVT")]
         public async Task EventSendWhenDisconnectedFromCluster()
         {
             var runtime = this.HostedCluster.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();


### PR DESCRIPTION
This way they can be skipped more easily when doing local development (they are still always ran in CI though).