### PR TITLE
Improve service cleanup

### DIFF
--- a/src/Orleans/Runtime/AsynchQueueAgent.cs
+++ b/src/Orleans/Runtime/AsynchQueueAgent.cs
@@ -108,7 +108,7 @@ namespace Orleans.Runtime
                 threadTracking.OnStopExecution();
             }
 #endif
-            requestQueue.CompleteAdding();
+            requestQueue?.CompleteAdding();
             base.Stop();
         }
 
@@ -143,11 +143,8 @@ namespace Orleans.Runtime
 #endif
             base.Dispose(disposing);
 
-            if (requestQueue != null)
-            {
-                requestQueue.Dispose();
-                requestQueue = null;
-            }
+            requestQueue?.Dispose();
+            requestQueue = null;
         }
 
         #endregion

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -781,6 +781,7 @@ namespace Orleans
                 }
             }
             catch (Exception) { }
+            Utils.SafeExecute(() => (this.ServiceProvider as IDisposable)?.Dispose());
             try
             {
                 LogManager.UnInitialize();

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -936,6 +936,7 @@ namespace Orleans.Runtime
             SafeExecute(LogManager.Close);
             SafeExecute(() => AppDomain.CurrentDomain.UnhandledException -= this.DomainUnobservedExceptionHandler);
             SafeExecute(() => this.assemblyProcessor?.Dispose());
+            SafeExecute(() => (this.Services as IDisposable)?.Dispose());
 
             // Setting the event should be the last thing we do.
             // Do nothijng after that!

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -933,10 +933,10 @@ namespace Orleans.Runtime
             UnobservedExceptionsHandlerClass.ResetUnobservedExceptionHandler();
 
             SafeExecute(() => this.SystemStatus = SystemStatus.Terminated);
-            SafeExecute(LogManager.Close);
             SafeExecute(() => AppDomain.CurrentDomain.UnhandledException -= this.DomainUnobservedExceptionHandler);
             SafeExecute(() => this.assemblyProcessor?.Dispose());
             SafeExecute(() => (this.Services as IDisposable)?.Dispose());
+            SafeExecute(LogManager.Close);
 
             // Setting the event should be the last thing we do.
             // Do nothijng after that!


### PR DESCRIPTION
- Dispose service provider when shutting down Silo and Client (which in turns disposes all disposable services in it).
- Close log after fully shutting down.
- Do not throw when calling Stop on AsynchQueueAgent after it was disposed.