### PR TITLE
Support custom DI container in ClientBuilder and unify with SiloBuilder

### DIFF
--- a/src/Orleans/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans/Core/ClientBuilderExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.CodeGeneration;
+using Orleans.Hosting;
 using Orleans.Runtime.Configuration;
 
 namespace Orleans
@@ -102,6 +103,17 @@ namespace Orleans
         public static IClientBuilder AddClusterConnectionLostHandler(this IClientBuilder builder, ConnectionToClusterLostHandler handler)
         {
             builder.ConfigureServices(services => services.AddSingleton(handler));
+            return builder;
+        }
+
+        /// <summary>
+        /// Specifies how the <see cref="IServiceProvider"/> for this client is configured. 
+        /// </summary>
+        /// <param name="factory">The service provider factory.</param>
+        /// <returns>The builder.</returns>
+        public static IClientBuilder UseServiceProviderFactory(this IClientBuilder builder, Func<IServiceCollection, IServiceProvider> factory)
+        {
+            builder.UseServiceProviderFactory(new DelegateServiceProviderFactory(factory));
             return builder;
         }
     }

--- a/src/Orleans/Core/IClientBuilder.cs
+++ b/src/Orleans/Core/IClientBuilder.cs
@@ -30,5 +30,19 @@ namespace Orleans
         /// <remarks>This method may only be called once per builder instance.</remarks>
         /// <returns>The builder.</returns>
         IClientBuilder UseConfiguration(ClientConfiguration configuration);
+
+        /// <summary>
+        /// Specifies how the <see cref="IServiceProvider"/> for this client is configured. 
+        /// </summary>
+        /// <param name="factory">The service provider factory.</param>
+        /// <returns>The builder.</returns>
+        IClientBuilder UseServiceProviderFactory<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory);
+
+        /// <summary>
+        /// Adds a container configuration delegate.
+        /// </summary>
+        /// <typeparam name="TContainerBuilder">The container builder type.</typeparam>
+        /// <param name="configureContainer">The container builder configuration delegate.</param>
+        IClientBuilder ConfigureContainer<TContainerBuilder>(Action<TContainerBuilder> configureContainer);
     }
 }

--- a/src/Orleans/Hosting/DelegateServiceProviderFactory.cs
+++ b/src/Orleans/Hosting/DelegateServiceProviderFactory.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans.Runtime.Hosting
+namespace Orleans.Hosting
 {
     internal class DelegateServiceProviderFactory : IServiceProviderFactory<IServiceCollection>
     {

--- a/src/Orleans/Hosting/IServiceProviderFactoryAdapter.cs
+++ b/src/Orleans/Hosting/IServiceProviderFactoryAdapter.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans.Runtime.Hosting
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Common interface for <see cref="IServiceProviderFactory{TContainerBuilder}"/> implementations.

--- a/src/Orleans/Hosting/ServiceProviderBuilder.cs
+++ b/src/Orleans/Hosting/ServiceProviderBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Orleans.Hosting
@@ -29,8 +30,7 @@ namespace Orleans.Hosting
             // If no service provider factory has been specified, set a default.
             if (this.serviceProviderFactory == null)
             {
-                var factory = new DelegateServiceProviderFactory(svc => svc.BuildServiceProvider());
-                this.UseServiceProviderFactory(factory);
+                this.UseDefaultServiceProviderFactory();
             }
 
             // Create the service provider using the configured factory.
@@ -76,6 +76,13 @@ namespace Orleans.Hosting
         {
             if (this.serviceProviderFactory != null) this.serviceProviderFactory.ConfigureContainer(configureContainer);
             else this.configureContainerDelegates.Add(configureContainer);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void UseDefaultServiceProviderFactory()
+        {
+            var factory = new DelegateServiceProviderFactory(svc => svc.BuildServiceProvider());
+            this.UseServiceProviderFactory(factory);
         }
     }
 }

--- a/src/Orleans/Hosting/ServiceProviderBuilder.cs
+++ b/src/Orleans/Hosting/ServiceProviderBuilder.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Functionality for building <see cref="IServiceProvider"/> instances.
+    /// </summary>
+    internal class ServiceProviderBuilder
+    {
+        private readonly List<Action<IServiceCollection>> configureServicesDelegates = new List<Action<IServiceCollection>>();
+        private readonly List<object> configureContainerDelegates = new List<object>();
+        private IServiceProviderFactoryAdapter serviceProviderFactory;
+
+        /// <summary>
+        /// Builds the service provider.
+        /// </summary>
+        /// <returns>The service provider.</returns>
+        public IServiceProvider BuildServiceProvider()
+        {
+            // Configure the container.
+            var services = new ServiceCollection();
+            foreach (var configureServices in this.configureServicesDelegates)
+            {
+                configureServices(services);
+            }
+
+            // If no service provider factory has been specified, set a default.
+            if (this.serviceProviderFactory == null)
+            {
+                var factory = new DelegateServiceProviderFactory(svc => svc.BuildServiceProvider());
+                this.UseServiceProviderFactory(factory);
+            }
+
+            // Create the service provider using the configured factory.
+            return this.serviceProviderFactory.BuildServiceProvider(services);
+        }
+
+        /// <summary>
+        /// Adds a service configuration delegate to the configuration pipeline.
+        /// </summary>
+        /// <param name="configureServices">The service configuration delegate.</param>
+        /// <returns>The builder.</returns>
+        public void ConfigureServices(Action<IServiceCollection> configureServices)
+        {
+            if (configureServices == null) throw new ArgumentNullException(nameof(configureServices));
+            this.configureServicesDelegates.Add(configureServices);
+        }
+
+        /// <summary>
+        /// Specifies how the <see cref="IServiceProvider"/> is configured. 
+        /// </summary>
+        /// <param name="factory">The service provider factory.</param>
+        /// <returns>The builder.</returns>
+        public void UseServiceProviderFactory<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory)
+        {
+            if (this.serviceProviderFactory != null)
+                throw new InvalidOperationException("The service provider factory has already been specified.");
+            this.serviceProviderFactory = new ServiceProviderFactoryAdapter<TContainerBuilder>(factory);
+            foreach (var builder in this.configureContainerDelegates)
+            {
+                var typedDelegate = (Action<TContainerBuilder>)builder;
+                this.serviceProviderFactory.ConfigureContainer(typedDelegate);
+            }
+
+            this.configureContainerDelegates.Clear();
+        }
+
+        /// <summary>
+        /// Adds a container configuration delegate.
+        /// </summary>
+        /// <typeparam name="TContainerBuilder">The container builder type.</typeparam>
+        /// <param name="configureContainer">The container builder configuration delegate.</param>
+        public void ConfigureContainer<TContainerBuilder>(Action<TContainerBuilder> configureContainer)
+        {
+            if (this.serviceProviderFactory != null) this.serviceProviderFactory.ConfigureContainer(configureContainer);
+            else this.configureContainerDelegates.Add(configureContainer);
+        }
+    }
+}

