### PR TITLE
Execute TypeManager timers in the correct runtime context 

### DIFF
--- a/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
+++ b/src/OrleansRuntime/GrainTypeManager/TypeManager.cs
@@ -52,6 +52,11 @@ namespace Orleans.Runtime
             this.versionSelectorManager = versionSelectorManager;
             this.scheduler = scheduler;
             this.refreshClusterMapInterval = refreshClusterMapInterval;
+            // We need this so we can place needed local activations
+            this.grainTypeManager.SetInterfaceMapsBySilo(new Dictionary<SiloAddress, GrainInterfaceMap>
+            {
+                {this.Silo, grainTypeManager.GetTypeCodeMap()}
+            });
         }
 
         internal async Task Initialize(IVersionStore store)

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -591,7 +591,8 @@ namespace Orleans.Runtime
             allSiloProviders.AddRange(storageProviderManager.GetProviders());
             var versionStore = Services.GetService<IVersionStore>() as GrainVersionStore;
             versionStore?.SetStorageManager(storageProviderManager);
-            typeManager.Initialize(versionStore);
+            scheduler.QueueTask(() => this.typeManager.Initialize(versionStore), this.typeManager.SchedulingContext)
+                     .WaitWithThrow(this.initTimeout);
             if (logger.IsVerbose) { logger.Verbose("Storage provider manager created successfully."); }
 
             // Initialize log consistency providers once we have a basic silo runtime environment operating

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -591,8 +591,6 @@ namespace Orleans.Runtime
             allSiloProviders.AddRange(storageProviderManager.GetProviders());
             var versionStore = Services.GetService<IVersionStore>() as GrainVersionStore;
             versionStore?.SetStorageManager(storageProviderManager);
-            scheduler.QueueTask(() => this.typeManager.Initialize(versionStore), this.typeManager.SchedulingContext)
-                     .WaitWithThrow(this.initTimeout);
             if (logger.IsVerbose) { logger.Verbose("Storage provider manager created successfully."); }
 
             // Initialize log consistency providers once we have a basic silo runtime environment operating
@@ -624,6 +622,8 @@ namespace Orleans.Runtime
             scheduler.QueueTask(this.membershipOracle.BecomeActive, statusOracleContext)
                 .WaitWithThrow(initTimeout);
             if (logger.IsVerbose) { logger.Verbose("Local silo status oracle became active successfully."); }
+            scheduler.QueueTask(() => this.typeManager.Initialize(versionStore), this.typeManager.SchedulingContext)
+                .WaitWithThrow(this.initTimeout);
 
             //if running in multi cluster scenario, start the MultiClusterNetwork Oracle
             if (GlobalConfig.HasMultiClusterNetwork) 

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
@@ -142,10 +142,10 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
             var grainV1 = Client.GetGrain<IVersionUpgradeTestGrain>(0);
             Assert.Equal(1, await grainV1.GetVersion());
 
+            await StartSiloV2();
+
             // Change default to minimum version
             await ManagementGrain.SetSelectorStrategy(MinimumVersion.Singleton);
-
-            await StartSiloV2();
 
             // But only activate V1
             for (int i = 0; i < 100; i++)

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
@@ -142,10 +142,10 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
             var grainV1 = Client.GetGrain<IVersionUpgradeTestGrain>(0);
             Assert.Equal(1, await grainV1.GetVersion());
 
-            await StartSiloV2();
-
             // Change default to minimum version
             await ManagementGrain.SetSelectorStrategy(MinimumVersion.Singleton);
+
+            await StartSiloV2();
 
             // But only activate V1
             for (int i = 0; i < 100; i++)


### PR DESCRIPTION
Replace PR #3256

> In Silo.DoStart() we should be scheduling TypeManager.Initialize() on the TypeManager's context (it's a system target), since it starts a timer which potentially makes grain calls.
> The timer started there also needs to invoke its callback on the TypeManager's context.

Also `TypeManager.Initialize` should be call after the Silo joined the cluster, otherwise the silo that is starting cannot talk to silo that are already active in the cluster. It means that we can have a very small window where a silo that join cluster can make placement without respecting versioning strategies. 

A more complete fix will be implemented in 2.0 since it will likely be a breaking change