### PR TITLE
Eviction strategy and fix Low traffic queue bug

### DIFF
--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="BuiltInProvidersConfigurationExtensions.cs" />
     <Compile Include="Streams\Common\EventSequenceTokenV2.cs" />
+    <Compile Include="Streams\Common\PooledCache\IEvictionStrategy.cs" />
     <Compile Include="Streams\Memory\IMemoryStreamQueueGrain.cs" />
     <Compile Include="Streams\Memory\MemoryAdapterConfig.cs" />
     <Compile Include="Streams\Memory\MemoryAdapterFactory.cs" />

--- a/src/OrleansProviders/Streams/Common/PooledCache/CachedMessageBlock.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/CachedMessageBlock.cs
@@ -59,6 +59,16 @@ namespace Orleans.Providers.Streams.Common
         public TCachedMessage NewestMessage => cachedMessages[NewestMessageIndex];
 
         /// <summary>
+        /// Message count in this block
+        /// </summary>
+        public int ItemCount { get
+            {
+                int count = writeIndex - readIndex;
+                return count >= 0 ? count : 0;
+            }  
+        }
+
+        /// <summary>
         /// Block of cached messages
         /// </summary>
         /// <param name="blockSize"></param>

--- a/src/OrleansProviders/Streams/Common/PooledCache/FixedSizeBuffer.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/FixedSizeBuffer.cs
@@ -77,8 +77,13 @@ namespace Orleans.Providers.Streams.Common
         /// </summary>
         public override void SignalPurge()
         {
-            count = 0;
             purgeAction?.Invoke(this);
+        }
+
+        /// <inheritdoc />
+        public override void OnResetState()
+        {
+            count = 0;
             purgeAction = null;
         }
     }

--- a/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ICacheDataAdapter.cs
@@ -46,19 +46,9 @@ namespace Orleans.Providers.Streams.Common
         StreamPosition GetStreamPosition(TQueueMessage queueMessage);
 
         /// <summary>
-        /// Given a purge request, indicates if a cached message should be purged from the cache
+        /// Should be set to OnBlockAllocated method of the cache's EvicationStrategy
         /// </summary>
-        /// <param name="cachedMessage"></param>
-        /// <param name="newestCachedMessage"></param>
-        /// <param name="purgeRequest"></param>
-        /// <param name="nowUtc"></param>
-        /// <returns></returns>
-        bool ShouldPurge(ref TCachedMessage cachedMessage, ref TCachedMessage newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc);
-
-        /// <summary>
-        /// Assignable purge action.  This is called when a purge request is triggered.
-        /// </summary>
-        Action<IDisposable> PurgeAction { set; }
+        Action<IDisposable> OnBlockAllocated { set; }
     }
 
     /// <summary>

--- a/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Providers.Streams.Common
+{
+    /// <summary>
+    /// Eviction strategy for the PooledQueueCache
+    /// </summary>
+    public interface IEvictionStrategy<TCachedMessage>
+        where TCachedMessage : struct
+    {
+        /// <summary>
+        /// IPurgeObservable is implemented by the cache to do purge related actions, and invoked by EvictionStrategy
+        /// </summary>
+        IPurgeObservable<TCachedMessage> PurgeObservable { set; }
+
+        /// <summary>
+        /// Method which will be called when purge is finished
+        /// </summary>
+        Action<TCachedMessage?, TCachedMessage?> OnPurged { get; set; }
+
+        /// <summary>
+        /// Method which should be called when pulling agent try to do a purge on the cache
+        /// </summary>
+        /// <param name="utcNow"></param>
+        void PerformPurge(DateTime utcNow);
+
+        /// <summary>
+        /// Method which should be called when data adapter allocated a new block
+        /// </summary>
+        /// <param name="newBlock"></param>
+        void OnBlockAllocated(IDisposable newBlock);
+    }
+
+    /// <summary>
+    /// IPurgeObservable is implemented by the cache to do purge related actions, and invoked by EvictionStrategy
+    /// </summary>
+    /// <typeparam name="TCachedMessage"></typeparam>
+    public interface IPurgeObservable<TCachedMessage>
+         where TCachedMessage : struct
+    {
+        /// <summary>
+        /// Remove oldest message in the cache
+        /// </summary>
+        void RemoveOldestMessage();
+
+        /// <summary>
+        /// Newest message in the cache
+        /// </summary>
+        TCachedMessage? Newest { get; }
+
+        /// <summary>
+        /// Oldest message in the cache
+        /// </summary>
+        TCachedMessage? Oldest { get; }
+
+        /// <summary>
+        /// Message count
+        /// </summary>
+        int ItemCount { get; }
+    }
+}

--- a/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
@@ -26,7 +26,8 @@ namespace Orleans.Providers.Streams.Common
         /// Method which should be called when pulling agent try to do a purge on the cache
         /// </summary>
         /// <param name="utcNow"></param>
-        void PerformPurge(DateTime utcNow);
+        /// <param name="purgeRequest"></param>
+        void PerformPurge(DateTime utcNow, IDisposable purgeRequest = null);
 
         /// <summary>
         /// Method which should be called when data adapter allocated a new block

--- a/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/IEvictionStrategy.cs
@@ -62,5 +62,10 @@ namespace Orleans.Providers.Streams.Common
         /// Message count
         /// </summary>
         int ItemCount { get; }
+
+        /// <summary>
+        /// Determine if the cache is empty
+        /// </summary>
+        bool IsEmpty { get; }
     }
 }

--- a/src/OrleansProviders/Streams/Common/PooledCache/ObjectPool.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ObjectPool.cs
@@ -14,7 +14,6 @@ namespace Orleans.Providers.Streams.Common
         private const int DefaultPoolCapacity = 1 << 10; // 1k
         private readonly Stack<T> pool;
         private readonly Func<T> factoryFunc;
-
         /// <summary>
         /// Simple object pool
         /// </summary>

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -71,12 +71,12 @@ namespace Orleans.Providers.Streams.Generator
             public void PerformPurge(DateTime utcNow, IDisposable purgeRequest)
             {
                 //if the cache is empty, then nothing to purge, return
-                if (this.PurgeObservable.ItemCount == 0)
+                if (this.PurgeObservable.IsEmpty)
                     return;
                 var itemCountBeforePurge = this.PurgeObservable.ItemCount;
                 CachedMessage neweswtMessageInCache = this.PurgeObservable.Newest.Value;
                 CachedMessage? lastMessagePurged = null;
-                while (this.PurgeObservable.ItemCount != 0)
+                while (!this.PurgeObservable.IsEmpty)
                 {
                     var oldestMessageInCache = this.PurgeObservable.Oldest.Value;
                     if (!ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -79,7 +79,7 @@ namespace Orleans.Providers.Streams.Generator
                 while (this.PurgeObservable.ItemCount != 0)
                 {
                     var oldestMessageInCache = this.PurgeObservable.Oldest.Value;
-                    if (ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))
+                    if (!ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))
                     {
                         break;
                     }

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -27,7 +27,9 @@ namespace Orleans.Providers.Streams.Generator
         {
             var dataAdapter = new CacheDataAdapter(bufferPool, serializationManager);
             cache = new PooledQueueCache<GeneratedBatchContainer, CachedMessage>(dataAdapter, CacheDataComparer.Instance, logger);
-            dataAdapter.PurgeAction = cache.Purge;
+            var evictionStrategy = new ExplicitEvictionStrategy();
+            evictionStrategy.PurgeObservable = cache;
+            dataAdapter.OnBlockAllocated = evictionStrategy.OnBlockAllocated;
         }
 
         // For fast GC this struct should contain only value types.  I included streamNamespace because I'm lasy and this is test code, but it should not be in here.
@@ -58,13 +60,64 @@ namespace Orleans.Providers.Streams.Generator
             }
         }
 
