### PR TITLE
Handle absolute path in IntermediateOutputPath to address issue #2864 in vNext

### DIFF
--- a/vNext/src/Orleans.SDK.targets
+++ b/vNext/src/Orleans.SDK.targets
@@ -52,7 +52,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 " />
     <PropertyGroup>
       <ArgsFile>$(IntermediateOutputPath)$(TargetName).codegen.args.txt</ArgsFile>
-      <CodeGenFilename>$(ProjectDir)$(IntermediateOutputPath)$(TargetName).codegen.cs</CodeGenFilename>
+      <CodeGenDirectory Condition="'$([System.IO.Path]::IsPathRooted($(IntermediateOutputPath)))' == 'true'">$(IntermediateOutputPath)</CodeGenDirectory>
+      <CodeGenDirectory Condition="'$(CodeGenDirectory)' == ''">$(ProjectDir)$(IntermediateOutputPath)</CodeGenDirectory>
+      <CodeGenFilename Condition="'$(CodeGenFilename)' == ''">$(CodeGenDirectory)$(TargetName).codegen.cs</CodeGenFilename>
       <ExcludeCodeGen>$(DefineConstants);EXCLUDE_CODEGEN</ExcludeCodeGen>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
This is the same change as in #2865, but in the vNext tree.