### PR TITLE
Add extension points to EventHubAdapterFactory

### DIFF
--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Providers\Streams\EventHub\EventHubCheckpointer.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubPartitionCheckpointEntity.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubQueueCache.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubQueueCacheFactory.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubQueueMapper.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSequenceToken.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubSequenceTokenV2.cs" />
@@ -68,6 +69,7 @@
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProvider.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubStreamProviderSettings.cs" />
     <Compile Include="Providers\Streams\EventHub\ICheckpointerSettings.cs" />
+    <Compile Include="Providers\Streams\EventHub\IEventHubQueueCacheFactory.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubQueueMapper.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubReceiverMonitor.cs" />
     <Compile Include="Providers\Streams\EventHub\IEventHubSettings.cs" />

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -28,26 +28,32 @@ namespace Orleans.ServiceBus.Providers
         /// Orleans logging
         /// </summary>
         protected Logger logger;
+
         /// <summary>
         /// Framework service provider
         /// </summary>
         protected IServiceProvider serviceProvider;
+
         /// <summary>
         /// Provider configuration
         /// </summary>
         protected IProviderConfiguration providerConfig;
+
         /// <summary>
         /// Stream provider settings
         /// </summary>
         protected EventHubStreamProviderSettings adapterSettings;
+
         /// <summary>
         /// Event Hub settings
         /// </summary>
         protected IEventHubSettings hubSettings;
+
         /// <summary>
         /// Checkpointer settings
         /// </summary>
         protected ICheckpointerSettings checkpointerSettings;
+
         private IEventHubQueueMapper streamQueueMapper;
         private string[] partitionIds;
         private ConcurrentDictionary<QueueId, EventHubAdapterReceiver> receivers;
@@ -79,22 +85,26 @@ namespace Orleans.ServiceBus.Providers
         /// <summary>
         /// Creates a message cache for an eventhub partition.
         /// </summary>
-        protected Func<string, IStreamQueueCheckpointer<string>, Logger, IEventHubQueueCache> CacheFactory { get; set; }
+        protected IEventHubQueueCacheFactory CacheFactory { get; set; }
+
         /// <summary>
         /// Creates a parition checkpointer.
         /// </summary>
         protected Func<string, Task<IStreamQueueCheckpointer<string>>> CheckpointerFactory { get; set; }
+
         /// <summary>
         /// Creates a failure handler for a partition.
         /// </summary>
         protected Func<string, Task<IStreamFailureHandler>> StreamFailureHandlerFactory { get; set; }
+
         /// <summary>
         /// Create a queue mapper to map EventHub partitions to queues
         /// </summary>
         protected Func<string[], IEventHubQueueMapper> QueueMapperFactory { get; set; }
+
         /// <summary>
         /// Create a receiver monitor to report performance metrics.
-        ///   Arguments are EventHub path, EventHub partition, and logger. 
+        ///   Arguments are EventHub path, EventHub partition, and logger.
         ///   Factory funciton should return an IEventHubReceiverMonitor.
         /// </summary>
         protected Func<string, string, Logger, IEventHubReceiverMonitor> ReceiverMonitorFactory { get; set; }
@@ -141,12 +151,7 @@ namespace Orleans.ServiceBus.Providers
 
             if (CacheFactory == null)
             {
-                var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterSettings.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
-                var timePurge = new TimePurgePredicate(adapterSettings.DataMinTimeInCache, adapterSettings.DataMaxAgeInCache);
-                CacheFactory = (partition, checkpointer, cacheLogger) =>
-                {
-                    return CreateCacheFactory(partition, checkpointer, cacheLogger, bufferPool, timePurge);
-                };
+                CacheFactory = CreateCacheFactory(adapterSettings);
             }
 
             if (StreamFailureHandlerFactory == null)
@@ -232,7 +237,7 @@ namespace Orleans.ServiceBus.Providers
 #if NETSTANDARD
             return client.SendAsync(eventData, streamGuid.ToString());
 #else
-            return client.SendAsync(eventData); 
+            return client.SendAsync(eventData);
 #endif
         }
 
@@ -260,33 +265,9 @@ namespace Orleans.ServiceBus.Providers
             return receivers.GetOrAdd(queueId, q => MakeReceiver(queueId));
         }
 
