### PR TITLE
Versioning placement & compatibility directors/strategies

### DIFF
--- a/src/Orleans/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans/Configuration/GlobalConfiguration.cs
@@ -11,6 +11,8 @@ using Orleans.Providers;
 using Orleans.Storage;
 using Orleans.Streams;
 using Orleans.LogConsistency;
+using Orleans.Versions.Compatibility;
+using Orleans.Versions.Placement;
 
 namespace Orleans.Runtime.Configuration
 {
@@ -449,6 +451,10 @@ namespace Orleans.Runtime.Configuration
 
         public string DefaultPlacementStrategy { get; set; }
 
+        public VersionCompatibilityStrategy DefaultVersionCompatibilityStrategy { get; set; }
+		
+		public VersionPlacementStrategy DefaultVersionPlacementStrategy { get; set; }
+
         public TimeSpan DeploymentLoadPublisherRefreshTime { get; set; }
 
         public int ActivationCountBasedPlacementChooseOutOf { get; set; }
@@ -593,6 +599,8 @@ namespace Orleans.Runtime.Configuration
 
             ProviderConfigurations = new Dictionary<string, ProviderCategoryConfiguration>();
             GrainServiceConfigurations = new GrainServiceConfigurations();
+            DefaultVersionCompatibilityStrategy = BackwardCompatible.Singleton;
+			DefaultVersionPlacementStrategy = MinimumVersionPlacement.Singleton;
         }
 
         public override string ToString()

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -183,6 +183,12 @@
     <Compile Include="Streams\PubSub\StreamSubscriptionManagerExtensions.cs" />
     <Compile Include="Utils\Factory.cs" />
     <Compile Include="Utils\IKeyedServiceCollection.cs" />
+    <Compile Include="Versions\Compatibility\AllVersionsCompatible.cs" />
+    <Compile Include="Versions\Compatibility\BackwardCompatible.cs" />
+    <Compile Include="Versions\Compatibility\ICompatibilityDirector.cs" />
+    <Compile Include="Versions\Placement\LatestVersion.cs" />
+    <Compile Include="Versions\Placement\MinimumVersion.cs" />
+    <Compile Include="Versions\Placement\IPlacementVersionDirector.cs" />
     <Compile Include="Utils\ReferenceEqualsComparer.cs" />
     <Compile Include="Serialization\ReflectedSerializationMethodInfo.cs" />
     <Compile Include="Streams\Core\StreamIdentity.cs" />
@@ -438,6 +444,7 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="GenerateVersionNumber" BeforeTargets="VersionInit" Condition="'$(BuildingInsideVisualStudio)' != 'true'" Outputs="$(SolutionDir)Build\Version.txt">
     <PropertyGroup Condition="'$(BuildNumber)' == ''">

--- a/src/Orleans/Versions/BackwardCompatible.cs
+++ b/src/Orleans/Versions/BackwardCompatible.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Orleans.Versions.Compatibility
+{
+    [Serializable]
+    public class BackwardCompatible : CompatibilityStrategy
+    {
+        internal static BackwardCompatible Singleton { get; } = new BackwardCompatible();
+
+        private BackwardCompatible()
+        { }
+
+        public override bool Equals(object obj)
+        {
+            return obj is BackwardCompatible;
+        }
+
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode();
+        }
+    }
+}

--- a/src/Orleans/Versions/Compatibility/AllVersionsCompatible.cs
+++ b/src/Orleans/Versions/Compatibility/AllVersionsCompatible.cs
@@ -1,5 +1,8 @@
-﻿namespace Orleans.Versions.Compatibility
+﻿using System;
+
+namespace Orleans.Versions.Compatibility
 {
+    [Serializable]
     public class AllVersionsCompatible : VersionCompatibilityStrategy
     {
         internal static AllVersionsCompatible Singleton { get; } = new AllVersionsCompatible();

--- a/src/Orleans/Versions/Compatibility/AllVersionsCompatible.cs
+++ b/src/Orleans/Versions/Compatibility/AllVersionsCompatible.cs
@@ -1,0 +1,20 @@
+﻿namespace Orleans.Versions.Compatibility
+{
+    public class AllVersionsCompatible : VersionCompatibilityStrategy
+    {
+        internal static AllVersionsCompatible Singleton { get; } = new AllVersionsCompatible();
+
+        private AllVersionsCompatible()
+        { }
+
+        public override bool Equals(object obj)
+        {
+            return obj is AllVersionsCompatible;
+        }
+
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode();
+        }
+    }
+}

--- a/src/Orleans/Versions/Compatibility/BackwardCompatible.cs
+++ b/src/Orleans/Versions/Compatibility/BackwardCompatible.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Orleans.Versions.Compatibility
+{
+    [Serializable]
+    public class BackwardCompatible : VersionCompatibilityStrategy
+    {
+        internal static BackwardCompatible Singleton { get; } = new BackwardCompatible();
+
+        private BackwardCompatible()
+        { }
+
+        public override bool Equals(object obj)
+        {
+            return obj is BackwardCompatible;
+        }
+
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode();
+        }
+    }
+}

