### PR TITLE
Downgrade Newtosoft.Json dependency in test projects to 7.0.1

### DIFF
--- a/src/OrleansServiceFabricUtils/App.config
+++ b/src/OrleansServiceFabricUtils/App.config
@@ -9,7 +9,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/OrleansServiceFabricUtils/project.json
+++ b/src/OrleansServiceFabricUtils/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.ServiceFabric.Services": "2.4.145",
-    "Newtonsoft.Json": "9.0.1"
+    "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {
     "net451": {}

--- a/test/AWSUtils.Tests/App.config
+++ b/test/AWSUtils.Tests/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/BondUtils.Tests/App.config
+++ b/test/BondUtils.Tests/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/Consul.Tests/App.config
+++ b/test/Consul.Tests/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/DefaultCluster.Tests/App.config
+++ b/test/DefaultCluster.Tests/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/GoogleUtils.Tests/App.config
+++ b/test/GoogleUtils.Tests/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/NonSiloTests/App.config
+++ b/test/NonSiloTests/App.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/NonSiloTests/project.json
+++ b/test/NonSiloTests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Newtonsoft.Json": "9.0.1"
+    "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {
     "net451": {}

--- a/test/PSUtils.Tests/App.config
+++ b/test/PSUtils.Tests/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/ServiceBus.Tests/App.config
+++ b/test/ServiceBus.Tests/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/Tester/App.config
+++ b/test/Tester/App.config
@@ -26,7 +26,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/test/Tester/project.json
+++ b/test/Tester/project.json
@@ -3,7 +3,7 @@
     "FluentAssertions": "4.18.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
     "Microsoft.Extensions.Configuration.Json": "1.0.0",
-    "Newtonsoft.Json": "9.0.1",
+    "Newtonsoft.Json": "7.0.1",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"

--- a/test/TesterAzureUtils/App.config
+++ b/test/TesterAzureUtils/App.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/TesterAzureUtils/project.json
+++ b/test/TesterAzureUtils/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "FluentAssertions": "4.18.0",
-    "Newtonsoft.Json": "9.0.1",
+    "Newtonsoft.Json": "7.0.1",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"

--- a/test/TesterInternal/App.config
+++ b/test/TesterInternal/App.config
@@ -10,7 +10,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/test/TesterSQLUtils/App.config
+++ b/test/TesterSQLUtils/App.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/TesterSQLUtils/project.json
+++ b/test/TesterSQLUtils/project.json
@@ -3,7 +3,7 @@
     "FluentAssertions": "4.18.0",
     "Microsoft.Data.SQLite": "1.1.0",
     "MySql.Data": "6.9.9",
-    "Newtonsoft.Json": "9.0.1",
+    "Newtonsoft.Json": "7.0.1",
     "Npgsql": "3.1.9",
     "system.data.sqlclient": "4.3.0",
     "xunit": "2.1.0",

--- a/test/TesterZooKeeperUtils/App.config
+++ b/test/TesterZooKeeperUtils/App.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/TesterZooKeeperUtils/project.json
+++ b/test/TesterZooKeeperUtils/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "FluentAssertions": "4.18.0",
-    "Newtonsoft.Json": "9.0.1",
+    "Newtonsoft.Json": "7.0.1",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0",
     "Xunit.SkippableFact": "1.2.14"


### PR DESCRIPTION
This is to simplify distributed tests for that branch by making dependency on Newtosoft.Json uniform.