### PR TITLE
Service Fabric: execute cluster update notifications on an Orleans thread

### DIFF
--- a/Samples/ServiceFabric/Stateless/StatelessCalculatorService/Program.cs
+++ b/Samples/ServiceFabric/Stateless/StatelessCalculatorService/Program.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Fabric;
 using System.Threading;
+using Grains;
 using Microsoft.ServiceFabric.Services.Runtime;
 
 namespace StatelessCalculatorService
@@ -15,6 +16,8 @@ namespace StatelessCalculatorService
         {
             try
             {
+                Console.WriteLine(typeof(CalculatorGrain).Name);
+
                 // The ServiceManifest.XML file defines one or more service type names.
                 // Registering a service maps a service type name to a .NET type.
                 // When Service Fabric creates an instance of this service type,

--- a/Samples/ServiceFabric/Stateless/StatelessCalculatorService/StatelessCalculatorService.cs
+++ b/Samples/ServiceFabric/Stateless/StatelessCalculatorService/StatelessCalculatorService.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Grains;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Microsoft.ServiceFabric.Services.Runtime;
 using Microsoft.Orleans.ServiceFabric;
@@ -112,6 +113,7 @@ namespace StatelessCalculatorService
         {
             var logger = providerRuntime.GetLogger(nameof(BootstrapProvider));
             this.Name = name;
+            
             var grain = providerRuntime.GrainFactory.GetGrain<ICalculatorGrain>(Guid.Empty);
             Task.Factory.StartNew(
                 async () =>
@@ -120,9 +122,8 @@ namespace StatelessCalculatorService
                     {
                         try
                         {
-                            var oldValue = await grain.Get();
                             var value = await grain.Add(1);
-                            //logger.Info($"{oldValue} + 1 = {value}");
+                            logger.Info($"{value - 1} + 1 = {value}");
                             await Task.Delay(TimeSpan.FromSeconds(4));
                         }
                         catch (Exception exception)

--- a/src/OrleansServiceFabricUtils/FabricMembershipOracle.cs
+++ b/src/OrleansServiceFabricUtils/FabricMembershipOracle.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 using Orleans;
@@ -35,6 +36,7 @@ namespace Microsoft.Orleans.ServiceFabric
 
         private Timer timer;
         private DateTime lastRefreshTime;
+        private TaskScheduler scheduler;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FabricMembershipOracle"/> class.
@@ -191,6 +193,7 @@ namespace Microsoft.Orleans.ServiceFabric
         /// </summary>
         public Task Start()
         {
+            this.scheduler = TaskScheduler.Current;
             this.timer = new Timer(
                 self => ((FabricMembershipOracle)self).RefreshAsync().Ignore(),
                 this,
@@ -376,20 +379,23 @@ namespace Microsoft.Orleans.ServiceFabric
 
         private void NotifySubscribers(SiloAddress address, SiloStatus newStatus, List<ISiloStatusListener> listeners)
         {
-            foreach (var subscriber in listeners)
+            Task.Factory.StartNew(() =>
             {
-                try
+                foreach (var subscriber in listeners)
                 {
-                    subscriber.SiloStatusChangeNotification(address, newStatus);
+                    try
+                    {
+                        subscriber.SiloStatusChangeNotification(address, newStatus);
+                    }
+                    catch (Exception exception)
+                    {
+                        this.log.Warn(
+                            (int) ErrorCode.ServiceFabric_MembershipOracle_ExceptionNotifyingSubscribers,
+                            "Exception notifying subscriber.",
+                            exception);
+                    }
                 }
-                catch (Exception exception)
-                {
-                    this.log.Warn(
-                        (int)ErrorCode.ServiceFabric_MembershipOracle_ExceptionNotifyingSubscribers,
-                        "Exception notifying subscriber.",
-                        exception);
-                }
-            }
+            }, CancellationToken.None, TaskCreationOptions.None, this.scheduler);
         }
 
         private async Task RefreshAsync()

--- a/test/TestServiceFabric/FabricMembershipOracleTests.cs
+++ b/test/TestServiceFabric/FabricMembershipOracleTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Orleans.ServiceFabric;
 using Microsoft.Orleans.ServiceFabric.Models;
@@ -132,7 +133,10 @@ namespace TestServiceFabric
                     "OtherNewSilo"),
             };
 
+            listener.VersionReached.Reset();
+            listener.WaitForVersion = 4;
             this.resolver.Notify(silos);
+            listener.VersionReached.WaitOne(TimeSpan.FromMinutes(1));
             Assert.Equal(3, listener.Silos.Count);
             Assert.Contains(silos[1].SiloAddress, listener.Silos.Keys);
             Assert.Equal(SiloStatus.Active, listener.Silos[silos[1].SiloAddress]);
@@ -150,7 +154,9 @@ namespace TestServiceFabric
             Assert.Equal(2, multiClusters.Count);
 
             // Remove a silo and verify that it's been removed.
+            listener.WaitForVersion = 5;
             this.resolver.Notify(new[] {silos[1]});
+            listener.VersionReached.WaitOne(TimeSpan.FromMinutes(1));
             Assert.Equal(3, listener.Silos.Count);
             Assert.Contains(silos[1].SiloAddress, listener.Silos.Keys);
             Assert.Equal(SiloStatus.Active, listener.Silos[silos[1].SiloAddress]);
@@ -162,6 +168,8 @@ namespace TestServiceFabric
 
             // Remove a silo and verify that it's been removed.
             this.resolver.Notify(new FabricSiloInfo[0]);
+            listener.VersionReached.WaitOne(TimeSpan.FromMinutes(1));
+
             Assert.Equal(3, listener.Silos.Count);
             Assert.Contains(silos[1].SiloAddress, listener.Silos.Keys);
             Assert.Equal(SiloStatus.Dead, listener.Silos[silos[0].SiloAddress]);
@@ -206,6 +214,9 @@ namespace TestServiceFabric
 
         private class MockStatusListener : ISiloStatusListener
         {
+            public int Version { get; private set; }
+            public int WaitForVersion { get; set; }
+            public AutoResetEvent VersionReached { get; } = new AutoResetEvent(false);
             public Dictionary<SiloAddress, SiloStatus> Silos { get; } = new Dictionary<SiloAddress, SiloStatus>();
             public List<Tuple<SiloAddress, SiloStatus>> Notifications { get; } = new List<Tuple<SiloAddress, SiloStatus>>();
 
@@ -213,6 +224,8 @@ namespace TestServiceFabric
             {
                 this.Notifications.Add(Tuple.Create(updatedSilo, status));
                 this.Silos[updatedSilo] = status;
+                this.Version++;
+                if (this.Version >= this.WaitForVersion) this.VersionReached.Set();
             }
         }
 


### PR DESCRIPTION
Fix for #3057, in which @rikbosch is experiencing threading issues caused by the `FabricMembershipOracle` not executing cluster status notifications on an Orleans thread.

Proposed solution is to capture the `OrleansTaskScheduler` in the `IMembershipOracle.Start` call and later use it to schedule notifications.