-        private IEventHubQueueCache CreateCacheFactory(string partition, IStreamQueueCheckpointer<string> checkpointer, Logger cacheLogger,
-            FixedSizeObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge)
+        protected virtual IEventHubQueueCacheFactory CreateCacheFactory(EventHubStreamProviderSettings providerSettings)
         {
-            var cache = CreateCache(checkpointer, cacheLogger, bufferPool, timePurge);
-            if (adapterSettings.AveragingCachePressureMonitorFlowControlThreshold.HasValue)
-            {
-                var avgMonitor = new AveragingCachePressureMonitor(adapterSettings.AveragingCachePressureMonitorFlowControlThreshold.Value, cacheLogger);
-cache.AddCachePressureMonitor(avgMonitor);
-            }
-            if (adapterSettings.SlowConsumingMonitorPressureWindowSize.HasValue
-            || adapterSettings.SlowConsumingMonitorFlowControlThreshold.HasValue)
-            {
-
-                var slowConsumeMonitor = new SlowConsumingPressureMonitor(cacheLogger);
-                if (adapterSettings.SlowConsumingMonitorFlowControlThreshold.HasValue)
-                    slowConsumeMonitor.FlowControlThreshold = adapterSettings.SlowConsumingMonitorFlowControlThreshold.Value;
-                if (adapterSettings.SlowConsumingMonitorPressureWindowSize.HasValue)
-                    slowConsumeMonitor.PressureWindowSize = adapterSettings.SlowConsumingMonitorPressureWindowSize.Value;
-cache.AddCachePressureMonitor(slowConsumeMonitor);
-            }
-            return cache;
-        }
-
-        protected virtual IEventHubQueueCache CreateCache(IStreamQueueCheckpointer<string> checkpointer, 
-            Logger cacheLogger, FixedSizeObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge)
-        {
-            return new EventHubQueueCache(checkpointer, bufferPool, timePurge, cacheLogger, SerializationManager);
+            return new EventHubQueueCacheFactory(providerSettings, SerializationManager);
         }
 
         private EventHubAdapterReceiver MakeReceiver(QueueId queueId)
@@ -308,7 +289,7 @@ cache.AddCachePressureMonitor(slowConsumeMonitor);
 #else
             NamespaceManager namespaceManager = NamespaceManager.CreateFromConnectionString(hubSettings.ConnectionString);
             EventHubDescription hubDescription = await namespaceManager.GetEventHubAsync(hubSettings.Path);
-            return hubDescription.PartitionIds; 
+            return hubDescription.PartitionIds;
 #endif
         }
     }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -85,7 +85,7 @@ namespace Orleans.ServiceBus.Providers
         /// <summary>
         /// Creates a message cache for an eventhub partition.
         /// </summary>
-        protected IEventHubQueueCacheFactory CacheFactory { get; set; }
+        protected Func<string, IStreamQueueCheckpointer<string>, Logger, IEventHubQueueCache> CacheFactory { get; set; }
 
         /// <summary>
         /// Creates a parition checkpointer.
@@ -151,7 +151,7 @@ namespace Orleans.ServiceBus.Providers
 
             if (CacheFactory == null)
             {
-                CacheFactory = CreateCacheFactory(adapterSettings);
+                CacheFactory = CreateCacheFactory(adapterSettings).CreateCache;
             }
 
             if (StreamFailureHandlerFactory == null)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -221,7 +221,7 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="token"></param>
         /// <param name="requestContext"></param>
         /// <returns></returns>
