### PR TITLE
Add extensibility point to replace the grain activator

### DIFF
--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Orleans.CodeGeneration;
+using Orleans.Core;
 using Orleans.GrainDirectory;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.Scheduler;
@@ -18,7 +19,7 @@ namespace Orleans.Runtime
     /// MUST lock this object for any concurrent access
     /// Consider: compartmentalize by usage, e.g., using separate interfaces for data for catalog, etc.
     /// </summary>
-    internal class ActivationData : IActivationData, IInvokable
+    internal class ActivationData : IGrainActivationContext, IActivationData, IInvokable
     {
         // This class is used for activations that have extension invokers. It keeps a dictionary of 
         // invoker objects to use with the activation, and extend the default invoker
@@ -200,6 +201,12 @@ namespace Orleans.Runtime
             this.SchedulingContext = new SchedulingContext(this);
         }
 
+        public Type GrainType => GrainTypeData.Type;
+
+        public IGrainIdentity GrainIdentity => this.Identity;
+
+        public IServiceProvider ActivationServices { get; private set; }
+
         #region Method invocation
 
         private ExtensionInvoker extensionInvoker;
@@ -264,17 +271,23 @@ namespace Orleans.Runtime
             }
         }
 
-        internal Type GrainInstanceType { get; private set; }
+        internal Type GrainInstanceType => GrainTypeData?.Type;
 
         internal void SetGrainInstance(Grain grainInstance)
         {
             GrainInstance = grainInstance;
-            if (grainInstance != null)
+        }
+
+        internal void SetupContext(GrainTypeData typeData, IServiceProvider grainServices)
+        {
+            this.GrainTypeData = typeData;
+            this.ActivationServices = grainServices;
+            if (typeData != null)
             {
-                GrainInstanceType = grainInstance.GetType();
+                var grainType = typeData.Type;
 
                 // Don't ever collect system grains or reminder table grain or memory store grains.
-                bool doNotCollect = typeof(IReminderTableGrain).IsAssignableFrom(GrainInstanceType) || typeof(IMemoryStorageGrain).IsAssignableFrom(GrainInstanceType);
+                bool doNotCollect = typeof(IReminderTableGrain).IsAssignableFrom(grainType) || typeof(IMemoryStorageGrain).IsAssignableFrom(grainType);
                 if (doNotCollect)
                 {
                     this.collector = null;
@@ -319,6 +332,8 @@ namespace Orleans.Runtime
         {
             get { return Grain; }
         }
+
+        public GrainTypeData GrainTypeData { get; private set; }
 
         public Grain GrainInstance { get; private set; }
 

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -1238,6 +1238,7 @@ namespace Orleans.Runtime
                 // step 4 - UnregisterMessageTarget and OnFinishedGrainDeactivate
                 foreach (var activationData in list)
                 {
+                    Grain grainInstance = activationData.GrainInstance;
                     try
                     {
                         lock (activationData)
@@ -1259,6 +1260,13 @@ namespace Orleans.Runtime
                         directory.InvalidateCacheEntry(activationData.Address);
 
                         RerouteAllQueuedMessages(activationData, null, "Finished Destroy Activation");
+                        if (grainInstance != null)
+                        {
+                            lock (activationData)
+                            {
+                                grainCreator.Release(activationData, grainInstance);
+                            }
+                        }
                     }
                     catch (Exception exc)
                     {

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -731,6 +731,8 @@ namespace Orleans.Runtime
             
             lock (data)
             {
+                data.SetupContext(grainTypeData, this.serviceProvider);
+
                 Grain grain;
 
                 if (typeof(IStatefulGrain).IsAssignableFrom(grainType))
@@ -740,14 +742,14 @@ namespace Orleans.Runtime
 
                     var storage = new GrainStateStorageBridge(grainType.FullName, data.StorageProvider);
 
-                    grain = grainCreator.CreateGrainInstance(grainType, data.Identity, stateObjectType, storage);
+                    grain = grainCreator.CreateGrainInstance(data, stateObjectType, storage);
 
                     storage.SetGrain(grain);
                 }
                 else
                 {
                     // Create a new instance of the given grain type
-                    grain = grainCreator.CreateGrainInstance(grainType, data.Identity);
+                    grain = grainCreator.CreateGrainInstance(data);
 
                     // for log-view grains, install log-view adaptor
                     if (grain is ILogConsistentGrain)

--- a/src/OrleansRuntime/Catalog/DefaultGrainActivator.cs
+++ b/src/OrleansRuntime/Catalog/DefaultGrainActivator.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// <see cref="IGrainActivator"/> that uses type activation to create grains.
+    /// </summary>
+    public class DefaultGrainActivator : IGrainActivator
+    {
+        private readonly Func<Type, ObjectFactory> createFactory = type => ActivatorUtilities.CreateFactory(type, Type.EmptyTypes);
+        private readonly ConcurrentDictionary<Type, ObjectFactory> typeActivatorCache = new ConcurrentDictionary<Type, ObjectFactory>();
+
+        /// <inheritdoc />
+        public virtual object Create(IGrainActivationContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+
+            var grainType = context.GrainType;
+
+            if (grainType == null)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture, "The '{0}' property of '{1}' must not be null.",
+                        nameof(context.GrainType),
+                        nameof(IGrainActivationContext)));
+            }
+
+            var serviceProvider = context.ActivationServices;
+            var activator = this.typeActivatorCache.GetOrAdd(grainType, this.createFactory);
+            var grain = activator(serviceProvider, arguments: null);
+            return grain;
+        }
+    }
+}

--- a/src/OrleansRuntime/Catalog/DefaultGrainActivator.cs
+++ b/src/OrleansRuntime/Catalog/DefaultGrainActivator.cs
@@ -38,5 +38,25 @@ namespace Orleans.Runtime
             var grain = activator(serviceProvider, arguments: null);
             return grain;
         }
+
+        /// <inheritdoc />
+        public virtual void Release(IGrainActivationContext context, object grain)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (grain == null)
+            {
+                throw new ArgumentNullException(nameof(grain));
+            }
+
+            var disposable = grain as IDisposable;
+            if (disposable != null)
+            {
+                disposable.Dispose();
+            }
+        }
     }
 }

