### PR TITLE
Add rule in docfx to copy gif in output folder

### DIFF
--- a/src/docfx.json
+++ b/src/docfx.json
@@ -29,6 +29,7 @@
           "logo.svg",
           "logo-light.svg",
           "Documentation/**/**.png",
+          "Documentation/**/**.gif",
           "Tutorials/**.png",
           "Community/**.png"
         ],


### PR DESCRIPTION
Gif file are not copied in docfx, I had to add a rule for that.

Without that we cannot see the beautiful gif I made for the rolling upgrade. It would be a shame, isn't it?