### PR TITLE
Fix leak in registration of partition notifications

### DIFF
--- a/src/OrleansServiceFabricUtils/FabricServiceSiloResolver.cs
+++ b/src/OrleansServiceFabricUtils/FabricServiceSiloResolver.cs
@@ -81,6 +81,13 @@ namespace Microsoft.Orleans.ServiceFabric
                 foreach (var partition in this.silos)
                 {
                     var partitionInfo = partition.Partition;
+                    if (oldRegistrations != null && oldRegistrations.ContainsKey(partitionInfo.Id))
+                    {
+                        updatedRegistrations[partitionInfo.Id] = oldRegistrations[partitionInfo.Id];
+                        oldRegistrations.Remove(partitionInfo.Id);
+                        if (this.log.IsVerbose) this.log.Verbose($"Partition change handler for partition {partition.Partition} already registered.");
+                        continue;
+                    }
                     var registrationId = updatedRegistrations[partitionInfo.Id] = this.queryManager.RegisterPartitionChangeHandler(
                         this.serviceName,
                         partitionInfo,
@@ -93,11 +100,8 @@ namespace Microsoft.Orleans.ServiceFabric
                 {
                     foreach (var registration in oldRegistrations)
                     {
-                        if (!updatedRegistrations.ContainsKey(registration.Key))
-                        {
-                            if (this.log.IsVerbose) this.log.Verbose($"Unregistering partition change handler 0x{registration.Value:X}");
-                            this.queryManager.UnregisterPartitionChangeHandler(registration.Value);
-                        }
+                        if (this.log.IsVerbose) this.log.Verbose($"Unregistering partition change handler 0x{registration.Value:X}");
+                        this.queryManager.UnregisterPartitionChangeHandler(registration.Value);
                     }
                 }
 


### PR DESCRIPTION
We were seeing a steadily increasing CPU usage on our service-fabric hosted silos & orleans clients. We tracked this down to Fabric Data Collection Agent, which writes ETW trace logs to disk (among other things, i assume). 
![cpu_graph](https://user-images.githubusercontent.com/8071240/30537837-9e3df0ec-9c6b-11e7-9257-1e601c95ad35.png)

After 3 days of uptime on our cluster, we were seeing about 700,000 events with the id 55639 per minute in the ETW logs and even though these events contain basically no useful information, we tracked this down to RegisterServicePartitionResolutionChangeHandler. Every time FabricServiceSiloResolver.Refresh() was called, the ETW logs would be spammed with all the current handler IDs as well as the new one. 

I believe one should not re-register for the notifications, especially if not cleaning up the old handler IDs for those partitions.

I opted to change the code to not re-register for partitions that were previously registered, to avoid constant re-registrations, and at the same time not leak old handler ids for existing partitions.