### PR TITLE
add blog link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ var friend = GrainClient.GrainFactory.GetGrain<IHello>(0);
 Console.WriteLine(await friend.SayHello("Good morning, my friend!"));
 ```
 
+Blog
+=========
+[Orleans Blog](https://blogs.msdn.microsoft.com/orleans/) is a place to share our thoughts, plans, learnings, tips and tricks, and ideas, crazy and otherwise, which don’t easily fit the documentation format. We would also like to see here posts from the community members, sharing their experiences, ideas, and wisdom. 
+So, welcome to Orleans Blog, both as a reader and as a blogger!
+
 Community
 =========
 


### PR DESCRIPTION
Added a section in README to introduce Orleans blog. Words mostly copied from our first Blog post:
https://blogs.msdn.microsoft.com/orleans/2016/12/01/welcome-to-orleans-blog/