### PR TITLE
Execute TypeManager timers in the correct runtime context

### DIFF
--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -591,7 +591,8 @@ namespace Orleans.Runtime
             allSiloProviders.AddRange(storageProviderManager.GetProviders());
             var versionStore = Services.GetService<IVersionStore>() as GrainVersionStore;
             versionStore?.SetStorageManager(storageProviderManager);
-            typeManager.Initialize(versionStore);
+            scheduler.QueueTask(() => this.typeManager.Initialize(versionStore), this.typeManager.SchedulingContext)
+                     .WaitWithThrow(this.initTimeout);
             if (logger.IsVerbose) { logger.Verbose("Storage provider manager created successfully."); }
 
             // Initialize log consistency providers once we have a basic silo runtime environment operating

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
@@ -142,10 +142,10 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
             var grainV1 = Client.GetGrain<IVersionUpgradeTestGrain>(0);
             Assert.Equal(1, await grainV1.GetVersion());
 
+            await StartSiloV2();
+
             // Change default to minimum version
             await ManagementGrain.SetSelectorStrategy(MinimumVersion.Singleton);
-
-            await StartSiloV2();
 
             // But only activate V1
             for (int i = 0; i < 100; i++)


### PR DESCRIPTION
In `Silo.DoStart()` we should be scheduling `TypeManager.Initialize()` on the TypeManager's context (it's a system target), since it starts a timer which potentially makes grain calls.

The timer started there also needs to invoke its callback on the TypeManager's context.

Otherwise errors (see stack):
![image](https://user-images.githubusercontent.com/203839/28651812-70e1de24-72c7-11e7-8304-e754a236b44b.png)