--- a/src/OrleansRuntime/Catalog/GrainCreator.cs
+++ b/src/OrleansRuntime/Catalog/GrainCreator.cs
@@ -96,5 +96,10 @@ namespace Orleans.Runtime
 
             ((ILogConsistentGrain)grain).InstallAdaptor(factory, state, grainType.FullName, storageProvider, svc);
         }
+
+        public void Release(IGrainActivationContext context, object grain)
+        {
+            this.grainActivator.Release(context, grain);
+        }
     }
 }

--- a/src/OrleansRuntime/Catalog/GrainCreator.cs
+++ b/src/OrleansRuntime/Catalog/GrainCreator.cs
@@ -1,63 +1,51 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using Microsoft.Extensions.DependencyInjection;
 using Orleans.Core;
 using Orleans.LogConsistency;
 using Orleans.Storage;
 using Orleans.Runtime.LogConsistency;
 using Orleans.GrainDirectory;
-using Orleans.Serialization;
-using Orleans.Runtime.MultiClusterNetwork;
-using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime
 {
     /// <summary>
-    /// Helper class used to create local instances of grains.
+    /// Helper class used to create local instances of grains. In the future this should be opened up for extension similar to ASP.NET's ControllerFactory.
     /// </summary>
     internal class GrainCreator
     {
+        private readonly IGrainActivator grainActivator;
+
         private readonly Lazy<IGrainRuntime> grainRuntime;
-
-        private readonly IServiceProvider services;
-
-        private readonly Func<Type, ObjectFactory> createFactory;
-
-        private readonly ConcurrentDictionary<Type, ObjectFactory> typeActivatorCache = new ConcurrentDictionary<Type, ObjectFactory>();
         
         private readonly Factory<Grain, IMultiClusterRegistrationStrategy, ProtocolServices> protocolServicesFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GrainCreator"/> class.
         /// </summary>
-        /// <param name="services">Service provider used to create new grains</param>
+        /// <param name="grainActivator">The activator used to used to create new grains</param>
         /// <param name="getGrainRuntime">The delegate used to get the grain runtime.</param>
         /// <param name="protocolServicesFactory"></param>
         public GrainCreator(
-            IServiceProvider services,
+            IGrainActivator grainActivator,
             Func<IGrainRuntime> getGrainRuntime,
             Factory<Grain, IMultiClusterRegistrationStrategy, ProtocolServices> protocolServicesFactory)
         {
-            this.services = services;
+            this.grainActivator = grainActivator;
             this.protocolServicesFactory = protocolServicesFactory;
             this.grainRuntime = new Lazy<IGrainRuntime>(getGrainRuntime);
-            this.createFactory = type => ActivatorUtilities.CreateFactory(type, Type.EmptyTypes);
         }
 
         /// <summary>
         /// Create a new instance of a grain
         /// </summary>
-        /// <param name="grainType">The grain type.</param>
-        /// <param name="identity">Identity for the new grain</param>
+        /// <param name="context">The <see cref="IGrainActivationContext"/> for the executing action.</param>
         /// <returns>The newly created grain.</returns>
-        public Grain CreateGrainInstance(Type grainType, IGrainIdentity identity)
+        public Grain CreateGrainInstance(IGrainActivationContext context)
         {
-            var activator = this.typeActivatorCache.GetOrAdd(grainType, this.createFactory);
-            var grain = (Grain)activator(this.services, arguments: null);
+            var grain = (Grain)grainActivator.Create(context);
 
             // Inject runtime hooks into grain instance
             grain.Runtime = this.grainRuntime.Value;
-            grain.Identity = identity;
+            grain.Identity = context.GrainIdentity;
 
             return grain;
         }
@@ -65,15 +53,14 @@ namespace Orleans.Runtime
         /// <summary>
         /// Create a new instance of a grain
         /// </summary>
-        /// <param name="grainType"></param>
-        /// <param name="identity">Identity for the new grain</param>
+        /// <param name="context">The <see cref="IGrainActivationContext"/> for the executing action.</param>
         /// <param name="stateType">If the grain is a stateful grain, the type of the state it persists.</param>
         /// <param name="storage">If the grain is a stateful grain, the storage used to persist the state.</param>
         /// <returns></returns>
-        public Grain CreateGrainInstance(Type grainType, IGrainIdentity identity, Type stateType, IStorage storage)
+        public Grain CreateGrainInstance(IGrainActivationContext context, Type stateType, IStorage storage)
 		{
             //Create a new instance of the grain
-            var grain = CreateGrainInstance(grainType, identity);
+            var grain = CreateGrainInstance(context);
 
             var statefulGrain = grain as IStatefulGrain;
 

--- a/src/OrleansRuntime/Catalog/IGrainActivationContext.cs
+++ b/src/OrleansRuntime/Catalog/IGrainActivationContext.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Orleans.Core;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// The context associated with the current grain activation.
+    /// </summary>
+    public interface IGrainActivationContext
+    {
+        /// <summary>Gets the .NET type of the grain activation instance.</summary>
+        Type GrainType { get; }
+
+        /// <summary>Gets the identity of the grain activation.</summary>
+        IGrainIdentity GrainIdentity { get; }
+
+        /// <summary>Gets the <see cref="IServiceProvider"/> that provides access to the grain activation's service container.</summary>
+        IServiceProvider ActivationServices { get; }
+    }
+}

--- a/src/OrleansRuntime/Catalog/IGrainActivator.cs
+++ b/src/OrleansRuntime/Catalog/IGrainActivator.cs
@@ -1,0 +1,15 @@
+﻿namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Provides methods to create a grain.
+    /// </summary>
+    public interface IGrainActivator
+    {
+        /// <summary>
+        /// Creates a grain.
+        /// </summary>
+        /// <param name="context">The <see cref="IGrainActivationContext"/> for the executing action.</param>
+        /// <returns>An instantiated grain.</returns>
+        object Create(IGrainActivationContext context);
+    }
+}

--- a/src/OrleansRuntime/Catalog/IGrainActivator.cs
+++ b/src/OrleansRuntime/Catalog/IGrainActivator.cs
@@ -11,5 +11,12 @@
         /// <param name="context">The <see cref="IGrainActivationContext"/> for the executing action.</param>
         /// <returns>An instantiated grain.</returns>
         object Create(IGrainActivationContext context);
+
+        /// <summary>
+        /// Releases a controller.
+        /// </summary>
+        /// <param name="context">The <see cref="IGrainActivationContext"/> for the executing action.</param>
+        /// <param name="grain">The grain to release.</param>
+        void Release(IGrainActivationContext context, object grain);
     }
 }

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -60,7 +60,10 @@
   <ItemGroup>
     <Compile Include="Cancellation\CancellationSourcesExtension.cs" />
     <Compile Include="Catalog\ActivationState.cs" />
