### PR TITLE
Replace DuplicateActivationException with a strongly-typed return value

### DIFF
--- a/src/Orleans/Statistics/StatisticNames.cs
+++ b/src/Orleans/Statistics/StatisticNames.cs
@@ -219,7 +219,7 @@ namespace Orleans.Runtime
         public static readonly StatisticName CATALOG_ACTIVATION_SHUTDOWN_VIA_DIRECT_SHUTDOWN                        = new StatisticName("Catalog.Activation.Shutdown.ViaDirectShutdown");
         public static readonly StatisticName CATALOG_ACTIVATION_SHUTDOWN_VIA_DEACTIVATE_STUCK_ACTIVATION            = new StatisticName("Catalog.Activation.Shutdown.ViaDeactivateStuckActivation");
         public static readonly StatisticName CATALOG_ACTIVATION_NON_EXISTENT_ACTIVATIONS                            = new StatisticName("Catalog.Activation.NonExistentActivations");
-        public static readonly StatisticName CATALOG_ACTIVATION_DUPLICATE_ACTIVATIONS                               = new StatisticName("Catalog.Activation.DuplicateActivations");
+        public static readonly StatisticName CATALOG_ACTIVATION_CONCURRENT_REGISTRATION_ATTEMPTS                    = new StatisticName("Catalog.Activation.ConcurrentRegistrationAttempts");
 
         // Dispatcher
         public static readonly StatisticName DISPATCHER_NEW_PLACEMENT                                               = new StatisticName("Dispatcher.NewPlacement");

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -28,59 +28,6 @@ namespace Orleans.Runtime
 {
     internal class Catalog : SystemTarget, ICatalog, IPlacementRuntime, ISiloStatusListener
     {
-        /// <summary>
-        /// Exception to indicate that the activation would have been a duplicate so messages pending for it should be redirected.
-        /// </summary>
-        [Serializable]
-        internal class DuplicateActivationException : Exception
-        {
-            public ActivationAddress ActivationToUse { get; private set; }
-
-            public SiloAddress PrimaryDirectoryForGrain { get; private set; } // for diagnostics only!
-
-            public DuplicateActivationException() : base("DuplicateActivationException") { }
-            public DuplicateActivationException(string msg) : base(msg) { }
-            public DuplicateActivationException(string message, Exception innerException) : base(message, innerException) { }
-
-            public DuplicateActivationException(ActivationAddress activationToUse)
-                : base("DuplicateActivationException")
-            {
-                ActivationToUse = activationToUse;
-            }
-
-            public DuplicateActivationException(ActivationAddress activationToUse, SiloAddress primaryDirectoryForGrain)
-                : base("DuplicateActivationException")
-            {
-                ActivationToUse = activationToUse;
-                PrimaryDirectoryForGrain = primaryDirectoryForGrain;
-            }
-
-#if !NETSTANDARD
-            // Implementation of exception serialization with custom properties according to:
-            // http://stackoverflow.com/questions/94488/what-is-the-correct-way-to-make-a-custom-net-exception-serializable
-            protected DuplicateActivationException(SerializationInfo info, StreamingContext context)
-                : base(info, context)
-            {
-                if (info != null)
-                {
-                    ActivationToUse = (ActivationAddress) info.GetValue("ActivationToUse", typeof (ActivationAddress));
-                    PrimaryDirectoryForGrain = (SiloAddress) info.GetValue("PrimaryDirectoryForGrain", typeof (SiloAddress));
-                }
-            }
-
-            public override void GetObjectData(SerializationInfo info, StreamingContext context)
-            {
-                if (info != null)
-                {
-                    info.AddValue("ActivationToUse", ActivationToUse, typeof (ActivationAddress));
-                    info.AddValue("PrimaryDirectoryForGrain", PrimaryDirectoryForGrain, typeof (SiloAddress));                   
-                }
-                // MUST call through to the base class to let it save its own state
-                base.GetObjectData(info, context);
-            }
-#endif
-        }
-
         [Serializable]
         internal class NonExistentActivationException : Exception
         {
@@ -567,130 +514,176 @@ namespace Orleans.Runtime
             }
         }
 
-        private async Task InitActivation(ActivationData activation, string grainType, string genericArguments, Dictionary<string, object> requestContextData)
+        private enum ActivationInitializationStage
+        {
+            None,
+            Register,
+            SetupState,
+            InvokeActivate,
+            Completed
+        }
+
+        private async Task InitActivation(ActivationData activation, string grainType, string genericArguments,
+            Dictionary<string, object> requestContextData)
         {
             // We've created a dummy activation, which we'll eventually return, but in the meantime we'll queue up (or perform promptly)
             // the operations required to turn the "dummy" activation into a real activation
-            ActivationAddress address = activation.Address;
+            var initStage = ActivationInitializationStage.None;
+            Exception exception = null;
+            var registrationResult = default(ActivationRegistrationResult);
 
-            int initStage = 0;
             // A chain of promises that will have to complete in order to complete the activation
             // Register with the grain directory, register with the store if necessary and call the Activate method on the new activation.
             try
             {
-                initStage = 1;
-                await RegisterActivationInGrainDirectoryAndValidate(activation);
+                initStage = ActivationInitializationStage.Register;
+                registrationResult = await RegisterActivationInGrainDirectoryAndValidate(activation);
 
-                initStage = 2;
-                await SetupActivationState(activation, String.IsNullOrEmpty(genericArguments) ? grainType : $"{grainType}[{genericArguments}]");
+                // If registration failed, recover from within the finally block.
+                if (!registrationResult.IsSuccess) return;
 
-                initStage = 3;
+                initStage = ActivationInitializationStage.SetupState;
+                await SetupActivationState(activation,
+                    string.IsNullOrEmpty(genericArguments) ? grainType : $"{grainType}[{genericArguments}]");
+
+                initStage = ActivationInitializationStage.InvokeActivate;
                 await InvokeActivate(activation, requestContextData);
 
                 ActivationCollector.ScheduleCollection(activation);
 
                 // Success!! Log the result, and start processing messages
-                if (logger.IsVerbose) logger.Verbose("InitActivation is done: {0}", address);
+                initStage = ActivationInitializationStage.Completed;
+                if (logger.IsVerbose) logger.Verbose("InitActivation is done: {0}", activation.Address);
             }
             catch (Exception ex)
             {
-                lock (activation)
+                // Store and re-throw the exception.
+                exception = ex;
+                throw;
+            }
+            finally
+            {
+                // If activation initialization was not successful, recover from the failing stage.
+                if (initStage != ActivationInitializationStage.Completed)
                 {
-                    activation.SetState(ActivationState.Invalid);
-                    try
-                    {
-                        UnregisterMessageTarget(activation);
-                    }
-                    catch (Exception exc)
-                    {
-                        logger.Warn(ErrorCode.Catalog_UnregisterMessageTarget4, String.Format("UnregisterMessageTarget failed on {0}.", activation), exc);
-                    }
+                    RecoverFailedInitActivation(activation, initStage, registrationResult, exception);
+                }
+            }
+        }
 
-                    switch (initStage)
-                    {
-                        case 1: // failed to RegisterActivationInGrainDirectory
-                            
-                            ActivationAddress target = null;
-                            Exception dupExc;
-                            // Failure!! Could it be that this grain uses single activation placement, and there already was an activation?
-                            if (Utils.TryFindException(ex, typeof (DuplicateActivationException), out dupExc))
+        /// <summary>
+        /// Recover from a failed attempt to initialize a new activation.
+        /// </summary>
+        /// <param name="activation">The activation which failed to be initialized.</param>
+        /// <param name="initStage">The initialization stage at which initialization failed.</param>
+        /// <param name="registrationResult">The result of registering the activation with the grain directory.</param>
+        /// <param name="exception">The exception, if present, for logging purposes.</param>
+        private void RecoverFailedInitActivation(ActivationData activation, ActivationInitializationStage initStage,
+            ActivationRegistrationResult registrationResult, Exception exception = null)
+        {
+            ActivationAddress address = activation.Address;
+            lock (activation)
+            {
+                activation.SetState(ActivationState.Invalid);
+                try
+                {
+                    UnregisterMessageTarget(activation);
+                }
+                catch (Exception exc)
+                {
+                    logger.Warn(ErrorCode.Catalog_UnregisterMessageTarget4,
+                        string.Format("UnregisterMessageTarget failed on {0}.", activation), exc);
+                }
+
+                switch (initStage)
+                {
+                    case ActivationInitializationStage.Register: // failed to RegisterActivationInGrainDirectory
+
+                        // Failure!! Could it be that this grain uses single activation placement, and there already was an activation?
+                        activation.ForwardingAddress = registrationResult.ExistingActivationAddress;
+                        if (activation.ForwardingAddress != null)
+                        {
+                            CounterStatistic
+                                .FindOrCreate(StatisticNames.CATALOG_ACTIVATION_DUPLICATE_ACTIVATIONS)
+                                .Increment();
+                            var primary = directory.GetPrimaryForGrain(activation.ForwardingAddress.Grain);
+                            if (logger.IsInfo)
                             {
-                                target = ((DuplicateActivationException) dupExc).ActivationToUse;
-                                CounterStatistic.FindOrCreate(StatisticNames.CATALOG_ACTIVATION_DUPLICATE_ACTIVATIONS)
-                                    .Increment();
-                            }
-                            activation.ForwardingAddress = target;
-                            if (target != null)
-                            {
-                                var primary = ((DuplicateActivationException)dupExc).PrimaryDirectoryForGrain;
                                 // If this was a duplicate, it's not an error, just a race.
                                 // Forward on all of the pending messages, and then forget about this activation.
-                                string logMsg = String.Format("Tried to create a duplicate activation {0}, but we'll use {1} instead. " +
-                                    "GrainInstanceType is {2}. " +
-                                                            "{3}" +
-                                                            "Full activation address is {4}. We have {5} messages to forward.",
-                                    address,
-                                    target,
-                                    activation.GrainInstanceType,
-                                                primary != null ? "Primary Directory partition for this grain is " + primary + ". " : String.Empty,
-                                    address.ToFullString(),
-                                    activation.WaitingCount);
+                                string logMsg =
+                                    string.Format(
+                                        "Tried to create a duplicate activation {0}, but we'll use {1} instead. " +
+                                        "GrainInstanceType is {2}. " +
+                                        "{3}" +
+                                        "Full activation address is {4}. We have {5} messages to forward.",
+                                        address,
+                                        activation.ForwardingAddress,
+                                        activation.GrainInstanceType,
+                                        primary != null
+                                            ? "Primary Directory partition for this grain is " + primary + ". "
+                                            : String.Empty,
+                                        address.ToFullString(),
+                                        activation.WaitingCount);
                                 if (activation.IsUsingGrainDirectory)
                                 {
                                     logger.Info(ErrorCode.Catalog_DuplicateActivation, logMsg);
                                 }
-                                else
+                                else if (logger.IsVerbose)
                                 {
-                                    if (logger.IsVerbose) logger.Verbose(ErrorCode.Catalog_DuplicateActivation, logMsg);
+                                    logger.Verbose(ErrorCode.Catalog_DuplicateActivation, logMsg);
                                 }
-                                RerouteAllQueuedMessages(activation, target, "Duplicate activation", ex);
                             }
-                            else
-                            {
-                                logger.Warn(ErrorCode.Runtime_Error_100064,
-                                    String.Format("Failed to RegisterActivationInGrainDirectory for {0}.",
-                                        activation), ex);
-                                // Need to undo the registration we just did earlier
-                                if (activation.IsUsingGrainDirectory)
-                                {
-                                    scheduler.RunOrQueueTask(() => directory.UnregisterAsync(address, UnregistrationCause.Force),
-                                        SchedulingContext).Ignore();
-                                }
-                                RerouteAllQueuedMessages(activation, null,
-                                    "Failed RegisterActivationInGrainDirectory", ex);
-                            }
-                            break;
 
-                        case 2: // failed to setup persistent state
-                            
-                            logger.Warn(ErrorCode.Catalog_Failed_SetupActivationState,
-                                String.Format("Failed to SetupActivationState for {0}.", activation), ex);
+                            RerouteAllQueuedMessages(activation, activation.ForwardingAddress, "Duplicate activation", exception);
+                        }
+                        else
+                        {
+                            logger.Warn(ErrorCode.Runtime_Error_100064,
+                                string.Format("Failed to RegisterActivationInGrainDirectory for {0}.",
+                                    activation), exception);
                             // Need to undo the registration we just did earlier
                             if (activation.IsUsingGrainDirectory)
                             {
-                                scheduler.RunOrQueueTask(() => directory.UnregisterAsync(address, UnregistrationCause.Force),
+                                scheduler.RunOrQueueTask(
+                                    () => directory.UnregisterAsync(address, UnregistrationCause.Force),
                                     SchedulingContext).Ignore();
                             }
+                            RerouteAllQueuedMessages(activation, null,
+                                "Failed RegisterActivationInGrainDirectory", exception);
+                        }
+                        break;
 
-                            RerouteAllQueuedMessages(activation, null, "Failed SetupActivationState", ex);
-                            break;
+                    case ActivationInitializationStage.SetupState: // failed to setup persistent state
 
-                        case 3: // failed to InvokeActivate
-                            
-                            logger.Warn(ErrorCode.Catalog_Failed_InvokeActivate,
-                                String.Format("Failed to InvokeActivate for {0}.", activation), ex);
-                            // Need to undo the registration we just did earlier
-                            if (activation.IsUsingGrainDirectory)
-                            {
-                                scheduler.RunOrQueueTask(() => directory.UnregisterAsync(address, UnregistrationCause.Force),
-                                    SchedulingContext).Ignore();
-                            }
+                        logger.Warn(ErrorCode.Catalog_Failed_SetupActivationState,
+                            string.Format("Failed to SetupActivationState for {0}.", activation), exception);
+                        // Need to undo the registration we just did earlier
+                        if (activation.IsUsingGrainDirectory)
+                        {
+                            scheduler.RunOrQueueTask(
+                                () => directory.UnregisterAsync(address, UnregistrationCause.Force),
+                                SchedulingContext).Ignore();
+                        }
 
-                            RerouteAllQueuedMessages(activation, null, "Failed InvokeActivate", ex);
-                            break;
-                    }
+                        RerouteAllQueuedMessages(activation, null, "Failed SetupActivationState", exception);
+                        break;
+
+                    case ActivationInitializationStage.InvokeActivate: // failed to InvokeActivate
+
+                        logger.Warn(ErrorCode.Catalog_Failed_InvokeActivate,
+                            string.Format("Failed to InvokeActivate for {0}.", activation), exception);
+                        // Need to undo the registration we just did earlier
+                        if (activation.IsUsingGrainDirectory)
+                        {
+                            scheduler.RunOrQueueTask(
+                                () => directory.UnregisterAsync(address, UnregistrationCause.Force),
+                                SchedulingContext).Ignore();
+                        }
+
+                        RerouteAllQueuedMessages(activation, null, "Failed InvokeActivate", exception);
+                        break;
                 }
-                throw;
             }
         }
 
@@ -1400,19 +1393,54 @@ namespace Orleans.Runtime
             return activation;
         }
 
-        private async Task RegisterActivationInGrainDirectoryAndValidate(ActivationData activation)
+        /// <summary>
+        /// Represents the results of an attempt to register an activation.
+        /// </summary>
+        private struct ActivationRegistrationResult
+        {
+            /// <summary>
+            /// Represents a successful activation.
+            /// </summary>
+            public static readonly ActivationRegistrationResult Success = new ActivationRegistrationResult
+            {
+                IsSuccess = true       
+            };
+
+            public ActivationRegistrationResult(ActivationAddress existingActivationAddress)
+            {
+                ValidateExistingActivationAddress(existingActivationAddress);
+                ExistingActivationAddress = existingActivationAddress;
+                IsSuccess = false;
+            }
+            
+            /// <summary>
+            /// Returns true if this instance represents a successful registration, false otheriwse.
+            /// </summary>
+            public bool IsSuccess { get; private set; }
+
+            /// <summary>
+            /// The existing activation address if this instance represents a duplicate activation.
+            /// </summary>
+            public ActivationAddress ExistingActivationAddress { get; }
+
+            private static void ValidateExistingActivationAddress(ActivationAddress existingActivationAddress)
+            {
+                if (existingActivationAddress == null)
+                    throw new ArgumentNullException(nameof(existingActivationAddress));
+            }
+        }
+
+        private async Task<ActivationRegistrationResult> RegisterActivationInGrainDirectoryAndValidate(ActivationData activation)
         {
             ActivationAddress address = activation.Address;
             // Currently, the only grain type that is not registered in the Grain Directory is StatelessWorker. 
             // Among those that are registered in the directory, we currently do not have any multi activations.
             if (activation.IsUsingGrainDirectory)
             {
-                
                 var result = await scheduler.RunOrQueueTask(() => directory.RegisterAsync(address, singleActivation:true), this.SchedulingContext);
-                if (address.Equals(result.Address)) return;
+                if (address.Equals(result.Address)) return ActivationRegistrationResult.Success;
                
-                SiloAddress primaryDirectoryForGrain = directory.GetPrimaryForGrain(address.Grain);
-                throw new DuplicateActivationException(result.Address, primaryDirectoryForGrain);
+                return new ActivationRegistrationResult(existingActivationAddress: result.Address);
             }
             else
             {
@@ -1422,10 +1450,10 @@ namespace Orleans.Runtime
                 {
                     List<ActivationData> local;
                     if (!LocalLookup(address.Grain, out local) || local.Count <= maxNumLocalActivations)
-                        return;
+                        return ActivationRegistrationResult.Success;
 
                     var id = StatelessWorkerDirector.PickRandom(local).Address;
-                    throw new DuplicateActivationException(id);
+                    return new ActivationRegistrationResult(existingActivationAddress: id);
                 }
             }
             // We currently don't have any other case for multiple activations except for StatelessWorker. 

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -475,8 +475,14 @@ namespace Orleans.Runtime
             {
                 this.localGrainDirectory.InvalidateCacheEntry(oldAddress);
             }
-            logger.Info(ErrorCode.Messaging_Dispatcher_ForwardingRequests, 
-                String.Format("Forwarding {0} requests to old address {1} after {2}.", messages.Count, oldAddress, failedOperation));
+
+            if (logger.IsInfo)
+            {
+                logger.Info(ErrorCode.Messaging_Dispatcher_ForwardingRequests,
+                    string.Format("Forwarding {0} requests destined for address {1} to address {2} after {3}.",
+                        messages.Count, oldAddress, forwardingAddress,
+                        failedOperation));
+            }
 
             // IMPORTANT: do not do anything on activation context anymore, since this activation is invalid already.
             scheduler.QueueWorkItem(new ClosureWorkItem(

--- a/src/OrleansTelemetryConsumers.Counters/PerfCounterConfigData.cs
+++ b/src/OrleansTelemetryConsumers.Counters/PerfCounterConfigData.cs
@@ -96,7 +96,7 @@ namespace OrleansTelemetryConsumers.Counters
             new PerfCounterConfigData {Name = StatisticNames.MESSAGE_CENTER_SEND_QUEUE_LENGTH},
             new PerfCounterConfigData {Name = StatisticNames.SCHEDULER_PENDINGWORKITEMS},
             new PerfCounterConfigData {Name = StatisticNames.CATALOG_ACTIVATION_COUNT},
-            new PerfCounterConfigData {Name = StatisticNames.CATALOG_ACTIVATION_DUPLICATE_ACTIVATIONS},
+            new PerfCounterConfigData {Name = StatisticNames.CATALOG_ACTIVATION_CONCURRENT_REGISTRATION_ATTEMPTS},
             new PerfCounterConfigData {Name = StatisticNames.RUNTIME_GC_TOTALMEMORYKB},
             new PerfCounterConfigData {Name = StatisticNames.RUNTIME_DOT_NET_THREADPOOL_INUSE_WORKERTHREADS},
             new PerfCounterConfigData {Name = StatisticNames.RUNTIME_DOT_NET_THREADPOOL_INUSE_COMPLETIONPORTTHREADS},

--- a/test/NonSilo.Tests/OrleansRuntime/ExceptionsTests.cs
+++ b/test/NonSilo.Tests/OrleansRuntime/ExceptionsTests.cs
@@ -22,30 +22,28 @@ namespace UnitTests.OrleansRuntime
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_Exception_DotNet()
         {
-            ActivationAddress activationAddress = ActivationAddress.NewActivationAddress(SiloAddress.NewLocalAddress(12345), GrainId.NewId());
-            SiloAddress primaryDirectoryForGrain = SiloAddress.NewLocalAddress(6789);
+            var activationAddress = ActivationAddress.NewActivationAddress(SiloAddress.NewLocalAddress(12345), GrainId.NewId());
            
-            Catalog.DuplicateActivationException original = new Catalog.DuplicateActivationException(activationAddress, primaryDirectoryForGrain);
-            Catalog.DuplicateActivationException output = TestingUtils.RoundTripDotNetSerializer(original, this.fixture.GrainFactory, this.fixture.SerializationManager);
+            var original = new Catalog.NonExistentActivationException("Some message", activationAddress, false);
+            var output = TestingUtils.RoundTripDotNetSerializer(original, this.fixture.GrainFactory, this.fixture.SerializationManager);
 
             Assert.Equal(original.Message, output.Message);
-            Assert.Equal(original.ActivationToUse, output.ActivationToUse);
-            Assert.Equal(original.PrimaryDirectoryForGrain, output.PrimaryDirectoryForGrain);
+            Assert.Equal(original.NonExistentActivation, output.NonExistentActivation);
+            Assert.Equal(original.IsStatelessWorker, output.IsStatelessWorker);
         }
 #endif
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_Exception_Orleans()
         {
-            ActivationAddress activationAddress = ActivationAddress.NewActivationAddress(SiloAddress.NewLocalAddress(12345), GrainId.NewId());
-            SiloAddress primaryDirectoryForGrain = SiloAddress.NewLocalAddress(6789);
+            var activationAddress = ActivationAddress.NewActivationAddress(SiloAddress.NewLocalAddress(12345), GrainId.NewId());
 
-            Catalog.DuplicateActivationException original = new Catalog.DuplicateActivationException(activationAddress, primaryDirectoryForGrain);
-            Catalog.DuplicateActivationException output = this.fixture.SerializationManager.RoundTripSerializationForTesting(original);
+            var original = new Catalog.NonExistentActivationException("Some message", activationAddress, false);
+            var output = this.fixture.SerializationManager.RoundTripSerializationForTesting(original);
 
             Assert.Equal(original.Message, output.Message);
-            Assert.Equal(original.ActivationToUse, output.ActivationToUse);
-            Assert.Equal(original.PrimaryDirectoryForGrain, output.PrimaryDirectoryForGrain);
+            Assert.Equal(original.NonExistentActivation, output.NonExistentActivation);
+            Assert.Equal(original.IsStatelessWorker, output.IsStatelessWorker);
         }
     }
 }

--- a/test/TestGrainInterfaces/ICatalogTestGrain.cs
+++ b/test/TestGrainInterfaces/ICatalogTestGrain.cs
@@ -3,7 +3,7 @@ using Orleans;
 
 namespace UnitTests.GrainInterfaces
 {
-    public interface ICatalogTestGrain : IGrainWithStringKey
+    public interface ICatalogTestGrain : IGrainWithIntegerKey
     {
         Task Initialize();
         Task BlastCallNewGrains(int nGrains, long startingKey, int nCallsToEach);

--- a/test/TestGrains/CatalogTestGrain.cs
+++ b/test/TestGrains/CatalogTestGrain.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Threading.Tasks;
 using Orleans;
 using UnitTests.GrainInterfaces;
@@ -19,19 +18,19 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public async Task BlastCallNewGrains(int nGrains, long startingKey, int nCallsToEach)
+        public Task BlastCallNewGrains(int nGrains, long startingKey, int nCallsToEach)
         {
-            var promises = new List<Task>();
+            var promises = new List<Task>(nGrains * nCallsToEach);
 
             for (int i = 0; i < nGrains; i++)
             {
-                var grain = GrainFactory.GetGrain<ICatalogTestGrain>((startingKey + i).ToString(CultureInfo.InvariantCulture));
+                var grain = GrainFactory.GetGrain<ICatalogTestGrain>(startingKey + i);
 
-                for(int j=0; j<nCallsToEach; j++)
+                for (int j = 0; j < nCallsToEach; j++)
                     promises.Add(grain.Initialize());
             }
 
-            await Task.WhenAll(promises);
+            return Task.WhenAll(promises);
         }
     }
 }

--- a/test/Tester/DuplicateActivationsTests.cs
+++ b/test/Tester/DuplicateActivationsTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
+using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using TestExtensions;
@@ -34,16 +35,16 @@ namespace UnitTests.CatalogTests
         public async Task DuplicateActivations()
         {
             const int nRunnerGrains = 100;
-            const int nTargetGRain = 10;
+            const int nTargetGrain = 10;
             const int startingKey = 1000;
             const int nCallsToEach = 100;
 
             var runnerGrains = new ICatalogTestGrain[nRunnerGrains];
 
-            var promises = new List<Task>();
+            var promises = new List<Task>(nRunnerGrains);
             for (int i = 0; i < nRunnerGrains; i++)
             {
-                runnerGrains[i] = this.fixture.GrainFactory.GetGrain<ICatalogTestGrain>(i.ToString(CultureInfo.InvariantCulture));
+                runnerGrains[i] = this.fixture.GrainFactory.GetGrain<ICatalogTestGrain>(-i);
                 promises.Add(runnerGrains[i].Initialize());
             }
 
@@ -52,7 +53,7 @@ namespace UnitTests.CatalogTests
 
             for (int i = 0; i < nRunnerGrains; i++)
             {
-                promises.Add(runnerGrains[i].BlastCallNewGrains(nTargetGRain, startingKey, nCallsToEach));
+                promises.Add(runnerGrains[i].BlastCallNewGrains(nTargetGrain, startingKey, nCallsToEach));
             }
 
             await Task.WhenAll(promises);


### PR DESCRIPTION
This PR resolves #2733.

The fix focuses on the logic in `Catalog.InitActivation(...)` and how it interacts with `Catalog.RegisterActivationInGrainDirectoryAndValidate(...)`. Specifically, it removes the `DuplicateActivationException` thrown by the latter and caught by the former. Doing that required slightly reworking the control flow in `InitActivation` so that exceptions aren't the only means of error handling.

* Move recovery logic in `InitActivation` from `catch` to a new method which is called from the `finally` block.
* Return a new `ActivationRegistrationResult` struct from `RegisterActivationInGrainDirectoryAndValidate` which replaces `DuplicateActivationException`.
* When an activation fails to register, return early from `InitActivation` so that the `finally` block can clean up the activation.

One change worth noting: `InitActivation` will no longer throw when there is a duplicate activation. The activation returned by `GetOrCreateActivation` (which calls into `InitActivation`) will eventually have its `ForwardingAddress` fixed to point to the existing activation. Note that the result of `InitActivation` is only used in one specific case: when creating the `IMembershipTableGrain`. I opened #3129 to discuss converting that into a SystemTarget instead of routing it through the directory.