### PR TITLE
[Abstractions] Remove dependency from Serialization in UniqueKey

### DIFF
--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -29,6 +29,24 @@ namespace UnitTests.General
             this.environment = fixture;
         }
 
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
+        public void UniqueKeyToByteArray()
+        {
+            var key = UniqueKey.NewKey(Guid.NewGuid(), category: UniqueKey.Category.KeyExtGrain, keyExt: "hello world");
+
+            var result = key.ToByteArray();
+
+            var sw = new BinaryTokenStreamWriter();
+            sw.Write(key);
+            var expected = sw.ToByteArray();
+
+            Assert.Equal(expected.Length, result.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], result[i]);
+            }
+        }
+
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void ID_IsSystem()
         {


### PR DESCRIPTION
Since this is a potentially dangerous change, please review this CR carefully.

~~This PR will consist of 2 commits:~~

- the first will remove the dependency to serialization in `UniqueKey` by duplicating the existing logic from `BinaryTokenStreamWriter.Write(UniqueKey key)`. I added a test to check that the value returned by the new method is consistent with the previous method.
- ~~the second (to come after this first commit pass the build) will remove the code duplication in `BinaryTokenStreamWriter` by calling the method added in the first commit.~~

~~Basically this will "invert" the dependency.~~

After thoughts, I don't think we should to the 2nd commit, since they are not supposed to share the same logic after all. But I will keep the test to show that the value used for the hash is consistent with the previous method.