### PR TITLE
Update A-Service-is-a-Collection-of-Communicating-Actors.md

### DIFF
--- a/src/Tutorials/A-Service-is-a-Collection-of-Communicating-Actors.md
+++ b/src/Tutorials/A-Service-is-a-Collection-of-Communicating-Actors.md
@@ -187,7 +187,7 @@ public class Employee : Grain, Interfaces.IEmployee
 and
 
 ``` csharp
-public class Manager : Employee, IManager
+public class Manager : Grain, IManager
 {
     public Task AddDirectReport(IEmployee employee)
     {


### PR DESCRIPTION
It was mentioned " we're choosing to not rely on inheritance when defining the `Manager` class, even though a `Manager` is clearly also an `Employee`." but Manager is inherited from Employee later on.