### PR TITLE
Throw InconsistenStateException in Azure storage providers

### DIFF
--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.Blob.Protocol;
 using Newtonsoft.Json;
 using Orleans.Providers;
 using Orleans.Providers.Azure;
@@ -132,21 +131,15 @@ namespace Orleans.Storage
                 {
                     json = await blob.DownloadTextAsync().ConfigureAwait(false);
                 }
-                catch (StorageException exception)
+                catch (StorageException exception) when (exception.IsBlobNotFound())
                 {
-                    var errorCode = exception.RequestInformation.ExtendedErrorInformation?.ErrorCode;
-                    if (errorCode == BlobErrorCodeStrings.BlobNotFound)
-                    {
-                        if (this.Log.IsVerbose2) this.Log.Verbose2((int)AzureProviderErrorCode.AzureBlobProvider_BlobNotFound, "BlobNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
-                        return;
-                    }
-                    if (errorCode == BlobErrorCodeStrings.ContainerNotFound)
-                    {
-                        if (this.Log.IsVerbose2) this.Log.Verbose2((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "ContainerNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
-                        return;
-                    }
-
-                    throw;
+                    if (this.Log.IsVerbose2) this.Log.Verbose2((int)AzureProviderErrorCode.AzureBlobProvider_BlobNotFound, "BlobNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                    return;
+                }
+                catch (StorageException exception) when (exception.IsContainerNotFound())
+                {
+                    if (this.Log.IsVerbose2) this.Log.Verbose2((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "ContainerNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                    return;
                 }
 
                 if (string.IsNullOrWhiteSpace(json))
@@ -189,33 +182,7 @@ namespace Orleans.Storage
                 var blob = container.GetBlockBlobReference(blobName);
                 blob.Properties.ContentType = "application/json";
 
-                try
-                {
-                    await DoConditionalUpdate(() => blob.UploadTextAsync(json, Encoding.UTF8, AccessCondition.GenerateIfMatchCondition(grainState.ETag), null, null),
-                        blobName, grainState.ETag).ConfigureAwait(false);
-                }
-                catch (StorageException exception)
-                {
-                    if (exception.IsPreconditionFailed())
-                    {
-                        throw new InconsistentStateException($"Blob storage condition not Satisfied.  BlobName: {blobName}, Container: {container.Name}, CurrentETag: {grainState.ETag}", "Unkown", grainState.ETag, exception);
-                    }
-
-                    var errorCode = exception.RequestInformation.ExtendedErrorInformation?.ErrorCode;
-                    if (errorCode != BlobErrorCodeStrings.ContainerNotFound)
-                    {
-                        throw;
-                    }
-
-                    // if the container does not exist, create it, and make another attempt
-                    if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "Creating container: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
-                    await container.CreateIfNotExistsAsync().ConfigureAwait(false);
-
-                    await DoConditionalUpdate(() => blob.UploadTextAsync(json, Encoding.UTF8, AccessCondition.GenerateIfMatchCondition(grainState.ETag), null, null),
-                        blobName, grainState.ETag).ConfigureAwait(false);
-                }
-
-                grainState.ETag = blob.Properties.ETag;
+                await WriteStateAndCreateContainerIfNotExists(grainType, grainId, grainState, json, blob);
 
                 if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Written: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
             }
@@ -255,6 +222,25 @@ namespace Orleans.Storage
 
                 throw;
             }
+        }
+
+        private async Task WriteStateAndCreateContainerIfNotExists(string grainType, GrainReference grainId, IGrainState grainState, string json, CloudBlockBlob blob)
+        {
+            try
+            {
+                await DoConditionalUpdate(() => blob.UploadTextAsync(json, Encoding.UTF8, AccessCondition.GenerateIfMatchCondition(grainState.ETag), null, null),
+                    blob.Name, grainState.ETag).ConfigureAwait(false);
+            }
+            catch (StorageException exception) when (exception.IsContainerNotFound())
+            {
+                // if the container does not exist, create it, and make another attempt
+                if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "Creating container: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blob.Name, container.Name);
+                await container.CreateIfNotExistsAsync().ConfigureAwait(false);
+
+                await WriteStateAndCreateContainerIfNotExists(grainType, grainId, grainState, json, blob).ConfigureAwait(false);
+            }
+
+            grainState.ETag = blob.Properties.ETag;
         }
 
         private async Task DoConditionalUpdate(Func<Task> updateOperation, string blobName, string currentETag)

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -178,18 +178,8 @@ namespace Orleans.Storage
             var record = new GrainStateRecord { Entity = entity, ETag = grainState.ETag };
             try
             {
-                await tableDataManager.Write(record);
+                await DoConditionalUpdate(() => tableDataManager.Write(record), grainType, grainReference, tableName, grainState.ETag).ConfigureAwait(false);
                 grainState.ETag = record.ETag;
-            }
-            catch (StorageException exc)
-            {
-                Log.Error((int)AzureProviderErrorCode.AzureTableProvider_WriteError,
-                    $"Error Writing: GrainType={grainType} Grainid={grainReference} ETag={grainState.ETag} to Table={tableName} Exception={exc.Message}", exc);
-                if (exc.IsUpdateConditionNotSatisfiedError())
-                {
-                    throw new TableStorageUpdateConditionNotSatisfiedException(grainType, grainReference, tableName, "Unknown", grainState.ETag, exc);
-                }
-                throw;
             }
             catch (Exception exc)
             {
@@ -220,11 +210,11 @@ namespace Orleans.Storage
                 if (isDeleteStateOnClear)
                 {
                     operation = "Deleting";
-                    await tableDataManager.Delete(record).ConfigureAwait(false);
+                    await DoConditionalUpdate(() => tableDataManager.Delete(record), grainType, grainReference, tableName, grainState.ETag).ConfigureAwait(false);
                 }
                 else
                 {
-                    await tableDataManager.Write(record).ConfigureAwait(false);
+                    await DoConditionalUpdate(() => tableDataManager.Write(record), grainType, grainReference, tableName, grainState.ETag).ConfigureAwait(false);
                 }
 
                 grainState.ETag = record.ETag; // Update in-memory data to the new ETag
@@ -234,6 +224,18 @@ namespace Orleans.Storage
                 Log.Error((int)AzureProviderErrorCode.AzureTableProvider_DeleteError, string.Format("Error {0}: GrainType={1} Grainid={2} ETag={3} from Table={4} Exception={5}",
                     operation, grainType, grainReference, grainState.ETag, tableName, exc.Message), exc);
                 throw;
+            }
+        }
+
+        private async Task DoConditionalUpdate(Func<Task> updateOperation, string grainType, GrainReference grainReference, string tableName, string currentETag)
+        {
+            try
+            {
+                await updateOperation.Invoke().ConfigureAwait(false);
+            }
+            catch (StorageException ex) when (ex.IsPreconditionFailed())
+            {
+                throw new TableStorageUpdateConditionNotSatisfiedException(grainType, grainReference, tableName, "Unknown", currentETag, ex);
             }
         }
 

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -178,7 +178,7 @@ namespace Orleans.Storage
             var record = new GrainStateRecord { Entity = entity, ETag = grainState.ETag };
             try
             {
-                await DoConditionalUpdate(() => tableDataManager.Write(record), grainType, grainReference, tableName, grainState.ETag).ConfigureAwait(false);
+                await DoOptimisticUpdate(() => tableDataManager.Write(record), grainType, grainReference, tableName, grainState.ETag).ConfigureAwait(false);
                 grainState.ETag = record.ETag;
             }
             catch (Exception exc)
@@ -210,11 +210,11 @@ namespace Orleans.Storage
                 if (isDeleteStateOnClear)
                 {
                     operation = "Deleting";
-                    await DoConditionalUpdate(() => tableDataManager.Delete(record), grainType, grainReference, tableName, grainState.ETag).ConfigureAwait(false);
+                    await DoOptimisticUpdate(() => tableDataManager.Delete(record), grainType, grainReference, tableName, grainState.ETag).ConfigureAwait(false);
                 }
                 else
                 {
-                    await DoConditionalUpdate(() => tableDataManager.Write(record), grainType, grainReference, tableName, grainState.ETag).ConfigureAwait(false);
+                    await DoOptimisticUpdate(() => tableDataManager.Write(record), grainType, grainReference, tableName, grainState.ETag).ConfigureAwait(false);
                 }
 
                 grainState.ETag = record.ETag; // Update in-memory data to the new ETag
@@ -227,7 +227,7 @@ namespace Orleans.Storage
             }
         }
 
