### PR TITLE
Fix scheduling of notification interfaces

### DIFF
--- a/src/Orleans/Streams/PersistentStreams/IStreamQueueBalancer.cs
+++ b/src/Orleans/Streams/PersistentStreams/IStreamQueueBalancer.cs
@@ -53,9 +53,8 @@ namespace Orleans.Streams
     /// indicating that the balance of queues has changed.
     /// It should be implemented by components interested in stream queue load balancing.
     /// When change notification is received, listener should request updated list of queues from the queue balancer.
-    /// This interface inherit from IAddressable for threading-safe concern
     /// </summary>
-    public interface IStreamQueueBalanceListener :IAddressable
+    public interface IStreamQueueBalanceListener
     {
         /// <summary>
         /// Receive notifications about adapter queue responsibility changes. 

--- a/src/OrleansRuntime/Core/SystemTargetExtensions.cs
+++ b/src/OrleansRuntime/Core/SystemTargetExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.Runtime.Scheduler;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Extensions for <see cref="SystemTarget"/>.
+    /// </summary>
+    public static class SystemTargetExtensions
+    {
+        /// <summary>
+        /// Schedules the provided <paramref name="action"/> on the <see cref="SystemTarget"/>'s <see cref="ISchedulingContext"/>.
+        /// </summary>
+        /// <param name="self">The <see cref="SystemTarget"/>.</param>
+        /// <param name="action">The action.</param>
+        /// <returns>A <see cref="Task"/> which completes when the <paramref name="action"/> has completed.</returns>
+        public static Task ScheduleTask(this SystemTarget self, Func<Task> action)
+        {
+            return self.RuntimeClient.Scheduler.RunOrQueueTask(action, self.SchedulingContext);
+        }
+
+        /// <summary>
+        /// Schedules the provided <paramref name="action"/> on the <see cref="SystemTarget"/>'s <see cref="ISchedulingContext"/>.
+        /// </summary>
+        /// <param name="self">The <see cref="SystemTarget"/>.</param>
+        /// <param name="action">The action.</param>
+        /// <returns>A <see cref="Task"/> which completes when the <paramref name="action"/> has completed.</returns>
+        public static Task ScheduleTask(this SystemTarget self, Action action)
+        {
+            return self.RuntimeClient.Scheduler.RunOrQueueAction(action, self.SchedulingContext);
+        }
+    }
+}

--- a/src/OrleansRuntime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/ILocalGrainDirectory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
@@ -122,5 +123,11 @@ namespace Orleans.Runtime.GrainDirectory
         /// The id of this cluster
         /// </summary>
         string ClusterId { get; }
+
+        /// <summary>
+        /// Sets the callback to <see cref="Catalog"/> which is called when a silo is removed from membership.
+        /// </summary>
+        /// <param name="catalogOnSiloRemoved">The callback.</param>
+        void SetSiloRemovedCatalogCallback(Action<SiloAddress, SiloStatus> catalogOnSiloRemoved);
     }
 }

--- a/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -114,7 +114,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
         {
             // any status change can cause changes in gateway list
-            PublishChanges();
+            this.ScheduleTask(() => Utils.SafeExecute(() => this.PublishChanges())).Ignore();
         }
 
         public bool SubscribeToMultiClusterConfigurationEvents(GrainReference observer)

