### PR TITLE
Service Fabric: Mark removed silos as Dead indefinitely

### DIFF
--- a/src/OrleansServiceFabricUtils/Utilities/ErrorCode.cs
+++ b/src/OrleansServiceFabricUtils/Utilities/ErrorCode.cs
@@ -13,5 +13,6 @@ namespace Microsoft.Orleans.ServiceFabric.Utilities
         ServiceFabric_MembershipOracle_ExceptionRefreshingPartitions = ServiceFabricBase + 4,
         ServiceFabric_Resolver_PartitionNotFound = ServiceFabricBase + 5,
         ServiceFabric_Resolver_PartitionResolutionException = ServiceFabricBase + 6,
+        ServiceFabric_MembershipOracle_EncounteredUndeadSilo = ServiceFabricBase + 7,
     }
 }

--- a/test/TestServiceFabric/FabricMembershipOracleTests.cs
+++ b/test/TestServiceFabric/FabricMembershipOracleTests.cs
@@ -156,7 +156,7 @@ namespace TestServiceFabric
             Assert.Equal(SiloStatus.Active, listener.Silos[silos[1].SiloAddress]);
             AssertStatus(silos[1].SiloAddress, SiloStatus.Active);
             Assert.Equal(SiloStatus.Dead, listener.Silos[silos[0].SiloAddress]);
-            AssertStatus(silos[0].SiloAddress, SiloStatus.None);
+            AssertStatus(silos[0].SiloAddress, SiloStatus.Dead);
             multiClusters = this.oracle.GetApproximateMultiClusterGateways();
             Assert.Equal(2, multiClusters.Count);
 
@@ -165,9 +165,9 @@ namespace TestServiceFabric
             Assert.Equal(3, listener.Silos.Count);
             Assert.Contains(silos[1].SiloAddress, listener.Silos.Keys);
             Assert.Equal(SiloStatus.Dead, listener.Silos[silos[0].SiloAddress]);
-            AssertStatus(silos[0].SiloAddress, SiloStatus.None);
+            AssertStatus(silos[0].SiloAddress, SiloStatus.Dead);
             Assert.Equal(SiloStatus.Dead, listener.Silos[silos[1].SiloAddress]);
-            AssertStatus(silos[1].SiloAddress, SiloStatus.None);
+            AssertStatus(silos[1].SiloAddress, SiloStatus.Dead);
 
             multiClusters = this.oracle.GetApproximateMultiClusterGateways();
             Assert.Equal(1, multiClusters.Count);


### PR DESCRIPTION
Instead of setting a no-longer-present silo's status to `SiloStatus.None`, leave a tombstone declaring it `Dead`.

Related to #3056