### PR TITLE
Blocked grains in "Deactivating" state detection and mitigation 

### DIFF
--- a/test/TestGrainInterfaces/IStuckGrain.cs
+++ b/test/TestGrainInterfaces/IStuckGrain.cs
@@ -11,6 +11,8 @@ namespace UnitTests.GrainInterfaces
         Task NonBlockingCall();
 
         Task<int> GetNonBlockingCallCounter();
+
+        Task BlockingDeactivation();
     }
 
     public interface IStuckCleanGrain : IGrainWithGuidKey


### PR DESCRIPTION
A Grain can be blocked on the Deactivating state. The following PR extends the logic implemented in #2387 to detect such case.