### PR TITLE
Add ISiloStatusOracle registration to servicecollection

### DIFF
--- a/src/OrleansRuntime/Core/ManagementGrain.cs
+++ b/src/OrleansRuntime/Core/ManagementGrain.cs
@@ -361,7 +361,6 @@ namespace Orleans.Runtime.Management
 
         private Task<IMembershipTable> GetMembershipTable()
         {
-            var membershipOracle = this.siloStatusOracle as MembershipOracle;
             if (!(this.siloStatusOracle is MembershipOracle)) throw new InvalidOperationException("The current membership oracle does not support detailed silo status reporting.");
             return this.membershipTableFactory.GetMembershipTable();
         }

--- a/src/OrleansServiceFabricUtils/OrleansServiceFabricExtensions.cs
+++ b/src/OrleansServiceFabricUtils/OrleansServiceFabricExtensions.cs
@@ -66,6 +66,9 @@ namespace Microsoft.Orleans.ServiceFabric
                         sp.GetService<IFabricQueryManager>(),
                         sp.GetService<Factory<string, Logger>>()));
             serviceCollection.AddSingleton<IMembershipOracle, FabricMembershipOracle>();
+
+            serviceCollection.AddSingleton<ISiloStatusOracle>(provider => provider.GetService<IMembershipOracle>());
+
             serviceCollection.AddSingleton<IGatewayListProvider, FabricGatewayProvider>();
             serviceCollection.AddTransient<ServiceContext>(_ => service.Context);
 

--- a/src/OrleansServiceFabricUtils/OrleansServiceFabricExtensions.cs
+++ b/src/OrleansServiceFabricUtils/OrleansServiceFabricExtensions.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Orleans.ServiceFabric
             serviceCollection.AddSingleton<IMembershipOracle, FabricMembershipOracle>();
             serviceCollection.AddSingleton<IGatewayListProvider, FabricGatewayProvider>();
 
+            serviceCollection.AddSingleton<ISiloStatusOracle>(provider => provider.GetService<IMembershipOracle>());
+
             // In order to support local, replicated persistence, the state manager must be registered.
             serviceCollection.AddTransient(_ => service.StateManager);
             serviceCollection.AddTransient<ServiceContext>(_ => service.Context);


### PR DESCRIPTION
This PR fixes #3159 

It explicitly adds implementation for ISiloStatusOracle, based on already registered IMembershipOracle.