### PR TITLE
Move contract to interfaces project

### DIFF
--- a/test/TestGrainInterfaces/IFilteredImplicitSubscriptionGrain.cs
+++ b/test/TestGrainInterfaces/IFilteredImplicitSubscriptionGrain.cs
@@ -1,4 +1,6 @@
 ﻿using Orleans;
+using Orleans.Streams;
+using System;
 using System.Threading.Tasks;
 
 namespace UnitTests.GrainInterfaces
@@ -6,5 +8,14 @@ namespace UnitTests.GrainInterfaces
     public interface IFilteredImplicitSubscriptionGrain : IGrainWithGuidKey
     {
         Task<int> GetCounter(string streamNamespace);
+    }
+
+    [Serializable]
+    public class RedStreamNamespacePredicate : IStreamNamespacePredicate
+    {
+        public bool IsMatch(string streamNamespace)
+        {
+            return streamNamespace.StartsWith("red");
+        }
     }
 }

--- a/test/TestGrains/FilteredImplicitSubscriptionGrain.cs
+++ b/test/TestGrains/FilteredImplicitSubscriptionGrain.cs
@@ -1,7 +1,6 @@
 ﻿using Orleans;
 using Orleans.Runtime;
 using Orleans.Streams;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnitTests.GrainInterfaces;
@@ -38,15 +37,6 @@ namespace UnitTests.Grains
         public Task<int> GetCounter(string streamNamespace)
         {
             return Task.FromResult(counters[streamNamespace]);
-        }
-    }
-
-    [Serializable]
-    public class RedStreamNamespacePredicate : IStreamNamespacePredicate
-    {
-        public bool IsMatch(string streamNamespace)
-        {
-            return streamNamespace.StartsWith("red");
         }
     }
 }


### PR DESCRIPTION
Tests were passing when the binaries are all placed in a single output folder (such as in Jenkins) but it fails when they are not (such as in VS), since when the client connect, it sends all the implicit subscriptions, and since that one is not in the interfaces project, deserialization fails