### PR TITLE
Added us-gov-west-1 as a possible region endpoint

### DIFF
--- a/src/OrleansAWSUtils/AWSUtils.cs
+++ b/src/OrleansAWSUtils/AWSUtils.cs
@@ -32,6 +32,8 @@ namespace OrleansAWSUtils
                     return RegionEndpoint.EUWest1;
                 case "sa-east-1":
                     return RegionEndpoint.SAEast1;
+                case "us-gov-west-1":
+                    return RegionEndpoint.USGovCloudWest1;
                 default:
                     return RegionEndpoint.USWest2;
             }


### PR DESCRIPTION
I have an Orleans project that worked fine in commercial AWS, but I kept getting "bad credentials" warnings for GovCloud when interfacing with a DynamoDB table.  It turns out, it was authenticating my GovCloud credentials against RegionEndpoint.USWest2, as us-west-2 is the default in this file, and RegionEndpoint.USGovCloudWest1 was not listed in this 'switch' statement.

This change adds us-gov-west-1 as a possible region.  http://docs.aws.amazon.com/sdkfornet1/latest/apidocs/html/T_Amazon_RegionEndpoint.htm