+        private class ExplicitEvictionStrategy : IEvictionStrategy<CachedMessage>
+        {
+            private FixedSizeBuffer currentBuffer;
+            public IPurgeObservable<CachedMessage> PurgeObservable { set; private get; }
+
+            public Action<CachedMessage?, CachedMessage?> OnPurged { get; set; }
+
+            public void PerformPurge(DateTime utcNow)
+            {
+                //do nothing, purge in GeneratorPooledCache is triggered by block pool and conduct by OnFreeBlockRequest method
+            }
+
+            public void OnBlockAllocated(IDisposable newBlock)
+            {
+                var newBuffer = newBlock as FixedSizeBuffer;
+                this.currentBuffer = newBuffer;
+                this.currentBuffer.SetPurgeAction(this.OnFreeBlockRequest);
+            }
+
+            private bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, IDisposable purgeRequest)
+            {
+                var purgedResource = (FixedSizeBuffer)purgeRequest;
+                // if we're purging our current buffer, don't use it any more
+                if (this.currentBuffer != null && this.currentBuffer.Id == purgedResource.Id)
+                {
+                    currentBuffer = null;
+                }
+                return cachedMessage.Payload.Array == purgedResource.Id;
+            }
+
+            private void OnFreeBlockRequest(IDisposable purgeRequest)
+            {
+                //if the cache is empty, then nothing to purge, return
+                if (this.PurgeObservable.ItemCount == 0)
+                    return;
+                var itemCountBeforePurge = this.PurgeObservable.ItemCount;
+                CachedMessage neweswtMessageInCache = this.PurgeObservable.Newest.Value;
+                CachedMessage? lastMessagePurged = null;
+                while (this.PurgeObservable.ItemCount != 0)
+                {
+                    var oldestMessageInCache = this.PurgeObservable.Oldest.Value;
+                    if (ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))
+                    {
+                        break;
+                    }
+                    lastMessagePurged = oldestMessageInCache;
+                    this.PurgeObservable.RemoveOldestMessage();
+                }
+            }
+        }
+
         private class CacheDataAdapter : ICacheDataAdapter<GeneratedBatchContainer, CachedMessage>
         {
             private readonly IObjectPool<FixedSizeBuffer> bufferPool;
             private readonly SerializationManager serializationManager;
             private FixedSizeBuffer currentBuffer;
 
-            public Action<IDisposable> PurgeAction { private get; set; }
+            public Action<IDisposable> OnBlockAllocated { private get; set; }
 
             public CacheDataAdapter(IObjectPool<FixedSizeBuffer> bufferPool, SerializationManager serializationManager)
             {
@@ -99,7 +152,10 @@ namespace Orleans.Providers.Streams.Generator
                 {
                     // no block or block full, get new block and try again
                     currentBuffer = bufferPool.Allocate();
-                    currentBuffer.SetPurgeAction(PurgeAction);
+                    if (this.OnBlockAllocated == null)
+                        throw new OrleansException("Eviction strategy's OnBlockAllocated is not set for current data adapter, this will affect cache purging");
+                    //call EvictionStrategy's OnBlockAllocated method
+                    this.OnBlockAllocated.Invoke(currentBuffer);
                     // if this fails with clean block, then requested size is too big
                     if (!currentBuffer.TryGetSegment(size, out segment))
                     {
@@ -129,17 +185,6 @@ namespace Orleans.Providers.Streams.Generator
             public StreamPosition GetStreamPosition(GeneratedBatchContainer queueMessage)
             {
                 return new StreamPosition(new StreamIdentity(queueMessage.StreamGuid, queueMessage.StreamNamespace), queueMessage.RealToken);
-            }
-
-            public bool ShouldPurge(ref CachedMessage cachedMessage, ref CachedMessage newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc)
-            {
-                var purgedResource = (FixedSizeBuffer) purgeRequest;
-                // if we're purging our current buffer, don't use it any more
-                if (currentBuffer != null && currentBuffer.Id == purgedResource.Id)
-                {
-                    currentBuffer = null;
-                }
-                return cachedMessage.Payload.Array == purgedResource.Id;
             }
         }
 

--- a/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
@@ -58,30 +58,8 @@ namespace Orleans.Providers
 
             public Action<MemoryMessageData?, MemoryMessageData?> OnPurged { get; set; }
 
-            public void PerformPurge(DateTime utcNow)
-            {
-                //do nothing, purge in MemoryPooledCache is triggered by block pool and conduct by OnFreeBlockRequest method
-            }
-
-            public void OnBlockAllocated(IDisposable newBlock)
-            {
-                var newBuffer = newBlock as FixedSizeBuffer;
-                this.currentBuffer = newBuffer;
-                this.currentBuffer.SetPurgeAction(this.OnFreeBlockRequest);
-            }
-
-            private bool ShouldPurge(ref MemoryMessageData cachedMessage, ref MemoryMessageData newestCachedMessage, IDisposable purgeRequest)
-            {
-                var purgedResource = (FixedSizeBuffer)purgeRequest;
-                // if we're purging our current buffer, don't use it any more
-                if (currentBuffer != null && currentBuffer.Id == purgedResource.Id)
-                {
-                    currentBuffer = null;
-                }
-                return cachedMessage.Payload.Array == purgedResource.Id;
-            }
-
-            private void OnFreeBlockRequest(IDisposable purgeRequest)
+            //Explicitly purge all messages in purgeRequestBlock
+            public void PerformPurge(DateTime utcNow, IDisposable purgeRequest)
             {
                 //if the cache is empty, then nothing to purge, return
                 if (this.PurgeObservable.ItemCount == 0)
@@ -99,6 +77,29 @@ namespace Orleans.Providers
                     lastMessagePurged = oldestMessageInCache;
                     this.PurgeObservable.RemoveOldestMessage();
                 }
+            }
+
+            public void OnBlockAllocated(IDisposable newBlock)
+            {
+                var newBuffer = newBlock as FixedSizeBuffer;
+                this.currentBuffer = newBuffer;
+                this.currentBuffer.SetPurgeAction(this.PerformPurge);
+            }
+
+            private bool ShouldPurge(ref MemoryMessageData cachedMessage, ref MemoryMessageData newestCachedMessage, IDisposable purgeRequest)
+            {
+                var purgedResource = (FixedSizeBuffer)purgeRequest;
+                // if we're purging our current buffer, don't use it any more
+                if (currentBuffer != null && currentBuffer.Id == purgedResource.Id)
+                {
+                    currentBuffer = null;
+                }
+                return cachedMessage.Payload.Array == purgedResource.Id;
+            }
+
+            private void PerformPurge(IDisposable purgeRequest)
+            {
+                this.PerformPurge(DateTime.UtcNow, purgeRequest);
             }
         }
 

--- a/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
@@ -62,12 +62,12 @@ namespace Orleans.Providers
             public void PerformPurge(DateTime utcNow, IDisposable purgeRequest)
             {
                 //if the cache is empty, then nothing to purge, return
-                if (this.PurgeObservable.ItemCount == 0)
+                if (this.PurgeObservable.IsEmpty)
                     return;
                 var itemCountBeforePurge = this.PurgeObservable.ItemCount;
                 MemoryMessageData neweswtMessageInCache = this.PurgeObservable.Newest.Value;
                 MemoryMessageData? lastMessagePurged = null;
-                while (this.PurgeObservable.ItemCount != 0)
+                while (!this.PurgeObservable.IsEmpty)
                 {
                     var oldestMessageInCache = this.PurgeObservable.Oldest.Value;
                     if (!ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))

--- a/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
@@ -70,7 +70,7 @@ namespace Orleans.Providers
                 while (this.PurgeObservable.ItemCount != 0)
                 {
                     var oldestMessageInCache = this.PurgeObservable.Oldest.Value;
-                    if (ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))
+                    if (!ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))
                     {
                         break;
                     }

--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Providers\Streams\EventHub\EventHubAdapterFactory.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubAdapterReceiver.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubBatchContainer.cs" />
+    <Compile Include="Providers\Streams\EventHub\EventHubCacheEvictionStrategy.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubConstants.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubDataAdapter.cs" />
     <Compile Include="Providers\Streams\EventHub\EventHubCheckpointer.cs" />

--- a/src/OrleansServiceBus/Properties/AssemblyInfo.cs
+++ b/src/OrleansServiceBus/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -15,3 +16,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("60c5eab4-80ac-4c12-a231-37a7f10db25a")]
+
+[assembly: InternalsVisibleTo("ServiceBus.Tests")]

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -192,6 +192,10 @@ namespace Orleans.ServiceBus.Providers
         public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
         {
             purgedItems = null;
+
+            //if not under pressure, signal the cache to do a time based purge
+            if (!this.IsUnderPressure())
+                this.cache.SignalPurge();
             return false;
         }
 
