### PR TITLE
Update EmitOptions used during runtime codegen

### DIFF
--- a/src/Orleans/CodeGeneration/GeneratedAssembly.cs
+++ b/src/Orleans/CodeGeneration/GeneratedAssembly.cs
@@ -26,7 +26,6 @@ namespace Orleans.CodeGeneration
         public GeneratedAssembly(GeneratedAssembly other)
         {
             this.RawBytes = other.RawBytes;
-            this.DebugSymbolRawBytes = other.DebugSymbolRawBytes;
             this.Assembly = other.Assembly;
         }
 
@@ -34,11 +33,6 @@ namespace Orleans.CodeGeneration
         /// Gets or sets a serialized representation of the assembly.
         /// </summary>
         public byte[] RawBytes { get; set; }
-
-        /// <summary>
-        /// Gets or sets a serialized representation of the assembly's debug symbol stream.
-        /// </summary>
-        public byte[] DebugSymbolRawBytes { get; set; }
 
         /// <summary>
         /// Gets or sets the assembly.

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -296,20 +296,11 @@ namespace Orleans.CodeGenerator
             throw new NotImplementedException();
 #elif NETSTANDARD
             Assembly result;
-            result = Orleans.PlatformServices.PlatformAssemblyLoader.LoadFromBytes(asm.RawBytes, asm.DebugSymbolRawBytes);
+            result = Orleans.PlatformServices.PlatformAssemblyLoader.LoadFromBytes(asm.RawBytes);
             AppDomain.CurrentDomain.AddAssembly(result);
             return result;
 #else
-            if (asm.DebugSymbolRawBytes != null)
-            {
-                return Assembly.Load(
-                    asm.RawBytes,
-                    asm.DebugSymbolRawBytes);
-            }
-            else
-            {
-                return Assembly.Load(asm.RawBytes);
-            }
+            return Assembly.Load(asm.RawBytes);
 #endif
         }
 


### PR DESCRIPTION
Fixes #3233

* Embed debug info into the asm instead of emitting a separate PDB
* Fix `EmitOptions` for the recent breakage in Roslyn 2.3.0. Technically, only `WithEmitMetadataOnly(false)` is needed, but `WithIncludePrivateMembers(true)` is added just to be explicit about it
* Cleanup redundancies
* I added `WithTolerateErrors(true)`, but I'm not sure entirely what it does. The way I see it, if Roslyn can ignore some kinds of errors (eg, obsolete member accesses), then that's good.