### PR TITLE
ProviderTypeLoader: do not enumerate types in ReflectionOnly assembly.

### DIFF
--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -538,7 +538,8 @@ namespace Orleans.Runtime
             {
                 if (logger != null && logger.IsWarning)
                 {
-                    var message = $"AssemblyLoader encountered an exception loading types from assembly '{assembly.FullName}': {exception}";
+                    var message =
+                        $"Exception loading types from assembly '{assembly.FullName}': {LogFormatter.PrintException(exception)}.";
                     logger.Warn(ErrorCode.Loader_TypeLoadError_5, message, exception);
                 }
                 

--- a/src/Orleans/Providers/ProviderTypeLoader.cs
+++ b/src/Orleans/Providers/ProviderTypeLoader.cs
@@ -87,6 +87,14 @@ namespace Orleans.Providers
 
         private static void ProcessNewAssembly(object sender, AssemblyLoadEventArgs args)
         {
+#if !NETSTANDARD
+            // If the assembly is loaded for reflection only avoid processing it.
+            if (args.LoadedAssembly.ReflectionOnly)
+            {
+                return;
+            }
+#endif
+
             // We do this under the lock to avoid race conditions when an assembly is added 
             // while a type manager is initializing.
             lock (managers)


### PR DESCRIPTION
Also improve logging for errors in `TypeUtils.GetDefinedTypes(...)` so that loader exceptions are made apparent.

Intention is to make debugging issues like #2840 more obvious