--- a/src/Orleans/Versions/Compatibility/ICompatibilityDirector.cs
+++ b/src/Orleans/Versions/Compatibility/ICompatibilityDirector.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Orleans.Versions.Compatibility
+{
+    public interface IVersionCompatibilityDirector
+    {
+        bool IsCompatible(ushort requestedVersion, ushort actualVersion);
+    }
+
+    public interface IVersionCompatibilityDirector<TStrategy> : IVersionCompatibilityDirector where TStrategy : VersionCompatibilityStrategy
+    {
+    }
+
+    [Serializable]
+    public abstract class VersionCompatibilityStrategy
+    {
+    }
+}

--- a/src/Orleans/Versions/CompatibilityDirectorManager.cs
+++ b/src/Orleans/Versions/CompatibilityDirectorManager.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.Configuration;
+using Orleans.Versions.Placement;
+
+namespace Orleans.Versions.Compatibility
+{
+    public class CompatibilityDirectorManager
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        public ICompatibilityDirector Default { get; }
+
+        public CompatibilityDirectorManager(IServiceProvider serviceProvider, GlobalConfiguration configuration)
+            : this(serviceProvider, BackwardCompatible.Singleton)
+        {
+        }
+
+        public CompatibilityDirectorManager(IServiceProvider serviceProvider, CompatibilityStrategy defaultCompatibilityStrategy)
+        {
+            this.serviceProvider = serviceProvider;
+            Default = ResolveVersionDirector(serviceProvider, defaultCompatibilityStrategy);
+        }
+
+        public ICompatibilityDirector GetPolicy(int ifaceId)
+        {
+            return Default;
+        }
+
+        private static ICompatibilityDirector ResolveVersionDirector(IServiceProvider serviceProvider,
+            CompatibilityStrategy versionStrategy)
+        {
+            var policyType = versionStrategy.GetType();
+            var directorType = typeof(IVersionDirector<>).MakeGenericType(policyType);
+            return (ICompatibilityDirector) serviceProvider.GetRequiredService(directorType);
+        }
+    }
+}

--- a/src/Orleans/Versions/ICompatibilityDirector.cs
+++ b/src/Orleans/Versions/ICompatibilityDirector.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Orleans.Versions.Compatibility
+{
+    public interface ICompatibilityDirector
+    {
+        IReadOnlyList<uint> GetCompatibleVersions(uint reqVersions, IReadOnlyList<uint> availableVersions);
+    }
+
+    public interface ICompatibilityDirector<TStrategy> : ICompatibilityDirector where TStrategy : CompatibilityStrategy
+    {
+    }
+
+    [Serializable]
+    public abstract class CompatibilityStrategy
+    {
+    }
+}

--- a/src/Orleans/Versions/Placement/IPlacementVersionDirector.cs
+++ b/src/Orleans/Versions/Placement/IPlacementVersionDirector.cs
@@ -1,0 +1,20 @@
+﻿using Orleans.Versions.Compatibility;
+using System;
+using System.Collections.Generic;
+
+namespace Orleans.Versions.Placement
+{
+    public interface IVersionPlacementDirector
+    {
+        ushort GetSuitableVersion(ushort requestedVersion, IReadOnlyList<ushort> availableVersions, IVersionCompatibilityDirector versionCompatibilityDirector);
+    }
+
+    public interface IVersionPlacementDirector<TPolicy> : IVersionPlacementDirector where TPolicy : VersionPlacementStrategy
+    {
+    }
+
+    [Serializable]
+    public abstract class VersionPlacementStrategy
+    {
+    }
+}

