### PR TITLE
Hosted Client

### DIFF
--- a/src/Orleans.Core/Runtime/IRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/IRuntimeClient.cs
@@ -51,6 +51,8 @@ namespace Orleans.Runtime
 
         void SendRequest(GrainReference target, InvokeMethodRequest request, TaskCompletionSource<object> context, Action<Message, TaskCompletionSource<object>> callback, string debugContext = null, InvokeMethodOptions options = InvokeMethodOptions.None, string genericArguments = null);
 
+        void SendResponse(Message request, Response response);
+
         void ReceiveResponse(Message message);
 
         void Reset(bool cleanup);

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans.CodeGeneration;
+using Orleans.Runtime;
+using Orleans.Serialization;
+
+namespace Orleans
+{
+    internal class InvokableObjectManager : IDisposable
+    {
+        private readonly CancellationTokenSource disposed = new CancellationTokenSource();
+        private readonly ConcurrentDictionary<GuidId, LocalObjectData> localObjects = new ConcurrentDictionary<GuidId, LocalObjectData>();
+        private readonly IRuntimeClient runtimeClient;
+        private readonly ILogger logger;
+        private readonly SerializationManager serializationManager;
+        private readonly Func<object, Task> dispatchFunc;
+
+        public InvokableObjectManager(IRuntimeClient runtimeClient, SerializationManager serializationManager, ILogger<InvokableObjectManager> logger)
+        {
+            this.runtimeClient = runtimeClient;
+            this.serializationManager = serializationManager;
+            this.logger = logger;
+
+            this.dispatchFunc = o =>
+                this.LocalObjectMessagePumpAsync((LocalObjectData) o);
+        }
+
+        public bool TryRegister(IAddressable obj, GuidId objectId, IGrainMethodInvoker invoker)
+        {
+            return this.localObjects.TryAdd(objectId, new LocalObjectData(obj, objectId, invoker));
+        }
+
+        public bool TryDeregister(GuidId objectId)
+        {
+            return this.localObjects.TryRemove(objectId, out LocalObjectData ignored);
+        }
+
+        public void Dispatch(Message message)
+        {
+            GuidId observerId = message.TargetObserverId;
+            if (observerId == null)
+            {
+                this.logger.Error(
+                    ErrorCode.ProxyClient_OGC_TargetNotFound_2,
+                    string.Format("Did not find TargetObserverId header in the message = {0}. A request message to a client is expected to have an observerId.", message));
+                return;
+            }
+
+            if (this.localObjects.TryGetValue(observerId, out var objectData))
+            {
+                this.Invoke(objectData, message);
+            }
+            else
+            {
+                this.logger.Error(
+                    ErrorCode.ProxyClient_OGC_TargetNotFound,
+                    String.Format(
+                        "Unexpected target grain in request: {0}. Message={1}",
+                        message.TargetGrain,
+                        message));
+            }
+        }
+
+        private void Invoke(LocalObjectData objectData, Message message)
+        {
+            var obj = (IAddressable)objectData.LocalObject.Target;
+            if (obj == null)
+            {
+                //// Remove from the dictionary record for the garbage collected object? But now we won't be able to detect invalid dispatch IDs anymore.
+                this.logger.Warn(
+                    ErrorCode.Runtime_Error_100162,
+                    string.Format(
+                        "Object associated with Observer ID {0} has been garbage collected. Deleting object reference and unregistering it. Message = {1}",
+                        objectData.ObserverId,
+                        message));
+                
+                // Try to remove. If it's not there, we don't care.
+                this.TryDeregister(objectData.ObserverId);
+                return;
+            }
+
+            bool start;
+            lock (objectData.Messages)
+            {
+                objectData.Messages.Enqueue(message);
+                start = !objectData.Running;
+                objectData.Running = true;
+            }
+
+            if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace($"InvokeLocalObjectAsync {message} start {start}");
+
+            if (start)
+            {
+                // we want to ensure that the message pump operates asynchronously
+                // with respect to the current thread. see
+                // http://channel9.msdn.com/Events/TechEd/Europe/2013/DEV-B317#fbid=aIWUq0ssW74
+                // at position 54:45.
+                //
+                // according to the information posted at:
+                // http://stackoverflow.com/questions/12245935/is-task-factory-startnew-guaranteed-to-use-another-thread-than-the-calling-thr
+                // this idiom is dependent upon the a TaskScheduler not implementing the
+                // override QueueTask as task inlining (as opposed to queueing). this seems
+                // implausible to the author, since none of the .NET schedulers do this and
+                // it is considered bad form (the OrleansTaskScheduler does not do this).
+                //
+                // if, for some reason this doesn't hold true, we can guarantee what we
+                // want by passing a placeholder continuation token into Task.StartNew()
+                // instead. i.e.:
+                //
+                // return Task.StartNew(() => ..., new CancellationToken());
+                // We pass these options to Task.Factory.StartNew as they make the call identical
+                // to Task.Run. See: https://blogs.msdn.microsoft.com/pfxteam/2011/10/24/task-run-vs-task-factory-startnew/
+                Task.Factory.StartNew(
+                    this.dispatchFunc,
+                    objectData,
+                    this.disposed.Token,
+                    TaskCreationOptions.DenyChildAttach,
+                    TaskScheduler.Default).Ignore();
+            }
+        }
+
+        private async Task LocalObjectMessagePumpAsync(LocalObjectData objectData)
+        {
+            while (true)
+            {
+                try
+                {
+                    Message message;
+                    lock (objectData.Messages)
+                    {
+                        if (objectData.Messages.Count == 0)
+                        {
+                            objectData.Running = false;
+                            break;
+                        }
+
+                        message = objectData.Messages.Dequeue();
+                    }
+
+                    if (ExpireMessageIfExpired(message, MessagingStatisticsGroup.Phase.Invoke))
+                        continue;
+
+                    RequestContextExtensions.Import(message.RequestContextData);
+                    var request = (InvokeMethodRequest)message.GetDeserializedBody(this.serializationManager);
+                    var targetOb = (IAddressable)objectData.LocalObject.Target;
+                    object resultObject = null;
+                    Exception caught = null;
+                    try
+                    {
+                        // exceptions thrown within this scope are not considered to be thrown from user code
+                        // and not from runtime code.
+                        var resultPromise = objectData.Invoker.Invoke(targetOb, request);
+                        if (resultPromise != null) // it will be null for one way messages
+                        {
+                            resultObject = await resultPromise;
+                        }
+                    }
+                    catch (Exception exc)
+                    {
+                        // the exception needs to be reported in the log or propagated back to the caller.
+                        caught = exc;
+                    }
+
+                    if (caught != null)
+                        this.ReportException(message, caught);
+                    else if (message.Direction != Message.Directions.OneWay)
+                        this.SendResponseAsync(message, resultObject);
+                }
+                catch (Exception)
+                {
+                    // ignore, keep looping.
+                }
+            }
+        }
+
+        private static bool ExpireMessageIfExpired(Message message, MessagingStatisticsGroup.Phase phase)
+        {
+            if (message.IsExpired)
+            {
+                message.DropExpiredMessage(phase);
+                return true;
+            }
+
+            return false;
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        private void SendResponseAsync(Message message, object resultObject)
+        {
+            if (ExpireMessageIfExpired(message, MessagingStatisticsGroup.Phase.Respond))
+            {
+                return;
+            }
+
+            object deepCopy;
+            try
+            {
+                // we're expected to notify the caller if the deep copy failed.
+                deepCopy = this.serializationManager.DeepCopy(resultObject);
+            }
+            catch (Exception exc2)
+            {
+                this.runtimeClient.SendResponse(message, Response.ExceptionResponse(exc2));
+                this.logger.Warn(
+                    ErrorCode.ProxyClient_OGC_SendResponseFailed,
+                    "Exception trying to send a response.",
+                    exc2);
+                return;
+            }
+
+            // the deep-copy succeeded.
+            this.runtimeClient.SendResponse(message, new Response(deepCopy));
+            return;
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        private void ReportException(Message message, Exception exception)
+        {
+            var request = (InvokeMethodRequest)message.GetDeserializedBody(this.serializationManager);
+            switch (message.Direction)
+            {
+                case Message.Directions.OneWay:
+                {
+                    this.logger.Error(
+                        ErrorCode.ProxyClient_OGC_UnhandledExceptionInOneWayInvoke,
+                        String.Format(
+                            "Exception during invocation of notification method {0}, interface {1}. Ignoring exception because this is a one way request.",
+                            request.MethodId,
+                            request.InterfaceId),
+                        exception);
+                    break;
+                }
+
+                case Message.Directions.Request:
+                {
+                    Exception deepCopy = null;
+                    try
+                    {
+                        // we're expected to notify the caller if the deep copy failed.
+                        deepCopy = (Exception)this.serializationManager.DeepCopy(exception);
+                    }
+                    catch (Exception ex2)
+                    {
+                        this.runtimeClient.SendResponse(message, Response.ExceptionResponse(ex2));
+                        this.logger.Warn(
+                            ErrorCode.ProxyClient_OGC_SendExceptionResponseFailed,
+                            "Exception trying to send an exception response", ex2);
+                        return;
+                    }
+                    // the deep-copy succeeded.
+                    var response = Response.ExceptionResponse(deepCopy);
+                    this.runtimeClient.SendResponse(message, response);
+                    break;
+                }
+
+                default:
+                    throw new InvalidOperationException($"Unrecognized direction for message {message}, request {request}, which resulted in exception: {exception}");
+            }
+        }
+
+        public class LocalObjectData
+        {
+            internal WeakReference LocalObject { get; }
+            internal IGrainMethodInvoker Invoker { get; }
+            internal GuidId ObserverId { get; }
+            internal Queue<Message> Messages { get; }
+            internal bool Running { get; set; }
+
+            internal LocalObjectData(IAddressable obj, GuidId observerId, IGrainMethodInvoker invoker)
+            {
+                this.LocalObject = new WeakReference(obj);
+                this.ObserverId = observerId;
+                this.Invoker = invoker;
+                this.Messages = new Queue<Message>();
+                this.Running = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            var tokenSource = this.disposed;
+            Utils.SafeExecute(() => tokenSource?.Cancel(false));
+            Utils.SafeExecute(() => tokenSource?.Dispose());
+        }
+    }
+}

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -114,12 +114,7 @@ namespace Orleans
                 // return Task.StartNew(() => ..., new CancellationToken());
                 // We pass these options to Task.Factory.StartNew as they make the call identical
                 // to Task.Run. See: https://blogs.msdn.microsoft.com/pfxteam/2011/10/24/task-run-vs-task-factory-startnew/
-                Task.Factory.StartNew(
-                    this.dispatchFunc,
-                    objectData,
-                    this.disposed.Token,
-                    TaskCreationOptions.DenyChildAttach,
-                    TaskScheduler.Default).Ignore();
+                Task.Run(async () => await this.LocalObjectMessagePumpAsync(objectData)).Ignore();
             }
         }
 

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -114,7 +114,12 @@ namespace Orleans
                 // return Task.StartNew(() => ..., new CancellationToken());
                 // We pass these options to Task.Factory.StartNew as they make the call identical
                 // to Task.Run. See: https://blogs.msdn.microsoft.com/pfxteam/2011/10/24/task-run-vs-task-factory-startnew/
-                Task.Run(async () => await this.LocalObjectMessagePumpAsync(objectData)).Ignore();
+                Task.Factory.StartNew(
+                        this.dispatchFunc,
+                        objectData,
+                        CancellationToken.None,
+                        TaskCreationOptions.DenyChildAttach,
+                        TaskScheduler.Default).Ignore();
             }
         }
 

