### PR TITLE
Support CultureInfo as built-in type

### DIFF
--- a/src/Orleans.sln
+++ b/src/Orleans.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{013DFD29-E1DB-4968-A67B-C2342E6F5B6E}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Orleans/Serialization/BuiltInTypes.cs
+++ b/src/Orleans/Serialization/BuiltInTypes.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -1700,6 +1701,26 @@ namespace Orleans.Serialization
         internal static object CopyUri(object obj, ICopyContext context)
         {
             return obj; // URIs are immutable
+        }
+
+        #endregion
+
+        #region CultureInfo
+
+        internal static void SerializeCultureInfo(object obj, ISerializationContext context, Type expected)
+        {
+            var cultureInfo = (CultureInfo)obj;
+            context.StreamWriter.Write(cultureInfo.Name);
+        }
+
+        internal static object DeserializeCultureInfo(Type expected, IDeserializationContext context)
+        {           
+            return new CultureInfo(context.StreamReader.ReadString());
+        }
+
+        internal static object CopyCultureInfo(object obj, ICopyContext context)
+        {
+            return obj;
         }
 
         #endregion

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -277,6 +278,7 @@ namespace Orleans.Serialization
             Register(typeof(IPAddress), BuiltInTypes.CopyIPAddress, BuiltInTypes.SerializeIPAddress, BuiltInTypes.DeserializeIPAddress);
             Register(typeof(IPEndPoint), BuiltInTypes.CopyIPEndPoint, BuiltInTypes.SerializeIPEndPoint, BuiltInTypes.DeserializeIPEndPoint);
             Register(typeof(Uri), BuiltInTypes.CopyUri, BuiltInTypes.SerializeUri, BuiltInTypes.DeserializeUri);
+            Register(typeof(CultureInfo), BuiltInTypes.CopyCultureInfo, BuiltInTypes.SerializeCultureInfo, BuiltInTypes.DeserializeCultureInfo);
 
             // Built-in handlers: Orleans internal types
             Register(typeof(InvokeMethodRequest), BuiltInTypes.CopyInvokeMethodRequest, BuiltInTypes.SerializeInvokeMethodRequest,

--- a/test/NonSilo.Tests/SerializationTests/SerializationTests.DifferentTypes.cs
+++ b/test/NonSilo.Tests/SerializationTests/SerializationTests.DifferentTypes.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Orleans.CodeGeneration;
 using Orleans.Serialization;
 using TestExtensions;
@@ -120,6 +121,7 @@ namespace UnitTests.Serialization
         }
 
 #if !NETSTANDARD_TODO
+
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_RecursiveSerialization()
         {
@@ -131,6 +133,28 @@ namespace UnitTests.Serialization
 
             TestTypeA output2 = this.fixture.SerializationManager.RoundTripSerializationForTesting(input);
         }
+
 #endif
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void SerializationTests_CultureInfo()
+        {
+            var input = new List<CultureInfo> { CultureInfo.GetCultureInfo("en"), CultureInfo.GetCultureInfo("de") };
+
+            foreach (var cultureInfo in input)
+            {
+                var output = this.fixture.SerializationManager.RoundTripSerializationForTesting(cultureInfo);
+                Assert.Equal(cultureInfo, output);
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Serialization")]
+        public void SerializationTests_CultureInfoList()
+        {
+            var input = new List<CultureInfo> { CultureInfo.GetCultureInfo("en"), CultureInfo.GetCultureInfo("de") };
+
+            var output = this.fixture.SerializationManager.RoundTripSerializationForTesting(input);
+            Assert.True(input.SequenceEqual(output));
+        }
     }
 }


### PR DESCRIPTION
I know that each and every type cannot be added as a built-in type for Orleans serialization, but I think `CultureInfo` deserves that as widely used system type. Json.Net also supports it out of the box meaning that most storage providers in Orleans already support `CultureInfo` for the grain state serialization. So let's have it supported for messaging as well.