### PR TITLE
[WIP] xplat build-time code generation via MSBuild Task

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,9 +39,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(BuildFlavor)' == 'Current' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
-    <TargetFramework>netstandard1.5</TargetFramework>
-    <TestProjectTargetFramework>net462</TestProjectTargetFramework>
+<!--    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD_TODO</DefineConstants>-->
+    <DefineConstants>$(DefineConstants);USE_EVENTHUB</DefineConstants>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <TestProjectTargetFramework>net461</TestProjectTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(BuildFlavor)' == 'Legacy' ">
@@ -55,6 +56,7 @@
     <SystemRuntimeVersion>4.3.0</SystemRuntimeVersion>
     <SystemReflectionTypeExtensionsVersion>4.4.0</SystemReflectionTypeExtensionsVersion>
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
+    <SystemValueTupleVersion>4.4.0</SystemValueTupleVersion>
 
     <!-- Microsoft packages -->
     <MicrosoftCodeAnalysisCSharpVersion>2.0.0</MicrosoftCodeAnalysisCSharpVersion>
@@ -93,6 +95,7 @@
   <PropertyGroup Condition=" '$(BuildFlavor)' == 'Current' ">
     <!-- System packages -->
     <SystemNetHttpVersion>4.3.2</SystemNetHttpVersion>
+    <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
 
     <!-- Microsoft packages -->
     <MicrosoftApplicationInsightsVersion>2.2.0</MicrosoftApplicationInsightsVersion>

--- a/Orleans.sln
+++ b/Orleans.sln
@@ -127,6 +127,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		src\ClientGenerator\BootstrapCodegen.proj = src\ClientGenerator\BootstrapCodegen.proj
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeGenerator.MSBuild", "src\CodeGenerator.MSBuild\CodeGenerator.MSBuild.csproj", "{5AB09240-0898-4D79-B062-3D55F9C83048}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -809,6 +811,18 @@ Global
 		{73514686-D25D-478B-9943-A86F6B0F3A37}.Release|x64.Build.0 = Release|Any CPU
 		{73514686-D25D-478B-9943-A86F6B0F3A37}.Release|x86.ActiveCfg = Release|Any CPU
 		{73514686-D25D-478B-9943-A86F6B0F3A37}.Release|x86.Build.0 = Release|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Debug|x64.Build.0 = Debug|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Debug|x86.Build.0 = Debug|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Release|x64.ActiveCfg = Release|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Release|x64.Build.0 = Release|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Release|x86.ActiveCfg = Release|Any CPU
+		{5AB09240-0898-4D79-B062-3D55F9C83048}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -872,6 +886,7 @@ Global
 		{6E5860C5-44E7-415C-80D6-3ECF15A80796} = {4CD3AA9E-D937-48CA-BB6C-158E12257D23}
 		{EBD697E3-91BE-4844-B3F0-6997300A8C12} = {A6573187-FD0D-4DF7-91D1-03E07E470C0A}
 		{73514686-D25D-478B-9943-A86F6B0F3A37} = {4CD3AA9E-D937-48CA-BB6C-158E12257D23}
+		{5AB09240-0898-4D79-B062-3D55F9C83048} = {4CD3AA9E-D937-48CA-BB6C-158E12257D23}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7BFB3429-B5BB-4DB1-95B4-67D77A864952}

--- a/src/ClientGenerator/ClientGenerator.csproj
+++ b/src/ClientGenerator/ClientGenerator.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(BuildFlavor)' == 'Current' ">
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CodeGenerator.MSBuild/ClientGenerator.cs
+++ b/src/CodeGenerator.MSBuild/ClientGenerator.cs
@@ -1,0 +1,36 @@
+using Microsoft.Orleans.CodeGenerator.MSBuild;
+using Orleans.CodeGenerator;
+
+namespace Orleans.CodeGeneration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Reflection;
+    using Orleans.Serialization;
+    using Orleans.Runtime.Configuration;
+
+    internal class CodeGenOptions
+    {
+        public FileInfo InputAssembly;
+
+        public List<string> ReferencedAssemblies = new List<string>();
+
+        public string OutputFileName;
+    }
+
+    internal class GrainClientGeneratorFlags
+    {
+        internal static bool Verbose = false;
+
+        internal static bool FailOnPathNotFound = false;
+    }
+
+    /// <summary>
+    /// Generates factory, grain reference, and invoker classes for grain interfaces.
+    /// Generates state object classes for grain implementation classes.
+    /// </summary>
+    public class GrainClientGenerator
+    {
+    }
+}