--- a/src/Orleans/Versions/Placement/LatestVersion.cs
+++ b/src/Orleans/Versions/Placement/LatestVersion.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Orleans.Versions.Placement
+{
+    [Serializable]
+    public class LatestVersionPlacement : VersionPlacementStrategy
+    {
+        internal static LatestVersionPlacement Singleton { get; } = new LatestVersionPlacement();
+
+        private LatestVersionPlacement()
+        { }
+
+        public override bool Equals(object obj)
+        {
+            return obj is LatestVersionPlacement;
+        }
+
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode();
+        }
+    }
+}

--- a/src/Orleans/Versions/Placement/MinimumVersion.cs
+++ b/src/Orleans/Versions/Placement/MinimumVersion.cs
@@ -1,0 +1,20 @@
+﻿namespace Orleans.Versions.Placement
+{
+    public class MinimumVersionPlacement : VersionPlacementStrategy
+    {
+        internal static MinimumVersionPlacement Singleton { get; } = new MinimumVersionPlacement();
+
+        private MinimumVersionPlacement()
+        { }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MinimumVersionPlacement;
+        }
+
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode();
+        }
+    }
+}

--- a/src/Orleans/Versions/Placement/MinimumVersion.cs
+++ b/src/Orleans/Versions/Placement/MinimumVersion.cs
@@ -1,5 +1,8 @@
-﻿namespace Orleans.Versions.Placement
+﻿using System;
+
+namespace Orleans.Versions.Placement
 {
+    [Serializable]
     public class MinimumVersionPlacement : VersionPlacementStrategy
     {
         internal static MinimumVersionPlacement Singleton { get; } = new MinimumVersionPlacement();

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -9,7 +9,9 @@ using Orleans.Runtime.GrainDirectory;
 using Orleans.Runtime.Messaging;
 using Orleans.Runtime.Placement;
 using Orleans.Runtime.Scheduler;
+using Orleans.Runtime.Versions.Compatibility;
 using Orleans.Serialization;
+using Orleans.Versions.Compatibility;
 
 
 namespace Orleans.Runtime
@@ -26,6 +28,7 @@ namespace Orleans.Runtime
         private readonly ILocalGrainDirectory localGrainDirectory;
         private readonly MessageFactory messagefactory;
         private readonly SerializationManager serializationManager;
+        private readonly CompatibilityDirectorManager compatibilityDirectorManager;
         private readonly double rejectionInjectionRate;
         private readonly bool errorInjection;
         private readonly double errorInjectionRate;
@@ -39,7 +42,8 @@ namespace Orleans.Runtime
             PlacementDirectorsManager placementDirectorsManager,
             ILocalGrainDirectory localGrainDirectory,
             MessageFactory messagefactory,
-            SerializationManager serializationManager)
+            SerializationManager serializationManager,
+            CompatibilityDirectorManager compatibilityDirectorManager)
         {
             this.scheduler = scheduler;
             this.catalog = catalog;
@@ -49,6 +53,7 @@ namespace Orleans.Runtime
             this.localGrainDirectory = localGrainDirectory;
             this.messagefactory = messagefactory;
             this.serializationManager = serializationManager;
+            this.compatibilityDirectorManager = compatibilityDirectorManager;
             logger = LogManager.GetLogger("Dispatcher", LoggerType.Runtime);
             rejectionInjectionRate = config.Globals.RejectionInjectionRate;
             double messageLossInjectionRate = config.Globals.MessageLossInjectionRate;
@@ -378,8 +383,9 @@ namespace Orleans.Runtime
                 if (targetActivation.Grain.IsGrain && message.IsUsingInterfaceVersions)
                 {
                     var request = ((InvokeMethodRequest)message.GetDeserializedBody(this.serializationManager));
-                    var supportedVersion = catalog.GrainTypeManager.GetLocalSupportedVersion(request.InterfaceId);
-                    if (supportedVersion < request.InterfaceVersion)
+                    var compatibilityDirector = compatibilityDirectorManager.GetDirector(request.InterfaceId);
+                    var actualVersion = catalog.GrainTypeManager.GetLocalSupportedVersion(request.InterfaceId);
+                    if (!compatibilityDirector.IsCompatible(request.InterfaceVersion, actualVersion))
                         catalog.DeactivateActivationOnIdle(targetActivation);
                 }
 

--- a/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/GrainTypeManager.cs
@@ -168,7 +168,7 @@ namespace Orleans.Runtime
             return supportedSilosByInterface[ifaceId].Keys.ToList();
         }
 
