### PR TITLE
Fix ClientGenerator nuget pack, add possibility to override build flags

### DIFF
--- a/Build-Core.cmd
+++ b/Build-Core.cmd
@@ -2,7 +2,7 @@
 setlocal
 
 SET CMDHOME=%~dp0.
-SET BUILD_FLAGS=/m:1 /v:m
+if "%BUILD_FLAGS%"=="" SET BUILD_FLAGS=/m:1 /v:m
 
 :: Clear the 'Platform' env variable for this session, as it's a per-project setting within the build, and
 :: misleading value (such as 'MCD' in HP PCs) may lead to build breakage (issue: #69).

--- a/src/ClientGenerator/ClientGenerator.csproj
+++ b/src/ClientGenerator/ClientGenerator.csproj
@@ -36,7 +36,7 @@
       <PackagePath>build\$(PackageId).targets</PackagePath>
       <Visible>false</Visible>
     </None>
-    <None Include="$(OutDir)/ClientGenerator.exe.config;$(OutDir)/Orleans.Core.Abstractions.dll;$(OutDir)/Orleans.dll;$(OutDir)/OrleansCodeGenerator.dll;$(OutDir)/Microsoft.CodeAnalysis.dll;$(OutDir)/Microsoft.CodeAnalysis.CSharp.dll;$(OutDir)/System*.dll">
+    <None Include="$(OutDir)/ClientGenerator.exe.config;$(OutDir)/*.dll">
       <Pack>true</Pack>
       <PackagePath>tools\</PackagePath>
       <Visible>false</Visible>


### PR DESCRIPTION
- Fix ClientGenerator nuget to include every dll from the output folder (netstandard 2.0 was left out after update)
- Add a possibility to override build flags if needed (for example to enable parallel build)