### PR TITLE
Make ReconstructClientIdPartitionTest_Request test more reliable

### DIFF
--- a/src/OrleansTestingHost/TestCluster.cs
+++ b/src/OrleansTestingHost/TestCluster.cs
@@ -389,6 +389,7 @@ namespace Orleans.TestingHost
         public void KillClient()
         {
             this.InternalClient?.Abort();
+            this.InternalClient = null;
         }
 
         /// <summary>

--- a/test/TesterInternal/MembershipTests/ClientIdPartitionDataRebuildTests.cs
+++ b/test/TesterInternal/MembershipTests/ClientIdPartitionDataRebuildTests.cs
@@ -63,7 +63,7 @@ namespace UnitTests.MembershipTests
             this.hostedCluster.SecondarySilos[0].StopSilo(stopGracefully: false);
             await Task.Delay(5000);
 
-            // Second notification should work since the directory was "rebuild" when
+            // Second notification should work since the directory was "rebuilt" when
             // silos in cluster detected the dead one
             await grain.SetB(20);
             await observer.WaitForNotification(10, 20, TimeSpan.FromSeconds(10));
@@ -79,7 +79,7 @@ namespace UnitTests.MembershipTests
             var promise = grain.DoLongAction(TimeSpan.FromSeconds(10), "LongAction");
             this.hostedCluster.SecondarySilos[0].StopSilo(stopGracefully: false);
 
-            // It should workince the directory was "rebuild" when
+            // It should work since the directory was "rebuilt" when
             // silos in cluster detected the dead one
             await promise;
         }
@@ -88,9 +88,14 @@ namespace UnitTests.MembershipTests
         {
             // Ensure the client entry is on Silo2 partition
             GrainId clientId = null;
+            CreateAndDeployTestCluster();
             for (var i = 0; i < 100; i++)
             {
-                CreateAndDeployTestCluster();
+                if (this.hostedCluster.Client == null)
+                {
+                    this.hostedCluster.InitializeClient();
+                }
+
                 var client = this.hostedCluster.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();
                 clientId = client.CurrentActivationAddress.Grain;
                 var report = await TestUtils.GetDetailedGrainReport(this.hostedCluster.InternalGrainFactory, clientId, hostedCluster.Primary);
@@ -98,8 +103,8 @@ namespace UnitTests.MembershipTests
                 {
                     break;
                 }
-                this.hostedCluster.StopAllSilos();
                 clientId = null;
+                this.hostedCluster.KillClient();
             }
             Assert.NotNull(clientId);
 
@@ -120,17 +125,14 @@ namespace UnitTests.MembershipTests
             return grain;
         }
 
-
         private void CreateAndDeployTestCluster()
         {
             var options = new TestClusterOptions(3);
 
             options.ClusterConfiguration.Globals.NumMissedProbesLimit = 1;
-            options.ClusterConfiguration.Globals.ProbeTimeout = TimeSpan.FromMilliseconds(100);
+            options.ClusterConfiguration.Globals.ProbeTimeout = TimeSpan.FromMilliseconds(500);
             options.ClusterConfiguration.Globals.NumVotesForDeathDeclaration = 1;
             options.ClusterConfiguration.Globals.CacheSize = 0;
-            options.ClusterConfiguration.Globals.TypeMapRefreshInterval = TimeSpan.FromMilliseconds(100);
-            options.ClusterConfiguration.Globals.ClientRegistrationRefresh = TimeSpan.FromMinutes(60);
 
             // use only Primary as the gateway
             options.ClientConfiguration.Gateways = options.ClientConfiguration.Gateways.Take(1).ToList();


### PR DESCRIPTION
Increase ProbeTimeout to reduce chances of failures in slower machines.
Speed up test setup by restarting client instead of entire cluster.