@@ -202,7 +206,7 @@ namespace Orleans.ServiceBus.Providers
 
         public bool IsUnderPressure()
         {
-            return false;
+            return this.GetMaxAddCount() < MaxMessagesPerRead;
         }
 
         public Task MessagesDeliveredAsync(IList<IBatchContainer> messages)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -206,7 +206,7 @@ namespace Orleans.ServiceBus.Providers
 
         public bool IsUnderPressure()
         {
-            return this.GetMaxAddCount() < MaxMessagesPerRead;
+            return this.GetMaxAddCount() <= 0;
         }
 
         public Task MessagesDeliveredAsync(IList<IBatchContainer> messages)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
@@ -82,9 +82,9 @@ namespace Orleans.ServiceBus.Providers
             if (itemsPurged == 0)
                 return;
 
-            //purge finished, time to conduct follow up actions 
+            //items got purged, time to conduct follow up actions 
             OnPurged?.Invoke(lastMessagePurged, this.PurgeObservable.Newest);
-            UpdatePurgedBuffers(lastMessagePurged, this.PurgeObservable.Oldest, itemsPurged > 0);
+            UpdatePurgedBuffers(lastMessagePurged.Value, this.PurgeObservable.Oldest);
             if (this.logger.IsVerbose)
             { 
                 var itemCountAfterPurge = this.PurgeObservable.ItemCount;
@@ -93,13 +93,11 @@ namespace Orleans.ServiceBus.Providers
             }
         }
 
