### PR TITLE
Fix warnings and skip some tests

### DIFF
--- a/src/OrleansAWSUtils/OrleansAWSUtils.csproj
+++ b/src/OrleansAWSUtils/OrleansAWSUtils.csproj
@@ -36,13 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">

--- a/src/OrleansBondUtils/OrleansBondUtils.csproj
+++ b/src/OrleansBondUtils/OrleansBondUtils.csproj
@@ -46,13 +46,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">

--- a/src/OrleansPSUtils/OrleansPSUtils.csproj
+++ b/src/OrleansPSUtils/OrleansPSUtils.csproj
@@ -60,13 +60,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">

--- a/src/OrleansTelemetryConsumers.AI/OrleansTelemetryConsumers.AI.csproj
+++ b/src/OrleansTelemetryConsumers.AI/OrleansTelemetryConsumers.AI.csproj
@@ -35,13 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">

--- a/src/OrleansTelemetryConsumers.NewRelic/OrleansTelemetryConsumers.NewRelic.csproj
+++ b/src/OrleansTelemetryConsumers.NewRelic/OrleansTelemetryConsumers.NewRelic.csproj
@@ -35,13 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">

--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -39,13 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">

--- a/test/TestServiceFabric/TestServiceFabric.csproj
+++ b/test/TestServiceFabric/TestServiceFabric.csproj
@@ -53,13 +53,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EndpointsCollection.cs" />

--- a/test/TesterZooKeeperUtils/LivenessTests.cs
+++ b/test/TesterZooKeeperUtils/LivenessTests.cs
@@ -16,6 +16,8 @@ namespace Tester.ZooKeeperUtils
 
         public override TestCluster CreateTestCluster()
         {
+            ZookeeperTestUtils.EnsureZooKeeper();
+
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.ZooKeeperConnectionString;
             options.ClusterConfiguration.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.ZooKeeper;
@@ -24,31 +26,31 @@ namespace Tester.ZooKeeperUtils
             return new TestCluster(options);
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_1()
         {
             await Do_Liveness_OracleTest_1();
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_2_Restart_Primary()
         {
             await Do_Liveness_OracleTest_2(0);
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_3_Restart_GW()
         {
             await Do_Liveness_OracleTest_2(1);
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_4_Restart_Silo_1()
         {
             await Do_Liveness_OracleTest_2(2);
         }
 
-        [Fact, TestCategory("Membership"), TestCategory("ZooKeeper")]
+        [SkippableFact, TestCategory("Membership"), TestCategory("ZooKeeper")]
         public async Task Liveness_ZooKeeper_5_Kill_Silo_1_With_Timers()
         {
             await Do_Liveness_OracleTest_2(2, false, true);

--- a/test/TesterZooKeeperUtils/TesterZooKeeperUtils.csproj
+++ b/test/TesterZooKeeperUtils/TesterZooKeeperUtils.csproj
@@ -33,13 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CollectionFixtures.cs" />

--- a/test/TesterZooKeeperUtils/TesterZooKeeperUtils.csproj
+++ b/test/TesterZooKeeperUtils/TesterZooKeeperUtils.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CollectionFixtures.cs" />
+    <Compile Include="ZookeeperTestUtils.cs" />
     <Compile Include="LivenessTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ZookeeperMembershipTableTests.cs" />

--- a/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -1,10 +1,10 @@
 using System.Threading.Tasks;
-using org.apache.zookeeper;
 using Orleans;
 using Orleans.Messaging;
 using Orleans.Runtime;
 using TestExtensions;
 using Xunit;
+using Tester.ZooKeeperUtils;
 
 namespace UnitTests.MembershipTests
 {
@@ -34,23 +34,8 @@ namespace UnitTests.MembershipTests
 
         protected override async Task<string> GetConnectionString()
         {
-            var connectionString = TestDefaultConfiguration.ZooKeeperConnectionString;
-            if (string.IsNullOrWhiteSpace(connectionString)) return null;
-
-            bool isReachable = false;
-            await ZooKeeper.Using(connectionString, 2000, null, async zk =>
-            {
-                try
-                {
-                    await zk.existsAsync("/test", false);
-                    isReachable = true;
-                }
-                catch (KeeperException.ConnectionLossException)
-                {
-                }
-            });
-
-            return isReachable ? connectionString : null;
+            bool isReachable = await ZookeeperTestUtils.EnsureZooKeeperAsync();
+            return isReachable ? TestDefaultConfiguration.ZooKeeperConnectionString : null;
         }
 
         [SkippableFact]

--- a/test/TesterZooKeeperUtils/ZookeeperTestUtils.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperTestUtils.cs
@@ -1,0 +1,40 @@
+﻿using org.apache.zookeeper;
+using System;
+using System.Threading.Tasks;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.ZooKeeperUtils
+{
+    public static class ZookeeperTestUtils
+    {
+        private static readonly Lazy<bool> EnsureZooKeeperLazy = new Lazy<bool>(() => EnsureZooKeeperAsync().Result);
+
+        public static void EnsureZooKeeper()
+        {
+            if (!EnsureZooKeeperLazy.Value)
+                throw new SkipException("ZooKeeper isn't running");
+        }
+
+        public static async Task<bool> EnsureZooKeeperAsync()
+        {
+            var connectionString = TestDefaultConfiguration.ZooKeeperConnectionString;
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                return false;
+            }
+            return await ZooKeeper.Using(connectionString, 2000, null, async zk =>
+            {
+                try
+                {
+                    await zk.existsAsync("/test", false);
+                    return true;
+                }
+                catch (KeeperException.ConnectionLossException)
+                {
+                    return false;
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
- Remove some unneeded assembly references that were causing warnings.
- Skip ZooKeeper tests if ZooKeper is not running (approach copied from Consul tests).