### PR TITLE
Run functionals without Azure requirement

### DIFF
--- a/test/TestExtensions/TestDefaultConfiguration.cs
+++ b/test/TestExtensions/TestDefaultConfiguration.cs
@@ -35,9 +35,9 @@ namespace TestExtensions
                 { nameof(ZooKeeperConnectionString), "127.0.0.1:2181" },
                 { nameof(TestClusterOptions.FallbackOptions.TraceToConsole), "false" },
             });
-            builder.AddEnvironmentVariables("Orleans");
 
             AddJsonFileInAncestorFolder(builder, "OrleansTestSecrets.json");
+            builder.AddEnvironmentVariables("Orleans");
 
             var config = builder.Build();
             return config;

--- a/test/TestInternalGrains/StreamingGrain.cs
+++ b/test/TestInternalGrains/StreamingGrain.cs
@@ -898,10 +898,8 @@ namespace UnitTests.Grains
             _observers = new Dictionary<string, IConsumerObserver>();
             // discuss: Note that we need to know the provider that will be used in advance. I think it would be beneficial if we specified the provider as an argument to ImplicitConsumerActivationAttribute.
 
-
-            await Task.WhenAll(
-                BecomeConsumer(this.GetPrimaryKey(), "SMSProvider", "TestNamespace1"),
-                BecomeConsumer(this.GetPrimaryKey(), "AzureQueueProvider", "TestNamespace1"));
+            var activeStreamProviders = Runtime.StreamProviderManager.GetStreamProviders().Select(x => x.Name).ToList();
+            await Task.WhenAll(activeStreamProviders.Select(stream => BecomeConsumer(this.GetPrimaryKey(), stream, "TestNamespace1")));
         }
 
         public override Task OnDeactivateAsync()

--- a/test/Tester/TestUtils.cs
+++ b/test/Tester/TestUtils.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Runtime;
-using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
 using Xunit;
