### PR TITLE
Only allow InconsistentStateException to deactivate the current activation

### DIFF
--- a/src/Orleans/Providers/IStorageProvider.cs
+++ b/src/Orleans/Providers/IStorageProvider.cs
@@ -77,11 +77,16 @@ namespace Orleans.Storage
     }
 
     /// <summary>
-    /// Exception thrown when a storage provider detects an Etag inconsistency when attemptiong to perform a WriteStateAsync operation.
+    /// Exception thrown when a storage provider detects an Etag inconsistency when attempting to perform a WriteStateAsync operation.
     /// </summary>
     [Serializable]
     public class InconsistentStateException : OrleansException
     {
+        /// <summary>
+        /// Whether or not this exception occurred on the current activation.
+        /// </summary>
+        internal bool IsSourceActivation { get; set; } = true;
+
         /// <summary>The Etag value currently held in persistent storage.</summary>
         public string StoredEtag { get; private set; }
 
@@ -102,6 +107,7 @@ namespace Orleans.Storage
         {
             this.StoredEtag = info.GetString(nameof(StoredEtag));
             this.CurrentEtag = info.GetString(nameof(CurrentEtag));
+            this.IsSourceActivation = info.GetBoolean(nameof(this.IsSourceActivation));
         }
 #endif
 
@@ -141,6 +147,7 @@ namespace Orleans.Storage
 
             info.AddValue(nameof(StoredEtag), this.StoredEtag);
             info.AddValue(nameof(CurrentEtag), this.CurrentEtag);
+            info.AddValue(nameof(this.IsSourceActivation), this.IsSourceActivation);
             base.GetObjectData(info, context);
         }
 #endif

--- a/test/TestGrainInterfaces/IPersistenceTestGrains.cs
+++ b/test/TestGrainInterfaces/IPersistenceTestGrains.cs
@@ -139,6 +139,14 @@ namespace UnitTests.GrainInterfaces
         Task<string> GetActivationId();
     }
 
+    public interface IPersistenceProviderErrorProxyGrain : IGrainWithGuidKey
+    {
+        Task<int> GetValue(IPersistenceProviderErrorGrain other);
+        Task DoWrite(int val, IPersistenceProviderErrorGrain other);
+        Task<int> DoRead(IPersistenceProviderErrorGrain other);
+        Task<string> GetActivationId();
+    }
+
     public interface IPersistenceUserHandledErrorGrain : IGrainWithGuidKey
     {
         Task<int> GetValue();

--- a/test/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/TestInternalGrains/PersistenceTestGrains.cs
@@ -202,6 +202,17 @@ namespace UnitTests.Grains
         }
     }
 
+    public class PersistenceProviderErrorProxyGrain : Grain, IPersistenceProviderErrorProxyGrain
+    {
+        public Task<int> GetValue(IPersistenceProviderErrorGrain other) => other.GetValue();
+
+        public Task DoWrite(int val, IPersistenceProviderErrorGrain other) => other.DoWrite(val);
+
+        public Task<int> DoRead(IPersistenceProviderErrorGrain other) => other.DoRead();
+
+        public Task<string> GetActivationId() => Task.FromResult(this.Data.ActivationId.ToString());
+    }
+
     [Orleans.Providers.StorageProvider(ProviderName = "test1")]
     public class PersistenceErrorGrain : Grain<PersistenceTestGrainState>, IPersistenceErrorGrain
     {


### PR DESCRIPTION
As pointed out by @jdom, if a grain allows an `InconsistentStateException` to escape, then every grain in the call chain will be deactivated.

This fixes that by introducing a flag onto the exception itself. The flag is reset when the exception first passes through the invoker and the current activation is deactivated.