--- a/src/Orleans/Hosting/ServiceProviderFactoryAdapter.cs
+++ b/src/Orleans/Hosting/ServiceProviderFactoryAdapter.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans.Runtime.Hosting
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Adapts an <see cref="IServiceProviderFactory{TContainerBuilder}"/> into an <see cref="IServiceProviderFactoryAdapter"/>.

--- a/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
+++ b/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.CodeGeneration;
@@ -28,9 +27,10 @@ using Orleans.Versions;
 using Orleans.Versions.Compatibility;
 using Orleans.Versions.Selector;
 using Orleans.Providers;
+using Orleans.Runtime;
 using Orleans.Runtime.Storage;
 
-namespace Orleans.Runtime.Hosting
+namespace Orleans.Hosting
 {
     internal static class DefaultSiloServices
     {

--- a/src/OrleansRuntime/Hosting/ISilo.cs
+++ b/src/OrleansRuntime/Hosting/ISilo.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Orleans.Runtime.Hosting
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Represents a silo instance.

--- a/src/OrleansRuntime/Hosting/ISiloBuilder.cs
+++ b/src/OrleansRuntime/Hosting/ISiloBuilder.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Orleans.Runtime.Hosting
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Functionality for building <see cref="ISilo"/> instances.

--- a/src/OrleansRuntime/Hosting/SiloBuilder.cs
+++ b/src/OrleansRuntime/Hosting/SiloBuilder.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Orleans.Hosting;
+using Orleans.Runtime;
 
-namespace Orleans.Runtime.Hosting
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Functionality for building <see cref="ISilo"/> instances.

--- a/src/OrleansRuntime/Hosting/SiloBuilderExtensions.cs
+++ b/src/OrleansRuntime/Hosting/SiloBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Hosting;
 using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.Hosting

--- a/src/OrleansRuntime/Hosting/SiloBuilderExtensions.cs
+++ b/src/OrleansRuntime/Hosting/SiloBuilderExtensions.cs
@@ -1,9 +1,9 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Hosting;
+using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 
-namespace Orleans.Runtime.Hosting
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Extensions for <see cref="ISiloBuilder"/> instances.

--- a/src/OrleansRuntime/Hosting/SiloWrapper.cs
+++ b/src/OrleansRuntime/Hosting/SiloWrapper.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Runtime;
 
-namespace Orleans.Runtime.Hosting
+namespace Orleans.Hosting
 {
     internal class SiloWrapper : ISilo
     {

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 #if NETSTANDARD
 using System.Reflection;
 #endif
@@ -14,6 +15,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.CodeGeneration;
 using Orleans.Core;
+using Orleans.Hosting;
 using Orleans.LogConsistency;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
@@ -31,7 +33,6 @@ using Orleans.Runtime.TestHooks;
 using Orleans.Services;
 using Orleans.Storage;
 using Orleans.Streams;
-using Orleans.Runtime.Hosting;
 using Orleans.Runtime.Versions;
 using Orleans.Versions;
 


### PR DESCRIPTION
* ClientBuilder supports custom containers in the same fashion as SiloBuilder
* Extracted common logic from ClientBuilder and SiloBuilder into internal ServiceProviderBuilder
* ClientBuilder adds its default services after the user-configured services. Default services are only added if the user did not configure an implementation for a given service (using TryAdd*) - this unifies it with SiloBuilder