--- a/src/CodeGenerator.MSBuild/CodeGenerator.MSBuild.csproj
+++ b/src/CodeGenerator.MSBuild/CodeGenerator.MSBuild.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
+    <AssemblyName>Microsoft.Orleans.CodeGenerator.MSBuild</AssemblyName>
+    <RootNamespace>Microsoft.Orleans.CodeGenerator.MSBuild</RootNamespace>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="build\**\*">
+      <Pack>true</Pack>
+      <PackagePath>build\%(RecursiveDir)</PackagePath>
+      <Visible>false</Visible>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Orleans\Orleans.csproj">
+      <Bootstrap>true</Bootstrap>
+      <Private>true</Private>
+      <PrivateAssets>all</PrivateAssets>
+      <DefineConstants>$(DefineConstants);EXCLUDE_CODEGEN</DefineConstants>
+    </ProjectReference>
+    <ProjectReference Include="..\OrleansCodeGenerator\OrleansCodeGenerator.csproj" />
+  </ItemGroup>
+
+  <Target Name="PackTaskDependencies" BeforeTargets="GenerateNuspec">
+   <!-- 
+    The include needs to happen after output has been copied to build output folder
+    but before NuGet generates a nuspec. See https://github.com/NuGet/Home/issues/4704.
+  -->
+    <ItemGroup>
+      <_PackageFiles Include="bin\$(Configuration)\**\*" Exclude="bin\$(Configuration)\**\$(AssemblyName).*">
+        <PackagePath>tasks\%(RecursiveDir)</PackagePath>
+        <Visible>false</Visible>
+        <BuildAction>Content</BuildAction>
+      </_PackageFiles>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/CodeGenerator.MSBuild/GenerateOrleansCode.cs
+++ b/src/CodeGenerator.MSBuild/GenerateOrleansCode.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Orleans.CodeGeneration;
+using Orleans.CodeGenerator;
+using Orleans.Runtime.Configuration;
+using Orleans.Serialization;
+using MSBuildTask = Microsoft.Build.Utilities.Task;
+
+namespace Microsoft.Orleans.CodeGenerator.MSBuild
+{
+    public class GenerateOrleansCode : MSBuildTask
+    {
+        private static readonly int[] SuppressCompilerWarnings =
+        {
+            162, // CS0162 - Unreachable code detected.
+            219, // CS0219 - The variable 'V' is assigned but its value is never used.
+            414, // CS0414 - The private field 'F' is assigned but its value is never used.
+            649, // CS0649 - Field 'F' is never assigned to, and will always have its default value.
+            693, // CS0693 - Type parameter 'type parameter' has the same name as the type parameter from outer type 'T'
+            1591, // CS1591 - Missing XML comment for publicly visible type or member 'Type_or_Member'
+            1998 // CS1998 - This async method lacks 'await' operators and will run synchronously
+        };
+        
+        [Required]
+        public ITaskItem InputAssembly { get; set; }
+
+        [Required]
+        public ITaskItem OutputFileName { get; set; }
+
+        [Required]
+        public ITaskItem[] ReferencePaths { get; set; }
+
+        public override bool Execute()
+        {
+            var options = new CodeGenOptions
+            {
+                InputAssembly = new FileInfo(this.InputAssembly.ItemSpec),
+                OutputFileName = this.OutputFileName.ItemSpec,
+                ReferencedAssemblies = this.ReferencePaths.Select(item => item.ItemSpec).ToList()
+            };
+            
+            return this.GenerateSource(options);
+        }
+        
+        /// <summary>
+        /// Generates one GrainReference class for each Grain Type in the inputLib file 
+        /// and output code file under outputLib directory
+        /// </summary>
+        private bool GenerateSource(CodeGenOptions options)
+        {
+            // Set up assembly resolver
+            var refResolver = new ReferenceResolver(options.ReferencedAssemblies, this.Log);
+            AppDomain.CurrentDomain.AssemblyResolve += refResolver.ResolveAssembly;
+
+            var generatedCode = this.GenerateCodeInner(options);
+
+            if (!string.IsNullOrWhiteSpace(generatedCode))
+            {
+                using (var sourceWriter = new StreamWriter(options.OutputFileName))
+                {
+                    sourceWriter.WriteLine("#if !EXCLUDE_CODEGEN");
+                    DisableWarnings(sourceWriter, SuppressCompilerWarnings);
+                    sourceWriter.WriteLine(generatedCode);
+                    RestoreWarnings(sourceWriter, SuppressCompilerWarnings);
+                    sourceWriter.WriteLine("#endif");
+                }
+
+                this.Log.LogMessage(MessageImportance.Normal, "Orleans-CodeGen - Generated file written {0}", options.OutputFileName);
+                return true;
+            }
+
+            return false;
+        }
+        
+        private string GenerateCodeInner(CodeGenOptions options)
+        {
+            // Load input assembly 
+            // Special-case Orleans.dll because there is a circular dependency.
+            var assemblyName = AssemblyName.GetAssemblyName(options.InputAssembly.FullName);
+            var grainAssembly = Path.GetFileName(options.InputAssembly.FullName) != "Orleans.dll"
+                ? Assembly.LoadFrom(options.InputAssembly.FullName)
+                : Assembly.Load(assemblyName);
+            
+            // Create directory for output file if it does not exist
+            var outputFileDirectory = Path.GetDirectoryName(options.OutputFileName);
+
+            if (!string.IsNullOrEmpty(outputFileDirectory) && !Directory.Exists(outputFileDirectory))
+            {
+                Directory.CreateDirectory(outputFileDirectory);
+            }
+
+            var config = new ClusterConfiguration();
+            var codeGenerator = new RoslynCodeGenerator(new SerializationManager(null, config.Globals, config.Defaults));
+
+            // Generate source
+            this.Log.LogMessage(MessageImportance.Normal, "Orleans-CodeGen - Generating file {0}", options.OutputFileName);
+
+            return codeGenerator.GenerateSourceForAssembly(grainAssembly);
+        }
+
+        private static void DisableWarnings(TextWriter sourceWriter, IEnumerable<int> warnings)
+        {
+            foreach (var warningNum in warnings) sourceWriter.WriteLine("#pragma warning disable {0}", warningNum);
+        }
+
+        private static void RestoreWarnings(TextWriter sourceWriter, IEnumerable<int> warnings)
+        {
+            foreach (var warningNum in warnings) sourceWriter.WriteLine("#pragma warning restore {0}", warningNum);
+        }
+    }
+}

