### PR TITLE
Support exceptions with reference cycles in ILBasedExceptionSerializer

### DIFF
--- a/src/Orleans/Serialization/DeserializationContext.cs
+++ b/src/Orleans/Serialization/DeserializationContext.cs
@@ -45,18 +45,18 @@ namespace Orleans.Serialization
     public static class DeserializationContextExtensions
     {
         /// <summary>
-        /// Returns a new nested context which begins at the specified offset into the stream.
+        /// Returns a new nested context which begins at the specified position.
         /// </summary>
         /// <param name="context"></param>
-        /// <param name="offset"></param>
+        /// <param name="position"></param>
         /// <param name="reader"></param>
         /// <returns></returns>
         public static IDeserializationContext CreateNestedContext(
             this IDeserializationContext context,
-            int offset,
+            int position,
             BinaryTokenStreamReader reader)
         {
-            return new DeserializationContext.NestedDeserializationContext(context, offset, reader);
+            return new DeserializationContext.NestedDeserializationContext(context, position, reader);
         }
     }
 
@@ -117,17 +117,17 @@ namespace Orleans.Serialization
         internal class NestedDeserializationContext : IDeserializationContext
         {
             private readonly IDeserializationContext parent;
-            private readonly int initialOffset;
+            private readonly int position;
 
             /// <summary>
             /// Initializes a new <see cref="NestedDeserializationContext"/> instance.
             /// </summary>
             /// <param name="parent"></param>
-            /// <param name="initialOffset">The offset relative to the parent at which this context begins.</param>
+            /// <param name="position">The position, relative to the outer-most context, at which this context begins.</param>
             /// <param name="reader"></param>
-            public NestedDeserializationContext(IDeserializationContext parent, int initialOffset, BinaryTokenStreamReader reader)
+            public NestedDeserializationContext(IDeserializationContext parent, int position, BinaryTokenStreamReader reader)
             {
-                this.initialOffset = initialOffset;
+                this.position = position;
                 this.parent = parent;
                 this.StreamReader = reader;
             }
@@ -137,7 +137,7 @@ namespace Orleans.Serialization
             public object AdditionalContext => this.parent.AdditionalContext;
             public BinaryTokenStreamReader StreamReader { get; }
             public int CurrentObjectOffset { get; set; }
-            public int CurrentPosition => this.initialOffset + this.StreamReader.CurrentPosition;
+            public int CurrentPosition => this.position + this.StreamReader.CurrentPosition;
             public void RecordObject(object obj, int offset) => this.parent.RecordObject(obj, offset);
             public void RecordObject(object obj) => this.RecordObject(obj, this.CurrentObjectOffset);
             public object FetchReferencedObject(int offset) => this.parent.FetchReferencedObject(offset);

--- a/src/Orleans/Serialization/DeserializationContext.cs
+++ b/src/Orleans/Serialization/DeserializationContext.cs
@@ -17,7 +17,19 @@ namespace Orleans.Serialization
         int CurrentObjectOffset { get; set; }
 
         /// <summary>
+        /// Gets the current position in the stream.
+        /// </summary>
+        int CurrentPosition { get; }
+
+        /// <summary>
         /// Records deserialization of the provided object.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="offset">The offset within <see cref="StreamReader"/>.</param>
+        void RecordObject(object obj, int offset);
+
+        /// <summary>
+        /// Records deserialization of the provided object at the current object offset.
         /// </summary>
         /// <param name="obj"></param>
         void RecordObject(object obj);
@@ -28,6 +40,24 @@ namespace Orleans.Serialization
         /// <param name="offset">The offset within <see cref="StreamReader"/>.</param>
         /// <returns>The object from the specified offset.</returns>
         object FetchReferencedObject(int offset);
+    }
+
+    public static class DeserializationContextExtensions
+    {
+        /// <summary>
+        /// Returns a new nested context which begins at the specified offset into the stream.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="offset"></param>
+        /// <param name="reader"></param>
+        /// <returns></returns>
+        public static IDeserializationContext CreateNestedContext(
+            this IDeserializationContext context,
+            int offset,
+            BinaryTokenStreamReader reader)
+        {
+            return new DeserializationContext.NestedDeserializationContext(context, offset, reader);
+        }
     }
 
     public class DeserializationContext : IDeserializationContext
@@ -49,10 +79,18 @@ namespace Orleans.Serialization
         /// <inheritdoc />
         public int CurrentObjectOffset { get; set; }
 
