### PR TITLE
Fix #3030: Serializers not being generated for some types

### DIFF
--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -503,7 +503,7 @@ namespace Orleans.CodeGenerator
             if (GrainInterfaceUtils.IsGrainInterface(type))
             {
                 // If code generation is being performed at runtime, the interface must be accessible to the generated code.
-                if (!runtime || TypeUtilities.IsTypePublic(type))
+                if (!runtime || TypeUtilities.IsAccessibleFromAssembly(type, targetAssembly))
                 {
                     if (Logger.IsVerbose2) Logger.Verbose2("Will generate code for: {0}", type.GetParseableName());
 

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -13,6 +13,7 @@ using Orleans.Concurrency;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using Orleans.Streams;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using UnitTests.Grains;
@@ -129,6 +130,9 @@ namespace UnitTests.Serialization
             Assert.True(
                 environment.SerializationManager.HasSerializer(grainReferenceType),
                 $"Should be able to serialize grain reference type {grainReferenceType}.");
+            Assert.True(
+                environment.SerializationManager.HasSerializer(typeof(PubSubGrainState)),
+                $"Should be able to serialize internal type {nameof(PubSubGrainState)}.");
         }
 
         [Theory, TestCategory("BVT"), TestCategory("Serialization")]


### PR DESCRIPTION
A regression introduced after 1.3.1 meant that serializers were not being generated for types which have fields with generic types which use specialized, hand-coded serializers.

This fixes the regression and adds more coverage.