--- a/src/CodeGenerator.MSBuild/ReferenceResolver.cs
+++ b/src/CodeGenerator.MSBuild/ReferenceResolver.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Orleans.CodeGenerator.MSBuild
+{
+    /// <summary>
+    /// Simple class that loads the reference assemblies upon the AppDomain.AssemblyResolve
+    /// </summary>
+    internal class ReferenceResolver
+    {
+        private readonly TaskLoggingHelper log;
+
+        /// <summary>
+        /// Needs to be public so can be serialized accross the the app domain.
+        /// </summary>
+        public Dictionary<string, string> ReferenceAssemblyPaths { get; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Inits the resolver
+        /// </summary>
+        /// <param name="referencedAssemblies">Full paths of referenced assemblies</param>
+        public ReferenceResolver(IEnumerable<string> referencedAssemblies, TaskLoggingHelper log)
+        {
+            this.log = log;
+            if (null == referencedAssemblies) return;
+
+            foreach (var assemblyPath in referencedAssemblies) this.ReferenceAssemblyPaths[Path.GetFileNameWithoutExtension(assemblyPath)] = assemblyPath;
+        }
+
+        /// <summary>
+        /// Handles System.AppDomain.AssemblyResolve event of an System.AppDomain
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="args">The event data.</param>
+        /// <returns>The assembly that resolves the type, assembly, or resource; 
+        /// or null if theassembly cannot be resolved.
+        /// </returns>
+        public Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+        {
+            Assembly assembly = null;
+            string path;
+            var asmName = new AssemblyName(args.Name);
+            if (this.ReferenceAssemblyPaths.TryGetValue(asmName.Name, out path)) assembly = Assembly.LoadFrom(path);
+            else this.log.LogWarning("Could not resolve {0}:", asmName.Name);
+            return assembly;
+        }
+    }
+}

--- a/src/CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
+++ b/src/CodeGenerator.MSBuild/build/Microsoft.Orleans.CodeGenerator.MSBuild.targets
@@ -1,0 +1,35 @@
+<Project TreatAsLocalProperty="TaskFolder;TaskAssembly">
+  <PropertyGroup>
+    <TaskFolder Condition=" '$(TaskFolder)' == '' ">netstandard2.0</TaskFolder>
+    <TaskAssembly>$(MSBuildThisFileDirectory)..\tasks\$(TaskFolder)\Microsoft.Orleans.CodeGenerator.MSBuild.dll</TaskAssembly>
+    <CodeGenDirectory Condition="'$([System.IO.Path]::IsPathRooted($(IntermediateOutputPath)))' == 'true'">$(IntermediateOutputPath)</CodeGenDirectory>
+    <CodeGenDirectory Condition="'$(CodeGenDirectory)' == ''">$(ProjectDir)$(IntermediateOutputPath)</CodeGenDirectory>
+    <OutputFileName>$(CodeGenDirectory)$(TargetName).$([System.DateTime]::UtcNow.Ticks).orleans.g.cs</OutputFileName>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Microsoft.Orleans.CodeGenerator.MSBuild.GenerateOrleansCode" AssemblyFile="$(TaskAssembly)" />
+
+  <!-- This target is run just before Compile for an Orleans Grain Interface Project -->
+  <Target Name="OrleansCodeGeneration"
+          AfterTargets="BeforeCompile"
+          BeforeTargets="CoreCompile"
+          Condition="'$(OrleansCodeGenPrecompile)'!='true'"
+          Inputs="@(Compile);@(ReferencePath)"
+          Outputs="$(OutputFileName)">
+    <PropertyGroup>
+      <ExcludeCodeGen>$(DefineConstants);EXCLUDE_CODEGEN</ExcludeCodeGen>
+      <IntermediateOutputPath>$(IntermediateOutputPath)codegen\</IntermediateOutputPath>
+      <InputAssembly>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</InputAssembly>
+    </PropertyGroup>
+    <ItemGroup>
+      <Compile Include="$(OutputFileName)" />
+      <FileWrites Include="$(OutputFileName)" />
+      <_ResolveAssemblyReferenceResolvedFiles Include="$(InputAssembly)" />
+    </ItemGroup>
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" Properties="IntermediateOutputPath=$(IntermediateOutputPath);OrleansCodeGenPrecompile=true;DefineConstants=$(ExcludeCodeGen)" UnloadProjectsOnCompletion="true" UseResultsCache="false" />
+    <GenerateOrleansCode
+      InputAssembly="$(InputAssembly)"
+      ReferencePaths="@(ReferencePath)"
+      OutputFileName="$(OutputFileName)" />      
+  </Target>
+</Project>

--- a/src/Orleans.PlatformServices/Orleans.PlatformServices.csproj
+++ b/src/Orleans.PlatformServices/Orleans.PlatformServices.csproj
@@ -10,25 +10,25 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework />
-    <TargetFrameworks>net462;netstandard1.5</TargetFrameworks>
+<!--    <TargetFramework />
+    <TargetFramework>netstandard2.0</TargetFramework>-->
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RootNamespace>Orleans.PlatformServices</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
+  <PropertyGroup>
     <DefineConstants>$(DefineConstants);NET46</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+<!--  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
+  </PropertyGroup>-->
 
   <ItemGroup>
     <PackageReference Include="System.Runtime" Version="$(SystemRuntimeVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+<!--  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeVersion)" />
-  </ItemGroup>
+  </ItemGroup>-->
 </Project>

--- a/src/Orleans/Configuration/ConfigUtilities.cs
+++ b/src/Orleans/Configuration/ConfigUtilities.cs
@@ -614,12 +614,13 @@ namespace Orleans.Runtime.Configuration
         {
             var sb = new StringBuilder();
             sb.Append("   Orleans version: ").AppendLine(RuntimeVersion.Current);
-#if !NETSTANDARD_TODO
+//ATTILA
+/*#if !NETSTANDARD_TODO
             // TODO: could use Microsoft.Extensions.PlatformAbstractions package to get this info
             sb.Append("   .NET version: ").AppendLine(Environment.Version.ToString());
             sb.Append("   OS version: ").AppendLine(Environment.OSVersion.ToString());
             sb.Append("   App config file: ").AppendLine(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile);
-#endif
+#endif*/
             sb.AppendFormat("   GC Type={0} GCLatencyMode={1}",
                               GCSettings.IsServerGC ? "Server" : "Client",
                               Enum.GetName(typeof(GCLatencyMode), GCSettings.LatencyMode))

--- a/src/Orleans/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans/Core/ClientBuilderExtensions.cs
@@ -109,6 +109,7 @@ namespace Orleans
         /// <summary>
         /// Specifies how the <see cref="IServiceProvider"/> for this client is configured. 
         /// </summary>
+        /// <param name="builder">The builder.</param>
         /// <param name="factory">The service provider factory.</param>
         /// <returns>The builder.</returns>
         public static IClientBuilder UseServiceProviderFactory(this IClientBuilder builder, Func<IServiceCollection, IServiceProvider> factory)

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -25,11 +25,12 @@
 
   <ItemGroup Condition=" '$(BuildFlavor)' == 'Current' ">
     <Compile Remove="Statistics\RuntimeStatisticsGroup.cs" />
+    <Compile Remove="Shims\AppDomain.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(BuildFlavor)' == 'Legacy' ">
-    <Compile Remove="Shims\AppDomain.cs" />
     <Compile Remove="Shims\RuntimeStatisticsGroup.cs" />
+    <Compile Remove="Shims\AppDomain.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(BuildFlavor)' == 'Legacy' ">
@@ -40,10 +41,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjection)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.ValueTuple" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(BuildFlavor)' == 'Legacy' ">
+  <ItemGroup>
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
 

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -461,24 +461,29 @@ namespace Orleans.Runtime
                 genericArg = null;
             genericArguments = genericArg;
 
-#if !NETSTANDARD_TODO
-            this.OnDeserialized(context);
-#endif
-        }
-
-#if !NETSTANDARD_TODO
-        /// <summary>
-        /// Called by BinaryFormatter after deserialization has completed.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        [OnDeserialized]
-        private void OnDeserialized(StreamingContext context)
-        {
+//ATTILA
             var serializerContext = context.Context as ISerializerContext;
             var runtimeClient = serializerContext?.AdditionalContext as IRuntimeClient;
             this.runtime = runtimeClient?.GrainReferenceRuntime;
+
+//#if !NETSTANDARD_TODO
+//            this.OnDeserialized(context);
+//#endif
         }
