### PR TITLE
Switch to gcConcurrent=true

### DIFF
--- a/src/OrleansHost/app.config
+++ b/src/OrleansHost/app.config
@@ -15,6 +15,6 @@
   </startup>
   <runtime>
     <gcServer enabled="true"/>
-    <gcConcurrent enabled="false"/>
+    <gcConcurrent enabled="true"/>
   </runtime>
 </configuration>

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -194,9 +194,9 @@ namespace Orleans.Runtime
             logger = LogManager.GetLogger("Silo", LoggerType.Runtime);
 
             logger.Info(ErrorCode.SiloGcSetting, "Silo starting with GC settings: ServerGC={0} GCLatencyMode={1}", GCSettings.IsServerGC, Enum.GetName(typeof(GCLatencyMode), GCSettings.LatencyMode));
-            if (!GCSettings.IsServerGC || !GCSettings.LatencyMode.Equals(GCLatencyMode.Batch))
+            if (!GCSettings.IsServerGC)
             {
-                logger.Warn(ErrorCode.SiloGcWarning, "Note: Silo not running with ServerGC turned on or with GCLatencyMode.Batch enabled - recommend checking app config : <configuration>-<runtime>-<gcServer enabled=\"true\"> and <configuration>-<runtime>-<gcConcurrent enabled=\"false\"/>");
+                logger.Warn(ErrorCode.SiloGcWarning, "Note: Silo not running with ServerGC turned on - recommend checking app config : <configuration>-<runtime>-<gcServer enabled=\"true\">");
                 logger.Warn(ErrorCode.SiloGcWarning, "Note: ServerGC only kicks in on multi-core systems (settings enabling ServerGC have no effect on single-core machines).");
             }
 

--- a/src/OrleansServiceFabricUtils/App.config
+++ b/src/OrleansServiceFabricUtils/App.config
@@ -5,6 +5,6 @@
   </startup>
   <runtime>
     <gcServer enabled="true"/>
-    <gcConcurrent enabled="false"/>
+    <gcConcurrent enabled="true"/>
   </runtime>
 </configuration>

--- a/test/AWSUtils.Tests/App.config
+++ b/test/AWSUtils.Tests/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/Benchmarks/Benchmarks/App.config
+++ b/test/Benchmarks/Benchmarks/App.config
@@ -5,6 +5,6 @@
   </startup>
   <runtime>
     <gcServer enabled="true"/>
-    <gcConcurrent enabled="false"/>
+    <gcConcurrent enabled="true"/>
   </runtime>
 </configuration>

--- a/test/BondUtils.Tests/App.config
+++ b/test/BondUtils.Tests/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/Consul.Tests/App.config
+++ b/test/Consul.Tests/App.config
@@ -3,7 +3,7 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/test/DefaultCluster.Tests/App.config
+++ b/test/DefaultCluster.Tests/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/GoogleUtils.Tests/App.config
+++ b/test/GoogleUtils.Tests/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/PSUtils.Tests/App.config
+++ b/test/PSUtils.Tests/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/ServiceBus.Tests/App.config
+++ b/test/ServiceBus.Tests/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/TestServiceFabric/App.config
+++ b/test/TestServiceFabric/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/Tester/App.config
+++ b/test/Tester/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/TesterAzureUtils/App.config
+++ b/test/TesterAzureUtils/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/TesterInternal/App.config
+++ b/test/TesterInternal/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/TesterSQLUtils/App.config
+++ b/test/TesterSQLUtils/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>

--- a/test/TesterZooKeeperUtils/App.config
+++ b/test/TesterZooKeeperUtils/App.config
@@ -3,6 +3,6 @@
   <runtime>
     <ThrowUnobservedTaskExceptions enabled="false" />
     <gcServer enabled="true" />
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="true" />
   </runtime>
 </configuration>


### PR DESCRIPTION
Tests on .NET 4.6.2 show that performance with concurrent GC enabled is the same or better than without it. Time to change the recommendation.