### PR TITLE
Remove usages of Silo class from the container

### DIFF
--- a/src/Orleans/SystemTargetInterfaces/ISiloControl.cs
+++ b/src/Orleans/SystemTargetInterfaces/ISiloControl.cs
@@ -26,6 +26,7 @@ namespace Orleans
 
         Task UpdateConfiguration(string configuration);
 
+        /// <summary>Load and initialize newly added stream providers. Remove providers that are not on the list that's being passed in.</summary>
         Task UpdateStreamProviders(IDictionary<string, ProviderCategoryConfiguration> streamProviderConfigurations);
   
         Task<int> GetActivationCount();

--- a/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
+++ b/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
@@ -67,28 +67,28 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ProviderManagerSystemTarget>();
 
             services.TryAddSingleton<StatisticsProviderManager>();
-            services.TryAddFromExisting<IProviderManager, StatisticsProviderManager>();
+            services.AddFromExisting<IProviderManager, StatisticsProviderManager>();
 
             // storage providers
             services.TryAddSingleton<StorageProviderManager>();
-            services.TryAddFromExisting<IProviderManager, StorageProviderManager>();
+            services.AddFromExisting<IProviderManager, StorageProviderManager>();
             services.TryAddFromExisting<IKeyedServiceCollection<string, IStorageProvider>, StorageProviderManager>(); // as named services
             services.TryAddSingleton<IStorageProvider>(sp => sp.GetRequiredService<StorageProviderManager>().GetDefaultProvider()); // default
 
             // log concistency providers
             services.TryAddSingleton<LogConsistencyProviderManager>();
-            services.TryAddFromExisting<IProviderManager, LogConsistencyProviderManager>();
+            services.AddFromExisting<IProviderManager, LogConsistencyProviderManager>();
             services.TryAddFromExisting<IKeyedServiceCollection<string, ILogConsistencyProvider>, LogConsistencyProviderManager>(); // as named services
             services.TryAddSingleton<ILogConsistencyProvider>(sp => sp.GetRequiredService<LogConsistencyProviderManager>().GetDefaultProvider()); // default
 
             services.TryAddSingleton<BootstrapProviderManager>();
-            services.TryAddFromExisting<IProviderManager, BootstrapProviderManager>();
+            services.AddFromExisting<IProviderManager, BootstrapProviderManager>();
             services.TryAddSingleton<LoadedProviderTypeLoaders>();
             services.TryAddSingleton<SerializationManager>();
             services.TryAddSingleton<ITimerRegistry, TimerRegistry>();
             services.TryAddSingleton<IReminderRegistry, ReminderRegistry>();
             services.TryAddSingleton<IStreamProviderManager, StreamProviderManager>();
-            services.TryAddFromExisting<IProviderManager, IStreamProviderManager>();
+            services.AddFromExisting<IProviderManager, IStreamProviderManager>();
             services.TryAddSingleton<GrainRuntime>();
             services.TryAddSingleton<IGrainRuntime, GrainRuntime>();
             services.TryAddSingleton<OrleansTaskScheduler>();

--- a/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
+++ b/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
@@ -64,24 +64,31 @@ namespace Orleans.Hosting
             services.TryAddTransient<ConsistentRingQueueBalancer>();
             services.TryAddTransient(typeof(IStreamSubscriptionObserver<>), typeof(StreamSubscriptionObserverProxy<>));
 
+            services.TryAddSingleton<ProviderManagerSystemTarget>();
+
             services.TryAddSingleton<StatisticsProviderManager>();
+            services.TryAddFromExisting<IProviderManager, StatisticsProviderManager>();
 
             // storage providers
             services.TryAddSingleton<StorageProviderManager>();
+            services.TryAddFromExisting<IProviderManager, StorageProviderManager>();
             services.TryAddFromExisting<IKeyedServiceCollection<string, IStorageProvider>, StorageProviderManager>(); // as named services
             services.TryAddSingleton<IStorageProvider>(sp => sp.GetRequiredService<StorageProviderManager>().GetDefaultProvider()); // default
 
             // log concistency providers
             services.TryAddSingleton<LogConsistencyProviderManager>();
