### PR TITLE
making JsonConverters inside OrleansJsonSerializer public

### DIFF
--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -162,7 +162,7 @@ namespace Orleans.Serialization
 
 #region JsonConverters
 
-    internal class IPAddressConverter : JsonConverter
+    public class IPAddressConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -182,7 +182,7 @@ namespace Orleans.Serialization
         }
     }
 
-    internal class GrainIdConverter : JsonConverter
+    public class GrainIdConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -206,7 +206,7 @@ namespace Orleans.Serialization
         }
     }
 
-    internal class SiloAddressConverter : JsonConverter
+    public class SiloAddressConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -230,7 +230,7 @@ namespace Orleans.Serialization
         }
     }
 
-    internal class UniqueKeyConverter : JsonConverter
+    public class UniqueKeyConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -254,7 +254,7 @@ namespace Orleans.Serialization
         }
     }
 
-    internal class IPEndPointConverter : JsonConverter
+    public class IPEndPointConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -281,7 +281,7 @@ namespace Orleans.Serialization
         }
     }
 
-    internal class GrainReferenceConverter : JsonConverter
+    public class GrainReferenceConverter : JsonConverter
     {
         private static readonly Type AddressableType = typeof(IAddressable);
         private readonly IGrainFactory grainFactory;


### PR DESCRIPTION
making the JsonCoverters public classes so they can be re-used by custom external serializers. This is following the discussion in issue #3298 