+        public int CurrentPosition => this.StreamReader.CurrentPosition;
+
         /// <inheritdoc />
         public void RecordObject(object obj)
         {
-            taggedObjects[CurrentObjectOffset] = obj;
+            this.RecordObject(obj, this.CurrentObjectOffset);
+        }
+
+        /// <inheritdoc />
+        public void RecordObject(object obj, int offset)
+        {
+            taggedObjects[offset] = obj;
         }
 
         /// <inheritdoc />
@@ -75,5 +113,34 @@ namespace Orleans.Serialization
         public IServiceProvider ServiceProvider => this.SerializationManager.ServiceProvider;
 
         public object AdditionalContext => this.SerializationManager.RuntimeClient;
+
+        internal class NestedDeserializationContext : IDeserializationContext
+        {
+            private readonly IDeserializationContext parent;
+            private readonly int initialOffset;
+
+            /// <summary>
+            /// Initializes a new <see cref="NestedDeserializationContext"/> instance.
+            /// </summary>
+            /// <param name="parent"></param>
+            /// <param name="initialOffset">The offset relative to the parent at which this context begins.</param>
+            /// <param name="reader"></param>
+            public NestedDeserializationContext(IDeserializationContext parent, int initialOffset, BinaryTokenStreamReader reader)
+            {
+                this.initialOffset = initialOffset;
+                this.parent = parent;
+                this.StreamReader = reader;
+            }
+
+            public SerializationManager SerializationManager => this.parent.SerializationManager;
+            public IServiceProvider ServiceProvider => this.parent.ServiceProvider;
+            public object AdditionalContext => this.parent.AdditionalContext;
+            public BinaryTokenStreamReader StreamReader { get; }
+            public int CurrentObjectOffset { get; set; }
+            public int CurrentPosition => this.initialOffset + this.StreamReader.CurrentPosition;
+            public void RecordObject(object obj, int offset) => this.parent.RecordObject(obj, offset);
+            public void RecordObject(object obj) => this.RecordObject(obj, this.CurrentObjectOffset);
+            public object FetchReferencedObject(int offset) => this.parent.FetchReferencedObject(offset);
+        }
     }
 }

--- a/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
+++ b/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
@@ -112,12 +112,17 @@ namespace Orleans.Serialization
 
             var typeKey = TypeSerializer.ReadTypeKey(outerReader);
             
-            // Read the serialized payload.
+            // Read the length of the serialized payload.
             var length = outerReader.ReadInt();
-            var initialOffset = outerContext.CurrentPosition;
-            var innerBytes = outerReader.ReadBytes(length);
 
-            var innerContext = outerContext.CreateNestedContext(initialOffset, new BinaryTokenStreamReader(innerBytes));
+            // The nested data was serialized beginning at the current offset (after the length property).
+            // Record the current offset for use when creating the nested deserialization context.
+            var position = outerContext.CurrentPosition;
+
+            // Read the nested payload.
+            var innerBytes = outerReader.ReadBytes(length);
+            
+            var innerContext = outerContext.CreateNestedContext(position: position, reader: new BinaryTokenStreamReader(innerBytes));
             object result;
 
             // If the concrete type is available and the exception is valid for reconstruction,

--- a/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
+++ b/src/Orleans/Serialization/ILBasedExceptionSerializer.cs
@@ -95,7 +95,7 @@ namespace Orleans.Serialization
 
             // Create a nested context which will be written to the outer context at an int-length offset from the current position.
             // This is because the inner context will be copied with a length prefix to the outer context.
-            var innerContext = outerContext.CreateNestedContext(offsetFromCurrent: sizeof(int), writer: new BinaryTokenStreamWriter());
+            var innerContext = outerContext.CreateNestedContext(position: outerContext.CurrentOffset + sizeof(int), writer: new BinaryTokenStreamWriter());
 
             // Serialize the exception itself.
             var methods = this.GetSerializerMethods(actualType);

