### PR TITLE
Add code generation to OrleansServiceBus

### DIFF
--- a/src/OrleansServiceBus/OrleansServiceBus.csproj
+++ b/src/OrleansServiceBus/OrleansServiceBus.csproj
@@ -119,4 +119,24 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <!-- Begin Orleans: Without these lines the project won't build properly -->
+  <PropertyGroup>
+    <OrleansProjectType>Server</OrleansProjectType>
+  </PropertyGroup>
+  <!-- Set path to ClientGenerator.exe -->
+  <Choose>
+    <When Condition="'$(builduri)' != ''">
+      <PropertyGroup>
+        <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
 </Project>

--- a/src/OrleansServiceBus/Properties/AssemblyInfo.cs
+++ b/src/OrleansServiceBus/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Orleans.CodeGeneration;
+using Orleans.ServiceBus.Providers;
 
 #if !EXCLUDE_ASSEMBLYINFO // TODO remove after source tree merge
 
@@ -22,3 +24,4 @@ using System.Runtime.InteropServices;
 #endif
 
 [assembly: InternalsVisibleTo("ServiceBus.Tests")]
+[assembly: KnownAssembly(typeof(EventHubSequenceTokenV2), TreatTypesAsSerializable = true)]

--- a/test/NonSilo.Tests/NonSilo.Tests.csproj
+++ b/test/NonSilo.Tests/NonSilo.Tests.csproj
@@ -180,10 +180,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\OrleansCodeGenerator\OrleansCodeGenerator.csproj">
-      <Project>{8d937706-f6da-4d33-b0a9-24a260bd3080}</Project>
-      <Name>OrleansCodeGenerator</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\OrleansProviders\OrleansProviders.csproj">
       <Project>{0054db14-2a92-4cc0-959e-a2c51f5e65d4}</Project>
       <Name>OrleansProviders</Name>
@@ -191,6 +187,10 @@
     <ProjectReference Include="..\..\src\OrleansRuntime\OrleansRuntime.csproj">
       <Project>{6ff2004c-cdf8-479c-bf27-c6bfe8ef93e0}</Project>
       <Name>OrleansRuntime</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\OrleansServiceBus\OrleansServiceBus.csproj">
+      <Project>{8bff0092-15d2-4425-80c0-29e381702f2b}</Project>
+      <Name>OrleansServiceBus</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\OrleansTestingHost\OrleansTestingHost.csproj">
       <Project>{40ee3b00-d381-485f-9c69-ff706837deed}</Project>

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -13,6 +13,7 @@ using Orleans.Concurrency;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
@@ -117,7 +118,7 @@ namespace UnitTests.Serialization
         [Fact, TestCategory("BVT"), TestCategory("Serialization"), TestCategory("CodeGen")]
         public void InternalSerializableTypesHaveSerializers()
         {
-            var environment = InitializeSerializer(SerializerToUse.Default);
+            var environment = InitializeSerializer(SerializerToUse.NoFallback);
             Assert.True(
                 environment.SerializationManager.HasSerializer(typeof(AddressesAndTag)),
                 $"Should be able to serialize internal type {nameof(AddressesAndTag)}.");
@@ -133,6 +134,12 @@ namespace UnitTests.Serialization
             Assert.True(
                 environment.SerializationManager.HasSerializer(typeof(PubSubGrainState)),
                 $"Should be able to serialize internal type {nameof(PubSubGrainState)}.");
+            Assert.True(
+                environment.SerializationManager.HasSerializer(typeof(EventHubBatchContainer)),
+                $"Should be able to serialize internal type {nameof(EventHubBatchContainer)}.");
+            Assert.True(
+                environment.SerializationManager.HasSerializer(typeof(EventHubSequenceTokenV2)),
+                $"Should be able to serialize internal type {nameof(EventHubSequenceTokenV2)}.");
         }
 
         [Theory, TestCategory("BVT"), TestCategory("Serialization")]


### PR DESCRIPTION
Note: this is targeted for the 1.5.1 branch. If committed, separate PR will be made for master (since these are mostly csproj changes and they've diverged). Does that sound fine?

This issue was discovered during ad-hoc testing. No code is generated for the OrleanServiceBus dll, causing serialization exceptions in cases where `OrleansCodeGenerator.dll` is not present at runtime.

This adds build-time code generation to OrleansServiceBus and a test to ensure that code is being generated.