### PR TITLE
Quick fix for .NET Core PNSE on ReflectionOnlyType

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -217,7 +217,7 @@ namespace Orleans.Runtime
                         if (IsCompatibleWithCurrentProcess(j, out complaints))
                         {
                             if (logger.IsVerbose) logger.Verbose("Trying to pre-load {0} to reflection-only context.", j);
-                            Assembly.ReflectionOnlyLoadFrom(j);
+                            Assembly.LoadFrom(j);
                         }
                         else
                         {
@@ -344,7 +344,7 @@ namespace Orleans.Runtime
 
                 if (IsCompatibleWithCurrentProcess(pathName, out complaints))
                 {
-                    assembly = Assembly.ReflectionOnlyLoadFrom(pathName);
+                    assembly = Assembly.LoadFrom(pathName);
                 }
                 else
                 {

--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -216,8 +216,12 @@ namespace Orleans.Runtime
 
                         if (IsCompatibleWithCurrentProcess(j, out complaints))
                         {
+#if BUILD_FLAVOR_LEGACY
                             if (logger.IsVerbose) logger.Verbose("Trying to pre-load {0} to reflection-only context.", j);
+                            Assembly.ReflectionOnlyLoadFrom(j);
+#else
                             Assembly.LoadFrom(j);
+#endif
                         }
                         else
                         {

--- a/src/Orleans/AssemblyLoader/CachedReflectionOnlyTypeResolver.cs
+++ b/src/Orleans/AssemblyLoader/CachedReflectionOnlyTypeResolver.cs
@@ -64,7 +64,7 @@ namespace Orleans.Runtime
 
                 try
                 {
-                    return Assembly.ReflectionOnlyLoadFrom(pathName);
+                    return Assembly.LoadFrom(pathName);
                 }
                 catch (FileNotFoundException)
                 {

--- a/src/Orleans/AssemblyLoader/CachedReflectionOnlyTypeResolver.cs
+++ b/src/Orleans/AssemblyLoader/CachedReflectionOnlyTypeResolver.cs
@@ -64,7 +64,11 @@ namespace Orleans.Runtime
 
                 try
                 {
+#if BUILD_FLAVOR_LEGACY
+                    return Assembly.ReflectionOnlyLoadFrom(pathName);
+#else
                     return Assembly.LoadFrom(pathName);
+#endif
                 }
                 catch (FileNotFoundException)
                 {

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -519,7 +519,7 @@ namespace Orleans.Runtime
 
         public static Type ToReflectionOnlyType(Type type)
         {
-            return type.Assembly.ReflectionOnly ? type : ResolveReflectionOnlyType(type.AssemblyQualifiedName);
+            return type;
         }
 
         public static IEnumerable<Type> GetTypes(Assembly assembly, Predicate<Type> whereFunc, Logger logger)

--- a/src/Orleans/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans/CodeGeneration/TypeUtils.cs
@@ -519,7 +519,11 @@ namespace Orleans.Runtime
 
         public static Type ToReflectionOnlyType(Type type)
         {
+#if BUILD_FLAVOR_LEGACY
+            return type.Assembly.ReflectionOnly ? type : ResolveReflectionOnlyType(type.AssemblyQualifiedName);
+#else
             return type;
+#endif
         }
 
         public static IEnumerable<Type> GetTypes(Assembly assembly, Predicate<Type> whereFunc, Logger logger)


### PR DESCRIPTION
This quick fix should allow loading on .NET Core 2.0. It's not ideal, but it ought to allow us to perform a 2.0 Technical Preview refresh