### PR TITLE
Update targets file to use released NuGet 4.0 always.

### DIFF
--- a/src/Before.Orleans.sln.targets
+++ b/src/Before.Orleans.sln.targets
@@ -11,8 +11,7 @@
 	</Target>
 
         <PropertyGroup>
-                <NugetDownloadUrl>https://dist.nuget.org/win-x86-commandline/latest/nuget.exe</NugetDownloadUrl>
-                <NugetDownloadUrl Condition=" '$(VisualStudioVersion)'=='15.0' ">https://dist.nuget.org/win-x86-commandline/v4.0.0-rc4/nuget.exe</NugetDownloadUrl>
+                <NugetDownloadUrl>https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe</NugetDownloadUrl>
         </PropertyGroup>
 
 	<PropertyGroup Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
Fix before targets to download NuGet 4.0 so NuGet.exe will have no MSBuild 14 dependency.