### PR TITLE
Allow registering a provider in DI

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -97,7 +97,7 @@ namespace Orleans.Runtime
                     return null;
                 }
 
-                return (T)ActivatorUtilities.CreateInstance(serviceProvider, foundType);
+                return (T)ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, foundType);
             }
             catch (FileNotFoundException)
             {
@@ -118,7 +118,7 @@ namespace Orleans.Runtime
                 var assembly = Assembly.Load(new AssemblyName(assemblyName));
                 var foundType = TypeUtils.GetTypes(assembly, type => typeof(T).IsAssignableFrom(type), logger).First();
 
-                return (T)ActivatorUtilities.CreateInstance(serviceProvider, foundType);
+                return (T)ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, foundType);
             }
             catch (Exception exc)
             {


### PR DESCRIPTION
If the user registered a concrete provider in the service collection for DI, then it will use the registration resolve it. Otherwise it falls back to activating a new instance as it was before (still using the container to fulfill dependencies).