### PR TITLE
[WIP] Shared state publisher prototype

### DIFF
--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -204,6 +204,9 @@
     <Compile Include="Utils\CachedReadConcurrentDictionary.cs" />
     <Compile Include="Utils\Factory.cs" />
     <Compile Include="Utils\IKeyedServiceCollection.cs" />
+    <Compile Include="Utils\SharedState\ISharedStatePublisher.cs" />
+    <Compile Include="Utils\SharedState\SharedState.cs" />
+    <Compile Include="Utils\SharedState\SharedStatePublisherBase.cs" />
     <Compile Include="Versions\Compatibility\AllVersionsCompatible.cs" />
     <Compile Include="Versions\Compatibility\BackwardCompatible.cs" />
     <Compile Include="Versions\Compatibility\StrictVersionCompatible.cs" />

--- a/src/Orleans/Utils/SharedState/ISharedStatePublisher.cs
+++ b/src/Orleans/Utils/SharedState/ISharedStatePublisher.cs
@@ -1,0 +1,17 @@
+﻿
+namespace Orleans
+{
+    /// <summary>
+    /// Shared state publisher
+    /// NOTE: All implementations must be thread safe
+    /// NOTE: All state must be immutable
+    /// </summary>
+    public interface ISharedStatePublisher<in T>
+    {
+        /// <summary>
+        /// Publish state
+        /// </summary>
+        /// <param name="state">immutable state to publish</param>
+        void Publish(T state);
+    }
+}

--- a/src/Orleans/Utils/SharedState/SharedState.cs
+++ b/src/Orleans/Utils/SharedState/SharedState.cs
@@ -1,0 +1,30 @@
+﻿
+using System.Threading.Tasks;
+
+namespace Orleans
+{
+    public interface ISharedState<T>
+    {
+        T State { get; }
+        Task<ISharedState<T>> NextAsync { get; }
+    }
+
+    public class SharedState<T> : ISharedState<T>
+    {
+        public SharedState(T state)
+        {
+            this.State = state;
+            this.NextCompletion = new TaskCompletionSource<ISharedState<T>>();
+        }
+
+        public SharedState(SharedState<T> sharedState)
+        {
+            this.State = sharedState.State;
+            this.NextCompletion = sharedState.NextCompletion;
+        }
+
+        public T State { get; }
+        public Task<ISharedState<T>> NextAsync => this.NextCompletion.Task;
+        public TaskCompletionSource<ISharedState<T>> NextCompletion { get; }
+    }
+}

--- a/src/Orleans/Utils/SharedState/SharedStatePublisherBase.cs
+++ b/src/Orleans/Utils/SharedState/SharedStatePublisherBase.cs
@@ -1,0 +1,22 @@
+﻿
+using System.Threading;
+
+namespace Orleans
+{
+    public class SharedStatePublisherBase<T> : ISharedStatePublisher<T>
+    {
+        protected SharedState<T> currentState;
+
+        public SharedStatePublisherBase(T startingState)
+        {
+            this.currentState = new SharedState<T>(startingState);
+        }
+
+        public void Publish(T state)
+        {
+            var newSateChange = new SharedState<T>(state);
+            SharedState<T> last = Interlocked.Exchange(ref this.currentState, newSateChange);
+            last.NextCompletion.TrySetResult(newSateChange);
+        }
+    }
+}

--- a/src/OrleansRuntime/MembershipService/SharedSiloStatusListener.cs
+++ b/src/OrleansRuntime/MembershipService/SharedSiloStatusListener.cs
@@ -1,0 +1,40 @@
+﻿
+namespace Orleans.Runtime
+{
+    public struct SiloStatusChange
+    {
+        public SiloStatusChange(SiloAddress updatedSilo, SiloStatus status)
+        {
+            this.UpdatedSilo = updatedSilo;
+            this.Status = status;
+        }
+
+        public SiloAddress UpdatedSilo { get; }
+        public SiloStatus Status { get; }
+    }
+
+    public static class SiloStatusSharedState
+    {
+        public static ISharedState<SiloStatusChange> CreateSiloStatusSharedState(this ISiloStatusOracle oracle)
+        {
+            var currentStatus = new SiloStatusChange(oracle.SiloAddress, oracle.CurrentStatus);
+            var listener = new SharedSiloStatusListener(currentStatus);
+            oracle.SubscribeToSiloStatusEvents(listener);
+            return listener.State;
+        }
+
+        private class SharedSiloStatusListener : SharedStatePublisherBase<SiloStatusChange>, ISiloStatusListener
+        {
+            public SharedState<SiloStatusChange> State => base.currentState;
+
+            public SharedSiloStatusListener(SiloStatusChange startingState) : base(startingState)
+            {
+            }
+
+            public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
+            {
+                this.Publish(new SiloStatusChange(updatedSilo, status));
+            }
+        }
+    }
+}

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Core\IInvokable.cs" />
     <Compile Include="Core\ISiloRuntimeClient.cs" />
     <Compile Include="Core\GrainMethodInvoker.cs" />
+    <Compile Include="MembershipService\SharedSiloStatusListener.cs" />
     <Compile Include="Messaging\ObjectPool.cs" />
     <Compile Include="Placement\HashBasedPlacementDirector.cs" />
     <Compile Include="Placement\IActivationSelector.cs" />


### PR DESCRIPTION
Prototype for discussion purposes.
NOT FOR CHECKIN

This PR explores using a shared state publisher pattern to notify other threads of immutable state in a thread safe manner.

In this prototype, the silo status change notifications are exposed as shared state to the queue balancer, so that no queue balancing logic is run on the silo status oracle's thread.
