### PR TITLE
Update unit test tutorial to use TestCluster

### DIFF
--- a/src/Tutorials/Unit-Testing-Grains.md
+++ b/src/Tutorials/Unit-Testing-Grains.md
@@ -151,8 +151,6 @@ namespace Tests
             var hello = _cluster.GrainFactory.GetGrain<IHelloGrain>(Guid.NewGuid());
             var greeting = await hello.SayHell();
 
-            cluster.StopAllSilos();
-
             Assert.Equal("Hello, World", greeting);
         }
     }

--- a/src/Tutorials/Unit-Testing-Grains.md
+++ b/src/Tutorials/Unit-Testing-Grains.md
@@ -93,7 +93,7 @@ namespace Tests
 ```
 
 Due to the overhead of starting an in-memory cluster you may wish to create a `TestCluster` and reuse it among multiple test cases.
-For example this can be done using Xunit's class or collection fixtures (see [https://xunit.github.io/docs/shared-context.html](https://xunit.github.io/docs/shared-context.html) for more details).
+For example this can be done using xUnit's class or collection fixtures (see [https://xunit.github.io/docs/shared-context.html](https://xunit.github.io/docs/shared-context.html) for more details).
 
 In order to share a `TestCluster` between multiple test cases, first create a fixture type:
 
@@ -159,5 +159,5 @@ namespace Tests
 }
 ```
 
-Xunit will call the `Dispose` method of the `ClusterFixture` type when all tests have been completed and the in-memory cluster silos will be stopped.
+xUnit will call the `Dispose` method of the `ClusterFixture` type when all tests have been completed and the in-memory cluster silos will be stopped.
 `TestCluster` also has a constructor which accepts `TestClusterOptions` that can be used to configure the silos in the cluster.

--- a/src/Tutorials/Unit-Testing-Grains.md
+++ b/src/Tutorials/Unit-Testing-Grains.md
@@ -7,7 +7,7 @@ title: Unit Testing Grains
 
 This tutorial shows how to unit test your grains to make sure they behave correctly.
 There are two main ways to unit test your grains, and the method you choose will depend on the type of functionality you are testing.
-You have use a mocking framework like [Moq](https://github.com/moq/moq) to mock parts of the Orleans runtime that your grain interacts with, or you can use the  `Microsoft.Orleans.TestingHost` NuGet package to create test silos for your grains.
+You can use a mocking framework like [Moq](https://github.com/moq/moq) to mock parts of the Orleans runtime that your grain interacts with, or you can use the  `Microsoft.Orleans.TestingHost` NuGet package to create test silos for your grains.
 
 ## Using Mocks
 
@@ -82,7 +82,7 @@ namespace Tests
             cluster.Deploy();
 
             var hello = cluster.GrainFactory.GetGrain<IHelloGrain>(Guid.NewGuid());
-            var greeting = await hello.SayHell();
+            var greeting = await hello.SayHello();
 
             cluster.StopAllSilos();
 


### PR DESCRIPTION
Hello,

I noticed when working through the [unit testing tutorial](https://dotnet.github.io/orleans/Tutorials/Unit-Testing-Grains.html) that it uses `TestingSiloHost` which is [marked as obsolete](https://github.com/dotnet/orleans/pull/2919).

I have rewritten this tutorial to use `TestCluster`, and also added a bit of detail about mocking. I have tried to incorporate as much of the relevant content from the previous version as possible.

Hope this helps. Feed / suggestions / requests more than welcome