### PR TITLE
Fixing MySQL assembly name for dotnet core and fixing SqliteFactory path

### DIFF
--- a/src/OrleansSQLUtils/Storage/DbConnectionFactory.cs
+++ b/src/OrleansSQLUtils/Storage/DbConnectionFactory.cs
@@ -17,10 +17,10 @@ namespace Orleans.SqlUtils
             new Dictionary<string, Tuple<string, string>>
             {
                 { AdoNetInvariants.InvariantNameSqlServer, new Tuple<string, string>("System.Data.SqlClient", "System.Data.SqlClient.SqlClientFactory") },
-                { AdoNetInvariants.InvariantNameMySql, new Tuple<string, string>("MySql.Data", "MySql.Data.MySqlClient.MySqlClientFactory") },
+                { AdoNetInvariants.InvariantNameMySql, new Tuple<string, string>("MySql.Data.Core", "MySql.Data.MySqlClient.MySqlClientFactory") },
                 { AdoNetInvariants.InvariantNameOracleDatabase, new Tuple<string, string>("System.Data.SqlClient", "System.Data.SqlClient.SqlClientFactory") },
                 { AdoNetInvariants.InvariantNamePostgreSql, new Tuple<string, string>("Npgsql", "Npgsql.NpgsqlFactory") },
-                { AdoNetInvariants.InvariantNameSqlLite, new Tuple<string, string>("Microsoft.Data.SQLite", "Microsoft.Data.SQLite.SqliteFactory") },
+                { AdoNetInvariants.InvariantNameSqlLite, new Tuple<string, string>("Microsoft.Data.SQLite", "Microsoft.Data.Sqlite.SqliteFactory") },
             };
 
         private static CachedFactory GetFactory(string invariantName)


### PR DESCRIPTION
Neither the MySQL or SQLite provider could be loaded for different reasons. The MySQL assembly for .netcore 1.1 is now Mysql.Data.Core. For SQLite, SqliteFactory's fully qualified path was wrong.

This is a quick and simple fix - a better fix, perhaps after, would maybe be to allow invariantName to include a fully qualified assembly?