### PR TITLE
SerializationManager.HasSerializer should account for primitive types.

### DIFF
--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -1077,6 +1077,7 @@ namespace Orleans.Serialization
                 Serializer ser;
                 if (serializers.TryGetValue(t.TypeHandle, out ser)) return true;
                 var typeInfo = t.GetTypeInfo();
+                if (typeInfo.IsOrleansPrimitive()) return true;
                 if (!typeInfo.IsGenericType) return false;
                 var genericTypeDefinition = typeInfo.GetGenericTypeDefinition();
                 return serializers.TryGetValue(genericTypeDefinition.TypeHandle, out ser) &&

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -120,6 +120,12 @@ namespace UnitTests.Serialization
         {
             var environment = InitializeSerializer(SerializerToUse.NoFallback);
             Assert.True(
+                environment.SerializationManager.HasSerializer(typeof(int)),
+                $"Should be able to serialize internal type {nameof(Int32)}.");
+            Assert.True(
+                environment.SerializationManager.HasSerializer(typeof(List<int>)),
+                $"Should be able to serialize internal type {nameof(List<int>)}.");
+            Assert.True(
                 environment.SerializationManager.HasSerializer(typeof(AddressesAndTag)),
                 $"Should be able to serialize internal type {nameof(AddressesAndTag)}.");
             Assert.True(
@@ -140,6 +146,9 @@ namespace UnitTests.Serialization
             Assert.True(
                 environment.SerializationManager.HasSerializer(typeof(EventHubSequenceTokenV2)),
                 $"Should be able to serialize internal type {nameof(EventHubSequenceTokenV2)}.");
+            Assert.True(
+                environment.SerializationManager.HasSerializer(typeof(ValueTuple<int, AddressAndTag>)),
+                $"Should be able to serialize internal type {nameof(ValueTuple<int, AddressAndTag>)}.");
         }
 
         [Theory, TestCategory("BVT"), TestCategory("Serialization")]


### PR DESCRIPTION
Fixes #3361 

@attilah was hitting this issue while porting to NETStandard 2.0. Not sure exactly why, but this is a deficiency anyway.