-        internal int GetLocalSupportedVersion(int ifaceId)
+        internal ushort GetLocalSupportedVersion(int ifaceId)
         {
             return grainInterfaceMap.GetInterfaceVersion(ifaceId);
         }

--- a/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Streams;
 using Orleans.Runtime.Scheduler;
+using Orleans.Runtime.Versions;
 
 namespace Orleans.Runtime
 {
@@ -14,6 +15,7 @@ namespace Orleans.Runtime
         private readonly ISiloStatusOracle statusOracle;
         private readonly ImplicitStreamSubscriberTable implicitStreamSubscriberTable;
         private readonly IInternalGrainFactory grainFactory;
+        private readonly CachedVersionDirectorManager versionDirectorManager;
         private readonly OrleansTaskScheduler scheduler;
         private bool hasToRefreshClusterGrainInterfaceMap;
         private readonly AsyncTaskSafeTimer refreshClusterGrainInterfaceMapTimer;
@@ -25,7 +27,8 @@ namespace Orleans.Runtime
             OrleansTaskScheduler scheduler,
             TimeSpan refreshClusterMapTimeout,
             ImplicitStreamSubscriberTable implicitStreamSubscriberTable,
-            IInternalGrainFactory grainFactory)
+            IInternalGrainFactory grainFactory,
+            CachedVersionDirectorManager versionDirectorManager)
             : base(Constants.TypeManagerId, myAddr)
         {
             if (grainTypeManager == null)
@@ -41,6 +44,7 @@ namespace Orleans.Runtime
             this.statusOracle = oracle;
             this.implicitStreamSubscriberTable = implicitStreamSubscriberTable;
             this.grainFactory = grainFactory;
+            this.versionDirectorManager = versionDirectorManager;
             this.scheduler = scheduler;
             this.hasToRefreshClusterGrainInterfaceMap = true;
             this.refreshClusterGrainInterfaceMapTimer = new AsyncTaskSafeTimer(
@@ -120,6 +124,7 @@ namespace Orleans.Runtime
             }
 
             grainTypeManager.SetInterfaceMapsBySilo(newSilosClusterGrainInterfaceMap);
+            versionDirectorManager.ResetCache();
         }
 
         private async Task<KeyValuePair<SiloAddress, GrainInterfaceMap>> GetTargetSiloGrainInterfaceMap(SiloAddress siloAddress)

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -205,6 +205,14 @@
     <Compile Include="Streams\StreamProviderManagerAgent.cs" />
     <Compile Include="Timers\TimerRegistry.cs" />
     <Compile Include="Utilities\FactoryUtility.cs" />
+    <Compile Include="Versions\CachedVersionDirector.cs" />
+    <Compile Include="Versions\CachedVersionDirectorManager.cs" />
+    <Compile Include="Versions\Compatibility\AllVersionsCompatibilityDirector.cs" />
+    <Compile Include="Versions\Compatibility\BackwardCompatilityDirector.cs" />
+    <Compile Include="Versions\Compatibility\CompatibilityDirectorManager.cs" />
+    <Compile Include="Versions\Placement\LatestVersionDirector.cs" />
+    <Compile Include="Versions\Placement\MinimumVersionDirector.cs" />
+    <Compile Include="Versions\Placement\VersionDirectorManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orleans\Orleans.csproj">