-#endif
+
+//#if !NETSTANDARD_TODO
+//        /// <summary>
+//        /// Called by BinaryFormatter after deserialization has completed.
+//        /// </summary>
+//        /// <param name="context">The context.</param>
+//        [OnDeserialized]
+//        private void OnDeserialized(StreamingContext context)
+//        {
+//            var serializerContext = context.Context as ISerializerContext;
+//            var runtimeClient = serializerContext?.AdditionalContext as IRuntimeClient;
+//            this.runtime = runtimeClient?.GrainReferenceRuntime;
+//        }
+//#endif
 #endregion
     }
 }

--- a/src/Orleans/Statistics/ThreadTrackingStatistic.cs
+++ b/src/Orleans/Statistics/ThreadTrackingStatistic.cs
@@ -206,7 +206,8 @@ namespace Orleans.Runtime
 
         private void TrackContextSwitches()
         {
-#if !NETSTANDARD_TODO
+//ATTILA
+/*#if !NETSTANDARD_TODO
             // TODO: this temporary exclusion should be resolved by #2147
             PerformanceCounterCategory allThreadsWithPerformanceCounters = new PerformanceCounterCategory("Thread");
             PerformanceCounter[] performanceCountersForThisThread = null;
@@ -235,7 +236,7 @@ namespace Orleans.Runtime
                     FloatValueStatistic.FindOrCreate(new StatisticName(StatisticNames.THREADS_CONTEXT_SWITCHES, Name), () => (float)performanceCounter.RawValue, CounterStorage.LogOnly);
                 }
             }
-#endif
+#endif*/
         }
     }
 }

--- a/src/Orleans/Streams/Internal/StreamImpl.cs
+++ b/src/Orleans/Streams/Internal/StreamImpl.cs
@@ -215,23 +215,27 @@ namespace Orleans.Streams
             streamId = (StreamId)info.GetValue("StreamId", typeof(StreamId));
             isRewindable = info.GetBoolean("IsRewindable");
             initLock = new object();
-#if !NETSTANDARD_TODO
-            this.OnDeserialized(context);
-#endif
+//ATTILA
+            var serializerContext = context.Context as ISerializerContext;
+            ((IOnDeserialized)this).OnDeserialized(serializerContext);
+
+//#if !NETSTANDARD_TODO
+//            this.OnDeserialized(context);
+//#endif
         }
 
-#if !NETSTANDARD_TODO
+//#if !NETSTANDARD_TODO
         /// <summary>
         /// Called by BinaryFormatter after deserialization has completed.
         /// </summary>
         /// <param name="context">The context.</param>
-        [OnDeserialized]
-        private void OnDeserialized(StreamingContext context)
-        {
-            var serializerContext = context.Context as ISerializerContext;
-            ((IOnDeserialized)this).OnDeserialized(serializerContext);
-        }
-#endif
+//        [OnDeserialized]
+//        private void OnDeserialized(StreamingContext context)
+//        {
+//            var serializerContext = context.Context as ISerializerContext;
+//            ((IOnDeserialized)this).OnDeserialized(serializerContext);
+//        }
+//#endif
 
         void IOnDeserialized.OnDeserialized(ISerializerContext context)
         {

--- a/src/OrleansAzureUtils/Hosting/AzureConfigUtils.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureConfigUtils.cs
@@ -124,7 +124,8 @@ namespace Orleans.Runtime.Host
                 if (appRootPath != null)
                     locations.Add(new DirectoryInfo(appRootPath));
             });
