### PR TITLE
Add support for hash-based grain placement

### DIFF
--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -81,6 +81,11 @@ namespace Orleans
             get { return Runtime?.SiloIdentity ?? string.Empty; }
         }
 
+        internal SiloAddress SiloAddress
+        {
+            get { return Runtime?.SiloAddress ?? SiloAddress.Zero; }
+        }
+
         /// <summary>
         /// Registers a timer to send periodic callbacks to this grain.
         /// </summary>

--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -191,19 +191,9 @@ namespace Orleans
         [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
         public sealed class HashBasedPlacementAttribute : PlacementAttribute
         {
-            // for testing
-            internal bool SortSiloList { get; }
-
-            public HashBasedPlacementAttribute() :
+			public HashBasedPlacementAttribute() :
                 base(HashBasedPlacement.Singleton)
             {}
-
-            // for testing
-            internal HashBasedPlacementAttribute(bool sortSiloList = false)
-                : base(sortSiloList ? new HashBasedPlacement(true) : HashBasedPlacement.Singleton)
-            {
-                this.SortSiloList = sortSiloList;
-            }
         }
 
         /// <summary>

--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -186,6 +186,27 @@ namespace Orleans
         }
 
         /// <summary>
+        /// Marks a grain class as using the <c>HashBasedPlacement</c> policy.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+        public sealed class HashBasedPlacementAttribute : PlacementAttribute
+        {
+            // for testing
+            internal bool SortSiloList { get; }
+
+            public HashBasedPlacementAttribute() :
+                base(HashBasedPlacement.Singleton)
+            {}
+
+            // for testing
+            internal HashBasedPlacementAttribute(bool sortSiloList = false)
+                : base(sortSiloList ? new HashBasedPlacement(true) : HashBasedPlacement.Singleton)
+            {
+                this.SortSiloList = sortSiloList;
+            }
+        }
+
+        /// <summary>
         /// Marks a grain class as using the <c>PreferLocalPlacement</c> policy.
         /// </summary>
         [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]

--- a/src/Orleans/Core/GrainExtensions.cs
+++ b/src/Orleans/Core/GrainExtensions.cs
@@ -96,7 +96,7 @@ namespace Orleans
             throw new ArgumentException(String.Format("GetGrainId has been called on an unexpected type: {0}.", grain.GetType().FullName), "grain");
         }
 
-        internal static IGrainIdentity GetGrainIdentity(IGrain grain)
+        public static IGrainIdentity GetGrainIdentity(this IGrain grain)
         {
             var grainBase = grain as Grain;
             if (grainBase != null)

--- a/src/Orleans/Core/IGrainIdentity.cs
+++ b/src/Orleans/Core/IGrainIdentity.cs
@@ -19,5 +19,7 @@ namespace Orleans.Core
         long GetPrimaryKeyLong(out string keyExt);
 
         Guid GetPrimaryKey(out string keyExt);
+
+        uint GetUniformHashCode();
     }
 }

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Core\IStatefulGrain.cs" />
     <Compile Include="GrainDirectory\MultiClusterStatus.cs" />
     <Compile Include="LogConsistency\ILogViewAdaptorHost.cs" />
+    <Compile Include="Placement\HashBasedPlacement.cs" />
     <Compile Include="Placement\IPlacementDirector.cs" />
     <Compile Include="Placement\IPlacementContext.cs" />
     <Compile Include="Placement\PlacementTarget.cs" />

--- a/src/Orleans/Placement/HashBasedPlacement.cs
+++ b/src/Orleans/Placement/HashBasedPlacement.cs
@@ -5,17 +5,11 @@ namespace Orleans.Runtime
     [Serializable]
     public  class HashBasedPlacement : PlacementStrategy
     {
-        internal bool SortSiloList { get; }
 
         internal static HashBasedPlacement Singleton { get; } = new HashBasedPlacement();
 
-        internal HashBasedPlacement(bool sortSiloList)
-        {
-            this.SortSiloList = sortSiloList;
-        }
 
         public HashBasedPlacement()
-            : this(false)
         {
         }
 

--- a/src/Orleans/Placement/HashBasedPlacement.cs
+++ b/src/Orleans/Placement/HashBasedPlacement.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Orleans.Runtime
+{
+    [Serializable]
+    public  class HashBasedPlacement : PlacementStrategy
+    {
+        internal bool SortSiloList { get; }
+
+        internal static HashBasedPlacement Singleton { get; } = new HashBasedPlacement();
+
+        internal HashBasedPlacement(bool sortSiloList)
+        {
+            this.SortSiloList = sortSiloList;
+        }
+
+        public HashBasedPlacement()
+            : this(false)
+        {
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is HashBasedPlacement;
+        }
+
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode();
+        }
+    }
+}

