### PR TITLE
Make EHStatisticMonitorTests more predictable

### DIFF
--- a/test/ServiceBus.Tests/StatisticMonitorTests/CacheMonitorForTesting.cs
+++ b/test/ServiceBus.Tests/StatisticMonitorTests/CacheMonitorForTesting.cs
@@ -17,10 +17,12 @@ namespace ServiceBus.Tests.MonitorTests
     {
         public static CacheMonitorForTesting Instance = new CacheMonitorForTesting(null, null);
         public CacheMonitorCounters CallCounters;
+        private Logger logger;
 
         private CacheMonitorForTesting(EventHubCacheMonitorDimensions dimensions, Logger logger)
         {
             this.CallCounters = new CacheMonitorCounters();
+            this.logger = logger;
         }
 
         public void TrackCachePressureMonitorStatusChange(string pressureMonitorType, bool underPressure, double? cachePressureContributionCount, double? currentPressure,

--- a/test/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -26,7 +26,7 @@ namespace ServiceBus.Tests.MonitorTests
     {
         private const string StreamProviderName = "EventHubStreamProvider";
         private const string StreamNamespace = "EHTestsNamespace";
-        private static readonly TimeSpan timeout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan timeout = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan monitorWriteInterval = TimeSpan.FromSeconds(2);
         private static readonly int ehPartitionCountPerSilo = 4;
         public static readonly EventHubGeneratorStreamProviderSettings ProviderSettings =
@@ -74,10 +74,6 @@ namespace ServiceBus.Tests.MonitorTests
         public async Task EHStatistics_MonitorCalledAccordingly()
         {
             var streamId = new FullStreamIdentity(Guid.NewGuid(), StreamNamespace, StreamProviderName);
-            //set up one slow consumer grain
-            var slowConsumer = this.fixture.GrainFactory.GetGrain<ISlowConsumingGrain>(Guid.NewGuid());
-            await slowConsumer.BecomeConsumer(streamId.Guid, StreamNamespace, StreamProviderName);
-
             //set up 30 healthy consumer grain to show how much we favor slow consumer 
             int healthyConsumerCount = 30;
             var healthyConsumers = await EHSlowConsumingTests.SetUpHealthyConsumerGrain(this.fixture.GrainFactory, streamId.Guid, StreamNamespace, StreamProviderName, healthyConsumerCount);
@@ -87,11 +83,13 @@ namespace ServiceBus.Tests.MonitorTests
             var randomStreamPlacementArg = new EventDataGeneratorStreamProvider.AdapterFactory.StreamRandomPlacementArg(streamId, this.seed.Next(100));
             await mgmtGrain.SendControlCommandToProvider(typeof(EHStreamProviderForMonitorTests).FullName, StreamProviderName,
                 (int)EventDataGeneratorStreamProvider.AdapterFactory.Commands.Randomly_Place_Stream_To_Queue, randomStreamPlacementArg);
-            //since there's an extreme slow consumer, so the back pressure algorithm should be triggered
-            await TestingUtils.WaitUntilAsync(lastTry => AssertCacheBackPressureTriggered(true, lastTry), timeout);
 
-            //make slow consumer stop consuming
-            await slowConsumer.StopConsuming();
+            // let the test to run for a while to build up some streaming traffic
+            await Task.Delay(timeout);
+            //wait sometime after cache pressure changing, for the system to notice it and trigger cache monitor to track it
+            await mgmtGrain.SendControlCommandToProvider(typeof(EHStreamProviderForMonitorTests).FullName, StreamProviderName,
+                (int)EHStreamProviderForMonitorTests.AdapterFactory.QueryCommands.ChangeCachePressure, null);
+            await Task.Delay(timeout);
 
             //assert EventHubReceiverMonitor call counters
             var receiverMonitorCounters = await mgmtGrain.SendControlCommandToProvider(typeof(EHStreamProviderForMonitorTests).FullName, StreamProviderName,
@@ -137,33 +135,6 @@ namespace ServiceBus.Tests.MonitorTests
         {
             Assert.True(totalObjectPoolMonitorCallCounters.TrackObjectAllocatedByCacheCallCounter > 0);
             Assert.Equal(totalObjectPoolMonitorCallCounters.TrackObjectReleasedFromCacheCallCounter, 0);
-        }
-
-        private async Task<bool> AssertCacheBackPressureTriggered(bool expectedResult, bool assertIsTrue)
-        {
-            if (assertIsTrue)
-            {
-                bool actualResult = await IsBackPressureTriggered();
-                Assert.True(expectedResult == actualResult, $"Back pressure algorithm should be triggered? expected: {expectedResult}, actual: {actualResult}");
-                return true;
-            }
-            else
-            {
-                return (await IsBackPressureTriggered()) == expectedResult;
-            }
-        }
-
-        private async Task<bool> IsBackPressureTriggered()
-        {
-            IManagementGrain mgmtGrain = this.fixture.HostedCluster.GrainFactory.GetGrain<IManagementGrain>(0);
-            object[] replies = await mgmtGrain.SendControlCommandToProvider(typeof(EHStreamProviderForMonitorTests).FullName,
-                             StreamProviderName, EHStreamProviderWithCreatedCacheList.AdapterFactory.IsCacheBackPressureTriggeredCommand, null);
-            foreach (var re in replies)
-            {
-                if ((bool)re)
-                    return true;
-            }
-            return false;
         }
     }
 }


### PR DESCRIPTION
EHStatictiscMonitorTests fail intermittently, because the test is taking a way to trigger cache pressure changing, which depends a lot on timing. Change this way to a more predictable model, which is  directly injecting cache pressure status.
