### PR TITLE
Fix resolve ip address.

### DIFF
--- a/src/Orleans/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans/Configuration/ClusterConfiguration.cs
@@ -427,6 +427,12 @@ namespace Orleans.Runtime.Configuration
                 addrOrHost = Dns.GetHostName();
             }
 
+            // Fix StreamFilteringTests_SMS tests
+            if (addrOrHost.Equals("loopback", StringComparison.OrdinalIgnoreCase))
+            {
+                return loopback;
+            }
+
             // check if addrOrHost is a valid IP address including loopback (127.0.0.0/8, ::1) and any (0.0.0.0/0, ::) addresses
             IPAddress address;
             if (IPAddress.TryParse(addrOrHost, out address))
@@ -436,7 +442,7 @@ namespace Orleans.Runtime.Configuration
 
             var candidates = new List<IPAddress>();
 
-            // Get IP address from DNS. If addrOrHost is localhost or loopback will 
+            // Get IP address from DNS. If addrOrHost is localhost will 
             // return loopback IPv4 address (or IPv4 and IPv6 addresses if OS is supported IPv6)
             var nodeIps = await Dns.GetHostAddressesAsync(addrOrHost);
             foreach (var nodeIp in nodeIps.Where(x => x.AddressFamily == family))


### PR DESCRIPTION
Fix resolve ip address.
We have a problem when configuring silo hosts. If I setup in hosts file network name (for example 'orleans') with IP 127.0.0.1 and set it as Address in SeedNode, Networking or ProxyingGateway the load configuration will trow `ArgumentException`. The host name 'orleans' is a valid host with valid loopback IP in this case.
So this fix checks any valid host name from hosts file, DNS entries (including case whena DNS responds 'localhost' or '127.0.0.1'). In additional I add parsing IP addresses (IPv4 and IPv6). So it possible to set not only 127.0.0.1, but any valid IP address.