### PR TITLE
Component lifecycle pattern, and preliminary grain lifecycle hooks.

### DIFF
--- a/src/Orleans/Lifecycle/ILifecycleObservable.cs
+++ b/src/Orleans/Lifecycle/ILifecycleObservable.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Observable lifecycle.
+    /// Each stage of lifecycle is observable.  All observers will be notified 
+    ///   when the stage is reached when starting, and stopping.
+    /// Stages are started in ascending order, and stopped in decending order.
+    /// </summary>
+    /// <typeparam name="TStage"></typeparam>
+    public interface ILifecycleObservable<in TStage>
+    {
+        /// <summary>
+        /// Subscribe for notification when a stage is reached while starting or stopping.
+        /// </summary>
+        /// <param name="stage">stage of interest</param>
+        /// <param name="observer">stage observer</param>
+        /// <returns>A disposable that can be disposed of to unsubscribe</returns>
+        IDisposable Subscribe(TStage stage, ILifecycleObserver observer);
+    }
+}

--- a/src/Orleans/Lifecycle/ILifecycleObserver.cs
+++ b/src/Orleans/Lifecycle/ILifecycleObserver.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Lifecycle observer used to handle start and stop notification.
+    /// </summary>
+    public interface ILifecycleObserver
+    {
+        /// <summary>
+        /// Handle start notifications
+        /// </summary>
+        /// <returns></returns>
+        Task OnStart(CancellationTokenSource cts = null);
+
+        /// <summary>
+        /// Handle stop notifications
+        /// </summary>
+        /// <returns></returns>
+        Task OnStop(CancellationTokenSource cts = null);
+    }
+}

--- a/src/Orleans/Lifecycle/ILifecycleObserver.cs
+++ b/src/Orleans/Lifecycle/ILifecycleObserver.cs
@@ -12,12 +12,12 @@ namespace Orleans
         /// Handle start notifications
         /// </summary>
         /// <returns></returns>
-        Task OnStart(CancellationTokenSource cts = null);
+        Task OnStart(CancellationToken ct);
 
         /// <summary>
         /// Handle stop notifications
         /// </summary>
         /// <returns></returns>
-        Task OnStop(CancellationTokenSource cts = null);
+        Task OnStop(CancellationToken ct);
     }
 }

--- a/src/Orleans/Lifecycle/ILifecycleParticipant.cs
+++ b/src/Orleans/Lifecycle/ILifecycleParticipant.cs
@@ -1,0 +1,20 @@
+﻿
+namespace Orleans
+{
+    /// <summary>
+    /// Provides hook to take part in grain lifecycle.
+    /// Also may act as a signal interface indicating that an object can take part in lifecycle.
+    /// </summary>
+    public interface ILifecycleParticipant<in TLifeCycle>
+    {
+        void Participate(TLifeCycle lifecycle);
+    }
+
+    public static class GrainLifecyleExtensions
+    {
+        public static void ParticipateInLifecycle<TLifeCycle>(this object obj, TLifeCycle lifecycle)
+        {
+            (obj as ILifecycleParticipant<TLifeCycle>)?.Participate(lifecycle);
+        }
+    }
+}

--- a/src/Orleans/Lifecycle/ILifecycleParticipant.cs
+++ b/src/Orleans/Lifecycle/ILifecycleParticipant.cs
@@ -2,19 +2,11 @@
 namespace Orleans
 {
     /// <summary>
-    /// Provides hook to take part in grain lifecycle.
+    /// Provides hook to take part in lifecycle.
     /// Also may act as a signal interface indicating that an object can take part in lifecycle.
     /// </summary>
-    public interface ILifecycleParticipant<in TLifeCycle>
+    public interface ILifecycleParticipant<out TStage>
     {
-        void Participate(TLifeCycle lifecycle);
-    }
-
-    public static class GrainLifecyleExtensions
-    {
-        public static void ParticipateInLifecycle<TLifeCycle>(this object obj, TLifeCycle lifecycle)
-        {
-            (obj as ILifecycleParticipant<TLifeCycle>)?.Participate(lifecycle);
-        }
+        void Participate(ILifecycleObservable<TStage> lifecycle);
     }
 }

