### PR TITLE
Separate logic from base GrainReference

### DIFF
--- a/src/Orleans/Core/ClientBuilder.cs
+++ b/src/Orleans/Core/ClientBuilder.cs
@@ -73,6 +73,7 @@ namespace Orleans
             services.AddFromExisting<IRuntimeClient, OutsideRuntimeClient>();
             services.AddFromExisting<IClusterConnectionStatusListener, OutsideRuntimeClient>();
             services.AddSingleton<GrainFactory>();
+            services.AddSingleton<IGrainReferenceRuntime, GrainReferenceRuntime>();
             services.AddFromExisting<IGrainFactory, GrainFactory>();
             services.AddFromExisting<IInternalGrainFactory, GrainFactory>();
             services.AddFromExisting<IGrainReferenceConverter, GrainFactory>();

--- a/src/Orleans/Core/GrainExtensions.cs
+++ b/src/Orleans/Core/GrainExtensions.cs
@@ -48,7 +48,7 @@ namespace Orleans
         {
             ThrowIfNullGrain(grain);
             var grainReference = grain.AsWeaklyTypedReference();
-            return grainReference.Runtime.Cast<TGrainInterface>(grainReference);
+            return grainReference.Runtime.Convert<TGrainInterface>(grainReference);
         }
 
         /// <summary>

--- a/src/Orleans/Core/GrainExtensions.cs
+++ b/src/Orleans/Core/GrainExtensions.cs
@@ -31,7 +31,7 @@ namespace Orleans
             }
 
             var systemTarget = grain as ISystemTargetBase;
-            if (systemTarget != null) return GrainReference.FromGrainId(systemTarget.GrainId, systemTarget.RuntimeClient, null, systemTarget.Silo);
+            if (systemTarget != null) return GrainReference.FromGrainId(systemTarget.GrainId, systemTarget.RuntimeClient.GrainReferenceRuntime, null, systemTarget.Silo);
 
             throw new ArgumentException(
                 $"AsWeaklyTypedReference has been called on an unexpected type: {grain.GetType().FullName}.",
@@ -48,7 +48,7 @@ namespace Orleans
         {
             ThrowIfNullGrain(grain);
             var grainReference = grain.AsWeaklyTypedReference();
-            return grainReference.RuntimeClient.InternalGrainFactory.Cast<TGrainInterface>(grainReference);
+            return grainReference.Runtime.Cast<TGrainInterface>(grainReference);
         }
 
         /// <summary>

--- a/src/Orleans/Core/GrainFactory.cs
+++ b/src/Orleans/Core/GrainFactory.cs
@@ -36,10 +36,9 @@ namespace Orleans
         /// </summary>
         private readonly TypeMetadataCache typeCache;
 
-        /// <summary>
-        /// The runtime client.
-        /// </summary>
         private readonly IRuntimeClient runtimeClient;
+
+        private IGrainReferenceRuntime GrainReferenceRuntime => this.runtimeClient.GrainReferenceRuntime;
 
         // Make this internal so that client code is forced to access the IGrainFactory using the 
         // GrainClient (to make sure they don't forget to initialize the client).
@@ -115,11 +114,11 @@ namespace Orleans
             if (grain == null) throw new ArgumentNullException(nameof(grain));
             var reference = grain as GrainReference;
             if (reference == null) throw new ArgumentException("Provided grain must be a GrainReference.", nameof(grain));
-            reference.Bind(this.runtimeClient);
+            reference.Bind(this.GrainReferenceRuntime);
         }
 
         /// <inheritdoc />
-        public GrainReference GetGrainFromKeyString(string key) => GrainReference.FromKeyString(key, this.runtimeClient);
+        public GrainReference GetGrainFromKeyString(string key) => GrainReference.FromKeyString(key, this.GrainReferenceRuntime);
 
         /// <inheritdoc />
         public Task<TGrainObserverInterface> CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
@@ -173,7 +172,7 @@ namespace Orleans
             var typeInfo = interfaceType.GetTypeInfo();
             return GrainReference.FromGrainId(
                 grainId,
-                this.runtimeClient,
+                this.GrainReferenceRuntime,
                 typeInfo.IsGenericType ? TypeUtils.GenericTypeArgsString(typeInfo.UnderlyingSystemType.FullName) : null);
         }
 
@@ -290,7 +289,7 @@ namespace Orleans
                 }
                 else
                 {
-                    reference = this.Cast<TGrainInterface>(GrainReference.FromGrainId(grainId, this.runtimeClient, null, destination));
+                    reference = this.Cast<TGrainInterface>(GrainReference.FromGrainId(grainId, this.GrainReferenceRuntime, null, destination));
                     cache[destination] = reference; // Store for next time
                 }
             }
