### PR TITLE
Account for additional assemblies being updated while in use

### DIFF
--- a/src/OrleansTestingHost/AppDomainSiloHandle.cs
+++ b/src/OrleansTestingHost/AppDomainSiloHandle.cs
@@ -22,7 +22,7 @@ namespace Orleans.TestingHost
     {
         private bool isActive = true;
 
-        private Dictionary<string, GeneratedAssembly> additionalAssemblies;
+        private IDictionary<string, GeneratedAssembly> additionalAssemblies;
 
         /// <summary> Get or set the AppDomain used by the silo </summary>
         public AppDomain AppDomain { get; set; }
@@ -34,7 +34,7 @@ namespace Orleans.TestingHost
         public override bool IsActive => isActive;
 
         /// <summary>Creates a new silo in a remote app domain and returns a handle to it.</summary>
-        public static SiloHandle Create(string siloName, Silo.SiloType type, ClusterConfiguration config, NodeConfiguration nodeConfiguration, Dictionary<string, GeneratedAssembly> additionalAssemblies, string applicationBase = null)
+        public static SiloHandle Create(string siloName, Silo.SiloType type, ClusterConfiguration config, NodeConfiguration nodeConfiguration, IDictionary<string, GeneratedAssembly> additionalAssemblies, string applicationBase = null)
         {
             AppDomainSetup setup = GetAppDomainSetupInfo(applicationBase);
 

--- a/src/OrleansTestingHost/TestCluster.cs
+++ b/src/OrleansTestingHost/TestCluster.cs
@@ -12,6 +12,7 @@ using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
 using Orleans.Streams;
 using Orleans.TestingHost.Utils;
+using System.Collections.Concurrent;
 
 namespace Orleans.TestingHost
 {
@@ -39,7 +40,7 @@ namespace Orleans.TestingHost
 
         private readonly List<SiloHandle> additionalSilos = new List<SiloHandle>();
 
-        private readonly Dictionary<string, GeneratedAssembly> additionalAssemblies = new Dictionary<string, GeneratedAssembly>();
+        private readonly IDictionary<string, GeneratedAssembly> additionalAssemblies = new ConcurrentDictionary<string, GeneratedAssembly>();
 
         /// <summary>
         /// Client configuration to use when initializing the client

--- a/src/OrleansTestingHost/TestingSiloHost.cs
+++ b/src/OrleansTestingHost/TestingSiloHost.cs
@@ -13,6 +13,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost.Extensions;
 using Orleans.TestingHost.Utils;
+using System.Collections.Concurrent;
 
 namespace Orleans.TestingHost
 {
@@ -46,7 +47,7 @@ namespace Orleans.TestingHost
         public SiloHandle Secondary { get; private set; }
 
         private readonly List<SiloHandle> additionalSilos = new List<SiloHandle>();
-        private readonly Dictionary<string, GeneratedAssembly> additionalAssemblies = new Dictionary<string, GeneratedAssembly>();
+        private readonly IDictionary<string, GeneratedAssembly> additionalAssemblies = new ConcurrentDictionary<string, GeneratedAssembly>();
 
         private TestingSiloOptions siloInitOptions { get; set; }
 


### PR DESCRIPTION
This fixes non-deterministic issues when a silo is stopped and another one started in parallel, such as in `Ring_1F1J`