### PR TITLE
Align our HostBuilder infrastructure with Microsoft.Extensions.Hosting

### DIFF
--- a/src/Orleans.Transactions.Azure/Hosting/SiloBuilderExtensions.cs
+++ b/src/Orleans.Transactions.Azure/Hosting/SiloBuilderExtensions.cs
@@ -10,7 +10,7 @@ namespace Orleans.Transactions.Azure
         /// <summary>
         /// Configure cluster to use azure transaction log.
         /// </summary>
-        public static ISiloBuilder UseAzureTransactionLog(this ISiloBuilder builder, AzureTransactionLogConfiguration config)
+        public static ISiloHostBuilder UseAzureTransactionLog(this ISiloHostBuilder builder, AzureTransactionLogConfiguration config)
         {
             return builder.ConfigureServices(UseAzureTransactionLog)
                           .Configure<AzureTransactionLogConfiguration>((cfg) => cfg.Copy(config));

--- a/src/Orleans.Transactions/Development/DevelopmentSiloBuilderExtensions.cs
+++ b/src/Orleans.Transactions/Development/DevelopmentSiloBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace Orleans.Transactions.Development
         /// Configure cluster to use an in-memory transaction log.
         /// For development and test purposes only
         /// </summary>
-        public static ISiloBuilder UseInMemoryTransactionLog(this ISiloBuilder builder)
+        public static ISiloHostBuilder UseInMemoryTransactionLog(this ISiloHostBuilder builder)
         {
             return builder.ConfigureServices(UseInMemoryTransactionLog);
         }

--- a/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
+++ b/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Orleans.Transactions
         /// <summary>
         /// Configure cluster to use an in-cluster transaction manager.
         /// </summary>
-        public static ISiloBuilder UseInClusterTransactionManager(this ISiloBuilder builder, TransactionsConfiguration config)
+        public static ISiloHostBuilder UseInClusterTransactionManager(this ISiloHostBuilder builder, TransactionsConfiguration config)
         {
             return builder.ConfigureServices(UseInClusterTransactionManager)
                           .Configure<TransactionsConfiguration>((cfg) => cfg.Copy(config));
@@ -20,7 +20,7 @@ namespace Orleans.Transactions
         /// <summary>
         /// Configure cluster to support the use of transactional state.
         /// </summary>
-        public static ISiloBuilder UseTransactionalState(this ISiloBuilder builder)
+        public static ISiloHostBuilder UseTransactionalState(this ISiloHostBuilder builder)
         {
             return builder.ConfigureServices(UseTransactionalState);
         }

--- a/src/Orleans/Configuration/ConfigurationExtensions.cs
+++ b/src/Orleans/Configuration/ConfigurationExtensions.cs
@@ -63,7 +63,7 @@ namespace Orleans.Runtime.Configuration
         /// Configures all cluster nodes to use the specified startup class for dependency injection.
         /// </summary>
         /// <typeparam name="TStartup">Startup type</typeparam>
-        [Obsolete("Using ISiloBuilder.ConfigureServices(Action configureServices) or ISiloBuilder.UseServiceProviderFactory(IServiceProviderFactory factory)")]
+        [Obsolete("Using ISiloHostBuilder.ConfigureServices(Action configureServices) or ISiloHostBuilder.UseServiceProviderFactory(IServiceProviderFactory factory)")]
         public static void UseStartupType<TStartup>(this ClusterConfiguration config) 
         {
             var startupName = typeof(TStartup).AssemblyQualifiedName;

--- a/src/Orleans/Hosting/HostBuilderContext.cs
+++ b/src/Orleans/Hosting/HostBuilderContext.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Context containing the common services on the host. Some properties may be null until set by the host.
+    /// </summary>
+    public class HostBuilderContext
+    {
+        public HostBuilderContext(IDictionary<object, object> properties)
+        {
+            Properties = properties ?? throw new System.ArgumentNullException(nameof(properties));
+        }
+
+        /// <summary>
+        /// The <see cref="IConfiguration" /> containing the merged configuration of the application and the host.
+        /// </summary>
+        public IConfiguration Configuration { get; set; }
+        
+        /// <summary>
+        /// A central location for sharing state between components during the host building process.
+        /// </summary>
+        public IDictionary<object, object> Properties { get; }
+    }
+}

--- a/src/Orleans/Hosting/IServiceProviderFactoryAdapter.cs
+++ b/src/Orleans/Hosting/IServiceProviderFactoryAdapter.cs
@@ -11,15 +11,16 @@ namespace Orleans.Hosting
         /// <summary>
         /// Creates a <see cref="IServiceProvider"/> from an <see cref="IServiceCollection" />.
         /// </summary>
+        /// <param name="context">The host builder context.</param>
         /// <param name="services">The collection of services.</param>
         /// <returns>A <see cref="IServiceProvider" />.</returns>
-        IServiceProvider BuildServiceProvider(IServiceCollection services);
+        IServiceProvider BuildServiceProvider(HostBuilderContext context, IServiceCollection services);
 
         /// <summary>
         /// Adds a container configuration delegate.
         /// </summary>
         /// <typeparam name="TContainerBuilder">The container builder type.</typeparam>
         /// <param name="configureContainer">The container builder configuration delegate.</param>
-        void ConfigureContainer<TContainerBuilder>(Action<TContainerBuilder> configureContainer);
+        void ConfigureContainer<TContainerBuilder>(Action<HostBuilderContext, TContainerBuilder> configureContainer);
     }
 }

