### PR TITLE
Add more  extensibility to EventDataGeneratorStreamProvider 

### DIFF
--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventDataGeneratorStreamProvider.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventDataGeneratorStreamProvider.cs
@@ -16,7 +16,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans.ServiceBus.Providers
+namespace Orleans.ServiceBus.Providers.Testing
 {
     /// <summary>
     /// Setting class for EHGeneratorStreamProvider

--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
@@ -12,15 +12,23 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Orleans.ServiceBus.Providers
+namespace Orleans.ServiceBus.Providers.Testing
 {
-    internal class EventHubPartitionGeneratorReceiver : IEventHubReceiver
+    /// <summary>
+    /// Eventhub receiver which configured with data generator
+    /// </summary>
+    public class EventHubPartitionGeneratorReceiver : IEventHubReceiver
     {
         private IDataGenerator<EventData> generator;
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="generator"></param>
         public EventHubPartitionGeneratorReceiver(IDataGenerator<EventData> generator)
         {
             this.generator = generator;
         }
+        /// <inheritdoc cref="IEventHubReceiver"/>
         public async Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
         {
             IEnumerable<EventData> events;
@@ -35,16 +43,19 @@ namespace Orleans.ServiceBus.Providers
             return new List<EventData>().AsEnumerable();
         }
 
+        /// <inheritdoc cref="IEventHubReceiver"/>
         public void StopProducingOnStream(IStreamIdentity streamId)
         {
             (this.generator as IStreamDataGeneratingController)?.StopProducingOnStream(streamId);
         }
 
+        /// <inheritdoc cref="IEventHubReceiver"/>
         public void ConfigureDataGeneratorForStream(IStreamIdentity streamId)
         {
             (this.generator as IStreamDataGeneratingController)?.AddDataGeneratorForStream(streamId);
         }
 
+        /// <inheritdoc cref="IEventHubReceiver"/>
         public Task CloseAsync()
         {
             return Task.CompletedTask;

--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubUtils.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubUtils.cs
@@ -11,25 +11,48 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Orleans.ServiceBus.Providers
+namespace Orleans.ServiceBus.Providers.Testing
 {
 
-    internal static class EventDataProxyMethods
+    /// <summary>
+    /// Setter for EventData members
+    /// </summary>
+    public static class EventDataProxyMethods
     {
+        /// <summary>
+        /// Set EventData.Offset
+        /// </summary>
+        /// <param name="eventData"></param>
+        /// <param name="offSet"></param>
         public static void SetOffset(this EventData eventData, string offSet)
         {
             EventDataMethodCache.Instance.SetOffset(eventData, offSet);
         }
 
+        /// <summary>
+        /// Setter for EventData.SequenceNumber
+        /// </summary>
+        /// <param name="eventData"></param>
+        /// <param name="sequenceNumber"></param>
         public static void SetSequenceNumber(this EventData eventData, long sequenceNumber)
         {
             EventDataMethodCache.Instance.SetSequenceNumber(eventData, sequenceNumber);
         }
+        /// <summary>
+        /// Setter for EventData.EnqueueTimeUtc
+        /// </summary>
+        /// <param name="eventData"></param>
+        /// <param name="enqueueTime"></param>
         public static void SetEnqueuedTimeUtc(this EventData eventData, DateTime enqueueTime)
         {
             EventDataMethodCache.Instance.SetEnqueuedTimeUtc(eventData, enqueueTime);
         }
 #if NETSTANDARD
+        /// <summary>
+        /// Setter for EventData.PartitionKey
+        /// </summary>
+        /// <param name="eventData"></param>
+        /// <param name="partitionKey"></param>
         public static void SetPartitionKey(this EventData eventData, string partitionKey)
         {
             EventDataMethodCache.Instance.SetPartitionKey(eventData, partitionKey);

--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/IEventDataGenerator.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/IEventDataGenerator.cs
@@ -10,7 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Orleans.ServiceBus.Providers
+namespace Orleans.ServiceBus.Providers.Testing
 {
     /// <summary>
     /// Data generator for test purpose
@@ -27,20 +27,59 @@ namespace Orleans.ServiceBus.Providers
         bool TryReadEvents(int maxCount, out IEnumerable<T> events);
     }
 
-    internal interface IStreamDataGeneratingController
+    /// <summary>
+    /// StreamDataGeneratingController control stream data generating start and stop
+    /// </summary>
+    public interface IStreamDataGeneratingController
     {
+        /// <summary>
+        /// configure data generator for a stream
+        /// </summary>
+        /// <param name="streamId"></param>
         void AddDataGeneratorForStream(IStreamIdentity streamId);
+        /// <summary>
+        /// Ask one stream to stop producing
+        /// </summary>
+        /// <param name="streamId"></param>
         void StopProducingOnStream(IStreamIdentity streamId);
     }
 
-    internal interface IStreamDataGenerator<T>: IDataGenerator<T>
+    /// <summary>
+    /// data generator for a specific stream
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IStreamDataGenerator<T>: IDataGenerator<T>
     {
-        IntCounter SequenceNumberCounter { set; }
+        /// <summary>
+        /// counter for sequence number
+        /// </summary>
+        IIntCounter SequenceNumberCounter { set; }
+        /// <summary>
+        /// Stream identity for this data generator
+        /// </summary>
         IStreamIdentity StreamId { get; }
+        /// <summary>
+        /// 
+        /// </summary>
         bool ShouldProduce { set; }
     }
 
-    internal class IntCounter
+    /// <summary>
+    /// counter for integer
+    /// </summary>
+    public interface IIntCounter
+    {
+        /// <summary>
+        /// counter value
+        /// </summary>
+        int Value { get; }
+        /// <summary>
+        /// increment the counter
+        /// </summary>
+        void Increment();
+    }
+
+    internal class IntCounter : IIntCounter
     {
         private int counter = 0;
         public int Value { get { return this.counter; } }

--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/IEventDataGenerator.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/IEventDataGenerator.cs
@@ -12,8 +12,18 @@ using System.Linq;
 
 namespace Orleans.ServiceBus.Providers
 {
-    internal interface IDataGenerator<T>
+    /// <summary>
+    /// Data generator for test purpose
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IDataGenerator<T>
     {
+        /// <summary>
+        /// Data generator mimic event reading
+        /// </summary>
+        /// <param name="maxCount"></param>
+        /// <param name="events"></param>
+        /// <returns></returns>
         bool TryReadEvents(int maxCount, out IEnumerable<T> events);
     }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -108,7 +108,10 @@ namespace Orleans.ServiceBus.Providers
         protected Func<string, string, Logger, IEventHubReceiverMonitor> ReceiverMonitorFactory { get; set; }
 
         //for testing purpose, used in EventHubGeneratorStreamProvider
-        internal Func<EventHubPartitionSettings, string, Logger, Task<IEventHubReceiver>> EventHubReceiverFactory;
+        /// <summary>
+        /// Factory to create a IEventHubReceiver
+        /// </summary>
+        protected Func<EventHubPartitionSettings, string, Logger, Task<IEventHubReceiver>> EventHubReceiverFactory;
         internal ConcurrentDictionary<QueueId, EventHubAdapterReceiver> EventHubReceivers { get { return this.receivers; } }
         internal IEventHubQueueMapper EventHubQueueMapper { get { return this.streamQueueMapper; } }
         /// <summary>

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -13,6 +13,7 @@ using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.Runtime.Configuration;
+using Orleans.ServiceBus.Providers.Testing;
 
 namespace Orleans.ServiceBus.Providers
 {

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -17,9 +17,18 @@ using Orleans.ServiceBus.Providers.Testing;
 
 namespace Orleans.ServiceBus.Providers
 {
-    internal class EventHubPartitionSettings
+    /// <summary>
+    /// Event Hub Partition settings
+    /// </summary>
+    public class EventHubPartitionSettings
     {
+        /// <summary>
+        /// Eventhub settings
+        /// </summary>
         public IEventHubSettings Hub { get; set; }
+        /// <summary>
+        /// Partition name
+        /// </summary>
         public string Partition { get; set; }
     }
 

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -104,7 +104,17 @@ namespace Orleans.ServiceBus.Providers
             return true;
         }
 
-        internal static EventData ToEventData<T>(SerializationManager serializationManager, Guid streamGuid, String streamNamespace, IEnumerable<T> events, Dictionary<string, object> requestContext)
+        /// <summary>
+        /// Put events list and its context into a EventData object
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="serializationManager"></param>
+        /// <param name="streamGuid"></param>
+        /// <param name="streamNamespace"></param>
+        /// <param name="events"></param>
+        /// <param name="requestContext"></param>
+        /// <returns></returns>
+        public static EventData ToEventData<T>(SerializationManager serializationManager, Guid streamGuid, String streamNamespace, IEnumerable<T> events, Dictionary<string, object> requestContext)
         {
             var payload = new Body
             {

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubReceiver.cs
@@ -15,9 +15,20 @@ namespace Orleans.ServiceBus.Providers
     /// Abstraction on EventhubReceiver class, used to configure EventHubReceiver class in EventhubAdapterReceiver,
     /// also used to configure EHGeneratorReceiver in EventHubAdapterReceiver for testing purpose
     /// </summary>
-    internal interface IEventHubReceiver
+    public interface IEventHubReceiver
     {
+        /// <summary>
+        /// Send a async message to the partition asking for more messages
+        /// </summary>
+        /// <param name="maxCount">Max amount of message which should be delivered in this request</param>
+        /// <param name="waitTime">Wait time of this request</param>
+        /// <returns></returns>
         Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime);
+
+        /// <summary>
+        /// Send a clean up message
+        /// </summary>
+        /// <returns></returns>
         Task CloseAsync();
     }
 

--- a/test/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -7,6 +7,7 @@ using Orleans.AzureUtils;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.ServiceBus.Providers;
+using Orleans.ServiceBus.Providers.Testing;
 using Orleans.Storage;
 using Orleans.Streams;
 using Orleans.TestingHost;

--- a/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
+++ b/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
@@ -6,6 +6,7 @@ using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Orleans.ServiceBus.Providers.Testing;
 
 namespace ServiceBus.Tests.TestStreamProviders
 {


### PR DESCRIPTION
Add more extensibility to EventDataGeneratorStreamProvider 
Open data generating infra to public, so user can create GeneratorStreamProvider with other behavior for event hub