### PR TITLE
Change to OrleansCodeGeneration target to fix incremental builds when grain interfaces change

### DIFF
--- a/src/Orleans.SDK.targets
+++ b/src/Orleans.SDK.targets
@@ -40,7 +40,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           AfterTargets="BeforeCompile"
           BeforeTargets="CoreCompile"
           Condition="'$(OrleansCodeGenPrecompile)'!='true'"
-          Inputs="@(ReferencePath)"
+          Inputs="@(Compile);@(ReferencePath)"
           Outputs="$(IntermediateOutputPath)$(TargetName).codegen.cs">
     <Message Text="[OrleansCodeGeneration] - Project=$(ProjectName)" Importance="high"/>
     <Error Text="$(CodeGenToolExe) could not be found!" Condition="!Exists('$(CodeGenToolExe)')" />


### PR DESCRIPTION
Since 1.4.0 our projects have been failing to build incrementally in both Visual Studio 2015 and MSBuild when we change a grain interface because of out-of-date codegen files. I tracked the problem down to the build target changes, and adding the @(Compile) list back to the inputs of the OrleansCodeGeneration target allows incremental builds to work again sice the codegen files are correctly rebuilt. It looks like this input was removed when the orleans.codegen.cs file was removed and changed into the target-specific files.

I'm not sure if this has any other side effects, however... I am not a build targets expert at all. :) I am not sure why it was removed with the codegen changes.