### PR TITLE
Exposing internal IsOrleansShallowCopyable to for external custom serializers 

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Serialization\IOnDeserialized.cs" />
     <Compile Include="Serialization\OrleansJsonSerializer.cs" />
     <Compile Include="Serialization\BinaryFormatterSerializer.cs" />
+    <Compile Include="Serialization\OrleansSerializer.cs" />
     <Compile Include="Services\IGrainServiceClient.cs" />
     <Compile Include="Services\IGrainService.cs" />
     <Compile Include="Serialization\RemoteNonDeserializableException.cs" />

--- a/src/Orleans/Serialization/OrleansSerializer.cs
+++ b/src/Orleans/Serialization/OrleansSerializer.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Orleans.Serialization
+{
+    public static class OrleansSerializer
+    {
+        /// <summary>        
+        /// Returns <see langword="true"/> if instances of the provided type can be safely shallow-copied;
+        /// otherwise <see langword="false"/>, indicating that instances must instead be deep-copied.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>
+        /// <see langword="true"/> if instances of the provided type can be safely shallow-copied; otherwise
+        /// <see langword="false"/>, indicating that instances must instead be deep-copied.
+        /// </returns>
+        public static bool IsTypeShallowCopyable(Type type)
+        {
+            return type.IsOrleansShallowCopyable();
+        }
+    }
+}

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1045,20 +1045,6 @@ namespace Orleans.Serialization
                 ". Perhaps you need to mark it [Serializable] or define a custom serializer for it?");
         }
 
-        /// <summary>        
-        /// Returns <see langword="true"/> if instances of the provided type can be safely shallow-copied;
-        /// otherwise <see langword="false"/>, indicating that instances must instead be deep-copied.
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <returns>
-        /// <see langword="true"/> if instances of the provided type can be safely shallow-copied; otherwise
-        /// <see langword="false"/>, indicating that instances must instead be deep-copied.
-        /// </returns>
-        public static bool IsTypeShallowCopyable(Type type)
-        {
-            return type.IsOrleansShallowCopyable();
-        }
-
 #endregion
 
 #region Serializing

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1046,11 +1046,15 @@ namespace Orleans.Serialization
         }
 
         /// <summary>        
-        /// This method exposes internal IsOrleansShallowCopyable to allow external custom serializers to check if is it ok to shallow copy objects when deep copying.               
+        /// Returns <see langword="true"/> if instances of the provided type can be safely shallow-copied;
+        /// otherwise <see langword="false"/>, indicating that instances must instead be deep-copied.
         /// </summary>
         /// <param name="type">The type to check.</param>
-        /// <returns>Returns true if ok to shallow copy.</returns>
-        public static bool IsTypeOrleansShallowCopyable(Type type)
+        /// <returns>
+        /// <see langword="true"/> if instances of the provided type can be safely shallow-copied; otherwise
+        /// <see langword="false"/>, indicating that instances must instead be deep-copied.
+        /// </returns>
+        public static bool IsTypeShallowCopyable(Type type)
         {
             return type.IsOrleansShallowCopyable();
         }

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1045,6 +1045,16 @@ namespace Orleans.Serialization
                 ". Perhaps you need to mark it [Serializable] or define a custom serializer for it?");
         }
 
+        /// <summary>        
+        /// This method exposes internal IsOrleansShallowCopyable to allow external custom serializers to check if is it ok to shallow copy objects when deep copying.               
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>Returns true if ok to shallow copy.</returns>
+        public static bool IsTypeOrleansShallowCopyable(Type type)
+        {
+            return type.IsOrleansShallowCopyable();
+        }
+
 #endregion
 
 #region Serializing


### PR DESCRIPTION
Hi,
As discussed with @ReubenBond in #3064 , I'm exposing `IsOrleansShallowCopyable` for external custom serializer.

Background: I've created a custom serializer for `ObservableCollection`, and copied the logic of copying `List<T>` from `BuiltInTypes.DeepCopyList()`, it uses this method to allow quick shallow copy.