--- a/src/OrleansRuntime/Versions/CachedVersionDirector.cs
+++ b/src/OrleansRuntime/Versions/CachedVersionDirector.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Orleans.Versions.Compatibility;
+using Orleans.Versions.Placement;
+
+namespace Orleans.Runtime.Versions
+{
+    internal class CachedVersionDirector
+    {
+        private readonly IVersionPlacementDirector versionPlacement;
+        private readonly IVersionCompatibilityDirector versionCompatibility;
+        private readonly IReadOnlyList<ushort> availableVersions;
+        private readonly ConcurrentDictionary<ushort, ushort> cachedResults;
+
+        public CachedVersionDirector(IVersionPlacementDirector versionPlacement, IVersionCompatibilityDirector versionCompatibility, IReadOnlyList<ushort> availableVersions)
+        {
+            this.versionPlacement = versionPlacement;
+            this.versionCompatibility = versionCompatibility;
+            this.availableVersions = availableVersions;
+            this.cachedResults = new ConcurrentDictionary<ushort, ushort>();
+        }
+
+        public ushort GetSuitableVersion(ushort requestedVersion)
+        {
+            return cachedResults.GetOrAdd(requestedVersion, GetSuitableVersionImpl);
+        }
+
+        private ushort GetSuitableVersionImpl(ushort requestedVersion)
+        {
+            return this.versionPlacement.GetSuitableVersion(requestedVersion, this.availableVersions, this.versionCompatibility);
+        }
+    }
+}

--- a/src/OrleansRuntime/Versions/CachedVersionDirectorManager.cs
+++ b/src/OrleansRuntime/Versions/CachedVersionDirectorManager.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+using Orleans.Runtime.Versions.Compatibility;
+using Orleans.Runtime.Versions.Placement;
+using Orleans.Versions.Compatibility;
+using Orleans.Versions.Placement;
+
+namespace Orleans.Runtime.Versions
+{
+    internal class CachedVersionDirectorManager
+    {
+        private readonly GrainTypeManager grainTypeManager;
+        private ConcurrentDictionary<int, CachedVersionDirector> directors;
+
+        public VersionPlacementDirectorManager VersionPlacementDirectorManager { get; }
+
+        public CompatibilityDirectorManager CompatibilityDirectorManager { get; }
+
+        public CachedVersionDirectorManager(GrainTypeManager grainTypeManager, VersionPlacementDirectorManager versionPlacementDirectorManager, CompatibilityDirectorManager compatibilityDirectorManager)
+        {
+            this.grainTypeManager = grainTypeManager;
+            this.VersionPlacementDirectorManager = versionPlacementDirectorManager;
+            this.CompatibilityDirectorManager = compatibilityDirectorManager;
+            this.directors = new ConcurrentDictionary<int, CachedVersionDirector>();
+        }
+
+        public ushort GetSuitableVersion(int ifaceId, ushort requestedVersion)
+        {
+            var director = this.directors.GetOrAdd(ifaceId, GetDirector);
+            return director.GetSuitableVersion(requestedVersion);
+        }
+
+        public void ResetCache()
+        {
+            this.directors = new ConcurrentDictionary<int, CachedVersionDirector>();
+        }
+
+        private CachedVersionDirector GetDirector(int ifaceId)
+        {
+            var version = this.VersionPlacementDirectorManager.GetDirector(ifaceId);
+            var compat = this.CompatibilityDirectorManager.GetDirector(ifaceId);
+            var availableVersions = this.grainTypeManager.GetAvailableVersions(ifaceId);
+
+            return new CachedVersionDirector(version, compat, availableVersions);
+        }
+    }
+}

--- a/src/OrleansRuntime/Versions/Compatibility/AllVersionsCompatibilityDirector.cs
+++ b/src/OrleansRuntime/Versions/Compatibility/AllVersionsCompatibilityDirector.cs
@@ -1,0 +1,12 @@
+﻿using Orleans.Versions.Compatibility;
+
+namespace Orleans.Runtime.Versions.Compatibility
+{
+    internal class AllVersionsCompatibilityDirector : IVersionCompatibilityDirector<AllVersionsCompatible>
+    {
+        public bool IsCompatible(ushort requestedVersion, ushort actualVersion)
+        {
+            return true;
+        }
+    }
+}

--- a/src/OrleansRuntime/Versions/Compatibility/BackwardCompatilityDirector.cs
+++ b/src/OrleansRuntime/Versions/Compatibility/BackwardCompatilityDirector.cs
@@ -1,0 +1,12 @@
+﻿using Orleans.Versions.Compatibility;
+
+namespace Orleans.Runtime.Versions.Compatibility
+{
+    internal class BackwardCompatilityDirector : IVersionCompatibilityDirector<BackwardCompatible>
+    {
+        public bool IsCompatible(ushort requestedVersion, ushort actualVersion)
+        {
+            return requestedVersion <= actualVersion;
+        }
+    }
+}

