### PR TITLE
Improve serialization of GrainReference when using JSON

### DIFF
--- a/test/DefaultCluster.Tests/GrainReferenceTest.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceTest.cs
@@ -111,22 +111,22 @@ namespace DefaultCluster.Tests.General
             await grain.SetA(56820);
             var input = new GenericGrainReferenceHolder
             {
-                Reference = grain
+                Reference = grain as GrainReference
             };
 
             var json = JsonConvert.SerializeObject(input, settings);
             var output = JsonConvert.DeserializeObject<GenericGrainReferenceHolder>(json, settings);
 
             Assert.Equal(input.Reference, output.Reference);
-            var reference = output.Reference.Cast<ISimpleGrain>();
-            Assert.Equal(56820, await reference.GetA());
+            var reference = output.Reference;
+            Assert.Equal(56820, await ((ISimpleGrain)reference).GetA());
         }
 
         [Serializable]
         public class GenericGrainReferenceHolder
         {
             [JsonProperty]
-            public ISimpleGrain Reference { get; set; }
+            public GrainReference Reference { get; set; }
         }
 
         [Fact, TestCategory("Serialization"), TestCategory("JSON")]
@@ -248,7 +248,7 @@ namespace DefaultCluster.Tests.General
             var settings = OrleansJsonSerializer.GetDefaultSerializerSettings(this.HostedCluster.SerializationManager, this.GrainFactory);
             // http://james.newtonking.com/json/help/index.html?topic=html/T_Newtonsoft_Json_JsonConvert.htm
             string json = JsonConvert.SerializeObject(obj, settings);
-            object other = JsonConvert.DeserializeObject(json, settings);
+            object other = JsonConvert.DeserializeObject(json, typeof(T), settings);
             return (T)other;
         }
     }


### PR DESCRIPTION
Fixes #3063.

We have a specific `JsonConverter` for grain references which was introduced along with the non-static `SerializationManager` changes. The converter is required to flow the runtime context into `GrainReferences` on .NET Standard, but it was incorrectly implemented.

On full .NET, this converter is technically not required, since `GrainReference` implements `ISerializable` and we flow the runtime into the `StreamingContext.Context` property. This property does not exist on .NET Standard < v2.0 and so this converter is required.

This PR involves a rewrite of the implementation of `GrainReferenceConverter` so that GrainReferences work even if they are passed via a field with an ambiguous type such as `object` or `GrainReference`.

It does this by having an internal serializer which defers to the `ISerializable` implementation, and then manually binding the reference to the runtime at deserialization time.