+    <Compile Include="Catalog\DefaultGrainActivator.cs" />
+    <Compile Include="Catalog\IGrainActivationContext.cs" />
     <Compile Include="Catalog\GrainCreator.cs" />
+    <Compile Include="Catalog\IGrainActivator.cs" />
     <Compile Include="Core\GrainRuntime.cs" />
     <Compile Include="Core\IInvokable.cs" />
     <Compile Include="Core\ISiloRuntimeClient.cs" />

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -243,7 +243,6 @@ namespace Orleans.Runtime
             services.AddFromExisting<IMessageCenter, MessageCenter>();
             services.AddFromExisting<ISiloMessageCenter, MessageCenter>();
             services.AddSingleton(FactoryUtility.Create<MessageCenter, Gateway>);
-            services.AddSingleton<Catalog>();
             services.AddSingleton<Dispatcher>(sp => sp.GetRequiredService<Catalog>().Dispatcher);
             services.AddSingleton<InsideRuntimeClient>();
             services.AddFromExisting<IRuntimeClient, InsideRuntimeClient>();
@@ -297,7 +296,12 @@ namespace Orleans.Runtime
             services.AddSingleton<CachedVersionSelectorManager>();
 
             services.AddSingleton<Func<IGrainRuntime>>(sp => () => sp.GetRequiredService<IGrainRuntime>());
