### PR TITLE
using wild card include in vNext test csproj

### DIFF
--- a/vNext/test/AWSUtils.Tests/AWSUtils.Tests.csproj
+++ b/vNext/test/AWSUtils.Tests/AWSUtils.Tests.csproj
@@ -44,56 +44,11 @@
     <ProjectReference Include="..\TestInternalGrainInterface\TestInternalGrainInterfaces.csproj" />
     <ProjectReference Include="..\TestInternalGrains\TestInternalGrains.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\MembershipTests\DynamoDBMembershipTableTest.cs">
-      <Link>MembershipTests\DynamoDBMembershipTableTest.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\MembershipTests\SiloInstanceRecordTests.cs">
-      <Link>MembershipTests\SiloInstanceRecordTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\Reminder\DynamoDBRemindersTableTests.cs">
-      <Link>Reminder\DynamoDBRemindersTableTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\StorageTests\AWSTestConstants.cs">
-      <Link>StorageTests\AWSTestConstants.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\StorageTests\Base_PersistenceGrainTests_AWSStore.cs">
-      <Link>StorageTests\Base_PersistenceGrainTests_AWSStore.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\StorageTests\DynamoDBStorageProviderTests.cs">
-      <Link>StorageTests\DynamoDBStorageProviderTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\StorageTests\DynamoDBStorageStressTests.cs">
-      <Link>StorageTests\DynamoDBStorageStressTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\StorageTests\DynamoDBStorageTestFixture.cs">
-      <Link>StorageTests\DynamoDBStorageTestFixture.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\StorageTests\DynamoDBStorageTests.cs">
-      <Link>StorageTests\DynamoDBStorageTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\StorageTests\PersistenceGrainTests_AWSDynamoDBStore.cs">
-      <Link>StorageTests\PersistenceGrainTests_AWSDynamoDBStore.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\StorageTests\UnitTestDynamoDBStorage.cs">
-      <Link>StorageTests\UnitTestDynamoDBStorage.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\Streaming\SQSAdapterTests.cs">
-      <Link>Streaming\SQSAdapterTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\Streaming\SQSClientStreamTests.cs">
-      <Link>Streaming\SQSClientStreamTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\Streaming\SQSStreamTests.cs">
-      <Link>Streaming\SQSStreamTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\Streaming\SQSSubscriptionMultiplicityTests.cs">
-      <Link>Streaming\SQSSubscriptionMultiplicityTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\AWSUtils.Tests\CollectionFixtures.cs">
-      <Link>CollectionFixtures.cs</Link>
-    </Compile>
+    <Compile Include="..\..\..\test\AWSUtils.Tests\**\*.cs" Exclude="..\..\..\test\AWSUtils.Tests\obj\**\*.cs;..\..\..\test\AWSUtils.Tests\bin\**\*.cs;..\..\..\test\AWSUtils.Tests\Properties\*.cs" />
   </ItemGroup>
+  
   <ItemGroup>
     <None Include="App.config" />
     <None Include="AWSUtils.Tests.xunit.runner.json">

--- a/vNext/test/BondUtils.Tests/BondUtils.Tests.csproj
+++ b/vNext/test/BondUtils.Tests/BondUtils.Tests.csproj
@@ -40,11 +40,11 @@
     <ProjectReference Include="..\TestInternalGrainInterface\TestInternalGrainInterfaces.csproj" />
     <ProjectReference Include="..\TestInternalGrains\TestInternalGrains.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="..\..\..\test\BondUtils.Tests\Serialization\BondSerializationTests.cs">
-      <Link>Serialization\BondSerializationTests.cs</Link>
-    </Compile>    
+    <Compile Include="..\..\..\test\BondUtils.Tests\**\*.cs" Exclude="..\..\..\test\BondUtils.Tests\obj\**\*.cs;..\..\..\test\BondUtils.Tests\bin\**\*.cs;..\..\..\test\BondUtils.Tests\Properties\*.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <None Include="App.config" />
     <None Include="BondUtils.Tests.xunit.runner.json">

--- a/vNext/test/Consul.Tests/Consul.Tests.csproj
+++ b/vNext/test/Consul.Tests/Consul.Tests.csproj
@@ -26,17 +26,11 @@
     <ProjectReference Include="..\Tester\Tester.csproj" />
     <ProjectReference Include="..\TestExtensions\TestExtensions.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="..\..\..\test\Consul.Tests\LivenessTests.cs">
