### PR TITLE
Allow Service Fabric FabricClient to be injected

### DIFF
--- a/src/Orleans/Messaging/GatewayProviderFactory.cs
+++ b/src/Orleans/Messaging/GatewayProviderFactory.cs
@@ -22,6 +22,8 @@ namespace Orleans.Messaging
 
         internal IGatewayListProvider CreateGatewayListProvider()
         {
+            this.cfg.CheckGatewayProviderSettings();
+
             IGatewayListProvider listProvider;
             ClientConfiguration.GatewayProviderType gatewayProviderToUse = cfg.GatewayProviderToUse;
             

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -62,6 +62,7 @@ namespace Orleans
         private AssemblyProcessor assemblyProcessor;
         private MessageFactory messageFactory;
         private IPAddress localAddress;
+        private IGatewayListProvider gatewayListProvider;
 
         public SerializationManager SerializationManager { get; set; }
 
@@ -170,8 +171,7 @@ namespace Orleans
                     throw new InvalidOperationException("TestOnlyThrowExceptionDuringInit");
                 }
 
-                config.CheckGatewayProviderSettings();
-
+                this.gatewayListProvider = this.ServiceProvider.GetRequiredService<IGatewayListProvider>();
                 if (StatisticsCollector.CollectThreadTimeTrackingStats)
                 {
                     incomingMessagesThreadTimeTracking = new ThreadTrackingStatistic("ClientReceiver");
@@ -247,8 +247,7 @@ namespace Orleans
         // used for testing to (carefully!) allow two clients in the same process
         private async Task StartInternal()
         {
-            var gatewayListProvider = this.ServiceProvider.GetRequiredService<IGatewayListProvider>();
-            await gatewayListProvider.InitializeGatewayListProvider(config, LogManager.GetLogger(gatewayListProvider.GetType().Name))
+            await this.gatewayListProvider.InitializeGatewayListProvider(config, LogManager.GetLogger(gatewayListProvider.GetType().Name))
                                .WithTimeout(initTimeout);
 
             var generation = -SiloAddress.AllocateNewGeneration(); // Client generations are negative


### PR DESCRIPTION
Fixes #2940.

* Check that a gateway provider is correctly configured only if it's not injected (enables injecting gateway providers)
* Configure Service Fabric support via `IClientBuilder`. The previous method was not actually valid since we didn't have client-side DI when it was implemented. It was just there as an example/stub for future use :)

There will be a separate PR which updates the samples to demonstrate this and make use of `ClientBuilder`, that relies on v1.5.0 NuGet packages (which don't exist yet)