### PR TITLE
dotnet CLI templates

### DIFF
--- a/vNext/Templates/Microsoft.Orleans.Templates.Client.nuspec
+++ b/vNext/Templates/Microsoft.Orleans.Templates.Client.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Orleans.Templates.Client</id>
+    <version>1.0.0</version>
+    <title>Microsoft Orleans (2.0 Technical Preview) Client Templates</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,Orleans</owners>
+    <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
+    <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
+    <summary>
+      Microsoft Orleans (2.0 Technical Preview) Client Templates
+    </summary>
+    <copyright>Copyright Microsoft 2015</copyright>
+    <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
+     <packageTypes>
+        <packageType name="Template" />
+    </packageTypes>
+  </metadata>
+  <files>
+    <file src="OrleansClient\**\*" target="content" />
+  </files>
+</package>

--- a/vNext/Templates/Microsoft.Orleans.Templates.Grains.nuspec
+++ b/vNext/Templates/Microsoft.Orleans.Templates.Grains.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Orleans.Templates.Silo</id>
+    <version>1.0.0</version>
+    <title>Microsoft Orleans (2.0 Technical Preview) Grain Templates</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,Orleans</owners>
+    <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
+    <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
+    <summary>
+      Microsoft Orleans (2.0 Technical Preview) Grain Templates
+    </summary>
+    <copyright>Copyright Microsoft 2015</copyright>
+    <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
+     <packageTypes>
+        <packageType name="Template" />
+    </packageTypes>
+  </metadata>
+  <files>
+    <file src="OrleansGrains\**\*" target="content" />
+  </files>
+</package>

--- a/vNext/Templates/Microsoft.Orleans.Templates.Interface.nuspec
+++ b/vNext/Templates/Microsoft.Orleans.Templates.Interface.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Orleans.Templates.Silo</id>
+    <version>1.0.0</version>
+    <title>Microsoft Orleans (2.0 Technical Preview) Interface Templates</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,Orleans</owners>
+    <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
+    <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
+    <summary>
+      Microsoft Orleans (2.0 Technical Preview) Interface Templates
+    </summary>
+    <copyright>Copyright Microsoft 2015</copyright>
+    <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
+    <packageTypes>
+        <packageType name="Template" />
+    </packageTypes>
+  </metadata>
+  <files>
+    <file src="OrleansInterface\**\*" target="content" />
+  </files>
+</package>

--- a/vNext/Templates/Microsoft.Orleans.Templates.Silo.nuspec
+++ b/vNext/Templates/Microsoft.Orleans.Templates.Silo.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Orleans.Templates.Silo</id>
+    <version>1.0.0</version>
+    <title>Microsoft Orleans (2.0 Technical Preview) Silo Templates</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,Orleans</owners>
+    <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
+    <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
+    <summary>
+      Microsoft Orleans (2.0 Technical Preview) Silo Templates
+    </summary>
+    <copyright>Copyright Microsoft 2015</copyright>
+    <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
+     <packageTypes>
+        <packageType name="Template" />
+    </packageTypes>
+  </metadata>
+  <files>
+    <file src="OrleansSilo\**\*" target="content" />
+  </files>
+</package>

--- a/vNext/Templates/Microsoft.Orleans.Templates.WebAPI.nuspec
+++ b/vNext/Templates/Microsoft.Orleans.Templates.WebAPI.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Orleans.Templates.WebAPI</id>
+    <version>1.0.0</version>
+    <title>Microsoft Orleans (2.0 Technical Preview) WebAPI Client Templates</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,Orleans</owners>
+    <projectUrl>https://github.com/dotnet/Orleans</projectUrl>
+    <licenseUrl>https://github.com/dotnet/Orleans#license</licenseUrl>
+    <iconUrl>https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png</iconUrl>
+    <summary>
+      Microsoft Orleans (2.0 Technical Preview) WebAPI Client Templates
+    </summary>
+    <copyright>Copyright Microsoft 2015</copyright>
+    <tags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET</tags>
+     <packageTypes>
+        <packageType name="Template" />
+    </packageTypes>
+  </metadata>
+  <files>
+    <file src="OrleansWebAPIClient\**\*" target="content" />
+  </files>
+</package>