--- a/src/Orleans/Runtime/IGrainRuntime.cs
+++ b/src/Orleans/Runtime/IGrainRuntime.cs
@@ -23,6 +23,8 @@ namespace Orleans.Runtime
         /// </summary>
         string SiloIdentity { get; }
 
+        SiloAddress SiloAddress { get; }
+
         IGrainFactory GrainFactory { get; }
 
         ITimerRegistry TimerRegistry { get; }

--- a/src/OrleansRuntime/Core/GrainRuntime.cs
+++ b/src/OrleansRuntime/Core/GrainRuntime.cs
@@ -21,7 +21,8 @@ namespace Orleans.Runtime
         {
             this.runtimeClient = runtimeClient;
             ServiceId = globalConfig.ServiceId;
-            SiloIdentity = localSiloDetails.SiloAddress.ToLongString();
+            SiloAddress = localSiloDetails.SiloAddress;
+            SiloIdentity = SiloAddress.ToLongString();
             GrainFactory = grainFactory;
             TimerRegistry = timerRegistry;
             ReminderRegistry = reminderRegistry;
@@ -32,6 +33,8 @@ namespace Orleans.Runtime
         public Guid ServiceId { get; }
 
         public string SiloIdentity { get; }
+
+        public SiloAddress SiloAddress { get; }
 
         public IGrainFactory GrainFactory { get; }
         

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Core\IInvokable.cs" />
     <Compile Include="Core\ISiloRuntimeClient.cs" />
     <Compile Include="Messaging\ObjectPool.cs" />
+    <Compile Include="Placement\HashBasedPlacementDirector.cs" />
     <Compile Include="Placement\IActivationSelector.cs" />
     <Compile Include="ReminderService\ReminderRegistry.cs" />
     <Compile Include="Services\GrainService.cs" />

--- a/src/OrleansRuntime/Placement/HashBasedPlacementDirector.cs
+++ b/src/OrleansRuntime/Placement/HashBasedPlacementDirector.cs
@@ -10,12 +10,6 @@ namespace Orleans.Runtime.Placement
         {
             var allSilos = context.GetCompatibleSilos(target);
 
-            // for testing
-            if (((HashBasedPlacement) strategy).SortSiloList)
-            {
-                allSilos = allSilos.OrderBy(s => s.ToString()).ToList();
-            }
-
             int hash = (int) (target.GrainIdentity.GetUniformHashCode() & 0x7fffffff); // reset highest order bit to avoid negative ints
 
             return Task.FromResult(allSilos[hash % allSilos.Count]);

--- a/src/OrleansRuntime/Placement/HashBasedPlacementDirector.cs
+++ b/src/OrleansRuntime/Placement/HashBasedPlacementDirector.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.Placement
+{
+    internal class HashBasedPlacementDirector : IPlacementDirector<HashBasedPlacement>
+    {
+        public virtual Task<SiloAddress> OnAddActivation(
+            PlacementStrategy strategy, PlacementTarget target, IPlacementContext context)
+        {
+            var allSilos = context.GetCompatibleSilos(target);
+
+            // for testing
+            if (((HashBasedPlacement) strategy).SortSiloList)
+            {
+                allSilos = allSilos.OrderBy(s => s.ToString()).ToList();
+            }
+
+            int hash = (int) (target.GrainIdentity.GetUniformHashCode() & 0x7fffffff); // reset highest order bit to avoid negative ints
+
+            return Task.FromResult(allSilos[hash % allSilos.Count]);
+        }
+    }
+}

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -282,6 +282,7 @@ namespace Orleans.Runtime
             services.AddSingleton<IPlacementDirector<StatelessWorkerPlacement>, StatelessWorkerDirector>();
             services.AddSingleton<IActivationSelector<StatelessWorkerPlacement>, StatelessWorkerDirector>();
             services.AddSingleton<IPlacementDirector<ActivationCountBasedPlacement>, ActivationCountPlacementDirector>();
+            services.AddSingleton<IPlacementDirector<HashBasedPlacement>, HashBasedPlacementDirector>();
             services.AddSingleton<DefaultPlacementStrategy>();
             services.AddSingleton<ClientObserversPlacementDirector>();
 

--- a/test/TestGrainInterfaces/CustomPlacement.cs
+++ b/test/TestGrainInterfaces/CustomPlacement.cs
@@ -15,6 +15,11 @@ namespace UnitTests.GrainInterfaces
         Task<string> GetRuntimeInstanceId();
     }
 
+    public interface IHashBasedPlacementGrain : IGrainWithGuidKey
+    {
+        Task<SiloAddress> GetSiloAddress();
+    }
+
 
     public enum CustomPlacementScenario
     {

--- a/test/TestGrains/CustomPlacementGrains.cs
+++ b/test/TestGrains/CustomPlacementGrains.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Orleans;
+using Orleans.Runtime;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains

--- a/test/TestInternalGrains/HashBasedPlacementGrain.cs
+++ b/test/TestInternalGrains/HashBasedPlacementGrain.cs
@@ -1,9 +1,18 @@
-﻿using Orleans.Placement;
+﻿using System.Threading.Tasks;
+using Orleans;
+using Orleans.Placement;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    [HashBasedPlacement(true)]
-    public class HashBasedPlacementGrain : CustomPlacementBaseGrain
+    [HashBasedPlacement(false)]
+    public class HashBasedBasedPlacementGrain : Grain, IHashBasedPlacementGrain
     {
+
+        public Task<SiloAddress> GetSiloAddress()
+        {
+            return Task.FromResult(this.Runtime.SiloAddress);
+        }
     }
 }

--- a/test/TestInternalGrains/HashBasedPlacementGrain.cs
+++ b/test/TestInternalGrains/HashBasedPlacementGrain.cs
@@ -1,0 +1,9 @@
+﻿using Orleans.Placement;
+
+namespace UnitTests.Grains
+{
+    [HashBasedPlacement(true)]
+    public class HashBasedPlacementGrain : CustomPlacementBaseGrain
+    {
+    }
+}

--- a/test/TestInternalGrains/HashBasedPlacementGrain.cs
+++ b/test/TestInternalGrains/HashBasedPlacementGrain.cs
@@ -6,7 +6,7 @@ using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    [HashBasedPlacement(false)]
+    [HashBasedPlacement]
     public class HashBasedBasedPlacementGrain : Grain, IHashBasedPlacementGrain
     {
 

--- a/test/TestInternalGrains/TestInternalGrains.csproj
+++ b/test/TestInternalGrains/TestInternalGrains.csproj
@@ -57,6 +57,7 @@
     <Compile Include="EchoTaskGrain.cs" />
     <Compile Include="ErrorGrain.cs" />
     <Compile Include="ExtensionTestGrain.cs" />
+    <Compile Include="HashBasedPlacementGrain.cs" />
     <Compile Include="InterlockedFlag.cs" />
     <Compile Include="MultifacetFactoryTestGrain.cs" />
     <Compile Include="MultifacetTestGrain.cs" />

--- a/test/Tester/Placement/CustomPlacementTests.cs
+++ b/test/Tester/Placement/CustomPlacementTests.cs
@@ -29,7 +29,9 @@ namespace Tester.CustomPlacementTests
             {
                 var options = new TestClusterOptions(nSilos);
                 options.ClusterConfiguration.UseStartupType<TestStartup>();
-                return new TestCluster(options);
+				options.ClusterConfiguration.Globals.AssumeHomogenousSilosForTesting = false;
+				options.ClusterConfiguration.Globals.TypeMapRefreshInterval = TimeSpan.FromMilliseconds(100);
+				return new TestCluster(options);
             }
         }
 


### PR DESCRIPTION
Add `HashBasedPlacement` placement strategy.
Add `HashBasedPlacementAttribute` for assigning `HashBasedPlacement` to grain classes.
Expose `GetUniformHashCode` via `IGrainIdentity`.
Add `HashBasedPlacementDirector` that leverages `GetUniformHashCode` to calculate hashes of `GrainIdentity.IdentityString` of target grains.

This partly implements #2167, and provides a way to collocate grains of different classes with same keys.