@@ -23,6 +22,11 @@ namespace Tester
 
         public static void CheckForAzureStorage()
         {
+            if (string.IsNullOrWhiteSpace(TestDefaultConfiguration.DataConnectionString))
+            {
+                throw new SkipException("No connection string found. Skipping");
+            }
+
             bool usingLocalWAS = string.Equals(TestDefaultConfiguration.DataConnectionString, "UseDevelopmentStorage=true", StringComparison.OrdinalIgnoreCase);
 
             if (!usingLocalWAS)

--- a/test/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
@@ -1,8 +1,6 @@
-
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Orleans;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
@@ -15,6 +13,7 @@ using Xunit;
 
 namespace Tester.AzureUtils.Streaming
 {
+    [TestCategory("Streaming")]
     public class DelayedQueueRebalancingTests : TestClusterPerTest
     {
         private const string adapterName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
@@ -26,6 +25,8 @@ namespace Tester.AzureUtils.Streaming
 
         public override TestCluster CreateTestCluster()
         {
+            TestUtils.CheckForAzureStorage();
+
             // Define a cluster of 4, but deploy ony 2 to start.
             var options = new TestClusterOptions(4);
 
@@ -43,7 +44,7 @@ namespace Tester.AzureUtils.Streaming
             return host;
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Streaming")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_1()
         {
             await ValidateAgentsState(2, 2, "1");
@@ -53,7 +54,7 @@ namespace Tester.AzureUtils.Streaming
             await ValidateAgentsState(2, 4, "2");
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Streaming")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_2()
         {
             await ValidateAgentsState(2, 2, "1");

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -11,6 +11,7 @@ using TestExtensions;
 using UnitTests.GrainInterfaces;
 using UnitTests.StreamingTests;
 using Xunit;
+using Tester.AzureUtils;
 
 namespace UnitTests.HaloTests.Streaming
 {
@@ -19,7 +20,7 @@ namespace UnitTests.HaloTests.Streaming
     {
         private readonly Fixture fixture;
 
-        public class Fixture : BaseTestClusterFixture
+        public class Fixture : BaseAzureTestClusterFixture
         {
             public const string AzureQueueStreamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
             public const string SmsStreamProviderName = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
@@ -44,9 +45,12 @@ namespace UnitTests.HaloTests.Streaming
 
             public override void Dispose()
             {
-                var deploymentId = this.HostedCluster.DeploymentId;
+                var deploymentId = this.HostedCluster?.DeploymentId;
                 base.Dispose();
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(AzureQueueStreamProviderName, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+                if (deploymentId != null)
+                {
+                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(AzureQueueStreamProviderName, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+                }
             }
         }
 
@@ -63,18 +67,19 @@ namespace UnitTests.HaloTests.Streaming
         {
             this.fixture = fixture;
             HostedCluster = fixture.HostedCluster;
+            fixture.EnsurePreconditionsMet();
         }
-        
+
         public void Dispose()
         {
-            var deploymentId = this.HostedCluster.DeploymentId;
-            if (_streamProvider != null && _streamProvider.Equals(AzureQueueStreamProviderName))
+            var deploymentId = this.HostedCluster?.DeploymentId;
+            if (deploymentId != null && _streamProvider != null && _streamProvider.Equals(AzureQueueStreamProviderName))
             {
                 AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(_streamProvider, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
             }
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task Halo_SMS_ResubscribeTest_ConsumerProducer()
         {
             this.fixture.Logger.Info("\n\n************************ Halo_SMS_ResubscribeTest_ConsumerProducer ********************************* \n\n");
@@ -86,7 +91,7 @@ namespace UnitTests.HaloTests.Streaming
             await ConsumerProducerTest(consumerGuid, producerGuid);
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task Halo_SMS_ResubscribeTest_ProducerConsumer()
         {
             this.fixture.Logger.Info("\n\n************************ Halo_SMS_ResubscribeTest_ProducerConsumer ********************************* \n\n");
@@ -98,7 +103,7 @@ namespace UnitTests.HaloTests.Streaming
             await ProducerConsumerTest(producerGuid, consumerGuid);
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task Halo_AzureQueue_ResubscribeTest_ConsumerProducer()
         {
             this.fixture.Logger.Info("\n\n************************ Halo_AzureQueue_ResubscribeTest_ConsumerProducer ********************************* \n\n");
@@ -110,7 +115,7 @@ namespace UnitTests.HaloTests.Streaming
             await ConsumerProducerTest(consumerGuid, producerGuid);
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task Halo_AzureQueue_ResubscribeTest_ProducerConsumer()
         {
             this.fixture.Logger.Info("\n\n************************ Halo_AzureQueue_ResubscribeTest_ProducerConsumer ********************************* \n\n");

--- a/test/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
@@ -30,11 +30,14 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.DeploymentId;
-            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(StreamProvider, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+            var deploymentId = HostedCluster?.DeploymentId;
+            if (deploymentId != null)
+            {
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(StreamProvider, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+            }
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task SampleStreamingTests_4()
         {
             logger.Info("************************ SampleStreamingTests_4 *********************************");
@@ -42,7 +45,7 @@ namespace Tester.AzureUtils.Streaming
             await runner.StreamingTests_Consumer_Producer(Guid.NewGuid());
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task SampleStreamingTests_5()
         {
             logger.Info("************************ SampleStreamingTests_5 *********************************");

--- a/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
@@ -10,6 +10,7 @@ using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using Xunit.Abstractions;
+using Tester;
 
 namespace UnitTests.StreamingTests
 {
@@ -28,6 +29,8 @@ namespace UnitTests.StreamingTests
 
         public override TestCluster CreateTestCluster()
         {
+            TestUtils.CheckForAzureStorage();
+
             var options = new TestClusterOptions();
 
             options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
@@ -62,31 +65,31 @@ namespace UnitTests.StreamingTests
             base.Dispose();
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task StreamCleanup_Deactivate()
         {
             await DoStreamCleanupTest_Deactivate(false, false);
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task StreamCleanup_BadDeactivate()
         {
             await DoStreamCleanupTest_Deactivate(true, false);
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task StreamCleanup_UseAfter_Deactivate()
         {
             await DoStreamCleanupTest_Deactivate(false, true);
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task StreamCleanup_UseAfter_BadDeactivate()
         {
             await DoStreamCleanupTest_Deactivate(true, true);
         }
 
-        [Fact, TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task Stream_Lifecycle_AddRemoveProducers()
         {
             string testName = "Stream_Lifecycle_AddRemoveProducers";

--- a/test/TesterInternal/General/ElasticPlacementTest.cs
+++ b/test/TesterInternal/General/ElasticPlacementTest.cs
@@ -1,21 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
-using Tester;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
 
 namespace UnitTests.General
 {
+    [TestCategory("Elasticity"), TestCategory("Placement")]
     public class ElasticPlacementTests : TestClusterPerTest
     {
         private readonly List<IActivationCountBasedPlacementTestGrain> grains = new List<IActivationCountBasedPlacementTestGrain>();
@@ -24,16 +22,10 @@ namespace UnitTests.General
 
         public override TestCluster CreateTestCluster()
         {
-            TestUtils.CheckForAzureStorage();
             var options = new TestClusterOptions();
 
             options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore");
             options.ClusterConfiguration.AddMemoryStorageProvider("Default");
-
-            options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
-            options.ClientConfiguration.GatewayProvider = ClientConfiguration.GatewayProviderType.AzureTable;
-            options.ClusterConfiguration.Globals.TypeMapRefreshInterval = TimeSpan.FromMilliseconds(100);
-
             return new TestCluster(options);
         }
 
@@ -41,7 +33,7 @@ namespace UnitTests.General
         /// Test placement behaviour for newly added silos. The grain placement strategy should favor them
         /// until they reach a similar load as the other silos.
         /// </summary>
-        [Fact, TestCategory("Functional"), TestCategory("Elasticity"), TestCategory("Placement")]
+        [Fact, TestCategory("Functional")]
         public async Task ElasticityTest_CatchingUp()
         {
 
@@ -95,7 +87,7 @@ namespace UnitTests.General
         /// This evaluates the how the placement strategy behaves once silos are stopped: The strategy should
         /// balance the activations from the stopped silo evenly among the remaining silos.
         /// </summary>
-        [Fact, TestCategory("Functional"), TestCategory("Elasticity"), TestCategory("Placement")]
+        [Fact, TestCategory("Functional")]
         public async Task ElasticityTest_StoppingSilos()
         {
             List<SiloHandle> runtimes = this.HostedCluster.StartAdditionalSilos(2);
@@ -136,7 +128,7 @@ namespace UnitTests.General
         /// <summary>
         /// Do not place activation in case all silos are above 110 CPU utilization.
         /// </summary>
-        [Fact, TestCategory("Functional"), TestCategory("Elasticity"), TestCategory("Placement")]
+        [Fact, TestCategory("Functional")]
         public async Task ElasticityTest_AllSilosCPUTooHigh()
         {
             var taintedGrainPrimary = await GetGrainAtSilo(this.HostedCluster.Primary.SiloAddress);
@@ -152,7 +144,7 @@ namespace UnitTests.General
         /// <summary>
         /// Do not place activation in case all silos are above 110 CPU utilization or have overloaded flag set.
         /// </summary>
-        [Fact, TestCategory("Functional"), TestCategory("Elasticity"), TestCategory("Placement")]
+        [Fact, TestCategory("Functional")]
         public async Task ElasticityTest_AllSilosOverloaded()
         {
             var taintedGrainPrimary = await GetGrainAtSilo(this.HostedCluster.Primary.SiloAddress);
@@ -169,7 +161,7 @@ namespace UnitTests.General
         }
 
 
-        [Fact, TestCategory("Functional"), TestCategory("Elasticity"), TestCategory("Placement")]
+        [Fact, TestCategory("Functional")]
         public async Task LoadAwareGrainShouldNotAttemptToCreateActivationsOnOverloadedSilo()
         {
             await ElasticityGrainPlacementTest(
@@ -181,7 +173,7 @@ namespace UnitTests.General
                 "A grain instantiated with the load-aware placement strategy should not attempt to create activations on an overloaded silo.");
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Elasticity"), TestCategory("Placement")]
+        [Fact, TestCategory("Functional")]
         public async Task LoadAwareGrainShouldNotAttemptToCreateActivationsOnBusySilos()
         {
             // a CPU usage of 110% will disqualify a silo from getting new grains.

--- a/test/TesterInternal/GeoClusterTests/BasicMultiClusterTest.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicMultiClusterTest.cs
@@ -5,9 +5,11 @@ using Orleans.Runtime;
 using Xunit;
 using Xunit.Abstractions;
 using Orleans.Runtime.Configuration;
+using Tester;
 
 namespace Tests.GeoClusterTests
 {
+    [TestCategory("GeoCluster")]
     public class BasicMultiClusterTest 
     {
 
@@ -37,9 +39,10 @@ namespace Tests.GeoClusterTests
         {
             this.output = output;
         }
+
         private ITestOutputHelper output;
 
-        [Fact, TestCategory("GeoCluster"), TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public void CreateTwoIndependentClusters()
         {
             using (var host = new TestingClusterHost(output))

--- a/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
+++ b/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
@@ -11,6 +11,7 @@ using TestGrainInterfaces;
 using Orleans.Runtime.Configuration;
 using Xunit;
 using Xunit.Abstractions;
+using Tester;
 
 // ReSharper disable InconsistentNaming
 
@@ -18,18 +19,19 @@ namespace Tests.GeoClusterTests
 {
     // We need use ClientWrapper to load a client object in a new app domain. 
     // This allows us to create multiple clients that are connected to different silos.
-
+    [TestCategory("GeoCluster")]
     public class GlobalSingleInstanceClusterTests : TestingClusterHost
     {
 
         public GlobalSingleInstanceClusterTests(ITestOutputHelper output) : base(output)
-        { }
+        {
+        }
 
         /// <summary>
         /// Run all tests on a small configuration (two clusters, one silo each, one client each)
         /// </summary>
         /// <returns></returns>
-        [Fact, TestCategory("Functional"), TestCategory("GeoCluster")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task All_Small()
         {
             await Setup_Clusters(false);
@@ -43,7 +45,7 @@ namespace Tests.GeoClusterTests
         /// Run all tests on a larger configuration (two clusters with 3 or 4 silos, respectively, and two clients each)
         /// </summary>
         /// <returns></returns>
-        [Fact, TestCategory("GeoCluster")]
+        [SkippableFact]
         public async Task All_Large()
         {
             await Setup_Clusters(true);

--- a/test/TesterInternal/GeoClusterTests/MultiClusterNetworkTests.cs
+++ b/test/TesterInternal/GeoClusterTests/MultiClusterNetworkTests.cs
@@ -9,15 +9,16 @@ using Orleans.Runtime.Configuration;
 using Orleans.Runtime.MultiClusterNetwork;
 using Xunit;
 using Xunit.Abstractions;
+using Tester;
 
 namespace Tests.GeoClusterTests
 {
+    [TestCategory("GeoCluster")]
     public class MultiClusterNetworkTests : TestingClusterHost
     {
         public MultiClusterNetworkTests(ITestOutputHelper output) : base(output)
-        { }
-
-       
+        {
+        }
 
         // We need use ClientWrapper to load a client object in a new app domain. 
         // This allows us to create multiple clients that are connected to different silos.
@@ -54,7 +55,7 @@ namespace Tests.GeoClusterTests
         }
 
 
-        [Fact, TestCategory("GeoCluster"), TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task TestMultiClusterConf_1_1()
         {
             // use a random global service id for testing purposes
@@ -145,7 +146,7 @@ namespace Tests.GeoClusterTests
             }
         }
 
-        [Fact, TestCategory("GeoCluster"), TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task TestMultiClusterConf_3_3()
         {
             // use a random global service id for testing purposes

--- a/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
+++ b/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
@@ -5,8 +5,6 @@ using Orleans.Streams;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Tester;
 using TestExtensions;
@@ -17,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace UnitTests.GeoClusterTests
 {
+    [TestCategory("GeoCluster")]
     public class MultiClusterRegistrationTests : TestingClusterHost
     {
         private string[] ClusterNames;
@@ -33,7 +32,7 @@ namespace UnitTests.GeoClusterTests
         {
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("GeoCluster")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task TwoClusterBattery()
         {
 
@@ -52,7 +51,7 @@ namespace UnitTests.GeoClusterTests
                 await t;
         }
 
-        [Fact, TestCategory("GeoCluster")]
+        [SkippableFact]
         public async Task ThreeClusterBattery()
         {
 
@@ -71,7 +70,7 @@ namespace UnitTests.GeoClusterTests
                 await t;
         }
 
-        [Fact, TestCategory("GeoCluster")]
+        [SkippableFact]
         public async Task FourClusterBattery()
         {
 
@@ -454,9 +453,7 @@ namespace UnitTests.GeoClusterTests
                 AssertEqual(1, p.Result, gref);
         }
 
-
-
-        [Fact, TestCategory("GeoCluster")]
+        [SkippableFact]
         public async Task BlockedDeact()
         {
             await RunWithTimeout("Start Clusters and Clients", 180 * 1000, () =>

--- a/test/TesterInternal/StreamProvidersTests.cs
+++ b/test/TesterInternal/StreamProvidersTests.cs
@@ -107,14 +107,8 @@ namespace UnitTests.Streaming
 
                 options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
 
-                options.ClusterConfiguration.AddAzureTableStorageProvider("AzureStore", deleteOnClear: true);
-                options.ClusterConfiguration.AddAzureTableStorageProvider("PubSubStore", deleteOnClear: true, useJsonFormat: false);
-
                 options.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME, fireAndForgetDelivery: false);
                 options.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", fireAndForgetDelivery: false, optimizeForImmutableData: false);
-
-                options.ClusterConfiguration.AddAzureQueueStreamProvider(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME);
-                options.ClusterConfiguration.AddAzureQueueStreamProvider("AzureQueueProvider2");
 
                 return new TestCluster(options);
             }

--- a/test/TesterInternal/StreamingTests/SMSStreamingTests.cs
+++ b/test/TesterInternal/StreamingTests/SMSStreamingTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Threading.Tasks;
 using Orleans.Providers;
 using Orleans.Providers.Streams.SimpleMessageStream;
@@ -7,8 +6,6 @@ using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using TestExtensions;
 using Xunit;
-using Tester;
-using System.Collections.Generic;
 
 namespace UnitTests.StreamingTests
 {
@@ -25,18 +22,12 @@ namespace UnitTests.StreamingTests
                 var options = new TestClusterOptions(initialSilosCount: 4);
 
                 options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
-
-                options.ClusterConfiguration.AddAzureTableStorageProvider("AzureStore", deleteOnClear: true);
-                options.ClusterConfiguration.AddAzureTableStorageProvider("PubSubStore", deleteOnClear: true, useJsonFormat: false);
+                options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
 
                 options.ClusterConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
                 options.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", fireAndForgetDelivery: false, optimizeForImmutableData: false);
 
-                options.ClusterConfiguration.AddAzureQueueStreamProvider(AzureQueueStreamProviderName);
-                options.ClusterConfiguration.AddAzureQueueStreamProvider("AzureQueueProvider2");
-
                 options.ClientConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
-                options.ClientConfiguration.AddAzureQueueStreamProvider(AzureQueueStreamProviderName);
 
                 options.ClusterConfiguration.Globals.ServiceId = serviceId;
                 return new TestCluster(options);


### PR DESCRIPTION
- Remove Azure dependency on some tests that do not require it
- Have a way to entirely opt out from using Azure (either real service or emulator) if the DataConnectionString is set to empty.
- Add some SkippableFact attribute that were missing from tests that require Azure.