-#if !NETSTANDARD
+//ATTILA
+/*#if !NETSTANDARD
             //System.Web namespace is deprecated in netstandard, considering drop this block, since it's expressing an obsolte way to looking for rootPath in IIS web app
             Utils.SafeExecute(() =>
             {
@@ -146,7 +147,7 @@ namespace Orleans.Runtime.Host
                 if (appRootPath != null)
                     locations.Add(new DirectoryInfo(appRootPath));
             });
-#endif
+#endif*/
             // Try current directory
             locations.Add(new DirectoryInfo("."));
             return locations;

--- a/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
+++ b/src/OrleansCodeGenerator/CodeGeneratorCommon.cs
@@ -63,11 +63,12 @@ namespace Orleans.CodeGenerator
 
             // Reference everything which can be referenced.
             var assemblies =
-#if NETSTANDARD
-                Orleans.AppDomain.CurrentDomain.GetAssemblies()
-#else
+//ATTILA
+//#if NETSTANDARD
+//                Orleans.AppDomain.CurrentDomain.GetAssemblies()
+//#else
                 AppDomain.CurrentDomain.GetAssemblies()
-#endif
+//#endif
                     .Where(asm => !asm.IsDynamic && !string.IsNullOrWhiteSpace(asm.Location))
                     .Select(asm => MetadataReference.CreateFromFile(asm.Location))
                     .Cast<MetadataReference>()

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -294,11 +294,12 @@ namespace Orleans.CodeGenerator
         {
 #if ORLEANS_BOOTSTRAP
             throw new NotImplementedException();
-#elif NETSTANDARD
+//ATTILA
+/*#elif NETSTANDARD
             Assembly result;
             result = Orleans.PlatformServices.PlatformAssemblyLoader.LoadFromBytes(asm.RawBytes);
             Orleans.AppDomain.CurrentDomain.AddAssembly(result);
-            return result;
+            return result;*/
 #else
             return Assembly.Load(asm.RawBytes);
 #endif

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -4,9 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Reflection;
-#if NETSTANDARD
-using System.Reflection;
-#endif
 using System.Runtime;
 using System.Text;
 using System.Threading;

--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventDataGeneratorStreamProvider.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventDataGeneratorStreamProvider.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+﻿#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;
@@ -52,7 +52,7 @@ namespace Orleans.ServiceBus.Providers.Testing
         }
 
         /// <summary>
-        /// Configure eventhub partition count wanted. EventDataGeneratorStreamProvider would generate the same set of partitions based on the count, when initializing. 
+        /// Configure eventhub partition count wanted. EventDataGeneratorStreamProvider would generate the same set of partitions based on the count, when initializing.
         /// For example, if parition count set at 5, the generated partitions will be  partition-0, partition-1, partition-2, partition-3, partiton-4
         /// </summary>
         public int EventHubPartitionCount = DefaultEventHubPartitionCount;
@@ -223,7 +223,7 @@ namespace Orleans.ServiceBus.Providers.Testing
             }
 
             /// <summary>
-            /// Execute Command 
+            /// Execute Command
             /// </summary>
             /// <param name="command"></param>
             /// <param name="arg"></param>
@@ -239,7 +239,7 @@ namespace Orleans.ServiceBus.Providers.Testing
                         this.StopProducingOnStream(arg as IStreamIdentity);
                         break;
                     default: break;
-                        
+
                 }
                 return Task.FromResult((object)true);
             }

--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-#if NETSTANDARD
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 using static Microsoft.Azure.EventHubs.EventData;
 #else
@@ -63,8 +63,8 @@ namespace Orleans.ServiceBus.Providers.Testing
                 this.SequenceNumberCounter.Increment();
                 var eventData = EventHubBatchContainer.ToEventData<int>(this.serializationManager, this.StreamId.Guid, this.StreamId.Namespace,
                     this.GenerateEvent(this.SequenceNumberCounter.Value), RequestContext.Export(this.serializationManager));
-#if NETSTANDARD
-//set partition key
+#if USE_EVENTHUB
+                //set partition key
                 eventData.SetPartitionKey(this.StreamId.Guid.ToString());
 #endif
                 //set offset

--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+﻿#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;

--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubUtils.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/EventHubUtils.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+﻿#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 using static Microsoft.Azure.EventHubs.EventData;
 #else
@@ -47,7 +47,7 @@ namespace Orleans.ServiceBus.Providers.Testing
         {
             EventDataMethodCache.Instance.SetEnqueuedTimeUtc(eventData, enqueueTime);
         }
-#if NETSTANDARD
+#if USE_EVENTHUB
         /// <summary>
         /// Setter for EventData.PartitionKey
         /// </summary>
@@ -59,11 +59,11 @@ namespace Orleans.ServiceBus.Providers.Testing
         }
 #endif
     }
-#if NETSTANDARD
+#if USE_EVENTHUB
     internal class EventDataMethodCache
     {
         public static EventDataMethodCache Instance = new EventDataMethodCache();
-        private Action<object, object> systemPropertiesSetter; 
+        private Action<object, object> systemPropertiesSetter;
         private EventDataMethodCache()
         {
             var ignore = new EventData(new byte[1]);

--- a/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/IEventDataGenerator.cs
+++ b/src/OrleansServiceBus/Providers/EventDataGeneratorStreamProvider/IEventDataGenerator.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+﻿#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;
@@ -59,7 +59,7 @@ namespace Orleans.ServiceBus.Providers.Testing
         /// </summary>
         IStreamIdentity StreamId { get; }
         /// <summary>
-        /// 
+        ///
         /// </summary>
         bool ShouldProduce { set; }
     }

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventDataExtensions.cs
@@ -1,8 +1,7 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-#if NETSTANDARD
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -1,10 +1,9 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-#if NETSTANDARD
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus;
@@ -229,7 +228,7 @@ namespace Orleans.ServiceBus.Providers
                 throw new NotImplementedException("EventHub stream provider currently does not support non-null StreamSequenceToken.");
             }
             EventData eventData = EventHubBatchContainer.ToEventData(this.SerializationManager, streamGuid, streamNamespace, events, requestContext);
