### PR TITLE
Rename Orleans.psd1 to OrleansPSUtils.psd1

### DIFF
--- a/src/OrleansPSUtils/OrleansPSUtils.csproj
+++ b/src/OrleansPSUtils/OrleansPSUtils.csproj
@@ -87,11 +87,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Orleans.psd1">
+    <None Include="OrleansPSUtils.psd1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -103,6 +101,6 @@
   </Target>
   -->
   <Target Name="AfterBuild">
-    <UpdateVersion InputFilename="$(SolutionDir)Build\Version.txt" OutputFilename="$(OutDir)Orleans.psd1" />
+    <UpdateVersion InputFilename="$(SolutionDir)Build\Version.txt" OutputFilename="$(OutDir)OrleansPSUtils.psd1" />
   </Target>
 </Project>

--- a/src/OrleansPSUtils/OrleansPSUtils.psd1
+++ b/src/OrleansPSUtils/OrleansPSUtils.psd1
@@ -4,7 +4,7 @@
 	GUID = 'afbcf490-ca4b-4039-9ffe-c6fec8a4f71b'
 	Author = 'Microsoft Orleans Team'
 	CompanyName = 'Microsoft'
-	Copyright = 'Copyright Microsoft 2016'
+	Copyright = 'Copyright Microsoft 2017'
 	Description = 'Orleans Client Powershell module'
 	PowerShellVersion = '5.0'
 	CLRVersion = '4.0'
@@ -18,7 +18,7 @@
         LicenseUri = 'https://github.com/dotnet/Orleans#license'
         ProjectUri = 'https://github.com/dotnet/orleans'
         IconUri = 'https://raw.githubusercontent.com/dotnet/orleans/gh-pages/assets/logo_128.png'
-        ReleaseNotes = 'Initial Release $version$'
+        ReleaseNotes = '$version$ Release'
     } 
   }
 }

--- a/vNext/src/OrleansPSUtils/OrleansPSUtils.csproj
+++ b/vNext/src/OrleansPSUtils/OrleansPSUtils.csproj
@@ -28,6 +28,11 @@
   <PropertyGroup Condition="'$(OutDir)' == ''">
     <OutDir>bin\$(Configuration)\$(TargetFramework)\Orleans\</OutDir>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\..\src\OrleansPSUtils\OrleansPSUtils.psd1" Link="OrleansPSUtils.psd1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.0.0" />
@@ -38,24 +43,13 @@
     <ProjectReference Include="..\OrleansCodeGenerator\OrleansCodeGenerator.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\..\src\OrleansPSUtils\Orleans.psd1">
-      <Link>Orleans.psd1</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
   <Target Name="AfterBuildHack" AfterTargets="AfterBuild">
     <ItemGroup>
-      <_PSDFileContent Include="$([System.IO.File]::ReadAllText('$(OutDir)Orleans.psd1'))"/>
+      <_PSDFileContent Include="$([System.IO.File]::ReadAllText('$(OutDir)OrleansPSUtils.psd1'))" />
     </ItemGroup>
     <PropertyGroup>
       <VersionToEmbed>$(Version)</VersionToEmbed>
     </PropertyGroup>
-    <WriteLinesToFile
-        File="$(OutDir)Orleans.psd1"
-        Lines="@(_PSDFileContent->Replace('$version$', '$(VersionToEmbed)'))"
-        Overwrite="true"
-        ContinueOnError="true" />
+    <WriteLinesToFile File="$(OutDir)OrleansPSUtils.psd1" Lines="@(_PSDFileContent-&gt;Replace('$version$', '$(VersionToEmbed)'))" Overwrite="true" ContinueOnError="true" />
   </Target>
 </Project>


### PR DESCRIPTION
Need to do this for publishing OrleansPSUtils.dll to the PS Gallery (#131).
I already published 1.5.0 version of it manually. This is to update the sources to match what I had to change by hand.