### PR TITLE
Serialize Type instances without requiring registration

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -184,6 +184,7 @@
     <Compile Include="Streams\Internal\StreamSubscriptionChangeHandler.cs" />
     <Compile Include="Streams\Providers\StreamProviderManagerExtensions.cs" />
     <Compile Include="Streams\PubSub\StreamSubscriptionManagerExtensions.cs" />
+    <Compile Include="Utils\CachedReadConcurrentDictionary.cs" />
     <Compile Include="Utils\Factory.cs" />
     <Compile Include="Utils\IKeyedServiceCollection.cs" />
     <Compile Include="Utils\ReferenceEqualsComparer.cs" />

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -302,6 +302,7 @@
     <Compile Include="Streams\Core\StreamSequenceToken.cs" />
     <Compile Include="Streams\Core\StreamSubscriptionHandle.cs" />
     <Compile Include="Timers\AsyncTaskSafeTimer.cs" />
+    <Compile Include="Utils\RuntimeTypeNameFormatter.cs" />
     <Compile Include="Utils\ServiceCollectionExtensions.cs" />
     <Compile Include="Utils\SetExtensions.cs" />
     <Compile Include="Placement\ActivationCountBasedPlacement.cs" />

--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using Orleans.CodeGeneration;
 using Orleans.Concurrency;
 using Orleans.Runtime;