-        public Task QueueMessageBatchAsync<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, StreamSequenceToken token,
+        public virtual Task QueueMessageBatchAsync<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, StreamSequenceToken token,
             Dictionary<string, object> requestContext)
         {
             if (token != null)
@@ -263,7 +263,7 @@ namespace Orleans.ServiceBus.Providers
         private IEventHubQueueCache CreateCacheFactory(string partition, IStreamQueueCheckpointer<string> checkpointer, Logger cacheLogger,
             FixedSizeObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge)
         {
-            var cache = new EventHubQueueCache(checkpointer, bufferPool, timePurge, cacheLogger, this.SerializationManager);
+            var cache = CreateCache(checkpointer, cacheLogger, bufferPool, timePurge);
             if (adapterSettings.AveragingCachePressureMonitorFlowControlThreshold.HasValue)
             {
                 var avgMonitor = new AveragingCachePressureMonitor(adapterSettings.AveragingCachePressureMonitorFlowControlThreshold.Value, cacheLogger);
@@ -281,6 +281,12 @@ cache.AddCachePressureMonitor(avgMonitor);
 cache.AddCachePressureMonitor(slowConsumeMonitor);
             }
             return cache;
+        }
+
+        protected virtual IEventHubQueueCache CreateCache(IStreamQueueCheckpointer<string> checkpointer, 
+            Logger cacheLogger, FixedSizeObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge)
+        {
+            return new EventHubQueueCache(checkpointer, bufferPool, timePurge, cacheLogger, SerializationManager);
         }
 
         private EventHubAdapterReceiver MakeReceiver(QueueId queueId)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -28,7 +28,7 @@ namespace Orleans.ServiceBus.Providers
         private static readonly TimeSpan ReceiveTimeout = TimeSpan.FromSeconds(5);
 
         private readonly EventHubPartitionSettings settings;
-        private readonly Func<string, IStreamQueueCheckpointer<string>, Logger, IEventHubQueueCache> cacheFactory;
+        private readonly IEventHubQueueCacheFactory cacheFactory;
         private readonly Func<string, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory;
         private readonly Logger baseLogger;
         private readonly Logger logger;
@@ -55,7 +55,7 @@ namespace Orleans.ServiceBus.Providers
         }
 
         public EventHubAdapterReceiver(EventHubPartitionSettings settings,
-            Func<string, IStreamQueueCheckpointer<string>, Logger, IEventHubQueueCache> cacheFactory,
+            IEventHubQueueCacheFactory cacheFactory,
             Func<string, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory,
             Logger baseLogger,
             IEventHubReceiverMonitor monitor,
@@ -94,7 +94,7 @@ namespace Orleans.ServiceBus.Providers
             try
             {
                 checkpointer = await checkpointerFactory(settings.Partition);
-                cache = cacheFactory(settings.Partition, checkpointer, baseLogger);
+                cache = cacheFactory.CreateCache(settings.Partition, checkpointer, baseLogger);
                 flowController = new AggregatedQueueFlowController(MaxMessagesPerRead) { cache, LoadShedQueueFlowController.CreateAsPercentOfLoadSheddingLimit(getNodeConfig) };
                 string offset = await checkpointer.Load();
                 receiver = await CreateReceiver(settings, offset, logger);

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -28,7 +28,7 @@ namespace Orleans.ServiceBus.Providers
         private static readonly TimeSpan ReceiveTimeout = TimeSpan.FromSeconds(5);
 
         private readonly EventHubPartitionSettings settings;
-        private readonly IEventHubQueueCacheFactory cacheFactory;
+        private readonly Func<string, IStreamQueueCheckpointer<string>, Logger, IEventHubQueueCache> cacheFactory;
         private readonly Func<string, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory;
         private readonly Logger baseLogger;
         private readonly Logger logger;
@@ -45,6 +45,7 @@ namespace Orleans.ServiceBus.Providers
 
         // Receiver life cycle
         private int recieverState = ReceiverShutdown;
+
         private const int ReceiverShutdown = 0;
         private const int ReceiverRunning = 1;
         private readonly Func<NodeConfiguration> getNodeConfig;
@@ -55,7 +56,7 @@ namespace Orleans.ServiceBus.Providers
         }
 
         public EventHubAdapterReceiver(EventHubPartitionSettings settings,
-            IEventHubQueueCacheFactory cacheFactory,
+            Func<string, IStreamQueueCheckpointer<string>, Logger, IEventHubQueueCache> cacheFactory,
             Func<string, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory,
             Logger baseLogger,
             IEventHubReceiverMonitor monitor,
@@ -94,7 +95,7 @@ namespace Orleans.ServiceBus.Providers
             try
             {
                 checkpointer = await checkpointerFactory(settings.Partition);
-                cache = cacheFactory.CreateCache(settings.Partition, checkpointer, baseLogger);
+                cache = cacheFactory(settings.Partition, checkpointer, baseLogger);
                 flowController = new AggregatedQueueFlowController(MaxMessagesPerRead) { cache, LoadShedQueueFlowController.CreateAsPercentOfLoadSheddingLimit(getNodeConfig) };
                 string offset = await checkpointer.Load();
                 receiver = await CreateReceiver(settings, offset, logger);
@@ -159,7 +160,7 @@ namespace Orleans.ServiceBus.Providers
             TimeSpan newest = dequeueTimeUtc - messages[messages.Count - 1].SystemProperties.EnqueuedTimeUtc;
 #else
             TimeSpan oldest = dequeueTimeUtc - messages[0].EnqueuedTimeUtc;
-            TimeSpan newest = dequeueTimeUtc - messages[messages.Count - 1].EnqueuedTimeUtc; 
+            TimeSpan newest = dequeueTimeUtc - messages[messages.Count - 1].EnqueuedTimeUtc;
 #endif
             monitor.TrackAgeOfMessagesRead(oldest, newest);
 
@@ -176,7 +177,7 @@ namespace Orleans.ServiceBus.Providers
 #if NETSTANDARD
                     messages[0].SystemProperties.Offset,
 #else
-                    messages[0].Offset,  
+                    messages[0].Offset,
 #endif
                     DateTime.UtcNow);
             }
@@ -250,7 +251,8 @@ namespace Orleans.ServiceBus.Providers
 #if NETSTANDARD
         private static async Task<PartitionReceiver> CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, Logger logger)
 #else
