### PR TITLE
Use non-blocking I/O in relational storage providers

### DIFF
--- a/src/OrleansSQLUtils/Storage/RelationalStorage.cs
+++ b/src/OrleansSQLUtils/Storage/RelationalStorage.cs
@@ -133,7 +133,7 @@ namespace Orleans.SqlUtils
         ///}).ConfigureAwait(continueOnCapturedContext: false);                
         /// </code>
         /// </example>
-        public Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default)
+        public async Task<IEnumerable<TResult>> ReadAsync<TResult>(string query, Action<IDbCommand> parameterProvider, Func<IDataRecord, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default)
         {
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
@@ -146,11 +146,7 @@ namespace Orleans.SqlUtils
                 throw new ArgumentNullException("selector");
             }
 
-            //It is certain the result is already ready here and can be collected straight away. Having a truly asynchronous result collection
-            //IAsyncEnumerable<TResult> or equivalent method ought to be used. Taking the result here without async-await saves for generating
-            //the async state machine.
-            var ret = ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, selector, cancellationToken, commandBehavior).GetAwaiter().GetResult().Item1;
-            return Task.FromResult(ret);
+            return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, selector, cancellationToken, commandBehavior).ConfigureAwait(false)).Item1;
         }
 
 
@@ -175,7 +171,7 @@ namespace Orleans.SqlUtils
         /// }).ConfigureAwait(continueOnCapturedContext: false);                
         /// </code>
         /// </example>
-        public Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default)
+        public async Task<int> ExecuteAsync(string query, Action<IDbCommand> parameterProvider, CancellationToken cancellationToken = default(CancellationToken), CommandBehavior commandBehavior = CommandBehavior.Default)
         {
             //If the query is something else that is not acceptable (e.g. an empty string), there will an appropriate database exception.
             if(query == null)
@@ -183,11 +179,7 @@ namespace Orleans.SqlUtils
                 throw new ArgumentNullException("query");
             }
 
-            //It is certain the result is already ready here and can be collected straight away. Having a truly asynchronous result collection
-            //IAsyncEnumerable<TResult> or equivalent method ought to be used. Taking the result here without async-await saves for generating
-            //the async state machine.
-            var ret = ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, (unit, id, c) => Task.FromResult(unit), cancellationToken, commandBehavior).GetAwaiter().GetResult().Item2;
-            return Task.FromResult(ret);
+            return (await ExecuteAsync(query, parameterProvider, ExecuteReaderAsync, (unit, id, c) => Task.FromResult(unit), cancellationToken, commandBehavior).ConfigureAwait(false)).Item2;
         }
 
         /// <summary>


### PR DESCRIPTION
Hi!
While playing with PostreSQL membersip provider I found issue with provider initialization.
I prepared demo code in separate branch where you can check issue https://github.com/Roman-Blinkov/orleans/commits/PostreSQL (use \vNext\Orleans.vNext.sln and edit connection string in \Samples\HelloWorld.NetCorePostgreSQL\src\SiloHost\OrleansConfiguration.xml )

P.S. Similar but closed thread https://github.com/dotnet/orleans/issues/2745