--- a/src/Orleans/Lifecycle/LifecycleExtensions.cs
+++ b/src/Orleans/Lifecycle/LifecycleExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans
+{
+    public static class LifecycleExtensions
+    {
+        private static Func<CancellationTokenSource, Task> NoOp => cts => Task.CompletedTask;
+
+        public static IDisposable Subscribe<TStage>(this ILifecycleObservable<TStage> observable, TStage stage, Func<CancellationTokenSource, Task> onStart, Func<CancellationTokenSource, Task> onStop)
+        {
+            if (observable == null) throw new ArgumentNullException(nameof(observable));
+            if (onStart == null) throw new ArgumentNullException(nameof(onStart));
+            if (onStop == null) throw new ArgumentNullException(nameof(onStop));
+
+            return observable.Subscribe(stage, new Observer(onStart, onStop));
+        }
+
+        public static IDisposable Subscribe<TStage>(this ILifecycleObservable<TStage> observable, TStage stage, Func<CancellationTokenSource, Task> onStart)
+        {
+            return observable.Subscribe(stage, new Observer(onStart, NoOp));
+        }
+
+        private class Observer : ILifecycleObserver
+        {
+            private readonly Func<CancellationTokenSource, Task> onStart;
+            private readonly Func<CancellationTokenSource, Task> onStop;
+
+            public Observer(Func<CancellationTokenSource, Task> onStart, Func<CancellationTokenSource, Task> onStop)
+            {
+                this.onStart = onStart;
+                this.onStop = onStop;
+            }
+
+            public Task OnStart(CancellationTokenSource cts = null) => onStart(cts);
+            public Task OnStop(CancellationTokenSource cts = null) => onStop(cts);
+        }
+    }
+
+}

--- a/src/Orleans/Lifecycle/LifecycleObservable.cs
+++ b/src/Orleans/Lifecycle/LifecycleObservable.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace Orleans
+{
+    public class LifecycleObservable<TStage> : ILifecycleObservable<TStage>, ILifecycleObserver
+    {
+        private readonly ConcurrentDictionary<object, OrderedObserver> subscribers;
+        private readonly Logger logger;
+        private TStage highStage;
+
+        public LifecycleObservable(Logger logger)
+        {
+            this.logger = logger?.GetLogger(GetType().Name);
+            subscribers = new ConcurrentDictionary<object, OrderedObserver>();
+        }
+
+        public async Task OnStart(CancellationTokenSource cts = null)
+        {
+            try
+            {
+                foreach (IGrouping<TStage, OrderedObserver> observerGroup in subscribers.Values
+                    .GroupBy(orderedObserver => orderedObserver.Stage)
+                    .OrderBy(group => group.Key))
+                {
+                    if (cts != null && cts.Token.IsCancellationRequested)
+                    {
+                        throw new OperationCanceledException();
+                    }
+                    highStage = observerGroup.Key;
+                    await Task.WhenAll(observerGroup.Select(orderedObserver => WrapExecution(cts, orderedObserver.Observer.OnStart)));
+                }
+            }
+            catch (Exception ex)
+            {
+                string error = $"Lifecycle start canceled due to errors at stage {this.highStage}";
+                logger?.Error(ErrorCode.LifecycleStartFailure, error, ex);
+                throw new OperationCanceledException(error, ex);
+            }
+        }
+
+        public async Task OnStop(CancellationTokenSource cts = null)
+        {
+            bool skip = true;
+            foreach (IGrouping<TStage, OrderedObserver> observerGroup in subscribers.Values
+                .GroupBy(orderedObserver => orderedObserver.Stage)
+                .OrderByDescending(group => group.Key))
+            {
+                // skip all until we hit the highest started stage
+                if (skip && highStage.Equals(observerGroup.Key))
+                {
+                    skip = false;
+                }
+                if (skip)
+                {
+                    continue;
+                }
+                highStage = observerGroup.Key;
+                try
+                {
+                    if (cts != null && cts.Token.IsCancellationRequested)
+                    {
+                        throw new OperationCanceledException();
+                    }
+                    await Task.WhenAll(observerGroup.Select(orderedObserver => WrapExecution(cts, orderedObserver.Observer.OnStop)));
+                }
+                catch (Exception ex)
+                {
+                    logger?.Error(ErrorCode.LifecycleStopFailure, $"Stopping lifecycle encountered an error at stage {this.highStage}.  Continuing to stop.", ex);
+                }
+            }
+        }
+
+        public IDisposable Subscribe(TStage stage, ILifecycleObserver observer)
+        {
+            if (observer == null) throw new ArgumentNullException(nameof(observer));
+
+            var orderedObserver = new OrderedObserver(stage, observer);
+            subscribers.TryAdd(orderedObserver, orderedObserver);
+            return new Disposable(() => Remove(orderedObserver));
+        }
+
+        private void Remove(object key)
+        {
+            OrderedObserver o;
+            subscribers.TryRemove(key, out o);
+        }
+
+        private static async Task WrapExecution(CancellationTokenSource cts, Func<CancellationTokenSource, Task> action)
+        {
+            await action(cts);
+        }
+
+        private class Disposable : IDisposable
+        {
+            private readonly Action dispose;
+
+            public Disposable(Action dispose)
+            {
+                this.dispose = dispose;
+            }
+
+            public void Dispose()
+            {
+                this.dispose();
+            }
+        }
+
+        private class OrderedObserver
+        {
+            public ILifecycleObserver Observer { get; }
+            public TStage Stage { get; }
+
+            public OrderedObserver(TStage stage, ILifecycleObserver observer)
+            {
+                Stage = stage;
+                Observer = observer;
+            }
+        }
+    }
+}

