### PR TITLE
Fix provider type for ADO.Net storage provider in config example

### DIFF
--- a/src/Documentation/Getting-Started-With-Orleans/Grain-Persistence.md
+++ b/src/Documentation/Getting-Started-With-Orleans/Grain-Persistence.md
@@ -117,7 +117,7 @@ Check with your database vendor for their latest supported ADO.NET provider.
 
 
 ```xml
-<Provider Type="Orleans.SqlUtils.StorageProvider.SqlStorageProvider" Name="SqlStore" DataConnectionString="Data Source = (localdb)\MSSQLLocalDB; Database = OrleansTestStorage; Integrated Security = True; Asynchronous Processing = True; Max Pool Size = 200;" />
+<Provider Type="Orleans.Storage.AdoNetStorageProvider" Name="SqlStore" DataConnectionString="Data Source = (localdb)\MSSQLLocalDB; Database = OrleansTestStorage; Integrated Security = True; Asynchronous Processing = True; Max Pool Size = 200;" />
 ```
 
 * __`DataConnectionString="..."`__ (mandatory) - The SQL connection string to use.


### PR DESCRIPTION
The type name in the configuration example appears to be incorrect - I could find no type named `Orleans.SqlUtils.StorageProvider.SqlStorageProvider` in the `Microsoft.Orleans.SqlUtils` package. I believe the correct type name is `Orleans.Storage.AdoNetStorageProvider` and have updated the example.