### PR TITLE
Directly propagate OnActivateAsync failures to callers

### DIFF
--- a/src/Orleans/Core/Exceptions.cs
+++ b/src/Orleans/Core/Exceptions.cs
@@ -253,26 +253,5 @@ namespace Orleans.Runtime
         { }
 #endif
     }
-
-    /// <summary>
-    /// Indicates that grain activation failed.
-    /// </summary>
-    [Serializable]
-    public class OrleansGrainActivationFailedException : OrleansException
-    {
-        internal OrleansGrainActivationFailedException(string message)
-            : base(message)
-        {
-        }
-
-        internal OrleansGrainActivationFailedException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-#if !NETSTANDARD
-        protected OrleansGrainActivationFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
-        { }
-#endif
-    }
 }
 

--- a/src/Orleans/Core/Exceptions.cs
+++ b/src/Orleans/Core/Exceptions.cs
@@ -253,5 +253,26 @@ namespace Orleans.Runtime
         { }
 #endif
     }
+
+    /// <summary>
+    /// Indicates that grain activation failed.
+    /// </summary>
+    [Serializable]
+    public class OrleansGrainActivationFailedException : OrleansException
+    {
+        internal OrleansGrainActivationFailedException(string message)
+            : base(message)
+        {
+        }
+
+        internal OrleansGrainActivationFailedException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+#if !NETSTANDARD
+        protected OrleansGrainActivationFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
+#endif
+    }
 }
 

--- a/src/Orleans/Messaging/MessageFactory.cs
+++ b/src/Orleans/Messaging/MessageFactory.cs
@@ -89,7 +89,7 @@ namespace Orleans.Runtime
             return response;
         }
 
-        public Message CreateRejectionResponse(Message request, Message.RejectionTypes type, string info, OrleansException ex = null)
+        public Message CreateRejectionResponse(Message request, Message.RejectionTypes type, string info, Exception ex = null)
         {
             var response = this.CreateResponseMessage(request);
             response.Result = Message.ResponseTypes.Rejection;

--- a/src/Orleans/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans/Runtime/GrainReferenceRuntime.cs
@@ -166,7 +166,7 @@ namespace Orleans.Runtime
                         return; // Ignore duplicates
 
                     default:
-                        rejection = message.GetDeserializedBody(this.serializationManager) as OrleansException;
+                        rejection = message.GetDeserializedBody(this.serializationManager) as Exception;
                         if (rejection == null)
                         {
                             if (string.IsNullOrEmpty(message.RejectionInfo))

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -680,7 +680,9 @@ namespace Orleans.Runtime
                                 SchedulingContext).Ignore();
                         }
 
-                        RerouteAllQueuedMessages(activation, null, "Failed InvokeActivate", exception);
+                        // Reject all of the messages queued for this activation.
+                        var activationFailedMsg = nameof(Grain.OnActivateAsync) + " failed";
+                        RejectAllQueuedMessages(activation, activationFailedMsg, exception);
                         break;
                 }
             }
@@ -1299,6 +1301,36 @@ namespace Orleans.Runtime
             }
         }
 
+        /// <summary>
+        /// Rejects all messages enqueued for the provided activation.
+        /// </summary>
+        /// <param name="activation">The activation.</param>
+        /// <param name="failedOperation">The operation which failed, resulting in this rejection.</param>
+        /// <param name="exception">The rejection exception.</param>
+        private void RejectAllQueuedMessages(
+            ActivationData activation,
+            string failedOperation,
+            Exception exception = null)
+        {
+            lock (activation)
+            {
+                List<Message> msgs = activation.DequeueAllWaitingMessages();
+                if (msgs == null || msgs.Count <= 0) return;
+
+                if (logger.IsVerbose)
+                    logger.Verbose(
+                        ErrorCode.Catalog_RerouteAllQueuedMessages,
+                        string.Format("RejectAllQueuedMessages: {0} msgs from Invalid activation {1}.", msgs.Count(), activation));
+                this.Dispatcher.ProcessRequestsToInvalidActivation(
+                    msgs,
+                    activation.Address,
+                    forwardingAddress: null,
+                    failedOperation: failedOperation,
+                    exc: exception,
+                    rejectMessages: true);
+            }
+        }
+
         private async Task CallGrainActivate(ActivationData activation, Dictionary<string, object> requestContextData)
         {
             var grainTypeName = activation.GrainInstanceType.FullName;
@@ -1343,7 +1375,7 @@ namespace Orleans.Runtime
 
                 activationsFailedToActivate.Increment();
 
-                throw;
+                throw new OrleansGrainActivationFailedException(nameof(Grain.OnActivateAsync) + " failed", exc);
             }
 
             if (activation.GrainInstance is ILogConsistencyProtocolParticipant)