-        private void UpdatePurgedBuffers(CachedEventHubMessage? lastMessagePurged, CachedEventHubMessage? oldestMessageInCache, bool itemsGotPurged)
+        private void UpdatePurgedBuffers(CachedEventHubMessage lastMessagePurged, CachedEventHubMessage? oldestMessageInCache)
         {
-            //if nothing purged, then no buffer was purged
-            //if items got purged, then potencially some buffer was purged
-            if (itemsGotPurged)
+            if (this.inUseBuffers.Count > 0)
             {
-                var IdOfLastPurgedBuffer = lastMessagePurged.Value.Segment.Array;
+                var IdOfLastPurgedBuffer = lastMessagePurged.Segment.Array;
                 // IdOfLastBufferInCache will be null if cache is empty after purge
                 var IdOfLastBufferInCache = oldestMessageInCache.HasValue ? oldestMessageInCache.Value.Segment.Array : null;
                 //all buffer older than LastPurgedBuffer should be purged 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
@@ -51,7 +51,7 @@ namespace Orleans.ServiceBus.Providers
         }
 
         /// <inheritdoc />
-        public void PerformPurge(DateTime nowUtc)
+        public void PerformPurge(DateTime nowUtc, IDisposable purgeRequest)
         {
             //if the cache is empty, then nothing to purge, return
             if (this.PurgeObservable.ItemCount == 0)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
@@ -1,0 +1,130 @@
+﻿using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.ServiceBus.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.ServiceBus.Providers
+{
+    /// <summary>
+    /// Eviction strategy for EventHubQueueCache
+    /// </summary>
+    public class EventHubCacheEvictionStrategy : IEvictionStrategy<CachedEventHubMessage>
+    {
+        //buffers which are still in use for current cache
+        private readonly Queue<FixedSizeBuffer> inUseBuffers;
+        private readonly TimePurgePredicate timePurge;
+        private readonly Queue<FixedSizeBuffer> purgedBuffers;
+        private readonly Logger logger;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="timePurage"></param>
+        public EventHubCacheEvictionStrategy(Logger logger, TimePurgePredicate timePurage = null)
+        {
+            this.inUseBuffers = new Queue<FixedSizeBuffer>();
+            this.logger = logger.GetSubLogger(this.GetType().Name);
+            this.purgedBuffers = new Queue<FixedSizeBuffer>();
+            this.timePurge = timePurage ?? TimePurgePredicate.Default;
+        }
+        /// <inheritdoc />
+        public IPurgeObservable<CachedEventHubMessage> PurgeObservable { private get; set; }
+
+        /// <summary>
+        /// Called with the newest item in the cache and last item purged after a cache purge has run.
+        /// For ordered reliable queues we shouldn't need to notify on every purged event, only on the last event 
+        ///   of every set of events that get purged.
+        /// </summary>
+        public Action<CachedEventHubMessage?, CachedEventHubMessage?> OnPurged { get; set; }
+
+        /// <inheritdoc />
+        public void OnBlockAllocated(IDisposable newBlock)
+        {
+            var newBuffer = newBlock as FixedSizeBuffer;
+            this.inUseBuffers.Enqueue(newBuffer);
+            newBuffer.SetPurgeAction(this.OnFreeBlockRequest);
+        }
+
+        /// <inheritdoc />
+        public void PerformPurge(DateTime nowUtc)
+        {
+            //if the cache is empty, then nothing to purge, return
+            if (this.PurgeObservable.ItemCount == 0)
+                return;
+            var itemCountBeforePurge = this.PurgeObservable.ItemCount;
+            CachedEventHubMessage neweswtMessageInCache = this.PurgeObservable.Newest.Value;
+            CachedEventHubMessage? lastMessagePurged = null;
+            while (this.PurgeObservable.ItemCount != 0)
+            {
+                var oldestMessageInCache = this.PurgeObservable.Oldest.Value;
+                if (ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, nowUtc))
+                {
+                    break;
+                }
+                lastMessagePurged = oldestMessageInCache;
+                this.PurgeObservable.RemoveOldestMessage();
+            }
+            var itemCountAfterPurge = this.PurgeObservable.ItemCount;
+
+            //purge finished, time to conduct follow up actions 
+            OnPurged?.Invoke(lastMessagePurged, this.PurgeObservable.Newest);
+            UpdatePurgedBuffers(lastMessagePurged, this.PurgeObservable.Oldest, itemCountBeforePurge, itemCountAfterPurge);
+            ReportPurge(itemCountBeforePurge, itemCountAfterPurge);
+        }
+
+        private void UpdatePurgedBuffers(CachedEventHubMessage? lastMessagePurged, CachedEventHubMessage? oldestMessageInCache, int itemCountBeforePurge, int itemCountAfterPurge)
+        {
+            //if nothing purged, then no buffer was purged
+            //if items got purged, then potencially some buffer was purged
+            if (itemCountBeforePurge > itemCountAfterPurge)
+            {
+                var IdOfLastPurgedBuffer = lastMessagePurged.Value.Segment.Array;
+                // IdOfLastBufferInCache will be null if cache is empty after purge
+                var IdOfLastBufferInCache = oldestMessageInCache.HasValue ? oldestMessageInCache.Value.Segment.Array : null;
+                //all buffer older than LastPurgedBuffer should be purged 
+                while (this.inUseBuffers.Peek().Id != IdOfLastPurgedBuffer)
+                {
+                    this.purgedBuffers.Enqueue(this.inUseBuffers.Dequeue());
+                }
+                // if last purged message does not share buffer with remaining messages in cache, or cache is empty after purge, 
+                //then last purged buffer should be in purgedBuffers too
+                if (IdOfLastBufferInCache == null || IdOfLastPurgedBuffer != IdOfLastBufferInCache)
+                {
+                   this.purgedBuffers.Enqueue(this.inUseBuffers.Dequeue());
+                }
+            }
+        }
+
+        // Given a purge cached message, indicates whether it should be purged from the cache
+        private bool ShouldPurge(ref CachedEventHubMessage cachedMessage, ref CachedEventHubMessage newestCachedMessage, DateTime nowUtc)
+        {
+            TimeSpan timeInCache = nowUtc - cachedMessage.DequeueTimeUtc;
+            // age of message relative to the most recent event in the cache.
+            TimeSpan relativeAge = newestCachedMessage.EnqueueTimeUtc - cachedMessage.EnqueueTimeUtc;
+
+            return timePurge.ShouldPurgFromTime(timeInCache, relativeAge);
+        }
+
+        private void OnFreeBlockRequest(IDisposable block)
+        {
+            while (this.purgedBuffers.Count > 0)
+            {
+                this.purgedBuffers.Dequeue().Dispose();
+            }
+        }
+
+        private void ReportPurge(int itemCountBeforePurge, int itemCountAfterPurge)
+        {
+            if (itemCountAfterPurge == 0)
+            {
+                logger.Verbose("BlockPurged: cache empty");
+            }
+            logger.Verbose($"BlockPurged: PurgeCount: {itemCountBeforePurge - itemCountAfterPurge}, CacheSize: {itemCountAfterPurge}");
+        }
+    }
+}

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
@@ -112,9 +112,13 @@ namespace Orleans.ServiceBus.Providers
 
         private void OnFreeBlockRequest(IDisposable block)
         {
-            while (this.purgedBuffers.Count > 0)
+            var purgeCandidate = block as FixedSizeBuffer;
+            //free all blocks before purgeCandidate and purgeCandidate
+            if (this.purgedBuffers.Contains(purgeCandidate))
             {
-                this.purgedBuffers.Dequeue().Dispose();
+                while (this.purgedBuffers.Peek() != purgeCandidate)
+                    this.purgedBuffers.Dequeue().Dispose();
+                purgeCandidate.Dispose();
             }
         }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
@@ -15,9 +15,15 @@ namespace Orleans.ServiceBus.Providers
     public class EventHubCacheEvictionStrategy : IEvictionStrategy<CachedEventHubMessage>
     {
         //buffers which are still in use for current cache
-        private readonly Queue<FixedSizeBuffer> inUseBuffers;
+        /// <summary>
+        /// Buffers which are currently in use in the cache
+        /// </summary>
+        protected readonly Queue<FixedSizeBuffer> inUseBuffers;
         private readonly TimePurgePredicate timePurge;
-        private readonly Queue<FixedSizeBuffer> purgedBuffers;
+        /// <summary>
+        /// Buffers which are purged
+        /// </summary>
+        protected readonly Queue<FixedSizeBuffer> purgedBuffers;
         private readonly Logger logger;
 
         /// <summary>

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -273,8 +273,8 @@ namespace Orleans.ServiceBus.Providers
                 // no block or block full, get new block and try again
                 currentBuffer = bufferPool.Allocate();
                 if (this.OnBlockAllocated == null)
-                    throw new OrleansException("Eviction strategy's OnBlockAllocated is set for current data adapter, this will affect cache purging");
-                //keep track of allocated buffers in cache's eviction strategy
+                    throw new OrleansException("Eviction strategy's OnBlockAllocated is not set for current data adapter, this will affect cache purging");
+                //call EvictionStrategy's OnBlockAllocated method
                 this.OnBlockAllocated.Invoke(currentBuffer);
                 // if this fails with clean block, then requested size is too big
                 if (!currentBuffer.TryGetSegment(size, out segment))

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -11,6 +11,8 @@ using Microsoft.ServiceBus.Messaging;
 using Orleans.Providers.Streams.Common;
 using Orleans.Serialization;
 using Orleans.Streams;
+using System.Collections.Concurrent;
+using Orleans.Runtime;
 
 namespace Orleans.ServiceBus.Providers
 {
@@ -164,21 +166,17 @@ namespace Orleans.ServiceBus.Providers
     {
         private readonly SerializationManager serializationManager;
         private readonly IObjectPool<FixedSizeBuffer> bufferPool;
-        private readonly TimePurgePredicate timePurage;
         private FixedSizeBuffer currentBuffer;
 
-        /// <summary>
-        /// Assignable purge action.  This is called when a purge request is triggered.
-        /// </summary>
-        public Action<IDisposable> PurgeAction { private get; set; }
+        /// <inheritdoc />
+        public Action<IDisposable> OnBlockAllocated { set; private get; }
 
         /// <summary>
         /// Cache data adapter that adapts EventHub's EventData to CachedEventHubMessage used in cache
         /// </summary>
         /// <param name="serializationManager"></param>
         /// <param name="bufferPool"></param>
-        /// <param name="timePurage"></param>
-        public EventHubDataAdapter(SerializationManager serializationManager, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurage = null)
+        public EventHubDataAdapter(SerializationManager serializationManager, IObjectPool<FixedSizeBuffer> bufferPool)
         {
             if (bufferPool == null)
             {
@@ -186,7 +184,6 @@ namespace Orleans.ServiceBus.Providers
             }
             this.serializationManager = serializationManager;
             this.bufferPool = bufferPool;
-            this.timePurage = timePurage ?? TimePurgePredicate.Default;
         }
 
         /// <summary>
@@ -267,36 +264,6 @@ namespace Orleans.ServiceBus.Providers
             return new StreamPosition(stremIdentity, token);
         }
 
-        /// <summary>
-        /// Given a purge request, indicates if a cached message should be purged from the cache
-        /// </summary>
-        /// <param name="cachedMessage"></param>
-        /// <param name="newestCachedMessage"></param>
-        /// <param name="purgeRequest"></param>
-        /// <param name="nowUtc"></param>
-        /// <returns></returns>
-        public bool ShouldPurge(ref CachedEventHubMessage cachedMessage, ref CachedEventHubMessage newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc)
-        {
-            // if we're purging our current buffer, don't use it any more
-            var purgedResource = (FixedSizeBuffer)purgeRequest;
-            if (currentBuffer != null && currentBuffer.Id == purgedResource.Id)
-            {
-                currentBuffer = null;
-            }
-
-            TimeSpan timeInCache = nowUtc - cachedMessage.DequeueTimeUtc;
-            // age of message relative to the most recent event in the cache.
-            TimeSpan relativeAge = newestCachedMessage.EnqueueTimeUtc - cachedMessage.EnqueueTimeUtc;
-
-            return ShouldPurgeFromResource(ref cachedMessage, purgedResource) || timePurage.ShouldPurgFromTime(timeInCache, relativeAge);
-        }
-
-        private static bool ShouldPurgeFromResource(ref CachedEventHubMessage cachedMessage, FixedSizeBuffer purgedResource)
-        {
-            // if message is from this resource, purge
-            return cachedMessage.Segment.Array == purgedResource.Id;
-        }
-
         private ArraySegment<byte> GetSegment(int size)
         {
             // get segment from current block
@@ -305,7 +272,10 @@ namespace Orleans.ServiceBus.Providers
             {
                 // no block or block full, get new block and try again
                 currentBuffer = bufferPool.Allocate();
-                currentBuffer.SetPurgeAction(PurgeAction);
+                if (this.OnBlockAllocated == null)
+                    throw new OrleansException("Eviction strategy's OnBlockAllocated is set for current data adapter, this will affect cache purging");
+                //keep track of allocated buffers in cache's eviction strategy
+                this.OnBlockAllocated.Invoke(currentBuffer);
                 // if this fails with clean block, then requested size is too big
                 if (!currentBuffer.TryGetSegment(size, out segment))
                 {
@@ -356,5 +326,6 @@ namespace Orleans.ServiceBus.Providers
 
             return segment;
         }
+       
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -209,7 +209,7 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="cacheDataAdapter">adapts queue data to cache</param>
         /// <param name="comparer">compares stream information to cached data</param>
         /// <param name="logger">cache logger</param>
-        /// <param name="evictionStrategy">eviction strategy for the cache<</param>
+        /// <param name="evictionStrategy">eviction strategy for the cache</param>
         public EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, 
             ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger, IEvictionStrategy<CachedEventHubMessage> evictionStrategy)
             : base(defaultMaxAddCount, checkpointer, cacheDataAdapter, comparer, logger, evictionStrategy)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -28,7 +28,10 @@ namespace Orleans.ServiceBus.Providers
         /// </summary>
         protected readonly PooledQueueCache<EventData, TCachedMessage> cache;
         private readonly AggregatedCachePressureMonitor cachePressureMonitor;
-
+        /// <summary>
+        /// Eviction stretagy manage purge related events
+        /// </summary>
+        private IEvictionStrategy<TCachedMessage> evictionStrategy;
         /// <summary>
         /// Logic used to store queue position
         /// </summary>
@@ -42,14 +45,23 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="cacheDataAdapter">Performs data transforms appropriate for the various types of queue data.</param>
         /// <param name="comparer">Compares cached data</param>
         /// <param name="logger"></param>
-        protected EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, TCachedMessage> cacheDataAdapter, ICacheDataComparer<TCachedMessage> comparer, Logger logger)
+        /// <param name="evictionStrategy">Eviction stretagy manage purge related events</param>
+        protected EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, TCachedMessage> cacheDataAdapter, 
+            ICacheDataComparer<TCachedMessage> comparer, Logger logger, IEvictionStrategy<TCachedMessage> evictionStrategy)
         {
             this.defaultMaxAddCount = defaultMaxAddCount;
             Checkpointer = checkpointer;
             cache = new PooledQueueCache<EventData, TCachedMessage>(cacheDataAdapter, comparer, logger);
-            cacheDataAdapter.PurgeAction = cache.Purge;
-            cache.OnPurged = OnPurge;
+            this.evictionStrategy.OnPurged = this.OnPurge;
+            this.evictionStrategy.PurgeObservable = cache;
+            cacheDataAdapter.OnBlockAllocated = this.evictionStrategy.OnBlockAllocated;
             this.cachePressureMonitor = new AggregatedCachePressureMonitor(logger);
+        }
+    
+        /// <inheritdoc />
+        public void SignalPurge()
+        {
+            this.evictionStrategy.PerformPurge(DateTime.UtcNow);
         }
 
         /// <summary>
@@ -84,7 +96,7 @@ namespace Orleans.ServiceBus.Providers
         /// <filterpriority>2</filterpriority>
         public void Dispose()
         {
-            cache.OnPurged = null;
+            this.evictionStrategy.OnPurged = null;
         }
 
         /// <summary>
@@ -171,7 +183,8 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="logger">cache logger</param>
         /// <param name="serializationManager"></param>
         public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, Logger logger, SerializationManager serializationManager)
-            : this(checkpointer, new EventHubDataAdapter(serializationManager, bufferPool, timePurge), EventHubDataComparer.Instance, logger)
+            : this(checkpointer, new EventHubDataAdapter(serializationManager, bufferPool), EventHubDataComparer.Instance, logger, 
+                  new EventHubCacheEvictionStrategy(logger, timePurge))
         {
         }
 
@@ -182,8 +195,10 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="cacheDataAdapter">adapts queue data to cache</param>
         /// <param name="comparer">compares stream information to cached data</param>
         /// <param name="logger">cache logger</param>
-        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger)
-            : base(EventHubAdapterReceiver.MaxMessagesPerRead, checkpointer, cacheDataAdapter, comparer, logger)
+        /// <param name="evictionStrategy">eviction strategy for the cache</param>
+        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, 
+            ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger, IEvictionStrategy<CachedEventHubMessage> evictionStrategy)
+            : base(EventHubAdapterReceiver.MaxMessagesPerRead, checkpointer, cacheDataAdapter, comparer, logger, evictionStrategy)
         {
             log = logger.GetSubLogger(this.GetType().Name);
         }
