### PR TITLE
Remove Bucket.TryCancel and use Bucket.TryRemove instead

### DIFF
--- a/src/OrleansRuntime/Catalog/ActivationCollector.cs
+++ b/src/OrleansRuntime/Catalog/ActivationCollector.cs
@@ -300,7 +300,7 @@ namespace Orleans.Runtime
                         {
                             if (activation.GetIdleness(now) >= ageLimit)
                             {
-                                if (bucket.TryCancel(activation))
+                                if (bucket.TryRemove(activation))
                                 {
                                     // we removed the activation from the collector. it's our responsibility to deactivate it.
                                     activation.PrepareForDeactivation();
@@ -430,21 +430,9 @@ namespace Orleans.Runtime
 
             public bool TryRemove(ActivationData item)
             {
-                if (!TryCancel(item)) return false;
-
-                // actual removal is a memory optimization and isn't technically necessary to cancel the timeout.
-                ActivationData unused;
-                return items.TryRemove(item.ActivationId, out unused);
-            }
-
-            public bool TryCancel(ActivationData item)
-            {
                 if (!item.TrySetCollectionCancelledFlag()) return false;
 
-                // we need to null out the ActivationData reference in the bucket in order to ensure that the memory gets collected. if we've succeeded in setting the cancellation flag, then we should have won the right to do this, so we throw an exception if we fail.
-                if (items.TryUpdate(item.ActivationId, null, item)) return true;
-                    
-                throw new InvalidOperationException("unexpected failure to cancel deactivation");
+                return items.TryRemove(item.ActivationId, out ActivationData unused);
             }
 
             public IEnumerable<ActivationData> CancelAll()


### PR DESCRIPTION
Fix for #3165 and #3352 

When an `Activation.ScanAll` is called, we do not remove the `ActivationData` from the bucket, instead we set the value to `null`, that can cause `NullReferenceException` when we iterate again the `ActivationData` from the bucket.

I removed completely the `Bucket.TryCancel` method and merged the logic in `Bucket.TryRemove`. I am not sure what was the idea behind setting this to null instead of removing it (freeing some memory when iterating on the bucket?), but I don't think it was necessary.