--- a/src/OrleansRuntime/Catalog/Catalog.cs
+++ b/src/OrleansRuntime/Catalog/Catalog.cs
@@ -1375,7 +1375,7 @@ namespace Orleans.Runtime
 
                 activationsFailedToActivate.Increment();
 
-                throw new OrleansGrainActivationFailedException(nameof(Grain.OnActivateAsync) + " failed", exc);
+                throw;
             }
 
             if (activation.GrainInstance is ILogConsistencyProtocolParticipant)

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -469,7 +469,8 @@ namespace Orleans.Runtime
             ActivationAddress oldAddress,
             ActivationAddress forwardingAddress, 
             string failedOperation,
-            Exception exc = null)
+            Exception exc = null,
+            bool rejectMessages = false)
         {
             // Just use this opportunity to invalidate local Cache Entry as well. 
             if (oldAddress != null)
@@ -491,7 +492,15 @@ namespace Orleans.Runtime
                 {
                     foreach (var message in messages)
                     {
-                        TryForwardRequest(message, oldAddress, forwardingAddress, failedOperation, exc);
+                        if (rejectMessages)
+                        {
+                            RejectMessage(message, Message.RejectionTypes.Transient, exc, failedOperation);
+                        }
+                        else
+                        {
+                            TryForwardRequest(message, oldAddress, forwardingAddress, failedOperation, exc);
+                        }
+                        
                     }
                 }
                 ), catalog.SchedulingContext);

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -219,7 +219,7 @@ namespace Orleans.Runtime
             {
                 var str = String.Format("{0} {1}", rejectInfo ?? "", exc == null ? "" : exc.ToString());
                 MessagingStatisticsGroup.OnRejectedMessage(message);
-                Message rejection = this.messagefactory.CreateRejectionResponse(message, rejectType, str, exc as OrleansException);
+                Message rejection = this.messagefactory.CreateRejectionResponse(message, rejectType, str, exc);
                 SendRejectionMessage(rejection);
             }
             else

--- a/test/DefaultCluster.Tests/BasicActivationTests.cs
+++ b/test/DefaultCluster.Tests/BasicActivationTests.cs
@@ -67,7 +67,7 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate"), TestCategory("ErrorHandling"), TestCategory("GetGrain")]
-        public void BasicActivation_Fail()
+        public async Task BasicActivation_Fail()
         {
             bool failed;
             long key = 0;
@@ -75,12 +75,11 @@ namespace DefaultCluster.Tests.General
             {
                 // Key values of -2 are not allowed in this case
                 ITestGrain fail = this.GrainFactory.GetGrain<ITestGrain>(-2);
-                key = fail.GetKey().Result;
+                key = await fail.GetKey();
                 failed = false;
             }
-            catch (Exception e)
+            catch (ArgumentException e)
             {
-                Assert.IsAssignableFrom<OrleansException>(e.GetBaseException()) ;
                 failed = true;
             }
 

--- a/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
+++ b/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
@@ -164,11 +164,9 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
 
                 Assert.True(false, "Expected ThrowSomething call to fail as unable to Activate grain");
             }
-            catch (OrleansGrainActivationFailedException exc)
+            catch (ApplicationException exc)
             {
-                Assert.NotNull(exc.InnerException);
-                Assert.IsType<ApplicationException>(exc.InnerException);
-                Assert.Contains("Application-OnActivateAsync", exc.InnerException.Message);
+                Assert.Contains("Application-OnActivateAsync", exc.Message);
             }
         }
 
@@ -184,11 +182,9 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
 
                 Assert.True(false, "Expected ThrowSomething call to fail as unable to Activate grain, but returned " + key);
             }
-            catch (OrleansGrainActivationFailedException exc)
+            catch (ApplicationException exc)
             {
-                Assert.NotNull(exc.InnerException);
-                Assert.IsType<ApplicationException>(exc.InnerException);
-                Assert.Contains("Application-OnActivateAsync", exc.InnerException.Message);
+                Assert.Contains("Application-OnActivateAsync", exc.Message);
             }
         }
 
@@ -204,11 +200,9 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
 
                 Assert.True(false, "Expected ThrowSomething call to fail as unable to Activate grain");
             }