@@ -196,8 +211,10 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="cacheDataAdapter">adapts queue data to cache</param>
         /// <param name="comparer">compares stream information to cached data</param>
         /// <param name="logger">cache logger</param>
-        public EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger)
-            : base(defaultMaxAddCount, checkpointer, cacheDataAdapter, comparer, logger)
+        /// <param name="evictionStrategy">eviction strategy for the cache<</param>
+        public EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, 
+            ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger, IEvictionStrategy<CachedEventHubMessage> evictionStrategy)
+            : base(defaultMaxAddCount, checkpointer, cacheDataAdapter, comparer, logger, evictionStrategy)
         {
             log = logger.GetSubLogger(this.GetType().Name);
         }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -28,9 +28,6 @@ namespace Orleans.ServiceBus.Providers
         /// </summary>
         protected readonly PooledQueueCache<EventData, TCachedMessage> cache;
         private readonly AggregatedCachePressureMonitor cachePressureMonitor;
-        /// <summary>
-        /// Eviction stretagy manage purge related events
-        /// </summary>
         private IEvictionStrategy<TCachedMessage> evictionStrategy;
         /// <summary>
         /// Logic used to store queue position
@@ -52,6 +49,7 @@ namespace Orleans.ServiceBus.Providers
             this.defaultMaxAddCount = defaultMaxAddCount;
             Checkpointer = checkpointer;
             cache = new PooledQueueCache<EventData, TCachedMessage>(cacheDataAdapter, comparer, logger);
+            this.evictionStrategy = evictionStrategy;
             this.evictionStrategy.OnPurged = this.OnPurge;
             this.evictionStrategy.PurgeObservable = cache;
             cacheDataAdapter.OnBlockAllocated = this.evictionStrategy.OnBlockAllocated;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderSettings.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubStreamProviderSettings.cs
@@ -69,7 +69,10 @@ namespace Orleans.ServiceBus.Providers
         /// CacheSizeMb setting name.
         /// </summary>
         public const string CacheSizeMbName = "CacheSizeMb";
-        private const int DefaultCacheSizeMb = 128; // default to 128mb cache.
+        /// <summary>
+        /// Default cache size in MB
+        /// </summary>
+        public const int DefaultCacheSizeMb = 128; // default to 128mb cache.
         private int? cacheSizeMb;
         /// <summary>
         /// Cache size in megabytes.
@@ -84,7 +87,10 @@ namespace Orleans.ServiceBus.Providers
         /// DataMinTimeInCache setting name.
         /// </summary>
         public const string DataMinTimeInCacheName = "DataMinTimeInCache";
-        private static readonly TimeSpan DefaultDataMinTimeInCache = TimeSpan.FromMinutes(5);
+        /// <summary>
+        /// Drfault DataMinTimeInCache
+        /// </summary>
+        public static readonly TimeSpan DefaultDataMinTimeInCache = TimeSpan.FromMinutes(5);
         private TimeSpan? dataMinTimeInCache;
         /// <summary>
         /// Minimum time message will stay in cache before it is available for time based purge.
@@ -99,7 +105,10 @@ namespace Orleans.ServiceBus.Providers
         /// DataMaxAgeInCache setting name.
         /// </summary>
         public const string DataMaxAgeInCacheName = "DataMaxAgeInCache";
-        private static readonly TimeSpan DefaultDataMaxAgeInCache = TimeSpan.FromMinutes(30);
+        /// <summary>
+        /// Default DataMaxAgeInCache
+        /// </summary>
+        public static readonly TimeSpan DefaultDataMaxAgeInCache = TimeSpan.FromMinutes(30);
         private TimeSpan? dataMaxAgeInCache;
         /// <summary>
         /// Difference in time between the newest and oldest messages in the cache.  Any messages older than this will be purged from the cache.

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -42,5 +42,10 @@ namespace Orleans.ServiceBus.Providers
         /// </summary>
         /// <param name="monitor"></param>
         void AddCachePressureMonitor(ICachePressureMonitor monitor);