-#if NETSTANDARD
+#if USE_EVENTHUB
             return client.SendAsync(eventData, streamGuid.ToString());
 #else
             return client.SendAsync(eventData);
@@ -262,7 +261,7 @@ namespace Orleans.ServiceBus.Providers
 
         protected virtual void InitEventHubClient()
         {
-#if NETSTANDARD
+#if USE_EVENTHUB
             var connectionStringBuilder = new EventHubsConnectionStringBuilder(hubSettings.ConnectionString)
             {
                 EntityPath = hubSettings.Path
@@ -274,9 +273,9 @@ namespace Orleans.ServiceBus.Providers
         }
 
         /// <summary>
-        /// Create a IEventHubQueueCacheFactory. It will create a EventHubQueueCacheFactory by default. 
-        /// User can override this function to return their own implementation of IEventHubQueueCacheFactory, 
-        /// and other customization of IEventHubQueueCacheFactory if they may. 
+        /// Create a IEventHubQueueCacheFactory. It will create a EventHubQueueCacheFactory by default.
+        /// User can override this function to return their own implementation of IEventHubQueueCacheFactory,
+        /// and other customization of IEventHubQueueCacheFactory if they may.
         /// </summary>
         /// <param name="providerSettings"></param>
         /// <returns></returns>
@@ -288,7 +287,7 @@ namespace Orleans.ServiceBus.Providers
             var sharedDimensions = new EventHubMonitorAggregationDimensions(globalConfig, nodeConfig, eventHubPath);
             return new EventHubQueueCacheFactory(providerSettings, SerializationManager, sharedDimensions);
         }
- 
+
         private EventHubAdapterReceiver MakeReceiver(QueueId queueId)
         {
             var config = new EventHubPartitionSettings
@@ -297,14 +296,14 @@ namespace Orleans.ServiceBus.Providers
                 Partition = streamQueueMapper.QueueToPartition(queueId),
             };
             Logger recieverLogger = logger.GetSubLogger($"{config.Partition}");
-            
+
             var receiverMonitorDimensions = new EventHubReceiverMonitorDimensions();
             receiverMonitorDimensions.EventHubPartition = config.Partition;
             receiverMonitorDimensions.EventHubPath = config.Hub.Path;
             receiverMonitorDimensions.NodeConfig = this.serviceProvider.GetRequiredService<NodeConfiguration>();
             receiverMonitorDimensions.GlobalConfig = this.serviceProvider.GetRequiredService<GlobalConfiguration>();
 
-            return new EventHubAdapterReceiver(config, CacheFactory, CheckpointerFactory, recieverLogger, ReceiverMonitorFactory(receiverMonitorDimensions, recieverLogger), 
+            return new EventHubAdapterReceiver(config, CacheFactory, CheckpointerFactory, recieverLogger, ReceiverMonitorFactory(receiverMonitorDimensions, recieverLogger),
                 this.serviceProvider.GetRequiredService<Factory<NodeConfiguration>>(),
                 this.EventHubReceiverFactory);
         }
