### PR TITLE
Implemented Custom Serializer for GrainStateWithMetaDataAndETag

### DIFF
--- a/src/OrleansCounterControl/OrleansCounterControl.csproj
+++ b/src/OrleansCounterControl/OrleansCounterControl.csproj
@@ -67,6 +67,7 @@
     <None Include="Microsoft.Orleans.CounterControl.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OrleansRuntime\OrleansRuntime.csproj">

--- a/src/OrleansCounterControl/project.json
+++ b/src/OrleansCounterControl/project.json
@@ -1,0 +1,11 @@
+﻿{
+  "dependencies": {
+  },
+  "frameworks": {
+    "net461": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}

--- a/src/OrleansEventSourcing/OrleansEventSourcing.csproj
+++ b/src/OrleansEventSourcing/OrleansEventSourcing.csproj
@@ -74,7 +74,9 @@
       <Name>Orleans</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/OrleansEventSourcing/StateStorage/GrainStateWithMetaData.cs
+++ b/src/OrleansEventSourcing/StateStorage/GrainStateWithMetaData.cs
@@ -69,7 +69,7 @@ namespace Orleans.EventSourcing.StateStorage
         /// <summary>
         /// Initialize a new instance of GrainStateWithMetaDataAndETag class with a initialVew
         /// </summary>
-        public GrainStateWithMetaDataAndETag(TView initialview) : this(null, initialview, 0, null) { }
+        public GrainStateWithMetaDataAndETag(TView initialview) : this(null, initialview, 0, string.Empty) { }
 
         /// <summary>
         /// Initializes a new instance of GrainStateWithMetaDataAndETag class

--- a/src/OrleansEventSourcing/StateStorage/GrainStateWithMetaData.cs
+++ b/src/OrleansEventSourcing/StateStorage/GrainStateWithMetaData.cs
@@ -14,50 +14,12 @@ namespace Orleans.EventSourcing.StateStorage
     /// can use a standard storage provider via <see cref="LogViewAdaptor{TView,TEntry}"/>
     /// </summary>
     /// <typeparam name="TView">The type used for log view</typeparam>
-    public class GrainStateWithMetaDataAndETag<TView> : GrainStateWithMetaData<TView>, IGrainState where TView : class, new()
-    {       
-        /// <summary>
-        /// Gets and Sets Etag
-        /// </summary>
-        public string ETag { get; set; }
-
-        object IGrainState.State
-        {
-            get
-            {
-                return State;
-            }
-            set
-            {
-                State = (TView)value;
-            }
-        }
-
-        /// <summary>
-        /// Initialize a new instance of GrainStateWithMetaDataAndETag class from deserialized values
-        /// </summary>
-        protected GrainStateWithMetaDataAndETag(string etag, TView initialview, int globalVersion, string writeVector) : base(initialview, globalVersion, writeVector) { }
-
-        /// <summary>
-        /// Initialize a new instance of GrainStateWithMetaDataAndETag class with a initialVew
-        /// </summary>
-        public GrainStateWithMetaDataAndETag(TView initialview) : base(initialview) { }
-
-        /// <summary>
-        /// Initializes a new instance of GrainStateWithMetaDataAndETag class
-        /// </summary>
-        public GrainStateWithMetaDataAndETag() : base() { }
-
-        /// <summary>
-        /// Convert current GrainStateWithMetaDataAndETag object information to a string
-        /// </summary>
-        public override string ToString()
-        {
-            return string.Format("v{0} Flags={1} ETag={2} Data={3}", GlobalVersion, WriteVector, ETag, State);
-        }
+    public class GrainStateWithMetaDataAndETag<TView> : IGrainState where TView : class, new()
+    {
+        #region Serialization Methods
 
         [CopierMethod]
-        public static object DeepCopier(object original, ICopyContext context)
+        internal static object DeepCopier(object original, ICopyContext context)
         {
             GrainStateWithMetaDataAndETag<TView> instance = (GrainStateWithMetaDataAndETag<TView>)original;
 
@@ -90,66 +52,48 @@ namespace Orleans.EventSourcing.StateStorage
 
             return new GrainStateWithMetaDataAndETag<TView>(etag, state, globalVersion, writeVector);
         }
-    }
 
-
-    /// <summary>
-    /// A class that extends grain state with versioning metadata, so that a log-consistent grain
-    /// can use a standard storage provider via <see cref="LogViewAdaptor{TView,TEntry}"/>
-    /// </summary>
-    /// <typeparam name="TView"></typeparam>
-    public class GrainStateWithMetaData<TView> where TView : class, new()
-    {
-        /// <summary>
-        /// The stored view of the log
-        /// </summary>
-        public TView State { get; set; }
-
-        /// <summary>
-        /// The length of the log
-        /// </summary>
-        public int GlobalVersion { get; set; }
-
-
-        /// <summary>
-        /// Metadata that is used to avoid duplicate appends.
-        /// Logically, this is a (string->bit) map, the keys being replica ids
-        /// But this map is represented compactly as a simple string to reduce serialization/deserialization overhead
-        /// Bits are read by <see cref="GetBit"/> and flipped by  <see cref="FlipBit"/>.
-        /// Bits are toggled when writing, so that the retry logic can avoid appending an entry twice
-        /// when retrying a failed append. 
-        /// </summary>
-        public string WriteVector { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GrainStateWithMetaData{TView}"/> class.
-        /// </summary>
-        public GrainStateWithMetaData()
-        {
-            State = new TView();
-            GlobalVersion = 0;
-            WriteVector = "";
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GrainStateWithMetaData{TView}"/> class.
-        /// </summary>
-        /// <param name="initialstate">The initial state of the view</param>
-        public GrainStateWithMetaData(TView initialstate)
-        {
-            this.State = initialstate;
-            GlobalVersion = 0;
-            WriteVector = "";
-        }
+        #endregion Serialization Methods
 
         /// <summary>
         /// Initialize a new instance of GrainStateWithMetaDataAndETag class from deserialized values
         /// </summary>
-        protected GrainStateWithMetaData(TView initialview, int globalVersion, string writeVector)
+        public GrainStateWithMetaDataAndETag(string etag, TView initialview, int globalVersion, string writeVector)
         {
+            ETag = etag;
             State = initialview;
             GlobalVersion = globalVersion;
             WriteVector = writeVector;
+        }
+
+        /// <summary>
+        /// Initialize a new instance of GrainStateWithMetaDataAndETag class with a initialVew
+        /// </summary>
+        public GrainStateWithMetaDataAndETag(TView initialview) : this(null, initialview, 0, null) { }
+
+        /// <summary>
+        /// Initializes a new instance of GrainStateWithMetaDataAndETag class
+        /// </summary>
+        public GrainStateWithMetaDataAndETag() : this(new TView()) { }
+
+        object IGrainState.State
+        {
+            get
+            {
+                return State;
+            }
+            set
+            {
+                State = (TView)value;
+            }
+        }
+
+        /// <summary>
+        /// Convert current GrainStateWithMetaDataAndETag object information to a string
+        /// </summary>
+        public override string ToString()
+        {
+            return string.Format("v{0} Flags={1} ETag={2} Data={3}", GlobalVersion, WriteVector, ETag, State);
         }
 
         /// <summary>
@@ -175,36 +119,29 @@ namespace Orleans.EventSourcing.StateStorage
             return rval;
         }
 
-        [CopierMethod]
-        public static object DeepCopier(object original, ICopyContext context)
-        {
-            GrainStateWithMetaData<TView> instance = (GrainStateWithMetaData<TView>)original;
-            
-            TView state = (TView)SerializationManager.DeepCopyInner(instance.State, context);
-            int globalVersion = (int)SerializationManager.DeepCopyInner(instance.GlobalVersion, context);
-            string writeVector = (string)SerializationManager.DeepCopyInner(instance.WriteVector, context);
+        /// <summary>
+        /// The stored view of the log
+        /// </summary>
+        public TView State { get; set; }
 
-            return new GrainStateWithMetaData<TView>(state, globalVersion, writeVector);
-        }
+        /// <summary>
+        /// The length of the log
+        /// </summary>
+        public int GlobalVersion { get; set; }
 
-        [SerializerMethod]
-        internal static void Serialize(object input, ISerializationContext context, Type expected)
-        {
-            GrainStateWithMetaData<TView> instance = (GrainStateWithMetaData<TView>)input;
-            
-            SerializationManager.SerializeInner(instance.State, context, typeof(TView));
-            SerializationManager.SerializeInner(instance.GlobalVersion, context, typeof(int));
-            SerializationManager.SerializeInner(instance.WriteVector, context, typeof(string));
-        }
+        /// <summary>
+        /// Metadata that is used to avoid duplicate appends.
+        /// Logically, this is a (string->bit) map, the keys being replica ids
+        /// But this map is represented compactly as a simple string to reduce serialization/deserialization overhead
+        /// Bits are read by <see cref="GetBit"/> and flipped by  <see cref="FlipBit"/>.
+        /// Bits are toggled when writing, so that the retry logic can avoid appending an entry twice
+        /// when retrying a failed append. 
+        /// </summary>
+        public string WriteVector { get; set; }
 
-        [DeserializerMethod]
-        internal static object Deserialize(Type expected, IDeserializationContext context)
-        {
-            TView state = SerializationManager.DeserializeInner<TView>(context);
-            int globalVersion = SerializationManager.DeserializeInner<int>(context);
-            string writeVector = SerializationManager.DeserializeInner<string>(context);
-
-            return new GrainStateWithMetaData<TView>(state, globalVersion, writeVector);
-        }
+        /// <summary>
+        /// Gets and Sets Etag
+        /// </summary>
+        public string ETag { get; set; }
     }
 }

--- a/src/OrleansEventSourcing/StateStorage/LogViewAdaptor.cs
+++ b/src/OrleansEventSourcing/StateStorage/LogViewAdaptor.cs
@@ -45,13 +45,13 @@ namespace Orleans.EventSourcing.StateStorage
         /// <inheritdoc/>
         protected override TLogView LastConfirmedView()
         {
-            return GlobalStateCache.StateAndMetaData.State;
+            return GlobalStateCache.State;
         }
 
         /// <inheritdoc/>
         protected override int GetConfirmedVersion()
         {
-            return GlobalStateCache.StateAndMetaData.GlobalVersion;
+            return GlobalStateCache.GlobalVersion;
         }
 
         /// <inheritdoc/>
@@ -111,11 +111,11 @@ namespace Orleans.EventSourcing.StateStorage
             bool batchsuccessfullywritten = false;
 
             var nextglobalstate = new GrainStateWithMetaDataAndETag<TLogView>(state);
-            nextglobalstate.StateAndMetaData.WriteVector = GlobalStateCache.StateAndMetaData.WriteVector;
-            nextglobalstate.StateAndMetaData.GlobalVersion = GlobalStateCache.StateAndMetaData.GlobalVersion + updates.Length;
+            nextglobalstate.WriteVector = GlobalStateCache.WriteVector;
+            nextglobalstate.GlobalVersion = GlobalStateCache.GlobalVersion + updates.Length;
             nextglobalstate.ETag = GlobalStateCache.ETag;
 
-            var writebit = nextglobalstate.StateAndMetaData.FlipBit(Services.MyClusterId);
+            var writebit = nextglobalstate.FlipBit(Services.MyClusterId);
 
             try
             {
@@ -166,7 +166,7 @@ namespace Orleans.EventSourcing.StateStorage
 
                 // check if last apparently failed write was in fact successful
 
-                if (writebit == GlobalStateCache.StateAndMetaData.GetBit(Services.MyClusterId))
+                if (writebit == GlobalStateCache.GetBit(Services.MyClusterId))
                 {
                     GlobalStateCache = nextglobalstate;
 
@@ -181,7 +181,7 @@ namespace Orleans.EventSourcing.StateStorage
             if (batchsuccessfullywritten)
                 BroadcastNotification(new UpdateNotificationMessage()
                    {
-                       Version = GlobalStateCache.StateAndMetaData.GlobalVersion,
+                       Version = GlobalStateCache.GlobalVersion,
                        Updates = updates.Select(se => se.Entry).ToList(),
                        Origin = Services.MyClusterId,
                        ETag = GlobalStateCache.ETag
@@ -289,14 +289,14 @@ namespace Orleans.EventSourcing.StateStorage
         protected override void ProcessNotifications()
         {
             // discard notifications that are behind our already confirmed state
-            while (notifications.Count > 0 && notifications.ElementAt(0).Key < GlobalStateCache.StateAndMetaData.GlobalVersion)
+            while (notifications.Count > 0 && notifications.ElementAt(0).Key < GlobalStateCache.GlobalVersion)
             {
                 Services.Log(Severity.Verbose, "discarding notification {0}", notifications.ElementAt(0).Value);
                 notifications.RemoveAt(0);
             }
 
             // process notifications that reflect next global version
-            while (notifications.Count > 0 && notifications.ElementAt(0).Key == GlobalStateCache.StateAndMetaData.GlobalVersion)
+            while (notifications.Count > 0 && notifications.ElementAt(0).Key == GlobalStateCache.GlobalVersion)
             {
                 var updateNotification = notifications.ElementAt(0).Value;
                 notifications.RemoveAt(0);
@@ -305,16 +305,16 @@ namespace Orleans.EventSourcing.StateStorage
                 foreach (var u in updateNotification.Updates)
                     try
                     {
-                        Host.UpdateView(GlobalStateCache.StateAndMetaData.State, u);
+                        Host.UpdateView(GlobalStateCache.State, u);
                     }
                     catch (Exception e)
                     {
                         Services.CaughtUserCodeException("UpdateView", nameof(ProcessNotifications), e);
                     }
 
-                GlobalStateCache.StateAndMetaData.GlobalVersion = updateNotification.Version;
+                GlobalStateCache.GlobalVersion = updateNotification.Version;
 
-                GlobalStateCache.StateAndMetaData.FlipBit(updateNotification.Origin);
+                GlobalStateCache.FlipBit(updateNotification.Origin);
 
                 GlobalStateCache.ETag = updateNotification.ETag;         
 

--- a/src/OrleansEventSourcing/project.json
+++ b/src/OrleansEventSourcing/project.json
@@ -1,0 +1,11 @@
+﻿{
+  "dependencies": {
+  },
+  "frameworks": {
+    "net461": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}

--- a/src/OrleansTelemetryConsumers.Counters/OrleansTelemetryConsumers.Counters.csproj
+++ b/src/OrleansTelemetryConsumers.Counters/OrleansTelemetryConsumers.Counters.csproj
@@ -66,6 +66,9 @@
       <Name>Orleans</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/OrleansTelemetryConsumers.Counters/project.json
+++ b/src/OrleansTelemetryConsumers.Counters/project.json
@@ -1,0 +1,11 @@
+﻿{
+  "dependencies": {
+  },
+  "frameworks": {
+    "net461": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}

--- a/test/TestExtensions/TestEnvironmentFixture.cs
+++ b/test/TestExtensions/TestEnvironmentFixture.cs
@@ -5,5 +5,14 @@ namespace TestExtensions
     public class TestEnvironmentFixture : SerializationTestEnvironment
     {
         public const string DefaultCollection = "DefaultTestEnvironment";
+
+        public T RoundTripSerialization<T>(T source)
+        {
+            BinaryTokenStreamWriter writer = new BinaryTokenStreamWriter();
+            SerializationManager.Serialize(source, writer);
+            T output = (T)SerializationManager.Deserialize(new BinaryTokenStreamReader(writer.ToByteArray()));
+
+            return output;
+        }
     }
 }

--- a/test/Tester/EventSourcingTests/EventSourceEnvironmentFixture.cs
+++ b/test/Tester/EventSourcingTests/EventSourceEnvironmentFixture.cs
@@ -1,0 +1,27 @@
+﻿using Orleans.EventSourcing.StateStorage;
+using Orleans.Serialization;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.EventSourcingTests
+{
+    [CollectionDefinition(EventSourceEnvironmentFixture.EventSource)]
+    public class TestEnvironmentFixtureCollection : ICollectionFixture<EventSourceEnvironmentFixture> { }
+
+    public class EventSourceEnvironmentFixture : SerializationTestEnvironment
+    {
+        // Force load of OrleansEventSourcing
+        private static readonly GrainStateWithMetaDataAndETag<object> dummy = new GrainStateWithMetaDataAndETag<object>();
+
+        public const string EventSource = "EventSourceTestEnvironment";
+
+        public T RoundTripSerialization<T>(T source)
+        {
+            BinaryTokenStreamWriter writer = new BinaryTokenStreamWriter();
+            SerializationManager.Serialize(source, writer);
+            T output = (T)SerializationManager.Deserialize(new BinaryTokenStreamReader(writer.ToByteArray()));
+
+            return output;
+        }
+    }
+}

--- a/test/Tester/EventSourcingTests/SerializationTests.cs
+++ b/test/Tester/EventSourcingTests/SerializationTests.cs
@@ -1,0 +1,149 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Orleans.CodeGeneration;
+using Orleans.Serialization;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+using System.Xml;
+using Orleans.EventSourcing.StateStorage;
+
+namespace Tester.EventSourcingTests
+{
+    /// <summary>
+    /// Summary description for SerializationTests
+    /// </summary>
+    [Collection(EventSourceEnvironmentFixture.EventSource)]
+    public class SerializationTestsJsonTypes
+    {
+        [Serializable]
+        public class SimplePOCO
+        {
+            public int A { get; set; }
+            public int B { get; set; }
+        }
+
+        public class AdvancedPOCO
+        {
+            public int A { get; set; }
+            public int B { get; set; }
+
+            [CopierMethod]
+            public static object DeepCopier(object original, ICopyContext context)
+            {
+                AdvancedPOCO instance = (AdvancedPOCO)original;
+
+                int a = (int)SerializationManager.DeepCopyInner(instance.A, context);
+                int b = (int)SerializationManager.DeepCopyInner(instance.B, context);
+
+                return new AdvancedPOCO { A = a, B = b };
+            }
+
+            [SerializerMethod]
+            internal static void Serialize(object input, ISerializationContext context, Type expected)
+            {
+                AdvancedPOCO instance = (AdvancedPOCO)input;
+
+                SerializationManager.SerializeInner(instance.A, context, typeof(int));
+                SerializationManager.SerializeInner(instance.B, context, typeof(int));
+            }
+
+            [DeserializerMethod]
+            internal static object Deserialize(Type expected, IDeserializationContext context)
+            {
+                int a = (int)SerializationManager.DeserializeInner<int>(context);
+                int b = (int)SerializationManager.DeserializeInner<int>(context);
+
+                return new AdvancedPOCO { A = a, B = b };
+            }
+        }
+
+        public class ReportingPOCO
+        {
+            public int A { get; set; }
+            public int B { get; set; }
+            public int CopyCount { get; set; }
+            public int SerializeCount { get; set; }
+            public int DeserializeCount { get; set; }
+
+            [CopierMethod]
+            public static object DeepCopier(object original, ICopyContext context)
+            {
+                ReportingPOCO instance = (ReportingPOCO)original;
+
+                int a = (int)SerializationManager.DeepCopyInner(instance.A, context);
+                int b = (int)SerializationManager.DeepCopyInner(instance.B, context);
+                int copyCount = (int)SerializationManager.DeepCopyInner(instance.CopyCount, context);
+                int serializeCount = (int)SerializationManager.DeepCopyInner(instance.SerializeCount, context);
+                int deserializeCount = (int)SerializationManager.DeepCopyInner(instance.DeserializeCount, context);
+
+                return new ReportingPOCO { A = a, B = b, CopyCount = copyCount + 1, SerializeCount = serializeCount, DeserializeCount = deserializeCount };
+            }
+
+            [SerializerMethod]
+            internal static void Serialize(object input, ISerializationContext context, Type expected)
+            {
+                ReportingPOCO instance = (ReportingPOCO)input;
+
+                SerializationManager.SerializeInner(instance.A, context, typeof(int));
+                SerializationManager.SerializeInner(instance.B, context, typeof(int));
+                SerializationManager.SerializeInner(instance.CopyCount, context, typeof(int));
+                SerializationManager.SerializeInner(instance.SerializeCount + 1, context, typeof(int));
+                SerializationManager.SerializeInner(instance.DeserializeCount, context, typeof(int));
+            }
+
+            [DeserializerMethod]
+            internal static object Deserialize(Type expected, IDeserializationContext context)
+            {
+                int a = SerializationManager.DeserializeInner<int>(context);
+                int b = SerializationManager.DeserializeInner<int>(context);
+                int copyCount = SerializationManager.DeserializeInner<int>(context);
+                int serializeCount = SerializationManager.DeserializeInner<int>(context);
+                int deserializeCount = SerializationManager.DeserializeInner<int>(context);
+
+                return new ReportingPOCO { A = a, B = b, CopyCount = copyCount, SerializeCount = serializeCount, DeserializeCount = deserializeCount + 1 };
+            }
+        }
+
+
+        private readonly EventSourceEnvironmentFixture fixture;
+
+        public SerializationTestsJsonTypes(EventSourceEnvironmentFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact, TestCategory("Serialization")]
+        public void SerializationTests_GrainStateWithMetaDataAndETag_SerializableView()
+        {
+            GrainStateWithMetaDataAndETag<SimplePOCO> input = new GrainStateWithMetaDataAndETag<SimplePOCO>(new SimplePOCO { A = 1, B = 2 });
+
+            GrainStateWithMetaDataAndETag<SimplePOCO> output = fixture.RoundTripSerialization(input);
+
+            Assert.Equal(input.ToString(), output.ToString());
+        }
+
+        [Fact, TestCategory("Serialization")]
+        public void SerializationTests_GrainStateWithMetaDataAndETag_NonSerializableView()
+        {
+            GrainStateWithMetaDataAndETag<AdvancedPOCO> input = new GrainStateWithMetaDataAndETag<AdvancedPOCO>(new AdvancedPOCO { A = 1, B = 2 });
+
+            GrainStateWithMetaDataAndETag<AdvancedPOCO> output = fixture.RoundTripSerialization(input);
+
+            Assert.Equal(input.ToString(), output.ToString());
+        }
+
+        [Fact, TestCategory("Serialization")]
+        public void SerializationTests_GrainStateWithMetaDataAndETag_CustomSerialization()
+        {
+            GrainStateWithMetaDataAndETag<ReportingPOCO> input = new GrainStateWithMetaDataAndETag<ReportingPOCO>(new ReportingPOCO { A = 1, B = 2 });
+
+            GrainStateWithMetaDataAndETag<ReportingPOCO> output = fixture.RoundTripSerialization(input);
+
+            Assert.Equal(0, output.State.CopyCount);
+            Assert.Equal(1, output.State.SerializeCount);
+            Assert.Equal(1, output.State.DeserializeCount);
+        }
+    }
+}

--- a/test/Tester/EventSourcingTests/SerializationTests.cs
+++ b/test/Tester/EventSourcingTests/SerializationTests.cs
@@ -134,6 +134,27 @@ namespace Tester.EventSourcingTests
             Assert.Equal(input.ToString(), output.ToString());
         }
 
+
+        [Fact, TestCategory("Serialization")]
+        public void SerializationTests_GrainStateWithMetaDataAndETag_CopySerializableView()
+        {
+            GrainStateWithMetaDataAndETag<SimplePOCO> input = new GrainStateWithMetaDataAndETag<SimplePOCO>("eTag", new SimplePOCO { A = 1, B = 2 }, 1, "writeVector");
+
+            GrainStateWithMetaDataAndETag<SimplePOCO> output = (GrainStateWithMetaDataAndETag<SimplePOCO>)fixture.SerializationManager.DeepCopy(input);
+
+            Assert.Equal(input.ToString(), output.ToString());
+        }
+
+        [Fact, TestCategory("Serialization")]
+        public void SerializationTests_GrainStateWithMetaDataAndETag_CopyNonSerializableView()
+        {
+            GrainStateWithMetaDataAndETag<AdvancedPOCO> input = new GrainStateWithMetaDataAndETag<AdvancedPOCO>("eTag", new AdvancedPOCO { A = 1, B = 2 }, 1, "writeVector");
+
+            GrainStateWithMetaDataAndETag<AdvancedPOCO> output = (GrainStateWithMetaDataAndETag<AdvancedPOCO>)fixture.SerializationManager.DeepCopy(input);
+
+            Assert.Equal(input.ToString(), output.ToString());
+        }
+
         [Fact, TestCategory("Serialization")]
         public void SerializationTests_GrainStateWithMetaDataAndETag_CustomSerialization()
         {

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ClientConnectionTests\GatewayConnectionTests.cs" />
     <Compile Include="CollectionFixtures.cs" />
     <Compile Include="DependencyInjectionDisambiguationTests.cs" />
+    <Compile Include="EventSourcingTests\SerializationTests.cs" />
     <Compile Include="GrainActivatorTests.cs" />
     <Compile Include="EventSourcingTests\AccountGrainTests.cs" />
     <Compile Include="EventSourcingTests\ChatGrainTests.cs" />
@@ -68,6 +69,7 @@
     <Compile Include="SerializationTests\DeepCopyTests.cs" />
     <Compile Include="SerializationTests\ConsiderForCodeGenerationAttributeTests.cs" />
     <Compile Include="SerializationTests\SerializationTestsUtils.cs" />
+    <Compile Include="EventSourcingTests\EventSourceEnvironmentFixture.cs" />
     <Compile Include="SiloInitializationTests.cs" />
     <Compile Include="StreamingTests\ClientStreamTestRunner.cs" />
     <Compile Include="GeoClusterTests\MultiClusterDataTests.cs" />


### PR DESCRIPTION
Implemented Custom Serializer for GrainStateWithMetaDataAndETag so that the state could also provide a custom serializer rather than being stuck with the fallback serializer.
Consolidated GrainStateWtihMetaData into GrainStateWithMetaDataAndETag as former was not used anywhere and this made code cleaner.
Added unit tests for customer serializers