+
+        /// <summary>
+        /// Send purge signal to the cache, the cache will perform a time based purge on its cached messages
+        /// </summary>
+        void SignalPurge();
     }
 }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/TimePurgePredicate.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/TimePurgePredicate.cs
@@ -34,7 +34,7 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="timeInCache">amount of time message has been in this cache</param>
         /// <param name="relativeAge">Age of message relative to the most recent events read</param>
         /// <returns></returns>
-        public bool ShouldPurgFromTime(TimeSpan timeInCache, TimeSpan relativeAge)
+        public virtual bool ShouldPurgFromTime(TimeSpan timeInCache, TimeSpan relativeAge)
         {
             // if time in cache exceeds the minimum and age of data is greater than max allowed, purge
             return timeInCache > minTimeInCache && relativeAge > maxRelativeMessageAge;

--- a/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -215,6 +215,8 @@ namespace ServiceBus.Tests.EvictionStrategyTests
 
             //Purged buffers should be returned to the pool and used to allocate new buffer
             purgedBuffers.ForEach(buffer => Assert.True(newBuffersAllocated.Contains(buffer)));
+            this.evictionStrategyList.ForEach(strategy => Assert.Equal(0, strategy.InUseBuffers.Count));
+            this.evictionStrategyList.ForEach(strategy => Assert.Equal(0, strategy.PurgedBuffers.Count));
         }
 #endif
 

--- a/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -1,0 +1,214 @@
+﻿using Microsoft.ServiceBus.Messaging;
+using Orleans;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.Serialization;
+using Orleans.ServiceBus.Providers;
+using Orleans.Streams;
+using Orleans.TestingHost.Utils;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TestExtensions;
+using Xunit;
+
+namespace ServiceBus.Tests.EventHubCacheEvictionStrategyTests
+{
+    public class EHPurgeLogicTests
+    {
+        private CachePressureInjectionMonitor cachePressureInjectionMonitor;
+        private PurgeDecisionInjectionPredicate purgePredicate;
+        private SerializationManager serializationManager;
+        private EventHubAdapterReceiver receiver1;
+        private EventHubAdapterReceiver receiver2;
+        private FixedSizeObjectPool<FixedSizeBuffer> bufferPool;
+        private int bufferPoolSizeInMB;
+        private Logger logger;
+        private TimeSpan timeOut = TimeSpan.FromSeconds(30);
+        private EventHubPartitionSettings ehSettings;
+        private ConcurrentBag<EventHubQueueCacheForTesting> cacheList;
+        public EHPurgeLogicTests()
+        {
+            //an mock eh settings
+            this.ehSettings = new EventHubPartitionSettings();
+            ehSettings.Hub = new EventHubSettings();
+            ehSettings.Partition = "MockPartition";
+
+            //set up cache pressure monitor and purge predicate
+            this.cachePressureInjectionMonitor = new CachePressureInjectionMonitor();
+            this.purgePredicate = new PurgeDecisionInjectionPredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(30));
+
+            //set up serialization env
+            var config = new ClientConfiguration();
+            var environment = SerializationTestEnvironment.InitializeWithDefaults(config);
+            this.serializationManager = environment.SerializationManager;
+
+            //set up buffer pool
+            this.bufferPoolSizeInMB = EventHubStreamProviderSettings.DefaultCacheSizeMb;
+            this.bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(this.bufferPoolSizeInMB, () => new FixedSizeBuffer(1 << 20));
+
+            //set up logger
+            this.logger = new NoOpTestLogger().GetLogger(this.GetType().Name);
+        }
+
+        [Fact, TestCategory("EventHub"), TestCategory("Streaming"), TestCategory("BVT")]
+        public async Task EventhubQueueCache_WontPurge_WhenUnderPressure()
+        {
+            InitForTesting();
+            var tasks = new List<Task>();
+            //add items into cache
+            int itemAddToCache = 10;
+            foreach(var cache in this.cacheList)
+                tasks.Add(AddDataIntoCache(cache, itemAddToCache));
+            await Task.WhenAll(tasks);
+
+            //set cachePressureMonitor to be underPressure
+            this.cachePressureInjectionMonitor.isUnderPressure = true;
+            //set purgePredicate to be ShouldPurge
+            this.purgePredicate.ShouldPurge = true;
+
+            //perform purge
+            IList<IBatchContainer> ignore; 
+            this.receiver1.TryPurgeFromCache(out ignore);
+            this.receiver2.TryPurgeFromCache(out ignore);
+
+            //Assert
+            int expectedItemCountInCacheList = itemAddToCache + itemAddToCache;
+            Assert.Equal(expectedItemCountInCacheList, GetItemCountInAllCache(this.cacheList));
+        }
+
+        [Fact, TestCategory("EventHub"), TestCategory("Streaming"), TestCategory("BVT")]
+        public async Task EventhubQueueCache_WontPurge_WhenTimePurgePredicateSaysDontPurge()
+        {
+            InitForTesting();
+            var tasks = new List<Task>();
+            //add items into cache
+            int itemAddToCache = 10;
+            foreach (var cache in this.cacheList)
+                tasks.Add(AddDataIntoCache(cache, itemAddToCache));
+            await Task.WhenAll(tasks);
+
+            //set cachePressureMonitor to be underPressure
+            this.cachePressureInjectionMonitor.isUnderPressure = false;
+            //set purgePredicate to be ShouldPurge
+            this.purgePredicate.ShouldPurge = false;
+
+            //perform purge
+            IList<IBatchContainer> ignore;
+            this.receiver1.TryPurgeFromCache(out ignore);
+            this.receiver2.TryPurgeFromCache(out ignore);
+
+            //Assert
+            int expectedItemCountInCacheList = itemAddToCache + itemAddToCache;
+            Assert.Equal(expectedItemCountInCacheList, GetItemCountInAllCache(this.cacheList));
+        }
+
+        [Fact, TestCategory("EventHub"), TestCategory("Streaming"), TestCategory("BVT")]
+        public async Task EventhubQueueCache_WillPurge_WhenTimePurgePredicateSaysPurge_And_NotUnderPressure()
+        {
+            InitForTesting();
+            var tasks = new List<Task>();
+            //add items into cache
+            int itemAddToCache = 10;
+            foreach (var cache in this.cacheList)
+                tasks.Add(AddDataIntoCache(cache, itemAddToCache));
+            await Task.WhenAll(tasks);
+
+            //set cachePressureMonitor to be underPressure
+            this.cachePressureInjectionMonitor.isUnderPressure = false;
+            //set purgePredicate to be ShouldPurge
+            this.purgePredicate.ShouldPurge = true;
+
+            //perform purge
+            IList<IBatchContainer> ignore;
+            this.receiver1.TryPurgeFromCache(out ignore);
+            this.receiver2.TryPurgeFromCache(out ignore);
+
+            //Assert
+            int expectedItemCountInCacheList = 0;
+            Assert.Equal(expectedItemCountInCacheList, GetItemCountInAllCache(this.cacheList));
+        }
+
+        [Fact, TestCategory("EventHub"), TestCategory("Streaming"), TestCategory("BVT")]
+        public async Task EventhubQueueCache_BufferPoolFull_WontCauseCacheMiss()
+        {
+            InitForTesting();
+            var tasks = new List<Task>();
+            //add items into cache
+            int itemAddToCache = 10;
+            foreach (var cache in this.cacheList)
+                tasks.Add(AddDataIntoCache(cache, itemAddToCache));
+            await Task.WhenAll(tasks);
+
+            //set cachePressureMonitor to be underPressure
+            this.cachePressureInjectionMonitor.isUnderPressure = false;
+            //set purgePredicate to be ShouldPurge
+            this.purgePredicate.ShouldPurge = false;
+
+            //keep allocate buffer on buffer pool to make it full
+            int bufferToAllocate = EventHubStreamProviderSettings.DefaultCacheSizeMb;
+            while (bufferToAllocate > 0)
+            {
+                this.bufferPool.Allocate();
+                bufferToAllocate--;
+            }
+
+            //Assert
+            int expectedItemCountInCacheList = itemAddToCache + itemAddToCache;
+            Assert.Equal(expectedItemCountInCacheList, GetItemCountInAllCache(this.cacheList));
+        }
+
+        private void InitForTesting()
+        {
+            this.cacheList = new ConcurrentBag<EventHubQueueCacheForTesting>();
+            this.receiver1 = new EventHubAdapterReceiver(ehSettings, this.CacheFactory, this.CheckPointerFactory, this.logger,
+                new DefaultEventHubReceiverMonitor(ehSettings.Hub.Path, ehSettings.Partition, this.logger), this.GetNodeConfiguration);
+            this.receiver2 = new EventHubAdapterReceiver(ehSettings, this.CacheFactory, this.CheckPointerFactory, this.logger,
+                new DefaultEventHubReceiverMonitor(ehSettings.Hub.Path, ehSettings.Partition, this.logger), this.GetNodeConfiguration);
+            this.receiver1.Initialize(this.timeOut);
+            this.receiver2.Initialize(this.timeOut);
+        }
+
+        private int GetItemCountInAllCache(ConcurrentBag<EventHubQueueCacheForTesting> caches)
+        {
+            int itemCount = 0;
+            foreach (var cache in caches)
+            {
+                itemCount += cache.ItemCount;
+            }
+            return itemCount;
+        }
+        private Task AddDataIntoCache(EventHubQueueCacheForTesting cache, int count)
+        {
+            while (count > 0) 
+            { 
+                count--;
+                cache.Add(new EventData(), DateTime.UtcNow);
+            }
+            return TaskDone.Done;
+        }
+
+        private NodeConfiguration GetNodeConfiguration()
+        {
+            return new NodeConfiguration();
+        }
+
+        private Task<IStreamQueueCheckpointer<string>> CheckPointerFactory(string partition)
+        {
+            return Task.FromResult<IStreamQueueCheckpointer<string>>(new MockStreamQueueCheckpointer());
+        }
+
+        private IEventHubQueueCache CacheFactory(string partition, IStreamQueueCheckpointer<string> checkpointer, Logger logger)
+        {
+            var cache = new EventHubQueueCacheForTesting(checkpointer, new MockEventHubCacheAdaptor(this.serializationManager, this.bufferPool), 
+                EventHubDataComparer.Instance, this.logger, new EventHubCacheEvictionStrategy(this.logger, this.purgePredicate));
+            cache.AddCachePressureMonitor(this.cachePressureInjectionMonitor);
+            this.cacheList.Add(cache);
+            return cache;
+        }
+    }
+}

