### PR TITLE
Avoid parallelization on INSERT

### DIFF
--- a/test/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
+++ b/test/AWSUtils.Tests/StorageTests/DynamoDBStorageProviderTests.cs
@@ -39,15 +39,15 @@ namespace AWSUtils.Tests.StorageTests
         }
 
         [SkippableFact, TestCategory("Functional")]
-        internal async Task WriteReadCyrillic()
+        public async Task WriteReadCyrillic()
         {
             await PersistenceStorageTests.PersistenceStorage_Relational_WriteReadIdCyrillic();
         }
 
         [SkippableFact, TestCategory("Functional")]
-        internal void WriteRead100StatesInParallel()
+        public async Task WriteRead100StatesInParallel()
         {
-            PersistenceStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel();
+            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel();
         }
     }
 }

--- a/test/TesterSQLUtils/StorageTests/Relational/MySqlStorageTests.cs
+++ b/test/TesterSQLUtils/StorageTests/Relational/MySqlStorageTests.cs
@@ -3,7 +3,6 @@ using Orleans.Runtime;
 using Orleans.SqlUtils;
 using System;
 using System.Threading.Tasks;
-using TestExtensions;
 using UnitTests.StorageTests.Relational.TestDataSets;
 using Xunit;
 
@@ -15,8 +14,8 @@ namespace UnitTests.StorageTests.Relational
     /// <remarks>To duplicate these tests to any back-end, not just for relational, copy and paste this class,
     /// optionally remove <see cref="RelationalStorageTests"/> inheritance and implement a provider and environment
     /// setup as done in <see cref="CommonFixture"/> and how it delegates it.</remarks>
-    [TestCategory("MySql")]
-    public class MySqlStorageTests: RelationalStorageTests, IDisposable, IClassFixture<CommonFixture>
+    [TestCategory("MySql"), TestCategory("Persistence")]
+    public class MySqlStorageTests: RelationalStorageTests, IClassFixture<CommonFixture>
     {
         /// <summary>
         /// The storage invariant, storage ID, or ADO.NET invariant for this test set.
@@ -29,37 +28,31 @@ namespace UnitTests.StorageTests.Relational
             Skip.If(PersistenceStorageTests == null, $"Persistence storage not available for MySql.");
         }
 