-        private async Task DoConditionalUpdate(Func<Task> updateOperation, string grainType, GrainReference grainReference, string tableName, string currentETag)
+        private static async Task DoOptimisticUpdate(Func<Task> updateOperation, string grainType, GrainReference grainReference, string tableName, string currentETag)
         {
             try
             {

--- a/src/OrleansAzureUtils/Storage/StorageExceptionExtensions.cs
+++ b/src/OrleansAzureUtils/Storage/StorageExceptionExtensions.cs
@@ -1,20 +1,13 @@
 ﻿using System.Net;
 using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table.Protocol;
 
 namespace Orleans.Storage
 {
     internal static class StorageExceptionExtensions
     {
-        /// <summary>
-        /// See https://msdn.microsoft.com/en-us/library/azure/dd179438.aspx
-        /// </summary>
-        internal static bool IsUpdateConditionNotSatisfiedError(this StorageException storageException)
+        internal static bool IsPreconditionFailed(this StorageException storageException)
         {
-            return storageException?.RequestInformation != null &&
-                   storageException.RequestInformation.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed &&
-                   (storageException.RequestInformation.ExtendedErrorInformation == null ||
-                    storageException.RequestInformation.ExtendedErrorInformation.ErrorCode.Equals(TableErrorCodeStrings.UpdateConditionNotSatisfied));
+            return storageException?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed;
         }
     }
 }

--- a/src/OrleansAzureUtils/Storage/StorageExceptionExtensions.cs
+++ b/src/OrleansAzureUtils/Storage/StorageExceptionExtensions.cs
@@ -1,13 +1,26 @@
 ﻿using System.Net;
 using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob.Protocol;
 
 namespace Orleans.Storage
 {
     internal static class StorageExceptionExtensions
     {
-        internal static bool IsPreconditionFailed(this StorageException storageException)
+        public static bool IsPreconditionFailed(this StorageException storageException)
         {
             return storageException?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed;
+        }
+
+        public static bool IsContainerNotFound(this StorageException storageException)
+        {
+            return storageException?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.NotFound
+                && storageException.RequestInformation.ExtendedErrorInformation.ErrorCode == BlobErrorCodeStrings.ContainerNotFound;
+        }
+
+        public static bool IsBlobNotFound(this StorageException storageException)
+        {
+            return storageException?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.NotFound
+                && storageException.RequestInformation.ExtendedErrorInformation.ErrorCode == BlobErrorCodeStrings.BlobNotFound;
         }
     }
 }


### PR DESCRIPTION
Update AzureTableStorage and AzureBlobStorage to consistently throw InconsistentStateException when there are conflicting eTags when updating the store.
- Update AzureTableStorage provider to throw InconsistentStateException also on Clear (it was only doing it on Write).
- Update AzureBlobStorage provider to throw InconsistentStateException on both Write and Clear (previously it was just bubbling up the StorageException).