--- a/src/OrleansRuntime/Versions/Compatibility/CompatibilityDirectorManager.cs
+++ b/src/OrleansRuntime/Versions/Compatibility/CompatibilityDirectorManager.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.Configuration;
+using Orleans.Versions.Compatibility;
+
+namespace Orleans.Runtime.Versions.Compatibility
+{
+    internal class CompatibilityDirectorManager
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        public IVersionCompatibilityDirector Default { get; }
+
+        public CompatibilityDirectorManager(IServiceProvider serviceProvider, GlobalConfiguration configuration)
+            : this(serviceProvider, configuration.DefaultVersionCompatibilityStrategy)
+        {
+        }
+
+        public CompatibilityDirectorManager(IServiceProvider serviceProvider, VersionCompatibilityStrategy defaultVersionCompatibilityStrategy)
+        {
+            this.serviceProvider = serviceProvider;
+            Default = ResolveVersionDirector(serviceProvider, defaultVersionCompatibilityStrategy);
+        }
+
+        public IVersionCompatibilityDirector GetDirector(int ifaceId)
+        {
+            return Default;
+        }
+
+        private static IVersionCompatibilityDirector ResolveVersionDirector(IServiceProvider serviceProvider,
+            VersionCompatibilityStrategy versionStrategy)
+        {
+            var policyType = versionStrategy.GetType();
+            var directorType = typeof(IVersionCompatibilityDirector<>).MakeGenericType(policyType);
+            return (IVersionCompatibilityDirector) serviceProvider.GetRequiredService(directorType);
+        }
+    }
+}

--- a/src/OrleansRuntime/Versions/Placement/LatestVersionDirector.cs
+++ b/src/OrleansRuntime/Versions/Placement/LatestVersionDirector.cs
@@ -1,0 +1,15 @@
+﻿using System.Linq;
+using Orleans.Versions.Placement;
+using System.Collections.Generic;
+using Orleans.Versions.Compatibility;
+
+namespace Orleans.Runtime.Versions.Placement
+{
+    internal sealed class LatestVersionPlacementDirector : IVersionPlacementDirector<LatestVersionPlacement>
+    {
+        public ushort GetSuitableVersion(ushort requestedVersion, IReadOnlyList<ushort> availableVersions, IVersionCompatibilityDirector versionCompatibilityDirector)
+        {
+            return availableVersions.Where(v => versionCompatibilityDirector.IsCompatible(requestedVersion, v)).Max();
+        }
+    }
+}

--- a/src/OrleansRuntime/Versions/Placement/MinimumVersionDirector.cs
+++ b/src/OrleansRuntime/Versions/Placement/MinimumVersionDirector.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Orleans.Versions.Compatibility;
+using Orleans.Versions.Placement;
+
+namespace Orleans.Runtime.Versions.Placement
+{
+    internal sealed class MinimumVersionPlacementDirector : IVersionPlacementDirector<MinimumVersionPlacement>
+    {
+        public ushort GetSuitableVersion(ushort requestedVersion, IReadOnlyList<ushort> availableVersions, IVersionCompatibilityDirector versionCompatibilityDirector)
+        {
+            return availableVersions.Where(v => versionCompatibilityDirector.IsCompatible(requestedVersion, v)).Min();
+        }
+    }
+}

