### PR TITLE
Make ClientConfiguration.ClientName an instance property

### DIFF
--- a/src/Orleans/Configuration/ClientConfiguration.cs
+++ b/src/Orleans/Configuration/ClientConfiguration.cs
@@ -43,7 +43,7 @@ namespace Orleans.Runtime.Configuration
         /// <summary>
         /// The name of this client.
         /// </summary>
-        public static string ClientName = "Client";
+        public string ClientName { get; set; } = "Client";
 
         private string traceFilePattern;
         private readonly DateTime creationTimestamp;


### PR DESCRIPTION
A minor change, this property is only used for logging.
This global is mutated in load tests, so I will have to follow up with a change to them in VSO