### PR TITLE
Support one-way grain calls using [OneWay] method attribute

### DIFF
--- a/src/Orleans/Core/GrainAttributes.cs
+++ b/src/Orleans/Core/GrainAttributes.cs
@@ -107,6 +107,14 @@ namespace Orleans
         public sealed class ImmutableAttribute : Attribute
         {
         }
+
+        /// <summary>
+        /// Indicates that a method on a grain interface is one-way and that no response message will be sent to the caller.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Method)]
+        public sealed class OneWayAttribute : Attribute
+        {
+        }
     }
 
     namespace MultiCluster

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -208,14 +208,14 @@ namespace Orleans.CodeGenerator
 
                     if (isOneWayTask)
                     {
-                        if (!method.ReturnType.IsInstanceOfType(TaskDone.Done))
+                        if (method.ReturnType != typeof(Task))
                         {
                             throw new CodeGenerationException(
                                 $"Method {grainType.GetParseableName()}.{method.Name} is marked with [{nameof(OneWayAttribute)}], " +
-                                $"but has a return type which is not assignable from {TaskDone.Done.GetType()}");
+                                $"but has a return type which is not assignable from {typeof(Task)}");
                         }
 
-                        var done = typeof(TaskDone).GetNameSyntax(true).Member((object _) => TaskDone.Done);
+                        var done = typeof(Task).GetNameSyntax(true).Member((object _) => Task.CompletedTask);
                         body.Add(SF.ReturnStatement(done));
                     }
                 }

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -11,6 +11,7 @@ namespace Orleans.CodeGenerator
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Orleans.CodeGeneration;
     using Orleans.CodeGenerator.Utilities;
+    using Orleans.Concurrency;
     using Orleans.Runtime;
     using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
     using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -191,7 +192,8 @@ namespace Orleans.CodeGenerator
                 var options = GetInvokeOptions(method);
 
                 // Construct the invocation call.
-                if (method.ReturnType == typeof(void))
+                var isOneWayTask = method.GetCustomAttribute<OneWayAttribute>() != null;
+                if (method.ReturnType == typeof(void) || isOneWayTask)
                 {
                     var invocation = SF.InvocationExpression(baseReference.Member("InvokeOneWayMethod"))
                         .AddArgumentListArguments(methodIdArgument)
@@ -203,6 +205,19 @@ namespace Orleans.CodeGenerator
                     }
 
                     body.Add(SF.ExpressionStatement(invocation));
+
+                    if (isOneWayTask)
+                    {
+                        if (!method.ReturnType.IsInstanceOfType(TaskDone.Done))
+                        {
+                            throw new CodeGenerationException(
+                                $"Method {grainType.GetParseableName()}.{method.Name} is marked with [{nameof(OneWayAttribute)}], " +
+                                $"but has a return type which is not assignable from {TaskDone.Done.GetType()}");
+                        }
+
+                        var done = typeof(TaskDone).GetNameSyntax(true).Member((object _) => TaskDone.Done);
+                        body.Add(SF.ReturnStatement(done));
+                    }
                 }
                 else
                 {

--- a/test/DefaultCluster.Tests/DefaultCluster.Tests.csproj
+++ b/test/DefaultCluster.Tests/DefaultCluster.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="MethodInterceptionTests.cs" />
     <Compile Include="MultifacetGrainTest.cs" />
     <Compile Include="ObserverTests.cs" />
+    <Compile Include="OneWayCallTests.cs" />
     <Compile Include="PolymorphicInterfaceTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\src\Build\GlobalAssemblyInfo.cs">

--- a/test/DefaultCluster.Tests/OneWayCallTests.cs
+++ b/test/DefaultCluster.Tests/OneWayCallTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace DefaultCluster.Tests.General
+{
+    public class OneWayCallTests : HostedTestClusterEnsureDefaultStarted
+    {
+        public OneWayCallTests(DefaultClusterFixture fixture) : base(fixture) { }
+
+        [Fact]
+        public async Task OneWayMethodsReturnSynchronously()
+        {
+            var grain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
+
+            var observer = new SimpleGrainObserver();
+            var task = grain.Notify(await this.Client.CreateObjectReference<ISimpleGrainObserver>(observer));
+            Assert.True(task.Status == TaskStatus.RanToCompletion, "Task should be synchronously completed.");
+            await observer.ReceivedValue;
+            var count = await grain.GetCount();
+            Assert.Equal(1, count);
+
+            // This should not throw.
+            task = grain.ThrowsOneWay();
+            Assert.True(task.Status == TaskStatus.RanToCompletion, "Task should be synchronously completed.");
+        }
+
+        private class SimpleGrainObserver : ISimpleGrainObserver
+        {
+            private readonly TaskCompletionSource<int> completion = new TaskCompletionSource<int>();
+            public Task ReceivedValue => this.completion.Task;
+            public void StateChanged(int a, int b)
+            {
+                this.completion.SetResult(b);
+            }
+        }
+    }
+}

--- a/test/TestGrainInterfaces/ITestGrain.cs
+++ b/test/TestGrainInterfaces/ITestGrain.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Concurrency;
 
 namespace UnitTests.GrainInterfaces
 {
@@ -45,5 +46,16 @@ namespace UnitTests.GrainInterfaces
         Task<string> GetRuntimeInstanceId();
 
         Task<string> GetActivationId();
+    }
+
+    public interface IOneWayGrain : IGrainWithGuidKey
+    {
+        [OneWay]
+        Task Notify(ISimpleGrainObserver observer);
+
+        [OneWay]
+        Task ThrowsOneWay();
+
+        Task<int> GetCount();
     }
 }

--- a/test/TestInternalGrains/TestGrain.cs
+++ b/test/TestInternalGrains/TestGrain.cs
@@ -178,4 +178,29 @@ namespace UnitTests.Grains
 
         #endregion
     }
+
+    public class OneWayGrain : Grain, IOneWayGrain
+    {
+        private int count;
+
+        public Task Notify()
+        {
+            this.count++;
+            return TaskDone.Done;
+        }
+
+        public Task Notify(ISimpleGrainObserver observer)
+        {
+            this.count++;
+            observer.StateChanged(this.count - 1, this.count);
+            return TaskDone.Done;
+        }
+
+        public Task<int> GetCount() => Task.FromResult(this.count);
+
+        public Task ThrowsOneWay()
+        {
+            throw new Exception("GET OUT!");
+        }
+    }
 }


### PR DESCRIPTION
This is an implementation of my take on #2893. I don't necessarily intend for this to be implemented, but maybe it demonstrates what's required and how it might look.

When a grain interface has a method is marked with `[OneWay]`, that method will be completed synchronously from the caller's perspective and the remote silo will not send a response message.

An alternative implementation could use a different return type as a marker, like `IOneWay` or `OneWayCall`.