### PR TITLE
Fix various unhandled exceptions happening during client close.

### DIFF
--- a/src/Orleans/Messaging/GatewayConnection.cs
+++ b/src/Orleans/Messaging/GatewayConnection.cs
@@ -189,7 +189,7 @@ namespace Orleans.Messaging
         protected override bool PrepareMessageForSend(Message msg)
         {
             // Check to make sure we're not stopped
-            if (Cts.IsCancellationRequested)
+            if (Cts!=null && Cts.IsCancellationRequested)
             {
                 // Recycle the message we've dequeued. Note that this will recycle messages that were queued up to be sent when the gateway connection is declared dead
                 MsgCenter.SendMessage(msg);

--- a/src/Orleans/Messaging/GatewayConnection.cs
+++ b/src/Orleans/Messaging/GatewayConnection.cs
@@ -188,8 +188,13 @@ namespace Orleans.Messaging
 
         protected override bool PrepareMessageForSend(Message msg)
         {
+            if (Cts == null)
+            {
+                return false;
+            }
+
             // Check to make sure we're not stopped
-            if (Cts!=null && Cts.IsCancellationRequested)
+            if (Cts.IsCancellationRequested)
             {
                 // Recycle the message we've dequeued. Note that this will recycle messages that were queued up to be sent when the gateway connection is declared dead
                 MsgCenter.SendMessage(msg);

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -163,7 +163,7 @@ namespace Orleans.Messaging
             }
             GatewayManager.Stop();
 
-            foreach (var gateway in gatewayConnections.Values)
+            foreach (var gateway in gatewayConnections.Values.ToArray())
             {
                 gateway.Stop();
             }
@@ -394,7 +394,7 @@ namespace Orleans.Messaging
         /// </summary>
         public void Disconnect()
         {
-            foreach (var connection in gatewayConnections.Values)
+            foreach (var connection in gatewayConnections.Values.ToArray())
             {
                 connection.Stop();
             }

--- a/src/Orleans/Runtime/AsynchQueueAgent.cs
+++ b/src/Orleans/Runtime/AsynchQueueAgent.cs
@@ -71,7 +71,7 @@ namespace Orleans.Runtime
         {            
             while (true)
             {
-                if (Cts==null || Cts.IsCancellationRequested)
+                if (Cts == null || Cts.IsCancellationRequested)
                 {
                     return;
                 }

--- a/src/Orleans/Runtime/AsynchQueueAgent.cs
+++ b/src/Orleans/Runtime/AsynchQueueAgent.cs
@@ -30,7 +30,10 @@ namespace Orleans.Runtime
                 queueTracking.OnEnQueueRequest(1, requestQueue.Count, request);
             }
 #endif
-            requestQueue.Add(request);
+            if (requestQueue != null)
+            {
+                requestQueue.Add(request);
+            }
         }
 
         protected abstract void Process(T request);
@@ -65,7 +68,7 @@ namespace Orleans.Runtime
         {            
             while (true)
             {
-                if (Cts.IsCancellationRequested)
+                if (Cts==null || Cts.IsCancellationRequested)
                 {
                     return;
                 }

--- a/src/Orleans/Runtime/AsynchQueueAgent.cs
+++ b/src/Orleans/Runtime/AsynchQueueAgent.cs
@@ -24,16 +24,19 @@ namespace Orleans.Runtime
 
         public void QueueRequest(T request)
         {
+            if (requestQueue==null)
+            {
+                return;
+            }
+
 #if TRACK_DETAILED_STATS
             if (StatisticsCollector.CollectQueueStats)
             {
                 queueTracking.OnEnQueueRequest(1, requestQueue.Count, request);
             }
 #endif
-            if (requestQueue != null)
-            {
-                requestQueue.Add(request);
-            }
+
+            requestQueue.Add(request);
         }
 
         protected abstract void Process(T request);


### PR DESCRIPTION
These came up during the debugging of client disconnect:

- AsynchQueueAgent.QueueRequest: NullReferenceException
- AsynchQueueAgent.RunNonBatching: NullReferenceException
- GatewayConnection.PrepareMessageForSend: NullReferenceException
- ProxiedMessageCenter.Disconnect: Collection was modified
- ProxiedMessageCenter.Stop: Collection was modified