+
+            // Grain activation
+            services.AddSingleton<Catalog>();
             services.AddSingleton<GrainCreator>();
+            services.AddSingleton<IGrainActivator, DefaultGrainActivator>();
+
             services.AddSingleton<IStreamSubscriptionManagerAdmin>(sp => new StreamSubscriptionManagerAdmin(sp.GetRequiredService<IStreamProviderRuntime>()));
             if (initializationParams.GlobalConfig.UseVirtualBucketsConsistentRing)
             {

--- a/test/TestGrainInterfaces/ISimpleDIGrain.cs
+++ b/test/TestGrainInterfaces/ISimpleDIGrain.cs
@@ -5,8 +5,9 @@ namespace UnitTests.GrainInterfaces
 {
     public interface ISimpleDIGrain : IGrainWithIntegerKey
     {
-        Task<long> GetTicksFromService();
+        Task<long> GetLongValue();
         Task<string> GetStringValue();
+        Task DoDeactivate();
     }
 
     public interface IDIGrainWithInjectedServices : ISimpleDIGrain

--- a/test/TestGrains/SimpleDIGrain.cs
+++ b/test/TestGrains/SimpleDIGrain.cs
@@ -25,7 +25,7 @@ namespace UnitTests.Grains
             this.grainFactoryId = ObjectIdGenerator.GetId(this.injectedGrainFactory, out set);
         }
 
-        public Task<long> GetTicksFromService()
+        public Task<long> GetLongValue()
         {
             return injectedService.GetTicks();
         }
@@ -39,27 +39,40 @@ namespace UnitTests.Grains
         {
             return Task.FromResult(this.grainFactoryId);
         }
+        public Task DoDeactivate()
+        {
+            this.DeactivateOnIdle();
+            return Task.CompletedTask;
+        }
     }
 
     public class ExplicitlyRegisteredSimpleDIGrain : Grain, ISimpleDIGrain
     {
         private readonly IInjectedService injectedService;
-        private string someValueThatIsNotRegistered;
+        private readonly string someValueThatIsNotRegistered;
+        private readonly int numberOfReleasedInstancesBeforeThisActivation;
 
-        public ExplicitlyRegisteredSimpleDIGrain(IInjectedService injectedService, string someValueThatIsNotRegistered)
+        public ExplicitlyRegisteredSimpleDIGrain(IInjectedService injectedService, string someValueThatIsNotRegistered, int numberOfReleasedInstancesBeforeThisActivation)
         {
             this.injectedService = injectedService;
             this.someValueThatIsNotRegistered = someValueThatIsNotRegistered;
+            this.numberOfReleasedInstancesBeforeThisActivation = numberOfReleasedInstancesBeforeThisActivation;
         }
 
-        public Task<long> GetTicksFromService()
+        public Task<long> GetLongValue()
         {
-            return injectedService.GetTicks();
+            return Task.FromResult((long)numberOfReleasedInstancesBeforeThisActivation);
         }
 
         public Task<string> GetStringValue()
         {
            return Task.FromResult(this.someValueThatIsNotRegistered);
+        }
+
+        public Task DoDeactivate()
+        {
+            this.DeactivateOnIdle();
+            return Task.CompletedTask;
         }
     }
 

