### PR TITLE
Remove WithTolerateErrors from EmitOptions

### DIFF
--- a/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
+++ b/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
@@ -109,8 +109,7 @@ namespace Orleans.CodeGenerator
             {
                 var emitOptions = new EmitOptions()
                     .WithEmitMetadataOnly(false)
-                    .WithIncludePrivateMembers(true)
-                    .WithTolerateErrors(true);
+                    .WithIncludePrivateMembers(true);
 
                 if (emitDebugSymbols)
                 {


### PR DESCRIPTION
This option was speculatively added here with reasoning that it sounds like a good thing, but the recommendation from Roslyn team is to avoid it. 

https://github.com/dotnet/orleans/pull/3234#issuecomment-320977718 :
> TolerateErrors is not implemented yet, but it will (in a couple of months). It allows producing a partial assembly with any parts that had errors dropped from it. I would recommend passing false unless you really know that you need this for your scenario.
The main scenario where this will be used is for multi project solutions, when a project doesn't compile yet but we still want a partial (best effort) assembly to reference.