### PR TITLE
Minor improvements to Service Fabric providers

### DIFF
--- a/src/OrleansServiceFabricUtils/FabricGatewayProvider.cs
+++ b/src/OrleansServiceFabricUtils/FabricGatewayProvider.cs
@@ -67,14 +67,16 @@ namespace Microsoft.Orleans.ServiceFabric
         /// <inheritdoc />
         public bool SubscribeToGatewayNotificationEvents(IGatewayListListener subscriber)
         {
+            this.log.Verbose($"Unsubscribing {subscriber} to gateway notification events.");
             this.subscribers.TryAdd(subscriber, subscriber);
             return true;
         }
 
         /// <inheritdoc />
-        public bool UnSubscribeFromGatewayNotificationEvents(IGatewayListListener listener)
+        public bool UnSubscribeFromGatewayNotificationEvents(IGatewayListListener subscriber)
         {
-            this.subscribers.TryRemove(listener, out listener);
+            this.log.Verbose($"Unsubscribing {subscriber} from gateway notification events.");
+            this.subscribers.TryRemove(subscriber, out subscriber);
             return true;
         }
 

--- a/src/OrleansServiceFabricUtils/FabricGatewayProvider.cs
+++ b/src/OrleansServiceFabricUtils/FabricGatewayProvider.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Orleans.ServiceFabric
         public FabricGatewayProvider(IFabricServiceSiloResolver siloResolver)
         {
             this.fabricServiceSiloResolver = siloResolver;
-            this.refreshPeriod = TimeSpan.FromSeconds(30);
-            this.MaxStaleness = TimeSpan.FromSeconds(this.refreshPeriod.TotalSeconds * 2);
+            this.refreshPeriod = TimeSpan.FromSeconds(5);
+            this.MaxStaleness = this.refreshPeriod;
         }
 
         /// <inheritdoc />

--- a/src/OrleansServiceFabricUtils/FabricGatewayProvider.cs
+++ b/src/OrleansServiceFabricUtils/FabricGatewayProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Orleans.ServiceFabric
         /// <inheritdoc />
         public bool SubscribeToGatewayNotificationEvents(IGatewayListListener subscriber)
         {
-            this.log.Verbose($"Unsubscribing {subscriber} to gateway notification events.");
+            this.log.Verbose($"Subscribing {subscriber} to gateway notification events.");
             this.subscribers.TryAdd(subscriber, subscriber);
             return true;
         }

--- a/src/OrleansServiceFabricUtils/FabricMembershipOracle.cs
+++ b/src/OrleansServiceFabricUtils/FabricMembershipOracle.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Orleans.ServiceFabric
 
         private readonly AutoResetEvent notificationEvent = new AutoResetEvent(false);
         private readonly BlockingCollection<StatusChangeNotification> notifications = new BlockingCollection<StatusChangeNotification>();
-        private readonly TimeSpan refreshPeriod = TimeSpan.FromSeconds(30);
+        private readonly TimeSpan refreshPeriod = TimeSpan.FromSeconds(5);
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly GlobalConfiguration globalConfig;
         private readonly IFabricServiceSiloResolver fabricServiceSiloResolver;

--- a/src/OrleansServiceFabricUtils/FabricServiceSiloResolver.cs
+++ b/src/OrleansServiceFabricUtils/FabricServiceSiloResolver.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Fabric;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -131,14 +132,6 @@ namespace Microsoft.Orleans.ServiceFabric
                     var existing = this.silos[i].Partition;
                     if (!existing.IsSamePartitionAs(updated.Partition)) continue;
                     found = true;
-
-                    if (updated.Partition.IsOlderThan(existing))
-                    {
-                        this.log.Info($"Update for partition {updated} is superseded by existing version.");
-
-                        // Do not update the partition if the exiting one has a newer version than the update.
-                        break;
-                    }
 
                     // Update the partition.
                     this.silos[i] = updated;

--- a/src/OrleansServiceFabricUtils/Models/IResolvedServicePartition.cs
+++ b/src/OrleansServiceFabricUtils/Models/IResolvedServicePartition.cs
@@ -14,9 +14,7 @@ namespace Microsoft.Orleans.ServiceFabric.Models
         Guid Id { get; }
 
         ServicePartitionKind Kind { get; }
-
-        bool IsOlderThan(IResolvedServicePartition other);
-
+        
         bool IsSamePartitionAs(IResolvedServicePartition other);
     }
 }

