### PR TITLE
[WIP] Configure grain-level interceptors via DI

### DIFF
--- a/src/Orleans/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans/Runtime/GrainReferenceRuntime.cs
@@ -11,7 +11,7 @@ namespace Orleans.Runtime
     {
         private const bool USE_DEBUG_CONTEXT = true;
         private const bool USE_DEBUG_CONTEXT_PARAMS = false;
-        private static ConcurrentDictionary<int, string> debugContexts = new ConcurrentDictionary<int, string>();
+        private static readonly ConcurrentDictionary<int, string> debugContexts = new ConcurrentDictionary<int, string>();
 
         private readonly Action<Message, TaskCompletionSource<object>> responseCallbackDelegate;
         private readonly Logger logger;
@@ -31,7 +31,7 @@ namespace Orleans.Runtime
             this.serializationManager = serializationManager;
         }
 
-        public IRuntimeClient RuntimeClient { get; private set; }
+        public IRuntimeClient RuntimeClient { get; }
 
         /// <inheritdoc />
         public void InvokeOneWayMethod(GrainReference reference, int methodId, object[] arguments, InvokeMethodOptions options, SiloAddress silo)

--- a/src/Orleans/Runtime/IActivationData.cs
+++ b/src/Orleans/Runtime/IActivationData.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using Orleans.Storage;
 
 namespace Orleans.Runtime

--- a/src/Orleans/Runtime/IGrainActivationContext.cs
+++ b/src/Orleans/Runtime/IGrainActivationContext.cs
@@ -29,5 +29,10 @@ namespace Orleans.Runtime
         /// Observable Grain life cycle
         /// </summary>
         IGrainLifecycle ObservableLifecycle { get; }
+
+        /// <summary>
+        /// Grain call filters for this instance.
+        /// </summary>
+        List<IGrainCallFilter> GrainCallFilters { get; }
     }
 }

--- a/src/OrleansRuntime/Catalog/ActivationData.cs
+++ b/src/OrleansRuntime/Catalog/ActivationData.cs
@@ -215,6 +215,8 @@ namespace Orleans.Runtime
 
         public IServiceProvider ActivationServices => this.serviceScope.ServiceProvider;
 
+        public List<IGrainCallFilter> GrainCallFilters { get; set; }
+
         #region Method invocation
 
         private ExtensionInvoker extensionInvoker;
@@ -290,6 +292,7 @@ namespace Orleans.Runtime
         {
             this.GrainTypeData = typeData;
             this.Items = new Dictionary<object, object>();
+            this.GrainCallFilters = new List<IGrainCallFilter>();
             this.serviceScope = grainServices.CreateScope();
 
             SetGrainActivationContextInScopedServices(this.ActivationServices, this);

--- a/test/TestGrainInterfaces/IMethodInterceptionGrain.cs
+++ b/test/TestGrainInterfaces/IMethodInterceptionGrain.cs
@@ -41,5 +41,6 @@ namespace UnitTests.GrainInterfaces
     { 
         Task<string> CallWithBadInterceptors(bool early, bool mid, bool late);
         Task<string> GetRequestContext();
+        Task<string> GetFavoriteColor();
     }
 }

--- a/test/Tester/GrainCallFilterTests.cs
+++ b/test/Tester/GrainCallFilterTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans;
 using Orleans.Configuration;
 using Orleans.Providers;
 using Orleans.Runtime;
@@ -54,7 +55,21 @@ namespace UnitTests.General
             Assert.NotNull(context);
             Assert.Equal("123456", context);
         }
-        
+
+        /// <summary>
+        /// Ensures that grain call filters can be configured via <see cref="IGrainActivationContext"/>.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        [Fact]
+        public async Task GrainCallFilter_ActivationContext_Test()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<IGrainCallFilterTestGrain>(random.Next());
+            
+            var color = await grain.GetFavoriteColor();
+            Assert.NotNull(color);
+            Assert.Equal("turkey", color);
+        }
+
         /// <summary>
         /// Ensures that the invocation interceptor is invoked for stream subscribers.
         /// </summary>
@@ -224,6 +239,9 @@ namespace UnitTests.General
 
                 return context.Invoke();
             });
+
+            // Inject a filter as a scoped service.
+            services.AddScoped<InjectedGrainLevelFilter>();
 
             return services.BuildServiceProvider();
         }


### PR DESCRIPTION
This PR allows grain-scoped injected services (eg, transactional storage, streams) to configure grain call filters. This is useful for features such as transactions where logic must be executed after a grain call has completed.

Hopefully something like this would allow us to integrate transactions without modifying core Orleans.

Note: the intention is *not* to merge this PR as-is, it's just a PoC.