--- a/src/Orleans/Logging/ErrorCodes.cs
+++ b/src/Orleans/Logging/ErrorCodes.cs
@@ -386,8 +386,10 @@ namespace Orleans
         SiloLoadedDI                    = SiloBase + 45, // Not used anymore
         SiloFailedToLoadDI              = SiloBase + 46, // Not used anymore
         SiloFileNotFoundLoadingDI       = SiloBase + 47, // Not used anymore
-        SiloStartupEventFailure           = SiloBase + 48,
+        SiloStartupEventFailure         = SiloBase + 48,
         SiloShutdownEventFailure        = SiloBase + 49,
+        LifecycleStartFailure           = SiloBase + 50,
+        LifecycleStopFailure            = SiloBase + 51,
 
         CatalogBase                     = Runtime + 500,
         CatalogNonExistingActivation1   = CatalogBase + 1,

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -136,7 +136,7 @@
     <Compile Include="Placement\PlacementTarget.cs" />
     <Compile Include="Providers\ProviderStateManager.cs" />
     <Compile Include="Providers\MemoryStorageEtagMismatchException.cs" />
-    <Compile Include="Runtime\IGrainLifeCycle.cs" />
+    <Compile Include="Runtime\IGrainLifecycle.cs" />
     <Compile Include="Runtime\IGrainReferenceConverter.cs" />
     <Compile Include="Runtime\IGrainReferenceRuntime.cs" />
     <Compile Include="Runtime\IGrainTimer.cs" />

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -95,9 +95,14 @@
     <Compile Include="Core\IInternalClusterClient.cs" />
     <Compile Include="Core\IClusterClient.cs" />
     <Compile Include="Core\ClusterClient.cs" />
+    <Compile Include="Lifecycle\ILifecycleParticipant.cs" />
     <Compile Include="Runtime\GrainReferenceRuntime.cs" />
     <Compile Include="Serialization\GrainReferenceSerializer.cs" />
     <Compile Include="Providers\ILeaseProvider.cs" />
+    <Compile Include="Lifecycle\ILifecycleObservable.cs" />
+    <Compile Include="Lifecycle\ILifecycleObserver.cs" />
+    <Compile Include="Lifecycle\LifecycleObservable.cs" />
+    <Compile Include="Lifecycle\LifecycleExtensions.cs" />
     <Compile Include="Runtime\IGrainActivationContext.cs" />
     <Compile Include="LogConsistency\ILogConsistencyDiagnostics.cs" />
     <Compile Include="Logging\LoggerExtensions.cs" />
@@ -131,6 +136,7 @@
     <Compile Include="Placement\PlacementTarget.cs" />
     <Compile Include="Providers\ProviderStateManager.cs" />
     <Compile Include="Providers\MemoryStorageEtagMismatchException.cs" />
+    <Compile Include="Runtime\IGrainLifeCycle.cs" />
     <Compile Include="Runtime\IGrainReferenceConverter.cs" />
     <Compile Include="Runtime\IGrainReferenceRuntime.cs" />
     <Compile Include="Runtime\IGrainTimer.cs" />

--- a/src/Orleans/Runtime/IGrainActivationContext.cs
+++ b/src/Orleans/Runtime/IGrainActivationContext.cs
@@ -24,5 +24,10 @@ namespace Orleans.Runtime
 
         /// <summary>Gets a key/value collection that can be used to share data within the scope of the grain activation.</summary>
         IDictionary<object, object> Items { get; }
+
+        /// <summary>
+        /// Observable Grain life cycle
+        /// </summary>
+        IGrainLifeCycle ObservableLifeCycle { get; }
     }
 }

--- a/src/Orleans/Runtime/IGrainActivationContext.cs
+++ b/src/Orleans/Runtime/IGrainActivationContext.cs
@@ -28,6 +28,6 @@ namespace Orleans.Runtime
         /// <summary>
         /// Observable Grain life cycle
         /// </summary>
-        IGrainLifeCycle ObservableLifeCycle { get; }
+        IGrainLifecycle ObservableLifecycle { get; }
     }
 }

--- a/src/Orleans/Runtime/IGrainLifeCycle.cs
+++ b/src/Orleans/Runtime/IGrainLifeCycle.cs
@@ -1,0 +1,26 @@
+﻿
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Stages of a grains lifecycle.
+    /// TODO: Add more later, see ActivationInitializationStage
+    /// Full grain lifecycle, including register, state setup, and 
+    ///   stream cleanup should all eventually be triggered by the 
+    ///   grain lifecycle.
+    /// </summary>
+    public enum GrainLifecyleStage
+    {
+        //None,
+        //Register,
+        SetupState,  // Setup grain state prior to activation
+        //InvokeActivate,
+        //Completed
+    }
+
+    /// <summary>
+    /// Grain life cycle
+    /// </summary>
+    public interface IGrainLifeCycle : ILifecycleObservable<GrainLifecyleStage>
+    {
+    }
+}

