### PR TITLE
Improve thrown NullReferenceException when calling GetStream<T>

### DIFF
--- a/src/Orleans/Streams/Internal/StreamDirectory.cs
+++ b/src/Orleans/Streams/Internal/StreamDirectory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Orleans.Streams
@@ -24,7 +25,7 @@ namespace Orleans.Streams
             var streamOfT = stream as IAsyncStream<T>;
             if (streamOfT == null)
             {
-                throw new Runtime.OrleansException($"Stream type mismatch. A stream can only support a single type of data. The generic type of the stream requested ({typeof(T)}) does not match the previously requested type ({stream.GetType().GetGenericArguments().FirstOrDefault()}).");
+                throw new Runtime.OrleansException($"Stream type mismatch. A stream can only support a single type of data. The generic type of the stream requested ({typeof(T)}) does not match the previously requested type ({stream.GetType().GetTypeInfo().GetGenericArguments().FirstOrDefault()}).");
             }
 
             return streamOfT;

--- a/src/Orleans/Streams/Internal/StreamDirectory.cs
+++ b/src/Orleans/Streams/Internal/StreamDirectory.cs
@@ -24,7 +24,7 @@ namespace Orleans.Streams
             var streamOfT = stream as IAsyncStream<T>;
             if (streamOfT == null)
             {
-                throw new Runtime.OrleansException($"Stream type mismatch. A stream can only support a single type of data. The generic type of the stream requested does not match the previously requested type {stream.GetType()}.");
+                throw new Runtime.OrleansException($"Stream type mismatch. A stream can only support a single type of data. The generic type of the stream requested ({typeof(T)}) does not match the previously requested type ({stream.GetType().GetGenericArguments().FirstOrDefault()}).");
             }
 
             return streamOfT;

--- a/src/Orleans/Streams/Internal/StreamDirectory.cs
+++ b/src/Orleans/Streams/Internal/StreamDirectory.cs
@@ -20,7 +20,14 @@ namespace Orleans.Streams
 
         internal IAsyncStream<T> GetOrAddStream<T>(StreamId streamId, Func<IAsyncStream<T>> streamCreator)
         {
-            return allStreams.GetOrAdd(streamId, _ => streamCreator()) as IAsyncStream<T>;
+            var stream = allStreams.GetOrAdd(streamId, _ => streamCreator());
+            var streamOfT = stream as IAsyncStream<T>;
+            if (streamOfT == null)
+            {
+                throw new Runtime.OrleansException($"Stream type mismatch. A stream can only support a single type of data. The generic type of the stream requested does not match the previously requested type {stream.GetType()}.");
+            }
+
+            return streamOfT;
         }
 
         internal async Task Cleanup(bool cleanupProducers, bool cleanupConsumers)

--- a/test/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/test/Tester/StreamingTests/SampleStreamingTests.cs
@@ -42,6 +42,17 @@ namespace UnitTests.StreamingTests
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public void SampleStreamingTests_StreamTypeMismatch_ShouldThrowOrleansException()
+        {
+            var streamId = Guid.NewGuid();
+            var streamNameSpace = "SmsStream";
+            var stream = this.fixture.Client.GetStreamProvider(StreamProvider).GetStream<int>(streamId, streamNameSpace);
+            Assert.Throws<Orleans.Runtime.OrleansException>(() => {
+                this.fixture.Client.GetStreamProvider(StreamProvider).GetStream<string>(streamId, streamNameSpace);
+                });
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
         public async Task SampleStreamingTests_1()
         {
             this.logger.Info("************************ SampleStreamingTests_1 *********************************");


### PR DESCRIPTION
Improve thrown NullReferenceException when calling `GetStream<T>`, by throwing a more understanable exception. 

Stream is typed, but stream id isn't. If application reference a stream with a different type, but using the same stream id, then `GetStream<T>` will throw a `NullReferenceException`. Because runtime is casting a `IAsyncStream<T1>` to a `IAsyncStream<T2>`

This is confusing to users. So throw a more understandable exception to help user fixing their application code. 