### PR TITLE
Remove [RegisterSerializer] and support for correspondig Register method

### DIFF
--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -296,16 +296,6 @@ namespace Orleans
         public sealed class DeserializerMethodAttribute : Attribute
         {
         }
-
-        /// <summary>
-        /// Used to make a class for auto-registration as a serialization helper.
-        /// </summary>
-        [AttributeUsage(AttributeTargets.Class)]
-        [Obsolete(
-            "[RegisterSerializer] is obsolete, please use [Serializer(typeof(TargetType))] instead. Note that the signature of Register has changed to 'void Register(SerializationManager sm)'.")]
-        public sealed class RegisterSerializerAttribute : Attribute
-        {
-        }
     }
 
     namespace Providers

--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -181,18 +181,20 @@ namespace Orleans
         {
             public RandomPlacementAttribute() :
                 base(RandomPlacement.Singleton)
-            { }
+            {
+            }
         }
 
         /// <summary>
         /// Marks a grain class as using the <c>PreferLocalPlacement</c> policy.
         /// </summary>
-        [AttributeUsage(AttributeTargets.Class, AllowMultiple = false) ]
+        [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
         public sealed class PreferLocalPlacementAttribute : PlacementAttribute
         {
             public PreferLocalPlacementAttribute() :
                 base(PreferLocalPlacement.Singleton)
-            { }
+            {
+            }
         }
 
         /// <summary>
@@ -203,7 +205,8 @@ namespace Orleans
         {
             public ActivationCountBasedPlacementAttribute() :
                 base(ActivationCountBasedPlacement.Singleton)
-            { }
+            {
+            }
         }
     }
 
@@ -270,38 +273,39 @@ namespace Orleans
             }
         }
 
-    /// <summary>
-    /// Used to mark a method as providing a copier function for that type.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    public sealed class CopierMethodAttribute : Attribute
-    {
-    }
+        /// <summary>
+        /// Used to mark a method as providing a copier function for that type.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class CopierMethodAttribute : Attribute
+        {
+        }
 
-    /// <summary>
-    /// Used to mark a method as providing a serializer function for that type.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    public sealed class SerializerMethodAttribute : Attribute
-    {
-    }
+        /// <summary>
+        /// Used to mark a method as providing a serializer function for that type.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class SerializerMethodAttribute : Attribute
+        {
+        }
 
-    /// <summary>
-    /// Used to mark a method as providing a deserializer function for that type.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    public sealed class DeserializerMethodAttribute : Attribute
-    {
-    }
+        /// <summary>
+        /// Used to mark a method as providing a deserializer function for that type.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class DeserializerMethodAttribute : Attribute
+        {
+        }
 
-    /// <summary>
-    /// Used to make a class for auto-registration as a serialization helper.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
-    [Obsolete("[RegisterSerializer] is obsolete, please use [Serializer(typeof(TargetType))] instead. Note that the signature of Register has changed to 'void Register(SerializationManager sm)'.")]
-    public sealed class RegisterSerializerAttribute : Attribute
-    {
-    }
+        /// <summary>
+        /// Used to make a class for auto-registration as a serialization helper.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Class)]
+        [Obsolete(
+            "[RegisterSerializer] is obsolete, please use [Serializer(typeof(TargetType))] instead. Note that the signature of Register has changed to 'void Register(SerializationManager sm)'.")]
+        public sealed class RegisterSerializerAttribute : Attribute
+        {
+        }
     }
 
     namespace Providers