--- a/src/Orleans/Runtime/IGrainLifeCycle.cs
+++ b/src/Orleans/Runtime/IGrainLifeCycle.cs
@@ -20,7 +20,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Grain life cycle
     /// </summary>
-    public interface IGrainLifeCycle : ILifecycleObservable<GrainLifecyleStage>
+    public interface IGrainLifecycle : ILifecycleObservable<GrainLifecyleStage>
     {
     }
 }

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -185,11 +185,12 @@ namespace Orleans.Runtime
 			TimeSpan maxRequestProcessingTime,
             IRuntimeClient runtimeClient)
         {
-            if (null == addr) throw new ArgumentNullException("addr");
-            if (null == placedUsing) throw new ArgumentNullException("placedUsing");
-            if (null == collector) throw new ArgumentNullException("collector");
+            if (null == addr) throw new ArgumentNullException(nameof(addr));
+            if (null == placedUsing) throw new ArgumentNullException(nameof(placedUsing));
+            if (null == collector) throw new ArgumentNullException(nameof(collector));
 
             logger = LogManager.GetLogger("ActivationData", LoggerType.Runtime);
+            this.lifeCycle = new GrainLifecycle(logger);
             this.maxRequestProcessingTime = maxRequestProcessingTime;
             this.maxWarningRequestProcessingTime = maxWarningRequestProcessingTime;
             this.nodeConfiguration = nodeConfiguration;
@@ -361,6 +362,14 @@ namespace Orleans.Runtime
         public IServiceProvider ServiceProvider => this.serviceScope?.ServiceProvider;
 
         public IDictionary<object, object> Items { get; private set; }
+
+#region lifecyle
+        private readonly GrainLifecycle lifeCycle;
+
+        public IGrainLifeCycle ObservableLifeCycle => lifeCycle;
+
+        internal ILifecycleObserver LifeCycle => lifeCycle;
+        #endregion lifecycle
 
         public void OnTimerCreated(IGrainTimer timer)
         {

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -363,13 +363,11 @@ namespace Orleans.Runtime
 
         public IDictionary<object, object> Items { get; private set; }
 
-#region lifecyle
         private readonly GrainLifecycle lifeCycle;
 
         public IGrainLifeCycle ObservableLifeCycle => lifeCycle;
 
         internal ILifecycleObserver LifeCycle => lifeCycle;
-        #endregion lifecycle
 
         public void OnTimerCreated(IGrainTimer timer)
         {

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -190,7 +190,7 @@ namespace Orleans.Runtime
             if (null == collector) throw new ArgumentNullException(nameof(collector));
 
             logger = LogManager.GetLogger("ActivationData", LoggerType.Runtime);
-            this.lifeCycle = new GrainLifecycle(logger);
+            this.lifecycle = new GrainLifecycle(logger);
             this.maxRequestProcessingTime = maxRequestProcessingTime;
             this.maxWarningRequestProcessingTime = maxWarningRequestProcessingTime;
             this.nodeConfiguration = nodeConfiguration;
@@ -363,11 +363,11 @@ namespace Orleans.Runtime
 
         public IDictionary<object, object> Items { get; private set; }
 
-        private readonly GrainLifecycle lifeCycle;
+        private readonly GrainLifecycle lifecycle;
 
-        public IGrainLifeCycle ObservableLifeCycle => lifeCycle;
+        public IGrainLifecycle ObservableLifecycle => lifecycle;
 
-        internal ILifecycleObserver LifeCycle => lifeCycle;
+        internal ILifecycleObserver Lifecycle => lifecycle;
 
         public void OnTimerCreated(IGrainTimer timer)
         {

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -1315,6 +1315,7 @@ namespace Orleans.Runtime
             try
             {
                 RequestContext.Import(requestContextData);
+                await activation.LifeCycle.OnStart();
                 await activation.GrainInstance.OnActivateAsync();
 
                 if (logger.IsVerbose) logger.Verbose(ErrorCode.Catalog_AfterCallingActivate, "Returned from calling {1} grain's OnActivateAsync() method {0}", activation, grainTypeName);
@@ -1370,6 +1371,7 @@ namespace Orleans.Runtime
                     {
                         RequestContext.Clear(); // Clear any previous RC, so it does not leak into this call by mistake. 
                         await activation.GrainInstance.OnDeactivateAsync();
+                        await activation.LifeCycle.OnStop();
                     }
                     if (logger.IsVerbose) logger.Verbose(ErrorCode.Catalog_AfterCallingDeactivate, "Returned from calling {1} grain's OnDeactivateAsync() method {0}", activation, grainTypeName);
                 }

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -1315,7 +1315,7 @@ namespace Orleans.Runtime
             try
             {
                 RequestContext.Import(requestContextData);
-                await activation.LifeCycle.OnStart();
+                await activation.Lifecycle.OnStart();
                 await activation.GrainInstance.OnActivateAsync();
 
                 if (logger.IsVerbose) logger.Verbose(ErrorCode.Catalog_AfterCallingActivate, "Returned from calling {1} grain's OnActivateAsync() method {0}", activation, grainTypeName);
@@ -1371,7 +1371,7 @@ namespace Orleans.Runtime
                     {
                         RequestContext.Clear(); // Clear any previous RC, so it does not leak into this call by mistake. 
                         await activation.GrainInstance.OnDeactivateAsync();
-                        await activation.LifeCycle.OnStop();
+                        await activation.Lifecycle.OnStop();
                     }
                     if (logger.IsVerbose) logger.Verbose(ErrorCode.Catalog_AfterCallingDeactivate, "Returned from calling {1} grain's OnDeactivateAsync() method {0}", activation, grainTypeName);
                 }

--- a/src/OrleansRuntime/Catalog/GrainLifecycle.cs
+++ b/src/OrleansRuntime/Catalog/GrainLifecycle.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Orleans.Runtime
+{
+    internal class GrainLifecycle : LifecycleObservable<GrainLifecyleStage>, IGrainLifeCycle
+    {
+        public GrainLifecycle(Logger logger) : base(logger)
+        {
+        }
+    }
+}

--- a/src/OrleansRuntime/Catalog/GrainLifecycle.cs
+++ b/src/OrleansRuntime/Catalog/GrainLifecycle.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace Orleans.Runtime
 {
-    internal class GrainLifecycle : LifecycleObservable<GrainLifecyleStage>, IGrainLifeCycle
+    internal class GrainLifecycle : LifecycleObservable<GrainLifecyleStage>, IGrainLifecycle
     {
         public GrainLifecycle(Logger logger) : base(logger)
         {

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Catalog\ActivationState.cs" />
     <Compile Include="Catalog\DefaultGrainActivator.cs" />
     <Compile Include="Catalog\GrainCreator.cs" />
+    <Compile Include="Catalog\GrainLifecycle.cs" />
     <Compile Include="Catalog\IGrainActivator.cs" />
     <Compile Include="Core\GrainRuntime.cs" />
     <Compile Include="Core\IInvokable.cs" />

--- a/test/Tester/Lifecycle/LifecycleTests.cs
+++ b/test/Tester/Lifecycle/LifecycleTests.cs
@@ -115,7 +115,7 @@ namespace Tester
         {
             var lifecycle = new LifecycleObservable<TestStages>(null);
             var multiStageObserver = new MultiStageObserver();
-            multiStageObserver.ParticipateInLifecycle(lifecycle);
+            multiStageObserver.Participate(lifecycle);
             await lifecycle.OnStart();
             await lifecycle.OnStop();
             Assert.Equal(4, multiStageObserver.Started.Count);
@@ -198,7 +198,7 @@ namespace Tester
         /// <summary>
         /// Single component which takes action at multiple stages of the lifecycle (most common expected pattern)
         /// </summary>
-        private class MultiStageObserver : ILifecycleParticipant<ILifecycleObservable<TestStages>>
+        private class MultiStageObserver : ILifecycleParticipant<TestStages>
         {
             public Dictionary<TestStages,bool> Started { get; } = new Dictionary<TestStages, bool>(); 
             public Dictionary<TestStages, bool> Stopped { get; } = new Dictionary<TestStages, bool>();

--- a/test/Tester/Lifecycle/LifecycleTests.cs
+++ b/test/Tester/Lifecycle/LifecycleTests.cs
@@ -1,0 +1,229 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans;
+using Xunit;
+
+namespace Tester
+{
+    public class LifecycleTests
+    {
+        [Fact, TestCategory("BVT"), TestCategory("Lifecycle")]
+        public async Task FullLifecycleTest()
+        {
+            const int observersPerStage = 2;
+            Dictionary<TestStages, int> observerCountByStage = new Dictionary<TestStages, int>();
+            foreach (TestStages stage in Enum.GetValues(typeof(TestStages)))
+            {
+                observerCountByStage[stage] = observersPerStage;
+            }
+            Dictionary<TestStages, List<Observer>> observersByStage = await RunLifeCycle(observerCountByStage, null, null);
+
+            Assert.Equal(observerCountByStage.Count, observersByStage.Count);
+            foreach (KeyValuePair<TestStages,List<Observer>> kvp in observersByStage)
+            {
+                Assert.Equal(observerCountByStage[kvp.Key], kvp.Value.Count);
+                Assert.True(kvp.Value.All(o => o.Started));
+                Assert.True(kvp.Value.All(o => o.Stopped));
+                Assert.True(kvp.Value.All(o => !o.FailedOnStart));
+                Assert.True(kvp.Value.All(o => !o.FailedOnStop));
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Lifecycle")]
+        public async Task FailOnStartOnEachStageLifecycleTest()
+        {
+            const int observersPerStage = 2;
+            Dictionary<TestStages, int> observerCountByStage = new Dictionary<TestStages, int>();
+            foreach (TestStages stage in Enum.GetValues(typeof(TestStages)))
+            {
+                observerCountByStage[stage] = observersPerStage;
+            }
+
+            foreach (TestStages stage in Enum.GetValues(typeof(TestStages)))
+            {
+                Dictionary<TestStages, List<Observer>> observersByStage = await RunLifeCycle(observerCountByStage, stage, null);
+
+                Assert.Equal(observerCountByStage.Count, observersByStage.Count);
+                foreach (KeyValuePair<TestStages, List<Observer>> kvp in observersByStage)
+                {
+                    Assert.Equal(observerCountByStage[kvp.Key], kvp.Value.Count);
+                    if (kvp.Key < stage)
+                    {
+                        Assert.True(kvp.Value.All(o => o.Started));
+                        Assert.True(kvp.Value.All(o => o.Stopped));
+                        Assert.True(kvp.Value.All(o => !o.FailedOnStart));
+                        Assert.True(kvp.Value.All(o => !o.FailedOnStop));
+                    } else if (kvp.Key == stage)
+                    {
+                        Assert.True(kvp.Value.All(o => o.Started));
+                        Assert.True(kvp.Value.All(o => o.Stopped));
+                        Assert.True(kvp.Value.All(o => o.FailedOnStart));
+                        Assert.True(kvp.Value.All(o => !o.FailedOnStop));
+                    } else if (kvp.Key > stage)
+                    {
+                        Assert.True(kvp.Value.All(o => !o.Started));
+                        Assert.True(kvp.Value.All(o => !o.Stopped));
+                        Assert.True(kvp.Value.All(o => !o.FailedOnStart));
+                        Assert.True(kvp.Value.All(o => !o.FailedOnStop));
+                    }
+                }
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Lifecycle")]
+        public async Task FailOnStopOnEachStageLifecycleTest()
+        {
+            const int observersPerStage = 2;
+            Dictionary<TestStages, int> observerCountByStage = new Dictionary<TestStages, int>();
+            foreach (TestStages stage in Enum.GetValues(typeof(TestStages)))
+            {
+                observerCountByStage[stage] = observersPerStage;
+            }
+
+            foreach (TestStages stage in Enum.GetValues(typeof(TestStages)))
+            {
+                Dictionary<TestStages, List<Observer>> observersByStage = await RunLifeCycle(observerCountByStage, null, stage);
+
+                Assert.Equal(observerCountByStage.Count, observersByStage.Count);
+                foreach (KeyValuePair<TestStages, List<Observer>> kvp in observersByStage)
+                {
+                    Assert.Equal(observerCountByStage[kvp.Key], kvp.Value.Count);
+                    if (kvp.Key != stage)
+                    {
+                        Assert.True(kvp.Value.All(o => o.Started));
+                        Assert.True(kvp.Value.All(o => o.Stopped));
+                        Assert.True(kvp.Value.All(o => !o.FailedOnStart));
+                        Assert.True(kvp.Value.All(o => !o.FailedOnStop));
+                    }
+                    else if (kvp.Key == stage)
+                    {
+                        Assert.True(kvp.Value.All(o => o.Started));
+                        Assert.True(kvp.Value.All(o => o.Stopped));
+                        Assert.True(kvp.Value.All(o => !o.FailedOnStart));
+                        Assert.True(kvp.Value.All(o => o.FailedOnStop));
+                    }
+                }
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Lifecycle")]
+        public async Task MultiStageObserverLifecycleTest()
+        {
+            var lifecycle = new LifecycleObservable<TestStages>(null);
+            var multiStageObserver = new MultiStageObserver();
+            multiStageObserver.ParticipateInLifecycle(lifecycle);
+            await lifecycle.OnStart();
+            await lifecycle.OnStop();
+            Assert.Equal(4, multiStageObserver.Started.Count);
+            Assert.Equal(4, multiStageObserver.Stopped.Count);
+            Assert.True(multiStageObserver.Started.Values.All(o => o));
+            Assert.True(multiStageObserver.Stopped.Values.All(o => o));
+        }
+
+        private async Task<Dictionary<TestStages,List<Observer>>> RunLifeCycle(Dictionary<TestStages,int> observerCountByStage, TestStages? failOnStart, TestStages? failOnStop)
+        {
+            // setup lifecycle observers
+            var observersByStage = new Dictionary<TestStages, List<Observer>>();
+            var lifecycle = new LifecycleObservable<TestStages>(null);
+            foreach (KeyValuePair<TestStages, int> kvp in observerCountByStage)
+            {
+                List<Observer> observers = Enumerable
+                    .Range(0, kvp.Value)
+                    .Select(i => new Observer(failOnStart.HasValue && kvp.Key == failOnStart, failOnStop.HasValue && kvp.Key == failOnStop))
+                    .ToList();
+                observersByStage[kvp.Key] = observers;
+                observers.ForEach(o => lifecycle.Subscribe(kvp.Key, o));
+            }
+
+            // run lifecycle
+            if (failOnStart.HasValue)
+            {
+                await Assert.ThrowsAsync<OperationCanceledException>(() => lifecycle.OnStart());
+            }
+            else
+            {
+                await lifecycle.OnStart();
+            }
+            await lifecycle.OnStop();
+
+            // return results
+            return observersByStage;
+        }
+
+        private enum TestStages
+        {
+            Down,
+            Initialize,
+            Configure,
+            Run,
+        }
+
+        private class Observer : ILifecycleObserver
+        {
+            private readonly bool failOnStart;
+            private readonly bool failOnStop;
+
+            public bool Started { get; private set; }
+            public bool Stopped { get; private set; }
+            public bool FailedOnStart { get; private set; }
+            public bool FailedOnStop { get; private set; }
+
+            public Observer(bool failOnStart, bool failOnStop)
+            {
+                this.failOnStart = failOnStart;
+                this.failOnStop = failOnStop;
+            }
+
+            public Task OnStart(CancellationTokenSource cts = null)
+            {
+                this.Started = true;
+                this.FailedOnStart = this.failOnStart;
+                if (this.failOnStart) throw new Exception("failOnStart");
+                return Task.CompletedTask;
+            }
+
+            public Task OnStop(CancellationTokenSource cts = null)
+            {
+                this.Stopped = true;
+                this.FailedOnStop = this.failOnStop;
+                if (this.failOnStop) throw new Exception("failOnStop");
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        /// Single component which takes action at multiple stages of the lifecycle (most common expected pattern)
+        /// </summary>
+        private class MultiStageObserver : ILifecycleParticipant<ILifecycleObservable<TestStages>>
+        {
+            public Dictionary<TestStages,bool> Started { get; } = new Dictionary<TestStages, bool>(); 
+            public Dictionary<TestStages, bool> Stopped { get; } = new Dictionary<TestStages, bool>();
+
+
+            private Task OnStartStage(TestStages stage)
+            {
+                this.Started[stage] = true;
+                return Task.CompletedTask;
+            }
+
+            private Task OnStopStage(TestStages stage)
+            {
+                this.Stopped[stage] = true;
+                return Task.CompletedTask;
+            }
+
+            public void Participate(ILifecycleObservable<TestStages> lifecycle)
+            {
+                lifecycle.Subscribe(TestStages.Down, cts => OnStartStage(TestStages.Down), cts => OnStopStage(TestStages.Down));
+                lifecycle.Subscribe(TestStages.Initialize, cts => OnStartStage(TestStages.Initialize), cts => OnStopStage(TestStages.Initialize));
+                lifecycle.Subscribe(TestStages.Configure, cts => OnStartStage(TestStages.Configure), cts => OnStopStage(TestStages.Configure));
+                lifecycle.Subscribe(TestStages.Run, cts => OnStartStage(TestStages.Run), cts => OnStopStage(TestStages.Run));
+            }
+        }
+
+    }
+}

--- a/test/Tester/Lifecycle/LifecycleTests.cs
+++ b/test/Tester/Lifecycle/LifecycleTests.cs
@@ -20,7 +20,7 @@ namespace Tester
             {
                 observerCountByStage[stage] = observersPerStage;
             }
-            Dictionary<TestStages, List<Observer>> observersByStage = await RunLifeCycle(observerCountByStage, null, null);
+            Dictionary<TestStages, List<Observer>> observersByStage = await RunLifecycle(observerCountByStage, null, null);
 
             Assert.Equal(observerCountByStage.Count, observersByStage.Count);
             foreach (KeyValuePair<TestStages,List<Observer>> kvp in observersByStage)
@@ -45,7 +45,7 @@ namespace Tester
 
             foreach (TestStages stage in Enum.GetValues(typeof(TestStages)))
             {
-                Dictionary<TestStages, List<Observer>> observersByStage = await RunLifeCycle(observerCountByStage, stage, null);
+                Dictionary<TestStages, List<Observer>> observersByStage = await RunLifecycle(observerCountByStage, stage, null);
 
                 Assert.Equal(observerCountByStage.Count, observersByStage.Count);
                 foreach (KeyValuePair<TestStages, List<Observer>> kvp in observersByStage)
@@ -86,7 +86,7 @@ namespace Tester
 
             foreach (TestStages stage in Enum.GetValues(typeof(TestStages)))
             {
-                Dictionary<TestStages, List<Observer>> observersByStage = await RunLifeCycle(observerCountByStage, null, stage);
+                Dictionary<TestStages, List<Observer>> observersByStage = await RunLifecycle(observerCountByStage, null, stage);
 
                 Assert.Equal(observerCountByStage.Count, observersByStage.Count);
                 foreach (KeyValuePair<TestStages, List<Observer>> kvp in observersByStage)
@@ -124,7 +124,7 @@ namespace Tester
             Assert.True(multiStageObserver.Stopped.Values.All(o => o));
         }
 
-        private async Task<Dictionary<TestStages,List<Observer>>> RunLifeCycle(Dictionary<TestStages,int> observerCountByStage, TestStages? failOnStart, TestStages? failOnStop)
+        private async Task<Dictionary<TestStages,List<Observer>>> RunLifecycle(Dictionary<TestStages,int> observerCountByStage, TestStages? failOnStart, TestStages? failOnStop)
         {
             // setup lifecycle observers
             var observersByStage = new Dictionary<TestStages, List<Observer>>();
@@ -178,7 +178,7 @@ namespace Tester
                 this.failOnStop = failOnStop;
             }
 
-            public Task OnStart(CancellationTokenSource cts = null)
+            public Task OnStart(CancellationToken ct)
             {
                 this.Started = true;
                 this.FailedOnStart = this.failOnStart;
@@ -186,7 +186,7 @@ namespace Tester
                 return Task.CompletedTask;
             }
 
-            public Task OnStop(CancellationTokenSource cts = null)
+            public Task OnStop(CancellationToken ct)
             {
                 this.Stopped = true;
                 this.FailedOnStop = this.failOnStop;
@@ -218,10 +218,10 @@ namespace Tester
 
             public void Participate(ILifecycleObservable<TestStages> lifecycle)
             {
-                lifecycle.Subscribe(TestStages.Down, cts => OnStartStage(TestStages.Down), cts => OnStopStage(TestStages.Down));
-                lifecycle.Subscribe(TestStages.Initialize, cts => OnStartStage(TestStages.Initialize), cts => OnStopStage(TestStages.Initialize));
-                lifecycle.Subscribe(TestStages.Configure, cts => OnStartStage(TestStages.Configure), cts => OnStopStage(TestStages.Configure));
-                lifecycle.Subscribe(TestStages.Run, cts => OnStartStage(TestStages.Run), cts => OnStopStage(TestStages.Run));
+                lifecycle.Subscribe(TestStages.Down, ct => OnStartStage(TestStages.Down), ct => OnStopStage(TestStages.Down));
+                lifecycle.Subscribe(TestStages.Initialize, ct => OnStartStage(TestStages.Initialize), ct => OnStopStage(TestStages.Initialize));
+                lifecycle.Subscribe(TestStages.Configure, ct => OnStartStage(TestStages.Configure), ct => OnStopStage(TestStages.Configure));
+                lifecycle.Subscribe(TestStages.Run, ct => OnStartStage(TestStages.Run), ct => OnStopStage(TestStages.Run));
             }
         }
 

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ClientConnectionTests\GatewayConnectionTests.cs" />
     <Compile Include="CollectionFixtures.cs" />
     <Compile Include="DependencyInjectionDisambiguationTests.cs" />
+    <Compile Include="Lifecycle\LifecycleTests.cs" />
     <Compile Include="GrainActivatorTests.cs" />
     <Compile Include="EventSourcingTests\AccountGrainTests.cs" />
     <Compile Include="EventSourcingTests\ChatGrainTests.cs" />


### PR DESCRIPTION
This PR is a prerequisite of Orleans Facet System #3223 and introduces a grain lifecycle framework to allow facets to participate in exposed aspects of the grain lifecycle.

**Lifecycle Management Pattern**
This PR introduces a general component lifecycle management pattern wherein participants in a component's lifecycle are notified as the component is started and stopped.

Component startup notifications are handled in order of the stages of the lifecycle.
Component shutdown notifications are handled in the reverse order of the stages, starting at the highest stage reached during startup.

This lifecycle management is intended to provide a more testable, maintainable, modular and extensible means of managing grain, silo, and possibly cluster startup and shutdown logic, all of which are areas Orleans has suffered from the lack of a common, tested pattern.

The interfaces ILifecycleObservable< TStage > and ILifecycleObserver are the core of this lifecycle management abstraction.

**Grain Lifecycle**
The first, minimal and preliminary, application of the lifecycle pattern is to the grain lifecycle.  This implementation is incomplete and simply provides some limited hooks required by "Orleans Facet System #3223".  Grain's lifecycle management is central to the virtual actor model and refactoring the logic to leverage the lifecycle pattern will be done incrementally (and carefully) over time as we address technical debt.

The interface IGrainLifeCycle is the initial application of the lifecycle pattern to the grain lifecycle.