### PR TITLE
Fix client side EHStreamProvider init

### DIFF
--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -282,8 +282,8 @@ namespace Orleans.ServiceBus.Providers
         /// <returns></returns>
         protected virtual IEventHubQueueCacheFactory CreateCacheFactory(EventHubStreamProviderSettings providerSettings)
         {
-            var globalConfig = this.serviceProvider.GetRequiredService<GlobalConfiguration>();
-            var nodeConfig = this.serviceProvider.GetRequiredService<NodeConfiguration>();
+            var globalConfig = this.serviceProvider.GetService<GlobalConfiguration>();
+            var nodeConfig = this.serviceProvider.GetService<NodeConfiguration>();
             var eventHubPath = hubSettings.Path;
             var sharedDimensions = new EventHubMonitorAggregationDimensions(globalConfig, nodeConfig, eventHubPath);
             return new EventHubQueueCacheFactory(providerSettings, SerializationManager, sharedDimensions);


### PR DESCRIPTION
GlobalConfig and NodeConfig is not available in client side. So those two shouldn't be required. 