--- a/src/Orleans.Core/Runtime/RuntimeContext.cs
+++ b/src/Orleans.Core/Runtime/RuntimeContext.cs
@@ -36,11 +36,6 @@ namespace Orleans.Runtime
             context = new RuntimeContext {Scheduler = scheduler};
         }
 
-        internal static void InitializeMainThread()
-        {
-            context = new RuntimeContext {Scheduler = null};
-        }
-
         internal static void SetExecutionContext(ISchedulingContext shedContext, TaskScheduler scheduler)
         {
             if (context == null) throw new InvalidOperationException("SetExecutionContext called on unexpected non-WorkerPool thread");

--- a/src/Orleans.Core/Runtime/RuntimeContext.cs
+++ b/src/Orleans.Core/Runtime/RuntimeContext.cs
@@ -5,7 +5,6 @@ namespace Orleans.Runtime
 {
     internal class RuntimeContext
     {
-        public TaskScheduler Scheduler { get; private set; }
         public ISchedulingContext ActivationContext { get; private set; }
 
         [ThreadStatic]
@@ -20,7 +19,7 @@ namespace Orleans.Runtime
             get { return RuntimeContext.Current != null ? RuntimeContext.Current.ActivationContext : null; }
         }
 
-        internal static void InitializeThread(TaskScheduler scheduler)
+        internal static void InitializeThread()
         {
             // There seems to be an implicit coupling of threads and contexts here that may be fragile. 
             // E.g. if InitializeThread() is mistakenly called on a wrong thread, would that thread be considered a worker pool thread from that point on? 
@@ -33,27 +32,24 @@ namespace Orleans.Runtime
                 return; 
             }
 
-            context = new RuntimeContext {Scheduler = scheduler};
+            context = new RuntimeContext();
         }
 
-        internal static void SetExecutionContext(ISchedulingContext shedContext, TaskScheduler scheduler)
+        internal static void SetExecutionContext(ISchedulingContext shedContext)
         {
             if (context == null) throw new InvalidOperationException("SetExecutionContext called on unexpected non-WorkerPool thread");
             context.ActivationContext = shedContext;
-            context.Scheduler = scheduler;
         }
 
         internal static void ResetExecutionContext()
         {
             context.ActivationContext = null;
-            context.Scheduler = null;
         }
 
         public override string ToString()
         {
-            return String.Format("RuntimeContext: ActivationContext={0}, Scheduler={1}", 
-                ActivationContext != null ? ActivationContext.ToString() : "null",
-                Scheduler != null ? Scheduler.ToString() : "null");
+            return String.Format("RuntimeContext: ActivationContext={0}", 
+                ActivationContext != null ? ActivationContext.ToString() : "null");
         }
     }
 }

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -165,7 +165,7 @@ namespace Orleans.Runtime
             Utils.SafeExecute(() => this.siloMessageCenter.SetHostedClient(null));
             Utils.SafeExecute(() => this.listeningCts.Cancel(false));
             Utils.SafeExecute(() => this.listeningCts.Dispose());
-            this.messagePump?.Join();
+            Utils.SafeExecute(() => this.messagePump?.Join());
         }
 
         private void Start()

--- a/src/Orleans.Runtime/Core/IHostedClient.cs
+++ b/src/Orleans.Runtime/Core/IHostedClient.cs
@@ -20,4 +20,26 @@ namespace Orleans.Runtime
             where TExtensionInterface : IGrainExtension;
         bool TryDispatchToClient(Message message);
     }
+
+    /// <summary>
+    /// An implementation of IHostedClient which throws an exception whenever it is accessed in order to instruct the user to enable external context calls.
+    /// </summary>
+    internal class DisabledHostedClient : IHostedClient
+    {
+        public ActivationAddress ClientAddress => ThrowDisabledException<ActivationAddress>();
+        public GrainId ClientId => ThrowDisabledException<GrainId>();
+        public StreamDirectory StreamDirectory => ThrowDisabledException<StreamDirectory>();
+        public GrainReference CreateObjectReference(IAddressable obj, IGrainMethodInvoker invoker) => ThrowDisabledException<GrainReference>();
+
+        public void DeleteObjectReference(IAddressable obj) => ThrowDisabledException<int>();
+
+        public Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
+            where TExtension : IGrainExtension where TExtensionInterface : IGrainExtension => ThrowDisabledException<Task<Tuple<TExtension, TExtensionInterface>>>();
+
+        public bool TryDispatchToClient(Message message) => ThrowDisabledException<bool>();
+
+        private static T ThrowDisabledException<T>() =>
+            throw new InvalidOperationException(
+                "Support for accessing the Orleans runtime from a non-Orleans context is not enabled. Enable support using the ISiloHostBuilder.EnableExternalContextCalls() method.");
+    }
 }

--- a/src/Orleans.Runtime/Core/IHostedClient.cs
+++ b/src/Orleans.Runtime/Core/IHostedClient.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans.CodeGeneration;
+using Orleans.Streams;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// A client which is hosted within a silo.
+    /// </summary>
+    internal interface IHostedClient
+    {
+        ActivationAddress ClientAddress { get; }
+        GrainId ClientId { get; }
+        StreamDirectory StreamDirectory { get; }
+        GrainReference CreateObjectReference(IAddressable obj, IGrainMethodInvoker invoker);
+        void DeleteObjectReference(IAddressable obj);
+        Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
+            where TExtension : IGrainExtension
+            where TExtensionInterface : IGrainExtension;
+        bool TryDispatchToClient(Message message);
+    }
+}

--- a/src/Orleans.Runtime/Core/ISiloRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/ISiloRuntimeClient.cs
@@ -48,9 +48,7 @@ namespace Orleans.Runtime
         Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
             where TExtension : IGrainExtension
             where TExtensionInterface : IGrainExtension;
-
-        IActivationData CurrentActivationData { get; }
-
+        
         void DeactivateOnIdle(ActivationId id);
 
         OrleansTaskScheduler Scheduler { get; }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -43,9 +43,9 @@ namespace Orleans.Runtime
         private Dispatcher dispatcher;
         private List<IIncomingGrainCallFilter> grainCallFilters;
         private SerializationManager serializationManager;
-        private ILocalClient localClient;
+        private IHostedClient hostedClient;
 
-        private ILocalClient LocalClient => this.localClient ?? (this.localClient = this.ServiceProvider.GetRequiredService<ILocalClient>());
+        private IHostedClient HostedClient => this.hostedClient ?? (this.hostedClient = this.ServiceProvider.GetRequiredService<IHostedClient>());
         private readonly InterfaceToImplementationMappingCache interfaceToImplementationMapping = new InterfaceToImplementationMappingCache();
         public TimeSpan ResponseTimeout { get; private set; }
         private readonly GrainTypeManager typeManager;
@@ -155,7 +155,7 @@ namespace Orleans.Runtime
             ActivationData sendingActivation = null;
             if (schedulingContext == null)
             {
-                var clientAddress = this.LocalClient.ClientAddress;
+                var clientAddress = this.HostedClient.ClientAddress;
                 message.SendingGrain = clientAddress.Grain;
                 message.SendingActivation = clientAddress.Activation;
             }