--- a/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
+++ b/src/OrleansRuntime/Placement/DeploymentLoadPublisher.cs
@@ -184,6 +184,11 @@ namespace Orleans.Runtime
 
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
         {
+            this.ScheduleTask(() => { Utils.SafeExecute(() => this.OnSiloStatusChange(updatedSilo, status), this.logger); }).Ignore();
+        }
+
+        private void OnSiloStatusChange(SiloAddress updatedSilo, SiloStatus status)
+        {
             if (!status.IsTerminating()) return;
 
             if (Equals(updatedSilo, this.Silo))

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -136,7 +136,11 @@ namespace Orleans.Runtime
         /// Test hook connection for white-box testing of silo.
         /// </summary>
         internal TestHooksSystemTarget testHook;
-        
+
+        private SchedulingContext membershipOracleContext;
+        private SchedulingContext multiClusterOracleContext;
+        private SchedulingContext reminderServiceContext;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Silo"/> class.
         /// </summary>
@@ -490,11 +494,12 @@ namespace Orleans.Runtime
             // Load and init grain services before silo becomes active.
             CreateGrainServices(GlobalConfig.GrainServiceConfigurations);
 
-            ISchedulingContext statusOracleContext = (this.membershipOracle as SystemTarget)?.SchedulingContext;
-            scheduler.QueueTask(() => this.membershipOracle.Start(), statusOracleContext)
+            this.membershipOracleContext = (this.membershipOracle as SystemTarget)?.SchedulingContext ??
+                                       this.providerManagerSystemTarget.SchedulingContext;
+            scheduler.QueueTask(() => this.membershipOracle.Start(), this.membershipOracleContext)
                 .WaitWithThrow(initTimeout);
             if (logger.IsVerbose) { logger.Verbose("Local silo status oracle created successfully."); }
-            scheduler.QueueTask(this.membershipOracle.BecomeActive, statusOracleContext)
+            scheduler.QueueTask(this.membershipOracle.BecomeActive, this.membershipOracleContext)
                 .WaitWithThrow(initTimeout);
             if (logger.IsVerbose) { logger.Verbose("Local silo status oracle became active successfully."); }
             scheduler.QueueTask(() => this.typeManager.Initialize(versionStore), this.typeManager.SchedulingContext)
@@ -506,8 +511,9 @@ namespace Orleans.Runtime
                 logger.Info("Starting multicluster oracle with my ServiceId={0} and ClusterId={1}.",
                     GlobalConfig.ServiceId, GlobalConfig.ClusterId);
 
-                ISchedulingContext clusterStatusContext = (multiClusterOracle as SystemTarget)?.SchedulingContext;
-                scheduler.QueueTask(() => multiClusterOracle.Start(), clusterStatusContext)
+                this.multiClusterOracleContext = (multiClusterOracle as SystemTarget)?.SchedulingContext ??
+                                                          this.providerManagerSystemTarget.SchedulingContext;
+                scheduler.QueueTask(() => multiClusterOracle.Start(), multiClusterOracleContext)
                                     .WaitWithThrow(initTimeout);
                 if (logger.IsVerbose) { logger.Verbose("multicluster oracle created successfully."); }
             }