@@ -301,12 +300,12 @@ namespace Orleans
         /// <inheritdoc />
         public TGrainInterface GetGrain<TGrainInterface>(GrainId grainId) where TGrainInterface : IAddressable
         {
-            return this.Cast<TGrainInterface>(GrainReference.FromGrainId(grainId, this.runtimeClient));
+            return this.Cast<TGrainInterface>(GrainReference.FromGrainId(grainId, this.GrainReferenceRuntime));
         }
 
         /// <inheritdoc />
         public GrainReference GetGrain(GrainId grainId, string genericArguments)
-            => GrainReference.FromGrainId(grainId, this.runtimeClient, genericArguments);
+            => GrainReference.FromGrainId(grainId, this.GrainReferenceRuntime, genericArguments);
 
         #endregion
     }

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -95,6 +95,8 @@
     <Compile Include="Core\IInternalClusterClient.cs" />
     <Compile Include="Core\IClusterClient.cs" />
     <Compile Include="Core\ClusterClient.cs" />
+    <Compile Include="Runtime\GrainReferenceRuntime.cs" />
+    <Compile Include="Serialization\GrainReferenceSerializer.cs" />
     <Compile Include="Runtime\IGrainActivationContext.cs" />
     <Compile Include="LogConsistency\ILogConsistencyDiagnostics.cs" />
     <Compile Include="Logging\LoggerExtensions.cs" />
@@ -129,6 +131,7 @@
     <Compile Include="Providers\ProviderStateManager.cs" />
     <Compile Include="Providers\MemoryStorageEtagMismatchException.cs" />
     <Compile Include="Runtime\IGrainReferenceConverter.cs" />
+    <Compile Include="Runtime\IGrainReferenceRuntime.cs" />
     <Compile Include="Runtime\IGrainTimer.cs" />
     <Compile Include="Runtime\ILocalSiloDetails.cs" />
     <Compile Include="Runtime\RingRange.cs" />

--- a/src/Orleans/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans/Runtime/GrainReferenceRuntime.cs
@@ -14,12 +14,14 @@ namespace Orleans.Runtime
 
         private readonly Action<Message, TaskCompletionSource<object>> responseCallbackDelegate;
         private readonly Logger logger;
+        private readonly IInternalGrainFactory internalGrainFactory;
 
-        public GrainReferenceRuntime(Factory<string, Logger> loggerFactory, IRuntimeClient runtimeClient)
+        public GrainReferenceRuntime(Factory<string, Logger> loggerFactory, IRuntimeClient runtimeClient, IInternalGrainFactory internalGrainFactory)
         {
             this.responseCallbackDelegate = this.ResponseCallback;
             this.logger = loggerFactory.Invoke(nameof(GrainReferenceRuntime));
             this.RuntimeClient = runtimeClient;
+            this.internalGrainFactory = internalGrainFactory;
         }
 
         public IRuntimeClient RuntimeClient { get; private set; }
@@ -67,9 +69,9 @@ namespace Orleans.Runtime
             return resultTask.Unbox<T>();
         }
 
-        public TGrainInterface Cast<TGrainInterface>(IAddressable grain)
+        public TGrainInterface Convert<TGrainInterface>(IAddressable grain)
         {
-            return this.RuntimeClient.InternalGrainFactory.Cast<TGrainInterface>(grain);
+            return this.internalGrainFactory.Cast<TGrainInterface>(grain);
         }
 
         private Task<object> InvokeMethod_Impl(GrainReference reference, InvokeMethodRequest request, string debugContext, InvokeMethodOptions options)

--- a/src/Orleans/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans/Runtime/GrainReferenceRuntime.cs
@@ -95,7 +95,7 @@ namespace Orleans.Runtime
             }
 
             // Call any registered client pre-call interceptor function.
-            CallClientInvokeCallback(request);
+            CallClientInvokeCallback(reference, request);
 
             bool isOneWayCall = ((options & InvokeMethodOptions.OneWay) != 0);
 
@@ -104,7 +104,7 @@ namespace Orleans.Runtime
             return isOneWayCall ? null : resolver.Task;
         }
 
-        private void CallClientInvokeCallback(InvokeMethodRequest request)
+        private void CallClientInvokeCallback(GrainReference reference, InvokeMethodRequest request)
         {
             // Make callback to any registered client callback function, allowing opportunity for an application to set any additional RequestContext info, etc.
             // Should we set some kind of callback-in-progress flag to detect and prevent any inappropriate callback loops on this GrainReference?
@@ -114,9 +114,10 @@ namespace Orleans.Runtime
                 if (callback == null) return;
 
                 // Call ClientInvokeCallback only for grain calls, not for system targets.
-                if (this is IGrain)
+                var grain = reference as IGrain;
+                if (grain != null)
                 {
-                    callback(request, (IGrain)this);
+                    callback(request, grain);
                 }
             }
             catch (Exception exc)