--- a/vNext/Templates/OrleansClient/.template.config/template.json
+++ b/vNext/Templates/OrleansClient/.template.config/template.json
@@ -1,0 +1,35 @@
+{
+    "author": "Microsoft",
+    "classification": [
+        "Orleans",
+        "Cloud-Computing",
+        "Actor-Model",
+        "Actors",
+        "Distributed-Systems",
+        "C#",
+        "Client",
+        ".NET"
+    ],
+    "name": "Microsoft Orleans (2.0 Technical Preview) Client",
+    "identity": "Microsoft.Orleans.Templates.Client",
+    "shortname": "orleans-client",
+    "tags": {
+        "language": "C#",
+        "type": "project"
+    },
+    "sourceName": "OrleansClient",
+    "preferNameDirectory": "true",
+    "postActions": [
+        {
+            "condition": "(!skipRestore)",
+            "description": "Restore Orleans NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
+}

--- a/vNext/Templates/OrleansClient/OrleansClient.csproj
+++ b/vNext/Templates/OrleansClient/OrleansClient.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
+  </ItemGroup>
+</Project>

--- a/vNext/Templates/OrleansClient/OrleansClient.csproj
+++ b/vNext/Templates/OrleansClient/OrleansClient.csproj
@@ -5,6 +5,6 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-*" />
   </ItemGroup>
 </Project>

--- a/vNext/Templates/OrleansClient/Program.cs
+++ b/vNext/Templates/OrleansClient/Program.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime.Configuration;
+
+namespace OrleansClient
+{
+    class Program
+    {
+        private static IClusterClient client;
+        private static bool running;
+
+        static void Main(string[] args)
+        {
+            Task.Run(() => InitializeOrleans());
+
+            Console.ReadLine();
+
+            running = false;
+        }
+
+        static async Task InitializeOrleans()
+        {
+            var config = new ClientConfiguration();
+            config.PropagateActivityId = true;
+            config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 10400));
+
+            Console.WriteLine("Initializing...");
+
+            client = new ClientBuilder().UseConfiguration(config).Build();
+            await client.Connect();
+            running = true;
+            Console.WriteLine("Initialized!");
+
+            var grain = client.GetGrain<IHellogGrain>(Guid.NewGuid());
+
+            while(running)
+            {
+                var response = await grain.SayHello("Hello Gutemberg!");
+                Console.WriteLine($"[{DateTime.UtcNow}] - {response}");
+                await Task.Delay(1000);
+            }
+            client.Dispose();
+        }
+    }
+}

