### PR TITLE
Changed TaskDone.Done to Task.CompletedTask

### DIFF
--- a/src/Orleans/Async/TaskExtensions.cs
+++ b/src/Orleans/Async/TaskExtensions.cs
@@ -359,17 +359,10 @@ namespace Orleans
     /// </summary>
     public static class TaskDone
     {
-        private static readonly Task<int> doneConstant = Task.FromResult(1);
-
         /// <summary>
         /// A special 'Done' Task that is already in the RunToCompletion state
         /// </summary>
-        public static Task Done
-        {
-            get
-            {
-                return doneConstant;
-            }
-        }
+        [Obsolete("Use Task.CompletedTask")]
+        public static Task Done => Task.CompletedTask;
     }
 }

--- a/src/Orleans/CodeGeneration/GenericMethodInvoker.cs
+++ b/src/Orleans/CodeGeneration/GenericMethodInvoker.cs
@@ -125,7 +125,7 @@ namespace Orleans.CodeGeneration
         private static MethodInfo GetTaskConversionMethod(Type taskType)
         {
             if (taskType == typeof(Task)) return TypeUtils.Method((Task task) => task.Box());
-            if (taskType == typeof(void)) return TypeUtils.Property(() => TaskDone.Done).GetMethod;
+            if (taskType == typeof(void)) return TypeUtils.Property(() => Task.CompletedTask).GetMethod;
 
             if (taskType.GetGenericTypeDefinition() != typeof(Task<>))
                 throw new ArgumentException($"Unsupported return type {taskType}.");

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -225,7 +225,7 @@ namespace Orleans
         /// </summary>
         public virtual Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Orleans
         /// </summary>
         public virtual Task OnDeactivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -133,7 +133,7 @@ namespace Orleans
             IGrainObserver obj) where TGrainObserverInterface : IGrainObserver
         {
             this.runtimeClient.DeleteObjectReference(obj);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />

--- a/src/Orleans/Messaging/GatewayProviderFactory.cs
+++ b/src/Orleans/Messaging/GatewayProviderFactory.cs
@@ -69,7 +69,7 @@ namespace Orleans.Messaging
         {
             config = cfg;
             knownGateways = cfg.Gateways.Select(ep => ep.ToGatewayUri()).ToList();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<IList<Uri>> GetGateways()

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -492,7 +492,7 @@ namespace Orleans
                 object resultObject)
         {
             if (ExpireMessageIfExpired(message, MessagingStatisticsGroup.Phase.Respond))
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             object deepCopy = null;
             try
@@ -506,12 +506,12 @@ namespace Orleans
                 logger.Warn(
                     ErrorCode.ProxyClient_OGC_SendResponseFailed,
                     "Exception trying to send a response.", exc2);
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             // the deep-copy succeeded.
             SendResponse(message, new Response(deepCopy));
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]

--- a/src/Orleans/Streams/Core/AsyncObservableExtensions.cs
+++ b/src/Orleans/Streams/Core/AsyncObservableExtensions.cs
@@ -5,8 +5,8 @@ namespace Orleans.Streams
 {
     public static class AsyncObservableExtensions
     {
-        private static readonly Func<Exception, Task> DefaultOnError = _ => TaskDone.Done;
-        private static readonly Func<Task> DefaultOnCompleted = () => TaskDone.Done;
+        private static readonly Func<Exception, Task> DefaultOnError = _ => Task.CompletedTask;
+        private static readonly Func<Task> DefaultOnCompleted = () => Task.CompletedTask;
 
         /// <summary>
         /// Subscribe a consumer to this observable using delegates.

--- a/src/Orleans/Streams/Core/StreamSubscriptionHandleExtensions.cs
+++ b/src/Orleans/Streams/Core/StreamSubscriptionHandleExtensions.cs
@@ -5,8 +5,8 @@ namespace Orleans.Streams
 {
     public static class StreamSubscriptionHandleExtensions
     {
-        private static readonly Func<Exception, Task> DefaultOnError = _ => TaskDone.Done;
-        private static readonly Func<Task> DefaultOnCompleted = () => TaskDone.Done;
+        private static readonly Func<Exception, Task> DefaultOnError = _ => Task.CompletedTask;
+        private static readonly Func<Task> DefaultOnCompleted = () => Task.CompletedTask;
 
         /// <summary>
         /// Resumes consumption of a stream using delegates.

--- a/src/Orleans/Streams/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans/Streams/Internal/StreamConsumerExtension.cs
@@ -146,7 +146,7 @@ namespace Orleans.Streams
                 providerRuntime.ExecutingEntityIdentity(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task ErrorInStream(GuidId subscriptionId, Exception exc)
@@ -161,7 +161,7 @@ namespace Orleans.Streams
                 providerRuntime.ExecutingEntityIdentity(), subscriptionId);
             // We got an item when we don't think we're the subscriber. This is a normal race condition.
             // We can drop the item on the floor, or pass it to the rendezvous, or ...
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<StreamHandshakeToken> GetSequenceToken(GuidId subscriptionId)

--- a/src/Orleans/Streams/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamSubscriptionHandleImpl.cs
@@ -129,22 +129,22 @@ namespace Orleans.Streams
             // This method could potentially be invoked after Dispose() has been called, 
             // so we have to ignore the request or we risk breaking unit tests AQ_01 - AQ_04.
             if (observer == null || !IsValid)
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             if (filterWrapper != null && !filterWrapper.ShouldReceive(streamImpl, filterWrapper.FilterData, typedItem))
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             return observer.OnNextAsync(typedItem, token);
         }
 
         public Task CompleteStream()
         {
-            return observer == null ? TaskDone.Done : observer.OnCompletedAsync();
+            return observer == null ? Task.CompletedTask : observer.OnCompletedAsync();
         }
 
         public Task ErrorInStream(Exception ex)
         {
-            return observer == null ? TaskDone.Done : observer.OnErrorAsync(ex);
+            return observer == null ? Task.CompletedTask : observer.OnErrorAsync(ex);
         }
 
         internal bool SameStreamId(StreamId streamId)

--- a/src/Orleans/Streams/PersistentStreams/NoOpStreamFailureHandler.cs
+++ b/src/Orleans/Streams/PersistentStreams/NoOpStreamFailureHandler.cs
@@ -23,13 +23,13 @@ namespace Orleans.Streams
         public Task OnDeliveryFailure(GuidId subscriptionId, string streamProviderName, IStreamIdentity streamIdentity,
             StreamSequenceToken sequenceToken)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnSubscriptionFailure(GuidId subscriptionId, string streamProviderName, IStreamIdentity streamIdentity,
             StreamSequenceToken sequenceToken)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Orleans/Streams/PersistentStreams/PersistentStreamProducer.cs
+++ b/src/Orleans/Streams/PersistentStreams/PersistentStreamProducer.cs
@@ -49,7 +49,7 @@ namespace Orleans.Streams
 
         public Task Cleanup()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Orleans/Streams/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans/Streams/PubSub/ImplicitStreamPubSub.cs
@@ -39,7 +39,7 @@ namespace Orleans.Streams
 
         public Task UnregisterProducer(StreamId streamId, string streamProvider, IStreamProducerExtension streamProducer)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task RegisterConsumer(GuidId subscriptionId, StreamId streamId, string streamProvider, IStreamConsumerExtension streamConsumer, IStreamFilterPredicateWrapper filter)
@@ -48,7 +48,7 @@ namespace Orleans.Streams
             {
                 throw new ArgumentOutOfRangeException(streamId.ToString(), "Only implicit subscriptions are supported.");
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task UnregisterConsumer(GuidId subscriptionId, StreamId streamId, string streamProvider)
@@ -57,7 +57,7 @@ namespace Orleans.Streams
             {
                 throw new ArgumentOutOfRangeException(streamId.ToString(), "Only implicit subscriptions are supported.");
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> ProducerCount(Guid streamId, string streamProvider, string streamNamespace)

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducerExtension.cs
@@ -86,7 +86,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                 // We got an item when we don't think we're the subscriber. This is a normal race condition.
                 // We can drop the item on the floor, or pass it to the rendezvous, or log a warning.
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         internal Task CompleteStream(StreamId streamId)
@@ -101,7 +101,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                 // We got an item when we don't think we're the subscriber. This is a normal race condition.
                 // We can drop the item on the floor, or pass it to the rendezvous, or log a warning.
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         internal Task ErrorInStream(StreamId streamId, Exception exc)
@@ -116,7 +116,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                 // We got an item when we don't think we're the subscriber. This is a normal race condition.
                 // We can drop the item on the floor, or pass it to the rendezvous, or log a warning.
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
 
@@ -138,7 +138,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                 // We got an item when we don't think we're the subscriber. This is a normal race condition.
                 // We can drop the item on the floor, or pass it to the rendezvous, or log a warning.
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task RemoveSubscriber(GuidId subscriptionId, StreamId streamId)
@@ -153,7 +153,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             {
                 consumers.RemoveRemoteSubscriber(subscriptionId);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
 
@@ -207,7 +207,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                     else tasks.Add(task);
                 }
                 // If there's no subscriber, presumably we just drop the item on the floor
-                return fireAndForgetDelivery ? TaskDone.Done : Task.WhenAll(tasks);
+                return fireAndForgetDelivery ? Task.CompletedTask : Task.WhenAll(tasks);
             }
 
             private async Task DeliverToRemote(IStreamConsumerExtension remoteConsumer, StreamId streamId, GuidId subscriptionId, object item, bool optimizeForImmutableData)
@@ -243,7 +243,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                     else tasks.Add(task);
                 }
                 // If there's no subscriber, presumably we just drop the item on the floor
-                return fireAndForgetDelivery ? TaskDone.Done : Task.WhenAll(tasks);
+                return fireAndForgetDelivery ? Task.CompletedTask : Task.WhenAll(tasks);
             }
 
             internal Task ErrorInStream(StreamId streamId, Exception exc, bool fireAndForgetDelivery)
@@ -258,7 +258,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
                     else tasks.Add(task);
                 }
                 // If there's no subscriber, presumably we just drop the item on the floor
-                return fireAndForgetDelivery ? TaskDone.Done : Task.WhenAll(tasks);
+                return fireAndForgetDelivery ? Task.CompletedTask : Task.WhenAll(tasks);
             }
         }
     }