@@ -183,7 +184,7 @@ namespace Orleans.Runtime
         private static String GetDebugContext(string interfaceName, string methodName, object[] arguments)
         {
             // String concatenation is approx 35% faster than string.Format here
-            //debugContext = String.Format("{0}:{1}()", this.InterfaceName, GetMethodName(this.InterfaceId, methodId));
+            //debugContext = String.Format("{0}:{1}()", interfaceName, methodName);
             var debugContext = new StringBuilder();
             debugContext.Append(interfaceName);
             debugContext.Append(":");

--- a/src/Orleans/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans/Runtime/GrainReferenceRuntime.cs
@@ -1,0 +1,230 @@
+﻿using Orleans.CodeGeneration;
+using System;
+using System.Collections.Concurrent;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime
+{
+    internal class GrainReferenceRuntime : IGrainReferenceRuntime
+    {
+        private const bool USE_DEBUG_CONTEXT = true;
+        private const bool USE_DEBUG_CONTEXT_PARAMS = false;
+        private static ConcurrentDictionary<int, string> debugContexts = new ConcurrentDictionary<int, string>();
+
+        private readonly Action<Message, TaskCompletionSource<object>> responseCallbackDelegate;
+        private readonly Logger logger;
+
+        public GrainReferenceRuntime(Factory<string, Logger> loggerFactory, IRuntimeClient runtimeClient)
+        {
+            this.responseCallbackDelegate = this.ResponseCallback;
+            this.logger = loggerFactory.Invoke(nameof(GrainReferenceRuntime));
+            this.RuntimeClient = runtimeClient;
+        }
+
+        public IRuntimeClient RuntimeClient { get; private set; }
+
+        /// <inheritdoc />
+        public void InvokeOneWayMethod(GrainReference reference, int methodId, object[] arguments, InvokeMethodOptions options, SiloAddress silo)
+        {
+            Task<object> resultTask = InvokeMethodAsync<object>(reference, methodId, arguments, options | InvokeMethodOptions.OneWay, silo);
+            if (!resultTask.IsCompleted && resultTask.Result != null)
+            {
+                throw new OrleansException("Unexpected return value: one way InvokeMethod is expected to return null.");
+            }
+        }
+
+        /// <inheritdoc />
+        public Task<T> InvokeMethodAsync<T>(GrainReference reference, int methodId, object[] arguments, InvokeMethodOptions options, SiloAddress silo)
+        {
+            object[] argsDeepCopy = null;
+            if (arguments != null)
+            {
+                CheckForGrainArguments(arguments);
+                SetGrainCancellationTokensTarget(arguments, reference);
+                argsDeepCopy = (object[])this.RuntimeClient.SerializationManager.DeepCopy(arguments);
+            }
+
+            var request = new InvokeMethodRequest(reference.InterfaceId, reference.InterfaceVersion, methodId, argsDeepCopy);
+
+            if (IsUnordered(reference))
+                options |= InvokeMethodOptions.Unordered;
+
+            Task<object> resultTask = InvokeMethod_Impl(reference, request, null, options);
+
+            if (resultTask == null)
+            {
+                if (typeof(T) == typeof(object))
+                {
+                    // optimize for most common case when using one way calls.
+                    return PublicOrleansTaskExtensions.CompletedTask as Task<T>;
+                }
+
+                return Task.FromResult(default(T));
+            }
+
+            resultTask = OrleansTaskExtentions.ConvertTaskViaTcs(resultTask);
+            return resultTask.Unbox<T>();
+        }
+
+        public TGrainInterface Cast<TGrainInterface>(IAddressable grain)
+        {
+            return this.RuntimeClient.InternalGrainFactory.Cast<TGrainInterface>(grain);
+        }
+
+        private Task<object> InvokeMethod_Impl(GrainReference reference, InvokeMethodRequest request, string debugContext, InvokeMethodOptions options)
+        {
+            if (debugContext == null && USE_DEBUG_CONTEXT)
+            {
+                if (USE_DEBUG_CONTEXT_PARAMS)
+                {
+#pragma warning disable 162
+                    // This is normally unreachable code, but kept for debugging purposes
+                    debugContext = GetDebugContext(reference.InterfaceName, reference.GetMethodName(reference.InterfaceId, request.MethodId), request.Arguments);
+#pragma warning restore 162
+                }
+                else
+                {
+                    var hash = reference.InterfaceId ^ request.MethodId;
+                    if (!debugContexts.TryGetValue(hash, out debugContext))
+                    {
+                        debugContext = GetDebugContext(reference.InterfaceName, reference.GetMethodName(reference.InterfaceId, request.MethodId), request.Arguments);
+                        debugContexts[hash] = debugContext;
+                    }
+                }
+            }
+
+            // Call any registered client pre-call interceptor function.
+            CallClientInvokeCallback(request);
+
+            bool isOneWayCall = ((options & InvokeMethodOptions.OneWay) != 0);
+
+            var resolver = isOneWayCall ? null : new TaskCompletionSource<object>();
+            this.RuntimeClient.SendRequest(reference, request, resolver, this.responseCallbackDelegate, debugContext, options, reference.GenericArguments);
+            return isOneWayCall ? null : resolver.Task;
+        }
+
+        private void CallClientInvokeCallback(InvokeMethodRequest request)
+        {
+            // Make callback to any registered client callback function, allowing opportunity for an application to set any additional RequestContext info, etc.
+            // Should we set some kind of callback-in-progress flag to detect and prevent any inappropriate callback loops on this GrainReference?
+            try
+            {
+                var callback = this.RuntimeClient.ClientInvokeCallback; // Take copy to avoid potential race conditions
+                if (callback == null) return;
+
+                // Call ClientInvokeCallback only for grain calls, not for system targets.
+                if (this is IGrain)
+                {
+                    callback(request, (IGrain)this);
+                }
+            }
+            catch (Exception exc)
+            {
+                logger.Warn(ErrorCode.ProxyClient_ClientInvokeCallback_Error,
+                    "Error while invoking ClientInvokeCallback function " + this.RuntimeClient?.ClientInvokeCallback,
+                    exc);
+                throw;
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        private void ResponseCallback(Message message, TaskCompletionSource<object> context)
+        {
+            Response response;
+            if (message.Result != Message.ResponseTypes.Rejection)
+            {
+                try
+                {
+                    response = (Response)message.GetDeserializedBody(this.RuntimeClient.SerializationManager);
+                }
+                catch (Exception exc)
+                {
+                    //  catch the Deserialize exception and break the promise with it.
+                    response = Response.ExceptionResponse(exc);
+                }
+            }
+            else
+            {
+                Exception rejection;
+                switch (message.RejectionType)
+                {
+                    case Message.RejectionTypes.GatewayTooBusy:
+                        rejection = new GatewayTooBusyException();
+                        break;
+                    case Message.RejectionTypes.DuplicateRequest:
+                        return; // Ignore duplicates
+
+                    default:
+                        rejection = message.GetDeserializedBody(this.RuntimeClient.SerializationManager) as OrleansException;
+                        if (rejection == null)
+                        {
+                            if (string.IsNullOrEmpty(message.RejectionInfo))
+                            {
+                                message.RejectionInfo = "Unable to send request - no rejection info available";
+                            }
+                            rejection = new OrleansMessageRejectionException(message.RejectionInfo);
+                        }
+                        break;
+                }
+                response = Response.ExceptionResponse(rejection);
+            }
+
+            if (!response.ExceptionFlag)
+            {
+                context.TrySetResult(response.Data);
+            }
+            else
+            {
+                context.TrySetException(response.Exception);
+            }
+        }
+
+        private static String GetDebugContext(string interfaceName, string methodName, object[] arguments)
+        {
+            // String concatenation is approx 35% faster than string.Format here
+            //debugContext = String.Format("{0}:{1}()", this.InterfaceName, GetMethodName(this.InterfaceId, methodId));
+            var debugContext = new StringBuilder();
+            debugContext.Append(interfaceName);
+            debugContext.Append(":");
+            debugContext.Append(methodName);
+            if (USE_DEBUG_CONTEXT_PARAMS && arguments != null && arguments.Length > 0)
+            {
+                debugContext.Append("(");
+                debugContext.Append(Utils.EnumerableToString(arguments));
+                debugContext.Append(")");
+            }
+            else
+            {
+                debugContext.Append("()");
+            }
+            return debugContext.ToString();
+        }
+
+        private static void CheckForGrainArguments(object[] arguments)
+        {
+            foreach (var argument in arguments)
+                if (argument is Grain)
+                    throw new ArgumentException(String.Format("Cannot pass a grain object {0} as an argument to a method. Pass this.AsReference<GrainInterface>() instead.", argument.GetType().FullName));
+        }
+
+        /// <summary>
+        /// Sets target grain to the found instances of type GrainCancellationToken
+        /// </summary>
+        /// <param name="arguments"> Grain method arguments list</param>
+        /// <param name="target"> Target grain reference</param>
+        private static void SetGrainCancellationTokensTarget(object[] arguments, GrainReference target)
+        {
+            if (arguments == null) return;
+            foreach (var argument in arguments)
+            {
+                (argument as GrainCancellationToken)?.AddGrainReference(target);
+            }
+        }
+
+        private bool IsUnordered(GrainReference reference)
+        {
+            return this.RuntimeClient.GrainTypeResolver?.IsUnordered(reference.GrainId.TypeCode) == true;
+        }
+    }
+}

--- a/src/Orleans/Runtime/IGrainReferenceRuntime.cs
+++ b/src/Orleans/Runtime/IGrainReferenceRuntime.cs
@@ -27,10 +27,10 @@ namespace Orleans.Runtime
         /// <returns>Returns the response from the remote object.</returns>
         Task<T> InvokeMethodAsync<T>(GrainReference reference, int methodId, object[] arguments, InvokeMethodOptions options, SiloAddress silo);
 
-        /// <summary>Casts the provided <paramref name="grain"/> to the specified interface.</summary>
+        /// <summary>Converts the provided <paramref name="grain"/> to the specified interface.</summary>
         /// <typeparam name="TGrainInterface">The target grain interface type.</typeparam>
         /// <param name="grain">The grain reference being cast.</param>
         /// <returns>A reference to <paramref name="grain"/> which implements <typeparamref name="TGrainInterface"/>.</returns>
-        TGrainInterface Cast<TGrainInterface>(IAddressable grain);
+        TGrainInterface Convert<TGrainInterface>(IAddressable grain);
     }
 }

--- a/src/Orleans/Runtime/IGrainReferenceRuntime.cs
+++ b/src/Orleans/Runtime/IGrainReferenceRuntime.cs
@@ -1,0 +1,36 @@
+﻿using Orleans.CodeGeneration;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Runtime logic for <see cref="GrainReference"/>s to be usable.
+    /// This service is not meant to be used directly by user code.
+    /// </summary>
+    public interface IGrainReferenceRuntime
+    {
+        /// <summary>Invokes a fire and forget method on a remote object.</summary>
+        /// <param name="reference">The reference to the addressable target.</param>
+        /// <param name="methodId">The method to invoke.</param>
+        /// <param name="arguments">The method payload.</param>
+        /// <param name="options">Invocation options.</param>
+        /// <param name="silo">The target silo.</param>
+        void InvokeOneWayMethod(GrainReference reference, int methodId, object[] arguments, InvokeMethodOptions options, SiloAddress silo);
+
+        /// <summary>Invokes a method on a remote object.</summary>
+        /// <typeparam name="T">The result type</typeparam>
+        /// <param name="reference">The reference to the addressable target.</param>
+        /// <param name="methodId">The method to invoke.</param>
+        /// <param name="arguments">The method payload.</param>
+        /// <param name="options">Invocation options.</param>
+        /// <param name="silo">The target silo.</param>
+        /// <returns>Returns the response from the remote object.</returns>
+        Task<T> InvokeMethodAsync<T>(GrainReference reference, int methodId, object[] arguments, InvokeMethodOptions options, SiloAddress silo);
+
+        /// <summary>Casts the provided <paramref name="grain"/> to the specified interface.</summary>
+        /// <typeparam name="TGrainInterface">The target grain interface type.</typeparam>
+        /// <param name="grain">The grain reference being cast.</param>
+        /// <returns>A reference to <paramref name="grain"/> which implements <typeparamref name="TGrainInterface"/>.</returns>
+        TGrainInterface Cast<TGrainInterface>(IAddressable grain);
+    }
+}