-        private static async Task<EventHubReceiver> CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, Logger logger) 
+
+        private static async Task<EventHubReceiver> CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, Logger logger)
 #endif
         {
             bool offsetInclusive = true;
@@ -261,7 +263,7 @@ namespace Orleans.ServiceBus.Providers
             };
             EventHubClient client = EventHubClient.CreateFromConnectionString(connectionStringBuilder.ToString());
 #else
-            EventHubClient client = EventHubClient.CreateFromConnectionString(partitionSettings.Hub.ConnectionString, partitionSettings.Hub.Path); 
+            EventHubClient client = EventHubClient.CreateFromConnectionString(partitionSettings.Hub.ConnectionString, partitionSettings.Hub.Path);
 
             EventHubConsumerGroup consumerGroup = client.GetConsumerGroup(partitionSettings.Hub.ConsumerGroup);
             if (partitionSettings.Hub.PrefetchCount.HasValue)
@@ -281,7 +283,7 @@ namespace Orleans.ServiceBus.Providers
 #if NETSTANDARD
                 EventHubPartitionRuntimeInformation partitionInfo =
 #else
-                PartitionRuntimeInformation partitionInfo = 
+                PartitionRuntimeInformation partitionInfo =
 #endif
                     await client.GetPartitionRuntimeInformationAsync(partitionSettings.Partition);
                 offset = partitionInfo.LastEnqueuedOffset;
@@ -296,7 +298,7 @@ namespace Orleans.ServiceBus.Providers
 
             return receiver;
 #else
-            return await consumerGroup.CreateReceiverAsync(partitionSettings.Partition, offset, offsetInclusive); 
+            return await consumerGroup.CreateReceiverAsync(partitionSettings.Partition, offset, offsetInclusive);
 #endif
         }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