--- a/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -59,7 +59,8 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             //set up logger
             this.logger = new NoOpTestLogger().GetLogger(this.GetType().Name);
         }
-
+        //Disable tests if in netstandard, because Eventhub framework doesn't provide proper hooks for tests to generate proper EventData in netstandard
+#if !NETSTANDARD
         [Fact, TestCategory("BVT")]
         public async Task EventhubQueueCache_WontPurge_WhenUnderPressure()
         {
@@ -215,6 +216,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             //Purged buffers should be returned to the pool and used to allocate new buffer
             purgedBuffers.ForEach(buffer => Assert.True(newBuffersAllocated.Contains(buffer)));
         }
+#endif
 
         private void InitForTesting()
         {

--- a/test/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
+++ b/test/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.ServiceBus.Messaging;
+﻿#if NETSTANDARD
+using Microsoft.Azure.EventHubs;
+#else
+using Microsoft.ServiceBus.Messaging;
+#endif
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
@@ -11,7 +15,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace ServiceBus.Tests.EventHubCacheEvictionStrategyTests
+namespace ServiceBus.Tests.EvictionStrategyTests
 {
     public class EventHubQueueCacheForTesting : EventHubQueueCache
     {
@@ -21,6 +25,15 @@ namespace ServiceBus.Tests.EventHubCacheEvictionStrategyTests
             { }
         
         public int ItemCount { get { return this.cache.ItemCount; } }
+    }
+    public class EHEvictionStrategyForTesting : EventHubCacheEvictionStrategy
+    {
+        public EHEvictionStrategyForTesting(Logger logger, TimePurgePredicate timePurage = null)
+            :base(logger, timePurage)
+        { }
+
+        public Queue<FixedSizeBuffer> InUseBuffers { get { return this.inUseBuffers; } }
+        public Queue<FixedSizeBuffer> PurgedBuffers { get { return this.purgedBuffers; } }
     }
 
     public class MockEventHubCacheAdaptor : EventHubDataAdapter

--- a/test/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
+++ b/test/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.ServiceBus.Messaging;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.Serialization;
+using Orleans.ServiceBus.Providers;
+using Orleans.Streams;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ServiceBus.Tests.EventHubCacheEvictionStrategyTests
+{
+    public class EventHubQueueCacheForTesting : EventHubQueueCache
+    {
+        public EventHubQueueCacheForTesting(IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter,
+            ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger, IEvictionStrategy<CachedEventHubMessage> evictionStrategy)
+            :base(checkpointer, cacheDataAdapter, comparer, logger, evictionStrategy)
+            { }
+        
+        public int ItemCount { get { return this.cache.ItemCount; } }
+    }
+
+    public class MockEventHubCacheAdaptor : EventHubDataAdapter
+    {
+        private long sequenceNumberCounter = 0;
+        private int eventIndex = 1;
+        private string eventHubOffset = "OffSet";
+        public MockEventHubCacheAdaptor(SerializationManager serializationManager, IObjectPool<FixedSizeBuffer> bufferPool)
+            : base(serializationManager, bufferPool)
+        { }
+
+        public override StreamPosition GetStreamPosition(EventData queueMessage)
+        {
+            var steamIdentity = new StreamIdentity(Guid.NewGuid(), "EmptySpace");
+            var sequenceToken = new EventHubSequenceTokenV2(this.eventHubOffset, this.sequenceNumberCounter++, this.eventIndex);
+            return new StreamPosition(steamIdentity, sequenceToken);
+        }
+    }
+
+    internal class MockStreamQueueCheckpointer : IStreamQueueCheckpointer<string>
+    {
+        public bool CheckpointExists => true;
+
+        public Task<string> Load()
+        {
+            //do nothing
+            return Task.FromResult<string>("");
+        }
+
+        public void Update(string offset, DateTime utcNow)
+        {
+            //do nothing
+        }
+    }
+
+    internal class CachePressureInjectionMonitor : ICachePressureMonitor
+    {
+        public bool isUnderPressure { get; set; }
+        public CachePressureInjectionMonitor()
+        {
+            this.isUnderPressure = false;
+        }
+
+        public void RecordCachePressureContribution(double cachePressureContribution)
+        {
+
+        }
+
+        public bool IsUnderPressure(DateTime utcNow)
+        {
+            return this.isUnderPressure;
+        }
+    }
+
+    internal class PurgeDecisionInjectionPredicate : TimePurgePredicate
+    {
+        public bool ShouldPurge { get; set; }
+        public PurgeDecisionInjectionPredicate(TimeSpan minTimeInCache, TimeSpan maxRelativeMessageAge)
+            : base(minTimeInCache, maxRelativeMessageAge)
+        {
+            this.ShouldPurge = false;
+        }
+
+        public override bool ShouldPurgFromTime(TimeSpan timeInCache, TimeSpan relativeAge)
+        {
+            return this.ShouldPurge;
+        }
+    }
+}

--- a/test/ServiceBus.Tests/ServiceBus.Tests.csproj
+++ b/test/ServiceBus.Tests/ServiceBus.Tests.csproj
@@ -127,6 +127,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CollectionFixtures.cs" />
+    <Compile Include="EvictionStrategyTests\EHPurgeLogicTests.cs" />
+    <Compile Include="EvictionStrategyTests\TestMocks.cs" />
     <Compile Include="SlowConsumingTests\EHSlowConsumingTests.cs" />
     <Compile Include="SlowConsumingTests\EventHubStreamProviderSettingsTests.cs" />
     <Compile Include="Streaming\EHClientStreamTests.cs" />
@@ -139,6 +141,7 @@
     <Compile Include="TestStreamProviders\StreamPerPartitionEventHubStreamProvider.cs" />
     <Compile Include="TestStreamProviders\TestEventHubStreamProvider.cs" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
+++ b/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
@@ -40,8 +40,8 @@ namespace ServiceBus.Tests.TestStreamProviders
                     IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, SerializationManager serializationManager)
                 {
                     //set defaultMaxAddCount to 2 so TryCalculateCachePressureContribution will start to calculate real contribution shortly.
-                    var cache = new EventHubQueueCache(defaultMaxAddCount, checkpointer, new EventHubDataAdapter(serializationManager, bufferPool, timePurge), 
-                        EventHubDataComparer.Instance, cacheLogger);
+                    var cache = new EventHubQueueCache(defaultMaxAddCount, checkpointer, new EventHubDataAdapter(serializationManager, bufferPool), 
+                        EventHubDataComparer.Instance, cacheLogger, new EventHubCacheEvictionStrategy(cacheLogger, timePurge));
                     _caches.Add(cache);
                     return cache;
                 }

--- a/test/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
@@ -38,8 +38,8 @@ namespace ServiceBus.Tests.TestStreamProviders.EventHub
             public IEventHubQueueCache CreateCache(string partition, IStreamQueueCheckpointer<string> checkpointer, Logger cacheLogger)
             {
                 var bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(adapterSettings.CacheSizeMb, () => new FixedSizeBuffer(1 << 20));
-                var dataAdapter = new CachedDataAdapter(partition, bufferPool, timePurgePredicate, this.serializationManager);
-                return new EventHubQueueCache(checkpointer, dataAdapter, EventHubDataComparer.Instance, cacheLogger);
+                var dataAdapter = new CachedDataAdapter(partition, bufferPool, this.serializationManager);
+                return new EventHubQueueCache(checkpointer, dataAdapter, EventHubDataComparer.Instance, cacheLogger, new EventHubCacheEvictionStrategy(cacheLogger, this.timePurgePredicate));
             }
         }
 