--- a/src/Orleans/Runtime/IRuntimeClient.cs
+++ b/src/Orleans/Runtime/IRuntimeClient.cs
@@ -72,6 +72,8 @@ namespace Orleans.Runtime
 
         SerializationManager SerializationManager { get; }
 
+        IGrainReferenceRuntime GrainReferenceRuntime { get; }
+
         void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo);
     }
 }

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -89,6 +89,8 @@ namespace Orleans
             get { return clientProviderRuntime; }
         }
 
+        public IGrainReferenceRuntime GrainReferenceRuntime { get; private set; }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "MessageCenter is IDisposable but cannot call Dispose yet as it lives past the end of this method call.")]
         public OutsideRuntimeClient()
@@ -122,6 +124,7 @@ namespace Orleans
             this.messageFactory = this.ServiceProvider.GetService<MessageFactory>();
 
             this.config = services.GetRequiredService<ClientConfiguration>();
+            this.GrainReferenceRuntime = this.ServiceProvider.GetRequiredService<IGrainReferenceRuntime>();
 
             if (!LogManager.IsInitialized) LogManager.Initialize(config);
             StatisticsCollector.Initialize(config);
@@ -803,7 +806,7 @@ namespace Orleans
             if (obj is GrainReference)
                 throw new ArgumentException("Argument obj is already a grain reference.");
 