+            services.TryAddFromExisting<IProviderManager, LogConsistencyProviderManager>();
             services.TryAddFromExisting<IKeyedServiceCollection<string, ILogConsistencyProvider>, LogConsistencyProviderManager>(); // as named services
             services.TryAddSingleton<ILogConsistencyProvider>(sp => sp.GetRequiredService<LogConsistencyProviderManager>().GetDefaultProvider()); // default
 
             services.TryAddSingleton<BootstrapProviderManager>();
+            services.TryAddFromExisting<IProviderManager, BootstrapProviderManager>();
             services.TryAddSingleton<LoadedProviderTypeLoaders>();
             services.TryAddSingleton<SerializationManager>();
             services.TryAddSingleton<ITimerRegistry, TimerRegistry>();
             services.TryAddSingleton<IReminderRegistry, ReminderRegistry>();
             services.TryAddSingleton<IStreamProviderManager, StreamProviderManager>();
+            services.TryAddFromExisting<IProviderManager, IStreamProviderManager>();
             services.TryAddSingleton<GrainRuntime>();
             services.TryAddSingleton<IGrainRuntime, GrainRuntime>();
             services.TryAddSingleton<OrleansTaskScheduler>();

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -88,7 +88,6 @@ namespace Orleans.Runtime
         private readonly object lockable = new object();
         private readonly GrainFactory grainFactory;
         private readonly IGrainRuntime grainRuntime;
-        private readonly List<IProvider> allSiloProviders = new List<IProvider>();
 
         /// <summary>
         /// Gets the type of this 
@@ -109,10 +108,6 @@ namespace Orleans.Runtime
         internal IStreamProviderManager StreamProviderManager { get { return grainRuntime.StreamProviderManager; } }
         internal IList<IBootstrapProvider> BootstrapProviders { get; private set; }
         internal ISiloPerformanceMetrics Metrics { get { return siloStatistics.MetricsTable; } }
-        internal IReadOnlyCollection<IProvider> AllSiloProviders 
-        {
-            get { return allSiloProviders.AsReadOnly();  }
-        }
         internal ICatalog Catalog => catalog;
 
         internal SystemStatus SystemStatus { get; set; }
@@ -298,7 +293,7 @@ namespace Orleans.Runtime
 
             logger.Verbose("Creating {0} System Target", "StreamProviderUpdateAgent");
             RegisterSystemTarget(
-                new StreamProviderManagerAgent(this, allSiloProviders, Services.GetRequiredService<IStreamProviderRuntime>()));
+                new StreamProviderManagerAgent(this, Services.GetRequiredService<IStreamProviderRuntime>()));
 
             logger.Verbose("Creating {0} System Target", "ProtocolGateway");
             RegisterSystemTarget(new ProtocolGateway(this.SiloAddress));
@@ -374,7 +369,7 @@ namespace Orleans.Runtime
                 .WaitWithThrow(initTimeout);
 
             // SystemTarget for provider init calls
-            providerManagerSystemTarget = new ProviderManagerSystemTarget(this);
+            providerManagerSystemTarget = Services.GetRequiredService<ProviderManagerSystemTarget>();
             RegisterSystemTarget(providerManagerSystemTarget);
         }
         
@@ -438,7 +433,6 @@ namespace Orleans.Runtime
                 .WaitForResultWithThrow(initTimeout);
             if (statsProviderName != null)
                 LocalConfig.StatisticsProviderName = statsProviderName;
-            allSiloProviders.AddRange(statisticsProviderManager.GetProviders());
 
             // can call SetSiloMetricsTableDataManager only after MessageCenter is created (dependency on this.SiloAddress).
             siloStatistics.SetSiloStatsTableDataManager(this, LocalConfig).WaitWithThrow(initTimeout);
@@ -459,7 +453,6 @@ namespace Orleans.Runtime
                 () => storageProviderManager.LoadStorageProviders(GlobalConfig.ProviderConfigurations),
                 providerManagerSystemTarget.SchedulingContext)
                     .WaitWithThrow(initTimeout);
-            allSiloProviders.AddRange(storageProviderManager.GetProviders());
 
             ITransactionAgent transactionAgent = this.Services.GetRequiredService<ITransactionAgent>();
             ISchedulingContext transactionAgentContext = (transactionAgent as SystemTarget)?.SchedulingContext;
@@ -485,7 +478,6 @@ namespace Orleans.Runtime
                     providerManagerSystemTarget.SchedulingContext)
                         .WaitWithThrow(initTimeout);
             runtimeClient.CurrentStreamProviderManager = siloStreamProviderManager;
