### PR TITLE
Limit test parallelization to avoid timing issues in few core machines

### DIFF
--- a/src/Parallel-Tests.ps1
+++ b/src/Parallel-Tests.ps1
@@ -3,6 +3,24 @@ param(
     [string] $testFilter,
     [string] $outDir)
 
+$maxDegreeOfParallelism = 3
+$failed = $false
+
+function Receive-CompletedJobs {
+    $anyFailures = $false
+    foreach($job in (Get-Job | Where-Object { $_.State -ne 'Running' }))
+    {
+        Receive-Job $job -AutoRemoveJob -Wait | Write-Host
+
+        if ($job.State -eq 'Failed') { 
+            $anyFailures = $true
+            Write-Host -ForegroundColor Red 'Failed: ' $job.Name '('$job.State')'
+        }
+        Write-Host ''  
+    }
+    return $anyFailures
+}
+
 # If there is multiple xunit packages installed, take the latest one
 $xunitRunner = Get-ChildItem packages -Directory -Filter "xunit.runner.console.*" | 
                 ForEach-Object { Get-ChildItem $_.FullName -Recurse -File -Filter "xunit.console.exe" } | 
@@ -21,16 +39,28 @@ $ExecuteCmd =
 
 foreach ($a in $assemblies)
 {
+    $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
+    if ($running.Count -ge $maxDegreeOfParallelism) {
+        $running | Wait-Job -Any | Out-Null
+    }
+
+    if (Receive-CompletedJobs) { $failed = $true }
+	
     $xmlName = 'xUnit-Results-' + [System.IO.Path]::GetFileNameWithoutExtension($a) + '.xml'
     $outXml = $(Join-Path $outDir $xmlName)
     $cmdLine = $xunitRunner.FullName + ' ' + $a + ' ' + $testFilter + ' -xml ' + $outXml + ' -parallel none -noshadow -verbose' 
     Write-Host $cmdLine
-    Start-Job $ExecuteCmd -ArgumentList $cmdLine -Name $([System.IO.Path]::GetFileNameWithoutExtension($a))
+    Start-Job $ExecuteCmd -ArgumentList $cmdLine -Name $([System.IO.Path]::GetFileNameWithoutExtension($a)) | Out-Null
+    Write-Host ''
 }
 
-Get-Job | Wait-Job | Receive-Job
+# Wait for all jobs to complete and results ready to be received
+Wait-Job * | Out-Null
 
-if (Get-Job -State Failed)
+if (Receive-CompletedJobs) { $failed = $true }
+
+if ($failed)
 {
+    Write-Host 'Test run failed'
     Exit 1
 }

--- a/vNext/Parallel-Tests.ps1
+++ b/vNext/Parallel-Tests.ps1
@@ -3,6 +3,24 @@ param(
     [string] $testFilter,
     [string] $outDir)
 
+$maxDegreeOfParallelism = 3
+$failed = $false
+
+function Receive-CompletedJobs {
+    $anyFailures = $false
+    foreach($job in (Get-Job | Where-Object { $_.State -ne 'Running' }))
+    {
+        Receive-Job $job -AutoRemoveJob -Wait | Write-Host
+
+        if ($job.State -eq 'Failed') { 
+            $anyFailures = $true
+            Write-Host -ForegroundColor Red 'Failed: ' $job.Name '('$job.State')'
+        }
+        Write-Host ''  
+    }
+    return $anyFailures
+}
+
 # If there is multiple xunit packages installed, take the latest one
 $xunitRunner = Get-ChildItem packages -Directory -Filter "xunit.runner.console.*" | 
                 ForEach-Object { Get-ChildItem $_.FullName -Recurse -File -Filter "xunit.console.exe" } | 
@@ -21,16 +39,28 @@ $ExecuteCmd =
 
 foreach ($a in $assemblies)
 {
+    $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
+    if ($running.Count -ge $maxDegreeOfParallelism) {
+        $running | Wait-Job -Any | Out-Null
+    }
+
+    if (Receive-CompletedJobs) { $failed = $true }
+	
     $xmlName = 'xUnit-Results-' + [System.IO.Path]::GetFileNameWithoutExtension($a) + '.xml'
     $outXml = $(Join-Path $outDir $xmlName)
     $cmdLine = $xunitRunner.FullName + ' ' + $a + ' ' + $testFilter + ' -xml ' + $outXml + ' -parallel none -noshadow -verbose' 
     Write-Host $cmdLine
-    Start-Job $ExecuteCmd -ArgumentList $cmdLine -Name $([System.IO.Path]::GetFileNameWithoutExtension($a))
+    Start-Job $ExecuteCmd -ArgumentList $cmdLine -Name $([System.IO.Path]::GetFileNameWithoutExtension($a)) | Out-Null
+    Write-Host ''
 }
 
-Get-Job | Wait-Job | Receive-Job
+# Wait for all jobs to complete and results ready to be received
+Wait-Job * | Out-Null
 
-if (Get-Job -State Failed)
+if (Receive-CompletedJobs) { $failed = $true }
+
+if ($failed)
 {
+    Write-Host 'Test run failed'
     Exit 1
 }


### PR DESCRIPTION
Limit parallelism to 3 test assemblies at a time.
Display test results as they come in, useful to see partial results as the test run finishes each of the test assemblies without having to wait for the entire run to finish.