--- a/test/Tester/GrainActivatorTests.cs
+++ b/test/Tester/GrainActivatorTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
+using Xunit;
+
+namespace UnitTests.General
+{
+    [TestCategory("DI")]
+    public class GrainActivatorTests : OrleansTestingBase, IClassFixture<GrainActivatorTests.Fixture>
+    {
+        private readonly Fixture fixture;
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override TestCluster CreateTestCluster()
+            {
+                var options = new TestClusterOptions(1);
+                options.ClusterConfiguration.UseStartupType<TestStartup>();
+                return new TestCluster(options);
+            }
+        }
+
+        public GrainActivatorTests(Fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task CanUseCustomGrainActivatorToCreateGrains()
+        {
+            ISimpleDIGrain grain = this.fixture.GrainFactory.GetGrain<ISimpleDIGrain>(GetRandomGrainId(), grainClassNamePrefix: "UnitTests.Grains.ExplicitlyRegistered");
+            var actual = await grain.GetStringValue();
+            Assert.Equal(TestStartup.HardcodedGrainActivator.HardcodedValue, actual);
+        }
+
+        public class TestStartup
+        {
+            public class HardcodedGrainActivator : DefaultGrainActivator, IGrainActivator
+            {
+                public const string HardcodedValue = "Hardcoded Test Value";
+
+                public override object Create(IGrainActivationContext context)
+                {
+                    if (context.GrainType == typeof(ExplicitlyRegisteredSimpleDIGrain))
+                    {
+                        return new ExplicitlyRegisteredSimpleDIGrain(new InjectedService(), HardcodedValue, 0);
+                    }
+
+                    return base.Create(context);
+                }
+            }
+
+            public IServiceProvider ConfigureServices(IServiceCollection services)
+            {
+                services.Replace(ServiceDescriptor.Singleton(typeof(IGrainActivator), typeof(HardcodedGrainActivator)));
+
+                return services.BuildServiceProvider();
+            }
+        }
+    }
+}

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ClientConnectionTests\GatewayConnectionTests.cs" />
     <Compile Include="CollectionFixtures.cs" />
     <Compile Include="DependencyInjectionDisambiguationTests.cs" />
+    <Compile Include="GrainActivatorTests.cs" />
     <Compile Include="EventSourcingTests\AccountGrainTests.cs" />
     <Compile Include="EventSourcingTests\ChatGrainTests.cs" />
     <Compile Include="EventSourcingTests\CountersGrainPerfTests.cs" />


### PR DESCRIPTION
This will instantiate grains preserving the current behavior (which is using `ActivatorUtilities`, similar to MVC
s `DefaultControllerActivator`), but allows replacing this service with a custom activator.
This enables less constraining integration with some 3rd party containers, or even manually instantiating grains.

In the future, I envision the `IGrainActivationContext` instance be resolved as a scoped service as defined in #2856.