-      <Link>LivenessTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\Consul.Tests\ConsulMembershipTableTest.cs">
-      <Link>ConsulMembershipTableTest.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\Consul.Tests\ConsulTestUtils.cs">
-      <Link>ConsulTestUtils.cs</Link>
-    </Compile>
+    <Compile Include="..\..\..\test\Consul.Tests\**\*.cs" Exclude="..\..\..\test\Consul.Tests\obj\**\*.cs;..\..\..\test\Consul.Tests\bin\**\*.cs;..\..\..\test\Consul.Tests\Properties\*.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <None Include="App.config" />
     <None Include="Consul.Tests.xunit.runner.json">

--- a/vNext/test/GoogleUtils.Tests/GoogleUtils.Tests.csproj
+++ b/vNext/test/GoogleUtils.Tests/GoogleUtils.Tests.csproj
@@ -40,17 +40,11 @@
     <ProjectReference Include="..\TestInternalGrainInterface\TestInternalGrainInterfaces.csproj" />
     <ProjectReference Include="..\TestInternalGrains\TestInternalGrains.csproj" />
   </ItemGroup>
+  
   <ItemGroup>
-    <Compile Include="..\..\..\test\GoogleUtils.Tests\ProtobufSerialization\Addressbook.cs">
-      <Link>ProtobufSerialization\Addressbook.cs</Link>
-    </Compile>
-	<Compile Include="..\..\..\test\GoogleUtils.Tests\ProtobufSerialization\Counter.cs">
-      <Link>ProtobufSerialization\Counter.cs</Link>
-    </Compile> 
-	<Compile Include="..\..\..\test\GoogleUtils.Tests\ProtobufSerialization\ProtobufSerializationTests.cs">
-      <Link>ProtobufSerialization\ProtobufSerializationTests.cs</Link>
-    </Compile> 	
+    <Compile Include="..\..\..\test\GoogleUtils.Tests\**\*.cs" Exclude="..\..\..\test\GoogleUtils.Tests\obj\**\*.cs;..\..\..\test\GoogleUtils.Tests\bin\**\*.cs;..\..\..\test\GoogleUtils.Tests\Properties\*.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <None Include="App.config" />
 	<None Include="..\..\..\test\GoogleUtils.Tests\ProtobufSerialization\addressbook.proto">

--- a/vNext/test/ServiceBus.Tests/ServiceBus.Tests.csproj
+++ b/vNext/test/ServiceBus.Tests/ServiceBus.Tests.csproj
@@ -44,31 +44,9 @@
     <ProjectReference Include="..\TestInternalDtosRefOrleans\TestInternalDtosRefOrleans.csproj" />
     <ProjectReference Include="..\TestInternalGrainInterface\TestInternalGrainInterfaces.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHClientStreamTests.cs">
-      <Link>Streaming\EHClientStreamTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHImplicitSubscriptionStreamRecoveryTests.cs">
-      <Link>Streaming\EHImplicitSubscriptionStreamRecoveryTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHStreamPerPartitionTests.cs">
-      <Link>Streaming\EHStreamPerPartitionTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHStreamProviderCheckpointTests.cs">
-      <Link>Streaming\EHStreamProviderCheckpointTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\EHSubscriptionMultiplicityTests.cs">
-      <Link>Streaming\EHSubscriptionMultiplicityTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\ServiceBus.Tests\Streaming\TimePurgePredicateTests.cs">
-      <Link>Streaming\TimePurgePredicateTests.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\ServiceBus.Tests\TestStreamProviders\StreamPerPartitionEventHubStreamProvider.cs">
-      <Link>TestStreamProviders\StreamPerPartitionEventHubStreamProvider.cs</Link>
-    </Compile>
-    <Compile Include="..\..\..\test\ServiceBus.Tests\TestStreamProviders\TestEventHubStreamProvider.cs">
-      <Link>TestStreamProviders\TestEventHubStreamProvider.cs</Link>
-    </Compile>
+
+   <ItemGroup>
+    <Compile Include="..\..\..\test\ServiceBus.Tests\**\*.cs" Exclude="..\..\..\test\ServiceBus.Tests\obj\**\*.cs;..\..\..\test\ServiceBus.Tests\bin\**\*.cs;..\..\..\test\ServiceBus.Tests\Properties\*.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
using wild card include in vNext test csproj, so that new tests added to Main sln will be added to vNext sln automatically. 