### PR TITLE
remove TestEnvironmentFixture annotation from EH tests

### DIFF
--- a/test/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -22,7 +22,6 @@ using Xunit;
 
 namespace ServiceBus.Tests.SlowConsumingTests
 {
-    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class EHSlowConsumingTests : OrleansTestingBase, IClassFixture<EHSlowConsumingTests.Fixture>
     {
         private const string StreamProviderName = "EventHubStreamProvider";

--- a/test/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -22,7 +22,6 @@ using Xunit;
 namespace ServiceBus.Tests.StreamingTests
 {
     [TestCategory("EventHub"), TestCategory("Streaming")]
-    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class EHImplicitSubscriptionStreamRecoveryTests : OrleansTestingBase, IClassFixture<EHImplicitSubscriptionStreamRecoveryTests.Fixture>
     {
         private readonly Fixture fixture;

--- a/test/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -21,7 +21,6 @@ using Xunit;
 namespace ServiceBus.Tests.StreamingTests
 {
     [TestCategory("EventHub"), TestCategory("Streaming")]
-    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class EHStreamPerPartitionTests : OrleansTestingBase, IClassFixture<EHStreamPerPartitionTests.Fixture>
     {
         private readonly Fixture fixture;

--- a/test/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -23,7 +23,6 @@ using Xunit;
 namespace ServiceBus.Tests.StreamingTests
 {
     [TestCategory("EventHub"), TestCategory("Streaming")]
-    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class EHStreamProviderCheckpointTests : TestClusterPerTest
     {
         private static readonly string StreamProviderTypeName = typeof(EventHubStreamProvider).FullName;

--- a/test/ServiceBus.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace ServiceBus.Tests.StreamingTests
 {
-    [Collection(TestEnvironmentFixture.DefaultCollection)]
     public class EHSubscriptionMultiplicityTests : OrleansTestingBase, IClassFixture<EHSubscriptionMultiplicityTests.Fixture>
     {
         private const string StreamProviderName = "EventHubStreamProvider";


### PR DESCRIPTION
TestEnvironmentFixture might interfere with OrleansTestingBase. 
It maybe the reason causing EHSlowConsumingTests.cs  to fall intermittently. Since removing it make EHSlowConsumingTests.cs  succeed 6 times in a row in VSO(main and vNext). I used it by mimic other EH tests. 

Not sure if other EH tests needs to use TestEnvironmentFixture . But TestEnvironmentFixture is designed to set up serialization env for non-silo tests. So I removed TestEnvironmentFixture  for other EH tests too. Stop me if they actually need it. 