+using Orleans.Utilities;
 
 namespace Orleans.Serialization
 {
@@ -1643,12 +1644,12 @@ namespace Orleans.Serialization
 
         internal static void SerializeType(object obj, ISerializationContext context, Type expected)
         {
-            context.StreamWriter.Write(((Type)obj).OrleansTypeKeyString());
+            context.StreamWriter.Write(RuntimeTypeNameFormatter.Format((Type)obj));
         }
 
         internal static object DeserializeType(Type expected, IDeserializationContext context)
         {
-            return context.SerializationManager.ResolveTypeName(context.StreamReader.ReadString());
+            return Type.GetType(context.StreamReader.ReadString());
         }
 
         internal static object CopyType(object obj, ICopyContext context)

--- a/src/Orleans/Utils/CachedReadConcurrentDictionary.cs
+++ b/src/Orleans/Utils/CachedReadConcurrentDictionary.cs
@@ -1,0 +1,203 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Orleans.Utilities
+{
+    /// <summary>
+    /// A thread-safe dictionary for read-heavy workloads.
+    /// </summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    internal class CachedReadConcurrentDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// The number of cache misses which are tolerated before the cache is regenerated.
+        /// </summary>
+        private const int CacheMissesBeforeCaching = 10;
+        private readonly ConcurrentDictionary<TKey, TValue> dictionary;
+        private readonly IEqualityComparer<TKey> comparer;
+
+        /// <summary>
+        /// Approximate number of reads which did not hit the cache since it was last invalidated.
+        /// This is used as a heuristic that the dictionary is not being modified frequently with respect to the read volume.
+        /// </summary>
+        private int cacheMissReads;
+
+        /// <summary>
+        /// Cached version of <see cref="dictionary"/>.
+        /// </summary>
+        private Dictionary<TKey, TValue> readCache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CachedReadConcurrentDictionary{TKey,TValue}"/> class.
+        /// </summary>
+        public CachedReadConcurrentDictionary()
+        {
+            this.dictionary = new ConcurrentDictionary<TKey, TValue>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CachedReadConcurrentDictionary{TKey,TValue}"/> class
+        /// that contains elements copied from the specified collection.
+        /// </summary>
+        /// <param name="collection">
+        /// The <see cref="T:IEnumerable{KeyValuePair{TKey,TValue}}"/> whose elements are copied to the new instance.
+        /// </param>
+        public CachedReadConcurrentDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection)
+        {
+            this.dictionary = new ConcurrentDictionary<TKey, TValue>(collection);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CachedReadConcurrentDictionary{TKey,TValue}"/> class
+        /// that contains elements copied from the specified collection and uses the specified
+        /// <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>.
+        /// </summary>
+        /// <param name="comparer">
+        /// The <see cref="IEqualityComparer{TKey}"/> implementation to use when comparing keys.
+        /// </param>
+        public CachedReadConcurrentDictionary(IEqualityComparer<TKey> comparer)
+        {
+            this.comparer = comparer;
+            this.dictionary = new ConcurrentDictionary<TKey, TValue>(comparer);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CachedReadConcurrentDictionary{TKey,TValue}"/>
+        /// class that contains elements copied from the specified collection and uses the specified
+        /// <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>.
+        /// </summary>
+        /// <param name="collection">
+        /// The <see cref="T:IEnumerable{KeyValuePair{TKey,TValue}}"/> whose elements are copied to the new instance.
+        /// </param>
+        /// <param name="comparer">
+        /// The <see cref="IEqualityComparer{TKey}"/> implementation to use when comparing keys.
+        /// </param>
+        public CachedReadConcurrentDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey> comparer)
+        {
+            this.comparer = comparer;
+            this.dictionary = new ConcurrentDictionary<TKey, TValue>(collection, comparer);
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+        /// <inheritdoc />
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => this.GetReadDictionary().GetEnumerator();
+
+        /// <inheritdoc />
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            ((IDictionary<TKey, TValue>) this.dictionary).Add(item);
+            this.InvalidateCache();
+        }
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            this.dictionary.Clear();
+            this.InvalidateCache();
+        }
+
+        /// <inheritdoc />
+        public bool Contains(KeyValuePair<TKey, TValue> item) => this.GetReadDictionary().Contains(item);
+
+        /// <inheritdoc />
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            this.GetReadDictionary().CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc />
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            var result = ((IDictionary<TKey, TValue>) this.dictionary).Remove(item);
+            if (result) this.InvalidateCache();
+            return result;
+        }
+
+        /// <inheritdoc />
+        public int Count => this.GetReadDictionary().Count;
+
+        /// <inheritdoc />
+        public bool IsReadOnly => false;
+
+        /// <inheritdoc />
+        public void Add(TKey key, TValue value)
+        {
+            ((IDictionary<TKey, TValue>) this.dictionary).Add(key, value);
+            this.InvalidateCache();
+        }
+
+        /// <summary>
+        /// Attempts to add the specified key and value.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value of the element to add. The value can be a null reference (Nothing
+        /// in Visual Basic) for reference types.</param>
+        /// <returns>true if the key/value pair was added successfully; otherwise, false.</returns>
+        public bool TryAdd(TKey key, TValue value)
+        {
+            if (this.dictionary.TryAdd(key, value))
+            {
+                this.InvalidateCache();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public bool ContainsKey(TKey key) => this.GetReadDictionary().ContainsKey(key);
+
+        /// <inheritdoc />
+        public bool Remove(TKey key)
+        {
+            var result = ((IDictionary<TKey, TValue>) this.dictionary).Remove(key);
+            if (result) this.InvalidateCache();
+            return result;
+        }
+
+        /// <inheritdoc />
+        public bool TryGetValue(TKey key, out TValue value) => this.GetReadDictionary().TryGetValue(key, out value);
+
+        /// <inheritdoc />
+        public TValue this[TKey key]
+        {
+            get { return this.GetReadDictionary()[key]; }
+            set
+            {
+                this.dictionary[key] = value;
+                this.InvalidateCache();
+            }
+        }
+
+        /// <inheritdoc />
+        public ICollection<TKey> Keys => this.GetReadDictionary().Keys;
+
+        /// <inheritdoc />
+        public ICollection<TValue> Values => this.GetReadDictionary().Values;
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private IDictionary<TKey, TValue> GetReadDictionary() => this.readCache ?? this.GetWithoutCache();
+
+        private IDictionary<TKey, TValue> GetWithoutCache()
+        {
+            // If the dictionary was recently modified or the cache is being recomputed, return the dictionary directly.
+            if (Interlocked.Increment(ref this.cacheMissReads) < CacheMissesBeforeCaching) return this.dictionary;
+
+            // Recompute the cache if too many cache misses have occurred.
+            this.cacheMissReads = 0;
+            return this.readCache = new Dictionary<TKey, TValue>(this.dictionary, this.comparer);
+        }
+
+        private void InvalidateCache()
+        {
+            this.cacheMissReads = 0;
+            this.readCache = null;
+        }
+    }
+}

--- a/src/Orleans/Utils/RuntimeTypeNameFormatter.cs
+++ b/src/Orleans/Utils/RuntimeTypeNameFormatter.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+
+namespace Orleans.Utilities
+{
+    /// <summary>
+    /// Utility methods for formatting <see cref="Type"/> and <see cref="TypeInfo"/> instances in a way which can be parsed by
+    /// <see cref="Type.GetType(string)"/>.
+    /// </summary>
+    public static class RuntimeTypeNameFormatter
+    {
+        private static readonly Assembly SystemAssembly = typeof(int).GetTypeInfo().Assembly;
+        private static readonly char[] SimpleNameTerminators = { '`', '*', '[', '&' };
+
+        private static readonly CachedReadConcurrentDictionary<TypeInfo, string> Cache =
+            new CachedReadConcurrentDictionary<TypeInfo, string>();
+
+        /// <summary>
+        /// Returns a <see cref="string"/> form of <paramref name="type"/> which can be parsed by <see cref="Type.GetType(string)"/>.
+        /// </summary>
+        /// <param name="type">The type to format.</param>
+        /// <returns>
+        /// A <see cref="string"/> form of <paramref name="type"/> which can be parsed by <see cref="Type.GetType(string)"/>.
+        /// </returns>
+        public static string Format(Type type) => Format(type?.GetTypeInfo());
+
+        /// <summary>
+        /// Returns a <see cref="string"/> form of <paramref name="type"/> which can be parsed by <see cref="Type.GetType(string)"/>.
+        /// </summary>
+        /// <param name="type">The type to format.</param>
+        /// <returns>
+        /// A <see cref="string"/> form of <paramref name="type"/> which can be parsed by <see cref="Type.GetType(string)"/>.
+        /// </returns>
+        public static string Format(TypeInfo type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            string result;
+            if (!Cache.TryGetValue(type, out result))
+            {
+                var builder = new StringBuilder();
+                Format(builder, type, isElementType: false);
+                result = builder.ToString();
+
+                if (!Cache.TryAdd(type, result))
+                {
+                    result = Cache[type];
+                }
+            }
+
+            return result;
+        }
+
+        private static void Format(StringBuilder builder, TypeInfo type, bool isElementType)
+        {
+            // Arrays, pointers, and by-ref types are all element types and need to be formatted with their own adornments.
+            if (type.HasElementType)
+            {
+                // Format the element type.
+                Format(builder, type.GetElementType().GetTypeInfo(), isElementType: true);
+
+                // Format this type's adornments to the element type.
+                AddArrayRank(builder, type);
+                AddPointerSymbol(builder, type);
+                AddByRefSymbol(builder, type);
+            }
+            else
+            {
+                AddNamespace(builder, type);
+                AddClassName(builder, type);
+                AddGenericParameters(builder, type);
+            }
+
+            // Types which are used as elements are not formatted with their assembly name, since that is added after the
+            // element type's adornments.
+            if (!isElementType) AddAssembly(builder, type);
+        }
+
+        private static void AddNamespace(StringBuilder builder, TypeInfo type)
+        {
+            if (string.IsNullOrWhiteSpace(type.Namespace)) return;
+            builder.Append(type.Namespace);
+            builder.Append('.');
+        }
+
+        private static void AddClassName(StringBuilder builder, TypeInfo type)
+        {
+            // Format the declaring type.
+            if (type.IsNested)
+            {
+                AddClassName(builder, type.DeclaringType.GetTypeInfo());
+                builder.Append('+');
+            }
+
+            // Format the simple type name.
+            var index = type.Name.IndexOfAny(SimpleNameTerminators);
+            builder.Append(index > 0 ? type.Name.Substring(0, index) : type.Name);
+
+            // Format this type's generic arity.
+            AddGenericArity(builder, type);
+        }
+
+        private static void AddGenericParameters(StringBuilder builder, TypeInfo type)
+        {
+            // Generic type definitions (eg, List<> without parameters) and non-generic types do not include any
+            // parameters in their formatting.
+            if (!type.AsType().IsConstructedGenericType) return;
+
+            var args = type.GetGenericArguments();
+            builder.Append('[');
+            for (var i = 0; i < args.Length; i++)
+            {
+                builder.Append('[');
+                Format(builder, args[i].GetTypeInfo(), isElementType: false);
+                builder.Append(']');
+                if (i + 1 < args.Length) builder.Append(',');
+            }
+
+            builder.Append(']');
+        }
+
+        private static void AddGenericArity(StringBuilder builder, TypeInfo type)
+        {
+            if (!type.IsGenericType) return;
+
+            // The arity is the number of generic parameters minus the number of generic parameters in the declaring types.
+            var baseTypeParameterCount =
+                type.IsNested ? type.DeclaringType.GetTypeInfo().GetGenericArguments().Length : 0;
+            var arity = type.GetGenericArguments().Length - baseTypeParameterCount;
+
+            // If all of the generic parameters are in the declaring types then this type has no parameters of its own.
+            if (arity == 0) return;
+
+            builder.Append('`');
+            builder.Append(arity);
+        }
+
+        private static void AddPointerSymbol(StringBuilder builder, TypeInfo type)
+        {
+            if (!type.IsPointer) return;
+            builder.Append('*');
+        }
+
+        private static void AddByRefSymbol(StringBuilder builder, TypeInfo type)
+        {
+            if (!type.IsByRef) return;
+            builder.Append('&');
+        }
+
+        private static void AddArrayRank(StringBuilder builder, TypeInfo type)
+        {
+            if (!type.IsArray) return;
+            builder.Append('[');
+            builder.Append(',', type.GetArrayRank() - 1);
+            builder.Append(']');
+        }
+
+        private static void AddAssembly(StringBuilder builder, TypeInfo type)
+        {
+            // Do not include the assembly name for the system assembly.
+            if (SystemAssembly.Equals(type.Assembly)) return;
+            builder.Append(',');
+            builder.Append(type.Assembly.GetName().Name);
+        }
+    }
+}

--- a/test/NonSilo.Tests/NonSilo.Tests.csproj
+++ b/test/NonSilo.Tests/NonSilo.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="RuntimeTypeNameFormatterTests.cs" />
     <Compile Include="SchedulerTests\OrleansTaskSchedulerAdvancedTests.cs" />
     <Compile Include="SchedulerTests\OrleansTaskSchedulerAdvancedTests_Set2.cs" />
     <Compile Include="SchedulerTests\OrleansTaskSchedulerBasicTests.cs" />

--- a/test/NonSilo.Tests/RuntimeTypeNameFormatterTests.cs
+++ b/test/NonSilo.Tests/RuntimeTypeNameFormatterTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using Orleans.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NonSilo.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="RuntimeTypeNameFormatter"/>.
+    /// </summary>
+    [TestCategory("BVT")]
+    public class RuntimeTypeNameFormatterTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public RuntimeTypeNameFormatterTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        /// <summary>
+        /// Tests that various strings formatted with <see cref="RuntimeTypeNameFormatter"/> can be loaded using <see cref="Type.GetType(string)"/>.
+        /// </summary>
+        [Fact]
+        public void FormattedTypeNamesAreRecoverable()
+        {
+            var types = new[]
+            {
+                typeof(int),
+                typeof(int[]),
+                typeof(int*[]),
+                typeof(List<>),
+                typeof(List<int>),
+                typeof(List<int*[]>),
+                typeof(Inner<int[,,]>.InnerInner<string, List<int>>.Bottom[,]),
+                typeof(Inner<>.InnerInner<,>.Bottom),
+                typeof(RuntimeTypeNameFormatterTests),
+                typeof(TestGrainInterfaces.CircularStateTestState),
+                typeof(int).MakeByRefType(),
+                typeof(Inner<int[]>.InnerInner<string, List<int>>.Bottom[,])
+                    .MakePointerType()
+                    .MakePointerType()
+                    .MakeArrayType(10)
+                    .MakeByRefType()
+            };
+
+            foreach (var type in types)
+            {
+                var formatted = RuntimeTypeNameFormatter.Format(type);
+                this.output.WriteLine($"Full Name: {type.FullName}");
+                this.output.WriteLine($"Formatted: {formatted}");
+                var isRecoverable = Type.GetType(formatted, throwOnError: false) == type;
+                Assert.True(isRecoverable, $"Type.GetType(\"{formatted}\") must be equal to the original type.");
+            }
+        }
+
+        public class Inner<T>
+        {
+            public class InnerInner<U, V>
+            {
+                public class Bottom { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, Types need to be registered by `SerializationManager.FindSerializationInfo(..)` before they can be serialized over the wire.

This PR removes that requirement.

Includes a utility class, `RuntimeTypeNameFormatter` which takes a `Type` and returns a string suitable for use with `Type.GetType` which does not include assembly metadata other than assembly name.

If it's preferred, I can remove the `CachedReadConcurrentDictionary`. In my benchmarks I find that it's significantly better than either `Dictionary` + `lock` or `ConcurrentDictionary` for our use-cases.

This can be merged without squashing.