-            allSiloProviders.AddRange(siloStreamProviderManager.GetProviders());
             if (logger.IsVerbose) { logger.Verbose("Stream provider manager created successfully."); }
 
             // Load and init grain services before silo becomes active.
@@ -550,7 +542,6 @@ namespace Orleans.Runtime
                     this.providerManagerSystemTarget.SchedulingContext)
                         .WaitWithThrow(this.initTimeout);
                 this.BootstrapProviders = this.bootstrapProviderManager.GetProviders(); // Data hook for testing & diagnotics
-                this.allSiloProviders.AddRange(this.BootstrapProviders);
 
                 if (this.logger.IsVerbose) { this.logger.Verbose("App bootstrap calls done successfully."); }
 
@@ -605,18 +596,6 @@ namespace Orleans.Runtime
                     this.logger.Verbose(String.Format("{0} Grain Service started successfully.", serviceConfig.Value.Name));
                 }
             }
-        }
-
-        /// <summary>
-        /// Load and initialize newly added stream providers. Remove providers that are not on the list that's being passed in.
-        /// </summary>
-        public async Task UpdateStreamProviders(IDictionary<string, ProviderCategoryConfiguration> streamProviderConfigurations)
-        {
-            IStreamProviderManagerAgent streamProviderUpdateAgent =
-                runtimeClient.InternalGrainFactory.GetSystemTarget<IStreamProviderManagerAgent>(Constants.StreamProviderManagerAgentSystemTargetId, this.SiloAddress);
-
-            await scheduler.QueueTask(() => streamProviderUpdateAgent.UpdateStreamProviders(streamProviderConfigurations), providerManagerSystemTarget.SchedulingContext)
-                    .WithTimeout(initTimeout);
         }
 
         private void ConfigureThreadPoolAndServicePointSettings()
@@ -960,8 +939,8 @@ namespace Orleans.Runtime
     // A dummy system target to use for scheduling context for provider Init calls, to allow them to make grain calls
     internal class ProviderManagerSystemTarget : SystemTarget
     {
-        public ProviderManagerSystemTarget(Silo currentSilo)
-            : base(Constants.ProviderManagerSystemTargetId, currentSilo.SiloAddress)
+        public ProviderManagerSystemTarget(ILocalSiloDetails localSiloDetails)
+            : base(Constants.ProviderManagerSystemTargetId, localSiloDetails.SiloAddress)
         {
         }
     }