@@ -9,7 +9,7 @@ namespace Orleans.ServiceBus.Providers
     {
         private readonly EventHubStreamProviderSettings _providerSettings;
         private readonly SerializationManager _serializationManager;
-        private readonly FixedSizeObjectPool<FixedSizeBuffer> _bufferPool;
+        private readonly IObjectPool<FixedSizeBuffer> _bufferPool;
         private readonly TimePurgePredicate _timePurge;
 
         public EventHubQueueCacheFactory(EventHubStreamProviderSettings providerSettings,
@@ -19,7 +19,7 @@ namespace Orleans.ServiceBus.Providers
         }
 
         public EventHubQueueCacheFactory(EventHubStreamProviderSettings providerSettings,
-            SerializationManager serializationManager, FixedSizeObjectPool<FixedSizeBuffer> bufferPool)
+            SerializationManager serializationManager, IObjectPool<FixedSizeBuffer> bufferPool)
         {
             _providerSettings = providerSettings;
             _serializationManager = serializationManager;
@@ -67,7 +67,7 @@ namespace Orleans.ServiceBus.Providers
         }
 
         protected virtual IEventHubQueueCache CreateCache(IStreamQueueCheckpointer<string> checkpointer,
-            Logger cacheLogger, FixedSizeObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge,
+            Logger cacheLogger, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge,
             SerializationManager serializationManager)
         {
             return new EventHubQueueCache(checkpointer, bufferPool, timePurge, cacheLogger, serializationManager);

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
@@ -1,0 +1,58 @@
+﻿using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Streams;
+
+namespace Orleans.ServiceBus.Providers
+{
+    public class EventHubQueueCacheFactory : IEventHubQueueCacheFactory
+    {
+        private readonly EventHubStreamProviderSettings _providerSettings;
+        private readonly SerializationManager _serializationManager;
+        private readonly FixedSizeObjectPool<FixedSizeBuffer> _bufferPool;
+        private readonly TimePurgePredicate _timePurge;
+
+        public EventHubQueueCacheFactory(EventHubStreamProviderSettings providerSettings, SerializationManager serializationManager)
+        {
+            _providerSettings = providerSettings;
+            _serializationManager = serializationManager;
+
+            _bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(_providerSettings.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
+            _timePurge = new TimePurgePredicate(_providerSettings.DataMinTimeInCache, _providerSettings.DataMaxAgeInCache);
+        }
+
+        public IEventHubQueueCache CreateCache(string partition, IStreamQueueCheckpointer<string> checkpointer, Logger cacheLogger)
+        {
+            var cache = CreateCache(checkpointer, cacheLogger, _bufferPool, _timePurge, _serializationManager);
+            if (_providerSettings.AveragingCachePressureMonitorFlowControlThreshold.HasValue)
+            {
+                var avgMonitor = new AveragingCachePressureMonitor(_providerSettings.AveragingCachePressureMonitorFlowControlThreshold.Value, cacheLogger);
+                cache.AddCachePressureMonitor(avgMonitor);
+            }
+
+            if (_providerSettings.SlowConsumingMonitorPressureWindowSize.HasValue
+                || _providerSettings.SlowConsumingMonitorFlowControlThreshold.HasValue)
+            {
+                var slowConsumeMonitor = new SlowConsumingPressureMonitor(cacheLogger);
+                if (_providerSettings.SlowConsumingMonitorFlowControlThreshold.HasValue)
+                {
+                    slowConsumeMonitor.FlowControlThreshold = _providerSettings.SlowConsumingMonitorFlowControlThreshold.Value;
+                }
+                if (_providerSettings.SlowConsumingMonitorPressureWindowSize.HasValue)
+                {
+                    slowConsumeMonitor.PressureWindowSize = _providerSettings.SlowConsumingMonitorPressureWindowSize.Value;
+                }
+
+                cache.AddCachePressureMonitor(slowConsumeMonitor);
+            }
+            return cache;
+        }
+
+        protected virtual IEventHubQueueCache CreateCache(IStreamQueueCheckpointer<string> checkpointer,
+            Logger cacheLogger, FixedSizeObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge,
+            SerializationManager serializationManager)
+        {
+            return new EventHubQueueCache(checkpointer, bufferPool, timePurge, cacheLogger, serializationManager);
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCacheFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCacheFactory.cs
@@ -1,0 +1,14 @@
+﻿using Orleans.Runtime;
+using Orleans.Streams;
+
+namespace Orleans.ServiceBus.Providers
+{
+    /// <summary>
+    /// Factory responsible for creating a message cache for an EventHub partition.
+    /// </summary>
+    public interface IEventHubQueueCacheFactory
+    {
+        IEventHubQueueCache CreateCache(string partition, IStreamQueueCheckpointer<string> checkpointer, 
+            Logger cacheLogger);
+    }
+}

--- a/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
+++ b/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
@@ -37,7 +37,7 @@ namespace ServiceBus.Tests.TestStreamProviders
                 }
 
                 protected override IEventHubQueueCache CreateCache(IStreamQueueCheckpointer<string> checkpointer, Logger cacheLogger,
-                    FixedSizeObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, SerializationManager serializationManager)
+                    IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, SerializationManager serializationManager)
                 {
                     var cache = base.CreateCache(checkpointer, cacheLogger, bufferPool, timePurge, serializationManager);
                     _caches.Add(cache);

--- a/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
+++ b/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
@@ -1,62 +1,52 @@
 ﻿using Orleans.Providers;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
+using Orleans.Serialization;
 using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ServiceBus.Tests.TestStreamProviders
 {
-    class EHStreamProviderWithCreatedCacheList : PersistentStreamProvider<EHStreamProviderWithCreatedCacheList.AdapterFactory>
+    internal class EHStreamProviderWithCreatedCacheList : PersistentStreamProvider<EHStreamProviderWithCreatedCacheList.AdapterFactory>
     {
         public class AdapterFactory : EventHubAdapterFactory, IControllable
         {
-            private List<IEventHubQueueCache> createdCaches;
-            private FixedSizeObjectPool<FixedSizeBuffer> bufferPool;
-            private TimePurgePredicate timePurge;
-            private static int defaultMaxAddCount = 10;
+            private readonly List<IEventHubQueueCache> createdCaches;
+
             public AdapterFactory()
             {
                 createdCaches = new List<IEventHubQueueCache>();
-                CacheFactory = CreateQueueCache;
             }
 
-            private IEventHubQueueCache CreateQueueCache(string partition, IStreamQueueCheckpointer<string> checkpointer, Logger cacheLogger)
+            protected override IEventHubQueueCacheFactory CreateCacheFactory(EventHubStreamProviderSettings providerSettings)
             {
-                // the same code block as with EventHubAdapterFactory to define default CacheFactory
-                // except for at the end we put the created cache in CreatedCaches list
-                if(this.bufferPool == null)
-                    this.bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterSettings.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
-                if(this.timePurge == null)
-                    this.timePurge = new TimePurgePredicate(adapterSettings.DataMinTimeInCache, adapterSettings.DataMaxAgeInCache);
+                return new CacheFactory(providerSettings, SerializationManager, createdCaches);
+            }
 
-                //ser defaultMaxAddCount to 10 so TryCalculateCachePressureContribution will start to calculate real contribution shortly.
-                var cache = new EventHubQueueCache(defaultMaxAddCount, checkpointer, new EventHubDataAdapter(this.SerializationManager, bufferPool, timePurge), EventHubDataComparer.Instance, cacheLogger);
-                if (adapterSettings.AveragingCachePressureMonitorFlowControlThreshold.HasValue)
-                {
-                    var avgMonitor = new AveragingCachePressureMonitor(adapterSettings.AveragingCachePressureMonitorFlowControlThreshold.Value, cacheLogger);
-                    cache.AddCachePressureMonitor(avgMonitor);
-                }
-                if (adapterSettings.SlowConsumingMonitorPressureWindowSize.HasValue
-                || adapterSettings.SlowConsumingMonitorFlowControlThreshold.HasValue)
-                {
+            private class CacheFactory : EventHubQueueCacheFactory
+            {
+                private readonly List<IEventHubQueueCache> _caches;
 
-                    var slowConsumeMonitor = new SlowConsumingPressureMonitor(cacheLogger);
-                    if (adapterSettings.SlowConsumingMonitorFlowControlThreshold.HasValue)
-                        slowConsumeMonitor.FlowControlThreshold = adapterSettings.SlowConsumingMonitorFlowControlThreshold.Value;
-                    if (adapterSettings.SlowConsumingMonitorPressureWindowSize.HasValue)
-                        slowConsumeMonitor.PressureWindowSize = adapterSettings.SlowConsumingMonitorPressureWindowSize.Value;
-                    cache.AddCachePressureMonitor(slowConsumeMonitor);
+                public CacheFactory(EventHubStreamProviderSettings providerSettings,
+                    SerializationManager serializationManager, List<IEventHubQueueCache> caches)
+                    : base(providerSettings, serializationManager)
+                {
+                    _caches = caches;
                 }
-                this.createdCaches.Add(cache);
-                return cache;
+
+                protected override IEventHubQueueCache CreateCache(IStreamQueueCheckpointer<string> checkpointer, Logger cacheLogger,
+                    FixedSizeObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, SerializationManager serializationManager)
+                {
+                    var cache = base.CreateCache(checkpointer, cacheLogger, bufferPool, timePurge, serializationManager);
+                    _caches.Add(cache);
+                    return cache;
+                }
             }
 
             public static int IsCacheBackPressureTriggeredCommand = (int)PersistentStreamProviderCommand.AdapterFactoryCommandStartRange + 3;
+
             /// <summary>
             /// Only command expecting: determine whether back pressure algorithm on any of the created caches
             /// is triggered.


### PR DESCRIPTION
Related to https://github.com/dotnet/orleans/issues/2844. In the current form, it is quite problematic to extend `EventHubAdapterFactory`, so these changes should make it easier a bit