--- a/src/Orleans/Serialization/SerializationContext.cs
+++ b/src/Orleans/Serialization/SerializationContext.cs
@@ -37,11 +37,37 @@ namespace Orleans.Serialization
 
     public interface ISerializationContext : ISerializerContext
     {
+        /// <summary>
+        /// Gets the stream writer.
+        /// </summary>
         BinaryTokenStreamWriter StreamWriter { get; }
-
-        void RecordObject(object original);
+        
+        /// <summary>
+        /// Records the provided object at the specified offset into <see cref="StreamWriter"/>.
+        /// </summary>
+        /// <param name="original"></param>
+        /// <param name="offset"></param>
+        void RecordObject(object original, int offset);
 
         int CheckObjectWhileSerializing(object raw);
+
+        int CurrentOffset { get; }
+    }
+
+    public static class SerializationContextExtensions
+    {
+        public static void RecordObject(this ISerializationContext context, object original)
+        {
+            context.RecordObject(original, context.CurrentOffset);
+        }
+
+        public static ISerializationContext CreateNestedContext(
+            this ISerializationContext context,
+            int offsetFromCurrent,
+            BinaryTokenStreamWriter writer)
+        {
+            return new SerializationContext.NestedSerializationContext(context, context.CurrentOffset + offsetFromCurrent, writer);
+        }
     }
 
     /// <summary>
@@ -107,11 +133,11 @@ namespace Orleans.Serialization
             }
         }
 
-        public void RecordObject(object original)
+        public void RecordObject(object original, int offset)
         {
-            processedObjects[original] = new Record(this.StreamWriter.CurrentOffset);
+            processedObjects[original] = new Record(offset);
         }
-        
+
         // Returns an object suitable for insertion if this is a back-reference, or null if it's new
         public object CheckObjectWhileCopying(object raw)
         {
@@ -138,8 +164,37 @@ namespace Orleans.Serialization
             return -1;
         }
 
+        public int CurrentOffset => this.StreamWriter.CurrentOffset;
+
         public IServiceProvider ServiceProvider => this.SerializationManager.ServiceProvider;
 
         public object AdditionalContext => this.SerializationManager.RuntimeClient;
+
+        internal class NestedSerializationContext : ISerializationContext
+        {
+            private readonly int initialOffset;
+            private readonly ISerializationContext parentContext;
+
+            /// <summary>
+            /// Creates a new instance of the <see cref="NestedSerializationContext"/> class.
+            /// </summary>
+            /// <param name="parent">The parent context.</param>
+            /// <param name="offset">The absolute offset at which this stream begins.</param>
+            /// <param name="writer">The writer.</param>
+            public NestedSerializationContext(ISerializationContext parent, int offset, BinaryTokenStreamWriter writer)
+            {
+                this.parentContext = parent;
+                this.initialOffset = offset;
+                this.StreamWriter = writer;
+            }
+
+            public SerializationManager SerializationManager => this.parentContext.SerializationManager;
+            public IServiceProvider ServiceProvider => this.parentContext.ServiceProvider;
+            public object AdditionalContext => this.parentContext.ServiceProvider;
+            public BinaryTokenStreamWriter StreamWriter { get; }
+            public int CurrentOffset => this.initialOffset + this.StreamWriter.CurrentOffset;
+            public void RecordObject(object original, int offset) => this.parentContext.RecordObject(original, offset);
+            public int CheckObjectWhileSerializing(object raw) => this.parentContext.CheckObjectWhileSerializing(raw);
+        }
     }
 }

--- a/src/Orleans/Serialization/SerializationContext.cs
+++ b/src/Orleans/Serialization/SerializationContext.cs
@@ -63,10 +63,10 @@ namespace Orleans.Serialization
 
         public static ISerializationContext CreateNestedContext(
             this ISerializationContext context,
-            int offsetFromCurrent,
+            int position,
             BinaryTokenStreamWriter writer)
         {
-            return new SerializationContext.NestedSerializationContext(context, context.CurrentOffset + offsetFromCurrent, writer);
+            return new SerializationContext.NestedSerializationContext(context, position, writer);
         }
     }
 

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1491,7 +1491,7 @@ namespace Orleans.Serialization
             var sm = context.SerializationManager;
             var previousOffset = context.CurrentObjectOffset;
             var reader = context.StreamReader;
-            context.CurrentObjectOffset = context.StreamReader.CurrentPosition;
+            context.CurrentObjectOffset = context.CurrentPosition;
 
             try
             {


### PR DESCRIPTION
The [initial PR](https://github.com/dotnet/orleans/pull/2633#issue-203027973) for failsafe exception serialization came with the caveat that it did not support self-referential exceptions.

Unfortunately, this deficiency has affected @josiahdecker (see #2997), so it should be fixed.

This PR fixes the issue by adding support for nested `IDeserializationContext` instances. It's quite simple:
* Instead of reading position from the stream reader/writer, read it from a property on the context.
* Add an extension method to nest contexts, where the nested context is created with a specified offset from its parent.