### PR TITLE
Fall back to full loading on .NET Core

### DIFF
--- a/src/Orleans/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans/AssemblyLoader/AssemblyLoader.cs
@@ -216,8 +216,7 @@ namespace Orleans.Runtime
 
                         if (IsCompatibleWithCurrentProcess(j, out complaints))
                         {
-                            if (logger.IsVerbose) logger.Verbose("Trying to pre-load {0} to reflection-only context.", j);
-                            Assembly.ReflectionOnlyLoadFrom(j);
+                            TryReflectionOnlyLoadFromOrFallback(j);
                         }
                         else
                         {
@@ -238,6 +237,18 @@ namespace Orleans.Runtime
             }
 
             return assemblies;
+        }
+
+        private static Assembly TryReflectionOnlyLoadFromOrFallback(string assembly)
+        {
+            if (TypeUtils.CanUseReflectionOnly)
+            {
+                return Assembly.ReflectionOnlyLoadFrom(assembly);
+            }
+            else
+            {
+                return Assembly.LoadFrom(assembly);
+            }
         }
 
         private bool ShouldExcludeAssembly(string pathName)
@@ -344,7 +355,7 @@ namespace Orleans.Runtime
 
                 if (IsCompatibleWithCurrentProcess(pathName, out complaints))
                 {
-                    assembly = Assembly.ReflectionOnlyLoadFrom(pathName);
+                    assembly = TryReflectionOnlyLoadFromOrFallback(pathName);
                 }
                 else
                 {

--- a/test/NonSilo.Tests/AssemblyLoaderTests.cs
+++ b/test/NonSilo.Tests/AssemblyLoaderTests.cs
@@ -100,20 +100,8 @@ namespace UnitTests
             var directories =
                 new Dictionary<string, SearchOption>
                     {
-                        {Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), 
-                            SearchOption.AllDirectories}
+                        { Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath), SearchOption.AllDirectories }
                     };
-
-            //
-            // We need to add current directory in case if xUnit is running an isolated copy of this test dll.
-            //
-
-            var currentDirectory = Path.GetDirectoryName(Environment.CurrentDirectory);
-
-            if (!directories.ContainsKey(currentDirectory))
-            {
-                directories.Add(currentDirectory, SearchOption.AllDirectories);
-            }
 
             var excludeCriteria =
                 new AssemblyLoaderPathNameCriterion[]


### PR DESCRIPTION
If ReflectionOnly assembly loading is not supported by the platform (which is the case in .NET Core), then fall back to fully loading every assembly for scanning.
In the future we will avoid this loading entirely, and only scan assemblies that were explicitly passed in (and pre-loaded) by the application developer.
In the meantime, the old behavior is preserved (by using ReflectionOnly) if the application is running in .NET.
This is a follow up from the PR https://github.com/dotnet/orleans/pull/3389 that was reverted