--- a/src/OrleansRuntime/Versions/Placement/VersionDirectorManager.cs
+++ b/src/OrleansRuntime/Versions/Placement/VersionDirectorManager.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.Configuration;
+using Orleans.Versions.Placement;
+
+namespace Orleans.Runtime.Versions.Placement
+{
+    internal class VersionPlacementDirectorManager
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        public IVersionPlacementDirector Default { get; }
+
+        public VersionPlacementDirectorManager(IServiceProvider serviceProvider, GlobalConfiguration configuration)
+            : this(serviceProvider, configuration.DefaultVersionPlacementStrategy)
+        {
+        }
+
+        public VersionPlacementDirectorManager(IServiceProvider serviceProvider, VersionPlacementStrategy defaultVersionPlacementStrategy)
+        {
+            this.serviceProvider = serviceProvider;
+            Default = ResolveVersionDirector(serviceProvider, defaultVersionPlacementStrategy);
+        }
+
+        public IVersionPlacementDirector GetDirector(int ifaceId)
+        {
+            return Default;
+        }
+
+        private static IVersionPlacementDirector ResolveVersionDirector(IServiceProvider serviceProvider,
+            VersionPlacementStrategy versionPlacementStrategy)
+        {
+            var policyType = versionPlacementStrategy.GetType();
+            var directorType = typeof(IVersionPlacementDirector<>).MakeGenericType(policyType);
+            return (IVersionPlacementDirector) serviceProvider.GetRequiredService(directorType);
+        }
+    }
+}

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests.cs
@@ -87,6 +87,51 @@ namespace Tester.HeterogeneousSilosTests
         }
 
         [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
+        public async Task AlwaysCreateActivationWithMinimumVersionTest()
+        {
+            await DeployCluster(MinimumVersionPlacement.Singleton, BackwardCompatible.Singleton);
+
+            const int numberOfGrains = 100;
+
+            // Only V1 exist for now
+            for (var i = 0; i < numberOfGrains; i++)
+            {
+                var grain = grainFactory.GetGrain<IVersionUpgradeTestGrain>(i);
+                Assert.Equal(1, await grain.GetVersion());
+            }
+
+            // Start a new silo with V2
+            await StartSiloV2();
+
+            // We still only use V1
+            for (var i = 0; i < numberOfGrains * 2; i++)
+            {
+                var grain = grainFactory.GetGrain<IVersionUpgradeTestGrain>(i);
+                Assert.Equal(1, await grain.GetVersion());
+            }
+        }
+
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
+        public async Task DoNotUpgradeIfCompatibleVersionsTest()
+        {
+            await DeployCluster(LatestVersionPlacement.Singleton, AllVersionsCompatible.Singleton);
+
+            // Only V1 exist for now
+            var grain0 = grainFactory.GetGrain<IVersionUpgradeTestGrain>(0);
+            Assert.Equal(1, await grain0.GetVersion());
+
+            await StartSiloV2();
+
+            // New activation should be V2
+            var grain1 = grainFactory.GetGrain<IVersionUpgradeTestGrain>(1);
+            Assert.Equal(2, await grain1.GetVersion());
+
+            // Since grain are compatible, no upgrade this time
+            Assert.Equal(1, await grain1.ProxyGetVersion(grain0));
+            Assert.Equal(1, await grain0.GetVersion());
+        }
+
+        [Fact, TestCategory("SlowBVT"), TestCategory("Functional")]
         public async Task AlwaysCreateNewActivationWithLatestVersionTest()
         {
             await DeployCluster(LatestVersionPlacement.Singleton, BackwardCompatible.Singleton);

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests.cs
@@ -68,6 +68,7 @@ namespace Tester.HeterogeneousSilosTests
             this.options = new TestClusterOptions(2);
             options.ClusterConfiguration.Globals.AssumeHomogenousSilosForTesting = false;
             options.ClusterConfiguration.Globals.TypeMapRefreshInterval = refreshInterval;
+            options.ClusterConfiguration.Globals.DefaultPlacementVersionStrategy = Orleans.Versions.Placement.LatestPlacementVersion.Singleton;
             options.ClientConfiguration.Gateways.RemoveAt(1); // Only use primary gw
 
             waitDelay = TestCluster.GetLivenessStabilizationTime(options.ClusterConfiguration.Globals, false);


### PR DESCRIPTION
Following #2837

## Proposed change
This PR I implemented configurable director/policies for versioning..

I implemented two basics compatibility and two basics versioning directors. it would be easy to inject custom directors in the future using dependency injection (like it should be possible for `PlacementDirector`)

For compatibility:
- Backward only compatible (default value)
- All versions compatible

For new placement:
- Always the minimum compatible version (default value)
- Always the latest compatible available version

More directors can be added later.

## Limitations
For now, the strategies are chosen at startup, the values or loaded from configuration. A future PR will allow changing these at runtime