--- a/src/Orleans/Hosting/ServiceProviderFactoryAdapter.cs
+++ b/src/Orleans/Hosting/ServiceProviderFactoryAdapter.cs
@@ -11,7 +11,7 @@ namespace Orleans.Hosting
     internal class ServiceProviderFactoryAdapter<TContainerBuilder> : IServiceProviderFactoryAdapter
     {
         private readonly IServiceProviderFactory<TContainerBuilder> serviceProviderFactory;
-        private readonly List<Action<TContainerBuilder>> configureContainerDelegates = new List<Action<TContainerBuilder>>();
+        private readonly List<Action<HostBuilderContext, TContainerBuilder>> configureContainerDelegates = new List<Action<HostBuilderContext, TContainerBuilder>>();
 
         public ServiceProviderFactoryAdapter(IServiceProviderFactory<TContainerBuilder> serviceProviderFactory)
         {
@@ -19,23 +19,23 @@ namespace Orleans.Hosting
         }
 
         /// <inheritdoc />
-        public IServiceProvider BuildServiceProvider(IServiceCollection services)
+        public IServiceProvider BuildServiceProvider(HostBuilderContext context, IServiceCollection services)
         {
             var builder = this.serviceProviderFactory.CreateBuilder(services);
 
             foreach (var configureContainer in this.configureContainerDelegates)
             {
-                configureContainer(builder);
+                configureContainer(context, builder);
             }
 
             return this.serviceProviderFactory.CreateServiceProvider(builder);
         }
 
         /// <inheritdoc />
-        public void ConfigureContainer<TBuilder>(Action<TBuilder> configureContainer)
+        public void ConfigureContainer<TBuilder>(Action<HostBuilderContext, TBuilder> configureContainer)
         {
             if (configureContainer == null) throw new ArgumentNullException(nameof(configureContainer));
-            var typedDelegate = configureContainer as Action<TContainerBuilder>;
+            var typedDelegate = configureContainer as Action<HostBuilderContext, TContainerBuilder>;
             if (typedDelegate == null)
             {
                 var msg = $"Type of configuration delegate requires builder of type {typeof(TBuilder)} which does not match previously configured container builder type {typeof(TContainerBuilder)}.";

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/OrleansRuntime/Development/DevelopmentSiloBuilderExtensions.cs
+++ b/src/OrleansRuntime/Development/DevelopmentSiloBuilderExtensions.cs
@@ -10,7 +10,7 @@ namespace Orleans.Runtime.Development
         /// Configure silo with test/developement features.
         /// NOT FOR PRODUCTION USE - dev/test only
         /// </summary>
-        public static ISiloBuilder UseInMemoryLeaseProvider(this ISiloBuilder builder)
+        public static ISiloHostBuilder UseInMemoryLeaseProvider(this ISiloHostBuilder builder)
         {
             return builder.ConfigureServices(UseInMemoryLeaseProvider);
         }

--- a/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
+++ b/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
@@ -39,7 +39,7 @@ namespace Orleans.Hosting
 {
     internal static class DefaultSiloServices
     {
-        internal static void AddDefaultServices(IServiceCollection services)
+        internal static void AddDefaultServices(HostBuilderContext context, IServiceCollection services)
         {
             services.AddOptions();
 

--- a/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
+++ b/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
@@ -44,7 +44,7 @@ namespace Orleans.Hosting
             services.AddOptions();
 
             // Register system services.
-            services.TryAddSingleton<ISilo, SiloWrapper>();
+            services.TryAddSingleton<ISiloHost, SiloWrapper>();
             services.TryAddFromExisting<ILocalSiloDetails, SiloInitializationParameters>();
             services.TryAddSingleton(sp => sp.GetRequiredService<SiloInitializationParameters>().ClusterConfig);
             services.TryAddSingleton(sp => sp.GetRequiredService<SiloInitializationParameters>().ClusterConfig.Globals);

--- a/src/OrleansRuntime/Hosting/ISiloHost.cs
+++ b/src/OrleansRuntime/Hosting/ISiloHost.cs
@@ -7,7 +7,7 @@ namespace Orleans.Hosting
     /// <summary>
     /// Represents a silo instance.
     /// </summary>
-    public interface ISilo
+    public interface ISiloHost
     {
         /// <summary>
         /// Starts this silo.

--- a/src/OrleansRuntime/Hosting/ISiloHostBuilder.cs
+++ b/src/OrleansRuntime/Hosting/ISiloHostBuilder.cs
@@ -6,13 +6,13 @@ namespace Orleans.Hosting
     /// <summary>
     /// Functionality for building <see cref="ISilo"/> instances.
     /// </summary>
-    public interface ISiloBuilder
+    public interface ISiloHostBuilder
     {
         /// <summary>
         /// Builds the silo.
         /// </summary>
         /// <remarks>This method may only be called once per builder instance.</remarks>
-        /// <returns>The newly created silo.</returns>
+        /// <returns>The newly created silo host.</returns>
         ISilo Build();
 
         /// <summary>
@@ -20,20 +20,20 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configureServices">The service configuration delegate.</param>
         /// <returns>The silo builder.</returns>
-        ISiloBuilder ConfigureServices(Action<IServiceCollection> configureServices);
+        ISiloHostBuilder ConfigureServices(Action<IServiceCollection> configureServices);
 
         /// <summary>
         /// Specifies how the <see cref="IServiceProvider"/> for this silo is configured. 
         /// </summary>
         /// <param name="factory">The service provider factory.</param>
         /// <returns>The silo builder.</returns>
-        ISiloBuilder UseServiceProviderFactory<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory);
+        ISiloHostBuilder UseServiceProviderFactory<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory);
 
         /// <summary>
         /// Adds a container configuration delegate.
         /// </summary>
         /// <typeparam name="TContainerBuilder">The container builder type.</typeparam>
         /// <param name="configureContainer">The container builder configuration delegate.</param>
-        ISiloBuilder ConfigureContainer<TContainerBuilder>(Action<TContainerBuilder> configureContainer);
+        ISiloHostBuilder ConfigureContainer<TContainerBuilder>(Action<TContainerBuilder> configureContainer);
     }
 }

--- a/src/OrleansRuntime/Hosting/ISiloHostBuilder.cs
+++ b/src/OrleansRuntime/Hosting/ISiloHostBuilder.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Orleans.Hosting
 {
     /// <summary>
-    /// Functionality for building <see cref="ISilo"/> instances.
+    /// Functionality for building <see cref="ISiloHost"/> instances.
     /// </summary>
     public interface ISiloHostBuilder
     {
@@ -13,7 +13,7 @@ namespace Orleans.Hosting
         /// </summary>
         /// <remarks>This method may only be called once per builder instance.</remarks>
         /// <returns>The newly created silo host.</returns>
-        ISilo Build();
+        ISiloHost Build();
 
         /// <summary>
         /// Adds a service configuration delegate to the configuration pipeline.

--- a/src/OrleansRuntime/Hosting/SiloBuilderExtensions.cs
+++ b/src/OrleansRuntime/Hosting/SiloBuilderExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 
@@ -11,18 +9,6 @@ namespace Orleans.Hosting
     /// </summary>
     public static class SiloBuilderExtensions
     {
-        /// <summary>
-        /// Registers an action used to configure a particular type of options.
-        /// </summary>
-        /// <typeparam name="TOptions">The options type to be configured.</typeparam>
-        /// <param name="builder">The host builder.</param>
-        /// <param name="configureOptions">The action used to configure the options.</param>
-        /// <returns>The silo builder.</returns>
-        public static ISiloHostBuilder Configure<TOptions>(this ISiloHostBuilder builder, Action<TOptions> configureOptions) where TOptions : class
-        {
-            return builder.ConfigureServices(services => services.Configure(configureOptions));
-        }
-
         /// <summary>
         /// Configures the name of this silo.
         /// </summary>
@@ -70,40 +56,6 @@ namespace Orleans.Hosting
         {
             builder.ConfigureSiloName(Silo.PrimarySiloName);
             return builder.UseConfiguration(ClusterConfiguration.LocalhostPrimarySilo(siloPort, gatewayPort));
-        }
-
-        /// <summary>
-        /// Specifies how the <see cref="IServiceProvider"/> for this silo is configured. 
-        /// </summary>
-        /// <param name="builder">The host builder.</param>
-        /// <param name="factory">The service provider configuration method.</param>
-        /// <returns>The silo builder.</returns>
-        public static ISiloHostBuilder UseServiceProviderFactory<TContainerBuilder>(ISiloHostBuilder builder, IServiceProviderFactory<TContainerBuilder> factory)
-        {
-            return builder.UseServiceProviderFactory(services => factory.CreateServiceProvider(factory.CreateBuilder(services)));
-        }
-
-        /// <summary>
-        /// Specifies how the <see cref="IServiceProvider"/> for this silo is configured. 
-        /// </summary>
-        /// <param name="builder">The host builder.</param>
-        /// <param name="configureServiceProvider">The service provider configuration method.</param>
-        /// <returns>The silo builder.</returns>
-        public static ISiloHostBuilder UseServiceProviderFactory(this ISiloHostBuilder builder, Func<IServiceCollection, IServiceProvider> configureServiceProvider)
-        {
-            if (configureServiceProvider == null) throw new ArgumentNullException(nameof(configureServiceProvider));
-            return builder.UseServiceProviderFactory(new DelegateServiceProviderFactory(configureServiceProvider));
-        }
-
-        /// <summary>
-        /// Adds a delegate for configuring the provided <see cref="ILoggingBuilder"/>. This may be called multiple times.
-        /// </summary>
-        /// <param name="builder">The <see cref="ISiloHostBuilder" /> to configure.</param>
-        /// <param name="configureLogging">The delegate that configures the <see cref="ILoggingBuilder"/>.</param>
-        /// <returns>The same instance of the <see cref="ISiloHostBuilder"/> for chaining.</returns>
-        public static ISiloHostBuilder ConfigureLogging(this ISiloHostBuilder builder, Action<ILoggingBuilder> configureLogging)
-        {
-            return builder.ConfigureServices(collection => collection.AddLogging(loggingBuilder => configureLogging(loggingBuilder)));
         }
     }
 }

--- a/src/OrleansRuntime/Hosting/SiloBuilderExtensions.cs
+++ b/src/OrleansRuntime/Hosting/SiloBuilderExtensions.cs
@@ -7,7 +7,7 @@ using Orleans.Runtime.Configuration;
 namespace Orleans.Hosting
 {
     /// <summary>
-    /// Extensions for <see cref="ISiloBuilder"/> instances.
+    /// Extensions for <see cref="ISiloHostBuilder"/> instances.
     /// </summary>
     public static class SiloBuilderExtensions
     {
@@ -15,10 +15,10 @@ namespace Orleans.Hosting
         /// Registers an action used to configure a particular type of options.
         /// </summary>
         /// <typeparam name="TOptions">The options type to be configured.</typeparam>
-        /// <param name="builder">The silo builder.</param>
+        /// <param name="builder">The host builder.</param>
         /// <param name="configureOptions">The action used to configure the options.</param>
         /// <returns>The silo builder.</returns>
-        public static ISiloBuilder Configure<TOptions>(this ISiloBuilder builder, Action<TOptions> configureOptions) where TOptions : class
+        public static ISiloHostBuilder Configure<TOptions>(this ISiloHostBuilder builder, Action<TOptions> configureOptions) where TOptions : class
         {
             return builder.ConfigureServices(services => services.Configure(configureOptions));
         }
@@ -26,10 +26,10 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configures the name of this silo.
         /// </summary>
-        /// <param name="builder">The silo builder.</param>
+        /// <param name="builder">The host builder.</param>
         /// <param name="siloName">The silo name.</param>
         /// <returns>The silo builder.</returns>
-        public static ISiloBuilder ConfigureSiloName(this ISiloBuilder builder, string siloName)
+        public static ISiloHostBuilder ConfigureSiloName(this ISiloHostBuilder builder, string siloName)
         {
             builder.Configure<SiloIdentityOptions>(options => options.SiloName = siloName);
             return builder;
@@ -38,11 +38,11 @@ namespace Orleans.Hosting
         /// <summary>
         /// Specifies the configuration to use for this silo.
         /// </summary>
-        /// <param name="builder">The silo builder.</param>
+        /// <param name="builder">The host builder.</param>
         /// <param name="configuration">The configuration.</param>
         /// <remarks>This method may only be called once per builder instance.</remarks>
         /// <returns>The silo builder.</returns>
-        public static ISiloBuilder UseConfiguration(this ISiloBuilder builder, ClusterConfiguration configuration)
+        public static ISiloHostBuilder UseConfiguration(this ISiloHostBuilder builder, ClusterConfiguration configuration)
         {
             return builder.ConfigureServices(services => services.AddSingleton(configuration));
         }
@@ -50,9 +50,9 @@ namespace Orleans.Hosting
         /// <summary>
         /// Loads <see cref="ClusterConfiguration"/> using <see cref="ClusterConfiguration.StandardLoad"/>.
         /// </summary>
-        /// <param name="builder">The silo builder.</param>
+        /// <param name="builder">The host builder.</param>
         /// <returns>The silo builder.</returns>
-        public static ISiloBuilder LoadClusterConfiguration(this ISiloBuilder builder)
+        public static ISiloHostBuilder LoadClusterConfiguration(this ISiloHostBuilder builder)
         {
             var configuration = new ClusterConfiguration();
             configuration.StandardLoad();
@@ -62,11 +62,11 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configures a localhost silo.
         /// </summary>
-        /// <param name="builder">The silo builder.</param>
+        /// <param name="builder">The host builder.</param>
         /// <param name="siloPort">The silo-to-silo communication port.</param>
         /// <param name="gatewayPort">The client-to-silo communication port.</param>
         /// <returns>The silo builder.</returns>
-        public static ISiloBuilder ConfigureLocalHostPrimarySilo(this ISiloBuilder builder, int siloPort = 22222, int gatewayPort = 40000)
+        public static ISiloHostBuilder ConfigureLocalHostPrimarySilo(this ISiloHostBuilder builder, int siloPort = 22222, int gatewayPort = 40000)
         {
             builder.ConfigureSiloName(Silo.PrimarySiloName);
             return builder.UseConfiguration(ClusterConfiguration.LocalhostPrimarySilo(siloPort, gatewayPort));
@@ -75,10 +75,10 @@ namespace Orleans.Hosting
         /// <summary>
         /// Specifies how the <see cref="IServiceProvider"/> for this silo is configured. 
         /// </summary>
-        /// <param name="builder">The silo builder.</param>
+        /// <param name="builder">The host builder.</param>
         /// <param name="factory">The service provider configuration method.</param>
         /// <returns>The silo builder.</returns>
-        public static ISiloBuilder UseServiceProviderFactory<TContainerBuilder>(ISiloBuilder builder, IServiceProviderFactory<TContainerBuilder> factory)
+        public static ISiloHostBuilder UseServiceProviderFactory<TContainerBuilder>(ISiloHostBuilder builder, IServiceProviderFactory<TContainerBuilder> factory)
         {
             return builder.UseServiceProviderFactory(services => factory.CreateServiceProvider(factory.CreateBuilder(services)));
         }
@@ -86,10 +86,10 @@ namespace Orleans.Hosting
         /// <summary>
         /// Specifies how the <see cref="IServiceProvider"/> for this silo is configured. 
         /// </summary>
-        /// <param name="builder">The silo builder.</param>
+        /// <param name="builder">The host builder.</param>
         /// <param name="configureServiceProvider">The service provider configuration method.</param>
         /// <returns>The silo builder.</returns>
-        public static ISiloBuilder UseServiceProviderFactory(this ISiloBuilder builder, Func<IServiceCollection, IServiceProvider> configureServiceProvider)
+        public static ISiloHostBuilder UseServiceProviderFactory(this ISiloHostBuilder builder, Func<IServiceCollection, IServiceProvider> configureServiceProvider)
         {
             if (configureServiceProvider == null) throw new ArgumentNullException(nameof(configureServiceProvider));
             return builder.UseServiceProviderFactory(new DelegateServiceProviderFactory(configureServiceProvider));
@@ -98,10 +98,10 @@ namespace Orleans.Hosting
         /// <summary>
         /// Adds a delegate for configuring the provided <see cref="ILoggingBuilder"/>. This may be called multiple times.
         /// </summary>
-        /// <param name="builder">The <see cref="ISiloBuilder" /> to configure.</param>
+        /// <param name="builder">The <see cref="ISiloHostBuilder" /> to configure.</param>
         /// <param name="configureLogging">The delegate that configures the <see cref="ILoggingBuilder"/>.</param>
-        /// <returns>The same instance of the <see cref="ISiloBuilder"/> for chaining.</returns>
-        public static ISiloBuilder ConfigureLogging(this ISiloBuilder builder, Action<ILoggingBuilder> configureLogging)
+        /// <returns>The same instance of the <see cref="ISiloHostBuilder"/> for chaining.</returns>
+        public static ISiloHostBuilder ConfigureLogging(this ISiloHostBuilder builder, Action<ILoggingBuilder> configureLogging)
         {
             return builder.ConfigureServices(collection => collection.AddLogging(loggingBuilder => configureLogging(loggingBuilder)));
         }

--- a/src/OrleansRuntime/Hosting/SiloHostBuilder.cs
+++ b/src/OrleansRuntime/Hosting/SiloHostBuilder.cs
@@ -8,7 +8,7 @@ namespace Orleans.Hosting
     /// <summary>
     /// Functionality for building <see cref="ISilo"/> instances.
     /// </summary>
-    public class SiloBuilder : ISiloBuilder
+    public class SiloHostBuilder : ISiloHostBuilder
     {
         private readonly ServiceProviderBuilder serviceProviderBuilder = new ServiceProviderBuilder();
         private bool built;
@@ -17,7 +17,7 @@ namespace Orleans.Hosting
         public ISilo Build()
         {
             if (this.built)
-                throw new InvalidOperationException($"{nameof(this.Build)} may only be called once per {nameof(SiloBuilder)} instance.");
+                throw new InvalidOperationException($"{nameof(this.Build)} may only be called once per {nameof(SiloHostBuilder)} instance.");
             this.built = true;
             
             // Configure the container, including the default silo name & services.
@@ -37,21 +37,21 @@ namespace Orleans.Hosting
         }
 
         /// <inheritdoc />
-        public ISiloBuilder ConfigureServices(Action<IServiceCollection> configureServices)
+        public ISiloHostBuilder ConfigureServices(Action<IServiceCollection> configureServices)
         {
             this.serviceProviderBuilder.ConfigureServices(configureServices);
             return this;
         }
 
         /// <inheritdoc />
-        public ISiloBuilder UseServiceProviderFactory<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory)
+        public ISiloHostBuilder UseServiceProviderFactory<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory)
         {
             this.serviceProviderBuilder.UseServiceProviderFactory(factory);
             return this;
         }
 
         /// <inheritdoc />
-        public ISiloBuilder ConfigureContainer<TContainerBuilder>(Action<TContainerBuilder> configureContainer)
+        public ISiloHostBuilder ConfigureContainer<TContainerBuilder>(Action<TContainerBuilder> configureContainer)
         {
             this.serviceProviderBuilder.ConfigureContainer(configureContainer);
             return this;

--- a/src/OrleansRuntime/Hosting/SiloHostBuilder.cs
+++ b/src/OrleansRuntime/Hosting/SiloHostBuilder.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.Runtime;
@@ -11,7 +13,14 @@ namespace Orleans.Hosting
     public class SiloHostBuilder : ISiloHostBuilder
     {
         private readonly ServiceProviderBuilder serviceProviderBuilder = new ServiceProviderBuilder();
+
         private bool built;
+        private HostBuilderContext hostBuilderContext;
+        private List<Action<HostBuilderContext, IConfigurationBuilder>> configureAppConfigActions = new List<Action<HostBuilderContext, IConfigurationBuilder>>();
+        private IConfiguration appConfiguration;
+
+        /// <inheritdoc />
+        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
 
         /// <inheritdoc />
         public ISiloHost Build()
@@ -24,22 +33,34 @@ namespace Orleans.Hosting
             this.Configure<SiloIdentityOptions>(
                 options => options.SiloName = options.SiloName ?? $"Silo_{Guid.NewGuid().ToString("N").Substring(0, 5)}");
             this.serviceProviderBuilder.ConfigureServices(
-                services =>
+                (context, services) =>
                 {
                     services.TryAddSingleton<SiloInitializationParameters>();
                     services.TryAddSingleton<Silo>(sp => new Silo(sp.GetRequiredService<SiloInitializationParameters>(), sp));
                 });
             this.serviceProviderBuilder.ConfigureServices(DefaultSiloServices.AddDefaultServices);
-            var serviceProvider = this.serviceProviderBuilder.BuildServiceProvider();
+
+            this.CreateHostBuilderContext();
+            this.BuildAppConfiguration();
+            var serviceProvider = this.serviceProviderBuilder.BuildServiceProvider(this.hostBuilderContext);
             
             // Construct and return the silo.
             return serviceProvider.GetRequiredService<ISiloHost>();
         }
 
         /// <inheritdoc />
-        public ISiloHostBuilder ConfigureServices(Action<IServiceCollection> configureServices)
+        public ISiloHostBuilder ConfigureAppConfiguration(Action<HostBuilderContext, IConfigurationBuilder> configureDelegate)
         {
-            this.serviceProviderBuilder.ConfigureServices(configureServices);
+            this.configureAppConfigActions.Add(configureDelegate ?? throw new ArgumentNullException(nameof(configureDelegate)));
+            return this;
+        }
+
+
+        /// <inheritdoc />
+        public ISiloHostBuilder ConfigureServices(Action<HostBuilderContext, IServiceCollection> configureDelegate)
+        {
+            if (configureDelegate == null) throw new ArgumentNullException(nameof(configureDelegate));
+            this.serviceProviderBuilder.ConfigureServices(configureDelegate);
             return this;
         }
 
@@ -51,10 +72,30 @@ namespace Orleans.Hosting
         }
 
         /// <inheritdoc />
-        public ISiloHostBuilder ConfigureContainer<TContainerBuilder>(Action<TContainerBuilder> configureContainer)
+        public ISiloHostBuilder ConfigureContainer<TContainerBuilder>(Action<HostBuilderContext, TContainerBuilder> configureDelegate)
         {
-            this.serviceProviderBuilder.ConfigureContainer(configureContainer);
+            this.serviceProviderBuilder.ConfigureContainer(configureDelegate);
             return this;
+        }
+
+        private void CreateHostBuilderContext()
+        {
+            this.hostBuilderContext = new HostBuilderContext(this.Properties)
+            {
+                Configuration = null
+            };
+        }
+
+
+        private void BuildAppConfiguration()
+        {
+            var configBuilder = new ConfigurationBuilder();
+            foreach (var buildAction in this.configureAppConfigActions)
+            {
+                buildAction(this.hostBuilderContext, configBuilder);
+            }
+            this.appConfiguration = configBuilder.Build();
+            this.hostBuilderContext.Configuration = this.appConfiguration;
         }
     }
 }

--- a/src/OrleansRuntime/Hosting/SiloHostBuilder.cs
+++ b/src/OrleansRuntime/Hosting/SiloHostBuilder.cs
@@ -6,7 +6,7 @@ using Orleans.Runtime;
 namespace Orleans.Hosting
 {
     /// <summary>
-    /// Functionality for building <see cref="ISilo"/> instances.
+    /// Functionality for building <see cref="ISiloHost"/> instances.
     /// </summary>
     public class SiloHostBuilder : ISiloHostBuilder
     {
@@ -14,7 +14,7 @@ namespace Orleans.Hosting
         private bool built;
 
         /// <inheritdoc />
-        public ISilo Build()
+        public ISiloHost Build()
         {
             if (this.built)
                 throw new InvalidOperationException($"{nameof(this.Build)} may only be called once per {nameof(SiloHostBuilder)} instance.");
@@ -33,7 +33,7 @@ namespace Orleans.Hosting
             var serviceProvider = this.serviceProviderBuilder.BuildServiceProvider();
             
             // Construct and return the silo.
-            return serviceProvider.GetRequiredService<ISilo>();
+            return serviceProvider.GetRequiredService<ISiloHost>();
         }
 
         /// <inheritdoc />

--- a/src/OrleansRuntime/Hosting/SiloHostBuilderExtensions.cs
+++ b/src/OrleansRuntime/Hosting/SiloHostBuilderExtensions.cs
@@ -1,0 +1,83 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Extensions for <see cref="ISiloHostBuilder"/> instances.
+    /// </summary>
+    public static class SiloHostBuilderExtensions
+    {
+        /// <summary>
+        /// Adds services to the container. This can be called multiple times and the results will be additive.
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="ISiloHostBuilder" /> to configure.</param>
+        /// <param name="configureDelegate"></param>
+        /// <returns>The same instance of the <see cref="ISiloHostBuilder"/> for chaining.</returns>
+        public static ISiloHostBuilder ConfigureServices(this ISiloHostBuilder hostBuilder, Action<IServiceCollection> configureDelegate)
+        {
+            return hostBuilder.ConfigureServices((context, collection) => configureDelegate(collection));
+        }
+
+        /// <summary>
+        /// Sets up the configuration for the remainder of the build process and application. This can be called multiple times and
+        /// the results will be additive. The results will be available at <see cref="HostBuilderContext.Configuration"/> for
+        /// subsequent operations, as well as in <see cref="ISiloHost.Services"/>.
+        /// </summary>
+        /// <param name="hostBuilder">The host builder to configure.</param>
+        /// <param name="configureDelegate"></param>
+        /// <returns>The same instance of the host builder for chaining.</returns>
+        public static ISiloHostBuilder ConfigureAppConfiguration(this ISiloHostBuilder hostBuilder, Action<IConfigurationBuilder> configureDelegate)
+        {
+            return hostBuilder.ConfigureAppConfiguration((context, builder) => configureDelegate(builder));
+        }
+
+        /// <summary>
+        /// Registers an action used to configure a particular type of options.
+        /// </summary>
+        /// <typeparam name="TOptions">The options type to be configured.</typeparam>
+        /// <param name="builder">The host builder.</param>
+        /// <param name="configureOptions">The action used to configure the options.</param>
+        /// <returns>The silo builder.</returns>
+        public static ISiloHostBuilder Configure<TOptions>(this ISiloHostBuilder builder, Action<TOptions> configureOptions) where TOptions : class
+        {
+            return builder.ConfigureServices(services => services.Configure(configureOptions));
+        }
+
+        /// <summary>
+        /// Specifies how the <see cref="IServiceProvider"/> for this silo is configured. 
+        /// </summary>
+        /// <param name="builder">The host builder.</param>
+        /// <param name="factory">The service provider configuration method.</param>
+        /// <returns>The silo builder.</returns>
+        public static ISiloHostBuilder UseServiceProviderFactory<TContainerBuilder>(ISiloHostBuilder builder, IServiceProviderFactory<TContainerBuilder> factory)
+        {
+            return builder.UseServiceProviderFactory(services => factory.CreateServiceProvider(factory.CreateBuilder(services)));
+        }
+
+        /// <summary>
+        /// Specifies how the <see cref="IServiceProvider"/> for this silo is configured. 
+        /// </summary>
+        /// <param name="builder">The host builder.</param>
+        /// <param name="configureServiceProvider">The service provider configuration method.</param>
+        /// <returns>The silo builder.</returns>
+        public static ISiloHostBuilder UseServiceProviderFactory(this ISiloHostBuilder builder, Func<IServiceCollection, IServiceProvider> configureServiceProvider)
+        {
+            if (configureServiceProvider == null) throw new ArgumentNullException(nameof(configureServiceProvider));
+            return builder.UseServiceProviderFactory(new DelegateServiceProviderFactory(configureServiceProvider));
+        }
+
+        /// <summary>
+        /// Adds a delegate for configuring the provided <see cref="ILoggingBuilder"/>. This may be called multiple times.
+        /// </summary>
+        /// <param name="builder">The <see cref="ISiloHostBuilder" /> to configure.</param>
+        /// <param name="configureLogging">The delegate that configures the <see cref="ILoggingBuilder"/>.</param>
+        /// <returns>The same instance of the <see cref="ISiloHostBuilder"/> for chaining.</returns>
+        public static ISiloHostBuilder ConfigureLogging(this ISiloHostBuilder builder, Action<ILoggingBuilder> configureLogging)
+        {
+            return builder.ConfigureServices(collection => collection.AddLogging(loggingBuilder => configureLogging(loggingBuilder)));
+        }
+    }
+}

--- a/src/OrleansRuntime/Hosting/SiloWrapper.cs
+++ b/src/OrleansRuntime/Hosting/SiloWrapper.cs
@@ -5,7 +5,7 @@ using Orleans.Runtime;
 
 namespace Orleans.Hosting
 {
-    internal class SiloWrapper : ISilo
+    internal class SiloWrapper : ISiloHost
     {
         private readonly Silo silo;
 

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -178,7 +178,7 @@ namespace Orleans.Runtime
                 var serviceCollection = new ServiceCollection();
                 serviceCollection.AddSingleton<Silo>(this);
                 serviceCollection.AddSingleton(initializationParams);
-                DefaultSiloServices.AddDefaultServices(serviceCollection);
+                DefaultSiloServices.AddDefaultServices(null, serviceCollection);
                 services = StartupBuilder.ConfigureStartup(this.LocalConfig.StartupTypeName, serviceCollection);
                 services.GetService<TelemetryManager>()?.AddFromConfiguration(services, LocalConfig.TelemetryConfiguration);
             }

--- a/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/OrleansRuntime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -21,14 +21,14 @@ namespace Orleans.Runtime.TestHooks
     /// </summary>
     internal class TestHooksSystemTarget : SystemTarget, ITestHooksSystemTarget
     {
-        private readonly ISilo silo;
+        private readonly ISiloHost host;
         private readonly IConsistentRingProvider consistentRingProvider;
 
-        public TestHooksSystemTarget(ISilo silo, ILocalSiloDetails siloDetails, ILoggerFactory loggerFactory)
+        public TestHooksSystemTarget(ISiloHost host, ILocalSiloDetails siloDetails, ILoggerFactory loggerFactory)
             : base(Constants.TestHooksSystemTargetId, siloDetails.SiloAddress, loggerFactory)
         {
-            this.silo = silo;
-            consistentRingProvider = this.silo.Services.GetRequiredService<IConsistentRingProvider>();
+            this.host = host;
+            consistentRingProvider = this.host.Services.GetRequiredService<IConsistentRingProvider>();
         }
 
         public Task<SiloAddress> GetConsistentRingPrimaryTargetSilo(uint key)
@@ -41,21 +41,21 @@ namespace Orleans.Runtime.TestHooks
             return Task.FromResult(consistentRingProvider.ToString());
         }
 
-        public Task<bool> HasStatisticsProvider() => Task.FromResult(this.silo.Services.GetService<StatisticsProviderManager>() != null);
+        public Task<bool> HasStatisticsProvider() => Task.FromResult(this.host.Services.GetService<StatisticsProviderManager>() != null);
 
-        public Task<Guid> GetServiceId() => Task.FromResult(this.silo.Services.GetRequiredService<GlobalConfiguration>().ServiceId);
+        public Task<Guid> GetServiceId() => Task.FromResult(this.host.Services.GetRequiredService<GlobalConfiguration>().ServiceId);
 
         public Task<bool> HasStorageProvider(string providerName)
         {
             IStorageProvider tmp;
-            return Task.FromResult(this.silo.Services.GetRequiredService<StorageProviderManager>().TryGetProvider(providerName, out tmp));
+            return Task.FromResult(this.host.Services.GetRequiredService<StorageProviderManager>().TryGetProvider(providerName, out tmp));
         }
 
         public Task<bool> HasStreamProvider(string providerName)
         {
             try
             {
-                this.silo.Services.GetRequiredService<IStreamProviderManager>().GetStreamProvider(providerName);
+                this.host.Services.GetRequiredService<IStreamProviderManager>().GetStreamProvider(providerName);
                 return Task.FromResult(true);
             }
             catch (KeyNotFoundException)
@@ -66,7 +66,7 @@ namespace Orleans.Runtime.TestHooks
 
         public Task<bool> HasBoostraperProvider(string providerName)
         {
-            foreach (var provider in this.silo.Services.GetRequiredService<BootstrapProviderManager>().GetProviders())
+            foreach (var provider in this.host.Services.GetRequiredService<BootstrapProviderManager>().GetProviders())
             {
                 if (String.Equals(providerName, provider.Name))
                 {
@@ -76,30 +76,30 @@ namespace Orleans.Runtime.TestHooks
             return Task.FromResult(false);
         }
 
-        public Task<ICollection<string>> GetStorageProviderNames() => Task.FromResult<ICollection<string>>(this.silo.Services.GetRequiredService<StorageProviderManager>().GetProviderNames().ToList());
+        public Task<ICollection<string>> GetStorageProviderNames() => Task.FromResult<ICollection<string>>(this.host.Services.GetRequiredService<StorageProviderManager>().GetProviderNames().ToList());
 
-        public Task<ICollection<string>> GetStreamProviderNames() => Task.FromResult<ICollection<string>>(this.silo.Services.GetRequiredService<IStreamProviderManager>().GetStreamProviders().Select(p => ((IProvider)p).Name).ToList());
+        public Task<ICollection<string>> GetStreamProviderNames() => Task.FromResult<ICollection<string>>(this.host.Services.GetRequiredService<IStreamProviderManager>().GetStreamProviders().Select(p => ((IProvider)p).Name).ToList());
 
         public Task<ICollection<string>> GetAllSiloProviderNames()
         {
             List<string> allProviders = new List<string>();
 
-            var storageProviderManager = this.silo.Services.GetRequiredService<StorageProviderManager>();
+            var storageProviderManager = this.host.Services.GetRequiredService<StorageProviderManager>();
             allProviders.AddRange(storageProviderManager.GetProviderNames());
 
-            var streamProviderManager = this.silo.Services.GetRequiredService<IStreamProviderManager>();
+            var streamProviderManager = this.host.Services.GetRequiredService<IStreamProviderManager>();
             allProviders.AddRange(streamProviderManager.GetStreamProviders().Select(p => p.Name));
 
-            var statisticsProviderManager = this.silo.Services.GetRequiredService<StatisticsProviderManager>();
+            var statisticsProviderManager = this.host.Services.GetRequiredService<StatisticsProviderManager>();
             allProviders.AddRange(statisticsProviderManager.GetProviders().Select(p => p.Name));
 
-            var booststrampProviderManager = this.silo.Services.GetRequiredService<BootstrapProviderManager>();
+            var booststrampProviderManager = this.host.Services.GetRequiredService<BootstrapProviderManager>();
             allProviders.AddRange(booststrampProviderManager.GetProviders().Select(p => p.Name));
 
             return Task.FromResult<ICollection<string>>(allProviders);
         }
 
-        public Task<int> UnregisterGrainForTesting(GrainId grain) => Task.FromResult(this.silo.Services.GetRequiredService<Catalog>().UnregisterGrainForTesting(grain));
+        public Task<int> UnregisterGrainForTesting(GrainId grain) => Task.FromResult(this.host.Services.GetRequiredService<Catalog>().UnregisterGrainForTesting(grain));
 
         public Task AddCachedAssembly(string targetAssemblyName, GeneratedAssembly cachedAssembly, ILogger logger)
         {
@@ -109,7 +109,7 @@ namespace Orleans.Runtime.TestHooks
 
         public Task LatchIsOverloaded(bool overloaded, TimeSpan latchPeriod)
         {
-            this.silo.Services.GetRequiredService<SiloStatisticsManager>().MetricsTable.LatchIsOverload(overloaded);
+            this.host.Services.GetRequiredService<SiloStatisticsManager>().MetricsTable.LatchIsOverload(overloaded);
             
             Task.Delay(latchPeriod).ContinueWith(t => UnlatchIsOverloaded()).Ignore();
             return Task.CompletedTask;
@@ -117,7 +117,7 @@ namespace Orleans.Runtime.TestHooks
 
         private void UnlatchIsOverloaded()
         {
-            this.silo.Services.GetRequiredService<SiloStatisticsManager>().MetricsTable.UnlatchIsOverloaded();
+            this.host.Services.GetRequiredService<SiloStatisticsManager>().MetricsTable.UnlatchIsOverloaded();
         }
     }
 }

--- a/src/OrleansTestingHost/AppDomainSiloHost.cs
+++ b/src/OrleansTestingHost/AppDomainSiloHost.cs
@@ -26,7 +26,7 @@ namespace Orleans.TestingHost
     /// <summary>Allows programmatically hosting an Orleans silo in the curent app domain, exposing some marshable members via remoting.</summary>
     public class AppDomainSiloHost : MarshalByRefObject
     {
-        private readonly ISilo silo;
+        private readonly ISiloHost host;
 
         /// <summary>Creates and initializes a silo in the current app domain.</summary>
         /// <param name="name">Name of this silo.</param>
@@ -37,13 +37,13 @@ namespace Orleans.TestingHost
             var builderFactory = (ISiloBuilderFactory)Activator.CreateInstance(siloBuilderFactoryType);
             ISiloHostBuilder builder = builderFactory.CreateSiloBuilder(name, config);
             builder.ConfigureServices((services) => services.AddSingleton<TestHooksSystemTarget>());
-            this.silo = builder.Build();
+            this.host = builder.Build();
             InitializeTestHooksSystemTarget();
-            this.AppDomainTestHook = new AppDomainTestHooks(this.silo);
+            this.AppDomainTestHook = new AppDomainTestHooks(this.host);
         }
 
         /// <summary> SiloAddress for this silo. </summary>
-        public SiloAddress SiloAddress => this.silo.Services.GetRequiredService<ILocalSiloDetails>().SiloAddress;
+        public SiloAddress SiloAddress => this.host.Services.GetRequiredService<ILocalSiloDetails>().SiloAddress;
         
         internal AppDomainTestHooks AppDomainTestHook { get; }
 
@@ -99,19 +99,19 @@ namespace Orleans.TestingHost
         /// <summary>Starts the silo</summary>
         public void Start()
         {
-            this.silo.StartAsync().GetAwaiter().GetResult();
+            this.host.StartAsync().GetAwaiter().GetResult();
         }
 
         /// <summary>Gracefully shuts down the silo</summary>
         public void Shutdown()
         {
-            this.silo.StopAsync().GetAwaiter().GetResult();
+            this.host.StopAsync().GetAwaiter().GetResult();
         }
 
         private void InitializeTestHooksSystemTarget()
         {
-            var testHook = this.silo.Services.GetRequiredService<TestHooksSystemTarget>();
-            var providerRuntime = this.silo.Services.GetRequiredService<SiloProviderRuntime>();
+            var testHook = this.host.Services.GetRequiredService<TestHooksSystemTarget>();
+            var providerRuntime = this.host.Services.GetRequiredService<SiloProviderRuntime>();
             providerRuntime.RegisterSystemTarget(testHook);
         }
     }
@@ -122,22 +122,22 @@ namespace Orleans.TestingHost
     /// </summary>
     internal class AppDomainTestHooks : MarshalByRefObject
     {
-        private readonly ISilo silo;
+        private readonly ISiloHost host;
 
-        public AppDomainTestHooks(ISilo silo)
+        public AppDomainTestHooks(ISiloHost host)
         {
-            this.silo = silo;
+            this.host = host;
         }
 
         internal IBootstrapProvider GetBootstrapProvider(string name)
         {
-            var bootstrapProviderManager = silo.Services.GetRequiredService<BootstrapProviderManager>();
+            var bootstrapProviderManager = this.host.Services.GetRequiredService<BootstrapProviderManager>();
             IBootstrapProvider provider = (IBootstrapProvider)bootstrapProviderManager.GetProvider(name);
             return CheckReturnBoundaryReference("bootstrap provider", provider);
         }
 
         /// <summary>Find the named storage provider loaded in this silo. </summary>
-        internal IStorageProvider GetStorageProvider(string name) => CheckReturnBoundaryReference("storage provider", (IStorageProvider)silo.Services.GetRequiredService<StorageProviderManager>().GetProvider(name));
+        internal IStorageProvider GetStorageProvider(string name) => CheckReturnBoundaryReference("storage provider", (IStorageProvider)this.host.Services.GetRequiredService<StorageProviderManager>().GetProvider(name));
 
         private static T CheckReturnBoundaryReference<T>(string what, T obj) where T : class
         {
@@ -154,8 +154,8 @@ namespace Orleans.TestingHost
         public IDictionary<GrainId, IGrainInfo> GetDirectoryForTypeNamesContaining(string expr)
         {
             var x = new Dictionary<GrainId, IGrainInfo>();
-            LocalGrainDirectory localGrainDirectory = silo.Services.GetRequiredService<LocalGrainDirectory>();
-            var catalog = silo.Services.GetRequiredService<Catalog>();
+            LocalGrainDirectory localGrainDirectory = this.host.Services.GetRequiredService<LocalGrainDirectory>();
+            var catalog = this.host.Services.GetRequiredService<Catalog>();
             foreach (var kvp in localGrainDirectory.DirectoryPartition.GetItems())
             {
                 if (kvp.Key.IsSystemTarget || kvp.Key.IsClient || !kvp.Key.IsGrain)
@@ -178,13 +178,13 @@ namespace Orleans.TestingHost
 
             simulatedMessageLoss[destination] = lossPercentage;
 
-            var mc = this.silo.Services.GetRequiredService<MessageCenter>();
+            var mc = this.host.Services.GetRequiredService<MessageCenter>();
             mc.ShouldDrop = ShouldDrop;
         }
 
         internal void UnblockSiloCommunication()
         {
-            var mc = this.silo.Services.GetRequiredService<MessageCenter>();
+            var mc = this.host.Services.GetRequiredService<MessageCenter>();
             mc.ShouldDrop = null;
             simulatedMessageLoss.Clear();
         }
@@ -193,12 +193,12 @@ namespace Orleans.TestingHost
         {
             get
             {
-                var mco = this.silo.Services.GetRequiredService<MultiClusterOracle>();
+                var mco = this.host.Services.GetRequiredService<MultiClusterOracle>();
                 return mco.ProtocolMessageFilterForTesting;
             }
             set
             {
-                var mco = this.silo.Services.GetRequiredService<MultiClusterOracle>();
+                var mco = this.host.Services.GetRequiredService<MultiClusterOracle>();
                 mco.ProtocolMessageFilterForTesting = value;
             }
         }

--- a/src/OrleansTestingHost/AppDomainSiloHost.cs
+++ b/src/OrleansTestingHost/AppDomainSiloHost.cs
@@ -30,12 +30,12 @@ namespace Orleans.TestingHost
 
         /// <summary>Creates and initializes a silo in the current app domain.</summary>
         /// <param name="name">Name of this silo.</param>
-        /// <param name="siloBuilderFactoryType">Type of silo builder factory.</param>
+        /// <param name="siloBuilderFactoryType">Type of silo host builder factory.</param>
         /// <param name="config">Silo config data to be used for this silo.</param>
         public AppDomainSiloHost(string name, Type siloBuilderFactoryType, ClusterConfiguration config)
         {
             var builderFactory = (ISiloBuilderFactory)Activator.CreateInstance(siloBuilderFactoryType);
-            ISiloBuilder builder = builderFactory.CreateSiloBuilder(name, config);
+            ISiloHostBuilder builder = builderFactory.CreateSiloBuilder(name, config);
             builder.ConfigureServices((services) => services.AddSingleton<TestHooksSystemTarget>());
             this.silo = builder.Build();
             InitializeTestHooksSystemTarget();

--- a/src/OrleansTestingHost/DefaultSiloBuilderFactory.cs
+++ b/src/OrleansTestingHost/DefaultSiloBuilderFactory.cs
@@ -9,9 +9,9 @@ namespace Orleans.TestingHost
 {
     public sealed class DefaultSiloBuilderFactory : ISiloBuilderFactory
     {
-        public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+        public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
         {
-            ISiloBuilder builder = new SiloBuilder();
+            var builder = new SiloHostBuilder();
             return builder.ConfigureSiloName(siloName)
                 .UseConfiguration(clusterConfiguration)
                 .ConfigureLogging(loggingBuilder => TestingUtils.ConfigureDefaultLoggingBuilder(loggingBuilder,

--- a/src/OrleansTestingHost/ISiloBuilderFactory.cs
+++ b/src/OrleansTestingHost/ISiloBuilderFactory.cs
@@ -5,6 +5,6 @@ namespace Orleans.TestingHost
 {
     public interface ISiloBuilderFactory
     {
-        ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration);
+        ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration);
     }
 }

--- a/test/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -19,9 +19,9 @@ namespace Orleans.Transactions.Azure.Tests
 
         private class SiloBuilderFactory : ISiloBuilderFactory
         {
-            public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+            public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
             {
-                return new SiloBuilder()
+                return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
                     .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, clusterConfiguration.GetOrCreateNodeConfigurationForSilo(siloName).TraceFileName))

--- a/test/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
+++ b/test/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
@@ -20,9 +20,9 @@ namespace Orleans.Transactions.Tests
 
         private class SiloBuilderFactory : ISiloBuilderFactory
         {
-            public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+            public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
             {
-                return new SiloBuilder()
+                return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
                     .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, clusterConfiguration.GetOrCreateNodeConfigurationForSilo(siloName).TraceFileName))

--- a/test/Tester/DependencyInjectionGrainTests.cs
+++ b/test/Tester/DependencyInjectionGrainTests.cs
@@ -31,9 +31,9 @@ namespace UnitTests.General
 
             private class TestSiloBuilderFactory : ISiloBuilderFactory
             {
-                public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+                public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
                 {
-                    return new SiloBuilder()
+                    return new SiloHostBuilder()
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)

--- a/test/Tester/EventSourcingTests/EventSourcingClusterFixture.cs
+++ b/test/Tester/EventSourcingTests/EventSourcingClusterFixture.cs
@@ -42,9 +42,9 @@ namespace Tester.EventSourcingTests
 
         private class TestSiloBuilderFactory : ISiloBuilderFactory
         {
-            public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+            public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
             {
-                return new SiloBuilder()
+                return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
                     .ConfigureLogging(builder => ConfigureLogging(builder, clusterConfiguration.GetOrCreateNodeConfigurationForSilo(siloName).TraceFileName));

--- a/test/Tester/GrainActivatorTests.cs
+++ b/test/Tester/GrainActivatorTests.cs
@@ -32,9 +32,9 @@ namespace UnitTests.General
 
             private class TestSiloBuilderFactory : ISiloBuilderFactory
             {
-                public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+                public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
                 {
-                    return new SiloBuilder()
+                    return new SiloHostBuilder()
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)

--- a/test/Tester/GrainCallFilterTests.cs
+++ b/test/Tester/GrainCallFilterTests.cs
@@ -36,9 +36,9 @@ namespace UnitTests.General
 
             private class SiloInvokerTestSiloBuilderFactory : ISiloBuilderFactory
             {
-                public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+                public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
                 {
-                    return new SiloBuilder()
+                    return new SiloHostBuilder()
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)

--- a/test/Tester/GrainServiceTests/GrainServiceTests.cs
+++ b/test/Tester/GrainServiceTests/GrainServiceTests.cs
@@ -30,9 +30,9 @@ namespace Tester
 
             private class GrainSiloBuilderFactory : ISiloBuilderFactory
             {
-                public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+                public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
                 {
-                    return new SiloBuilder()
+                    return new SiloHostBuilder()
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)

--- a/test/Tester/Placement/CustomPlacementTests.cs
+++ b/test/Tester/Placement/CustomPlacementTests.cs
@@ -38,9 +38,9 @@ namespace Tester.CustomPlacementTests
 
             private class TestSiloBuilderFactory : ISiloBuilderFactory
             {
-                public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+                public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
                 {
-                    return new SiloBuilder()
+                    return new SiloHostBuilder()
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)

--- a/test/Tester/StorageFacet/Feature.Implementations/BlobExampleStorage.cs
+++ b/test/Tester/StorageFacet/Feature.Implementations/BlobExampleStorage.cs
@@ -47,7 +47,7 @@ namespace Tester.StorageFacet.Implementations
 
     public static class BlobExampleStorageExtensions
     {
-        public static void UseBlobExampleStorage(this ISiloBuilder builder, string name)
+        public static void UseBlobExampleStorage(this ISiloHostBuilder builder, string name)
         {
             builder.ConfigureServices(services =>
             {

--- a/test/Tester/StorageFacet/Feature.Implementations/TableExampleStorage.cs
+++ b/test/Tester/StorageFacet/Feature.Implementations/TableExampleStorage.cs
@@ -62,7 +62,7 @@ namespace Tester.StorageFacet.Implementations
 
     public static class TableExampleStorageExtensions
     {
-        public static void UseTableExampleStorage(this ISiloBuilder builder, string name)
+        public static void UseTableExampleStorage(this ISiloHostBuilder builder, string name)
         {
             builder.ConfigureServices(services =>
             {

--- a/test/Tester/StorageFacet/Feature.Infrastructure/ExampleStorageExtensions.cs
+++ b/test/Tester/StorageFacet/Feature.Infrastructure/ExampleStorageExtensions.cs
@@ -7,7 +7,7 @@ namespace Tester.StorageFacet.Infrastructure
 {
     public static class ExampleStorageExtensions
     {
-        public static void UseExampleStorage(this ISiloBuilder builder)
+        public static void UseExampleStorage(this ISiloHostBuilder builder)
         {
             builder.ConfigureServices(services =>
             {
@@ -19,7 +19,7 @@ namespace Tester.StorageFacet.Infrastructure
             });
         }
 
-        public static void UseAsDefaultExampleStorage<TFactoryType>(this ISiloBuilder builder)
+        public static void UseAsDefaultExampleStorage<TFactoryType>(this ISiloHostBuilder builder)
             where TFactoryType : class, IExampleStorageFactory
         {
             builder.ConfigureServices(services =>

--- a/test/Tester/StorageFacet/StorageFacetTests.cs
+++ b/test/Tester/StorageFacet/StorageFacetTests.cs
@@ -28,9 +28,9 @@ namespace Tester
 
             private class TestSiloBuilderFactory : ISiloBuilderFactory
             {
-                public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+                public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
                 {
-                    ISiloBuilder builder = new SiloBuilder()
+                    var builder = new SiloHostBuilder()
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureLogging(loggingBuilder => TestingUtils.ConfigureDefaultLoggingBuilder(loggingBuilder, clusterConfiguration.GetOrCreateNodeConfigurationForSilo(siloName).TraceFileName));

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -46,9 +46,9 @@ namespace Tester.StreamingTests
 
         public class SiloBuilderFactory : ISiloBuilderFactory
         {
-            public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+            public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
             {
-                return new SiloBuilder()
+                return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
                     .ConfigureServices(ConfigureServices)

--- a/test/TesterAzureUtils/Lease/LeaseBasedQueueBalancerTests.cs
+++ b/test/TesterAzureUtils/Lease/LeaseBasedQueueBalancerTests.cs
@@ -49,9 +49,9 @@ namespace Tester.AzureUtils.Lease
 
         private class TestSiloBuilderFactory : ISiloBuilderFactory
         {
-            public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+            public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
             {
-                return new SiloBuilder()
+                return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
                     .ConfigureServices(ConfigureServices)

--- a/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
@@ -47,9 +47,9 @@ namespace Tests.GeoClusterTests
 
             private class TestSiloBuilderFactory : ISiloBuilderFactory
             {
-                public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+                public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
                 {
-                    return new SiloBuilder()
+                    return new SiloHostBuilder()
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(services => ConfigureLogging(services, clusterConfiguration.GetOrCreateNodeConfigurationForSilo(siloName).TraceFileName));

--- a/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -165,9 +165,9 @@ namespace Tests.GeoClusterTests
 
         private class TestSiloBuilderFactory : ISiloBuilderFactory
         {
-            public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+            public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
             {
-                return new SiloBuilder()
+                return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
                     .ConfigureLogging(builder => ConfigureLogging(builder, clusterConfiguration.GetOrCreateNodeConfigurationForSilo(siloName).TraceFileName));

--- a/test/Versions/TestVersionGrains/VersionGrainsSiloBuilderfactory.cs
+++ b/test/Versions/TestVersionGrains/VersionGrainsSiloBuilderfactory.cs
@@ -11,9 +11,9 @@ namespace TestVersionGrains
 {
     public class VersionGrainsSiloBuilderFactory : ISiloBuilderFactory
     {
-        public ISiloBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
+        public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)
         {
-            return new SiloBuilder()
+            return new SiloHostBuilder()
                 .ConfigureSiloName(siloName)
                 .UseConfiguration(clusterConfiguration)
                 .ConfigureServices(ConfigureServices)


### PR DESCRIPTION
Microsoft.Extensions.Hosting (from https://github.com/aspnet/Hosting/issues/1163) is still in preview and won't be released for a few months. Nevertheless, we want to align as much as possible with it, so then migrating to it is not a big breaking change for our users, as well as trying to use common and familiar patterns.

This change has something I'd like to validate more openly with you before merging.

* Renamed `SiloHostBuilder` to `HostBuilder` and made it more generic, similar to the one in `Microsoft.Extensions.Hosting.HostBuilder` (but kept it in `Orleans.Hosting` namespace).
* Renamed `ISilo` to `IHost`. In the near term, the code in `SiloWrapper` will be rewritten as a generic `IHostedService`, similar to how we expect the integration with Microsoft.Extensions.Hosting to work. Basically a single generic IHost should be be able to host an Orleans silo, ASP.NET, etc.
* Added `HostBuilderContext` for the `HostBuilder`, as well as a Properties property bag, similar to the generic version we are emulating.
* Introduced `ISiloBuilder` as a non-generic silo builder. **I'd like feedback here!**
  * Currently this builder is used when calling the `ConfigureSiloHost` extension method, like this:

```
return new HostBuilder()
    .ConfigureServices(ConfigureServices)
    .ConfigureSiloHost(ISiloBuilder silo => silo  // Made type explicit here in snippet for review
        .ConfigureSiloName(siloName)
        .UseConfiguration(clusterConfiguration));
```
   * An alternate approach I considered is to return the `ISiloBuilder` instead of nesting it in a delegate, such as this:

```
return new HostBuilder()
    .ConfigureServices(ConfigureServices)
    .ConfigureSiloHost() // The silo builder could be returned here, instead of the original IHostBuilder
        .ConfigureSiloName(siloName)
        .UseConfiguration(clusterConfiguration);
```

By the way, it is not strictly required to introduce a builder, but I found it more explicit for cases where you would configure ASP.NET as well as Orleans (and potentially others in the future) into the same HostBuilder. If I didn't add the ISiloBuilder, then tons of extension methods would hang from IHostBuilder or ServiceCollection, and it could be tricky to understand the scope of the method (whether it configures something in Orleans or in ASP.NET).

Do you have thoughts especially on this last design question?

I will continue to polish this PR, but I wanted to get it out to gather feedback before I'm done with everything and then decide to go into a different approach.