-            catch (OrleansGrainActivationFailedException exc)
+            catch (ApplicationException exc)
             {
-                Assert.NotNull(exc.InnerException);
-                Assert.IsType<ApplicationException>(exc.InnerException);
-                Assert.Contains("Application-OnActivateAsync", exc.InnerException.Message);
+                Assert.Contains("Application-OnActivateAsync", exc.Message);
             }
         }
 
@@ -272,12 +266,12 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
                 string activation = await grain.DoSomething();
                 Assert.True(false, "Should have thrown.");
             }
-            catch(Exception exc)
+            catch(InvalidOperationException exc)
             {
                 this.Logger.Info("Thrown as expected:", exc);
-                Exception e = exc.GetBaseException();
-                Assert.True(e.Message.Contains("Forwarding failed"),
-                        "Did not get expected exception message returned: " + e.Message);
+                Assert.True(
+                    exc.Message.Contains("DeactivateOnIdle from within OnActivateAsync"),
+                    "Did not get expected exception message returned: " + exc.Message);
             }  
         }
 

--- a/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
+++ b/test/DefaultCluster.Tests/GrainActivateDeactivateTests.cs
@@ -164,11 +164,12 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
 
                 Assert.True(false, "Expected ThrowSomething call to fail as unable to Activate grain");
             }
-            catch (Exception exc)
+            catch (OrleansGrainActivationFailedException exc)
             {
-                AssertIsNotInvalidOperationException(exc, "Application-OnActivateAsync");
+                Assert.NotNull(exc.InnerException);
+                Assert.IsType<ApplicationException>(exc.InnerException);
+                Assert.Contains("Application-OnActivateAsync", exc.InnerException.Message);
             }
-            
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("ActivateDeactivate")]
@@ -183,9 +184,11 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
 
                 Assert.True(false, "Expected ThrowSomething call to fail as unable to Activate grain, but returned " + key);
             }
-            catch (Exception exc)
+            catch (OrleansGrainActivationFailedException exc)
             {
-                AssertIsNotInvalidOperationException(exc, "Application-OnActivateAsync");
+                Assert.NotNull(exc.InnerException);
+                Assert.IsType<ApplicationException>(exc.InnerException);
+                Assert.Contains("Application-OnActivateAsync", exc.InnerException.Message);
             }
         }
 
@@ -201,9 +204,11 @@ namespace DefaultCluster.Tests.ActivationsLifeCycleTests
 
                 Assert.True(false, "Expected ThrowSomething call to fail as unable to Activate grain");
             }
-            catch (Exception exc)
+            catch (OrleansGrainActivationFailedException exc)
             {
-                AssertIsNotInvalidOperationException(exc, "Application-OnActivateAsync");
+                Assert.NotNull(exc.InnerException);
+                Assert.IsType<ApplicationException>(exc.InnerException);
+                Assert.Contains("Application-OnActivateAsync", exc.InnerException.Message);
             }
         }
 

--- a/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
+++ b/test/TesterInternal/StorageTests/PersistenceGrainTests.cs
@@ -179,7 +179,7 @@ namespace UnitTests.StorageTests
 
             SetErrorInjection(providerName, ErrorInjectionPoint.BeforeRead);
 
-            await Assert.ThrowsAsync<OrleansMessageRejectionException>(() =>
+            await Assert.ThrowsAsync<StorageProviderInjectedError>(() =>
                 grain.GetValue());
         }
 

--- a/test/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
+++ b/test/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
@@ -74,7 +74,7 @@ namespace UnitTests.StreamingTests
             SetErrorInjection(PubSubStoreProviderName, ErrorInjectionPoint.BeforeRead);
 
             // TODO: expect StorageProviderInjectedError directly instead of OrleansException
-            await Assert.ThrowsAsync<OrleansMessageRejectionException>(() =>
+            await Assert.ThrowsAsync<StorageProviderInjectedError>(() =>
                 Test_PubSub_Stream(StreamProviderName, StreamId));
         }
 


### PR DESCRIPTION
Fixes #3213

* Failures in `OnActivateAsync` will be propagated directly back to the caller.
* Calls will be retried up to `IMessagingConfiguration.MaxResendCount` times (default is 0) because the rejection is marked as `Transient`.
* Other message rejections which include an exception will also be propagated directly back to the caller, but this doesn't seem undesirable. The difference is that previously the exception would be discarded in favor of a generic exception (`OrleansMessageRejectionException`) which typically contained the original exception's `Message` in its `Message` property.