-            GrainReference gr = GrainReference.NewObserverGrainReference(clientId, GuidId.GetNewGuidId(), this);
+            GrainReference gr = GrainReference.NewObserverGrainReference(clientId, GuidId.GetNewGuidId(), this.GrainReferenceRuntime);
             if (!localObjects.TryAdd(gr.ObserverId, new LocalObjectData(obj, gr.ObserverId, invoker)))
             {
                 throw new ArgumentException(String.Format("Failed to add new observer {0} to localObjects collection.", gr), "gr");

--- a/src/Orleans/Serialization/GrainReferenceSerializer.cs
+++ b/src/Orleans/Serialization/GrainReferenceSerializer.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Orleans.CodeGeneration;
+using Orleans.Runtime;
+
+namespace Orleans.Serialization
+{
+    [Serializer(typeof(GrainReference))]
+    internal class GrainReferenceSerializer
+    {
+        /// <summary> Serializer function for grain reference.</summary>
+        /// <seealso cref="SerializationManager"/>
+        [SerializerMethod]
+        protected internal static void SerializeGrainReference(object obj, ISerializationContext context, Type expected)
+        {
+            var writer = context.StreamWriter;
+            var input = (GrainReference)obj;
+            writer.Write(input.GrainId);
+            if (input.IsSystemTarget)
+            {
+                writer.Write((byte)1);
+                writer.Write(input.SystemTargetSilo);
+            }
+            else
+            {
+                writer.Write((byte)0);
+            }
+
+            if (input.IsObserverReference)
+            {
+                input.ObserverId.SerializeToStream(writer);
+            }
+
+            // store as null, serialize as empty.
+            var genericArg = string.Empty;
+            if (input.HasGenericArgument)
+                genericArg = input.GenericArguments;
+            writer.Write(genericArg);
+        }
+
+        /// <summary> Deserializer function for grain reference.</summary>
+        /// <seealso cref="SerializationManager"/>
+        [DeserializerMethod]
+        protected internal static object DeserializeGrainReference(Type t, IDeserializationContext context)
+        {
+            var reader = context.StreamReader;
+            GrainId id = reader.ReadGrainId();
+            SiloAddress silo = null;
+            GuidId observerId = null;
+            byte siloAddressPresent = reader.ReadByte();
+            if (siloAddressPresent != 0)
+            {
+                silo = reader.ReadSiloAddress();
+            }
+            bool expectObserverId = id.IsClient;
+            if (expectObserverId)
+            {
+                observerId = GuidId.DeserializeFromStream(reader);
+            }
+            // store as null, serialize as empty.
+            var genericArg = reader.ReadString();
+            if (string.IsNullOrEmpty(genericArg))
+                genericArg = null;
+
+            var runtimeClient = context.AdditionalContext as IRuntimeClient;
+            var runtime = runtimeClient?.GrainReferenceRuntime;
+            if (expectObserverId)
+            {
+                return GrainReference.NewObserverGrainReference(id, observerId, runtime);
+            }
+
+            return GrainReference.FromGrainId(id, runtime, genericArg, silo);
+        }
+
+        /// <summary> Copier function for grain reference. </summary>
+        /// <seealso cref="SerializationManager"/>
+        [CopierMethod]
+        protected internal static object CopyGrainReference(object original, ICopyContext context)
+        {
+            return (GrainReference)original;
+        }
+    }
+}

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -752,12 +752,12 @@ namespace Orleans.Serialization
             // Register GrainReference serialization methods.
             Register(
                 type,
-                GrainReference.CopyGrainReference,
-                GrainReference.SerializeGrainReference,
+                GrainReferenceSerializer.CopyGrainReference,
+                GrainReferenceSerializer.SerializeGrainReference,
                 (expected, context) =>
                 {
                     Func<GrainReference, GrainReference> ctorDelegate;
-                    var deserialized = (GrainReference)GrainReference.DeserializeGrainReference(expected, context);
+                    var deserialized = (GrainReference)GrainReferenceSerializer.DeserializeGrainReference(expected, context);
                     if (expected.IsConstructedGenericType == false)
                     {
                         return defaultCtorDelegate(deserialized);

--- a/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
+++ b/src/OrleansCodeGenerator/GrainReferenceGenerator.cs
@@ -308,7 +308,7 @@ namespace Orleans.CodeGenerator
 
         private static MemberDeclarationSyntax GenerateInterfaceIdProperty(Type grainType)
         {
-            var property = TypeUtils.Member((IGrainMethodInvoker _) => _.InterfaceId);
+            var property = TypeUtils.Member((GrainReference _) => _.InterfaceId);
             var returnValue = SF.LiteralExpression(
                 SyntaxKind.NumericLiteralExpression,
                 SF.Literal(GrainInterfaceUtils.GetGrainInterfaceId(grainType)));
@@ -317,12 +317,12 @@ namespace Orleans.CodeGenerator
                     .AddAccessorListAccessors(
                         SF.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
                             .AddBodyStatements(SF.ReturnStatement(returnValue)))
-                    .AddModifiers(SF.Token(SyntaxKind.ProtectedKeyword), SF.Token(SyntaxKind.OverrideKeyword));
+                    .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.OverrideKeyword));
         }
 
         private static MemberDeclarationSyntax GenerateInterfaceVersionProperty(Type grainType)
         {
-            var property = TypeUtils.Member((IGrainMethodInvoker _) => _.InterfaceVersion);
+            var property = TypeUtils.Member((GrainReference _) => _.InterfaceVersion);
             var returnValue = SF.LiteralExpression(
                 SyntaxKind.NumericLiteralExpression,
                 SF.Literal(GrainInterfaceUtils.GetGrainInterfaceVersion(grainType))); 
@@ -331,7 +331,7 @@ namespace Orleans.CodeGenerator
                     .AddAccessorListAccessors(
                         SF.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
                             .AddBodyStatements(SF.ReturnStatement(returnValue)))
-                    .AddModifiers(SF.Token(SyntaxKind.ProtectedKeyword), SF.Token(SyntaxKind.OverrideKeyword));
+                    .AddModifiers(SF.Token(SyntaxKind.PublicKeyword), SF.Token(SyntaxKind.OverrideKeyword));
         }
 
         private static MemberDeclarationSyntax GenerateIsCompatibleMethod(Type grainType)
@@ -378,12 +378,7 @@ namespace Orleans.CodeGenerator
 
         private static MethodDeclarationSyntax GenerateGetMethodNameMethod(Type grainType)
         {
-            // Get the method with the correct type.
-            var method =
-                typeof(GrainReference).GetTypeInfo()
-                    .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
-                    .FirstOrDefault(m => m.Name == "GetMethodName");
-
+            var method = TypeUtils.Method((GrainReference _) => _.GetMethodName(default(int), default(int)));
             var methodDeclaration =
                 method.GetDeclarationSyntax()
                     .AddModifiers(SF.Token(SyntaxKind.OverrideKeyword));

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -204,7 +204,7 @@ namespace Orleans.Runtime
             }
             CollectionAgeLimit = ageLimit;
 
-            GrainReference = GrainReference.FromGrainId(addr.Grain, runtimeClient, genericArguments, Grain.IsSystemTarget ? addr.Silo : null);
+            GrainReference = GrainReference.FromGrainId(addr.Grain, runtimeClient.GrainReferenceRuntime, genericArguments, Grain.IsSystemTarget ? addr.Silo : null);
             this.SchedulingContext = new SchedulingContext(this);
         }
 

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -11,8 +11,6 @@ using Orleans.Runtime.Placement;
 using Orleans.Runtime.Scheduler;
 using Orleans.Runtime.Versions.Compatibility;
 using Orleans.Serialization;
-using Orleans.Versions.Compatibility;
-
 
 namespace Orleans.Runtime
 {
@@ -61,6 +59,8 @@ namespace Orleans.Runtime
             errorInjectionRate = rejectionInjectionRate + messageLossInjectionRate;
             random = new SafeRandom();
         }
+
+        public ISiloRuntimeClient RuntimeClient => this.catalog.RuntimeClient;
 
         #region Receive path
 

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -40,6 +40,7 @@ namespace Orleans.Runtime
         private readonly GrainTypeManager typeManager;
         private readonly MessageFactory messageFactory;
         private readonly List<IGrainCallFilter> siloInterceptors;
+        private IGrainReferenceRuntime grainReferenceRuntime;
 
         public InsideRuntimeClient(
             ILocalSiloDetails siloDetails,
@@ -97,6 +98,8 @@ namespace Orleans.Runtime
         private Dispatcher Dispatcher => this.dispatcher ?? (this.dispatcher = this.ServiceProvider.GetRequiredService<Dispatcher>());
 
         #region Implementation of IRuntimeClient
+
+        public IGrainReferenceRuntime GrainReferenceRuntime => this.grainReferenceRuntime ?? (this.grainReferenceRuntime = this.ServiceProvider.GetRequiredService<IGrainReferenceRuntime>());
 
         public void SendRequest(
             GrainReference target,

--- a/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
+++ b/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
@@ -43,7 +43,8 @@ namespace Orleans.Runtime.Scheduler
             try
             {
                 var grain = activation.GrainInstance;
-                var runtimeClient = (ISiloRuntimeClient)grain.GrainReference.RuntimeClient;
+                var runtime = (GrainReferenceRuntime)grain.GrainReference.Runtime;
+                var runtimeClient = (ISiloRuntimeClient)runtime.RuntimeClient;
                 Task task = runtimeClient.Invoke(grain, this.activation, this.message);
                 task.ContinueWith(t =>
                 {

--- a/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
+++ b/src/OrleansRuntime/Scheduler/InvokeWorkItem.cs
@@ -43,8 +43,7 @@ namespace Orleans.Runtime.Scheduler
             try
             {
                 var grain = activation.GrainInstance;
-                var runtime = (GrainReferenceRuntime)grain.GrainReference.Runtime;
-                var runtimeClient = (ISiloRuntimeClient)runtime.RuntimeClient;
+                var runtimeClient = this.dispatcher.RuntimeClient;
                 Task task = runtimeClient.Invoke(grain, this.activation, this.message);
                 task.ContinueWith(t =>
                 {

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -235,6 +235,7 @@ namespace Orleans.Runtime
             services.AddFromExisting<IGrainFactory, GrainFactory>();
             services.AddFromExisting<IInternalGrainFactory, GrainFactory>();
             services.AddFromExisting<IGrainReferenceConverter, GrainFactory>();
+            services.AddSingleton<IGrainReferenceRuntime, GrainReferenceRuntime>();
             services.AddSingleton<TypeMetadataCache>();
             services.AddSingleton<AssemblyProcessor>();
             services.AddSingleton<ActivationDirectory>();

--- a/test/DefaultCluster.Tests/KeyExtensionTests.cs
+++ b/test/DefaultCluster.Tests/KeyExtensionTests.cs
@@ -126,7 +126,7 @@ namespace DefaultCluster.Tests.General
 
                 var grainRef2 = GrainReference.FromKeyString(
                     grainRef.ToKeyString(),
-                    this.Client.ServiceProvider.GetRequiredService<IRuntimeClient>());
+                    this.Client.ServiceProvider.GetRequiredService<IGrainReferenceRuntime>());
                 Assert.True(grainRef.Equals(grainRef2));
             }
 
@@ -142,7 +142,7 @@ namespace DefaultCluster.Tests.General
 
                 var grainRef2 = GrainReference.FromKeyString(
                     grainRef.ToKeyString(),
-                    this.Client.ServiceProvider.GetRequiredService<IRuntimeClient>());
+                    this.Client.ServiceProvider.GetRequiredService<IGrainReferenceRuntime>());
                 Assert.True(grainRef.Equals(grainRef2));
             }
         }

--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -435,12 +435,12 @@ namespace UnitTests.General
             TestGrainReference(grainRef);
 
             GrainId observerGrainId = GrainId.NewClientId();
-            grainRef = GrainReference.NewObserverGrainReference(observerGrainId, GuidId.GetNewGuidId(), this.environment.RuntimeClient);
+            grainRef = GrainReference.NewObserverGrainReference(observerGrainId, GuidId.GetNewGuidId(), this.environment.RuntimeClient.GrainReferenceRuntime);
             this.environment.GrainFactory.BindGrainReference(grainRef);
             TestGrainReference(grainRef);
 
             GrainId geoObserverGrainId = GrainId.NewClientId("clusterid");
-            grainRef = GrainReference.NewObserverGrainReference(geoObserverGrainId, GuidId.GetNewGuidId(), this.environment.RuntimeClient);
+            grainRef = GrainReference.NewObserverGrainReference(geoObserverGrainId, GuidId.GetNewGuidId(), this.environment.RuntimeClient.GrainReferenceRuntime);
             this.environment.GrainFactory.BindGrainReference(grainRef);
             TestGrainReference(grainRef);
         }


### PR DESCRIPTION
In preparation to move `GrainReference` to an Abstractions assembly, but still keep the logic inside the Orleans implementation.
- `GrainReference` is now bound to `IGrainReferenceRuntime` instead of `IRuntimeClient`. The new runtime abstraction includes all the logic that was previously part of `GrainReference`, and it's a much more reduced surface area compared to `IRuntimeClient`, to expose to the public.
- Moved Orleans-specific serialization outside the base abstraction.