-
-        public void Dispose()
-        {
-            //XUnit.NET will automatically call this after every test method run. There is no need to always call this method.
-        }
-
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
-        internal async Task WriteReadCyrillic()
+        [TestCategory("Functional")]
+        public async Task WriteReadCyrillic()
         {
             await PersistenceStorageTests.PersistenceStorage_Relational_WriteReadIdCyrillic();
         }
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
-        internal void WriteRead100StatesInParallel()
+        [TestCategory("Functional")]
+        public async Task WriteRead100StatesInParallel()
         {
-            Relational_WriteReadWriteRead100StatesInParallel();
+            await Relational_WriteReadWriteRead100StatesInParallel();
         }
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
-        internal void StorageDataSetGeneric_HashCollisionTests()
+        [TestCategory("Functional")]
+        public async Task StorageDataSetGeneric_HashCollisionTests()
         {
-            Relational_HashCollisionTests();
+            await Relational_HashCollisionTests();
         }
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task ChangeStorageFormatFromBinaryToJson_WriteRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestState1> grainState)
         {
             await this.Relational_ChangeStorageFormatFromBinaryToJsonInMemory_WriteRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -67,23 +60,23 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
-        internal async Task PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException()
+        [TestCategory("Functional")]
+        public async Task PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException()
         {
             await Relational_WriteDuplicateFailsWithInconsistentStateException();
         }
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
-        internal async Task WriteInconsistentFailsWithIncosistentStateException()
+        [TestCategory("Functional")]
+        public async Task WriteInconsistentFailsWithIncosistentStateException()
         {
             await Relational_WriteInconsistentFailsWithIncosistentStateException();
         }
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task PersistenceStorage_StorageDataSetPlain_IntegerKey_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestState1> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -91,7 +84,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<Guid>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetPlain_GuidKey_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestState1> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -99,7 +92,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetPlain_StringKey_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestState1> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -107,7 +100,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSet2CyrillicIdsAndGrainNames<string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task DataSet2_Cyrillic_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrain, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrain(this.Fixture.InternalGrainFactory), grainState);
@@ -115,7 +108,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<long, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_IntegerKey_Generic_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -123,7 +116,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<Guid, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_GuidKey_Generic_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -131,7 +124,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_StringKey_Generic_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -139,7 +132,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_Json_WriteRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.Relational_Json_WriteRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -147,7 +140,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGenericHuge<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGenericHuge_Json_WriteReadStreaming(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.Relational_Json_WriteReadStreaming(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -155,7 +148,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_Xml_WriteRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.Relational_Xml_WriteRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);
@@ -163,7 +156,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGenericHuge<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGenericHuge_Xml_WriteReadStreaming(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.Relational_Xml_WriteReadStreaming(grainType, getGrainReference(this.Fixture.InternalGrainFactory),grainState);

--- a/test/TesterSQLUtils/StorageTests/Relational/RelationalStorageTests.cs
+++ b/test/TesterSQLUtils/StorageTests/Relational/RelationalStorageTests.cs
@@ -62,16 +62,16 @@ namespace UnitTests.StorageTests.Relational
         }
 
 
-        internal void Relational_WriteReadWriteRead100StatesInParallel()
+        internal async Task Relational_WriteReadWriteRead100StatesInParallel()
         {
-            PersistenceStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel(nameof(Relational_WriteReadWriteRead100StatesInParallel));
+            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel(nameof(Relational_WriteReadWriteRead100StatesInParallel));
         }
 
 
-        internal void Relational_HashCollisionTests()
+        internal async Task Relational_HashCollisionTests()
         {
             ((AdoNetStorageProvider)PersistenceStorageTests.Storage).HashPicker = ConstantHasher;
-            PersistenceStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel(nameof(Relational_HashCollisionTests), 2);
+            await PersistenceStorageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel(nameof(Relational_HashCollisionTests), 2);
         }
 
 

--- a/test/TesterSQLUtils/StorageTests/Relational/SqlServerStorageTests.cs
+++ b/test/TesterSQLUtils/StorageTests/Relational/SqlServerStorageTests.cs
@@ -16,7 +16,7 @@ namespace UnitTests.StorageTests.Relational
     /// <remarks>To duplicate these tests to any back-end, not just for relational, copy and paste this class,
     /// optionally remove <see cref="RelationalStorageTests"/> inheritance and implement a provider and environment
     /// setup as done in <see cref="CommonFixture"/> and how it delegates it.</remarks>
-    [TestCategory("SqlServer")]
+    [TestCategory("SqlServer"), TestCategory("Persistence")]
     public class SqlServerStorageTests: RelationalStorageTests, IClassFixture<CommonFixture>
     {
         /// <summary>
@@ -31,7 +31,7 @@ namespace UnitTests.StorageTests.Relational
         }
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         public async Task WriteReadCyrillic()
         {
             await PersistenceStorageTests.PersistenceStorage_Relational_WriteReadIdCyrillic();
@@ -39,22 +39,22 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
-        public void WriteReadWriteRead100StatesInParallel()
+        [TestCategory("Functional")]
+        public async Task WriteReadWriteRead100StatesInParallel()
         {
-            Relational_WriteReadWriteRead100StatesInParallel();
+            await Relational_WriteReadWriteRead100StatesInParallel();
         }
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
-        public void StorageDataSetGeneric_HashCollisionTests()
+        [TestCategory("Functional")]
+        public async Task StorageDataSetGeneric_HashCollisionTests()
         {
-            Relational_HashCollisionTests();
+            await Relational_HashCollisionTests();
         }
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task ChangeStorageFormatFromBinaryToJson_WriteRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestState1> grainState)
         {
             await this.Relational_ChangeStorageFormatFromBinaryToJsonInMemory_WriteRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -62,7 +62,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         public async Task WriteDuplicateFailsWithInconsistentStateException()
         {
             await Relational_WriteDuplicateFailsWithInconsistentStateException();
@@ -70,7 +70,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableFact]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         public async Task WriteInconsistentFailsWithIncosistentStateException()
         {
             await Relational_WriteInconsistentFailsWithIncosistentStateException();
@@ -78,7 +78,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetPlain_IntegerKey_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestState1> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -86,7 +86,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<Guid>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetPlain_GuidKey_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestState1> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -94,7 +94,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task PersistenceStorage_StorageDataSetPlain_StringKey_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestState1> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -102,7 +102,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSet2CyrillicIdsAndGrainNames<string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task DataSet2_Cyrillic_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -110,7 +110,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<long, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_IntegerKey_Generic_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -118,7 +118,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<Guid, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_GuidKey_Generic_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -126,7 +126,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_StringKey_Generic_WriteClearRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.PersistenceStorageTests.Store_WriteClearRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -134,7 +134,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_Json_WriteRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.Relational_Json_WriteRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -142,7 +142,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGenericHuge<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGenericHuge_Json_WriteReadStreaming(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.Relational_Json_WriteReadStreaming(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -150,7 +150,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGeneric<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGeneric_Xml_WriteRead(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.Relational_Xml_WriteRead(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);
@@ -158,7 +158,7 @@ namespace UnitTests.StorageTests.Relational
 
 
         [SkippableTheory, ClassData(typeof(StorageDataSetGenericHuge<string, string>))]
-        [TestCategory("Functional"), TestCategory("Persistence")]
+        [TestCategory("Functional")]
         internal async Task StorageDataSetGenericHuge_Xml_WriteReadStreaming(string grainType, Func<IInternalGrainFactory, GrainReference> getGrainReference, GrainState<TestStateGeneric1<string>> grainState)
         {
             await this.Relational_Xml_WriteReadStreaming(grainType, getGrainReference(this.Fixture.InternalGrainFactory), grainState);


### PR DESCRIPTION
This would hopefully fix the non-deterministic failure on Relational_WriteReadWriteRead100StatesInParallel once and for all.