--- a/src/OrleansRuntime/Silo/SiloControl.cs
+++ b/src/OrleansRuntime/Silo/SiloControl.cs
@@ -177,7 +177,7 @@ namespace Orleans.Runtime
                 try
                 {
                     var candidate = providerManager.GetProvider(providerName);
-                    if (candidate?.GetType()?.FullName?.Equals(providerTypeFullName) == true)
+                    if (string.Equals(providerTypeFullName, candidate?.GetType()?.FullName))
                     {
                         provider = candidate;
                         break;

--- a/src/OrleansRuntime/Silo/SiloControl.cs
+++ b/src/OrleansRuntime/Silo/SiloControl.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
@@ -17,31 +16,43 @@ namespace Orleans.Runtime
     internal class SiloControl : SystemTarget, ISiloControl
     {
         private static readonly Logger logger = LogManager.GetLogger("SiloControl", LoggerType.Runtime);
-        private readonly Silo silo;
+        private readonly ILocalSiloDetails localSiloDetails;
+        private readonly Factory<NodeConfiguration> localConfiguration;
+        private readonly ClusterConfiguration clusterConfiguration;
         private readonly DeploymentLoadPublisher deploymentLoadPublisher;
         private readonly Catalog catalog;
         private readonly GrainTypeManager grainTypeManager;
         private readonly ISiloPerformanceMetrics siloMetrics;
+        private readonly ProviderManagerSystemTarget providerManagerSystemTarget;
+        private readonly ICollection<IProviderManager> providerManagers;
         private readonly CachedVersionSelectorManager cachedVersionSelectorManager;
         private readonly CompatibilityDirectorManager compatibilityDirectorManager;
         private readonly VersionSelectorManager selectorManager;
 
         public SiloControl(
-            Silo silo,
+            ILocalSiloDetails localSiloDetails,
+            Factory<NodeConfiguration> localConfiguration,
+            ClusterConfiguration clusterConfiguration,
             DeploymentLoadPublisher deploymentLoadPublisher,
             Catalog catalog,
             GrainTypeManager grainTypeManager,
-            ISiloPerformanceMetrics siloMetrics, 
+            ISiloPerformanceMetrics siloMetrics,
+            IEnumerable<IProviderManager> providerManagers,
+            ProviderManagerSystemTarget providerManagerSystemTarget,
             CachedVersionSelectorManager cachedVersionSelectorManager, 
             CompatibilityDirectorManager compatibilityDirectorManager,
             VersionSelectorManager selectorManager)
-            : base(Constants.SiloControlId, silo.SiloAddress)
+            : base(Constants.SiloControlId, localSiloDetails.SiloAddress)
         {
-            this.silo = silo;
+            this.localSiloDetails = localSiloDetails;
+            this.localConfiguration = localConfiguration;
+            this.clusterConfiguration = clusterConfiguration;
             this.deploymentLoadPublisher = deploymentLoadPublisher;
             this.catalog = catalog;
             this.grainTypeManager = grainTypeManager;
             this.siloMetrics = siloMetrics;
+            this.providerManagerSystemTarget = providerManagerSystemTarget;
+            this.providerManagers = providerManagers.ToList();
             this.cachedVersionSelectorManager = cachedVersionSelectorManager;
             this.compatibilityDirectorManager = compatibilityDirectorManager;
             this.selectorManager = selectorManager;
@@ -60,7 +71,7 @@ namespace Orleans.Runtime
             var newTraceLevel = (Severity)traceLevel;
             logger.Info("SetSystemLogLevel={0}", newTraceLevel);
             LogManager.SetRuntimeLogLevel(newTraceLevel);
-            silo.LocalConfig.DefaultTraceLevel = newTraceLevel;
+            this.localConfiguration().DefaultTraceLevel = newTraceLevel;
             return Task.CompletedTask;
         }
 
@@ -126,7 +137,7 @@ namespace Orleans.Runtime
         {
             logger.Info("GetSimpleGrainStatistics");
             return Task.FromResult( this.catalog.GetSimpleGrainStatistics().Select(p =>
-                new SimpleGrainStatistic { SiloAddress = silo.SiloAddress, GrainType = p.Key, ActivationCount = (int)p.Value }).ToArray());
+                new SimpleGrainStatistic { SiloAddress = this.localSiloDetails.SiloAddress, GrainType = p.Key, ActivationCount = (int)p.Value }).ToArray());
         }
 
         public Task<DetailedGrainReport> GetDetailedGrainReport(GrainId grainId)
@@ -138,14 +149,19 @@ namespace Orleans.Runtime
         public Task UpdateConfiguration(string configuration)
         {
             logger.Info("UpdateConfiguration with {0}", configuration);
-            silo.OrleansConfig.Update(configuration);
-            logger.Info(ErrorCode.Runtime_Error_100318, "UpdateConfiguration - new config is now {0}", silo.OrleansConfig.ToString(silo.Name));
+            this.clusterConfiguration.Update(configuration);
+            logger.Info(ErrorCode.Runtime_Error_100318, "UpdateConfiguration - new config is now {0}", this.clusterConfiguration.ToString(this.localSiloDetails.Name));
             return Task.CompletedTask;
         }
 
-        public Task UpdateStreamProviders(IDictionary<string, ProviderCategoryConfiguration> streamProviderConfigurations)
+        /// <inheritdoc />
+        public async Task UpdateStreamProviders(IDictionary<string, ProviderCategoryConfiguration> streamProviderConfigurations)
         {
-            return silo.UpdateStreamProviders(streamProviderConfigurations);
+            IStreamProviderManagerAgent streamProviderUpdateAgent =
+                RuntimeClient.InternalGrainFactory.GetSystemTarget<IStreamProviderManagerAgent>(Constants.StreamProviderManagerAgentSystemTargetId, this.localSiloDetails.SiloAddress);
+
+            await this.providerManagerSystemTarget.ScheduleTask(() => streamProviderUpdateAgent.UpdateStreamProviders(streamProviderConfigurations))
+                .WithTimeout(TimeSpan.FromSeconds(25));
         }
 
         public Task<int> GetActivationCount()
@@ -155,18 +171,25 @@ namespace Orleans.Runtime
 
         public Task<object> SendControlCommandToProvider(string providerTypeFullName, string providerName, int command, object arg)
         {
-            IReadOnlyCollection<IProvider> allProviders = silo.AllSiloProviders;
-            IProvider provider = allProviders.FirstOrDefault(pr => pr.GetType().FullName.Equals(providerTypeFullName) && pr.Name.Equals(providerName));
+            IProvider provider = null;
+            foreach (var providerManager in this.providerManagers)
+            {
+                try
+                {
+                    var candidate = providerManager.GetProvider(providerName);
+                    if (candidate?.GetType()?.FullName?.Equals(providerTypeFullName) == true)
+                    {
+                        provider = candidate;
+                        break;
+                    }
+                }
+                catch (Exception)
+                {
+                }
+            }
             if (provider == null)
             {
-                string allProvidersList = Utils.EnumerableToString(
-                    allProviders.Select(p => string.Format(
-                        "[Name = {0} Type = {1} Location = {2}]",
-                        p.Name, p.GetType().FullName, p.GetType().GetTypeInfo().Assembly.Location)));
-                string error = string.Format(
-                    "Could not find provider for type {0} and name {1} \n"
-                    + " Providers currently loaded in silo are: {2}", 
-                    providerTypeFullName, providerName, allProvidersList);
+                string error = $"Could not find provider for type {providerTypeFullName} and name {providerName}.";
                 logger.Error(ErrorCode.Provider_ProviderNotFound, error);
                 throw new ArgumentException(error);
             }
@@ -174,9 +197,7 @@ namespace Orleans.Runtime
             IControllable controllable = provider as IControllable;
             if (controllable == null)
             {
-                string error = string.Format(
-                    "The found provider of type {0} and name {1} is not controllable.", 
-                    providerTypeFullName, providerName);
+                string error = $"The found provider of type {providerTypeFullName} and name {providerName} is not controllable.";
                 logger.Error(ErrorCode.Provider_ProviderNotControllable, error);
                 throw new ArgumentException(error);
             }

--- a/src/OrleansRuntime/Streams/StreamProviderManagerAgent.cs
+++ b/src/OrleansRuntime/Streams/StreamProviderManagerAgent.cs
@@ -13,19 +13,17 @@ namespace Orleans.Runtime
     internal class StreamProviderManagerAgent : SystemTarget, IStreamProviderManagerAgent
     {
         private readonly StreamProviderManager streamProviderManager;
-        private readonly List<IProvider> allSiloProviders;
         private readonly IStreamProviderRuntime streamProviderRuntime;
         private readonly IDictionary<string, ProviderCategoryConfiguration> providerConfigurations;
         private readonly Logger logger;
         private readonly AsyncSerialExecutor nonReentrancyGuarantor;
 
-        public StreamProviderManagerAgent(Silo silo, List<IProvider> allSiloProviders, IStreamProviderRuntime streamProviderRuntime)
+        public StreamProviderManagerAgent(Silo silo, IStreamProviderRuntime streamProviderRuntime)
             : base(Constants.StreamProviderManagerAgentSystemTargetId, silo.SiloAddress)
         {
             logger = LogManager.GetLogger("StreamProviderUpdateAgent", LoggerType.Runtime);
             this.streamProviderManager = (StreamProviderManager)silo.StreamProviderManager;
             providerConfigurations = silo.GlobalConfig.ProviderConfigurations;
-            this.allSiloProviders = allSiloProviders;
             this.streamProviderRuntime = streamProviderRuntime;
             nonReentrancyGuarantor = new AsyncSerialExecutor();
         }
@@ -91,12 +89,6 @@ namespace Orleans.Runtime
                 logger.Error(ErrorCode.Provider_ErrorFromInit, exc.Message, exc);
                 throw;
             }
-
-            IList<IProvider> providerList = siloStreamProviderManager.GetProviders();
-
-            // update allSiloProviders
-            allSiloProviders.Clear();
-            allSiloProviders.AddRange(providerList);
 
             if (logger.IsVerbose) { logger.Verbose("Stream providers updated successfully."); }
             providerConfigurations[ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME] = 


### PR DESCRIPTION
Remove usages of Silo class that were being resolved from the container.
This reduces the exposure of this big class as a dependency to other components.

It enables silo builders that do not register `Silo` in the container, which is useful as we experiment with the generic HostBuilder in Microsoft.Extensions.Hosting (pre-release)