### PR TITLE
OrleansAwsUtils: support implicit authentication to DynamoDB (e.g. via IAM Roles)

### DIFF
--- a/src/OrleansAWSUtils/Storage/DynamoDBStorage.cs
+++ b/src/OrleansAWSUtils/Storage/DynamoDBStorage.cs
@@ -118,13 +118,20 @@ namespace OrleansAWSUtils.Storage
             if (service.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
                 service.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
             {
+                // Local DynamoDB instance (for testing)
                 var credentials = new BasicAWSCredentials("dummy", "dummyKey");
                 ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig { ServiceURL = service });
             }
-            else
+            else if (!string.IsNullOrEmpty(accessKey) && !string.IsNullOrEmpty(secretKey))
             {
+                // AWS DynamoDB instance (auth via explicit credentials)
                 var credentials = new BasicAWSCredentials(accessKey, secretKey);
                 ddbClient = new AmazonDynamoDBClient(credentials, new AmazonDynamoDBConfig { ServiceURL = service, RegionEndpoint = AWSUtils.GetRegionEndpoint(service) });
+            }
+            else
+            {
+                // AWS DynamoDB instance (implicit auth - EC2 IAM Roles etc)
+                ddbClient = new AmazonDynamoDBClient(new AmazonDynamoDBConfig { ServiceURL = service, RegionEndpoint = AWSUtils.GetRegionEndpoint(service) });
             }
         }
 


### PR DESCRIPTION
OrleansAwsUtils currently requires explicit credentials to connect to DynamoDB. These are supplied via the Orleans SystemStore DataConnectionString in the silo config.

This change introduces support for implicit authentication via EC2 IAM Roles, which avoids the need to have explicit credentials in the config files.

If no 'AccessKey' and 'SecretKey' attributes are included in the connection string, the AmazonDynamoDBClient is created without any credentials supplied, which results in the AWS SDK checking the usual locations for credentials (including the EC2 instance profile service):
http://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/DynamoDBv2/MDynamoDBv2DynamoDBctorDynamoDBConfig.html

This is not a breaking change - the present behaviour will remain the same for any users already supplying explicit credentials.