### PR TITLE
Skip VSIX build unless BuildOrleansVSIX env variable is set to true

### DIFF
--- a/src/Build.cmd
+++ b/src/Build.cmd
@@ -110,6 +110,8 @@ SET OutDir=%CMDHOME%\..\Binaries\%CONFIGURATION%
 
 REM Build VSIX only if new tooling was found
 
+:VSIX
+if NOT "%BuildOrleansVSIX%" == "true" goto :EOF
 if "%VS2017InstallDir%" == "" goto :EOF
 
 @echo Build VSIX ============================


### PR DESCRIPTION
Make VSIX build opt-in