### PR TITLE
Fix LeaseBasedQueueBalancerTests

### DIFF
--- a/test/TesterAzureUtils/Lease/LeaseBasedQueueBalancerTests.cs
+++ b/test/TesterAzureUtils/Lease/LeaseBasedQueueBalancerTests.cs
@@ -31,7 +31,7 @@ namespace Tester.AzureUtils.Lease
         public static readonly LeaseBasedQueueBalancerConfig BalancerConfig = new LeaseBasedQueueBalancerConfig()
         {
             LeaseProviderType = typeof(AzureBlobLeaseProvider),
-            LeaseLength = TimeSpan.FromSeconds(10)
+            LeaseLength = TimeSpan.FromSeconds(15)
         };
 
         //since lease length is 1 min, so set time out to be two minutes to fulfill some test scenario


### PR DESCRIPTION
-set leaseLength to be 15 sec, which is the new minimum allowable lease length for azure blob lease. 