--- a/src/OrleansServiceFabricUtils/Utilities/FabricQueryManager.cs
+++ b/src/OrleansServiceFabricUtils/Utilities/FabricQueryManager.cs
@@ -155,14 +155,6 @@ namespace Microsoft.Orleans.ServiceFabric.Utilities
 
             public ServicePartitionKind Kind => this.Partition.Info.Kind;
 
-            public bool IsOlderThan(IResolvedServicePartition other)
-            {
-                var otherWrapper = other as ResolvedServicePartitionWrapper;
-                if (otherWrapper == null) return false;
-
-                return this.Partition.IsOlderThan(otherWrapper.Partition);
-            }
-
             public bool IsSamePartitionAs(IResolvedServicePartition other)
             {
                 var otherWrapper = other as ResolvedServicePartitionWrapper;

--- a/src/OrleansServiceFabricUtils/Utilities/ResolvedServicePartitionExtensions.cs
+++ b/src/OrleansServiceFabricUtils/Utilities/ResolvedServicePartitionExtensions.cs
@@ -14,8 +14,10 @@ namespace Microsoft.Orleans.ServiceFabric.Utilities
         /// <returns>The active endpoints published by the specified partition.</returns>
         public static List<FabricSiloInfo> GetPartitionEndpoints(this ResolvedServicePartition partition)
         {
-            var results = new List<FabricSiloInfo>(partition.Endpoints.Count);
-            foreach (var silo in partition.Endpoints)
+            var resolvedServiceEndpoints = partition.Endpoints;
+            if (resolvedServiceEndpoints == null) return new List<FabricSiloInfo>();
+            var results = new List<FabricSiloInfo>(resolvedServiceEndpoints.Count);
+            foreach (var silo in resolvedServiceEndpoints)
             {
                 // Find the primary endpoint. If this is a stateless service, find any endpoint.
                 if (silo.Role != ServiceEndpointRole.Stateless && silo.Role != ServiceEndpointRole.StatefulPrimary) continue;
@@ -30,7 +32,7 @@ namespace Microsoft.Orleans.ServiceFabric.Utilities
         }
 
         /// <summary>
-        /// Respresents endpoints returned from <see cref="ResolvedServiceEndpoint.Address"/> in JSON form.
+        /// Represents endpoints returned from <see cref="ResolvedServiceEndpoint.Address"/> in JSON form.
         /// </summary>
         internal class ServicePartitionEndpoints
         {

--- a/src/OrleansServiceFabricUtils/Utilities/ServiceFabricExtensions.cs
+++ b/src/OrleansServiceFabricUtils/Utilities/ServiceFabricExtensions.cs
@@ -7,19 +7,6 @@ namespace Microsoft.Orleans.ServiceFabric.Utilities
     internal static class ServiceFabricExtensions
     {
         /// <summary>
-        /// Returns a value indicating whether or not <paramref name="left"/> is older than <paramref name="right"/>.
-        /// </summary>
-        /// <param name="left">One resolved partition.</param>
-        /// <param name="right">The other resolved partition.</param>
-        /// <returns>
-        /// <see langword="true"/> if <paramref name="left"/> is older than <paramref name="right"/>, <see langword="false"/> otherwise.
-        /// </returns>
-        public static bool IsOlderThan(this ResolvedServicePartition left, ResolvedServicePartition right)
-        {
-            return left.Info.Id == right.Info.Id && left.CompareVersion(right) < 0;
-        }
-
-        /// <summary>
         /// Returns a value indicating whether or not <paramref name="left"/> is the same partition as <paramref name="right"/>.
         /// </summary>
         /// <param name="left">One resolved partition.</param>


### PR DESCRIPTION
In testing, I found that the method I had eagerly employed to ensure that we were not processing outdated Service Fabric partition change notifications was the cause of many lost updates during disaster recovery scenarios. Not blaming SF, it's likely because of how I was comparing partition equality. i.e, two `ResolvedServicePartition` instances which belong to a `Singleton` partition must belong to the same partition because logically there can only be one singleton partition. This PR removes that check, since it's unnecessary (any stale information will quickly be superseded by fresh information).

Fixed a `NullReferenceException` which was being thrown when a client attempts to resolve silos before the silo service has been successfully created.

Increased logging.

Reduced the eager refresh interval from 30s to 5s. If logging is verbose, then this will cause 5x more logs from that process. The `MaxStaleness` was also reduced to the refresh interval. This has the effect of blacklisted gateways being cleared much more quickly. I see no downside to this - the shortened polling interval is still not aggressive.