@@ -355,11 +359,11 @@ namespace Orleans
 
     }
 
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple=true)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class ImplicitStreamSubscriptionAttribute : Attribute
     {
         public string Namespace { get; private set; }
-        
+
         // We have not yet come to an agreement whether the provider should be specified as well.
         public ImplicitStreamSubscriptionAttribute(string streamNamespace)
         {

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -596,55 +596,7 @@ namespace Orleans.Serialization
                             || (!typeInfo.Namespace.Equals("System", StringComparison.Ordinal)
                                 && !typeInfo.Namespace.StartsWith("System.", StringComparison.Ordinal))))
                     {
-#pragma warning disable 618
-                        if (typeInfo.GetCustomAttributes(typeof(RegisterSerializerAttribute), false).Any())
-#pragma warning restore 618
-                        {
-                            // Call the static Register method on the type
-                            if (logger.IsVerbose3)
-                                logger.Verbose3(
-                                    "Running register method for type {0} from assembly {1}",
-                                    typeInfo.Name,
-                                    assembly.GetName().Name);
-
-                            var register = typeInfo.GetMethod("Register", new[] {typeof(SerializationManager)});
-                            if (register != null)
-                            {
-                                try
-                                {
-                                    if (register.ContainsGenericParameters) throw new OrleansException("Type serializer '" + register.GetType().FullName + "' contains generic parameters and can not be registered. Did you mean to provide a split your type serializer into a combination of nongeneric RegisterSerializerAttribute and generic SerializableAttribute classes?");
-                                    register.Invoke(null, new object[] {this});
-                                }
-                                catch (OrleansException ex)
-                                {
-                                    logger.Error(
-                                        ErrorCode.SerMgr_TypeRegistrationFailure,
-                                        "Failure registering type " + type.OrleansTypeName() + " from assembly "
-                                        + assembly.GetLocationSafe(),
-                                        ex);
-                                    throw;
-                                }
-                                catch (Exception)
-                                {
-                                    // Ignore failures to load our own serializers, such as the F# ones in case F# isn't installed.
-                                    if (safeFailSerializers.Contains(assembly.GetName().Name))
-                                        logger.Warn(
-                                            ErrorCode.SerMgr_TypeRegistrationFailureIgnore,
-                                            "Failure registering type " + type.OrleansTypeName() + " from assembly "
-                                            + assembly.GetLocationSafe() + ". Ignoring it.");
-                                    else throw;
-                                }
-                            }
-                            else
-                            {
-                                logger.Warn(
-                                    ErrorCode.SerMgr_MissingRegisterMethod,
-                                    "Type {0} from assembly {1} has the RegisterSerializer attribute but no public static void Register(SerializationManager sm) method.",
-                                    type.Name,
-                                    assembly.GetName().Name);
-                            }
-                        }
-                        else if (IsGeneratedGrainReference(typeInfo))
+                        if (IsGeneratedGrainReference(typeInfo))
                         {
                             RegisterGrainReferenceSerializers(type);
                         }

--- a/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.JsonTypes.cs
@@ -37,46 +37,7 @@ namespace UnitTests.Serialization
             JObject output = fixture.SerializationManager.RoundTripSerializationForTesting(input);
             Assert.Equal(input.ToString(), output.ToString());
         }
-
-#pragma warning disable 618
-        [RegisterSerializer]
-#pragma warning restore 618
-        public class JObjectSerializationExample1
-        {
-            public static bool RegisterWasCalled;
-            public static object DeepCopier(object original, ICopyContext context)
-            {
-                // I assume JObject is immutable, so no need to deep copy.
-                // Alternatively, can copy via JObject.ToString and JObject.Parse().
-                return original;
-            }
-
-            public static void Serializer(object untypedInput, ISerializationContext context, Type expected)
-            {
-                var input = (JObject)untypedInput;
-                string str = input.ToString();
-                context.SerializationManager.Serialize(str, context.StreamWriter);
-            }
-
-            public static object Deserializer(Type expected, IDeserializationContext context)
-            {
-                var str = (string)context.SerializationManager.Deserialize(typeof(string), context.StreamReader);
-                return JObject.Parse(str);
-            }
-
-            public static void Register(SerializationManager serializationManager)
-            {
-                RegisterWasCalled = true;
-                serializationManager.Register(typeof(JObject), DeepCopier, Serializer, Deserializer);
-            }
-        }
-
-        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
-        public void SerializationTests_RegisterMethod_IsCalled()
-        {
-            Assert.True(JObjectSerializationExample1.RegisterWasCalled);
-        }
-
+        
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization"), TestCategory("JSON")]
         public void SerializationTests_Json_InnerTypes_TypeNameHandling()
         {


### PR DESCRIPTION
Removes the deprecated & obsolete `[RegisterSerializer]` attribute and support for the corresponding `Register` method.

Also fixed the formatting in GrainAttributes.cs since I dislike always having to undo the auto-formatting whenever I make a change.

Fixes #2610