@@ -531,7 +537,9 @@ namespace Orleans.Runtime
                 if (this.reminderService != null)
                 {
                     // so, we have the view of the membership in the consistentRingProvider. We can start the reminder service
-                    this.scheduler.QueueTask(this.reminderService.Start, (this.reminderService as SystemTarget)?.SchedulingContext)
+                    this.reminderServiceContext = (this.reminderService as SystemTarget)?.SchedulingContext ??
+                                                           this.providerManagerSystemTarget.SchedulingContext;
+                    this.scheduler.QueueTask(this.reminderService.Start, this.reminderServiceContext)
                         .WaitWithThrow(this.initTimeout);
                     if (this.logger.IsVerbose)
                     {
@@ -725,14 +733,14 @@ namespace Orleans.Runtime
                     {
                         logger.Info(ErrorCode.SiloShuttingDown, "Silo starting to Shutdown()");
                         // 1: Write "ShutDown" state in the table + broadcast gossip msgs to re-read the table to everyone
-                        scheduler.QueueTask(this.membershipOracle.ShutDown, (this.membershipOracle as SystemTarget)?.SchedulingContext)
+                        scheduler.QueueTask(this.membershipOracle.ShutDown, this.membershipOracleContext)
                             .WaitWithThrow(stopTimeout);
                     }
                     else
                     {
                         logger.Info(ErrorCode.SiloStopping, "Silo starting to Stop()");
                         // 1: Write "Stopping" state in the table + broadcast gossip msgs to re-read the table to everyone
-                        scheduler.QueueTask(this.membershipOracle.Stop, (this.membershipOracle as SystemTarget)?.SchedulingContext)
+                        scheduler.QueueTask(this.membershipOracle.Stop, this.membershipOracleContext)
                             .WaitWithThrow(stopTimeout);
                     }
                 }
@@ -745,7 +753,7 @@ namespace Orleans.Runtime
                 if (reminderService != null)
                 {
                     // 2: Stop reminder service
-                    scheduler.QueueTask(reminderService.Stop, (reminderService as SystemTarget)?.SchedulingContext)
+                    scheduler.QueueTask(reminderService.Stop, this.reminderServiceContext)
                         .WaitWithThrow(stopTimeout);
                 }
 
@@ -817,7 +825,7 @@ namespace Orleans.Runtime
             if (!GlobalConfig.LivenessType.Equals(GlobalConfiguration.LivenessProviderType.MembershipTableGrain))
             {
                 // do not execute KillMyself if using MembershipTableGrain, since it will fail, as we've already stopped app scheduler turns.
-                SafeExecute(() => scheduler.QueueTask( this.membershipOracle.KillMyself, (this.membershipOracle as SystemTarget)?.SchedulingContext)
+                SafeExecute(() => scheduler.QueueTask( this.membershipOracle.KillMyself, this.membershipOracleContext)
                     .WaitWithThrow(stopTimeout));
             }
 

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -351,7 +351,6 @@ namespace Orleans.Runtime
             healthCheckParticipants.Add(membershipOracle);
 
             catalog.SiloStatusOracle = this.membershipOracle;
-            localGrainDirectory.CatalogSiloStatusListener = catalog;
             this.membershipOracle.SubscribeToSiloStatusEvents(localGrainDirectory);
             messageCenter.SiloDeadOracle = this.membershipOracle.IsDeadSilo;
 

--- a/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingManager.cs
+++ b/src/OrleansRuntime/Streams/PersistentStream/PersistentStreamPullingManager.cs
@@ -89,8 +89,7 @@ namespace Orleans.Streams
             // Remove cast once we cleanup
             queueAdapter = qAdapter.Value;
             await this.queueBalancer.Initialize(this.streamProviderName, this.adapterFactory.GetStreamQueueMapper(), config.SiloMaturityPeriod, this.providerConfig);
-            var meAsQueueBalanceListener = this.AsReference<IStreamQueueBalanceListener>();
-            queueBalancer.SubscribeToQueueDistributionChangeEvents(meAsQueueBalanceListener);
+            queueBalancer.SubscribeToQueueDistributionChangeEvents(this);
 
             List<QueueId> myQueues = queueBalancer.GetMyQueues().ToList();
             Log(ErrorCode.PersistentStreamPullingManager_03, String.Format("Initialize: I am now responsible for {0} queues: {1}.", myQueues.Count, PrintQueues(myQueues)));
@@ -140,6 +139,11 @@ namespace Orleans.Streams
         /// and don't execute an older notification if a newer one was already delivered.
         /// </summary>
         public Task QueueDistributionChangeNotification()
+        {
+            return this.ScheduleTask(() => this.HandleQueueDistributionChangeNotification());
+        }
+
+        public Task HandleQueueDistributionChangeNotification()
         {
             latestRingNotificationSequenceNumber++;
             int notificationSeqNumber = latestRingNotificationSequenceNumber;


### PR DESCRIPTION
Fixes #3273

Implementations of `ISiloStatusListener` and `IRingRangeListener` must correctly marshall calls onto their own execution context in order to preserve correct scheduling semantics.

* Add `.ScheduleTask(...)` extension methods to `SystemTarget` so that implementations can easily schedule these callbacks.
* ~~Add `IAddressableContextScheduler` which provides methods for executing actions on an addressable scheduling context (so that grain calls can be made). It can be injected via `Factory<IAddressableContextScheduler>`.~~
* Remove `IAddressable` from `IStreamQueueBalanceListener` and have `PersistentStreamPullingManager` subscribe to ring range change notifications directly (instead of via a ref, `.AsReference<IStreamQueueBalanceListener>()`)
* Verified locally using Service Fabric Sample (modified to include streams)