### PR TITLE
Update Actor-Identity.md

### DIFF
--- a/src/Tutorials/Actor-Identity.md
+++ b/src/Tutorials/Actor-Identity.md
@@ -104,7 +104,7 @@ public interface IExampleGrain : Orleans.IGrainWithIntegerCompoundKey
 In client code, this adds a second argument to the `GetGrain` method on the grain factory.
 
 ``` csharp
-var grain = GrainClient.GrainFactory.GetGrain<IExample>(0, "a string!");
+var grain = GrainClient.GrainFactory.GetGrain<IExample>(0, "a string!", null);
 ```
 
 To access the compound key in the grain, we can call an overload on the `GetPrimaryKey` method:


### PR DESCRIPTION
The third argument must be passed to disambiguate between two overloads of  GetGrain() . Otherwise, the compiler thinks it's the  GetGrain(<int key>, <implementation class name prefix>) .