@@ -55,8 +55,8 @@ namespace ServiceBus.Tests.TestStreamProviders.EventHub
         {
             private readonly Guid partitionStreamGuid;
 
-            public CachedDataAdapter(string partitionKey, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, SerializationManager serializationManager)
-                : base(serializationManager, bufferPool, timePurge)
+            public CachedDataAdapter(string partitionKey, IObjectPool<FixedSizeBuffer> bufferPool, SerializationManager serializationManager)
+                : base(serializationManager, bufferPool)
             {
                 partitionStreamGuid = GetPartitionGuid(partitionKey);
             }

--- a/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/CachedMessageBlockTests.cs
@@ -63,10 +63,9 @@ namespace UnitTests.OrleansRuntime.Streams
             }
         }
 
-
         private class TestCacheDataAdapter : ICacheDataAdapter<TestQueueMessage, TestCachedMessage>
         {
-            public Action<IDisposable> PurgeAction { private get; set; }
+            public Action<IDisposable> OnBlockAllocated { set; private get; }
 
             public StreamPosition QueueMessageToCachedMessage(ref TestCachedMessage cachedMessage, TestQueueMessage queueMessage, DateTime dequeueTimeUtc)
             {
@@ -96,11 +95,6 @@ namespace UnitTests.OrleansRuntime.Streams
                 IStreamIdentity streamIdentity = new StreamIdentity(queueMessage.StreamGuid, null);
                 StreamSequenceToken sequenceToken = queueMessage.SequenceToken;
                 return new StreamPosition(streamIdentity, sequenceToken);
-            }
-
-            public bool ShouldPurge(ref TestCachedMessage cachedMessage, ref TestCachedMessage newestCachedMessage, IDisposable purgeRequest, DateTime nowUtc)
-            {
-                throw new NotImplementedException();
             }
         }
 

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -96,7 +96,7 @@ namespace UnitTests.OrleansRuntime.Streams
                 while (this.PurgeObservable.ItemCount != 0)
                 {
                     var oldestMessageInCache = this.PurgeObservable.Oldest.Value;
-                    if (ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))
+                    if (!ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))
                     {
                         break;
                     }

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -88,12 +88,12 @@ namespace UnitTests.OrleansRuntime.Streams
             public void PerformPurge(DateTime utcNow, IDisposable purgeRequest)
             {
                 //if the cache is empty, then nothing to purge, return
-                if (this.PurgeObservable.ItemCount == 0)
+                if (this.PurgeObservable.IsEmpty)
                     return;
                 var itemCountBeforePurge = this.PurgeObservable.ItemCount;
                 TestCachedMessage neweswtMessageInCache = this.PurgeObservable.Newest.Value;
                 TestCachedMessage? lastMessagePurged = null;
-                while (this.PurgeObservable.ItemCount != 0)
+                while (!this.PurgeObservable.IsEmpty)
                 {
                     var oldestMessageInCache = this.PurgeObservable.Oldest.Value;
                     if (!ShouldPurge(ref oldestMessageInCache, ref neweswtMessageInCache, purgeRequest))

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -80,8 +80,13 @@ namespace UnitTests.OrleansRuntime.Streams
         private class ExplicitEvictionStrategy : IEvictionStrategy<TestCachedMessage>
         {
             private FixedSizeBuffer currentBuffer;
+            private Queue<FixedSizeBuffer> purgedBuffers;
             public IPurgeObservable<TestCachedMessage> PurgeObservable { set; private get; }
 
+            public ExplicitEvictionStrategy()
+            {
+                this.purgedBuffers = new Queue<FixedSizeBuffer>();
+            }
             public Action<TestCachedMessage?, TestCachedMessage?> OnPurged { get; set; }
 
             //Explicitly purge all messages in purgeRequestBlock
@@ -103,6 +108,19 @@ namespace UnitTests.OrleansRuntime.Streams
                     lastMessagePurged = oldestMessageInCache;
                     this.PurgeObservable.RemoveOldestMessage();
                 }
+
+                //return purged buffer to the pool. except for the current buffer.
+                //if purgeCandidate is current buffer, put it in purgedBuffers and free it in next circle
+                var purgeCandidate = purgeRequest as FixedSizeBuffer;
+                this.purgedBuffers.Enqueue(purgeCandidate);
+                while (this.purgedBuffers.Count > 0)
+                {
+                    if (this.purgedBuffers.Peek() != this.currentBuffer)
+                    {
+                        this.purgedBuffers.Dequeue().Dispose();
+                    }
+                    else { break; }
+                }
             }
 
             public void OnBlockAllocated(IDisposable newBlock)
@@ -115,11 +133,6 @@ namespace UnitTests.OrleansRuntime.Streams
             private bool ShouldPurge(ref TestCachedMessage cachedMessage, ref TestCachedMessage newestCachedMessage, IDisposable purgeRequest)
             {
                 var purgedResource = (FixedSizeBuffer)purgeRequest;
-                // if we're purging our current buffer, don't use it any more
-                if (currentBuffer != null && currentBuffer.Id == purgedResource.Id)
-                {
-                    currentBuffer = null;
-                }
                 return cachedMessage.Payload.Array == purgedResource.Id;
             }
 

--- a/vNext/src/OrleansServiceBus/Properties/AssemblyInfo.cs
+++ b/vNext/src/OrleansServiceBus/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ServiceBus.Tests")]


### PR DESCRIPTION
Fix low traffic queue share pool with high traffic queue bug in EventhubQueueCache… 
-increase TimeBasedPurge frequency on EventHubQueueCache
-for EventHubQueueCache, don't purge the block when message is still valid, based on its TimePurgePredicate
-prevent EventHubQueueCache to purge if it's under pressure, to ensure its rewindability