### PR TITLE
Remove warning in GatewayManager

### DIFF
--- a/src/Orleans/Messaging/GatewayManager.cs
+++ b/src/Orleans/Messaging/GatewayManager.cs
@@ -253,8 +253,8 @@ namespace Orleans.Messaging
 
         public void Dispose()
         {
-            if (gatewayRefreshTimer != null)
-                gatewayRefreshTimer.Dispose();
+            var timer = gatewayRefreshTimer;
+            if (timer != null) timer.Dispose();
         }
     }
 }

--- a/src/Orleans/Messaging/GatewayManager.cs
+++ b/src/Orleans/Messaging/GatewayManager.cs
@@ -253,7 +253,8 @@ namespace Orleans.Messaging
 
         public void Dispose()
         {
-            gatewayRefreshTimer?.Dispose();
+            if (gatewayRefreshTimer != null)
+                gatewayRefreshTimer.Dispose();
         }
     }
 }


### PR DESCRIPTION
It seems that VS complains because `GatewayManager.gatewayRefreshTimer` is not properly disposed. Switching "to "explicit null check" seems to remove the warning.