### PR TITLE
Dispose IServiceProvider during client shutdown.

### DIFF
--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -886,6 +886,7 @@ namespace Orleans
             }
 
             (this.ServiceProvider as IDisposable)?.Dispose();
+            this.ServiceProvider = null;
             GC.SuppressFinalize(this);
         }
 

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -884,6 +884,8 @@ namespace Orleans
                 ClientStatistics.Dispose();
                 ClientStatistics = null;
             }
+
+            (this.ServiceProvider as IDisposable)?.Dispose();
             GC.SuppressFinalize(this);
         }
 


### PR DESCRIPTION
`IServiceProvider` implementations do not necessarily implement `IDisposable`, but most do.