### PR TITLE
Add generic SerializeInner variant

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1118,6 +1118,13 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="obj">The input data to be serialized.</param>
         /// <param name="context">The serialization context.</param>
+        public static void SerializeInner<T>(T obj, ISerializationContext context) => SerializeInner(obj, context, typeof(T));
+
+        /// <summary>
+        /// Encodes the object to the provided binary token stream.
+        /// </summary>
+        /// <param name="obj">The input data to be serialized.</param>
+        /// <param name="context">The serialization context.</param>
         /// <param name="expected">Current expected Type on this stream.</param>
         [SuppressMessage("Microsoft.Usage", "CA2201:DoNotRaiseReservedExceptionTypes")]
         public static void SerializeInner(object obj, ISerializationContext context, Type expected)


### PR DESCRIPTION
There is room for confusion and error when developers write custom serializers when it comes to passing the correct value for `expectedType` in both `SerializationManager.DeserializeInner(...)` and `SerializationManager.SerializeInner(...)`. The `expectedType` values passed to those methods must correspond and must be equal to the static type of each field (not the runtime type).

This PR introduces a generic `SerializeInner` variant: `void SerializeInner<T>(T obj, ISerializationContext context)` to match with the existing generic `DeserializeInner` method, `T DeserializeInner<T>(IDeserializationContext context)`.

The intention is to use this method in samples in the custom serializer documentation. For example:
```C#
public class User
{
    public User BestFriend { get; set; }
    public string NickName { get; set; }
    public int FavoriteNumber { get; set; }
    public DateTimeOffset BirthDate { get; set; }
}

[Serializer(typeof(User))]
internal class UserSerializer
{
    [CopierMethod]
    public static object DeepCopier(object original, ICopyContext context)
    {
        var input = (User) original;
        var result = new User();

        // Record 'result' as a copy of 'input'. Doing this immediately after construction allows for
        // data structures which have cyclic references or duplicate references.
        // For example, imagine that 'input.BestFriend' is set to 'input'. In that case, failing to record
        // the copy before trying to copy the 'BestFriend' field would result in infinite recursion.
        context.RecordCopy(original, result);

        // Deep-copy each of the fields.
        result.BestFriend = (User)context.SerializationManager.DeepCopy(input.BestFriend);
        result.NickName = input.NickName; // strings in .NET are immutable, so they can be shallow-copied.
        result.FavoriteNumber = input.FavoriteNumber; // ints are primitive value types, so they can be shallow-copied.
        result.BirthDate = (DateTimeOffset)context.SerializationManager.DeepCopy(input.BirthDate);
                
        return result;
    }

    [SerializerMethod]
    public static void Serializer(object untypedInput, ISerializationContext context, Type expected)
    {
        var input = (User) untypedInput;

        // Serialize each field.
        SerializationManager.SerializeInner(input.BestFriend, context);
        SerializationManager.SerializeInner(input.NickName, context);
        SerializationManager.SerializeInner(input.FavoriteNumber, context);
        SerializationManager.SerializeInner(input.BirthDate, context);
    }

    [DeserializerMethod]
    public static object Deserializer(Type expected, IDeserializationContext context)
    {
        var result = new User();

        // Record 'result' immediately after constructing it. As with with the deep copier, this
        // allows for cyclic references and de-duplication.
        context.RecordObject(result);

        // Deserialize each field in the order that they were serialized.
        // Note: the types here match the types provided to the SerializeInner calls.
        result.BestFriend = SerializationManager.DeserializeInner<User>(context);
        result.NickName = SerializationManager.DeserializeInner<string>(context);
        result.FavoriteNumber = SerializationManager.DeserializeInner<int>(context);
        result.BirthDate = SerializationManager.DeserializeInner<DateTimeOffset>(context);

        return result;
    }
}
```

Prior to this change, the `Serializer(...)` sample would have to come with a slab of text, like so:
```C#
[SerializerMethod]
public static void Serializer(object untypedInput, ISerializationContext context, Type expected)
{
    var input = (User) untypedInput;

    // Serialize each field.
    // Note: we are calling the static SerializeInner method and passing the compile-time type of
    // the field as the expected type. Do not pass the runtime type of the field.
    // In other words, always use typeof(User) here and not input.BestFriend.GetType() since the
    // latter can result in runtime failures when polymorphism is used.
    SerializationManager.SerializeInner(input.BestFriend, context, typeof(User));
    SerializationManager.SerializeInner(input.NickName, context, typeof(string));
    SerializationManager.SerializeInner(input.FavoriteNumber, context, typeof(int));
    SerializationManager.SerializeInner(input.BirthDate, context, typeof(DateTimeOffset));
}
```