### PR TITLE
Remove IGrainInvokeInterceptor obsoletion warning in test

### DIFF
--- a/test/TestGrains/StreamInterceptionGrain.cs
+++ b/test/TestGrains/StreamInterceptionGrain.cs
@@ -8,7 +8,9 @@ using UnitTests.GrainInterfaces;
 namespace UnitTests.Grains
 {
     [ImplicitStreamSubscription("InterceptedStream")]
+#pragma warning disable 618
     public class StreamInterceptionGrain : Grain, IStreamInterceptionGrain, IGrainInvokeInterceptor
+#pragma warning restore 618
     {
         private int lastStreamValue;
 


### PR DESCRIPTION
Apparently, I missed this one in #3083 and introduced a build warning