### PR TITLE
fix warnings

### DIFF
--- a/src/Orleans/Async/TaskExtensions.cs
+++ b/src/Orleans/Async/TaskExtensions.cs
@@ -289,7 +289,7 @@ namespace Orleans
             try
             {
                 action();
-                return TaskDone.Done;
+                return Task.CompletedTask;
             }
             catch (Exception exc)
             {


### PR DESCRIPTION
TaskDone.Done is obsolete. remove the remaining one. 0 warmings !  