### PR TITLE
Support grains with key extensions containing + symbols

### DIFF
--- a/src/Orleans/IDs/UniqueKey.cs
+++ b/src/Orleans/IDs/UniqueKey.cs
@@ -10,6 +10,7 @@ namespace Orleans.Runtime
     internal class UniqueKey : IComparable<UniqueKey>, IEquatable<UniqueKey>
     {
         private const ulong TYPE_CODE_DATA_MASK = 0xFFFFFFFF; // Lowest 4 bytes
+        private static readonly char[] KeyExtSeparationChar = {'+'};
 
         /// <summary>
         /// Type id values encoded into UniqueKeys
@@ -87,7 +88,7 @@ namespace Orleans.Runtime
                 return NewKey(guid);
             else
             {
-                var fields = trimmed.Split('+');
+                var fields = trimmed.Split(KeyExtSeparationChar, 2);
                 var n0 = ulong.Parse(fields[0].Substring(0, 16), NumberStyles.HexNumber);
                 var n1 = ulong.Parse(fields[0].Substring(16, 16), NumberStyles.HexNumber);
                 var typeCodeData = ulong.Parse(fields[0].Substring(32, 16), NumberStyles.HexNumber);

--- a/test/DefaultCluster.Tests/KeyExtensionTests.cs
+++ b/test/DefaultCluster.Tests/KeyExtensionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
 using TestExtensions;
@@ -109,6 +110,41 @@ namespace DefaultCluster.Tests.General
             var key2 = ((GrainReference) grain).GetPrimaryKeyString();
 
             Assert.Equal(key, key2); // Unexpected key was returned.
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]
+        public void KeysAllowPlusSymbols()
+        {
+            const string key = "foo+bar+zaz";
+
+            {
+                // Verify that grains with string keys can include + symbols in their key.
+                var grain = this.GrainFactory.GetGrain<IStringGrain>(key);
+                var grainRef = (GrainReference) grain;
+                var key2 = grainRef.GetPrimaryKeyString();
+                Assert.Equal(key, key2);
+
+                var grainRef2 = GrainReference.FromKeyString(
+                    grainRef.ToKeyString(),
+                    this.Client.ServiceProvider.GetRequiredService<IRuntimeClient>());
+                Assert.True(grainRef.Equals(grainRef2));
+            }
+
+            {
+                // Verify that grains with compound keys can include + symbols in their key extension.
+                var primaryKey = Guid.NewGuid();
+                var grain = this.GrainFactory.GetGrain<IKeyExtensionTestGrain>(primaryKey, keyExtension: key);
+                string keyExt;
+                var grainRef = (GrainReference) grain;
+                var actualPrimaryKey = grainRef.GetPrimaryKey(out keyExt);
+                Assert.Equal(primaryKey, actualPrimaryKey);
+                Assert.Equal(key, keyExt);
+
+                var grainRef2 = GrainReference.FromKeyString(
+                    grainRef.ToKeyString(),
+                    this.Client.ServiceProvider.GetRequiredService<IRuntimeClient>());
+                Assert.True(grainRef.Equals(grainRef2));
+            }
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("PrimaryKeyExtension")]


### PR DESCRIPTION
This removes a limitation in the how keys are parsed, allowing keys which contain `+` symbols.

This is in response to #2943, however I do not believe that this alone would solve that issue - a configuration change to the JSON serializer being used is also likely needed.