### PR TITLE
Fix NullReferenceException when no LogConsistencyProvider attribute is provided

### DIFF
--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -882,7 +882,7 @@ namespace Orleans.Runtime
                     SetupStorageProvider(grainType, data);
 
                 string msg = string.Format("Assigned log consistency provider with Name={0} to grain type {1}",
-                    attr.ProviderName, grainType.FullName);
+                    consistencyProvider.Name, grainType.FullName);
                 logger.Verbose2(ErrorCode.Provider_CatalogLogConsistencyProviderAllocated, msg);
 
                 return consistencyProvider;


### PR DESCRIPTION
If a `LogConsistencyProvider` is configured with the name `Default` then a `JournaledGrain` without a `LogConsistencyProviderAttribute` will use that provider. However, a bug in a logging statement resulted in a `NullReferenceException`. The name of the provider was retrieved from the variable `attr` that is `null` when no attribute is specified.

The fix is to get the name of the provider from the provider itself.

It took me some time to pinpoint the location of this bug in the source code. Interestingly, when I opened the file in Visual Studio ReSharper flagged the exact statement I had located by code inspection with a green squiggly to indicate a possible `NullReferenceException`.