### PR TITLE
SMS: avoid copy in OnNextAsync if user has specified immutable data optimization

### DIFF
--- a/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
+++ b/src/Orleans/Streams/SimpleMessageStream/SimpleMessageStreamProducer.cs
@@ -96,9 +96,13 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
 
             if (!connectedToRendezvous)
             {
-                // In order to avoid potential concurrency errors, synchronously copy the input before yielding the
-                // thread. DeliverItem below must also be take care to avoid yielding before copying for non-immutable objects.
-                item = (T)this.serializationManager.DeepCopy(item);
+                if (!this.optimizeForImmutableData)
+                {
+                    // In order to avoid potential concurrency errors, synchronously copy the input before yielding the
+                    // thread. DeliverItem below must also be take care to avoid yielding before copying for non-immutable objects.
+                    item = (T) this.serializationManager.DeepCopy(item);
+                }
+
                 await ConnectToRendezvous();
             }
 


### PR DESCRIPTION
Fixes a minor test breakage introduced in #3048.

A test was relying on data not being copied if the optimization for immutable data was set. In reality this isn't an issue, since we don't guarantee consumers and producers are on the same silo, but the fix is trivial. I didn't realize previously that this field was available, my mistake.