@@ -315,7 +314,7 @@ namespace Orleans.ServiceBus.Providers
         /// <returns></returns>
         protected virtual async Task<string[]> GetPartitionIdsAsync()
         {
-#if NETSTANDARD
+#if USE_EVENTHUB
             EventHubRuntimeInformation runtimeInfo = await client.GetRuntimeInformationAsync();
             return runtimeInfo.PartitionIds;
 #else

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-#if NETSTANDARD
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;
@@ -171,7 +171,7 @@ namespace Orleans.ServiceBus.Providers
 
             // monitor message age
             var dequeueTimeUtc = DateTime.UtcNow;
-#if NETSTANDARD
+#if USE_EVENTHUB
             DateTime oldestMessageEnqueueTime = messages[0].SystemProperties.EnqueuedTimeUtc;
             DateTime newestMessageEnqueueTime = messages[messages.Count - 1].SystemProperties.EnqueuedTimeUtc;
 #else
@@ -189,7 +189,7 @@ namespace Orleans.ServiceBus.Providers
             if (!checkpointer.CheckpointExists)
             {
                 checkpointer.Update(
-#if NETSTANDARD
+#if USE_EVENTHUB
                     messages[0].SystemProperties.Offset,
 #else
                     messages[0].Offset,
@@ -273,7 +273,7 @@ namespace Orleans.ServiceBus.Providers
         private static async Task<IEventHubReceiver> CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, Logger logger)
         {
             bool offsetInclusive = true;
-#if NETSTANDARD
+#if USE_EVENTHUB
             var connectionStringBuilder = new EventHubsConnectionStringBuilder(partitionSettings.Hub.ConnectionString)
             {
                 EntityPath = partitionSettings.Hub.Path
@@ -297,7 +297,7 @@ namespace Orleans.ServiceBus.Providers
             else
             {
                 // to start reading from most recent data, we get the latest offset from the partition.
-#if NETSTANDARD
+#if USE_EVENTHUB
                 EventHubPartitionRuntimeInformation partitionInfo =
 #else
                 PartitionRuntimeInformation partitionInfo =
@@ -307,7 +307,7 @@ namespace Orleans.ServiceBus.Providers
                 offsetInclusive = false;
                 logger.Info("Starting to read latest messages from EventHub partition {0}-{1} at offset {2}", partitionSettings.Hub.Path, partitionSettings.Partition, offset);
             }
-#if NETSTANDARD
+#if USE_EVENTHUB
             PartitionReceiver receiver = client.CreateReceiver(partitionSettings.Hub.ConsumerGroup, partitionSettings.Partition, offset, offsetInclusive);
 
             if (partitionSettings.Hub.PrefetchCount.HasValue)

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubBatchContainer.cs
@@ -1,9 +1,8 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
-#if NETSTANDARD
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;
@@ -49,7 +48,7 @@ namespace Orleans.ServiceBus.Providers
         // Payload is local cache of deserialized payloadBytes.  Should never be serialized as part of batch container.  During batch container serialization raw payloadBytes will always be used.
         [NonSerialized]
         private Body payload;
-        
+
         private Body GetPayload() => payload ?? (payload = this.serializationManager.DeserializeFromByteArray<Body>(eventHubMessage.Payload));
 
         [Serializable]
@@ -122,10 +121,10 @@ namespace Orleans.ServiceBus.Providers
                 RequestContext = requestContext
             };
             var bytes = serializationManager.SerializeToByteArray(payload);
-#if NETSTANDARD
+#if USE_EVENTHUB
             var eventData = new EventData(bytes);
 #else
-            var eventData = new EventData(bytes) { PartitionKey = streamGuid.ToString() }; 
+            var eventData = new EventData(bytes) { PartitionKey = streamGuid.ToString() };
 #endif
 
             if (!string.IsNullOrWhiteSpace(streamNamespace))
@@ -134,7 +133,7 @@ namespace Orleans.ServiceBus.Providers
             }
             return eventData;
         }
-       
+
         void IOnDeserialized.OnDeserialized(ISerializerContext context)
         {
             this.serializationManager = context.SerializationManager;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubConstants.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubConstants.cs
@@ -3,7 +3,7 @@ namespace Orleans.ServiceBus.Providers
     internal class EventHubConstants
     {
         public readonly static string StartOfStream =
-#if NETSTANDARD
+#if USE_EVENTHUB
             Microsoft.Azure.EventHubs.PartitionReceiver.StartOfStream;
 #else
             Microsoft.ServiceBus.Messaging.EventHubConsumerGroup.StartOfStream;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -1,6 +1,5 @@
-﻿
-using System;
-#if NETSTANDARD
+﻿using System;
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;
@@ -47,8 +46,8 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="evictionStrategy">Eviction stretagy manage purge related events</param>
         /// <param name="cacheMonitor"></param>
         /// <param name="cacheMonitorWriteInterval"></param>
-        protected EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, TCachedMessage> cacheDataAdapter, 
-            ICacheDataComparer<TCachedMessage> comparer, Logger logger, IEvictionStrategy<TCachedMessage> evictionStrategy, 
+        protected EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, TCachedMessage> cacheDataAdapter,
+            ICacheDataComparer<TCachedMessage> comparer, Logger logger, IEvictionStrategy<TCachedMessage> evictionStrategy,
             ICacheMonitor cacheMonitor, TimeSpan? cacheMonitorWriteInterval)
         {
             this.defaultMaxAddCount = defaultMaxAddCount;
@@ -83,7 +82,7 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="lastItemPurged"></param>
         /// <returns></returns>
         protected abstract string GetOffset(TCachedMessage lastItemPurged);
-        
+
         /// <summary>
         /// cachePressureContribution should be a double between 0-1, indicating how much danger the item is of being removed from the cache.
         ///   0 indicating  no danger,
@@ -185,7 +184,7 @@ namespace Orleans.ServiceBus.Providers
     /// Message cache that stores EventData as a CachedEventHubMessage in a pooled message cache
     /// </summary>
     public class EventHubQueueCache : EventHubQueueCache<CachedEventHubMessage>
-    {    
+    {
         private readonly Logger log;
 
         /// <summary>
@@ -198,9 +197,9 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="serializationManager"></param>
         /// <param name="cacheMonitor"></param>
         /// <param name="cacheMonitorWriteInterval"></param>
-        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, Logger logger, 
+        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate timePurge, Logger logger,
             SerializationManager serializationManager, ICacheMonitor cacheMonitor, TimeSpan? cacheMonitorWriteInterval)
-            : this(checkpointer, new EventHubDataAdapter(serializationManager, bufferPool), EventHubDataComparer.Instance, logger, 
+            : this(checkpointer, new EventHubDataAdapter(serializationManager, bufferPool), EventHubDataComparer.Instance, logger,
                   new EventHubCacheEvictionStrategy(logger, timePurge, cacheMonitor, cacheMonitorWriteInterval), cacheMonitor, cacheMonitorWriteInterval)
         {
         }
@@ -215,8 +214,8 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="evictionStrategy">eviction strategy for the cache</param>
         /// <param name="cacheMonitor"></param>
         /// <param name="cacheMonitorWriteInterval"></param>
-        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, 
-            ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger, IEvictionStrategy<CachedEventHubMessage> evictionStrategy, 
+        public EventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter,
+            ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger, IEvictionStrategy<CachedEventHubMessage> evictionStrategy,
             ICacheMonitor cacheMonitor, TimeSpan? cacheMonitorWriteInterval)
             : base(EventHubAdapterReceiver.MaxMessagesPerRead, checkpointer, cacheDataAdapter, comparer, logger, evictionStrategy, cacheMonitor, cacheMonitorWriteInterval)
         {
@@ -234,8 +233,8 @@ namespace Orleans.ServiceBus.Providers
         /// <param name="evictionStrategy">eviction strategy for the cache</param>
         /// <param name="cacheMonitor"></param>
         /// <param name="cacheMonitorWriteInterval"></param>
-        public EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter, 
-            ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger, IEvictionStrategy<CachedEventHubMessage> evictionStrategy, 
+        public EventHubQueueCache(int defaultMaxAddCount, IStreamQueueCheckpointer<string> checkpointer, ICacheDataAdapter<EventData, CachedEventHubMessage> cacheDataAdapter,
+            ICacheDataComparer<CachedEventHubMessage> comparer, Logger logger, IEvictionStrategy<CachedEventHubMessage> evictionStrategy,
             ICacheMonitor cacheMonitor, TimeSpan? cacheMonitorWriteInterval)
             : base(defaultMaxAddCount, checkpointer, cacheDataAdapter, comparer, logger, evictionStrategy, cacheMonitor, cacheMonitorWriteInterval)
         {
@@ -292,7 +291,7 @@ namespace Orleans.ServiceBus.Providers
             IEventHubPartitionLocation location = (IEventHubPartitionLocation) token;
             double cacheSize = cache.Newest.Value.SequenceNumber - cache.Oldest.Value.SequenceNumber;
             long distanceFromNewestMessage = cache.Newest.Value.SequenceNumber - location.SequenceNumber;
-            // pressure is the ratio of the distance from the front of the cache to the 
+            // pressure is the ratio of the distance from the front of the cache to the
             cachePressureContribution = distanceFromNewestMessage/cacheSize;
 
             return true;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -1,6 +1,5 @@
-﻿
-using System;
-#if NETSTANDARD
+﻿using System;
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubReceiver.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubReceiver.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+﻿#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;
@@ -37,7 +37,7 @@ namespace Orleans.ServiceBus.Providers
     /// </summary>
     internal class EventHubReceiverProxy: IEventHubReceiver
     {
-#if NETSTANDARD
+#if USE_EVENTHUB
         private PartitionReceiver receiver;
         public EventHubReceiverProxy(PartitionReceiver receiver)
         {

--- a/test/NonSilo.Tests/NonSilo.Tests.csproj
+++ b/test/NonSilo.Tests/NonSilo.Tests.csproj
@@ -8,6 +8,10 @@
     <Compile Remove="AssemblyLoaderTests.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(BuildFlavor)' == 'Current' ">
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\OrleansTestingHost\OrleansTestingHost.csproj" />

--- a/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -9,7 +9,7 @@ using Orleans.TestingHost.Utils;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-#if NETSTANDARD
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;
@@ -60,7 +60,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             this.logger = new NoOpTestLogger().GetLogger(this.GetType().Name);
         }
         //Disable tests if in netstandard, because Eventhub framework doesn't provide proper hooks for tests to generate proper EventData in netstandard
-#if !NETSTANDARD
+#if !USE_EVENTHUB
         [Fact, TestCategory("BVT")]
         public async Task EventhubQueueCache_WontPurge_WhenUnderPressure()
         {

--- a/test/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
+++ b/test/ServiceBus.Tests/EvictionStrategyTests/TestMocks.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+﻿#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus.Messaging;

--- a/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderForMonitorTests.cs
+++ b/test/ServiceBus.Tests/TestStreamProviders/EHStreamProviderForMonitorTests.cs
@@ -14,7 +14,7 @@ using Orleans.Serialization;
 using Orleans.Streams;
 using Orleans.Runtime.Configuration;
 using System.Threading;
-#if NETSTANDARD
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
 using Microsoft.ServiceBus;

--- a/test/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
+++ b/test/ServiceBus.Tests/TestStreamProviders/StreamPerPartitionEventHubStreamProvider.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Text;
-
-#if NETSTANDARD
+#if USE_EVENTHUB
 using Microsoft.Azure.EventHubs;
 #else
-
 using Microsoft.ServiceBus.Messaging;
-
 #endif
-
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Serialization;
@@ -66,7 +62,7 @@ namespace ServiceBus.Tests.TestStreamProviders.EventHub
             {
                 IStreamIdentity stremIdentity = new StreamIdentity(partitionStreamGuid, null);
                 StreamSequenceToken token =
-#if NETSTANDARD
+#if USE_EVENTHUB
                 new EventHubSequenceTokenV2(queueMessage.SystemProperties.Offset, queueMessage.SystemProperties.SequenceNumber, 0);
 #else
                 new EventHubSequenceTokenV2(queueMessage.Offset, queueMessage.SequenceNumber, 0);

--- a/test/TestFSharp/TestFSharp.fsproj
+++ b/test/TestFSharp/TestFSharp.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/test/TestFSharpInterfaces/TestFSharpInterfaces.fsproj
+++ b/test/TestFSharpInterfaces/TestFSharpInterfaces.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="$(SystemRuntimeVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is based upon @attilah NETStandard2.0 PR.

This PR enables build time code generation on linux via a new NuGet package: `Microsoft.Orleans.CodeGenerator.MSBuild`.

Sample project file:
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>netcoreapp2.0</TargetFramework>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.0.0-preview3" PrivateAssets="All" />
  </ItemGroup>
</Project>
```

It includes a small hack to remove a build warning:
```xml
<_ResolveAssemblyReferenceResolvedFiles Include="$(InputAssembly)" />
```

That suppresses a warning during the [`IncrementalClean` target](https://github.com/Microsoft/msbuild/blob/e7019886b3fd520b547a7353d78d106d72a4b828/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets#L4463-L4520) caused by the lack of AppDomains in the codegen task: no AppDomain -> no unloading assembly once codegen completes -> file remains locked -> cannot delete file during `IncrementalClean`.

Note: this enables building Orleans apps on linux/mac with build time codegen - but it's not complete. We need to also enable building Orleans itself, which is an MSBuild change (at its core: instead of using Orleans.SDK.targets we use this package). We also need to consider NuGet changes so that the existing nuget package is replaced by this, for example.