### PR TITLE
Turn on Info on pressure monitor logging

### DIFF
--- a/src/OrleansServiceBus/Providers/Streams/EventHub/CachePressureMonitors/AveragingCachePressureMonitor.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/CachePressureMonitors/AveragingCachePressureMonitor.cs
@@ -16,7 +16,7 @@ namespace Orleans.ServiceBus.Providers
         /// <summary>
         /// Default flow control threshold
         /// </summary>
-        public static readonly double DefaultThreshold = 1 / 3;
+        public static readonly double DefaultThreshold = 1.0 / 3.0;
         private static readonly TimeSpan checkPeriod = TimeSpan.FromSeconds(2);
         private readonly Logger logger;
 
@@ -84,7 +84,7 @@ namespace Orleans.ServiceBus.Providers
             // If we changed state, log
             if (isUnderPressure != wasUnderPressure)
             {
-                logger.Verbose(isUnderPressure
+                logger.Info(isUnderPressure
                     ? $"Ingesting messages too fast. Throttling message reading. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {flowControlThreshold}"
                     : $"Message ingestion is healthy. AccumulatedCachePressure: {accumulatedCachePressure}, Contributions: {cachePressureContributionCount}, AverageCachePressure: {pressure}, Threshold: {flowControlThreshold}");
             }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/CachePressureMonitors/SlowConsumingPressureMonitor.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/CachePressureMonitors/SlowConsumingPressureMonitor.cs
@@ -95,7 +95,7 @@ namespace Orleans.ServiceBus.Providers
                 //if under pressure, extend the nextCheckedTime, make sure wasUnderPressure is true for a whole window  
                 this.wasUnderPressure = underPressure;
                 this.nextCheckedTime = utcNow + this.PressureWindowSize;
-                logger.Verbose($"Ingesting messages too fast. Throttling message reading. BiggestPressureInCurrentPeriod: {biggestPressureInCurrentWindow}, Threshold: {FlowControlThreshold}");
+                logger.Info($"Ingesting messages too fast. Throttling message reading. BiggestPressureInCurrentPeriod: {biggestPressureInCurrentWindow}, Threshold: {FlowControlThreshold}");
                 this.biggestPressureInCurrentWindow = 0;
             }
 
@@ -106,7 +106,7 @@ namespace Orleans.ServiceBus.Providers
                 this.biggestPressureInCurrentWindow = 0;
                 //if at the end of the window, pressure clears out, log
                 if(this.wasUnderPressure && !underPressure)
-                    logger.Verbose($"Message ingestion is healthy. BiggestPressureInCurrentPeriod: {biggestPressureInCurrentWindow}, Threshold: {FlowControlThreshold}");
+                    logger.Info($"Message ingestion is healthy. BiggestPressureInCurrentPeriod: {biggestPressureInCurrentWindow}, Threshold: {FlowControlThreshold}");
                 this.wasUnderPressure = underPressure;
             }
 

--- a/test/ServiceBus.Tests/SlowConsumingTests/EventHubStreamProviderSettingsTests.cs
+++ b/test/ServiceBus.Tests/SlowConsumingTests/EventHubStreamProviderSettingsTests.cs
@@ -31,7 +31,7 @@ namespace ServiceBus.Tests.SlowConsumingTests
         {
             var expectedSetting = new EventHubStreamProviderSettings(StreamProviderName);
             expectedSetting.SlowConsumingMonitorPressureWindowSize = TimeSpan.FromMinutes(2);
-            expectedSetting.SlowConsumingMonitorFlowControlThreshold = 1 / 3;
+            expectedSetting.SlowConsumingMonitorFlowControlThreshold = 0.6;
             AssertSettingEqual_After_WriteInto_ProviderConfiguration_AndPopulateBack(expectedSetting);
         }
 
@@ -39,7 +39,7 @@ namespace ServiceBus.Tests.SlowConsumingTests
         public void SettingWithAvgConsumingMonitorSetUp_Write_Into_ProviderConfiguration_PopulateBack()
         {
             var expectedSetting = new EventHubStreamProviderSettings(StreamProviderName);
-            expectedSetting.AveragingCachePressureMonitorFlowControlThreshold = 1 / 10;
+            expectedSetting.AveragingCachePressureMonitorFlowControlThreshold = 0.1;
             AssertSettingEqual_After_WriteInto_ProviderConfiguration_AndPopulateBack(expectedSetting);
         }
 
@@ -55,15 +55,31 @@ namespace ServiceBus.Tests.SlowConsumingTests
         }
         private void AssertEqual(EventHubStreamProviderSettings expectedSettings, EventHubStreamProviderSettings actualSettings)
         {
+
             Assert.Equal(expectedSettings.StreamProviderName, actualSettings.StreamProviderName);
-            Assert.Equal(expectedSettings.SlowConsumingMonitorFlowControlThreshold, actualSettings.SlowConsumingMonitorFlowControlThreshold);
+            Assert.True(TwoSettingValueEquals(expectedSettings.SlowConsumingMonitorFlowControlThreshold, 
+                actualSettings.SlowConsumingMonitorFlowControlThreshold));
             Assert.Equal(expectedSettings.SlowConsumingMonitorPressureWindowSize, actualSettings.SlowConsumingMonitorPressureWindowSize);
-            Assert.Equal(expectedSettings.AveragingCachePressureMonitorFlowControlThreshold, actualSettings.AveragingCachePressureMonitorFlowControlThreshold);
+            Assert.True(TwoSettingValueEquals(expectedSettings.AveragingCachePressureMonitorFlowControlThreshold, 
+                actualSettings.AveragingCachePressureMonitorFlowControlThreshold));
             Assert.Equal(expectedSettings.EventHubSettingsType, actualSettings.EventHubSettingsType);
             Assert.Equal(expectedSettings.CheckpointerSettingsType, actualSettings.CheckpointerSettingsType);
             Assert.Equal(expectedSettings.CacheSizeMb, actualSettings.CacheSizeMb);
             Assert.Equal(expectedSettings.DataMinTimeInCache, actualSettings.DataMinTimeInCache);
             Assert.Equal(expectedSettings.DataMaxAgeInCache, actualSettings.DataMaxAgeInCache);
+        }
+
+        private bool TwoSettingValueEquals(double? v1, double? v2)
+        {
+            //if both null. then return true
+            if (!v1.HasValue && !v2.HasValue)
+                return true;
+            if (v1.HasValue && v2.HasValue)
+            {
+                double tolerance = Math.Min(Math.Abs(v1.Value * .00001), Math.Abs(v2.Value * .00001));
+                return Math.Abs(v1.Value - v2.Value) < tolerance;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
-Turn on Info on pressure monitor logging, so get more valuable trouble shooting information without changing logging config and reproduce. Just three more line of logging 
-Fix double division bug in pressure monitor settings