@@ -643,7 +643,7 @@ namespace Orleans.Runtime
         {
             get
             {
-                if (RuntimeContext.Current == null) return this.LocalClient.ToString();
+                if (RuntimeContext.Current == null) return this.HostedClient.ToString();
 
                 var currentActivation = this.GetCurrentActivationData();
                 return currentActivation.Address.ToString();
@@ -667,7 +667,7 @@ namespace Orleans.Runtime
 
         public GrainReference CreateObjectReference(IAddressable obj, IGrainMethodInvoker invoker)
         {
-            if (RuntimeContext.Current == null) return this.LocalClient.CreateObjectReference(obj, invoker);
+            if (RuntimeContext.Current == null) return this.HostedClient.CreateObjectReference(obj, invoker);
             throw new InvalidOperationException("Cannot create a local object reference from a grain.");
         }
 
@@ -675,7 +675,7 @@ namespace Orleans.Runtime
         {
             if (RuntimeContext.Current == null)
             {
-                this.LocalClient.DeleteObjectReference(obj);
+                this.HostedClient.DeleteObjectReference(obj);
             }
             else
             {
@@ -738,7 +738,7 @@ namespace Orleans.Runtime
 
         public StreamDirectory GetStreamDirectory()
         {
-            if (RuntimeContext.Current == null) return this.LocalClient.StreamDirectory;
+            if (RuntimeContext.Current == null) return this.HostedClient.StreamDirectory;
             var currentActivation = GetCurrentActivationData();
             return currentActivation.GetStreamDirectory();
         }
@@ -749,7 +749,7 @@ namespace Orleans.Runtime
         {
             if (RuntimeContext.Current == null)
             {
-                return this.LocalClient.BindExtension<TExtension, TExtensionInterface>(newExtensionFunc);
+                return this.HostedClient.BindExtension<TExtension, TExtensionInterface>(newExtensionFunc);
             }
 
             if (!TryGetExtensionHandler(out TExtension extension))

--- a/src/Orleans.Runtime/Core/LocalClient.cs
+++ b/src/Orleans.Runtime/Core/LocalClient.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Options;
 using Orleans.CodeGeneration;
 using Orleans.Configuration;
 using Orleans.Runtime.Messaging;
-using Orleans.Runtime.Scheduler;
 using Orleans.Streams;
 
 namespace Orleans.Runtime
@@ -34,12 +33,11 @@ namespace Orleans.Runtime
         private readonly AsyncLock lockable = new AsyncLock();
         private readonly IGrainReferenceRuntime grainReferenceRuntime;
         private readonly InvokableObjectManager invokableObjects;
-        private readonly OrleansTaskScheduler scheduler;
         private readonly IRuntimeClient runtimeClient;
         private readonly ClientObserverRegistrar clientObserverRegistrar;
         private readonly ILogger logger;
         private readonly IInternalGrainFactory grainFactory;
-        private bool disposing;
+        //private bool disposing;
 
         public LocalClient(
             IRuntimeClient runtimeClient,
@@ -50,7 +48,6 @@ namespace Orleans.Runtime
             IInternalGrainFactory grainFactory,
             InvokableObjectManager invokableObjectManager,
             ISiloMessageCenter messageCenter,
-            OrleansTaskScheduler scheduler,
             IOptions<MultiClusterOptions> multiClusterOptions,
             IOptions<ClusterOptions> clusterOptions)
         {
@@ -59,9 +56,8 @@ namespace Orleans.Runtime
             this.grainReferenceRuntime = grainReferenceRuntime;
             this.grainFactory = grainFactory;
             this.invokableObjects = invokableObjectManager;
-            this.scheduler = scheduler;
 
-            this.ClientAddress = CreateClientAddress(siloDetails.SiloAddress, multiClusterOptions, clusterOptions);
+            //this.ClientAddress = CreateClientAddress(siloDetails.SiloAddress, multiClusterOptions, clusterOptions);
             this.logger = logger;
 
             // Register with the directory and message center so that we can receive messages.
@@ -69,15 +65,16 @@ namespace Orleans.Runtime
             this.clientObserverRegistrar.ClientAdded(this.ClientId);
             messageCenter.SetLocalClient(this);
 
+            throw new InvalidOperationException("ERROR! Local Client Should NOT BE USED YET 1");
             // Start pumping messages.
-            this.Start();
+            //this.Start();
         }
 
-        public ActivationAddress ClientAddress { get; }
+        public ActivationAddress ClientAddress => throw new InvalidOperationException("ERROR! Local Client Should NOT BE USED YET 2");
 
-        public GrainId ClientId => this.ClientAddress.Grain;
+        public GrainId ClientId => throw new InvalidOperationException("ERROR! Local Client Should NOT BE USED YET 3");
 
-        public StreamDirectory StreamDirectory { get; } = new StreamDirectory();
+        public StreamDirectory StreamDirectory => throw new InvalidOperationException("ERROR! Local Client Should NOT BE USED YET 4");
 
         private static ActivationAddress CreateClientAddress(SiloAddress localAddress, IOptions<MultiClusterOptions> multiClusterOptions, IOptions<ClusterOptions> clusterOptions)
         {
@@ -91,7 +88,8 @@ namespace Orleans.Runtime
 
         public GrainReference CreateObjectReference(IAddressable obj, IGrainMethodInvoker invoker)
         {
-            if (obj is GrainReference) throw new ArgumentException("Argument obj is already a grain reference.");
+            throw new InvalidOperationException("ERROR! Local Client Should NOT BE USED YET 5");
+           /* if (obj is GrainReference) throw new ArgumentException("Argument obj is already a grain reference.");
 
             var grainReference = GrainReference.NewObserverGrainReference(this.ClientAddress.Grain, GuidId.GetNewGuidId(), this.grainReferenceRuntime);
             if (!this.invokableObjects.TryRegister(obj, grainReference.ObserverId, invoker))
@@ -101,24 +99,26 @@ namespace Orleans.Runtime
                     nameof(grainReference));
             }
 
-            return grainReference;
+            return grainReference;*/
         }
 
         public void DeleteObjectReference(IAddressable obj)
         {
-            if (!(obj is GrainReference reference)) throw new ArgumentException("Argument reference is not a grain reference.");
+            throw new InvalidOperationException("ERROR! Local Client Should NOT BE USED YET 6");
+            /*if (!(obj is GrainReference reference)) throw new ArgumentException("Argument reference is not a grain reference.");
 
-            if (!this.invokableObjects.TryDeregister(reference.ObserverId))throw new ArgumentException("Reference is not associated with a local object.", nameof(obj));
+            if (!this.invokableObjects.TryDeregister(reference.ObserverId))throw new ArgumentException("Reference is not associated with a local object.", nameof(obj));*/
         }
 
-        public async Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
+        public Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
             where TExtension : IGrainExtension
             where TExtensionInterface : IGrainExtension
         {
-            IAddressable addressable;
+            throw new InvalidOperationException("ERROR! Local Client Should NOT BE USED YET 7");
+            /*IAddressable addressable;
             TExtension extension;
 
-            using (await this.lockable.LockAsync())
+            using (await this.lockable.LockAsync().ConfigureAwait(false))
             {
                 if (this.extensionsTable.TryGetValue(typeof(TExtensionInterface), out var entry))
                 {
@@ -144,40 +144,42 @@ namespace Orleans.Runtime
             var typedAddressable = addressable.Cast<TExtensionInterface>();
             // we have to return the extension as well as the IAddressable because the caller needs to root the extension
             // to prevent it from being collected (the IAddressable uses a weak reference).
-            return Tuple.Create(extension, typedAddressable);
+            return Tuple.Create(extension, typedAddressable);*/
         }
 
         void IDisposable.Dispose()
         {
-            if (this.disposing) return;
+            throw new InvalidOperationException("ERROR! Local Client Should NOT BE USED YET 8");
+           /* if (this.disposing) return;
             this.disposing = true;
             Utils.SafeExecute(() => this.clientObserverRegistrar.ClientDropped(this.ClientId));
             Utils.SafeExecute(() => this.clientObserverRegistrar.SetLocalClient(null));
             Utils.SafeExecute(() => this.listeningCts.Cancel(false));
-            Utils.SafeExecute(() => this.listeningCts.Dispose());
+            Utils.SafeExecute(() => this.listeningCts.Dispose());*/
         }
         
         public bool TryDispatchToClient(Message message)
         {
-            if (!this.ClientId.Equals(message.TargetGrain)) return false;
-            if (message.IsExpired)
-            {
-                message.DropExpiredMessage(MessagingStatisticsGroup.Phase.Receive);
-                return true;
-            }
+            throw new InvalidOperationException("ERROR! Local Client Should NOT BE USED YET 9");
+            /*  if (!this.ClientId.Equals(message.TargetGrain)) return false;
+              if (message.IsExpired)
+              {
+                  message.DropExpiredMessage(MessagingStatisticsGroup.Phase.Receive);
+                  return true;
+              }
 
-            if (message.Direction == Message.Directions.Response)
-            {
-                // Requests are made through the runtime client, so deliver responses to the rutnime client so that the request callback can be executed.
-                this.runtimeClient.ReceiveResponse(message);
-            }
-            else
-            {
-                // Requests agrainst client objects are scheduled for execution on the client.
-                this.incomingMessages.Add(message);
-            }
+              if (message.Direction == Message.Directions.Response)
+              {
+                  // Requests are made through the runtime client, so deliver responses to the rutnime client so that the request callback can be executed.
+                  this.runtimeClient.ReceiveResponse(message);
+              }
+              else
+              {
+                  // Requests agrainst client objects are scheduled for execution on the client.
+                  this.incomingMessages.Add(message);
+              }
 
-            return true;
+              return true;*/
         }
 
         private void Start()

--- a/src/Orleans.Runtime/Core/LocalClient.cs
+++ b/src/Orleans.Runtime/Core/LocalClient.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.CodeGeneration;
+using Orleans.Configuration;
+using Orleans.Runtime.Messaging;
+using Orleans.Runtime.Scheduler;
+using Orleans.Streams;
+
+namespace Orleans.Runtime
+{
+    internal interface ILocalClient
+    {
+        ActivationAddress ClientAddress { get; }
+        GrainId ClientId { get; }
+        StreamDirectory StreamDirectory { get; }
+        GrainReference CreateObjectReference(IAddressable obj, IGrainMethodInvoker invoker);
+        void DeleteObjectReference(IAddressable obj);
+        Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
+            where TExtension : IGrainExtension
+            where TExtensionInterface : IGrainExtension;
+        bool TryDispatchToClient(Message message);
+    }
+
+    internal sealed class LocalClient : IDisposable, ILocalClient
+    {
+        private readonly BlockingCollection<Message> incomingMessages = new BlockingCollection<Message>();
+        private readonly CancellationTokenSource listeningCts = new CancellationTokenSource();
+        private readonly Dictionary<Type, Tuple<IGrainExtension, IAddressable>> extensionsTable = new Dictionary<Type, Tuple<IGrainExtension, IAddressable>>();
+        private readonly AsyncLock lockable = new AsyncLock();
+        private readonly IGrainReferenceRuntime grainReferenceRuntime;
+        private readonly InvokableObjectManager invokableObjects;
+        private readonly OrleansTaskScheduler scheduler;
+        private readonly IRuntimeClient runtimeClient;
+        private readonly ClientObserverRegistrar clientObserverRegistrar;
+        private readonly ILogger logger;
+        private readonly IInternalGrainFactory grainFactory;
+        private bool disposing;
+
+        public LocalClient(
+            IRuntimeClient runtimeClient,
+            ClientObserverRegistrar clientObserverRegistrar,
+            ILocalSiloDetails siloDetails,
+            ILogger<LocalClient> logger,
+            IGrainReferenceRuntime grainReferenceRuntime,
+            IInternalGrainFactory grainFactory,
+            InvokableObjectManager invokableObjectManager,
+            ISiloMessageCenter messageCenter,
+            OrleansTaskScheduler scheduler,
+            IOptions<MultiClusterOptions> multiClusterOptions,
+            IOptions<ClusterOptions> clusterOptions)
+        {
+            this.runtimeClient = runtimeClient;
+            this.clientObserverRegistrar = clientObserverRegistrar;
+            this.grainReferenceRuntime = grainReferenceRuntime;
+            this.grainFactory = grainFactory;
+            this.invokableObjects = invokableObjectManager;
+            this.scheduler = scheduler;
+
+            this.ClientAddress = CreateClientAddress(siloDetails.SiloAddress, multiClusterOptions, clusterOptions);
+            this.logger = logger;
+
+            // Register with the directory and message center so that we can receive messages.
+            this.clientObserverRegistrar.SetLocalClient(this);
+            this.clientObserverRegistrar.ClientAdded(this.ClientId);
+            messageCenter.SetLocalClient(this);
+
+            // Start pumping messages.
+            this.Start();
+        }
+
+        public ActivationAddress ClientAddress { get; }
+
+        public GrainId ClientId => this.ClientAddress.Grain;
+
+        public StreamDirectory StreamDirectory { get; } = new StreamDirectory();
+
+        private static ActivationAddress CreateClientAddress(SiloAddress localAddress, IOptions<MultiClusterOptions> multiClusterOptions, IOptions<ClusterOptions> clusterOptions)
+        {
+            // Set a cluster id only if this cluster is a part of a multi-cluster network.
+            var clusterId = multiClusterOptions.Value.HasMultiClusterNetwork ? clusterOptions.Value.ClusterId : null;
+            var clientId = GrainId.NewClientId(clusterId);
+            return ActivationAddress.NewActivationAddress(localAddress, clientId);
+        }
+
+        public override string ToString() => $"{nameof(LocalClient)}_{this.ClientAddress}";
+
+        public GrainReference CreateObjectReference(IAddressable obj, IGrainMethodInvoker invoker)
+        {
+            if (obj is GrainReference) throw new ArgumentException("Argument obj is already a grain reference.");
+
+            var grainReference = GrainReference.NewObserverGrainReference(this.ClientAddress.Grain, GuidId.GetNewGuidId(), this.grainReferenceRuntime);
+            if (!this.invokableObjects.TryRegister(obj, grainReference.ObserverId, invoker))
+            {
+                throw new ArgumentException(
+                    string.Format("Failed to add new observer {0} to localObjects collection.", grainReference),
+                    nameof(grainReference));
+            }
+
+            return grainReference;
+        }
+
+        public void DeleteObjectReference(IAddressable obj)
+        {
+            if (!(obj is GrainReference reference)) throw new ArgumentException("Argument reference is not a grain reference.");
+
+            if (!this.invokableObjects.TryDeregister(reference.ObserverId))throw new ArgumentException("Reference is not associated with a local object.", nameof(obj));
+        }
+
+        public async Task<Tuple<TExtension, TExtensionInterface>> BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
+            where TExtension : IGrainExtension
+            where TExtensionInterface : IGrainExtension
+        {
+            IAddressable addressable;
+            TExtension extension;
+
+            using (await this.lockable.LockAsync())
+            {
+                if (this.extensionsTable.TryGetValue(typeof(TExtensionInterface), out var entry))
+                {
+                    extension = (TExtension) entry.Item1;
+                    addressable = entry.Item2;
+                }
+                else
+                {
+                    extension = newExtensionFunc();
+                    var obj = this.grainFactory.CreateObjectReference<TExtensionInterface>(extension);
+
+                    addressable = obj;
+
+                    if (null == addressable)
+                    {
+                        throw new NullReferenceException("addressable");
+                    }
+                    entry = Tuple.Create((IGrainExtension) extension, addressable);
+                    this.extensionsTable.Add(typeof(TExtensionInterface), entry);
+                }
+            }
+
+            var typedAddressable = addressable.Cast<TExtensionInterface>();
+            // we have to return the extension as well as the IAddressable because the caller needs to root the extension
+            // to prevent it from being collected (the IAddressable uses a weak reference).
+            return Tuple.Create(extension, typedAddressable);
+        }
+
+        void IDisposable.Dispose()
+        {
+            if (this.disposing) return;
+            this.disposing = true;
+            Utils.SafeExecute(() => this.clientObserverRegistrar.ClientDropped(this.ClientId));
+            Utils.SafeExecute(() => this.clientObserverRegistrar.SetLocalClient(null));
+            Utils.SafeExecute(() => this.listeningCts.Cancel(false));
+            Utils.SafeExecute(() => this.listeningCts.Dispose());
+        }
+        
+        public bool TryDispatchToClient(Message message)
+        {
+            if (!this.ClientId.Equals(message.TargetGrain)) return false;
+            if (message.IsExpired)
+            {
+                message.DropExpiredMessage(MessagingStatisticsGroup.Phase.Receive);
+                return true;
+            }
+
+            if (message.Direction == Message.Directions.Response)
+            {
+                // Requests are made through the runtime client, so deliver responses to the rutnime client so that the request callback can be executed.
+                this.runtimeClient.ReceiveResponse(message);
+            }
+            else
+            {
+                // Requests agrainst client objects are scheduled for execution on the client.
+                this.incomingMessages.Add(message);
+            }
+
+            return true;
+        }
+
+        private void Start()
+        {
+            var thread = new Thread(_ => this.RunClientMessagePump())
+            {
+                Name = nameof(LocalClient) + "." + nameof(RunClientMessagePump),
+                IsBackground = true,
+            };
+            thread.Start();
+        }
+
+        private void RunClientMessagePump()
+        {
+            while (!this.listeningCts.IsCancellationRequested)
+            {
+                try
+                {
+                    var message = this.incomingMessages.Take(this.listeningCts.Token);
+                    if (message == null) continue;
+                    switch (message.Direction)
+                    {
+                        case Message.Directions.OneWay:
+                        case Message.Directions.Request:
+                            this.invokableObjects.Dispatch(message);
+                            break;
+                        default:
+                            this.logger.Error(ErrorCode.Runtime_Error_100327, string.Format("Message not supported: {0}.", message));
+                            break;
+                    }
+                }
+                catch (Exception exc)
+                {
+                    this.logger.Error(ErrorCode.Runtime_Error_100326, "RunClientMessagePump has thrown exception", exc);
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Runtime/GrainDirectory/ClientObserverRegistrar.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientObserverRegistrar.cs
@@ -44,7 +44,10 @@ namespace Orleans.Runtime
         internal void SetLocalClient(ILocalClient client)
         {
             this.localClient = client;
-            this.scheduler.QueueAction(Start, this.SchedulingContext).Ignore();
+            if (client != null)
+            {
+                this.scheduler.QueueAction(Start, this.SchedulingContext).Ignore();
+            }
         }
 
         internal void SetGateway(Gateway gateway)

--- a/src/Orleans.Runtime/GrainDirectory/ClientObserverRegistrar.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientObserverRegistrar.cs
@@ -22,10 +22,10 @@ namespace Orleans.Runtime
         private readonly OrleansTaskScheduler scheduler;
         private readonly SiloMessagingOptions messagingOptions;
         private readonly ILogger logger;
+        private ILocalClient localClient;
         private Gateway gateway;
         private IDisposable refreshTimer;
-
-
+        
         public ClientObserverRegistrar(
             ILocalSiloDetails siloDetails,
             ILocalGrainDirectory dir,
@@ -41,6 +41,12 @@ namespace Orleans.Runtime
             logger = loggerFactory.CreateLogger<ClientObserverRegistrar>();
         }
 
+        internal void SetLocalClient(ILocalClient client)
+        {
+            this.localClient = client;
+            this.scheduler.QueueAction(Start, this.SchedulingContext).Ignore();
+        }
+
         internal void SetGateway(Gateway gateway)
         {
             this.gateway = gateway;
@@ -51,6 +57,7 @@ namespace Orleans.Runtime
 
         private void Start()
         {
+            if (this.refreshTimer != null) return;
             var random = new SafeRandom();
             var randomOffset = random.NextTimeSpan(this.messagingOptions.ClientRegistrationRefresh);
             this.refreshTimer = this.RegisterTimer(
@@ -109,11 +116,14 @@ namespace Orleans.Runtime
 
         private async Task OnClientRefreshTimer(object data)
         {
-            if (gateway == null) return;
             try
             {
-                ICollection<GrainId> clients = gateway.GetConnectedClients().ToList();
-                List<Task> tasks = new List<Task>();
+                var clients = new List<GrainId>();
+                if (this.gateway != null) clients.AddRange(gateway.GetConnectedClients());
+                var localClientId = this.localClient?.ClientId;
+                if (localClientId != null) clients.Add(localClientId);
+
+                var tasks = new List<Task>();
                 foreach (GrainId clientId in clients)
                 {
                     var addr = GetClientActivationAddress(clientId);

--- a/src/Orleans.Runtime/GrainDirectory/ClientObserverRegistrar.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientObserverRegistrar.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -22,7 +21,7 @@ namespace Orleans.Runtime
         private readonly OrleansTaskScheduler scheduler;
         private readonly SiloMessagingOptions messagingOptions;
         private readonly ILogger logger;
-        private ILocalClient localClient;
+        private IHostedClient hostedClient;
         private Gateway gateway;
         private IDisposable refreshTimer;
         
@@ -41,9 +40,9 @@ namespace Orleans.Runtime
             logger = loggerFactory.CreateLogger<ClientObserverRegistrar>();
         }
 
-        internal void SetLocalClient(ILocalClient client)
+        internal void SetHostedClient(IHostedClient client)
         {
-            this.localClient = client;
+            this.hostedClient = client;
             if (client != null)
             {
                 this.scheduler.QueueAction(Start, this.SchedulingContext).Ignore();
@@ -123,8 +122,8 @@ namespace Orleans.Runtime
             {
                 var clients = new List<GrainId>();
                 if (this.gateway != null) clients.AddRange(gateway.GetConnectedClients());
-                var localClientId = this.localClient?.ClientId;
-                if (localClientId != null) clients.Add(localClientId);
+                var hostedClientId = this.hostedClient?.ClientId;
+                if (hostedClientId != null) clients.Add(hostedClientId);
 
                 var tasks = new List<Task>();
                 foreach (GrainId clientId in clients)

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -135,7 +135,7 @@ namespace Orleans.Hosting
         /// <summary>
         /// Enables support for interacting with the runtime from an external context such as a outside of the context of a grain.
         /// </summary>
-        public static ISiloHostBuilder EnableExternalContextCalls(
+        public static ISiloHostBuilder EnableDirectClient(
             this ISiloHostBuilder builder)
         {
             return builder.ConfigureServices(services =>

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -131,5 +131,29 @@ namespace Orleans.Hosting
                         .AddFromExisting<IMembershipTable, SystemTargetBasedMembershipTable>();
                 });
         }
+
+        /// <summary>
+        /// Enables support for interacting with the runtime from an external context such as a outside of the context of a grain.
+        /// </summary>
+        public static ISiloHostBuilder EnableExternalContextCalls(
+            this ISiloHostBuilder builder)
+        {
+            return builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IHostedClient>();
+                services.TryAddSingleton<IHostedClient, HostedClient>();
+                services.TryAddSingleton<InvokableObjectManager>();
+                services.TryAddSingleton<IClusterClient>(
+                    sp =>
+                    {
+                        var result = ActivatorUtilities.CreateInstance<ClusterClient>(sp);
+                        var task = result.Connect();
+                        if (!task.IsCompleted)
+                            throw new InvalidOperationException(
+                                $"{nameof(result.Connect)}() method for internal {nameof(IClusterClient)} must complete synchronously.");
+                        return result;
+                    });
+            });
+        }
     }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -270,19 +270,8 @@ namespace Orleans.Hosting
             services.AddTransient<IConfigurationValidator, ClusterOptionsValidator>();
             services.AddTransient<IConfigurationValidator, SiloClusteringValidator>();
 
-            // Local client support
-            services.TryAddSingleton<IHostedClient, HostedClient>();
-            services.TryAddSingleton<InvokableObjectManager>();
-            services.TryAddSingleton<IClusterClient>(
-                sp =>
-                {
-                    var result = ActivatorUtilities.CreateInstance<ClusterClient>(sp);
-                    var task = result.Connect();
-                    if (!task.IsCompleted)
-                        throw new InvalidOperationException(
-                            $"{nameof(result.Connect)}() method for internal {nameof(IClusterClient)} must complete synchronously.");
-                    return result;
-                });
+            // Disable hosted client by default.
+            services.TryAddSingleton<IHostedClient, DisabledHostedClient>();
         }
     }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -271,7 +271,7 @@ namespace Orleans.Hosting
             services.AddTransient<IConfigurationValidator, SiloClusteringValidator>();
 
             // Local client support
-            services.TryAddSingleton<ILocalClient, LocalClient>();
+            services.TryAddSingleton<IHostedClient, HostedClient>();
             services.TryAddSingleton<InvokableObjectManager>();
             services.TryAddSingleton<IClusterClient>(
                 sp =>

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -270,7 +270,7 @@ namespace Orleans.Hosting
             services.AddTransient<IConfigurationValidator, ClusterOptionsValidator>();
             services.AddTransient<IConfigurationValidator, SiloClusteringValidator>();
 
-            // Local client support
+/*            // Local client support
             services.TryAddSingleton<ILocalClient, LocalClient>();
             services.TryAddSingleton<InvokableObjectManager>();
             services.TryAddSingleton<IClusterClient>(
@@ -282,7 +282,7 @@ namespace Orleans.Hosting
                         throw new InvalidOperationException(
                             $"{nameof(result.Connect)}() method for internal {nameof(IClusterClient)} must complete synchronously.");
                     return result;
-                });
+                });*/
         }
     }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -270,7 +270,7 @@ namespace Orleans.Hosting
             services.AddTransient<IConfigurationValidator, ClusterOptionsValidator>();
             services.AddTransient<IConfigurationValidator, SiloClusteringValidator>();
 
-/*            // Local client support
+            // Local client support
             services.TryAddSingleton<ILocalClient, LocalClient>();
             services.TryAddSingleton<InvokableObjectManager>();
             services.TryAddSingleton<IClusterClient>(
@@ -282,7 +282,7 @@ namespace Orleans.Hosting
                         throw new InvalidOperationException(
                             $"{nameof(result.Connect)}() method for internal {nameof(IClusterClient)} must complete synchronously.");
                     return result;
-                });*/
+                });
         }
     }
 }

--- a/src/Orleans.Runtime/Messaging/ISiloMessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/ISiloMessageCenter.cs
@@ -19,5 +19,6 @@ namespace Orleans.Runtime.Messaging
         void BlockApplicationMessages();
 
         Func<SiloAddress, bool> SiloDeadOracle { get; set; }
+        void SetLocalClient(ILocalClient client);
     }
 }

--- a/src/Orleans.Runtime/Messaging/ISiloMessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/ISiloMessageCenter.cs
@@ -19,6 +19,6 @@ namespace Orleans.Runtime.Messaging
         void BlockApplicationMessages();
 
         Func<SiloAddress, bool> SiloDeadOracle { get; set; }
-        void SetLocalClient(ILocalClient client);
+        void SetHostedClient(IHostedClient client);
     }
 }

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ILogger log;
         private Action<Message> rerouteHandler;
         internal Func<Message, bool> ShouldDrop;
-        private ILocalClient localClient;
+        private IHostedClient hostedClient;
 
         // ReSharper disable NotAccessedField.Local
         private IntValueStatistic sendQueueLengthCounter;
@@ -34,15 +34,15 @@ namespace Orleans.Runtime.Messaging
 
         internal bool IsBlockingApplicationMessages { get; private set; }
 
-        public void SetLocalClient(ILocalClient client) => this.localClient = client;
+        public void SetHostedClient(IHostedClient client) => this.hostedClient = client;
 
-        public bool IsProxying => this.Gateway != null || this.localClient?.ClientId != null;
+        public bool IsProxying => this.Gateway != null || this.hostedClient?.ClientId != null;
 
         public bool TryDeliverToProxy(Message msg)
         {
             if (!msg.TargetGrain.IsClient) return false;
             if (this.Gateway != null && this.Gateway.TryDeliverToProxy(msg)) return true;
-            return this.localClient?.TryDispatchToClient(msg) ?? false;
+            return this.hostedClient?.TryDispatchToClient(msg) ?? false;
         }
         
         // This is determined by the IMA but needed by the OMS, and so is kept here in the message center itself.

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -16,6 +16,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ILogger log;
         private Action<Message> rerouteHandler;
         internal Func<Message, bool> ShouldDrop;
+        private ILocalClient localClient;
 
         // ReSharper disable NotAccessedField.Local
         private IntValueStatistic sendQueueLengthCounter;
@@ -32,12 +33,16 @@ namespace Orleans.Runtime.Messaging
         private readonly Action<Message>[] localMessageHandlers;
 
         internal bool IsBlockingApplicationMessages { get; private set; }
-        
-        public bool IsProxying { get { return Gateway != null; } }
+
+        public void SetLocalClient(ILocalClient client) => this.localClient = client;
+
+        public bool IsProxying => this.Gateway != null || this.localClient?.ClientId != null;
 
         public bool TryDeliverToProxy(Message msg)
         {
-            return msg.TargetGrain.IsClient && Gateway != null && Gateway.TryDeliverToProxy(msg);
+            if (!msg.TargetGrain.IsClient) return false;
+            if (this.Gateway != null && this.Gateway.TryDeliverToProxy(msg)) return true;
+            return this.localClient?.TryDispatchToClient(msg) ?? false;
         }
         
         // This is determined by the IMA but needed by the OMS, and so is kept here in the message center itself.

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -43,7 +43,7 @@ namespace Orleans.Runtime.Scheduler
 
         public void RunTask(Task task)
         {
-            RuntimeContext.SetExecutionContext(workerGroup.SchedulingContext, this);
+            RuntimeContext.SetExecutionContext(workerGroup.SchedulingContext);
             bool done = TryExecuteTask(task);
             if (!done)
                 logger.Warn(ErrorCode.SchedulerTaskExecuteIncomplete4, "RunTask: Incomplete base.TryExecuteTask for Task Id={0} with Status={1}",

--- a/src/Orleans.Runtime/Scheduler/OrleansSchedulerAsynchAgent.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansSchedulerAsynchAgent.cs
@@ -39,10 +39,10 @@ namespace Orleans.Runtime.Scheduler
 
         protected override void Process(IWorkItem request)
         {
-            RuntimeContext.InitializeThread(scheduler);
+            RuntimeContext.InitializeThread();
             try
             {
-                RuntimeContext.SetExecutionContext(request.SchedulingContext, scheduler);
+                RuntimeContext.SetExecutionContext(request.SchedulingContext);
                 request.Execute();
             }
             finally

--- a/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/OrleansTaskScheduler.cs
@@ -250,18 +250,17 @@ namespace Orleans.Runtime.Scheduler
             }
 
             workItem.SchedulingContext = context;
-
+            
             // We must wrap any work item in Task and enqueue it as a task to the right scheduler via Task.Start.
+            Task t = TaskSchedulerUtils.WrapWorkItemAsTask(workItem);
+
             // This will make sure the TaskScheduler.Current is set correctly on any task that is created implicitly in the execution of this workItem.
             if (workItemGroup == null)
             {
-                Task t = TaskSchedulerUtils.WrapWorkItemAsTask(workItem, context, this);
                 t.Start(this);
             }
             else
             {
-                // Create Task wrapper for this work item
-                Task t = TaskSchedulerUtils.WrapWorkItemAsTask(workItem, context, workItemGroup.TaskRunner);
                 t.Start(workItemGroup.TaskRunner);
             }
         }
@@ -375,7 +374,7 @@ namespace Orleans.Runtime.Scheduler
 
             if (workItemGroup == null)
             {
-                RuntimeContext.SetExecutionContext(null, this);
+                RuntimeContext.SetExecutionContext(null);
                 bool done = TryExecuteTask(task);
                 if (!done)
                     logger.Warn(ErrorCode.SchedulerTaskExecuteIncomplete2, "RunTask: Incomplete base.TryExecuteTask for Task Id={0} with Status={1}",

--- a/src/Orleans.Runtime/Scheduler/TaskSchedulerUtils.cs
+++ b/src/Orleans.Runtime/Scheduler/TaskSchedulerUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 
@@ -5,17 +6,18 @@ namespace Orleans.Runtime.Scheduler
 {
     internal class TaskSchedulerUtils
     {
-        internal static Task WrapWorkItemAsTask(IWorkItem todo, ISchedulingContext context, TaskScheduler sched)
+        private static readonly Action<object> TaskFunc = state => RunWorkItemTask((IWorkItem)state);
+
+        internal static Task WrapWorkItemAsTask(IWorkItem todo)
         {
-            var task = new Task(state => RunWorkItemTask(todo, sched), context);
-            return task;
+            return new Task(TaskFunc, todo);
         }
 
-        private static void RunWorkItemTask(IWorkItem todo, TaskScheduler sched)
+        private static void RunWorkItemTask(IWorkItem todo)
         {
             try
             {
-                RuntimeContext.SetExecutionContext(todo.SchedulingContext, sched);
+                RuntimeContext.SetExecutionContext(todo.SchedulingContext);
                 todo.Execute();
             }
             finally

--- a/src/Orleans.Runtime/Services/GrainServiceClient.cs
+++ b/src/Orleans.Runtime/Services/GrainServiceClient.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.CodeGeneration;
 using Orleans.Runtime.ConsistentRing;
+using Orleans.Runtime.Scheduler;
 using Orleans.Services;
 
 namespace Orleans.Runtime.Services
@@ -48,17 +49,11 @@ namespace Orleans.Runtime.Services
                 return grainService;
             }
         }
-        
+
         /// <summary>
         /// Resolves the Grain Reference invoking this request.
         /// </summary>
-        protected GrainReference CallingGrainReference
-        {
-            get
-            {
-                return runtimeClient.CurrentActivationData.GrainReference;
-            }
-        }
+        protected GrainReference CallingGrainReference => (RuntimeContext.Current?.ActivationContext as SchedulingContext)?.Activation?.GrainReference;
 
         /// <summary>
         /// Moved from InsideRuntimeClient.cs

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -410,9 +410,6 @@ namespace Orleans.Runtime
 
             StartTaskWithPerfAnalysis("Start local grain directory", LocalGrainDirectory.Start,stopWatch);
 
-            // Set up an execution context for this thread so that the target creation steps can use asynch values.
-            RuntimeContext.InitializeMainThread();
-
             StartTaskWithPerfAnalysis("Init implicit stream subscribe table", InitImplicitStreamSubscribeTable, stopWatch);
             void InitImplicitStreamSubscribeTable()
             {             

--- a/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
+++ b/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
@@ -137,14 +137,6 @@ namespace Orleans.Runtime.Providers
         /// <inheritdoc />
         public StreamDirectory GetStreamDirectory()
         {
-            if (runtimeClient.CurrentActivationData == null)
-            {
-                throw new InvalidOperationException(
-                    String.Format("Trying to get a Stream or send a stream message on a silo not from within grain and not from within system target (CurrentActivationData is null) "
-                        + "RuntimeContext.Current={0} TaskScheduler.Current={1}",
-                        RuntimeContext.Current == null ? "null" : RuntimeContext.Current.ToString(),
-                        TaskScheduler.Current));
-            }
             return runtimeClient.GetStreamDirectory();
         }
 

--- a/src/Orleans.TestingHost/TestClusterNetworkHelper.cs
+++ b/src/Orleans.TestingHost/TestClusterNetworkHelper.cs
@@ -1,0 +1,13 @@
+namespace Orleans.TestingHost
+{
+    /// <summary>
+    /// Methods for assisting in networking configuration for test clusters.
+    /// </summary>
+    public static class TestClusterNetworkHelper
+    {
+        /// <summary>
+        /// Returns two ports which are not currently in use by any TCP listeners.
+        /// </summary>
+        public static (int siloPort, int gatewayPort) GetRandomAvailableServerPorts() => TestClusterBuilder.GetAvailableConsecutiveServerPortsPair(1);
+    }
+}

--- a/test/DefaultCluster.Tests/HostedClientDisabledTests.cs
+++ b/test/DefaultCluster.Tests/HostedClientDisabledTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
+using Tester.CodeGenTests;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace DefaultCluster.Tests.General
+{
+    [TestCategory("BVT"), TestCategory("HostedClient")]
+    public class HostedClientDisabledTests : IClassFixture<HostedClientDisabledTests.Fixture>
+    {
+        private readonly ISiloHost silo;
+
+        public class Fixture : IDisposable
+        {
+            public ISiloHost Silo { get; }
+
+            public Fixture()
+            {
+                var (siloPort, gatewayPort) = TestClusterNetworkHelper.GetRandomAvailableServerPorts();
+                this.Silo = new SiloHostBuilder()
+                    .UseLocalhostClustering(siloPort, gatewayPort)
+                    .Configure<ClusterOptions>(options =>
+                    {
+                        options.ClusterId = Guid.NewGuid().ToString();
+                        options.ServiceId = Guid.NewGuid().ToString();
+                    })
+                    .AddMemoryGrainStorage("PubSubStore")
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>("MemStream")
+                    .Build();
+                this.Silo.StartAsync().GetAwaiter().GetResult();
+            }
+
+            public void Dispose()
+            {
+                this.Silo?.Dispose();
+            }
+        }
+
+        public HostedClientDisabledTests(Fixture fixture)
+        {
+            this.silo = fixture.Silo;
+        }
+
+        [Fact]
+        public void HostedClient_Disabled_IClusterClient()
+        {
+            var client = this.silo.Services.GetService<IClusterClient>();
+            Assert.Null(client);
+        }
+
+        [Fact]
+        public async Task HostedClient_Disabled_GrainCallTest()
+        {
+            // IGrainFactory will always be present in the container, since it's used by the runtime itself.
+            var client = this.silo.Services.GetRequiredService<IGrainFactory>();
+            var grain = client.GetGrain<IGrainWithGenericMethods>(Guid.NewGuid());
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => grain.RoundTrip("hi"));
+            Assert.Contains("not enabled", exception.Message);
+        }
+
+        [Fact]
+        public async Task HostedClient_Disabled_ObserverTest()
+        {
+            var client = this.silo.Services.GetRequiredService<IGrainFactory>();
+
+            var observer = new ObserverTests.SimpleGrainObserver((i, i1, arg3) => { }, new AsyncResultHandle(), new NullLogger<HostedClientDisabledTests>());
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.CreateObjectReference<ISimpleGrainObserver>(observer));
+            Assert.Contains("not enabled", exception.Message);
+        }
+
+        [Fact]
+        public void HostedClient_Disabled_StreamTest()
+        {
+            var streamProvider = this.silo.Services.GetRequiredServiceByName<IStreamProvider>("MemStream");
+            var exception = Assert.Throws<InvalidOperationException>(() => streamProvider.GetStream<int>(Guid.Empty, "hi"));
+            Assert.Contains("not enabled", exception.Message);
+        }
+    }
+}

--- a/test/DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/DefaultCluster.Tests/HostedClientTests.cs
@@ -41,7 +41,7 @@ namespace DefaultCluster.Tests.General
                     })
                     .AddMemoryGrainStorage("PubSubStore")
                     .AddMemoryStreams<DefaultMemoryMessageBodySerializer>("MemStream")
-                    .EnableExternalContextCalls()
+                    .EnableDirectClient()
                     .Build();
                 this.Silo.StartAsync().GetAwaiter().GetResult();
             }

--- a/test/DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/DefaultCluster.Tests/HostedClientTests.cs
@@ -18,17 +18,17 @@ using Xunit;
 
 namespace DefaultCluster.Tests.General
 {
-    [TestCategory("BVT"), TestCategory("LocalClient")]
-    public class LocalClientTests : IClassFixture<LocalClientTests.LocalClientFixture>
+    [TestCategory("BVT"), TestCategory("HostedClient")]
+    public class HostedClientTests : IClassFixture<HostedClientTests.Fixture>
     {
         private readonly TimeSpan timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(10);
         private readonly ISiloHost silo;
 
-        public class LocalClientFixture
+        public class Fixture : IDisposable
         {
             public ISiloHost Silo { get; }
 
-            public LocalClientFixture()
+            public Fixture()
             {
                 this.Silo = new SiloHostBuilder().ConfigureLocalHostPrimarySilo()
                     .Configure<ClusterOptions>(options =>
@@ -41,15 +41,20 @@ namespace DefaultCluster.Tests.General
                     .Build();
                 this.Silo.StartAsync().GetAwaiter().GetResult();
             }
+
+            public void Dispose()
+            {
+                this.Silo?.Dispose();
+            }
         }
 
-        public LocalClientTests(LocalClientFixture fixture)
+        public HostedClientTests(Fixture fixture)
         {
             this.silo = fixture.Silo;
         }
 
         [Fact]
-        public async Task LocalClient_GrainCallTest()
+        public async Task HostedClient_GrainCallTest()
         {
             var client = this.silo.Services.GetRequiredService<IClusterClient>();
 
@@ -60,7 +65,7 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact]
-        public async Task LocalClient_ReferenceEquality_GrainCallTest()
+        public async Task HostedClient_ReferenceEquality_GrainCallTest()
         {
             var client = this.silo.Services.GetRequiredService<IClusterClient>();
             var grain = client.GetGrain<IGrainWithGenericMethods>(Guid.NewGuid());
@@ -86,7 +91,7 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact]
-        public async Task LocalClient_ObserverTest()
+        public async Task HostedClient_ObserverTest()
         {
             var client = this.silo.Services.GetRequiredService<IClusterClient>();
 
@@ -138,7 +143,7 @@ namespace DefaultCluster.Tests.General
         }
 
         [Fact]
-        public async Task LocalClient_StreamTest()
+        public async Task HostedClient_StreamTest()
         {
             var client = this.silo.Services.GetRequiredService<IClusterClient>();
 

--- a/test/DefaultCluster.Tests/LocalClientTests.cs
+++ b/test/DefaultCluster.Tests/LocalClientTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace DefaultCluster.Tests.General
 {
-    [TestCategory("BVT"), TestCategory("LocalClient")]
+    //[TestCategory("BVT"), TestCategory("LocalClient")]
     public class LocalClientTests : IClassFixture<LocalClientTests.LocalClientFixture>
     {
         private readonly TimeSpan timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(10);

--- a/test/DefaultCluster.Tests/LocalClientTests.cs
+++ b/test/DefaultCluster.Tests/LocalClientTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace DefaultCluster.Tests.General
 {
-    //[TestCategory("BVT"), TestCategory("LocalClient")]
+    [TestCategory("BVT"), TestCategory("LocalClient")]
     public class LocalClientTests : IClassFixture<LocalClientTests.LocalClientFixture>
     {
         private readonly TimeSpan timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(10);

--- a/test/DefaultCluster.Tests/LocalClientTests.cs
+++ b/test/DefaultCluster.Tests/LocalClientTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Concurrency;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.TestingHost.Utils;
+using Tester.CodeGenTests;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace DefaultCluster.Tests.General
+{
+    [TestCategory("BVT"), TestCategory("LocalClient")]
+    public class LocalClientTests : IClassFixture<LocalClientTests.LocalClientFixture>
+    {
+        private readonly TimeSpan timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(10);
+        private readonly ISiloHost silo;
+
+        public class LocalClientFixture
+        {
+            public ISiloHost Silo { get; }
+
+            public LocalClientFixture()
+            {
+                this.Silo = new SiloHostBuilder().ConfigureLocalHostPrimarySilo()
+                    .Configure<ClusterOptions>(options =>
+                    {
+                        options.ClusterId = Guid.NewGuid().ToString();
+                        options.ServiceId = Guid.NewGuid().ToString();
+                    })
+                    .AddMemoryGrainStorage("PubSubStore")
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>("MemStream")
+                    .Build();
+                this.Silo.StartAsync().GetAwaiter().GetResult();
+            }
+        }
+
+        public LocalClientTests(LocalClientFixture fixture)
+        {
+            this.silo = fixture.Silo;
+        }
+
+        [Fact]
+        public async Task LocalClient_GrainCallTest()
+        {
+            var client = this.silo.Services.GetRequiredService<IClusterClient>();
+
+            var grain = client.GetGrain<ISimpleGrain>(65);
+            await grain.SetA(23);
+            var val = await grain.GetA();
+            Assert.Equal(23, val);
+        }
+
+        [Fact]
+        public async Task LocalClient_ReferenceEquality_GrainCallTest()
+        {
+            var client = this.silo.Services.GetRequiredService<IClusterClient>();
+            var grain = client.GetGrain<IGrainWithGenericMethods>(Guid.NewGuid());
+
+            // Strings are immutable.
+            object expected = new string('*', 5);
+            var actual = await grain.RoundTrip(expected);
+            Assert.Same(expected, actual);
+
+            // Grain references are immutable.
+            actual = await grain.RoundTrip(grain);
+            Assert.Same(grain, actual);
+
+            // Arrays are not immutable, so a copy is expected.
+            var collection = new int[] { 1, 3, 9 };
+            actual = await grain.RoundTrip(collection);
+            Assert.NotSame(expected, actual);
+
+            // Immutable<T> should round-trip without any copying.
+            expected = new Immutable<int[]>(collection);
+            actual = await grain.RoundTrip(expected);
+            Assert.Same(expected, actual);
+        }
+
+        [Fact]
+        public async Task LocalClient_ObserverTest()
+        {
+            var client = this.silo.Services.GetRequiredService<IClusterClient>();
+
+            var handle = new AsyncResultHandle();
+
+            var callbackCounter = new int[1];
+            var callbacksRecieved = new bool[2];
+
+            var grain = client.GetGrain<ISimpleObserverableGrain>(0);
+            var observer = new ObserverTests.SimpleGrainObserver(
+                (a, b, result) =>
+                {
+                    Assert.Null(RuntimeContext.Current);
+                    callbackCounter[0]++;
+
+                    if (a == 3 && b == 0)
+                        callbacksRecieved[0] = true;
+                    else if (a == 3 && b == 2)
+                        callbacksRecieved[1] = true;
+                    else
+                        throw new ArgumentOutOfRangeException("Unexpected callback with values: a=" + a + ",b=" + b);
+
+                    if (callbackCounter[0] == 1)
+                    {
+                        // Allow for callbacks occurring in any order
+                        Assert.True(callbacksRecieved[0] || callbacksRecieved[1]);
+                    }
+                    else if (callbackCounter[0] == 2)
+                    {
+                        Assert.True(callbacksRecieved[0] && callbacksRecieved[1]);
+                        result.Done = true;
+                    }
+                    else
+                    {
+                        Assert.True(false);
+                    }
+                },
+                handle,
+                client.ServiceProvider.GetRequiredService<ILogger<ISimpleGrainObserver>>());
+            var reference = await client.CreateObjectReference<ISimpleGrainObserver>(observer);
+            await grain.Subscribe(reference);
+            await grain.SetA(3);
+            await grain.SetB(2);
+
+            Assert.True(await handle.WaitForFinished(timeout));
+
+            await client.DeleteObjectReference<ISimpleGrainObserver>(reference);
+            Assert.NotNull(observer);
+        }
+
+        [Fact]
+        public async Task LocalClient_StreamTest()
+        {
+            var client = this.silo.Services.GetRequiredService<IClusterClient>();
+
+            var handle = new AsyncResultHandle();
+            var vals = new List<int>();
+            await client.GetStreamProvider("MemStream").GetStream<int>(Guid.Empty, "hi")
+                        .SubscribeAsync(
+                            (val, token) =>
+                            {
+                                vals.Add(val);
+                                if (vals.Count >= 2) handle.Done = true;
+                                return Task.CompletedTask;
+                            });
+            var stream = client.GetStreamProvider("MemStream").GetStream<int>(Guid.Empty, "hi");
+            await stream.OnNextAsync(1);
+            await stream.OnNextAsync(409);
+            Assert.True(await handle.WaitForFinished(timeout));
+            Assert.Equal(new[] {1, 409}, vals);
+        }
+    }
+}

--- a/test/Extensions/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/Extensions/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -113,25 +113,29 @@ namespace ServiceBus.Tests.MonitorTests
 
         private void AssertCacheMonitorCallCounters(CacheMonitorCounters totalCacheMonitorCallCounters)
         {
-            Assert.True(totalCacheMonitorCallCounters.TrackCachePressureMonitorStatusChangeCallCounter > 0);
-            Assert.True(totalCacheMonitorCallCounters.TrackMemoryAllocatedCallCounter > 0);
-            Assert.Equal(0, totalCacheMonitorCallCounters.TrackMemoryReleasedCallCounter);
-            Assert.True(totalCacheMonitorCallCounters.TrackMessageAddedCounter > 0);
-            Assert.Equal(0, totalCacheMonitorCallCounters.TrackMessagePurgedCounter);
+            var c = totalCacheMonitorCallCounters;
+            Assert.True(c.TrackCachePressureMonitorStatusChangeCallCounter > 0,
+                $"Expected {nameof(c.TrackCachePressureMonitorStatusChangeCallCounter)} > 0, got {c.TrackCachePressureMonitorStatusChangeCallCounter}");
+            Assert.True(c.TrackMemoryAllocatedCallCounter > 0, $"Expected {nameof(c.TrackMemoryAllocatedCallCounter)} > 0, got {c.TrackMemoryAllocatedCallCounter}");
+            Assert.True(0 == c.TrackMemoryReleasedCallCounter, $"Expected {nameof(c.TrackMemoryReleasedCallCounter)} == 0, got {c.TrackMemoryReleasedCallCounter}");
+            Assert.True(c.TrackMessageAddedCounter > 0, $"Expected {nameof(c.TrackMessageAddedCounter)} > 0, got {c.TrackMessageAddedCounter}");
+            Assert.True(0 == c.TrackMessagePurgedCounter, $"Expected {nameof(c.TrackMessagePurgedCounter)} == 0, got {c.TrackMessagePurgedCounter}");
         }
 
         private void AssertReceiverMonitorCallCounters(EventHubReceiverMonitorCounters totalReceiverMonitorCallCounters)
         {
-            Assert.Equal(ehPartitionCountPerSilo, totalReceiverMonitorCallCounters.TrackInitializationCallCounter);
-            Assert.True(totalReceiverMonitorCallCounters.TrackMessagesReceivedCallCounter > 0);
-            Assert.True(totalReceiverMonitorCallCounters.TrackReadCallCounter > 0);
-            Assert.Equal(0, totalReceiverMonitorCallCounters.TrackShutdownCallCounter);
+            var c = totalReceiverMonitorCallCounters;
+            Assert.True(ehPartitionCountPerSilo == c.TrackInitializationCallCounter, $"Expected {nameof(c.TrackInitializationCallCounter)} == {ehPartitionCountPerSilo}, got {c.TrackInitializationCallCounter}");
+            Assert.True(c.TrackMessagesReceivedCallCounter > 0, $"Expected {nameof(c.TrackMessagesReceivedCallCounter)} > 0, got {c.TrackMessagesReceivedCallCounter}");
+            Assert.True(c.TrackReadCallCounter > 0, $"Expected {nameof(c.TrackReadCallCounter)} > 0, got {c.TrackReadCallCounter}");
+            Assert.True(0 == c.TrackShutdownCallCounter, $"Expected {nameof(c.TrackShutdownCallCounter)} == 0, got {c.TrackShutdownCallCounter}");
         }
 
         private void AssertObjectPoolMonitorCallCounters(ObjectPoolMonitorCounters totalObjectPoolMonitorCallCounters)
         {
-            Assert.True(totalObjectPoolMonitorCallCounters.TrackObjectAllocatedByCacheCallCounter > 0);
-            Assert.Equal(0, totalObjectPoolMonitorCallCounters.TrackObjectReleasedFromCacheCallCounter);
+            var c = totalObjectPoolMonitorCallCounters;
+            Assert.True(c.TrackObjectAllocatedByCacheCallCounter > 0, $"Expected {nameof(c.TrackObjectAllocatedByCacheCallCounter)} > 0, got {c.TrackObjectAllocatedByCacheCallCounter}");
+            Assert.True(0 == c.TrackObjectReleasedFromCacheCallCounter, $"Expected {nameof(c.TrackObjectReleasedFromCacheCallCounter)} == 0, got {c.TrackObjectReleasedFromCacheCallCounter}");
         }
     }
 }

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -685,7 +685,8 @@ namespace UnitTests.SchedulerTests
                 SiloAddress = SiloAddressUtils.NewLocalSiloAddress(23)
             };
             var grain = NonReentrentStressGrainWithoutState.Create(grainId, new GrainRuntime(Options.Create(new ClusterOptions()), silo, null, null, null, null, null, NullLoggerFactory.Instance));
-            await grain.OnActivateAsync();
+
+            await Task.Factory.StartNew(() => grain.OnActivateAsync(), CancellationToken.None, TaskCreationOptions.None, scheduler).Unwrap();
 
             Task wrapped = null;
             var wrapperDone = new TaskCompletionSource<bool>();
@@ -694,7 +695,7 @@ namespace UnitTests.SchedulerTests
             {
                 this.output.WriteLine("#0 - new Task - SynchronizationContext.Current={0} TaskScheduler.Current={1}",
                     SynchronizationContext.Current, TaskScheduler.Current);
-
+                
                 Task t1 = grain.Test1();
 
                 Action wrappedDoneAction = () => { wrappedDone.SetResult(true); };

--- a/test/Tester/LocalhostSiloTests.cs
+++ b/test/Tester/LocalhostSiloTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Orleans;
 using Orleans.Hosting;
 using Orleans.Runtime;
+using Orleans.TestingHost;
 using UnitTests.GrainInterfaces;
 using UnitTests.Grains;
 using Xunit;
@@ -20,13 +21,14 @@ namespace Tester
         [Fact]
         public async Task LocalhostSiloTest()
         {
+            var opts = TestSiloSpecificOptions.Create(new TestClusterOptions(), 1, true);
             var silo = new SiloHostBuilder()
                 .AddMemoryGrainStorage("MemoryStore")
-                .UseLocalhostClustering()
+                .UseLocalhostClustering(opts.SiloPort, opts.GatewayPort)
                 .Build();
 
             var client = new ClientBuilder()
-                .UseLocalhostClustering()
+                .UseLocalhostClustering(opts.GatewayPort)
                 .Build();
             try
             {


### PR DESCRIPTION
This PR adds seamless support to silos for calling grain methods, using streams, local objects, and any other client functionality from outside of the context of an activation or system target.

The primary scenarios this enables are:
* Efficient co-hosting of HTTP/etc servers (ASP.NET, Orleans Dashboard, gRPC) - no extra serialization/scheduling overhead.
* Ability to make grain calls from injected services, such as `IPlacementDirectors`, without having to use `TaskScheduler` capturing tricks.

Since this enables grain calls from non-grain threads, this also adds some guard rails: methods on `Grain`/`Grain<T>` are barred from outside of an activation context by virtue of `RuntimeContext` checks on `GrainRuntime` and `GrainStorageBridge`.

CI looks good, VSO looks good, load tests look good.

Reviewed by @dVakulen.

I changed the name from LocalClient/Silo-Local Client to Hosted Client. I think that sounds better, but please let me know if you feel that's an unsuitable name.

## How it works

* When accessing runtime from an outside thread for the first time, we instantiate & install `IHostedClient` into `ISiloMessageCenter` and `IClientObserverRegistrar`.
* `IHostedClient` creates and registers its own ClientId so that it can receive calls.
* Client-bound calls are routed to `IHostedClient` if the id matches
* `IRuntimeClient` methods behave differently depending on whether `RuntimeContext.Current` is `null` (hosted client) or not (running in activation context). Generally speaking, instead of throwing an exception when the context is null, we handle the operation via the hosted client.
* Grain method calls go through the regular `InsideRuntimeClient` pathway, but calls to grain observers (aka LocalObject aka InvokableObject) are routed to the `IHostedClient` implementation, which maintains a thread to schedule `Messages` which are destined for local objects. This logic was largely extracted from `OutsideRuntimeClient` and into a shared class, `InvokableObjectManager`. So this thread is only used for those calls and not for regular calls. This Grain Observer flow is an area to optimize in future (via shared executor service), but is not in need of optimization now: performance for those objects ought to be the same as it is for the external client today.

## OLD, busted description (ignore this)
This PR is a work-in-progress of an `IClusterClient` implementation which communicates directly with a silo in the same process.

The current implementation requires serialization for the `Message` objects sent between the client and silo. This is because `GrainReferences` must have their `IRuntimeClient` property set to the appropriate value (in this case either the `LocalClient` instance or the `InsideRuntimeClient` instance).

An alternative implementation might be feasible: instead of providing a completely separate `IRuntimeClient` implementation we could modify `InsideRuntimeClient` so that when it's being called from a non-Orleans context (`RuntimeContext.Current == null`) it defers to the implementations in this PR's `LocalClient`. As a result, issues such as #3273 and #3256 might not arise. However this also means that it's more difficult to catch bugs where we *should* be executing within a `SystemTarget` or `Grain` but have not correctly set the `RuntimeContext`. It's not inherently wrong to make grain calls from within a grain via `Task.Run()`, but that is the primary way we catch things which *are* bad (eg, modifying grain state). Another way to catch these kinds of bugs is to insert checks on `Grain` and `Grain<T>` members: that way, accessing `GrainFactory` or calling `WriteStateAsync()` from within `Task.Run()` would be disallowed (it's permitted today). I think this is a good approach - we can gain some coverage there, even if we're also losing some coverage because of this PR.

@gabikliot & others, do you have thoughts on that previous paragraph?

This ought to help with use cases such as alternative networking layers such as for HTTP & gRPC support.

* Installs a second 'gateway' called `ILocalClientGateway` into the silo
* Multiple `ILocalClient` implementations can be created and customized based upon the silo instance (maybe this should be changed to one!)
* Supports grain calls, observers, and streaming, but I have not yet added in-depth tests.
* Still a work in progress