### PR TITLE
Ensure items are copied before yielding the thread in SMS stream provider

### DIFF
--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -82,7 +82,8 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         IInternalAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> stream)
         {
             return new SimpleMessageStreamProducer<T>((StreamImpl<T>)stream, Name, providerRuntime,
-                fireAndForgetDelivery, optimizeForImmutableData, providerRuntime.PubSub(pubSubType), IsRewindable);
+                fireAndForgetDelivery, optimizeForImmutableData, providerRuntime.PubSub(pubSubType), IsRewindable,
+                this.runtimeClient.SerializationManager);
         }
 
         IInternalAsyncObservable<T> IInternalStreamProvider.GetConsumerInterface<T>(IAsyncStream<T> streamId)


### PR DESCRIPTION
In #3043, @danvanderboom highlighted an issue in the current SMS stream provider whereby the thread can be yielded before an item is copied.

The cleanest fix to this which minimizes overhead and doesn't add unwanted complexity is to eagerly copy the item before we know the thread will be yielded.