### PR TITLE
NuGet updates and Debug type change for test projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -68,10 +68,10 @@
     <MicrosoftExtensionsDependencyInjection>1.1.1</MicrosoftExtensionsDependencyInjection>
 
     <MicrosoftDataSQLiteVersion>1.1.0</MicrosoftDataSQLiteVersion>
-    <MicrosoftPowerShell5ReferenceAssembliesVersion>1.0.0</MicrosoftPowerShell5ReferenceAssembliesVersion>
+    <MicrosoftPowerShell5ReferenceAssembliesVersion>1.1.0</MicrosoftPowerShell5ReferenceAssembliesVersion>
     <MicrosoftServiceFabricServicesVersion>2.4.145</MicrosoftServiceFabricServicesVersion>
 
-    <FSharpCoreVersion>4.2.1</FSharpCoreVersion>
+    <FSharpCoreVersion>4.2.3</FSharpCoreVersion>
 
     <SystemManagementAutomationdllVersion>10.0.10586</SystemManagementAutomationdllVersion>
 
@@ -92,22 +92,33 @@
 
   <PropertyGroup Condition=" '$(BuildFlavor)' == 'Current' ">
     <!-- System packages -->
+    <SystemCollectionsImmutableVersion>1.4.0</SystemCollectionsImmutableVersion>
     <SystemNetHttpVersion>4.3.2</SystemNetHttpVersion>
-    <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>1.5.0</SystemReflectionMetadataVersion>
     <SystemValueTupleVersion>4.4.0</SystemValueTupleVersion>
 
     <!-- Microsoft packages -->
-    <MicrosoftApplicationInsightsVersion>2.2.0</MicrosoftApplicationInsightsVersion>
-    <MicrosoftAzureEventHubsVersion>1.0.0</MicrosoftAzureEventHubsVersion>
-    <WindowsAzureStorageVersion>8.1.1</WindowsAzureStorageVersion>
+    <MicrosoftExtensionsConfigurationBinderVersion>2.0.0</MicrosoftExtensionsConfigurationBinderVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>2.0.0</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>2.0.0</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsConfigurationVersion>2.0.0</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsOptionsVersion>2.0.0</MicrosoftExtensionsOptionsVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsVersion>2.0.0</MicrosoftExtensionsOptionsConfigurationExtensionsVersion>
+    <MicrosoftExtensionsDependencyInjection>2.0.0</MicrosoftExtensionsDependencyInjection>
+
+    <MicrosoftApplicationInsightsVersion>2.4.0</MicrosoftApplicationInsightsVersion>
+    <MicrosoftAzureEventHubsVersion>1.0.3</MicrosoftAzureEventHubsVersion>
+    <MicrosoftDataSQLiteVersion>2.0.0</MicrosoftDataSQLiteVersion>
+    <MicrosoftServiceFabricServicesVersion>2.7.198</MicrosoftServiceFabricServicesVersion>
+    <WindowsAzureStorageVersion>8.2.1</WindowsAzureStorageVersion>
 
     <!-- 3rd party packages -->
-    <AWSSDKDynamoDBv2Version>3.3.3</AWSSDKDynamoDBv2Version>
-    <AWSSDKSQSVersion>3.3.1.7</AWSSDKSQSVersion>
-    <BondCoreCSharpVersion>5.2.0</BondCoreCSharpVersion>
-    <ConsulVersion>0.7.2.1</ConsulVersion>
-    <GoogleProtobufVersion>3.2.0</GoogleProtobufVersion>
-    <ZooKeeperNetExVersion>3.4.9.2</ZooKeeperNetExVersion>
+    <AWSSDKDynamoDBv2Version>3.3.4.17</AWSSDKDynamoDBv2Version>
+    <AWSSDKSQSVersion>3.3.2.7</AWSSDKSQSVersion>
+    <BondCoreCSharpVersion>5.3.1</BondCoreCSharpVersion>
+    <ConsulVersion>0.7.2.3</ConsulVersion>
+    <GoogleProtobufVersion>3.4.0</GoogleProtobufVersion>
+    <ZooKeeperNetExVersion>3.4.9.4</ZooKeeperNetExVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(BuildFlavor)' == 'Legacy' ">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -17,6 +17,11 @@
     <TargetFramework>$(TestProjectTargetFramework)</TargetFramework>
   </PropertyGroup>
 
+  <!-- To make CodeLens and Test Explorer happy, we're generating full symbols -->
+  <PropertyGroup>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
   <!-- Needed for to not to have failed tests because wrong binding redirects were generated for older packages -->
   <ItemGroup Condition=" '$(BuildFlavor)' == 'Current' ">
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />


### PR DESCRIPTION
- Update nuget package versions for 2.0 to align with .NET Core 2.0 release and other minor upgrades based on NetStandard compatibility and/or features.
- Change Debug type to full for test projects, so Test Explorer source code navigation and CodeLens will work again in VS.