--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -29,7 +29,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
         public Task Init(string name, IProviderRuntime providerUtilitiesManager, IProviderConfiguration config)
         {
-            if (!stateManager.PresetState(ProviderState.Initialized)) return TaskDone.Done;
+            if (!stateManager.PresetState(ProviderState.Initialized)) return Task.CompletedTask;
             this.Name = name;
             providerRuntime = (IStreamProviderRuntime) providerUtilitiesManager;
             this.runtimeClient = this.providerRuntime.ServiceProvider.GetRequiredService<IRuntimeClient>();
@@ -51,19 +51,19 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             logger.Info("Initialized SimpleMessageStreamProvider with name {0} and with property FireAndForgetDelivery: {1}, OptimizeForImmutableData: {2} " +
                 "and PubSubType: {3}", Name, fireAndForgetDelivery, optimizeForImmutableData, pubSubType);
             stateManager.CommitState();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Start()
         {
             if (stateManager.PresetState(ProviderState.Started)) stateManager.CommitState();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Close()
         {
             if (stateManager.PresetState(ProviderState.Closed)) stateManager.CommitState();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public IStreamSubscriptionManager GetStreamSubscriptionManager()

--- a/src/OrleansAWSUtils/Storage/DynamoDBStorage.cs
+++ b/src/OrleansAWSUtils/Storage/DynamoDBStorage.cs
@@ -378,7 +378,7 @@ namespace OrleansAWSUtils.Storage
             if (toDelete == null) throw new ArgumentNullException("collection");
 
             if (toDelete.Count == 0)
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             try
             {
@@ -539,7 +539,7 @@ namespace OrleansAWSUtils.Storage
             if (toCreate == null) throw new ArgumentNullException("collection");
 
             if (toCreate.Count == 0)
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             try
             {

--- a/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
+++ b/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
@@ -124,7 +124,7 @@ namespace Orleans.Storage
         /// <see cref="IProvider.Close"/>
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary> Read state data function for this storage provider. </summary>

--- a/src/OrleansAWSUtils/Streams/SQSAdapterReceiver.cs
+++ b/src/OrleansAWSUtils/Streams/SQSAdapterReceiver.cs
@@ -52,7 +52,7 @@ namespace OrleansAWSUtils.Streams
             {
                 return queue.InitQueueAsync();
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Shutdown(TimeSpan timeout)

--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -111,7 +111,7 @@ namespace Orleans.Storage
         /// <see cref="IProvider.Close"/>
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary> Read state data function for this storage provider. </summary>

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -135,7 +135,7 @@ namespace Orleans.Storage
         public Task Close()
         {
             tableDataManager = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary> Read state data function for this storage provider. </summary>

--- a/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -57,7 +57,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             {
                 return queue.InitQueueAsync();
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Shutdown(TimeSpan timeout)

--- a/src/OrleansConsulUtils/ConsulBasedMembershipTable.cs
+++ b/src/OrleansConsulUtils/ConsulBasedMembershipTable.cs
@@ -39,7 +39,7 @@ namespace Orleans.Runtime.Host
 
             Init(config.DeploymentId, config.DataConnectionString, logger);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Orleans.Runtime.Host
         {
             Init(config.DeploymentId, config.DataConnectionString, logger);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private void Init(String deploymentId, String dataConnectionString, Logger logger)

--- a/src/OrleansEventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
+++ b/src/OrleansEventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
@@ -151,7 +151,7 @@ namespace Orleans.EventSourcing.Common
         protected virtual Task OnConfigurationChange(MultiClusterConfiguration next)
         {
             Configuration = next;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -217,7 +217,7 @@ namespace Orleans.EventSourcing.Common
 
             Services.Log(Severity.Verbose2, "PostActivation Complete");
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc/>

--- a/src/OrleansEventSourcing/CustomStorage/LogConsistencyProvider.cs
+++ b/src/OrleansEventSourcing/CustomStorage/LogConsistencyProvider.cs
@@ -65,13 +65,13 @@ namespace Orleans.EventSourcing.CustomStorage
             Log.Info("Init (Severity={0}) PrimaryCluster={1}", Log.SeverityLevel, 
                 string.IsNullOrEmpty(PrimaryCluster) ? "(none specified)" : PrimaryCluster);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc/>
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc/>

--- a/src/OrleansEventSourcing/LogStorage/LogConsistencyProvider.cs
+++ b/src/OrleansEventSourcing/LogStorage/LogConsistencyProvider.cs
@@ -61,7 +61,7 @@ namespace Orleans.EventSourcing.LogStorage
             Log = providerRuntime.GetLogger(GetLoggerName());
             Log.Info("Init (Severity={0})", Log.SeverityLevel);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
       
         /// <summary>
@@ -69,7 +69,7 @@ namespace Orleans.EventSourcing.LogStorage
         /// </summary>
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/OrleansEventSourcing/StateStorage/LogConsistencyProvider.cs
+++ b/src/OrleansEventSourcing/StateStorage/LogConsistencyProvider.cs
@@ -61,7 +61,7 @@ namespace Orleans.EventSourcing.StateStorage
             Log = providerRuntime.GetLogger(GetLoggerName());
             Log.Info("Init (Severity={0})", Log.SeverityLevel);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
       
         /// <summary>
@@ -69,7 +69,7 @@ namespace Orleans.EventSourcing.StateStorage
         /// </summary>
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/OrleansProviders/Storage/MemoryStorage.cs
+++ b/src/OrleansProviders/Storage/MemoryStorage.cs
@@ -95,7 +95,7 @@ namespace Orleans.Storage
                 int idx = i; // Capture variable to avoid modified closure error
                 storageGrains[idx] = new Lazy<IMemoryStorageGrain>(() => providerRuntime.GrainFactory.GetGrain<IMemoryStorageGrain>(idx));
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary> Shutdown function for this storage provider. </summary>
@@ -104,7 +104,7 @@ namespace Orleans.Storage
             for (int i = 0; i < numStorageGrains; i++)
                 storageGrains[i] = null;
             
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary> Read state data function for this storage provider. </summary>

--- a/src/OrleansProviders/Storage/ShardedStorageProvider.cs
+++ b/src/OrleansProviders/Storage/ShardedStorageProvider.cs
@@ -96,7 +96,7 @@ namespace Orleans.Storage
             }
             storageProviders = providers.ToArray();
             // Storage providers will already have been initialized by the provider manager, so we don't need to orchestrate that
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary> Shutdown function for this storage provider. </summary>

--- a/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorAdapterFactory.cs
@@ -138,7 +138,7 @@ namespace Orleans.Providers.Streams.Generator
         public Task QueueMessageBatchAsync<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, StreamSequenceToken token,
             Dictionary<string, object> requestContext)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace Orleans.Providers.Streams.Generator
 
             public Task Initialize(TimeSpan timeout)
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
@@ -204,12 +204,12 @@ namespace Orleans.Providers.Streams.Generator
 
             public Task MessagesDeliveredAsync(IList<IBatchContainer> messages)
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             public Task Shutdown(TimeSpan timeout)
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
         }
 

--- a/src/OrleansProviders/Streams/Memory/MemoryAdapterReceiver.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryAdapterReceiver.cs
@@ -26,7 +26,7 @@ namespace Orleans.Providers
 
         public Task Initialize(TimeSpan timeout)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
@@ -54,7 +54,7 @@ namespace Orleans.Providers
 
         public Task MessagesDeliveredAsync(IList<IBatchContainer> messages)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Shutdown(TimeSpan timeout)

--- a/src/OrleansProviders/Streams/Memory/MemoryStreamQueueGrain.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryStreamQueueGrain.cs
@@ -32,7 +32,7 @@ namespace Orleans.Providers
             }
             data.SequenceNumber = sequenceNumber++;
             eventQueue.Enqueue(data);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/OrleansRuntime/Cancellation/CancellationSourcesExtension.cs
+++ b/src/OrleansRuntime/Cancellation/CancellationSourcesExtension.cs
@@ -32,7 +32,7 @@ namespace Orleans.Runtime
             if (!_cancellationTokens.TryFind(token.Id, out gct))
             {
                 _logger.Value.Error(ErrorCode.CancellationTokenCancelFailed,  $"Remote token cancellation failed: token with id {token.Id} was not found");
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             return gct.Cancel();

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -766,7 +766,7 @@ namespace Orleans.Runtime
             { 
                 if (timers == null)
                 {
-                    return TaskDone.Done;
+                    return Task.CompletedTask;
                 }
                 var tasks = new List<Task>();
                 var timerCopy = timers.ToList(); // need to copy since OnTimerDisposed will change the timers set.

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -493,7 +493,7 @@ namespace Orleans.Runtime
             out Task activatedPromise)
         {
             ActivationData result;
-            activatedPromise = TaskDone.Done;
+            activatedPromise = Task.CompletedTask;
             PlacementStrategy placement;
 
             lock (activations)
@@ -1500,7 +1500,7 @@ namespace Orleans.Runtime
             ActivationAddress target = ActivationAddress.NewActivationAddress(LocalSilo, grainId);
             Task activatedPromise;
             GetOrCreateActivation(target, true, grainType, null, null, out activatedPromise);
-            return activatedPromise ?? TaskDone.Done;
+            return activatedPromise ?? Task.CompletedTask;
         }
 
 

--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.Management
         public override Task OnActivateAsync()
         {
             logger = LogManager.GetLogger("ManagementGrain", LoggerType.Runtime);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<Dictionary<SiloAddress, SiloStatus>> GetHosts(bool onlyActive = false)

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
@@ -152,7 +152,7 @@ namespace Orleans.Runtime.GrainDirectory
                 TrackDoubtfulGrain(entry.Item1);
             }
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private async Task RunBatchedActivationRequests(List<string> remoteClusters, List<GrainId> grains)

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
@@ -202,10 +202,10 @@ namespace Orleans.Runtime.GrainDirectory
             }
 
             if (formerActivationsInThisCluster == null)
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             if (!this.hasMultiClusterNetwork)
-                return TaskDone.Done; // single cluster - no broadcast required
+                return Task.CompletedTask; // single cluster - no broadcast required
 
             // we must also remove cached references to former activations in this cluster
             // from remote clusters; thus, we broadcast the unregistration
@@ -254,7 +254,7 @@ namespace Orleans.Runtime.GrainDirectory
             directoryPartition.RemoveGrain(gid);
 
             if (!this.hasMultiClusterNetwork)
-                return TaskDone.Done; // single cluster - no broadcast required
+                return Task.CompletedTask; // single cluster - no broadcast required
 
             // broadcast deletion to all other clusters
             var myClusterId = this.clusterId;

--- a/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/RemoteGrainDirectory.cs
@@ -97,13 +97,13 @@ namespace Orleans.Runtime.GrainDirectory
         public Task AcceptHandoffPartition(SiloAddress source, Dictionary<GrainId, IGrainInfo> partition, bool isFullCopy)
         {
             router.HandoffManager.AcceptHandoffPartition(source, partition, isFullCopy);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task RemoveHandoffPartition(SiloAddress source)
         {
             router.HandoffManager.RemoveHandoffPartition(source);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrleansRuntime/LogConsistency/LogConsistencyProviderManager.cs
+++ b/src/OrleansRuntime/LogConsistency/LogConsistencyProviderManager.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime.LogConsistency
             providerLoader = new ProviderLoader<ILogConsistencyProvider>();
 
             if (!configs.ContainsKey(ProviderCategoryConfiguration.LOG_CONSISTENCY_PROVIDER_CATEGORY_NAME))
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             providerLoader.LoadProviders(configs[ProviderCategoryConfiguration.LOG_CONSISTENCY_PROVIDER_CATEGORY_NAME].Providers, this);
             return providerLoader.InitProviders(this);

--- a/src/OrleansRuntime/MembershipService/GrainBasedMembershipTable.cs
+++ b/src/OrleansRuntime/MembershipService/GrainBasedMembershipTable.cs
@@ -19,26 +19,26 @@ namespace Orleans.Runtime.MembershipService
             logger = LogManager.GetLogger("GrainBasedMembershipTable", LoggerType.Runtime);
             logger.Info(ErrorCode.MembershipGrainBasedTable1, "GrainBasedMembershipTable Activated.");
             table = new InMemoryMembershipTable(this.ServiceProvider.GetRequiredService<SerializationManager>());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             logger.Info("GrainBasedMembershipTable Deactivated.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task InitializeMembershipTable(GlobalConfiguration config, bool tryInitTableVersion, Logger traceLogger)
         {
             logger.Info("InitializeMembershipTable {0}.", tryInitTableVersion);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task DeleteMembershipTableEntries(string deploymentId)
         {
             logger.Info("DeleteMembershipTableEntries {0}", deploymentId);
             table = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<MembershipTableData> ReadRow(SiloAddress key)
@@ -80,7 +80,7 @@ namespace Orleans.Runtime.MembershipService
         {
             if (logger.IsVerbose) logger.Verbose("UpdateIAmAlive entry = {0}", entry.ToFullString());
             table.UpdateIAmAlive(entry);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrleansRuntime/MembershipService/MembershipOracle.cs
+++ b/src/OrleansRuntime/MembershipService/MembershipOracle.cs
@@ -332,7 +332,7 @@ namespace Orleans.Runtime.MembershipService
         public Task Ping(int pingNumber)
         {
             // do not do anything here -- simply returning back will indirectly notify the prober that this silo is alive
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         #endregion

--- a/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -365,7 +365,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
 
             logger.Verbose("--- Publish: done");
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         // called by remote nodes' full background gossip

--- a/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
+++ b/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
@@ -91,16 +91,16 @@ namespace Orleans.Runtime
         {
             if (logger.IsVerbose) logger.Verbose("UpdateRuntimeStatistics from {0}", siloAddress);
             if (this.siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             SiloRuntimeStatistics old;
             // Take only if newer.
             if (periodicStats.TryGetValue(siloAddress, out old) && old.DateTime > siloStats.DateTime)
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             periodicStats[siloAddress] = siloStats;
             NotifyAllStatisticsChangeEventsSubscribers(siloAddress, siloStats);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         internal async Task<ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics>> RefreshStatistics()

--- a/src/OrleansRuntime/ReminderService/GrainBasedReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/GrainBasedReminderTable.cs
@@ -20,18 +20,18 @@ namespace Orleans.Runtime.ReminderService
             logger.Info("GrainBasedReminderTable {0} Activated. Full identity: {1}", Identity, Data.Address.ToFullString());
             remTable = new InMemoryRemindersTable();
             base.DelayDeactivation(TimeSpan.FromDays(10 * 365)); // Delay Deactivation for GrainBasedReminderTable virtually indefinitely.
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Init(GlobalConfiguration config, Logger logger)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             logger.Info("GrainBasedReminderTable {0} OnDeactivateAsync. Full identity: {1}", Identity, Data.Address.ToFullString());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<ReminderTableData> ReadRows(GrainReference grainRef)
@@ -79,7 +79,7 @@ namespace Orleans.Runtime.ReminderService
         {
             logger.Info("TestOnlyClearTable");
             remTable.Reset();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrleansRuntime/ReminderService/MockReminderTable.cs
+++ b/src/OrleansRuntime/ReminderService/MockReminderTable.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime.ReminderService
 
         public Task Init(GlobalConfiguration config, Logger logger)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<ReminderTableData> ReadRows(GrainReference key)

--- a/src/OrleansRuntime/Scheduler/ShedulerExtensions.cs
+++ b/src/OrleansRuntime/Scheduler/ShedulerExtensions.cs
@@ -98,7 +98,7 @@ namespace Orleans.Runtime.Scheduler
             return scheduler.RunOrQueueTask(() =>
             {
                 action();
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }, targetContext);
         }
 

--- a/src/OrleansRuntime/Services/GrainService.cs
+++ b/src/OrleansRuntime/Services/GrainService.cs
@@ -60,7 +60,7 @@ namespace Orleans.Runtime
         /// <summary>Invoked upon initialization of the service</summary>
         public virtual Task Init(IServiceProvider serviceProvider)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private void OnStatusChange(GrainServiceStatus oldStatus, GrainServiceStatus newStatus)
@@ -83,7 +83,7 @@ namespace Orleans.Runtime
 
             StartInBackground().Ignore();
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>Deferred part of initialization that executes after the service is already started (to speed up startup)</summary>
@@ -97,7 +97,7 @@ namespace Orleans.Runtime
             Logger.Info(ErrorCode.RS_ServiceStopping, $"Stopping {this.typeName} grain service");
             Status = GrainServiceStatus.Stopped;
             
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
 
@@ -113,7 +113,7 @@ namespace Orleans.Runtime
             RingRange = newRange;
             RangeSerialNumber++;
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>Possible statuses of a grain service</summary>

--- a/src/OrleansRuntime/Silo/SiloControl.cs
+++ b/src/OrleansRuntime/Silo/SiloControl.cs
@@ -38,7 +38,7 @@ namespace Orleans.Runtime
         public Task Ping(string message)
         {
             logger.Info("Ping");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetSystemLogLevel(int traceLevel)
@@ -47,7 +47,7 @@ namespace Orleans.Runtime
             logger.Info("SetSystemLogLevel={0}", newTraceLevel);
             LogManager.SetRuntimeLogLevel(newTraceLevel);
             silo.LocalConfig.DefaultTraceLevel = newTraceLevel;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetAppLogLevel(int traceLevel)
@@ -55,7 +55,7 @@ namespace Orleans.Runtime
             var newTraceLevel = (Severity)traceLevel;
             logger.Info("SetAppLogLevel={0}", newTraceLevel);
             LogManager.SetAppLogLevel(newTraceLevel);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetLogLevel(string logName, int traceLevel)
@@ -67,7 +67,7 @@ namespace Orleans.Runtime
             if (log == null) throw new ArgumentException(string.Format("Logger {0} not found", logName));
             
             log.SetSeverityLevel(newTraceLevel);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.GC.Collect")]
@@ -75,7 +75,7 @@ namespace Orleans.Runtime
         {
             logger.Info("ForceGarbageCollection");
             GC.Collect();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task ForceActivationCollection(TimeSpan ageLimit)
@@ -126,7 +126,7 @@ namespace Orleans.Runtime
             logger.Info("UpdateConfiguration with {0}", configuration);
             silo.OrleansConfig.Update(configuration);
             logger.Info(ErrorCode.Runtime_Error_100318, "UpdateConfiguration - new config is now {0}", silo.OrleansConfig.ToString(silo.Name));
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task UpdateStreamProviders(IDictionary<string, ProviderCategoryConfiguration> streamProviderConfigurations)

--- a/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -82,7 +82,7 @@ namespace Orleans.Runtime.TestHooks
         public Task AddCachedAssembly(string targetAssemblyName, GeneratedAssembly cachedAssembly)
         {
             CodeGeneratorManager.AddGeneratedAssembly(targetAssemblyName, cachedAssembly);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task LatchIsOverloaded(bool overloaded, TimeSpan latchPeriod)
@@ -90,7 +90,7 @@ namespace Orleans.Runtime.TestHooks
             this.silo.Metrics.LatchIsOverload(overloaded);
             
             Task.Delay(latchPeriod).ContinueWith(t => UnlatchIsOverloaded()).Ignore();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private void UnlatchIsOverloaded()

--- a/src/OrleansRuntime/Storage/MemoryStorageGrain.cs
+++ b/src/OrleansRuntime/Storage/MemoryStorageGrain.cs
@@ -22,14 +22,14 @@ namespace Orleans.Storage
             base.DelayDeactivation(TimeSpan.FromDays(10 * 365)); // Delay Deactivation for MemoryStorageGrain virtually indefinitely.
             logger = GetLogger(GetType().Name);
             logger.Info("OnActivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
             grainStore = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<IGrainState> ReadStateAsync(string stateStore, string grainStoreKey)
@@ -53,7 +53,7 @@ namespace Orleans.Storage
         {
             GrainStateStore storage = GetStoreForGrain(grainType);
             storage.DeleteGrainState(grainId, etag);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private GrainStateStore GetStoreForGrain(string grainType)

--- a/src/OrleansRuntime/Storage/StorageProviderManager.cs
+++ b/src/OrleansRuntime/Storage/StorageProviderManager.cs
@@ -25,7 +25,7 @@ namespace Orleans.Runtime.Storage
             storageProviderLoader = new ProviderLoader<IStorageProvider>();
 
             if (!configs.ContainsKey(ProviderCategoryConfiguration.STORAGE_PROVIDER_CATEGORY_NAME))
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             storageProviderLoader.LoadProviders(configs[ProviderCategoryConfiguration.STORAGE_PROVIDER_CATEGORY_NAME].Providers, this);
             return storageProviderLoader.InitProviders(providerRuntime);

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingAgent.cs
@@ -224,7 +224,7 @@ namespace Orleans.Streams
                 .LogException(logger, ErrorCode.PersistentStreamPullingAgent_26,
                     $"Failed to add subscription for stream {streamId}.")
                 .Ignore();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         // Called by rendezvous when new remote subscriber subscribes to this stream.
@@ -313,7 +313,7 @@ namespace Orleans.Streams
         public Task RemoveSubscriber(GuidId subscriptionId, StreamId streamId)
         {
             RemoveSubscriber_Impl(subscriptionId, streamId);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public void RemoveSubscriber_Impl(GuidId subscriptionId, StreamId streamId)

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingManager.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingManager.cs
@@ -93,7 +93,7 @@ namespace Orleans.Streams
 
             queuePrintTimer = this.RegisterTimer(AsyncTimerCallback, null, QUEUES_PRINT_PERIOD, QUEUES_PRINT_PERIOD);
             managerState = PersistentStreamProviderState.Initialized;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Stop()
@@ -142,7 +142,7 @@ namespace Orleans.Streams
 
             if (managerState == PersistentStreamProviderState.AgentsStopped)
             {
-                return TaskDone.Done; // if agents not running, no need to rebalance the queues among them.
+                return Task.CompletedTask; // if agents not running, no need to rebalance the queues among them.
             }
 
             return nonReentrancyGuarantor.AddNext(() =>
@@ -154,11 +154,11 @@ namespace Orleans.Streams
                         "Skipping execution of QueueChangeNotification number {0} from the queue allocator since already received a later notification " +
                         "(already have notification number {1}).",
                         notificationSeqNumber, latestRingNotificationSequenceNumber);
-                    return TaskDone.Done;
+                    return Task.CompletedTask;
                 }
                 if (managerState == PersistentStreamProviderState.AgentsStopped)
                 {
-                    return TaskDone.Done; // if agents not running, no need to rebalance the queues among them.
+                    return Task.CompletedTask; // if agents not running, no need to rebalance the queues among them.
                 }
                 return QueueDistributionChangeNotification(notificationSeqNumber);
             });
@@ -361,7 +361,7 @@ namespace Orleans.Streams
                     Log(ErrorCode.PersistentStreamPullingManager_15,
                         "Skipping execution of command number {0} since already received a later command (already have command number {1}).",
                         commandSeqNumber, latestCommandNumber);
-                    return TaskDone.Done;
+                    return Task.CompletedTask;
                 }
                 switch (command)
                 {
@@ -386,7 +386,7 @@ namespace Orleans.Streams
             Log(ErrorCode.PersistentStreamPullingManager_PeriodicPrint, 
                         "I am responsible for a total of {0} queues on stream provider {1}: {2}.", 
                         NumberRunningAgents, streamProviderName, PrintQueues(queuesToAgentsMap.Keys));
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private void Log(ErrorCode logCode, string format, params object[] args)

--- a/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/OrleansRuntime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -63,7 +63,7 @@ namespace Orleans.Streams
         public override Task OnDeactivateAsync()
         {
             LogPubSubCounts("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private int RemoveDeadProducers()

--- a/src/OrleansRuntime/Timers/GrainTimer.cs
+++ b/src/OrleansRuntime/Timers/GrainTimer.cs
@@ -57,7 +57,7 @@ namespace Orleans.Runtime
                 {
                     if (callback != null)
                         callback(ob);
-                    return TaskDone.Done;
+                    return Task.CompletedTask;
                 },
                 state,
                 dueTime,
@@ -149,7 +149,7 @@ namespace Orleans.Runtime
 
         public Task GetCurrentlyExecutingTickTask()
         {
-            return currentlyExecutingTickTask ?? TaskDone.Done;
+            return currentlyExecutingTickTask ?? Task.CompletedTask;
         }
 
         private string GetFullName()

--- a/src/OrleansSQLUtils/Storage/Provider/AdoNetStorageProvider.cs
+++ b/src/OrleansSQLUtils/Storage/Provider/AdoNetStorageProvider.cs
@@ -212,7 +212,7 @@ namespace Orleans.Storage
         /// </summary>
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
 

--- a/src/OrleansSQLUtils/Storage/RelationalOrleansQueries.cs
+++ b/src/OrleansSQLUtils/Storage/RelationalOrleansQueries.cs
@@ -148,7 +148,7 @@ namespace Orleans.SqlUtils
                 counters.Where(i => !"0".Equals(i.IsValueDelta ? i.GetDeltaString() : i.GetValueString())).ToList();
             if (counters.Count == 0)
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             //Note that the following is almost the same as RelationalStorageExtensions.ExecuteMultipleInsertIntoAsync

--- a/src/OrleansSQLUtils/Storage/SqlStatisticsPublisher.cs
+++ b/src/OrleansSQLUtils/Storage/SqlStatisticsPublisher.cs
@@ -60,7 +60,7 @@ namespace Orleans.Providers.SqlServer
         /// <returns>Resolved task</returns>
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace Orleans.Providers.SqlServer
 
         Task ISiloMetricsDataPublisher.Init(string deploymentId, string storageConnectionString, SiloAddress siloAddress, string siloName, IPEndPoint gateway, string hostName)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Orleans.Providers.SqlServer
 
         Task IStatisticsPublisher.Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName, string hostName)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -81,7 +81,7 @@ namespace Orleans.ServiceBus.Providers
             logger.Info("Initializing EventHub partition {0}-{1}.", settings.Hub.Path, settings.Partition);
             // if receiver was already running, do nothing
             return ReceiverRunning == Interlocked.Exchange(ref recieverState, ReceiverRunning)
-                ? TaskDone.Done
+                ? Task.CompletedTask
                 : Initialize();
         }
 
@@ -211,7 +211,7 @@ namespace Orleans.ServiceBus.Providers
 
         public Task MessagesDeliveredAsync(IList<IBatchContainer> messages)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Shutdown(TimeSpan timeout)
@@ -232,7 +232,7 @@ namespace Orleans.ServiceBus.Providers
                 var localReceiver = Interlocked.Exchange(ref receiver, null);
 
                 // start closing receiver
-                Task closeTask = TaskDone.Done;
+                Task closeTask = Task.CompletedTask;
                 if (localReceiver != null)
                 {
                     closeTask = localReceiver.CloseAsync();

--- a/src/OrleansTestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
+++ b/src/OrleansTestingHost/TestStorageProviders/FaultInjectionStorageProvider.cs
@@ -68,7 +68,7 @@ namespace Orleans.TestingHost
             if (delayMilliseconds > 0)
                 return Task.Delay(delayMilliseconds);
             else
-                return TaskDone.Done;
+                return Task.CompletedTask;
         }
            
         /// <summary>Faults if exception is provided, otherwise calls through to  decorated storage provider.</summary>

--- a/src/OrleansTestingHost/TestStorageProviders/StorageFaultGrain.cs
+++ b/src/OrleansTestingHost/TestStorageProviders/StorageFaultGrain.cs
@@ -41,7 +41,7 @@ namespace Orleans.TestingHost
         {
             readFaults.Add(grainReference, exception);
             logger.Info($"Added ReadState fault for {grainReference}.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Orleans.TestingHost
         {
             writeFaults.Add(grainReference, exception);
             logger.Info($"Added WriteState fault for {grainReference}.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Orleans.TestingHost
         {
             clearfaults.Add(grainReference, exception);
             logger.Info($"Added ClearState fault for {grainReference}.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace Orleans.TestingHost
                 readFaults.Remove(grainReference);
                 throw exception;
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Orleans.TestingHost
                 writeFaults.Remove(grainReference);
                 throw exception;
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Orleans.TestingHost
                 clearfaults.Remove(grainReference);
                 throw exception;
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
+++ b/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
@@ -64,7 +64,7 @@ namespace Orleans.Runtime.Host
         {
             InitConfig(logger,config.DataConnectionString, config.DeploymentId);
             maxStaleness = config.GatewayListRefreshPeriod;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -388,7 +388,7 @@ namespace Orleans.Runtime.Host
                 {
                     logger.Verbose(@event.ToString());
                 }
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
         }
     }

--- a/test/Benchmarks/BenchmarkGrains/MapReduce/BufferGrain.cs
+++ b/test/Benchmarks/BenchmarkGrains/MapReduce/BufferGrain.cs
@@ -18,7 +18,7 @@ namespace BenchmarkGrains.MapReduce
         public Task SendAsync(T t)
         {
             this._items.Add(t);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SendAsync(T t, GrainCancellationToken gct)

--- a/test/Benchmarks/BenchmarkGrains/MapReduce/TargetGrain.cs
+++ b/test/Benchmarks/BenchmarkGrains/MapReduce/TargetGrain.cs
@@ -12,7 +12,7 @@ namespace BenchmarkGrains.MapReduce
         public Task Init(ITargetProcessor<TInput> processor)
         {
             this._processor = processor;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<GrainDataflowMessageStatus> OfferMessage(TInput messageValue, bool consumeToAccept)

--- a/test/Benchmarks/BenchmarkGrains/MapReduce/TransformGrain.cs
+++ b/test/Benchmarks/BenchmarkGrains/MapReduce/TransformGrain.cs
@@ -28,7 +28,7 @@ namespace BenchmarkGrains.MapReduce
         {
             if (processor == null) throw new ArgumentNullException(nameof(processor));
             this._processor = processor;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<TOutput> ConsumeMessage()
@@ -39,7 +39,7 @@ namespace BenchmarkGrains.MapReduce
         public Task LinkTo(ITargetGrain<TOutput> t)
         {
             this._target = t;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<GrainDataflowMessageStatus> OfferMessage(TInput messageValue, bool consumeToAccept)
@@ -51,7 +51,7 @@ namespace BenchmarkGrains.MapReduce
         {
             this._input.Enqueue(t);
             NotifyOfPendingWork();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SendAsync(TInput t, GrainCancellationToken gct)

--- a/test/DefaultCluster.Tests/LocalErrorGrain.cs
+++ b/test/DefaultCluster.Tests/LocalErrorGrain.cs
@@ -15,13 +15,13 @@ namespace DefaultCluster.Tests
         public Task SetA(int a)
         {
             m_a = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetB(int b)
         {
             m_b = b;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<Int32> GetAxB()
@@ -31,20 +31,20 @@ namespace DefaultCluster.Tests
 
         public async Task<Int32> GetAxBError()
         {
-            await TaskDone.Done;
+            await Task.CompletedTask;
             throw new Exception("GetAxBError-Exception");
         }
 
         public Task LongMethod(int waitTime)
         {
             Thread.Sleep(waitTime);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task LongMethodWithError(int waitTime)
         {
             Thread.Sleep(waitTime);
-            await TaskDone.Done;
+            await Task.CompletedTask;
             throw new Exception("LongMethodWithError(" + waitTime + ")");
         }
     }

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
@@ -188,7 +188,7 @@ namespace UnitTests.SchedulerTests
                 Task task4 = task3.ContinueWith((_) => { SubProcess1(14); result1.SetResult(true); });
                 task4.Ignore();
 
-                Task task21 = TaskDone.Done.ContinueWith((_) => SubProcess2(21));
+                Task task21 = Task.CompletedTask.ContinueWith((_) => SubProcess2(21));
                 Task task22 = task21.ContinueWith((_) => { SubProcess2(22); result2.SetResult(true); });
                 task22.Ignore();
 

--- a/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -251,7 +251,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
                 byte[] ignore = { 12, 23 };
                 cache.Add(new EventData(ignore), DateTime.UtcNow);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private NodeConfiguration GetNodeConfiguration()

--- a/test/TestExtensions/MockStorageProvider.cs
+++ b/test/TestExtensions/MockStorageProvider.cs
@@ -151,7 +151,7 @@ namespace UnitTests.StorageTests
             StateStore = new HierarchicalKeyStore(numKeys);
             
             Log.Info(0, "Finished Init Name={0} Config={1}", name, config);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual Task Close()
@@ -159,7 +159,7 @@ namespace UnitTests.StorageTests
             Log.Info(0, "Close");
             Interlocked.Increment(ref closeCount);
             StateStore.Clear();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
@@ -171,7 +171,7 @@ namespace UnitTests.StorageTests
                 var storedState = GetLastState(grainType, grainReference, grainState);
                 grainState.State = this.serializationManager.DeepCopy(storedState); // Read current state data
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
@@ -187,7 +187,7 @@ namespace UnitTests.StorageTests
                 LastId = GetId(grainReference);
                 LastState = storedState;
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
@@ -201,7 +201,7 @@ namespace UnitTests.StorageTests
                 LastId = GetId(grainReference);
                 LastState = null;
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 #endregion
 

--- a/test/TestFSharp/Grains.fs
+++ b/test/TestFSharp/Grains.fs
@@ -8,7 +8,7 @@ type Generic1ArgumentGrain<'T>() =
     inherit Grain()
 
     interface INonGenericBase with 
-        member x.Ping() = TaskDone.Done
+        member x.Ping() = Task.CompletedTask
 
     interface IGeneric1Argument<'T> with 
         member x.Ping(t:'T) = Task.FromResult(t);

--- a/test/TestGrains/ActivateDeactivateWatcherGrain.cs
+++ b/test/TestGrains/ActivateDeactivateWatcherGrain.cs
@@ -27,20 +27,20 @@ namespace UnitTests.Grains
             if (logger.IsVerbose) logger.Verbose("Clear");
             activationCalls.Clear();
             deactivationCalls.Clear();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         public Task RecordActivateCall(string activation)
         {
             if (logger.IsVerbose) logger.Verbose("RecordActivateCall: " + activation);
             activationCalls.Add(activation);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task RecordDeactivateCall(string activation)
         {
             if (logger.IsVerbose) logger.Verbose("RecordDeactivateCall: " + activation);
             deactivationCalls.Add(activation);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/AsyncSimpleGrain.cs
+++ b/test/TestGrains/AsyncSimpleGrain.cs
@@ -54,7 +54,7 @@ namespace UnitTests.Grains
         public Task SetX(int x)
         {
             resolver.SetResult(x);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/CatalogTestGrain.cs
+++ b/test/TestGrains/CatalogTestGrain.cs
@@ -16,7 +16,7 @@ namespace UnitTests.Grains
 
         public Task Initialize()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task BlastCallNewGrains(int nGrains, long startingKey, int nCallsToEach)

--- a/test/TestGrains/ChainedGrain.cs
+++ b/test/TestGrains/ChainedGrain.cs
@@ -58,13 +58,13 @@ namespace UnitTests.Grains
         public Task SetNext(IChainedGrain next)
         {
             State.Next = next;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetNextNested(ChainGrainHolder next)
         {
             State.Next = next.Next;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Validate(bool nextIsSet)
@@ -72,7 +72,7 @@ namespace UnitTests.Grains
             if ((nextIsSet && State.Next != null) || (!nextIsSet && State.Next == null))
             {
                 // logger.Verbose("Id={0} validated successfully: Next={1}", State.Id, State.Next);
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             string msg = String.Format("ChainGrain Id={0} is in an invalid state. Next={1}", State.Id, State.Next);

--- a/test/TestGrains/ClusterTestGrains.cs
+++ b/test/TestGrains/ClusterTestGrains.cs
@@ -79,7 +79,7 @@ namespace UnitTests.Grains
         public Task Deactivate()
         {
             this.DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private List<IClusterTestListener> observers = new List<IClusterTestListener>();
@@ -88,7 +88,7 @@ namespace UnitTests.Grains
         {
             observers.Add(listener);
             logger.Info("AddedSubscription {0}", observers.Count);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         IAsyncStream<int> stream;
@@ -98,7 +98,7 @@ namespace UnitTests.Grains
             IStreamProvider streamProvider = this.GetStreamProvider("SMSProvider");
             Guid guid = new Guid((int) this.GetPrimaryKeyLong(), 0, 0, new byte[8]);
             stream = streamProvider.GetStream<int>(guid, "notificationtest");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         
     }
@@ -118,27 +118,27 @@ namespace UnitTests.Grains
             string id = this.GetPrimaryKeyLong().ToString();
             logger = GetLogger(String.Format("{0}-{1}", GetType().Name, id));
             logger.Info("Activate.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             logger.Info("Deactivate.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetA(int a)
         {
             logger.Info("SetA={0}", a);
             this.A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetB(int b)
         {
             logger.Info("SetB={0}", b);
             this.B = b;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetAxB()

--- a/test/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
+++ b/test/TestGrains/ConcreteGrainsWithGenericInterfaces.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Grains
         public Task SetT(int t)
         {
             T = t;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<float> MapT2U()
@@ -28,7 +28,7 @@ namespace UnitTests.Grains
         public Task SetT(float t)
         {
             T = t;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> MapT2U()
@@ -46,7 +46,7 @@ namespace UnitTests.Grains
         public Task SetT(int t)
         {
             T = t;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> MapT2U()
@@ -64,7 +64,7 @@ namespace UnitTests.Grains
         public Task Transform()
         {
             T = T * 10;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> Get()

--- a/test/TestGrains/ConcurrentGrain.cs
+++ b/test/TestGrains/ConcurrentGrain.cs
@@ -83,7 +83,7 @@ namespace UnitTests.Grains
             index = ind;
             logger = GetLogger("ConcurrentGrain-" + index);
             logger.Info("Initialize(" + index + ")");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         // start a long tail call on the 1st grain by calling into the 2nd grain 
@@ -121,7 +121,7 @@ namespace UnitTests.Grains
             index = ind;
             logger = GetLogger("ConcurrentReentrantGrain-" + index);
             logger.Info("Initialize(" + index + ")");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> TailCall_Called()

--- a/test/TestGrains/ConsumerEventCountingGrain.cs
+++ b/test/TestGrains/ConsumerEventCountingGrain.cs
@@ -32,12 +32,12 @@ namespace UnitTests.Grains
 
             public Task OnCompletedAsync()
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             public Task OnErrorAsync(Exception ex)
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
         }
 
@@ -80,7 +80,7 @@ namespace UnitTests.Grains
         {
             _numConsumedItems++;
             _logger.Info("Consumer.EventArrived. NumConsumed so far: " + _numConsumedItems);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task StopConsuming()

--- a/test/TestGrains/DeadlockGrain.cs
+++ b/test/TestGrains/DeadlockGrain.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Grains
     {
         internal static Task CallNext(IGrainFactory grainFactory, List<Tuple<long, bool>> callChain, int currCallIndex)
         {
-            if (currCallIndex >= callChain.Count) return TaskDone.Done;
+            if (currCallIndex >= callChain.Count) return Task.CompletedTask;
             Tuple<long, bool> next = callChain[currCallIndex];
             bool call_1 = (currCallIndex % 2) == 1; // odd (1) call 1, even (zero) - call 2.
             if (next.Item2)

--- a/test/TestGrains/EventSourcing/ChatGrain.cs
+++ b/test/TestGrains/EventSourcing/ChatGrain.cs
@@ -69,19 +69,19 @@ namespace TestGrains
         public Task Post(Guid guid, string user, string text)
         {
             RaiseEvent(new PostedEvent() { Guid = guid, User = user, Text = text, Timestamp = DateTime.UtcNow });
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Delete(Guid guid)
         {
             RaiseEvent(new DeletedEvent() { Guid = guid });
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Edit(Guid guid, string text)
         {
             RaiseEvent(new EditedEvent() { Guid = guid, Text = text});
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/EventSourcing/CountersGrain.cs
+++ b/test/TestGrains/EventSourcing/CountersGrain.cs
@@ -69,7 +69,7 @@ namespace TestGrains
         public override Task OnActivateAsync()
         {
             // on activation, we load lazily (do not wait until the current state is loaded).
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Add(string key, int amount, bool wait_for_confirmation)

--- a/test/TestGrains/EventSourcing/PersonGrain.cs
+++ b/test/TestGrains/EventSourcing/PersonGrain.cs
@@ -22,7 +22,7 @@ namespace TestGrains
                 return ConfirmEvents();
             }
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Marry(IPersonGrain spouse)
@@ -53,7 +53,7 @@ namespace TestGrains
             // we are not confirming this event here!
             // therefore, the tentative state and the confirmed state can differ for some time
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task ConfirmChanges()

--- a/test/TestGrains/ExternalTypeGrain.cs
+++ b/test/TestGrains/ExternalTypeGrain.cs
@@ -13,7 +13,7 @@ namespace UnitTests.Grains
         public Task GetAbstractModel(IEnumerable<NameObjectCollectionBase> list)
         {
             base.GetLogger().Verbose("GetAbstractModel: Success");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<EnumClass> GetEnumModel()

--- a/test/TestGrains/FaultableConsumerGrain.cs
+++ b/test/TestGrains/FaultableConsumerGrain.cs
@@ -28,13 +28,13 @@ namespace UnitTests.Grains
             eventsFailedCount = 0;
             consumerHandle = null;
             failPeriodTimer = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
@@ -49,7 +49,7 @@ namespace UnitTests.Grains
         {
             failPeriod = failurePeriod;
             failPeriodTimer = Stopwatch.StartNew();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task StopConsuming()
@@ -95,20 +95,20 @@ namespace UnitTests.Grains
                 throw new AggregateException("GO WAY!");
             }
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnCompletedAsync()
         {
             logger.Info("OnCompletedAsync()");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {
             logger.Info("OnErrorAsync({0})", ex);
             errorsCount++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/GeneratedEventCollectorGrain.cs
+++ b/test/TestGrains/GeneratedEventCollectorGrain.cs
@@ -33,7 +33,7 @@ namespace TestGrains
                     logger.Info("Received a generated event {0}, of {1} events", e, counter);
                     if (e.EventType == GeneratedEvent.GeneratedEventType.Fill)
                     {
-                        return TaskDone.Done;
+                        return Task.CompletedTask;
                     }
                     var reporter = this.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
                     return reporter.ReportResult(this.GetPrimaryKey(), GeneratedStreamTestConstants.StreamProviderName, StreamNamespace, counter);

--- a/test/TestGrains/GeneratedEventReporterGrain.cs
+++ b/test/TestGrains/GeneratedEventReporterGrain.cs
@@ -33,7 +33,7 @@ namespace TestGrains
             }
             logger.Info("ReportResult. StreamProvider: {0}, StreamNamespace: {1}, StreamGuid: {2}, Count: {3}", streamProvider, streamNamespace, streamGuid, count);
             counts[streamGuid] = count;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<IDictionary<Guid, int>> GetReport(string streamProvider, string streamNamespace)
@@ -50,7 +50,7 @@ namespace TestGrains
         public Task Reset()
         {
             reports = new Dictionary<Tuple<string, string>, Dictionary<Guid, int>>();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<bool> IsLocatedOnSilo(SiloAddress siloAddress)

--- a/test/TestGrains/GeneratorTestGrain.cs
+++ b/test/TestGrains/GeneratorTestGrain.cs
@@ -22,7 +22,7 @@ namespace UnitTests.Grains
         {
             myGrainString = str;
             //RaiseStateUpdateEvent();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<bool> StringIsNullOrEmpty()
@@ -42,7 +42,7 @@ namespace UnitTests.Grains
             myGrainString = x.stringVar;
             myCode = x.code;
             //RaiseStateUpdateEvent();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/GenericGrains.cs
+++ b/test/TestGrains/GenericGrains.cs
@@ -29,13 +29,13 @@ namespace UnitTests.Grains
         public Task SetA(T a)
         {
             State.A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetB(T b)
         {
             State.B = b;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetAxB()
@@ -101,13 +101,13 @@ namespace UnitTests.Grains
         public Task SetA(U a)
         {
             State.A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetB(U b)
         {
             State.B = b;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetAxB()
@@ -141,13 +141,13 @@ namespace UnitTests.Grains
         public Task SetA(T a)
         {
             State.A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetB(U b)
         {
             State.B = b;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetAxB()
@@ -199,7 +199,7 @@ namespace UnitTests.Grains
         public Task AddItem(string item)
         {
             State.Items.Add(item);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<IList<string>> GetItems()
@@ -228,7 +228,7 @@ namespace UnitTests.Grains
         public Task AddItem(T item)
         {
             State.Items.Add(item);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<IList<T>> GetItems()
@@ -272,7 +272,7 @@ namespace UnitTests.Grains
         public Task SetValue(T value)
         {
             State.Value = value;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<T> GetValue()
@@ -287,12 +287,12 @@ namespace UnitTests.Grains
         public Task SetValue1(TOne value)
         {
             State.Value1 = value;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         public Task SetValue2(TTwo value)
         {
             State.Value2 = value;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<TOne> GetValue1()
@@ -312,17 +312,17 @@ namespace UnitTests.Grains
         public Task SetValue1(TOne value)
         {
             State.Value1 = value;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         public Task SetValue2(TTwo value)
         {
             State.Value2 = value;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         public Task SetValue3(TThree value)
         {
             State.Value3 = value;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<TThree> GetValue3()
@@ -366,13 +366,13 @@ namespace UnitTests.Grains
         public Task SetA(T a)
         {
             this._a = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetB(U b)
         {
             this._b = b;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -391,12 +391,12 @@ namespace UnitTests.Grains
         public Task Foo(TKey key, TMessage message, int x)
         {
             _x = x;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task Bar(TKey key, TMessage message1, TMessage message2)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetX()
@@ -456,7 +456,7 @@ namespace UnitTests.Grains
     {
         public Task Ping()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -485,7 +485,7 @@ namespace UnitTests.Grains
 
         public Task Ping()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -504,7 +504,7 @@ namespace UnitTests.Grains
         public Task SetValue(T value)
         {
             _value = value;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<T> GetValue()
@@ -551,7 +551,7 @@ namespace UnitTests.Grains
                 null,
                 delay,
                 TimeSpan.FromMilliseconds(-1));
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
 
@@ -569,13 +569,13 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             GetLogger().Verbose("***Activating*** {0}", this.GetPrimaryKey());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             GetLogger().Verbose("***Deactivating*** {0}", this.GetPrimaryKey());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -590,7 +590,7 @@ namespace UnitTests.Grains
                 throw new InvalidOperationException("From cancellation token callback");
             });
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<T> GetLastValue()
@@ -673,7 +673,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             collection = new A();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetCount() { return Task.FromResult(collection.Count); }
@@ -681,7 +681,7 @@ namespace UnitTests.Grains
         public Task Add(B item)
         {
             collection.Add(item);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<C> RoundTrip(C value)
@@ -694,7 +694,7 @@ namespace UnitTests.Grains
     public class NonGenericCastableGrain : Grain, INonGenericCastableGrain, ISomeGenericGrain<string>, IIndependentlyConcretizedGenericGrain<string>, IIndependentlyConcretizedGrain
     {
         public Task DoSomething() {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> Hello() {

--- a/test/TestGrains/GrainInterfaceHierarchyGrains.cs
+++ b/test/TestGrains/GrainInterfaceHierarchyGrains.cs
@@ -17,13 +17,13 @@ namespace TestGrains
         public Task SetA(int a)
         {
             A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task IncrementA()
         {
             A++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetA()
@@ -49,13 +49,13 @@ namespace TestGrains
         public Task SetA(int a)
         {
             A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task IncrementA()
         {
             A++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetA()
@@ -82,13 +82,13 @@ namespace TestGrains
         public Task SetA(int a)
         {
             A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task IncrementA()
         {
             A++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetA()
@@ -99,13 +99,13 @@ namespace TestGrains
         public Task SetB(int b)
         {
             B = b;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task IncrementB()
         {
             B++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetB()
@@ -127,13 +127,13 @@ namespace TestGrains
         public Task SetA(int a)
         {
             A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task IncrementA()
         {
             A++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetA()
@@ -173,13 +173,13 @@ namespace TestGrains
         public Task SetA(int a)
         {
             A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task IncrementA()
         {
             A++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetA()
@@ -190,13 +190,13 @@ namespace TestGrains
         public Task SetB(int b)
         {
             B = b;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task IncrementB()
         {
             B++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetB()
@@ -207,13 +207,13 @@ namespace TestGrains
         public Task SetC(int c)
         {
             C = c;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task IncrementC()
         {
             C++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetC()

--- a/test/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/TestGrains/ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.cs
@@ -95,7 +95,7 @@ namespace TestGrains
         {
             logger.Info("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
             Faults.FaultCleared = true;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private void InjectFault()

--- a/test/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
+++ b/test/TestGrains/ImplicitSubscription_RecoverableStream_CollectorGrain.cs
@@ -81,7 +81,7 @@ namespace TestGrains
         private Task OnErrorAsync(Exception ex)
         {
             logger.Info("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
+++ b/test/TestGrains/ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.cs
@@ -139,7 +139,7 @@ namespace TestGrains
         private Task OnErrorAsync(Exception ex)
         {
             logger.Info("Received an error on stream. StreamGuid: {0}, StreamNamespace: {1}, Exception: {2}.", State.StreamGuid, State.StreamNamespace, ex);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private void InjectFault()

--- a/test/TestGrains/JsonEchoGrain.cs
+++ b/test/TestGrains/JsonEchoGrain.cs
@@ -9,7 +9,7 @@ namespace UnitTests.Grains
     {
         public Task Ping()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<JObject> EchoJson(JObject data)

--- a/test/TestGrains/LivenessTestGrain.cs
+++ b/test/TestGrains/LivenessTestGrain.cs
@@ -43,7 +43,7 @@ namespace UnitTests.Grains
         {
             this.label = label;
             logger.Info("SetLabel {0} received", label);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StartTimer()
@@ -51,13 +51,13 @@ namespace UnitTests.Grains
             logger.Info("StartTimer.");
             timer = base.RegisterTimer(TimerTick, null, TimeSpan.Zero, TimeSpan.FromSeconds(10));
             
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private Task TimerTick(object data)
         {
             logger.Info("TimerTick.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetRuntimeInstanceId()

--- a/test/TestGrains/LogTestGrain.cs
+++ b/test/TestGrains/LogTestGrain.cs
@@ -66,7 +66,7 @@ namespace TestGrains
 
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done; // do not wait for initial load
+            return Task.CompletedTask; // do not wait for initial load
         }
 
         public async Task SetAGlobal(int x)
@@ -85,7 +85,7 @@ namespace TestGrains
         public Task SetALocal(int x)
         {
             RaiseEvent(new UpdateA() { Val = x });
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         public async Task SetBGlobal(int x)
         {
@@ -96,7 +96,7 @@ namespace TestGrains
         public Task SetBLocal(int x)
         {
             RaiseEvent(new UpdateB() { Val = x });
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task IncrementAGlobal()
@@ -108,7 +108,7 @@ namespace TestGrains
         public Task IncrementALocal()
         {
             RaiseEvent(new IncrementA());
-            return TaskDone.Done;
+            return Task.CompletedTask;
 
         }
 
@@ -137,13 +137,13 @@ namespace TestGrains
         public Task AddReservationLocal(int val)
         {
             RaiseEvent(new AddReservation() { Val = val });
-            return TaskDone.Done;
+            return Task.CompletedTask;
 
         }
         public Task RemoveReservationLocal(int val)
         {
             RaiseEvent(new RemoveReservation() { Val = val });
-            return TaskDone.Done;
+            return Task.CompletedTask;
 
         }
         public async Task<int[]> GetReservationsGlobal()
@@ -184,7 +184,7 @@ namespace TestGrains
         public Task Deactivate()
         {
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<IReadOnlyList<object>> GetEventLog() {

--- a/test/TestGrains/MultipleImplicitSubscriptionGrain.cs
+++ b/test/TestGrains/MultipleImplicitSubscriptionGrain.cs
@@ -30,7 +30,7 @@ namespace UnitTests.Grains
                 {
                     logger.Info("Received a red event {0}", e);
                     redCounter++;
-                    return TaskDone.Done;
+                    return Task.CompletedTask;
                 });
 
             await blueStream.SubscribeAsync(
@@ -38,7 +38,7 @@ namespace UnitTests.Grains
                 {
                     logger.Info("Received a blue event {0}", e);
                     blueCounter++;
-                    return TaskDone.Done;
+                    return Task.CompletedTask;
                 });
         }
 

--- a/test/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/test/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -39,7 +39,7 @@ namespace UnitTests.Grains
         {
             logger = base.GetLogger("MultipleSubscriptionConsumerGrain " + base.IdentityString);
             logger.Info("OnActivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<StreamSubscriptionHandle<int>> BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
@@ -134,19 +134,19 @@ namespace UnitTests.Grains
                 counters.Item1.Clear();
                 counters.Item2.Clear();
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Deactivate()
         {
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private Task OnNext(int e, StreamSequenceToken token, int countCapture, Counter count)
@@ -158,14 +158,14 @@ namespace UnitTests.Grains
                 throw new Exception(String.Format("Got the wrong RequestContext value {0}.", contextValue));
             }
             count.Increment();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private Task OnError(Exception e, int countCapture, Counter error)
         {
             logger.Info("Got exception {0} on handle {1}", e.ToString(), countCapture);
             error.Increment();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/ObserverGrain.cs
+++ b/test/TestGrains/ObserverGrain.cs
@@ -21,7 +21,7 @@ namespace UnitTests.Grains
         public Task Subscribe(ISimpleGrainObserver observer)
         {
             this.Observer = observer;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         #endregion

--- a/test/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/TestGrains/ProducerEventCountingGrain.cs
@@ -43,7 +43,7 @@ namespace UnitTests.Grains
             IStreamProvider streamProvider = GetStreamProvider(providerToUse);
             IAsyncStream<int> stream = streamProvider.GetStream<int>(streamId, ConsumerEventCountingGrain.StreamNamespace);
             _producer = stream;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetNumberProduced()

--- a/test/TestGrains/ProgrammaticSubscribe/Passive_ConsumerGrain.cs
+++ b/test/TestGrains/ProgrammaticSubscribe/Passive_ConsumerGrain.cs
@@ -22,7 +22,7 @@ namespace UnitTests.Grains
             onAddCalledCount = 0;
             consumerObservers = new List<ICounterObserver>();
             consumerHandles = new List<IExternalStreamSubscriptionHandle>();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetCountOfOnAddFuncCalled()
@@ -56,7 +56,7 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task OnSubscribed(StreamSubscriptionHandle<int> handle)
@@ -88,7 +88,7 @@ namespace UnitTests.Grains
         {
             logger = base.GetLogger("Jerk_ConsumerGrain" + base.IdentityString);
             logger.Info("OnActivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         //Jerk_ConsumerGrai would unsubscrube on any subscription added to it
@@ -117,19 +117,19 @@ namespace UnitTests.Grains
         {
             this.NumConsumed++;
             this.logger.Info($"Consumer {this.GetHashCode()} OnNextAsync() with NumConsumed {this.NumConsumed}");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnCompletedAsync()
         {
             this.logger.Info($"Consumer {this.GetHashCode()} OnCompletedAsync()");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {
             this.logger.Info($"Consumer {this.GetHashCode()} OnErrorAsync({ex})");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 

--- a/test/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
+++ b/test/TestGrains/ProgrammaticSubscribe/TypedProducerGrain.cs
@@ -24,7 +24,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
             logger = base.GetLogger(this.GetType() + base.IdentityString);
             logger.Info("OnActivateAsync");
             numProducedItems = 0;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task BecomeProducer(Guid streamId, string streamNamespace, string providerToUse)
@@ -32,7 +32,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
             logger.Info("BecomeProducer");
             IStreamProvider streamProvider = base.GetStreamProvider(providerToUse);
             producer = streamProvider.GetStream<T>(streamId, streamNamespace);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StartPeriodicProducing(TimeSpan? firePeriod = null)
@@ -40,7 +40,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
             logger.Info("StartPeriodicProducing");
             var period = (firePeriod == null)? defaultFirePeriod : firePeriod;
             producerTimer = base.RegisterTimer(TimerCallback, null, TimeSpan.Zero, period.Value);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StopPeriodicProducing()
@@ -48,7 +48,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
             logger.Info("StopPeriodicProducing");
             producerTimer.Dispose();
             producerTimer = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetNumberProduced()
@@ -60,7 +60,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
         public Task ClearNumberProduced()
         {
             numProducedItems = 0;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Produce()
@@ -70,7 +70,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
 
         private Task TimerCallback(object state)
         {
-            return producerTimer != null ? Fire() : TaskDone.Done;
+            return producerTimer != null ? Fire() : Task.CompletedTask;
         }
 
         protected virtual Task ProducerOnNextAsync(IAsyncStream<T> theProducer)
@@ -88,7 +88,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
     public class TypedProducerGrainProducingInt : TypedProducerGrain<int>, ITypedProducerGrainProducingInt

--- a/test/TestGrains/PromiseForwardGrain.cs
+++ b/test/TestGrains/PromiseForwardGrain.cs
@@ -82,13 +82,13 @@ namespace UnitTests.Grains
         public Task Subscribe(ISimpleGrainObserver observer)
         {
             State.Observers.Subscribe(observer);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Unsubscribe(ISimpleGrainObserver observer)
         {
             State.Observers.Unsubscribe(observer);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         protected void RaiseStateUpdateEvent()

--- a/test/TestGrains/ProxyGrain.cs
+++ b/test/TestGrains/ProxyGrain.cs
@@ -11,7 +11,7 @@ namespace TestInternalGrains
         public Task CreateProxy(long key)
         {
             proxy = GrainFactory.GetGrain<ITestGrain>(key);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetRuntimeInstanceId()

--- a/test/TestGrains/ReentrantGrain.cs
+++ b/test/TestGrains/ReentrantGrain.cs
@@ -29,7 +29,7 @@ namespace UnitTests.Grains
         public Task SetSelf(IReentrantGrain self)
         {
             Self = self;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -67,7 +67,7 @@ namespace UnitTests.Grains
         {
             logger.Info("SetSelf {0}", self);
             Self = self;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -130,7 +130,7 @@ namespace UnitTests.Grains
             {
                 var logger = GetLogger();
                 logger.Info("Received stream item:" + item);
-                return TaskDone.Done;
+                return Task.CompletedTask;
             });
         }
 
@@ -145,7 +145,7 @@ namespace UnitTests.Grains
         public Task SetSelf(IMayInterleavePredicateGrain self)
         {
             Self = self;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -166,7 +166,7 @@ namespace UnitTests.Grains
         public Task SetSelf(IUnorderedNonReentrantGrain self)
         {
             Self = self;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
     [Reentrant]
@@ -178,7 +178,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             logger = GetLogger(GetType().Name + "-" + this.GetPrimaryKeyLong());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetCounter()
@@ -189,7 +189,7 @@ namespace UnitTests.Grains
         public Task SetDestination(long id)
         {
             destination = id;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Ping(int seconds)
@@ -221,7 +221,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             logger = GetLogger(GetType().Name + "-" + this.GetPrimaryKeyLong());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetCounter()
@@ -232,7 +232,7 @@ namespace UnitTests.Grains
         public Task SetDestination(long id)
         {
             destination = id;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Ping(int seconds)
@@ -265,7 +265,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             logger = GetLogger(GetType().Name + "-" + this.GetPrimaryKeyLong());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task FanOutReentrant(int offset, int num)
@@ -381,7 +381,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             logger = GetLogger(GetType().Name + "-" + this.GetPrimaryKeyLong());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task FanOutACReentrant(int offset, int num)
@@ -495,13 +495,13 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             logger = GetLogger(GetType().Name + "-" + this.GetPrimaryKeyLong());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetDestination(long id)
         {
             otherId = id;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Ping(TimeSpan wait)
@@ -529,13 +529,13 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             logger = GetLogger(GetType().Name + "-" + this.GetPrimaryKeyLong());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetDestination(long id)
         {
             otherId = id;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Ping(TimeSpan wait)

--- a/test/TestGrains/RequestContextTestGrain.cs
+++ b/test/TestGrains/RequestContextTestGrain.cs
@@ -29,7 +29,7 @@ namespace UnitTests.Grains
 
         public async Task<string> TraceIdDelayedEcho2()
         {
-            await TaskDone.Done;
+            await Task.CompletedTask;
             return RequestContext.Get("TraceId") as string;
         }
 
@@ -57,7 +57,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             logger = base.GetLogger();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
 #region Implementation of IRequestContextTaskGrain
@@ -97,7 +97,7 @@ namespace UnitTests.Grains
             string traceIdOutside = RequestContext.Get("TraceId") as string;
             logger.Info(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
 
-            return TaskDone.Done.ContinueWith(task =>
+            return Task.CompletedTask.ContinueWith(task =>
             {
                 string traceIdInside = RequestContext.Get("TraceId") as string;
                 logger.Info(0, "{0}: Inside TraceId={1}", method, traceIdInside);
@@ -112,7 +112,7 @@ namespace UnitTests.Grains
             string traceIdOutside = RequestContext.Get("TraceId") as string;
             logger.Info(0, "{0}: Outside TraceId={1}", method, traceIdOutside);
 
-            string traceId = await TaskDone.Done.ContinueWith(task =>
+            string traceId = await Task.CompletedTask.ContinueWith(task =>
             {
                 string traceIdInside = RequestContext.Get("TraceId") as string;
                 logger.Info(0, "{0}: Inside TraceId={1}", method, traceIdInside);

--- a/test/TestGrains/SampleStreamingGrain.cs
+++ b/test/TestGrains/SampleStreamingGrain.cs
@@ -21,19 +21,19 @@ namespace UnitTests.Grains
         {
             hostingGrain.logger.Info("OnNextAsync(item={0}, token={1})", item, token != null ? token.ToString() : "null");
             hostingGrain.numConsumedItems++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnCompletedAsync()
         {
             hostingGrain.logger.Info("OnCompletedAsync()");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {
             hostingGrain.logger.Info("OnErrorAsync({0})", ex);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -51,7 +51,7 @@ namespace UnitTests.Grains
             logger = base.GetLogger("SampleStreaming_ProducerGrain " + base.IdentityString);
             logger.Info("OnActivateAsync");
             numProducedItems = 0;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task BecomeProducer(Guid streamId, string streamNamespace, string providerToUse)
@@ -59,14 +59,14 @@ namespace UnitTests.Grains
             logger.Info("BecomeProducer");
             IStreamProvider streamProvider = base.GetStreamProvider(providerToUse);
             producer = streamProvider.GetStream<int>(streamId, streamNamespace);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StartPeriodicProducing()
         {
             logger.Info("StartPeriodicProducing");
             producerTimer = base.RegisterTimer(TimerCallback, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(10));
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StopPeriodicProducing()
@@ -74,7 +74,7 @@ namespace UnitTests.Grains
             logger.Info("StopPeriodicProducing");
             producerTimer.Dispose();
             producerTimer = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetNumberProduced()
@@ -86,7 +86,7 @@ namespace UnitTests.Grains
         public Task ClearNumberProduced()
         {
             numProducedItems = 0;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Produce()
@@ -96,7 +96,7 @@ namespace UnitTests.Grains
 
         private Task TimerCallback(object state)
         {
-            return producerTimer != null? Fire(): TaskDone.Done;
+            return producerTimer != null? Fire(): Task.CompletedTask;
         }
 
         private async Task Fire([CallerMemberName] string caller = null)
@@ -110,7 +110,7 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -128,7 +128,7 @@ namespace UnitTests.Grains
             logger.Info("OnActivateAsync");
             numConsumedItems = 0;
             consumerHandle = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
@@ -158,7 +158,7 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -175,7 +175,7 @@ namespace UnitTests.Grains
             logger.Info( "OnActivateAsync" );
             numConsumedItems = 0;
             consumerHandle = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
@@ -206,25 +206,25 @@ namespace UnitTests.Grains
         {
             logger.Info( "OnNextAsync({0}{1})", item, token != null ? token.ToString() : "null" );
             numConsumedItems++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnCompletedAsync()
         {
             logger.Info( "OnCompletedAsync()" );
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnErrorAsync( Exception ex )
         {
             logger.Info( "OnErrorAsync({0})", ex );
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/SimpleGenericGrain.cs
+++ b/test/TestGrains/SimpleGenericGrain.cs
@@ -12,12 +12,12 @@ namespace UnitTests.Grains
         public virtual Task Set(T t)
         {
             Value = t;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual Task Transform()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<T> Get()
@@ -32,7 +32,7 @@ namespace UnitTests.Grains
             if(!thisReference.Equals(clientReference))
                 throw new Exception(String.Format("Case_3: 2 grain references are different, while should have been the same: gr1={0}, gr2={1}", thisReference, clientReference));
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/SimpleGrain.cs
+++ b/test/TestGrains/SimpleGrain.cs
@@ -22,26 +22,26 @@ namespace UnitTests.Grains
         {
             logger = GetLogger(String.Format("{0}-{1}-{2}", typeof(SimpleGrain).Name, base.IdentityString, base.RuntimeIdentity));
             logger.Info("Activate.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetA(int a)
         {
             logger.Info("SetA={0}", a);
             A = a;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetB(int b)
         {
             this.B = b;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task IncrementA()
         {
             A = A + 1;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetAxB()
@@ -62,7 +62,7 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/SimpleObserverableGrain.cs
+++ b/test/TestGrains/SimpleObserverableGrain.cs
@@ -21,7 +21,7 @@ namespace UnitTests.Grains
             Observers = new ObserverSubscriptionManager<ISimpleGrainObserver>();
             logger = GetLogger(String.Format("{0}-{1}-{2}", typeof(SimpleObserverableGrain).Name, base.IdentityString, base.RuntimeIdentity));
             logger.Info("Activate.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task SetA(int a)
@@ -80,13 +80,13 @@ namespace UnitTests.Grains
         public Task Subscribe(ISimpleGrainObserver observer)
         {
             Observers.Subscribe(observer);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Unsubscribe(ISimpleGrainObserver observer)
         {
             Observers.Unsubscribe(observer);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetRuntimeInstanceId()

--- a/test/TestGrains/SimplePersistentGrain.cs
+++ b/test/TestGrains/SimplePersistentGrain.cs
@@ -83,7 +83,7 @@ namespace UnitTests.Grains
         public Task SetRequestContext(int data)
         {
             RequestContext.Set("GrainInfo", data);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
+++ b/test/TestGrains/SlowConsumingGrains/SlowConsumingGrain.cs
@@ -23,7 +23,7 @@ namespace UnitTests.Grains
             logger = base.GetLogger(this.GetType().Name + base.IdentityString);
             logger.Info("OnActivateAsync");
             ConsumerHandle = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetNumberConsumed()
@@ -78,13 +78,13 @@ namespace UnitTests.Grains
         public Task OnCompletedAsync()
         {
             this.logger.Info($"Consumer {this.GetHashCode()} OnCompletedAsync()");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {
             this.logger.Info($"Consumer {this.GetHashCode()} OnErrorAsync({ex})");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 

--- a/test/TestGrains/SpecializedSimpleGenericGrain.cs
+++ b/test/TestGrains/SpecializedSimpleGenericGrain.cs
@@ -8,7 +8,7 @@ namespace UnitTests.Grains
         public override Task Transform()
         {
             Value = Value * 2.0;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/StatelessWorkerGrain.cs
+++ b/test/TestGrains/StatelessWorkerGrain.cs
@@ -26,7 +26,7 @@ namespace UnitTests.Grains
             activationGuid = Guid.NewGuid();
             logger = GetLogger(String.Format("{0}", activationGuid));
             logger.Info("Activate.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task LongCall()
@@ -56,7 +56,7 @@ namespace UnitTests.Grains
         private static Task TimerCallback(object state)
         {
             ((TaskCompletionSource<bool>)state).SetResult(true);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
 

--- a/test/TestGrains/StatsCollectorGrain.cs
+++ b/test/TestGrains/StatsCollectorGrain.cs
@@ -13,13 +13,13 @@ namespace UnitTests.Stats
         public Task ReportMetricsCalled()
         {
             numStatsCalls++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task ReportStatsCalled()
         {
             numMetricsCalls++;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<long> GetReportMetricsCallCount()

--- a/test/TestGrains/StreamInterceptionGrain.cs
+++ b/test/TestGrains/StreamInterceptionGrain.cs
@@ -35,7 +35,7 @@ namespace UnitTests.Grains
                 (value, token) =>
                 {
                     this.lastStreamValue = value;
-                    return TaskDone.Done;
+                    return Task.CompletedTask;
                 });
             await base.OnActivateAsync();
         }

--- a/test/TestGrains/StuckGrain.cs
+++ b/test/TestGrains/StuckGrain.cs
@@ -54,7 +54,7 @@ namespace UnitTests.Grains
         public Task NonBlockingCall()
         {
             counters[this.GetPrimaryKey()] = counters[this.GetPrimaryKey()] + 1;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetNonBlockingCallCounter()
@@ -97,7 +97,7 @@ namespace UnitTests.Grains
         public Task Release(Guid key)
         {
             StuckGrain.Release(key);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<bool> IsActivated(Guid key)

--- a/test/TestInternalGrains/ActivateDeactivateTestGrain.cs
+++ b/test/TestInternalGrains/ActivateDeactivateTestGrain.cs
@@ -55,7 +55,7 @@ namespace UnitTests.Grains
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -114,7 +114,7 @@ namespace UnitTests.Grains
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -195,7 +195,7 @@ namespace UnitTests.Grains
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -296,7 +296,7 @@ namespace UnitTests.Grains
             Assert.False(doingActivate, "Activate method should have finished");
             Assert.False(doingDeactivate, "Deactivate method should not be running yet");
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -369,13 +369,13 @@ namespace UnitTests.Grains
             logger = GetLogger();
             logger.Info("OnActivateAsync");
             this.DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> DoSomething()
@@ -398,7 +398,7 @@ namespace UnitTests.Grains
             grain = GrainFactory.GetGrain<ITestGrain>(1);
             logger.Info("OnActivateAsync");
             grain = GrainFactory.GetGrain<ITestGrain>(1);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<string> DoSomething()

--- a/test/TestInternalGrains/ActivationGCTestGrains.cs
+++ b/test/TestInternalGrains/ActivationGCTestGrains.cs
@@ -11,7 +11,7 @@ namespace UnitTests.Grains
     {
         public Task Nop()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -19,7 +19,7 @@ namespace UnitTests.Grains
     {
         public Task Nop()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -35,7 +35,7 @@ namespace UnitTests.Grains
 
         public Task Nop()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Delay(TimeSpan dt)
@@ -57,7 +57,7 @@ namespace UnitTests.Grains
 
             burstCount = count;
             this.catalog.ActivationCollector.Debug_OnDecideToCollectActivation = OnCollectActivation;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private void OnCollectActivation(GrainId grainId)
@@ -79,7 +79,7 @@ namespace UnitTests.Grains
     {
         public Task Nop()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -88,7 +88,7 @@ namespace UnitTests.Grains
     {
         public Task Nop()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Delay(TimeSpan dt)

--- a/test/TestInternalGrains/ClientAddressableTestGrain.cs
+++ b/test/TestInternalGrains/ClientAddressableTestGrain.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Grains
         public Task SetTarget(IClientAddressableTestClientObject target)
         {
             this.target = target;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> HappyPath(string message)

--- a/test/TestInternalGrains/ClientAddressableTestRendezvousGrain.cs
+++ b/test/TestInternalGrains/ClientAddressableTestRendezvousGrain.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Grains
         public Task SetProducer(IClientAddressableTestProducer producer)
         {
             this.producer = producer;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestInternalGrains/CollectionTestGrain.cs
+++ b/test/TestInternalGrains/CollectionTestGrain.cs
@@ -27,13 +27,13 @@ namespace UnitTests.Grains
             logger.Info("OnActivateAsync.");
             activated = DateTime.UtcNow;
             counter = 0;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             Logger().Info("OnDeactivateAsync.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual Task<int> IncrCounter()
@@ -55,14 +55,14 @@ namespace UnitTests.Grains
         {
             Logger().Info("DeactivateSelf.");
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetOther(ICollectionTestGrain other)
         {
             Logger().Info("SetOther.");
             this.other = other;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<TimeSpan> GetOtherAge()
@@ -85,7 +85,7 @@ namespace UnitTests.Grains
         public Task StartTimer(TimeSpan timerPeriod, TimeSpan delayPeriod)
         {
             RegisterTimer(TimerCallback, delayPeriod, TimeSpan.Zero, timerPeriod);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private async Task TimerCallback(object state)
@@ -119,13 +119,13 @@ namespace UnitTests.Grains
             logger = GetLogger(String.Format("ReentrantCollectionTestGrain {0} {1} on {2}.", Identity, Data.ActivationId, RuntimeIdentity));
             logger.Info("OnActivateAsync.");
             counter = 0;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             Logger().Info("OnDeactivateAsync.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override async Task<int> IncrCounter()

--- a/test/TestInternalGrains/EchoTaskGrain.cs
+++ b/test/TestInternalGrains/EchoTaskGrain.cs
@@ -124,7 +124,7 @@ namespace UnitTests.Grains
         public Task PingAsync()
         {
             logger.Info("IEchoGrainAsync.Ping");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task PingLocalSiloAsync()

--- a/test/TestInternalGrains/ErrorGrain.cs
+++ b/test/TestInternalGrains/ErrorGrain.cs
@@ -19,13 +19,13 @@ namespace UnitTests.Grains
         {
             logger = GetLogger(String.Format("ErrorGrain-{0}-{1}-{2}", RuntimeIdentity, Identity, Data.ActivationId));
             logger.Info("Activate.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task LogMessage(string msg)
         {
            logger.Info(msg);
-           return TaskDone.Done;
+           return Task.CompletedTask;
         }
 
         public Task SetAError(int a)
@@ -53,7 +53,7 @@ namespace UnitTests.Grains
         public Task LongMethod(int waitTime)
         {
             Thread.Sleep(waitTime);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task LongMethodWithError(int waitTime)
@@ -72,7 +72,7 @@ namespace UnitTests.Grains
         public Task Dispose()
         {
             logger.Info("Dispose()");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> UnobservedErrorImmideate()
@@ -177,7 +177,7 @@ namespace UnitTests.Grains
 
         public Task AddChildren(List<IErrorGrain> children)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<bool> ExecuteDelayed(TimeSpan delay)

--- a/test/TestInternalGrains/ExtensionTestGrain.cs
+++ b/test/TestInternalGrains/ExtensionTestGrain.cs
@@ -36,14 +36,14 @@ namespace UnitTests.Grains
                 }
             }
             ExtensionProperty = name;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task RemoveExtension()
         {
             runtimeClient.RemoveExtension(extender);
             extender = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -76,14 +76,14 @@ namespace UnitTests.Grains
                 }
             }
             ExtensionProperty = name;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task RemoveExtension()
         {
             runtimeClient.RemoveExtension(extender);
             extender = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -98,7 +98,7 @@ namespace UnitTests.Grains
         }
         
         public Task DoSomething() {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         
         public override Task OnActivateAsync()

--- a/test/TestInternalGrains/MultifacetFactoryTestGrain.cs
+++ b/test/TestInternalGrains/MultifacetFactoryTestGrain.cs
@@ -38,13 +38,13 @@ namespace UnitTests.Grains
         public Task SetReader(IMultifacetReader reader)
         {
             State.Reader = reader;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task SetWriter(IMultifacetWriter writer)
         {
             State.Writer = writer;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestInternalGrains/MultifacetTestGrain.cs
+++ b/test/TestInternalGrains/MultifacetTestGrain.cs
@@ -26,7 +26,7 @@ namespace UnitTests.Grains
         public Task SetValue(int x)
         {
             State.Value = x;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         #endregion

--- a/test/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/TestInternalGrains/PersistenceTestGrains.cs
@@ -67,7 +67,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<bool> CheckStateInit()
@@ -90,7 +90,7 @@ namespace UnitTests.Grains
 
         public Task DoSomething()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task DoWrite(int val)
@@ -128,7 +128,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetValue()
@@ -159,7 +159,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             this.serializationManager = this.ServiceProvider.GetRequiredService<SerializationManager>();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetValue()
@@ -207,7 +207,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetValue()
@@ -249,7 +249,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             GetLogger().Warn(1, "OnActivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task DoSomething()
@@ -266,13 +266,13 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync()
         {
             GetLogger().Info(1, "OnActivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task DoSomething()
         {
             GetLogger().Info(1, "DoSomething");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -282,7 +282,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetValue()
@@ -314,7 +314,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<T> GetValue()
@@ -346,7 +346,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetValue()
@@ -385,7 +385,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetValue()
@@ -419,7 +419,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<T> GetValue()
@@ -451,7 +451,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetValue()
@@ -491,7 +491,7 @@ namespace UnitTests.Grains
     {
         public override Task OnActivateAsync()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetValue()
@@ -582,7 +582,7 @@ namespace UnitTests.Grains
             else
                 throw new Exception("Already a friend.");
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<List<IUser>> GetFriends()
@@ -666,7 +666,7 @@ namespace UnitTests.Grains
         {
             logger.Info("Setup");
             _other = other;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task SetOne(int val)
@@ -863,7 +863,7 @@ namespace UnitTests.Grains
             if (level > 0)
             {
                 Log("SetOne {0}-{1}_1. Before await Task.Done.", iter, level);
-                await TaskDone.Done;
+                await Task.CompletedTask;
                 Log("SetOne {0}-{1}_2. After await Task.Done.", iter, level);
                 CheckRuntimeEnvironment(String.Format("SetOne {0}-{1}_3", iter, level));
                 Log("SetOne {0}-{1}_4. Before await Task.Delay.", iter, level);
@@ -990,7 +990,7 @@ namespace UnitTests.Grains
         {
             logger.Info("SetOne");
             State.One = val;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -1072,7 +1072,7 @@ namespace UnitTests.Grains
             //TestSerializeFuncPtr("Instance Func In Grain Class", instanceFuncInGrainClass);
             //TestSerializeFuncPtr("Func Lambda - Instance field", instanceFilterFunc);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Test_Serialize_Predicate()
@@ -1089,7 +1089,7 @@ namespace UnitTests.Grains
             // Fails
             //TestSerializePredicate("Predicate Lambda - Instance field", instancePredicate);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Test_Serialize_Predicate_Class()
@@ -1099,7 +1099,7 @@ namespace UnitTests.Grains
             // Works OK
             TestSerializePredicate("Predicate Class Instance", pred.FilterFunc);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Test_Serialize_Predicate_Class_Param(IMyPredicate pred)
@@ -1107,7 +1107,7 @@ namespace UnitTests.Grains
             // Works OK
             TestSerializePredicate("Predicate Class Instance passed as param", pred.FilterFunc);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         // Utility methods

--- a/test/TestInternalGrains/PlacementTestGrain.cs
+++ b/test/TestInternalGrains/PlacementTestGrain.cs
@@ -38,7 +38,7 @@ namespace UnitTests.Grains
 
         public Task Nop()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StartLocalGrains(List<Guid> keys)

--- a/test/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/TestInternalGrains/ReminderTestGrain2.cs
@@ -53,7 +53,7 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<IGrainReminder> StartReminder(string reminderName, TimeSpan? p = null, bool validate = false)
@@ -105,7 +105,7 @@ namespace UnitTests.Grains
             if (sequenceNumber < sequence[reminderName])
             {
                 logger.Info("ReceiveReminder: {0} Incorrect tick {1} vs. {2} with status {3}.", reminderName, sequence[reminderName], sequenceNumber, status);
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             sequence[reminderName] = sequenceNumber;
@@ -115,7 +115,7 @@ namespace UnitTests.Grains
             string counterValue = sequence[reminderName].ToString(CultureInfo.InvariantCulture);
             File.WriteAllText(fileName, counterValue);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task StopReminder(string reminderName)
@@ -259,7 +259,7 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync()
         {
             logger.Info("OnDeactivateAsync.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<IGrainReminder> StartReminder(string reminderName, TimeSpan? p = null, bool validate = false)
@@ -320,7 +320,7 @@ namespace UnitTests.Grains
             if (sequenceNumber < sequence[reminderName])
             {
                 logger.Info("{0} Incorrect tick {1} vs. {2} with status {3}.", reminderName, sequence[reminderName], sequenceNumber, status);
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             sequence[reminderName] = sequenceNumber;
@@ -328,7 +328,7 @@ namespace UnitTests.Grains
 
             File.WriteAllText(GetFileName(reminderName), sequence[reminderName].ToString());
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task StopReminder(string reminderName)
@@ -406,7 +406,7 @@ namespace UnitTests.Grains
         {
             logger = GetLogger(String.Format("WrongReminderGrain_{0}", Identity));
             logger.Info("OnActivateAsync.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<bool> StartReminder(string reminderName)

--- a/test/TestInternalGrains/SerializerPresenceTestGrain.cs
+++ b/test/TestInternalGrains/SerializerPresenceTestGrain.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Grains
         public Task TakeSerializedData(object data)
         {
             // nothing to do
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -99,7 +99,7 @@ namespace UnitTests.Grains
             watcher = GrainFactory.GetGrain<IActivateDeactivateWatcherGrain>(0);
             return watcher.RecordActivateCall(IdentityString);
 #else
-            return TaskDone.Done;
+            return Task.CompletedTask;
 #endif
         }
 
@@ -108,7 +108,7 @@ namespace UnitTests.Grains
 #if COUNT_ACTIVATE_DEACTIVATE
             return watcher.RecordDeactivateCall(IdentityString);
 #else
-            return TaskDone.Done;
+            return Task.CompletedTask;
 #endif
         }
 
@@ -212,7 +212,7 @@ namespace UnitTests.Grains
         public Task Ping()
         {
             logger.Info("Ping");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
@@ -410,7 +410,7 @@ namespace UnitTests.Grains
         public Task Ping()
         {
             logger.Info("Ping");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task SendItem(int item)
@@ -496,7 +496,7 @@ namespace UnitTests.Grains
                 logger.Verbose("Received OnNextAsync - Item={0} - Total Items={1} Errors={2}", item, NumItems, NumErrors);
             }
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnCompletedAsync()
@@ -505,7 +505,7 @@ namespace UnitTests.Grains
             {
                 logger.Info("Receive OnCompletedAsync - Total Items={0} Errors={1}", NumItems, NumErrors);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
@@ -517,7 +517,7 @@ namespace UnitTests.Grains
                 logger.Warn(1, "Received OnErrorAsync - Exception={0} - Total Items={1} Errors={2}", ex, NumItems, NumErrors);
             }
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 

--- a/test/TestInternalGrains/StreamReliabilityTestGrains.cs
+++ b/test/TestInternalGrains/StreamReliabilityTestGrains.cs
@@ -131,7 +131,7 @@ namespace UnitTests.Grains
         public Task Ping()
         {
             logger.Info("Ping");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
 #if USE_GENERICS
@@ -318,20 +318,20 @@ namespace UnitTests.Grains
     //        NumItems++;
     //        if (logger.IsVerbose)
     //            logger.Verbose("Received OnNextAsync - Item={0} - Total Items={1} Errors={2}", item, NumItems, NumErrors);
-    //        return TaskDone.Done;
+    //        return Task.CompletedTask;
     //    }
 
     //    public Task OnCompletedAsync()
     //    {
     //        logger.Info("Receive OnCompletedAsync - Total Items={0} Errors={1}", NumItems, NumErrors);
-    //        return TaskDone.Done;
+    //        return Task.CompletedTask;
     //    }
 
     //    public Task OnErrorAsync(Exception ex)
     //    {
     //        NumErrors++;
     //        logger.Warn(1, "Received OnErrorAsync - Exception={0} - Total Items={1} Errors={2}", ex, NumItems, NumErrors);
-    //        return TaskDone.Done;
+    //        return Task.CompletedTask;
     //    }
     //}
 
@@ -349,7 +349,7 @@ namespace UnitTests.Grains
             logger = GetLogger("StreamUnsubscribeTestGrain-" + this.IdentityString);
             logger.Info(String.Format("OnActivateAsync IsProducer = {0}, IsConsumer = {1}.",
                 State.IsProducer, State.ConsumerSubscriptionHandles != null && State.ConsumerSubscriptionHandles.Count > 0));
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task Subscribe(Guid streamId, string providerName)

--- a/test/TestInternalGrains/StreamingGrain.cs
+++ b/test/TestInternalGrains/StreamingGrain.cs
@@ -82,19 +82,19 @@ namespace UnitTests.Grains
             {
                 _logger.Verbose(str);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnCompletedAsync()
         {            
             _logger.Info("ConsumerObserver.OnCompletedAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task OnErrorAsync(Exception ex)
         {            
             _logger.Info("ConsumerObserver.OnErrorAsync: ex={0}", ex);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task BecomeConsumer(Guid streamId, IStreamProvider streamProvider, string streamNamespace)
@@ -306,7 +306,7 @@ namespace UnitTests.Grains
             _timers.Add(timer.Handle, timer);
             _expectedItemsProduced += count;
             timer.StartTimer();
-            return TaskDone.Done;        
+            return Task.CompletedTask;        
         }
 
         private void RemoveTimer(IDisposable handle)
@@ -360,7 +360,7 @@ namespace UnitTests.Grains
         {
             _logger.Info("StopBeingProducer");
             if (!_cleanedUpFlag.TrySet())
-                return TaskDone.Done;
+                return Task.CompletedTask;
 
             if (_timers != null)
             {
@@ -378,7 +378,7 @@ namespace UnitTests.Grains
                 _timers = null;
             }
             _observer = null; // Disposing
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task VerifyFinished()
@@ -477,13 +477,13 @@ namespace UnitTests.Grains
             _logger.Info("OnActivateAsync");
              _producers = new List<IProducerObserver>();
             _cleanedUpFlag = new InterlockedFlag();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             _logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual Task BecomeProducer(Guid streamId, string providerToUse, string streamNamespace)
@@ -493,7 +493,7 @@ namespace UnitTests.Grains
             ProducerObserver producer = ProducerObserver.NewObserver(_logger, GrainFactory);
             producer.BecomeProducer(streamId, GetStreamProvider(providerToUse), streamNamespace);
             _producers.Add(producer);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual async Task ProduceSequentialSeries(int count)
@@ -573,7 +573,7 @@ namespace UnitTests.Grains
         {
             _logger.Info("DeactivateProducerOnIdle");
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -655,13 +655,13 @@ namespace UnitTests.Grains
             _logger = GetLogger("Test.Streaming_ConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
             _logger.Info("OnActivateAsync");    
             _observers = new List<IConsumerObserver>();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
         {
             _logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async virtual Task BecomeConsumer(Guid streamId, string providerToUse, string streamNamespace)
@@ -699,7 +699,7 @@ namespace UnitTests.Grains
 
             Task.Delay(TimeSpan.FromSeconds(2)).ContinueWith(task => { _logger.Info("DeactivateConsumerOnIdle ContinueWith fired."); }).Ignore(); // .WithTimeout(TimeSpan.FromSeconds(2));
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -785,19 +785,19 @@ namespace UnitTests.Grains
         {
             _logger = GetLogger("Test.Streaming_ProducerConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + Data.ActivationId);
             _logger.Info("OnActivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         public override Task OnDeactivateAsync()
         {
             _logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task BecomeProducer(Guid streamId, string providerToUse, string streamNamespace)
         {
             _producer = ProducerObserver.NewObserver(MyLogger(), GrainFactory);
             _producer.BecomeProducer(streamId, GetStreamProvider(providerToUse), streamNamespace);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task ProduceSequentialSeries(int count)
@@ -875,14 +875,14 @@ namespace UnitTests.Grains
         public Task DeactivateConsumerOnIdle()
         {
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task DeactivateProducerOnIdle()
         {
             _logger.Info("DeactivateProducerOnIdle");
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -905,7 +905,7 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync()
         {
             _logger.Info("OnDeactivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task BecomeConsumer(Guid streamGuid, string providerToUse, string streamNamespace)
@@ -963,7 +963,7 @@ namespace UnitTests.Grains
 
             Task.Delay(TimeSpan.FromSeconds(2)).ContinueWith(task => { _logger.Info("DeactivateConsumerOnIdle ContinueWith fired."); }).Ignore(); // .WithTimeout(TimeSpan.FromSeconds(2));
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
     

--- a/test/TestInternalGrains/StreamingImmutabilityTestGrain.cs
+++ b/test/TestInternalGrains/StreamingImmutabilityTestGrain.cs
@@ -35,7 +35,7 @@ namespace UnitTests.Grains
                 _myObject = new StreamImmutabilityTestObject();
 
             _myObject.MyString = value;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetTestObjectStringProperty()
@@ -51,7 +51,7 @@ namespace UnitTests.Grains
         private Task OnNextAsync(StreamImmutabilityTestObject myObject, StreamSequenceToken streamSequenceToken)
         {
             _myObject = myObject;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 

--- a/test/TestInternalGrains/StressTestGrain.cs
+++ b/test/TestInternalGrains/StressTestGrain.cs
@@ -23,7 +23,7 @@ namespace UnitTests.Grains
             label = this.GetPrimaryKeyLong().ToString();
             logger.Info("OnActivateAsync");
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetLabel()
@@ -36,7 +36,7 @@ namespace UnitTests.Grains
             this.label = label;
 
             //logger.Info("SetLabel {0} received", label);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<IStressTestGrain> GetGrainReference()
@@ -80,7 +80,7 @@ namespace UnitTests.Grains
 
         public Task Ping(byte[] data)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task PingWithDelay(byte[] data, TimeSpan delay)
@@ -90,13 +90,13 @@ namespace UnitTests.Grains
 
         public Task Send(byte[] data)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task DeactivateSelf()
         {
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -111,7 +111,7 @@ namespace UnitTests.Grains
             label = this.GetPrimaryKeyLong().ToString();
             logger = base.GetLogger("ReentrantStressTestGrain " + base.Data.Address.ToString());
             logger.Info("OnActivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetRuntimeInstanceId()
@@ -126,7 +126,7 @@ namespace UnitTests.Grains
 
         public Task Ping(byte[] data)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task PingWithDelay(byte[] data, TimeSpan delay)
@@ -145,7 +145,7 @@ namespace UnitTests.Grains
                 return GrainFactory.GetGrain<IReentrantLocalStressTestGrain>(nextGrain)
                     .PingMutableArray(data, -1, false);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task PingImmutableArray(Immutable<byte[]> data, long nextGrain, bool nextGrainIsRemote)
@@ -160,7 +160,7 @@ namespace UnitTests.Grains
                 return GrainFactory.GetGrain<IReentrantLocalStressTestGrain>(nextGrain)
                     .PingImmutableArray(data, -1, false);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task PingMutableDictionary(Dictionary<int, string> data, long nextGrain, bool nextGrainIsRemote)
@@ -175,7 +175,7 @@ namespace UnitTests.Grains
                 return GrainFactory.GetGrain<IReentrantLocalStressTestGrain>(nextGrain)
                     .PingMutableDictionary(data, -1, false);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task PingImmutableDictionary(Immutable<Dictionary<int, string>> data, long nextGrain,
@@ -191,7 +191,7 @@ namespace UnitTests.Grains
                 return GrainFactory.GetGrain<IReentrantLocalStressTestGrain>(nextGrain)
                     .PingImmutableDictionary(data, -1, false);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task InterleavingConsistencyTest(int numItems)
@@ -266,7 +266,7 @@ namespace UnitTests.Grains
             label = this.GetPrimaryKeyLong().ToString();
             logger = base.GetLogger("ReentrantLocalStressTestGrain " + base.Data.Address.ToString());
             logger.Info("OnActivateAsync");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<byte[]> Echo(byte[] data)
@@ -281,7 +281,7 @@ namespace UnitTests.Grains
 
         public Task Ping(byte[] data)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task PingWithDelay(byte[] data, TimeSpan delay)
@@ -300,7 +300,7 @@ namespace UnitTests.Grains
                 return GrainFactory.GetGrain<IReentrantLocalStressTestGrain>(nextGrain)
                     .PingMutableArray(data, -1, false);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task PingImmutableArray(Immutable<byte[]> data, long nextGrain, bool nextGrainIsRemote)
@@ -315,7 +315,7 @@ namespace UnitTests.Grains
                 return GrainFactory.GetGrain<IReentrantLocalStressTestGrain>(nextGrain)
                     .PingImmutableArray(data, -1, false);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task PingMutableDictionary(Dictionary<int, string> data, long nextGrain, bool nextGrainIsRemote)
@@ -330,7 +330,7 @@ namespace UnitTests.Grains
                 return GrainFactory.GetGrain<IReentrantLocalStressTestGrain>(nextGrain)
                     .PingMutableDictionary(data, -1, false);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task PingImmutableDictionary(Immutable<Dictionary<int, string>> data, long nextGrain,
@@ -346,7 +346,7 @@ namespace UnitTests.Grains
                 return GrainFactory.GetGrain<IReentrantLocalStressTestGrain>(nextGrain)
                     .PingImmutableDictionary(data, -1, false);
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestInternalGrains/TestGrain.cs
+++ b/test/TestInternalGrains/TestGrain.cs
@@ -54,7 +54,7 @@ namespace UnitTests.Grains
         {
             this.label = label;
             logger.Info("SetLabel {0} received", label);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StartTimer()
@@ -62,13 +62,13 @@ namespace UnitTests.Grains
             logger.Info("StartTimer.");
             timer = base.RegisterTimer(TimerTick, null, TimeSpan.Zero, TimeSpan.FromSeconds(10));
             
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private Task TimerTick(object data)
         {
             logger.Info("TimerTick.");
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public async Task<Tuple<string, string>> TestRequestContext()
@@ -145,7 +145,7 @@ namespace UnitTests.Grains
             logger = GetLogger("GuidTestGrain " + Data.Address);
             logger.Info("OnActivateAsync");
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         #region Implementation of ITestGrain
@@ -163,7 +163,7 @@ namespace UnitTests.Grains
         public Task SetLabel(string label)
         {
             this.label = label;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<string> GetRuntimeInstanceId()

--- a/test/TestInternalGrains/TimerGrain.cs
+++ b/test/TestInternalGrains/TimerGrain.cs
@@ -30,14 +30,14 @@ namespace UnitTestGrains
             context = RuntimeContext.Current.ActivationContext;
             defaultTimer = this.RegisterTimer(Tick, DefaultTimerName, period, period);
             allTimers = new Dictionary<string, IDisposable>();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StopDefaultTimer()
         {
             ThrowIfDeactivating();
             defaultTimer.Dispose();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private Task Tick(object data)
@@ -65,7 +65,7 @@ namespace UnitTestGrains
                 timer.Dispose();
             }
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<TimeSpan> GetTimerPeriod()
@@ -85,14 +85,14 @@ namespace UnitTestGrains
             {
                 counter = value;
             }
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         public Task StartTimer(string timerName)
         {
             ThrowIfDeactivating();
             IDisposable timer = this.RegisterTimer(Tick, timerName, TimeSpan.Zero, period);
             allTimers.Add(timerName, timer);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StopTimer(string timerName)
@@ -100,21 +100,21 @@ namespace UnitTestGrains
             ThrowIfDeactivating();
             IDisposable timer = allTimers[timerName];
             timer.Dispose();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task LongWait(TimeSpan time)
         {
             ThrowIfDeactivating();
             Thread.Sleep(time);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Deactivate()
         {
             deactivating = true;
             DeactivateOnIdle();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private void ThrowIfDeactivating()
@@ -142,7 +142,7 @@ namespace UnitTestGrains
             logger = this.GetLogger("TimerCallGrain_" + base.Data.Address);
             context = RuntimeContext.Current.ActivationContext;
             activationTaskScheduler = TaskScheduler.Current;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StartTimer(string name, TimeSpan delay)
@@ -150,7 +150,7 @@ namespace UnitTestGrains
             logger.Info("StartTimer Name={0} Delay={1}", name, delay);
             this.timerName = name;
             this.timer = base.RegisterTimer(TimerTick, name, delay, Constants.INFINITE_TIMESPAN); // One shot timer
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task StopTimer(string name)
@@ -161,7 +161,7 @@ namespace UnitTestGrains
                 throw new ArgumentException(string.Format("Wrong timer name: Expected={0} Actual={1}", this.timerName, name));
             }
             timer.Dispose();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private async Task TimerTick(object data)

--- a/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
@@ -30,7 +30,7 @@ namespace Tester.ClientConnectionTests
 
         public Task InitializeGatewayListProvider(ClientConfiguration clientConfiguration, Logger logger)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<IList<Uri>> GetGateways()

--- a/test/Tester/GrainServiceTests/CustomGrainService.cs
+++ b/test/Tester/GrainServiceTests/CustomGrainService.cs
@@ -76,7 +76,7 @@ namespace Tester
         protected override Task StartInBackground()
         {
             startedInBackground = true;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task<bool> HasStarted()

--- a/test/Tester/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Tester/StreamingTests/ClientStreamTestRunner.cs
@@ -51,7 +51,7 @@ namespace Tester.StreamingTests
 
             // become stream consumers
             await SubscribeToStream(streamProviderName, streamGuid, streamNamespace,
-                (e, t) => { eventCount[0]++; return TaskDone.Done; });
+                (e, t) => { eventCount[0]++; return Task.CompletedTask; });
 
             // setup producer
             var producer = this.testHost.GrainFactory.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
@@ -78,7 +78,7 @@ namespace Tester.StreamingTests
 
             // become stream consumers
             await SubscribeToStream(streamProviderName, streamGuid, streamNamespace,
-                (e, t) => { eventCount[0]++; return TaskDone.Done; });
+                (e, t) => { eventCount[0]++; return Task.CompletedTask; });
 
             // setup producer
             producer = this.testHost.GrainFactory.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());

--- a/test/Tester/StreamingTests/DeactivationTestRunner.cs
+++ b/test/Tester/StreamingTests/DeactivationTestRunner.cs
@@ -22,7 +22,7 @@ namespace UnitTests.StreamingTests
             public Task Increment()
             {
                 Value++;
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             public void Clear()

--- a/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/test/Tester/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -316,7 +316,7 @@ namespace UnitTests.StreamingTests
             var handle = await stream.SubscribeAsync((e,t) =>
             {
                 eventCount++;
-                return TaskDone.Done;
+                return Task.CompletedTask;
             });
 
             // produce some messages

--- a/test/Tester/TestStreamProviders/Controllable/ControllableTestStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/Controllable/ControllableTestStreamProvider.cs
@@ -24,7 +24,7 @@ namespace Tester.TestStreamProviders.Controllable
             public Task QueueMessageBatchAsync<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, StreamSequenceToken token,
                 Dictionary<string, object> requestContext)
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             public IQueueAdapterReceiver CreateReceiver(QueueId queueId)

--- a/test/Tester/TestStreamProviders/FailureInjectionStreamProvider.cs
+++ b/test/Tester/TestStreamProviders/FailureInjectionStreamProvider.cs
@@ -36,7 +36,7 @@ namespace Tester.TestStreamProviders
 
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Init(string name, IProviderRuntime providerUtilitiesManager, IProviderConfiguration providerConfig)
@@ -45,14 +45,14 @@ namespace Tester.TestStreamProviders
             mode = providerConfig.GetEnumProperty(FailureInjectionModeString, FailureInjectionStreamProviderMode.NoFault);
             return mode == FailureInjectionStreamProviderMode.InitializationThrowsException
                 ? TaskUtility.Faulted(new ProviderInitializationException("Error initializing provider " + typeof(FailureInjectionStreamProvider)))
-                : TaskDone.Done;
+                : Task.CompletedTask;
         }
 
         public Task Start()
         {
             return mode == FailureInjectionStreamProviderMode.StartThrowsException
                 ? TaskUtility.Faulted(new ProviderStartException("Error starting provider " + typeof(FailureInjectionStreamProvider).Name))
-                : TaskDone.Done;
+                : Task.CompletedTask;
         }
     }
 }

--- a/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
@@ -430,7 +430,7 @@ namespace UnitTests.StreamingTests
             double rps = totalSubscriptions / elapsed.TotalSeconds;
             output.WriteLine("Subscriptions-per-second = {0} during period {1}", rps, elapsed);
             Assert.NotEqual(0.0,  rps);  // "RPS greater than zero"
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private Task Test_Stream_Churn_NumStreams(
@@ -486,7 +486,7 @@ namespace UnitTests.StreamingTests
             double rps = totalSubscriptions / elapsed.TotalSeconds;
             output.WriteLine("Subscriptions-per-second = {0} during period {1}", rps, elapsed);
             Assert.NotEqual(0.0,  rps);  // "RPS greater than zero"
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         //private async Task Test_Stream_Churn_TimePeriod(

--- a/test/TesterInternal/GatewaySelectionTest.cs
+++ b/test/TesterInternal/GatewaySelectionTest.cs
@@ -143,7 +143,7 @@ namespace UnitTests.MessageCenterTests
             }
             public Task InitializeGatewayListProvider(ClientConfiguration clientConfiguration, Logger logger)
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
 #endregion

--- a/test/TesterInternal/General/TestingBootstrapProviders.cs
+++ b/test/TesterInternal/General/TestingBootstrapProviders.cs
@@ -47,13 +47,13 @@ namespace UnitTests.General
             logger = providerRuntime.GetLogger(GetType().Name);
             logger.Info("Init Name={0}", Name);
             Interlocked.Increment(ref initCount);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Close()
         {
             logger.Info("Close Name={0}", Name);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public virtual Task<object> ExecuteCommand(int command, object arg)
@@ -134,7 +134,7 @@ namespace UnitTests.General
         public Task Close()
         {
             logger.Info("Close Name={0}", Name);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 

--- a/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
+++ b/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
@@ -185,7 +185,7 @@ namespace Tests.GeoClusterTests
             Assert.Equal(requested0, base_requested0);
             Assert.Equal(requested1, base_requested1);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         #endregion
@@ -280,7 +280,7 @@ namespace Tests.GeoClusterTests
 
             ValidateClusterRaceResults(results, grains);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private volatile int threadsDone;

--- a/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
+++ b/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
@@ -152,7 +152,7 @@ namespace UnitTests.GeoClusterTests
             stopwatch.Stop();
             WriteLog("Multicluster is ready (elapsed = {0}).", stopwatch.Elapsed);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
 
@@ -253,7 +253,7 @@ namespace UnitTests.GeoClusterTests
             public Task OnNextAsync(int item, StreamSequenceToken token = null)
             {
                 GotHello(item);
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             public Task OnCompletedAsync()

--- a/test/TesterInternal/MockStatsCollectors.cs
+++ b/test/TesterInternal/MockStatsCollectors.cs
@@ -54,7 +54,7 @@ namespace UnitTests.Stats
         {
             Trace.TraceInformation("{0} Init called", GetType().Name);
             Name = name;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Init(ClientConfiguration config, IPAddress address, string clientId)
@@ -66,24 +66,24 @@ namespace UnitTests.Stats
         {
             Trace.TraceInformation("{0} ReportMetrics called", GetType().Name);
             Interlocked.Increment(ref numMetricsCalls);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         public Task ReportStats(List<ICounter> statsCounters)
         {
             Trace.TraceInformation("{0} ReportStats called", GetType().Name);
             Interlocked.Increment(ref numStatsCalls);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName,
             string hostName)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -106,7 +106,7 @@ namespace UnitTests.Stats
             this.taskScheduler = providerRuntime.ServiceProvider.GetRequiredService<OrleansTaskScheduler>();
             this.schedulingContext = providerRuntime.ServiceProvider.GetRequiredService<Silo>().testHook.SchedulingContext;
             logger.Info("{0} Init called", GetType().Name);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Init(string deploymentId, string storageConnectionString, SiloAddress siloAddress, string siloName,
@@ -119,24 +119,24 @@ namespace UnitTests.Stats
         {
             logger.Info("{0} ReportMetrics called", GetType().Name);
             taskScheduler.QueueTask(() => grain.ReportMetricsCalled(), schedulingContext).Ignore();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
         public Task ReportStats(List<ICounter> statsCounters)
         {
             logger.Info("{0} ReportStats called", GetType().Name);
             taskScheduler.QueueTask(() => grain.ReportStatsCalled(), schedulingContext).Ignore();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName,
             string hostName)
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task Close()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TesterInternal/StorageTests/StorageProviders/BaseJSONStorageProvider.cs
+++ b/test/TesterInternal/StorageTests/StorageProviders/BaseJSONStorageProvider.cs
@@ -65,7 +65,7 @@ namespace Samples.StorageProviders
         public virtual Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
         {
             Log = providerRuntime.GetLogger(this.GetType().FullName);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace Samples.StorageProviders
             if (DataManager != null)
                 DataManager.Dispose();
             DataManager = null;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Samples.StorageProviders
         {
             if (DataManager == null) throw new ArgumentException("DataManager property not initialized");
             DataManager.Delete(grainState.GetType().Name, grainReference.ToKeyString());
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/test/TesterInternal/StorageTests/StorageProviders/FileStorageProvider.cs
+++ b/test/TesterInternal/StorageTests/StorageProviders/FileStorageProvider.cs
@@ -93,7 +93,7 @@ namespace Samples.StorageProviders
             if (fileInfo.Exists)
                 fileInfo.Delete();
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
+++ b/test/TesterInternal/StreamingTests/PubSubRendezvousGrainTests.cs
@@ -194,12 +194,12 @@ namespace UnitTests.StreamingTests
             public Task AddSubscriber(GuidId subscriptionId, StreamId streamId, IStreamConsumerExtension streamConsumer,
                 IStreamFilterPredicateWrapper filter)
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             public Task RemoveSubscriber(GuidId subscriptionId, StreamId streamId)
             {
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
 
             public override bool Equals(object obj)

--- a/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/TesterInternal/StreamingTests/StreamTestHelperClasses.cs
@@ -72,7 +72,7 @@ namespace UnitTests.StreamingTests
 
         public Task DeactivateConsumerOnIdle()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 
@@ -97,7 +97,7 @@ namespace UnitTests.StreamingTests
         public Task BecomeProducer(Guid streamId, string providerToUse, string streamNamespace)
         {
             this.producer.BecomeProducer(streamId, this.client.GetStreamProvider(providerToUse), streamNamespace);
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task ProduceSequentialSeries(int count)
@@ -160,7 +160,7 @@ namespace UnitTests.StreamingTests
 
         public Task DeactivateProducerOnIdle()
         {
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 

--- a/test/TesterSQLUtils/StorageTests/RelationalStoreTests.cs
+++ b/test/TesterSQLUtils/StorageTests/RelationalStoreTests.cs
@@ -209,7 +209,7 @@ namespace UnitTests.StorageTests.SQLAdapter
                 }
             }
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Since the code is migrated to .Net 4.6.1 now, it seems there is no point to use non-standard `TaskDone.Done` instead of `Task.CompletedTask` anymore. I marked it as deprecated and changed all usages to `Task.CompletedTask`.

Feel free to close this PR without merging if you feel that this change has too little value.