### PR TITLE
Correct ClusterFixture's Dispose() method in unit testing tutorial

### DIFF
--- a/src/Tutorials/Unit-Testing-Grains.md
+++ b/src/Tutorials/Unit-Testing-Grains.md
@@ -57,7 +57,7 @@ public class ClusterFixture : IDisposable
 
     public void Dispose()
     {
-        this.Cluster.Dispose();
+        this.Cluster.StopAllSilos();
     }
 
     public TestCluster Cluster { get; private set; }


### PR DESCRIPTION
As per the comments on #3028 fix the `Dispose()` method on `ClusterFixture` so that it calls `StopAllSilos()`.