--- a/vNext/Templates/OrleansGrains/.template.config/template.json
+++ b/vNext/Templates/OrleansGrains/.template.config/template.json
@@ -1,0 +1,35 @@
+{
+    "author": "Microsoft",
+    "classification": [
+        "Orleans",
+        "Cloud-Computing",
+        "Actor-Model",
+        "Actors",
+        "Distributed-Systems",
+        "C#",
+        "Grain",
+        ".NET"
+    ],
+    "name": "Microsoft Orleans (2.0 Technical Preview) Grains",
+    "identity": "Microsoft.Orleans.Templates.Grains",
+    "shortname": "orleans-grains",
+    "tags": {
+        "language": "C#",
+        "type": "project"
+    },
+    "sourceName": "OrleansGrains",
+    "preferNameDirectory": "true",
+    "postActions": [
+        {
+            "condition": "(!skipRestore)",
+            "description": "Restore Orleans NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
+}

--- a/vNext/Templates/OrleansGrains/HelloGrain.cs
+++ b/vNext/Templates/OrleansGrains/HelloGrain.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans;
+using OrleansInterface;
+
+namespace OrleansGrains
+{
+    public class HelloGrain : Grain, IHelloGrain
+    {
+        public Task<string> SayHello(string greeting) => Task.FromResult($"You said: '{greeting}', I say: Hello!");
+    }
+}

--- a/vNext/Templates/OrleansGrains/OrleansGrains.csproj
+++ b/vNext/Templates/OrleansGrains/OrleansGrains.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard1.6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-*" />
   </ItemGroup>
 </Project>

--- a/vNext/Templates/OrleansGrains/OrleansGrains.csproj
+++ b/vNext/Templates/OrleansGrains/OrleansGrains.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
+  </ItemGroup>
+</Project>

--- a/vNext/Templates/OrleansInterface/.template.config/template.json
+++ b/vNext/Templates/OrleansInterface/.template.config/template.json
@@ -1,0 +1,35 @@
+{
+    "author": "Microsoft",
+    "classification": [
+        "Orleans",
+        "Cloud-Computing",
+        "Actor-Model",
+        "Actors",
+        "Distributed-Systems",
+        "C#",
+        "Silo",
+        ".NET"
+    ],
+    "name": "Microsoft Orleans (2.0 Technical Preview) Interface",
+    "identity": "Microsoft.Orleans.Templates.Interface",
+    "shortname": "orleans-interface",
+    "tags": {
+        "language": "C#",
+        "type": "project"
+    },
+    "sourceName": "OrleansInterface",
+    "preferNameDirectory": "true",
+    "postActions": [
+        {
+            "condition": "(!skipRestore)",
+            "description": "Restore Orleans NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
+}

--- a/vNext/Templates/OrleansInterface/IHelloGrain.cs
+++ b/vNext/Templates/OrleansInterface/IHelloGrain.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace OrleansInterface
+{
+    public interface IHelloGrain : IGrainWithIntegerKey
+    {
+        Task<string> SayHello(string greeting);
+    }
+}

--- a/vNext/Templates/OrleansInterface/OrleansInterface.csproj
+++ b/vNext/Templates/OrleansInterface/OrleansInterface.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard1.6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-*" />
   </ItemGroup>
 </Project>

--- a/vNext/Templates/OrleansInterface/OrleansInterface.csproj
+++ b/vNext/Templates/OrleansInterface/OrleansInterface.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
+  </ItemGroup>
+</Project>

--- a/vNext/Templates/OrleansSilo/.template.config/template.json
+++ b/vNext/Templates/OrleansSilo/.template.config/template.json
@@ -1,0 +1,35 @@
+{
+    "author": "Microsoft",
+    "classification": [
+        "Orleans",
+        "Cloud-Computing",
+        "Actor-Model",
+        "Actors",
+        "Distributed-Systems",
+        "C#",
+        "Silo",
+        ".NET"
+    ],
+    "name": "Microsoft Orleans (2.0 Technical Preview) Silo",
+    "identity": "Microsoft.Orleans.Templates.Silo",
+    "shortname": "orleans-silo",
+    "tags": {
+        "language": "C#",
+        "type": "project"
+    },
+    "sourceName": "OrleansSilo",
+    "preferNameDirectory": "true",
+    "postActions": [
+        {
+            "condition": "(!skipRestore)",
+            "description": "Restore Orleans NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
+}

--- a/vNext/Templates/OrleansSilo/OrleansHostWrapper.cs
+++ b/vNext/Templates/OrleansSilo/OrleansHostWrapper.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Net;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Host;
+
+namespace OrleansSilo
+{
+    public class OrleansHostWrapper
+    {
+        private readonly SiloHost siloHost;
+
+        public OrleansHostWrapper(ClusterConfiguration config)
+        {
+            siloHost = new SiloHost(Dns.GetHostName(), config);
+            siloHost.LoadOrleansConfig();
+        }
+
+        public int Run()
+        {
+            if (siloHost == null)
+            {
+                return 1;
+            }
+
+            try
+            {
+                siloHost.InitializeOrleansSilo();
+
+                if (siloHost.StartOrleansSilo())
+                {
+                    Console.WriteLine($"Successfully started Orleans silo '{siloHost.Name}' as a {siloHost.Type} node.");
+                    return 0;
+                }
+                else
+                {
+                    throw new OrleansException($"Failed to start Orleans silo '{siloHost.Name}' as a {siloHost.Type} node.");
+                }
+            }
+            catch (Exception exc)
+            {
+                siloHost.ReportStartupError(exc);
+                Console.Error.WriteLine(exc);
+                return 1;
+            }
+        }
+
+        public int Stop()
+        {
+            if (siloHost != null)
+            {
+                try
+                {
+                    siloHost.StopOrleansSilo();
+                    siloHost.Dispose();
+                    Console.WriteLine($"Orleans silo '{siloHost.Name}' shutdown.");
+                }
+                catch (Exception exc)
+                {
+                    siloHost.ReportStartupError(exc);
+                    Console.Error.WriteLine(exc);
+                    return 1;
+                }
+            }
+            return 0;
+        }
+    }
+}

--- a/vNext/Templates/OrleansSilo/OrleansSilo.csproj
+++ b/vNext/Templates/OrleansSilo/OrleansSilo.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-preview2-201705020000" />
+  </ItemGroup>
+</Project>

--- a/vNext/Templates/OrleansSilo/OrleansSilo.csproj
+++ b/vNext/Templates/OrleansSilo/OrleansSilo.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-preview2-201705020000" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-*" />
   </ItemGroup>
 </Project>

--- a/vNext/Templates/OrleansSilo/Program.cs
+++ b/vNext/Templates/OrleansSilo/Program.cs
@@ -24,17 +24,7 @@ namespace OrleansSilo
 
         private static int InitializeOrleans()
         {
-            var config = new ClusterConfiguration();
-            config.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.MembershipTableGrain;
-            config.Globals.ReminderServiceType = GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain;
-            var ep = new IPEndPoint(IPAddress.Loopback, 10300);
-            config.Globals.SeedNodes.Add(ep);
-            config.PrimaryNode = ep;
-            config.Defaults.PropagateActivityId = true;
-            config.Defaults.ProxyGatewayEndpoint = new IPEndPoint(IPAddress.Any, 10400);
-            config.Defaults.Port = 10300;
-            var ips = Dns.GetHostAddressesAsync(Dns.GetHostName()).Result;
-            config.Defaults.HostNameOrIPAddress = ips.FirstOrDefault()?.ToString();
+            var config = ClusterConfiguration.LocalhostSilo();
             config.UseStartupType<Startup>();
             hostWrapper = new OrleansHostWrapper(config);
             return hostWrapper.Run();

--- a/vNext/Templates/OrleansSilo/Program.cs
+++ b/vNext/Templates/OrleansSilo/Program.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Orleans.Runtime.Configuration;
+
+namespace OrleansSilo
+{
+    public class Program
+    {
+        private static OrleansHostWrapper hostWrapper;
+
+        static int Main(string[] args)
+        {
+            int exitCode = InitializeOrleans();
+
+            Console.WriteLine("Press Enter to terminate...");
+            Console.ReadLine();
+
+            exitCode += ShutdownSilo();
+
+            return exitCode;
+        }
+
+        private static int InitializeOrleans()
+        {
+            var config = new ClusterConfiguration();
+            config.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.MembershipTableGrain;
+            config.Globals.ReminderServiceType = GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain;
+            var ep = new IPEndPoint(IPAddress.Loopback, 10300);
+            config.Globals.SeedNodes.Add(ep);
+            config.PrimaryNode = ep;
+            config.Defaults.PropagateActivityId = true;
+            config.Defaults.ProxyGatewayEndpoint = new IPEndPoint(IPAddress.Any, 10400);
+            config.Defaults.Port = 10300;
+            var ips = Dns.GetHostAddressesAsync(Dns.GetHostName()).Result;
+            config.Defaults.HostNameOrIPAddress = ips.FirstOrDefault()?.ToString();
+            config.UseStartupType<Startup>();
+            hostWrapper = new OrleansHostWrapper(config);
+            return hostWrapper.Run();
+        }
+
+        private static int ShutdownSilo()
+        {
+            if (hostWrapper != null)
+            {
+                return hostWrapper.Stop();
+            }
+            return 0;
+        }
+    }
+}

--- a/vNext/Templates/OrleansSilo/Startup.cs
+++ b/vNext/Templates/OrleansSilo/Startup.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OrleansSilo
+{
+    public class Startup
+    {
+        public IServiceProvider ConfigureServices(IServiceCollection services)
+        {
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/vNext/Templates/OrleansWebAPIClient/.template.config/template.json
+++ b/vNext/Templates/OrleansWebAPIClient/.template.config/template.json
@@ -1,0 +1,35 @@
+{
+    "author": "Microsoft",
+    "classification": [
+        "Orleans",
+        "Cloud-Computing",
+        "Actor-Model",
+        "Actors",
+        "Distributed-Systems",
+        "C#",
+        "Silo",
+        ".NET"
+    ],
+    "name": "Microsoft Orleans (2.0 Technical Preview) WebAPI Client",
+    "identity": "Microsoft.Orleans.Templates.WebAPI",
+    "shortname": "orleans-webapi",
+    "tags": {
+        "language": "C#",
+        "type": "project"
+    },
+    "sourceName": "OrleansWebAPIClient",
+    "preferNameDirectory": "true",
+    "postActions": [
+        {
+            "condition": "(!skipRestore)",
+            "description": "Restore Orleans NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
+}

--- a/vNext/Templates/OrleansWebAPIClient/Controllers/GreetingsController.cs
+++ b/vNext/Templates/OrleansWebAPIClient/Controllers/GreetingsController.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Orleans;
+
+namespace OrleansWebAPIClient.Controllers
+{
+    [Route("api/[controller]")]
+    public class GreetingsController : Controller
+    {
+        private IClusterClient _clusterClient;
+
+        public GreetingsController(IClusterClient clusterClient)
+        {
+            _clusterClient = clusterClient;
+        }
+
+        [HttpGet]
+        public Task<string> Greet(string greet)
+        {
+            var grain = _clusterClient.GetGrain<IHellogGrain>(Guid.NewGuid());
+
+            return grain.SayHello("Hello Gutemberg!");
+        }
+    }
+}

--- a/vNext/Templates/OrleansWebAPIClient/OrleansWebAPIClient.csproj
+++ b/vNext/Templates/OrleansWebAPIClient/OrleansWebAPIClient.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
+  </ItemGroup>
+
+</Project>

--- a/vNext/Templates/OrleansWebAPIClient/OrleansWebAPIClient.csproj
+++ b/vNext/Templates/OrleansWebAPIClient/OrleansWebAPIClient.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-201705020000" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-*" />
   </ItemGroup>
 
 </Project>

--- a/vNext/Templates/OrleansWebAPIClient/Program.cs
+++ b/vNext/Templates/OrleansWebAPIClient/Program.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace OrleansWebAPIClient
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/vNext/Templates/OrleansWebAPIClient/Startup.cs
+++ b/vNext/Templates/OrleansWebAPIClient/Startup.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Runtime.Configuration;
+
+namespace OrleansWebAPIClient
+{
+    public class Startup
+    {
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+            Configuration = builder.Build();
+        }
+
+        public IConfigurationRoot Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Add framework services.
+            services.AddMvc();
+
+            var config = new ClientConfiguration();
+            config.PropagateActivityId = true;
+            config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 10400));
+
+            //Build Orleans Client
+            var client = new ClientBuilder().UseConfiguration(config).Build();
+            client.Connect().Wait();
+
+            //Register it on DI so we can get it inside the API controller
+            services.AddSingleton(client);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
+            loggerFactory.AddDebug();
+
+            app.UseMvc();
+        }
+    }
+}

--- a/vNext/Templates/OrleansWebAPIClient/appsettings.Development.json
+++ b/vNext/Templates/OrleansWebAPIClient/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/vNext/Templates/OrleansWebAPIClient/appsettings.json
+++ b/vNext/Templates/OrleansWebAPIClient/appsettings.json
@@ -1,0 +1,8 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
Added `dotnet new` CLI templates that uses Orleans 2.0 Technical Preview.

To test the template without generate nuget packages:

`dotnet new --install <templateDirectory>`

After that, you will see the template in your `dotnet new` template list.

To remove the manually installed/debug templates:

`dotnet new --debug:reinit`

To pack/release the template, you can't use `dotnet pack` today (tooling limitations). You need to use regular `nuget.exe pack project.nuspec` and that is why the `.nuspec files` were included.

Once the package is generated, just publish it to nuget.org (or whatever alternative nuget feed) and to install from there, just run: 

`dotnet new --install <template_package_id>`