### PR TITLE
Redact more connection strings when logging

### DIFF
--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -81,7 +81,7 @@ namespace Orleans.Storage
                 await container.CreateIfNotExistsAsync().ConfigureAwait(false);
 
                 Log.Info((int)AzureProviderErrorCode.AzureBlobProvider_InitProvider, "Init: Name={0} ServiceId={1} {2}", name, providerRuntime.ServiceId.ToString(), string.Join(" ", FormatPropertyMessage(config)));
-                Log.Info((int)AzureProviderErrorCode.AzureBlobProvider_ParamConnectionString, "AzureBlobStorage Provider is using DataConnectionString: {0}", ConfigUtilities.PrintDataConnectionInfo(config.Properties["DataConnectionString"]));
+                Log.Info((int)AzureProviderErrorCode.AzureBlobProvider_ParamConnectionString, "AzureBlobStorage Provider is using DataConnectionString: {0}", ConfigUtilities.RedactConnectionStringInfo(config.Properties["DataConnectionString"]));
             }
             catch (Exception ex)
             {

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -119,7 +119,7 @@ namespace Orleans.Storage
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 
             Log.Info((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, initMsg);
-            Log.Info((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, "AzureTableStorage Provider is using DataConnectionString: {0}", ConfigUtilities.PrintDataConnectionInfo(dataConnectionString));
+            Log.Info((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, "AzureTableStorage Provider is using DataConnectionString: {0}", ConfigUtilities.RedactConnectionStringInfo(dataConnectionString));
             tableDataManager = new GrainStateTableDataManager(tableName, dataConnectionString, Log);
             return tableDataManager.InitTableAsync();
         }

--- a/test/NonSilo.Tests/ConfigTests.cs
+++ b/test/NonSilo.Tests/ConfigTests.cs
@@ -610,7 +610,7 @@ namespace UnitTests
             string azureConnectionStringInput =
                 @"DefaultEndpointsProtocol=https;AccountName=test;AccountKey=q-SOMEKEY-==";
             output.WriteLine("Input = " + azureConnectionStringInput);
-            string azureConnectionString = ConfigUtilities.PrintDataConnectionInfo(azureConnectionStringInput);
+            string azureConnectionString = ConfigUtilities.RedactConnectionStringInfo(azureConnectionStringInput);
             output.WriteLine("Output = " + azureConnectionString);
             Assert.True(azureConnectionString.EndsWith("AccountKey=<--SNIP-->", StringComparison.InvariantCultureIgnoreCase),
                 "Removed account key info from Azure connection string " + azureConnectionString);
@@ -622,7 +622,7 @@ namespace UnitTests
             string sqlConnectionStringInput =
                 @"Server=myServerName\myInstanceName;Database=myDataBase;User Id=myUsername;Password=myPassword";
             output.WriteLine("Input = " + sqlConnectionStringInput);
-            string sqlConnectionString = ConfigUtilities.PrintSqlConnectionString(sqlConnectionStringInput);
+            string sqlConnectionString = ConfigUtilities.RedactConnectionStringInfo(sqlConnectionStringInput);
             output.WriteLine("Output = " + sqlConnectionString);
             Assert.True(sqlConnectionString.EndsWith("Password=<--SNIP-->", StringComparison.InvariantCultureIgnoreCase),
                 "Removed password info from SqlServer connection string " + sqlConnectionString);


### PR DESCRIPTION
Mask DynamoDB and ServiceBus connection strings, as well as SAS tokens in Azure Storage.