### PR TITLE
add necessary xml comment and make test EHSlowConsuming_ShouldFavorSlowConsumer more reliable

### DIFF
--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -261,6 +261,13 @@ namespace Orleans.ServiceBus.Providers
             return receivers.GetOrAdd(queueId, q => MakeReceiver(queueId));
         }
 
+        /// <summary>
+        /// Create a IEventHubQueueCacheFactory. It will create a EventHubQueueCacheFactory by default. 
+        /// User can override this function to return their own implementation of IEventHubQueueCacheFactory, 
+        /// and other customization of IEventHubQueueCacheFactory if they may. 
+        /// </summary>
+        /// <param name="providerSettings"></param>
+        /// <returns></returns>
         protected virtual IEventHubQueueCacheFactory CreateCacheFactory(EventHubStreamProviderSettings providerSettings)
         {
             return new EventHubQueueCacheFactory(providerSettings, SerializationManager);

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
@@ -5,6 +5,9 @@ using Orleans.Streams;
 
 namespace Orleans.ServiceBus.Providers
 {
+    /// <summary>
+    /// Factory class to configure and create IEventHubQueueCache
+    /// </summary>
     public class EventHubQueueCacheFactory : IEventHubQueueCacheFactory
     {
         private readonly EventHubStreamProviderSettings _providerSettings;
@@ -12,6 +15,11 @@ namespace Orleans.ServiceBus.Providers
         private IObjectPool<FixedSizeBuffer> _bufferPool;
         private readonly TimePurgePredicate _timePurge;
 
+        /// <summary>
+        /// Constructor for EventHubQueueCacheFactory
+        /// </summary>
+        /// <param name="providerSettings"></param>
+        /// <param name="serializationManager"></param>
         public EventHubQueueCacheFactory(EventHubStreamProviderSettings providerSettings,
             SerializationManager serializationManager
         )
@@ -21,6 +29,14 @@ namespace Orleans.ServiceBus.Providers
             _timePurge = new TimePurgePredicate(_providerSettings.DataMinTimeInCache, _providerSettings.DataMaxAgeInCache);
         }
 
+        /// <summary>
+        /// Function which create an EventHubQueueCache, which by default will configure the EventHubQueueCache using configuration in CreateBufferPool function
+        /// and AddCachePressureMonitors function.
+        /// </summary>
+        /// <param name="partition"></param>
+        /// <param name="checkpointer"></param>
+        /// <param name="logger"></param>
+        /// <returns></returns>
         public IEventHubQueueCache CreateCache(string partition, IStreamQueueCheckpointer<string> checkpointer, Logger logger)
         {
             var bufferPool = CreateBufferPool(_providerSettings);
@@ -29,12 +45,24 @@ namespace Orleans.ServiceBus.Providers
             return cache;
         }
 
+        /// <summary>
+        /// Function used to configure BufferPool for EventHubQueueCache. User can override this function to provide more customization on BufferPool creation
+        /// </summary>
+        /// <param name="providerSettings"></param>
+        /// <returns></returns>
         protected virtual IObjectPool<FixedSizeBuffer> CreateBufferPool(EventHubStreamProviderSettings providerSettings)
         {
             return _bufferPool ?? (_bufferPool = new FixedSizeObjectPool<FixedSizeBuffer>(providerSettings.CacheSizeMb,
                 () => new FixedSizeBuffer(1 << 20)));
         }
 
+        /// <summary>
+        /// Function used to configure cache pressure monitors for EventHubQueueCache. 
+        /// User can override this function to provide more customization on cache pressure monitors
+        /// </summary>
+        /// <param name="cache"></param>
+        /// <param name="providerSettings"></param>
+        /// <param name="cacheLogger"></param>
         protected virtual void AddCachePressureMonitors(IEventHubQueueCache cache, EventHubStreamProviderSettings providerSettings,
             Logger cacheLogger)
         {
@@ -62,6 +90,16 @@ namespace Orleans.ServiceBus.Providers
             }
         }
 
+        /// <summary>
+        /// Default function to be called to create an EventhubQueueCache in IEventHubQueueCacheFactory.CreateCache method. User can 
+        /// override this method to add more customization.
+        /// </summary>
+        /// <param name="checkpointer"></param>
+        /// <param name="cacheLogger"></param>
+        /// <param name="bufferPool"></param>
+        /// <param name="timePurge"></param>
+        /// <param name="serializationManager"></param>
+        /// <returns></returns>
         protected virtual IEventHubQueueCache CreateCache(IStreamQueueCheckpointer<string> checkpointer,
             Logger cacheLogger, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge,
             SerializationManager serializationManager)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCacheFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCacheFactory.cs
@@ -8,6 +8,13 @@ namespace Orleans.ServiceBus.Providers
     /// </summary>
     public interface IEventHubQueueCacheFactory
     {
+        /// <summary>
+        /// Function used to create a IEventHubQueueCache
+        /// </summary>
+        /// <param name="partition"></param>
+        /// <param name="checkpointer"></param>
+        /// <param name="cacheLogger"></param>
+        /// <returns></returns>
         IEventHubQueueCache CreateCache(string partition, IStreamQueueCheckpointer<string> checkpointer, 
             Logger cacheLogger);
     }

--- a/test/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -13,7 +13,6 @@ using ServiceBus.Tests.TestStreamProviders;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
@@ -119,9 +118,9 @@ namespace ServiceBus.Tests.SlowConsumingTests
             var healthyConsumers = await SetUpHealthyConsumerGrain(this.fixture.GrainFactory, streamId.Guid, StreamNamespace, StreamProviderName, healthyConsumerCount);
 
             //set up producer and start producing
-            var producer = this.fixture.GrainFactory.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
+            var producer = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingInt>(Guid.NewGuid());
             await producer.BecomeProducer(streamId.Guid, StreamNamespace, StreamProviderName);
-            await producer.StartPeriodicProducing();
+            await producer.StartPeriodicProducing(TimeSpan.FromMilliseconds(100));
 
             //since there's an extreme slow consumer, so the back pressure algorithm should be triggered
             await TestingUtils.WaitUntilAsync(lastTry => AssertCacheBackPressureTriggered(true, lastTry), timeout);


### PR DESCRIPTION
This is a following up PR for PR 2930 , to fix issues we didn't notice in PR 2930 .

1. Add missing xml comments for EventHubQueueCacheFactory and related
2. Add back necessary config for EHSlowConsuming_ShouldFavorSlowConsumer's EH stream provider, and also tune the test to make it pass more consistently. 