### PR TITLE
Update all xUnit related packages to the latest stable release

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="FSharp.Compiler.Tools" version="4.1.17" />
   <package id="Google.Protobuf.Tools" version="3.0.0" />
-  <package id="xunit.runner.console" version="2.1.0" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" />
+  <package id="xunit.runner.console" version="2.2.0" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" />
 </packages>

--- a/test/AWSUtils.Tests/project.json
+++ b/test/AWSUtils.Tests/project.json
@@ -3,9 +3,9 @@
     "AWSSDK.DynamoDBv2": "3.1.5.2",
     "AWSSDK.SQS": "3.1.0.9",
     "FluentAssertions": "4.18.0",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/Benchmarks/Benchmarks/project.json
+++ b/test/Benchmarks/Benchmarks/project.json
@@ -3,7 +3,7 @@
     "BenchmarkDotNet": "0.9.9",
     "BenchmarkDotNet.Diagnostics.Windows": "0.9.9",
     "BenchmarkDotNet.Toolchains.Roslyn": "0.9.9",
-    "xunit.extensibility.core": "2.1.0"
+    "xunit.extensibility.core": "2.2.0"
   },
   "frameworks": {
     "net461": {}

--- a/test/BondUtils.Tests/project.json
+++ b/test/BondUtils.Tests/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
     "FluentAssertions": "4.18.0",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/Consul.Tests/project.json
+++ b/test/Consul.Tests/project.json
@@ -2,9 +2,9 @@
   "dependencies": {
     "FluentAssertions": "4.18.0",
     "System.Net.Http": "4.3.0",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/DefaultCluster.Tests/project.json
+++ b/test/DefaultCluster.Tests/project.json
@@ -2,9 +2,9 @@
   "dependencies": {
     "FluentAssertions": "4.18.0",
     "Microsoft.Extensions.Options": "1.1.2",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/GoogleUtils.Tests/project.json
+++ b/test/GoogleUtils.Tests/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
     "FluentAssertions": "4.18.0",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/PSUtils.Tests/project.json
+++ b/test/PSUtils.Tests/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
     "FluentAssertions": "4.18.0",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/ServiceBus.Tests/project.json
+++ b/test/ServiceBus.Tests/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
     "FluentAssertions": "4.18.0",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/TestExtensions/project.json
+++ b/test/TestExtensions/project.json
@@ -2,10 +2,10 @@
   "dependencies": {
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.1",
     "Microsoft.Extensions.Configuration.Json": "1.1.1",
-    "xunit.abstractions": "2.0.0",
-    "xunit.core": "2.1.0",
-    "xunit.extensibility.core": "2.1.0",
-    "xunit.extensibility.execution": "2.1.0"
+    "xunit.abstractions": "2.0.1",
+    "xunit.core": "2.2.0",
+    "xunit.extensibility.core": "2.2.0",
+    "xunit.extensibility.execution": "2.2.0"
   },
   "frameworks": {
     "net461": {}

--- a/test/TestFSharp/TestFSharp.fsproj
+++ b/test/TestFSharp/TestFSharp.fsproj
@@ -36,10 +36,10 @@
   <!--BEGIN: Workaround allowing the use of the FSharp.Compiler.Tools package from within Visual Studio-->
   <Choose>
     <When Condition="Exists('..\..\src\packages\FSharp.Compiler.Tools.4.1.17\tools\Microsoft.FSharp.Targets')">
-  <PropertyGroup>
+      <PropertyGroup>
         <FSharpTargets>..\..\src\packages\FSharp.Compiler.Tools.4.1.17\tools\Microsoft.FSharp.Targets</FSharpTargets>
         <PackagesRestored>true</PackagesRestored>
-  </PropertyGroup>
+      </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
@@ -82,8 +82,18 @@
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console">
+      <HintPath>..\..\src\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Threading.Thread">
+      <HintPath>..\..\src\packages\System.Threading.Thread.4.0.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.ThreadPool">
+      <HintPath>..\..\src\packages\System.Threading.ThreadPool.4.0.10\lib\net46\System.Threading.ThreadPool.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <!--END: Workaround allowing the use of the FSharp.Compiler.Tools package from within Visual Studio-->
 </Project>

--- a/test/TestFSharp/packages.config
+++ b/test/TestFSharp/packages.config
@@ -2,4 +2,27 @@
 <packages>
   <package id="FSharp.Compiler.Tools" version="4.1.17" targetFramework="net461" />
   <package id="FSharp.Core" version="4.1.17" targetFramework="net461" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net461" />
+  <package id="System.Console" version="4.0.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net461" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net461" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net461" />
+  <package id="System.IO" version="4.1.0" targetFramework="net461" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net461" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Linq.Queryable" version="4.0.1" targetFramework="net461" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net461" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net461" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net461" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net461" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net461" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net461" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net461" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Parallel" version="4.0.1" targetFramework="net461" />
+  <package id="System.Threading.Thread" version="4.0.0" targetFramework="net461" />
+  <package id="System.Threading.ThreadPool" version="4.0.10" targetFramework="net461" />
+  <package id="System.Threading.Timer" version="4.0.1" targetFramework="net461" />
 </packages>

--- a/test/TestFSharpInterfaces/TestFSharpInterfaces.fsproj
+++ b/test/TestFSharpInterfaces/TestFSharpInterfaces.fsproj
@@ -72,8 +72,18 @@
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console">
+      <HintPath>..\..\src\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Threading.Thread">
+      <HintPath>..\..\src\packages\System.Threading.Thread.4.0.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.ThreadPool">
+      <HintPath>..\..\src\packages\System.Threading.ThreadPool.4.0.10\lib\net46\System.Threading.ThreadPool.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <!--END: Workaround allowing the use of the FSharp.Compiler.Tools package from within Visual Studio-->
 </Project>

--- a/test/TestFSharpInterfaces/packages.config
+++ b/test/TestFSharpInterfaces/packages.config
@@ -2,4 +2,27 @@
 <packages>
   <package id="FSharp.Compiler.Tools" version="4.1.17" targetFramework="net461" />
   <package id="FSharp.Core" version="4.1.17" targetFramework="net461" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net461" />
+  <package id="System.Console" version="4.0.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net461" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net461" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net461" />
+  <package id="System.IO" version="4.1.0" targetFramework="net461" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net461" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Linq.Queryable" version="4.0.1" targetFramework="net461" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net461" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net461" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net461" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net461" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net461" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net461" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net461" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Parallel" version="4.0.1" targetFramework="net461" />
+  <package id="System.Threading.Thread" version="4.0.0" targetFramework="net461" />
+  <package id="System.Threading.ThreadPool" version="4.0.10" targetFramework="net461" />
+  <package id="System.Threading.Timer" version="4.0.1" targetFramework="net461" />
 </packages>

--- a/test/TestInternalGrains/project.json
+++ b/test/TestInternalGrains/project.json
@@ -1,6 +1,6 @@
-{
+﻿{
   "dependencies": {
-    "xunit.assert": "2.1.0"
+    "xunit.assert": "2.2.0"
   },
   "frameworks": {
     "net461": {}

--- a/test/TestServiceFabric/project.json
+++ b/test/TestServiceFabric/project.json
@@ -4,7 +4,7 @@
     "Microsoft.ServiceFabric.Services": "2.4.145",
     "NSubstitute": "1.10.0",
     "System.Runtime.Numerics": "4.3.0",
-    "xunit": "2.1.0"
+    "xunit": "2.2.0"
   },
   "frameworks": {
     "net461": {}

--- a/test/Tester/project.json
+++ b/test/Tester/project.json
@@ -5,9 +5,9 @@
     "Microsoft.Extensions.Configuration.Json": "1.1.1",
     "Microsoft.Extensions.Options": "1.1.2",
     "Newtonsoft.Json": "10.0.3",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/TesterAzureUtils/project.json
+++ b/test/TesterAzureUtils/project.json
@@ -2,9 +2,9 @@
   "dependencies": {
     "FluentAssertions": "4.18.0",
     "Newtonsoft.Json": "10.0.3",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/TesterInternal/project.json
+++ b/test/TesterInternal/project.json
@@ -1,8 +1,8 @@
-{
+﻿{
   "dependencies": {
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/TesterSQLUtils/project.json
+++ b/test/TesterSQLUtils/project.json
@@ -6,9 +6,9 @@
     "Newtonsoft.Json": "10.0.3",
     "Npgsql": "3.1.9",
     "system.data.sqlclient": "4.3.0",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}

--- a/test/TesterZooKeeperUtils/project.json
+++ b/test/TesterZooKeeperUtils/project.json
@@ -2,9 +2,9 @@
   "dependencies": {
     "FluentAssertions": "4.18.0",
     "Newtonsoft.Json": "10.0.3",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0",
-    "Xunit.SkippableFact": "1.2.14"
+    "xunit": "2.2.0",
+    "xunit.runner.visualstudio": "2.2.0",
+    "Xunit.SkippableFact": "1.3.3"
   },
   "frameworks": {
     "net461": {}


### PR DESCRIPTION
Looks like test discovery was finding a lot less tests that it should, when using xunit.testrunner.console in our CI builds.
Specifically, non of the SkippableFact tests were being found