### PR TITLE
UpgradeTests fixes

### DIFF
--- a/src/OrleansTestingHost/TestCluster.cs
+++ b/src/OrleansTestingHost/TestCluster.cs
@@ -242,7 +242,7 @@ namespace Orleans.TestingHost
         }
 
         /// <summary>
-        /// Get the timeout value to use to wit for the silo liveness sub-system to detect and act on any recent cluster membership changes.
+        /// Get the timeout value to use to wait for the silo liveness sub-system to detect and act on any recent cluster membership changes.
         /// <seealso cref="WaitForLivenessToStabilizeAsync"/>
         /// </summary>
         public static TimeSpan GetLivenessStabilizationTime(GlobalConfiguration global, bool didKill = false)

--- a/src/OrleansTestingHost/TestCluster.cs
+++ b/src/OrleansTestingHost/TestCluster.cs
@@ -241,7 +241,11 @@ namespace Orleans.TestingHost
             WriteLog("WaitForLivenessToStabilize is done sleeping");
         }
 
-        private static TimeSpan GetLivenessStabilizationTime(GlobalConfiguration global, bool didKill = false)
+        /// <summary>
+        /// Get the timeout value to use to wit for the silo liveness sub-system to detect and act on any recent cluster membership changes.
+        /// <seealso cref="WaitForLivenessToStabilizeAsync"/>
+        /// </summary>
+        public static TimeSpan GetLivenessStabilizationTime(GlobalConfiguration global, bool didKill = false)
         {
             TimeSpan stabilizationTime = TimeSpan.Zero;
             if (didKill)

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Tester.HeterogeneousSilosTests
 {
+    [TestCategory("ExcludeXAML")]
     public class UpgradeTests : IDisposable
     {
 
@@ -199,7 +200,7 @@ namespace Tester.HeterogeneousSilosTests
         {
             siloV2?.Dispose();
             siloV1?.Dispose();
-            GrainClient.Uninitialize();
+            client?.Dispose();
         }
     }
 }


### PR DESCRIPTION
- Change test categories
- Increase waiting time after silo started/stopped
- Remove usage of static client