### PR TITLE
SerializationManager: register additional generic collection interfaces

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -324,6 +324,11 @@ namespace Orleans.Serialization
             Register(typeof(IList<>));
             Register(typeof(IDictionary<,>));
             Register(typeof(IEnumerable<>));
+            Register(typeof(ICollection<>));
+            Register(typeof(ISet<>));
+            Register(typeof(IReadOnlyDictionary<,>));
+            Register(typeof(IReadOnlyCollection<>));
+            Register(typeof(IReadOnlyList<>));
 
             // Enum names we need to recognize
             Register(typeof(Message.Categories));


### PR DESCRIPTION
Fixes #3268

This is not blocking for 1.5.1, but it's small and low risk to include.