### PR TITLE
Add minimal Orleans.runsettings for tests.

### DIFF
--- a/Orleans.runsettings
+++ b/Orleans.runsettings
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <TargetPlatform>x64</TargetPlatform>
+    <TargetFrameworkVersion>Framework45</TargetFrameworkVersion>
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
These minimal runsettings can be used for unit tests. We can consider adding more settings to it afterwards (eg, code coverage / exclusions).

A very similar file is used in LoadTests