### PR TITLE
Transactional state storage abstraction

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IStorage.cs
+++ b/src/Orleans.Core.Abstractions/Core/IStorage.cs
@@ -7,6 +7,8 @@ namespace Orleans.Core
     {
         TState State { get; set; }
 
+        string Etag { get; }
+
         /// <summary>
         /// Async method to cause the current grain state data to be cleared and reset. 
         /// This will usually mean the state record is deleted from backing store, but the specific behavior is defined by the storage provider instance configured for this grain.

--- a/src/Orleans.Core/Core/StateStorageBridge.cs
+++ b/src/Orleans.Core/Core/StateStorageBridge.cs
@@ -21,6 +21,11 @@ namespace Orleans.Core
             set { grainState.State = value; }
         }
 
+        public string Etag
+        {
+            get { return grainState.ETag; }
+        }
+
         public StateStorageBridge(string name, GrainReference grainRef, IStorageProvider store)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));

--- a/src/Orleans.Transactions/Abstractions/INamedTransactionalStateStorageFactory.cs
+++ b/src/Orleans.Transactions/Abstractions/INamedTransactionalStateStorageFactory.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Orleans.Transactions.Abstractions
+{
+    public interface INamedTransactionalStateStorageFactory
+    {
+        ITransactionalStateStorage<TState> Create<TState>(string storageName) where TState : class, new();
+    }
+}

--- a/src/Orleans.Transactions/Abstractions/INamedTransactionalStateStorageFactory.cs
+++ b/src/Orleans.Transactions/Abstractions/INamedTransactionalStateStorageFactory.cs
@@ -1,8 +1,17 @@
 ﻿
 namespace Orleans.Transactions.Abstractions
 {
+    /// <summary>
+    /// Factory which creates an ITransactionalStateStorage by name.
+    /// </summary>
     public interface INamedTransactionalStateStorageFactory
     {
+        /// <summary>
+        /// Create an ITransactionalStateStorage by name.
+        /// </summary>
+        /// <typeparam name="TState"></typeparam>
+        /// <param name="storageName">Name of transaction state storage to create.</param>
+        /// <returns>ITransactionalStateStorage, null if not found.</returns>
         ITransactionalStateStorage<TState> Create<TState>(string storageName) where TState : class, new();
     }
 }

--- a/src/Orleans.Transactions/Abstractions/ITransactionalStateStorage.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionalStateStorage.cs
@@ -1,0 +1,66 @@
+﻿using Orleans.Concurrency;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Orleans.Transactions.Abstractions
+{
+    public interface ITransactionalStateStorage<TState>
+        where TState : class, new()
+    {
+        Task<TransactionalStorageLoadResponse<TState>> Load(string stateName);
+
+        Task<string> Persist(
+            string stateName,
+            string expectedETag,
+            string metadata,
+            List<PendingTransactionState<TState>> statesToPrepare);
+
+        Task<string> Confirm(
+            string stateName,
+            string expectedETag,
+            string metadata,
+            string transactionIdToCommit);
+    }
+
+    [Serializable]
+    [Immutable]
+    public class PendingTransactionState<TState>
+        where TState : class, new()
+    {
+        public PendingTransactionState(string transactionId, long sequenceId, TState state)
+        {
+            this.TransactionId = transactionId;
+            this.SequenceId = sequenceId;
+            this.State = state;
+        }
+
+        public string TransactionId { get; }
+
+        public long SequenceId { get; }
+
+        public TState State { get; }
+    }
+
+    [Serializable]
+    [Immutable]
+    public class TransactionalStorageLoadResponse<TState>
+        where TState : class, new()
+    {
+        public TransactionalStorageLoadResponse(string etag, TState committedState, string metadata, List<PendingTransactionState<TState>> pendingStates)
+        {
+            this.ETag = etag;
+            this.CommittedState = committedState;
+            this.Metadata = metadata;
+            this.PendingStates = pendingStates;
+        }
+
+        public string ETag { get; }
+
+        public TState CommittedState { get; }
+
+        public string Metadata { get;  }
+
+        public IReadOnlyList<PendingTransactionState<TState>> PendingStates { get; }
+    }
+}

--- a/src/Orleans.Transactions/Abstractions/ITransactionalStateStorage.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionalStateStorage.cs
@@ -47,7 +47,7 @@ namespace Orleans.Transactions.Abstractions
     public class TransactionalStorageLoadResponse<TState>
         where TState : class, new()
     {
-        public TransactionalStorageLoadResponse(string etag, TState committedState, string metadata, List<PendingTransactionState<TState>> pendingStates)
+        public TransactionalStorageLoadResponse(string etag, TState committedState, string metadata, IReadOnlyList<PendingTransactionState<TState>> pendingStates)
         {
             this.ETag = etag;
             this.CommittedState = committedState;

--- a/src/Orleans.Transactions/Abstractions/ITransactionalStateStorageFactory.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionalStateStorageFactory.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Orleans.Transactions.Abstractions
+{
+    public interface ITransactionalStateStorageFactory
+    {
+        ITransactionalStateStorage<TState> Create<TState>() where TState : class, new();
+    }
+}

--- a/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
+++ b/src/Orleans.Transactions/Hosting/SiloBuilderExtensions.cs
@@ -38,6 +38,7 @@ namespace Orleans.Transactions
             services.TryAddSingleton(typeof(ITransactionDataCopier<>), typeof(DefaultTransactionDataCopier<>));
             services.AddSingleton<IAttributeToFactoryMapper<TransactionalStateAttribute>, TransactionalStateAttributeMapper>();
             services.TryAddTransient<ITransactionalStateFactory, TransactionalStateFactory>();
+            services.TryAddTransient<INamedTransactionalStateStorageFactory, NamedTransactionalStateStorageFactory>();
             services.AddTransient(typeof(ITransactionalState<>), typeof(TransactionalState<>));
         }
     }

--- a/src/Orleans.Transactions/Properties/AssemblyInfo.cs
+++ b/src/Orleans.Transactions/Properties/AssemblyInfo.cs
@@ -5,7 +5,6 @@ using Orleans.Transactions;
 [assembly: GenerateSerializer(typeof(TransactionalExtensionExtensions.TransactionalResourceExtensionWrapper))]
 [assembly: GenerateSerializer(typeof(CommitRecord))]
 [assembly: GenerateSerializer(typeof(TransactionsConfiguration))]
-[assembly: GenerateSerializer(typeof(LogRecord<>))]
 [assembly: GenerateSerializer(typeof(TransactionalStateRecord<>))]
 [assembly: GenerateSerializer(typeof(PendingTransactionState<>))]
 [assembly: GenerateSerializer(typeof(TransactionalStorageLoadResponse<>))]

--- a/src/Orleans.Transactions/Properties/AssemblyInfo.cs
+++ b/src/Orleans.Transactions/Properties/AssemblyInfo.cs
@@ -7,3 +7,5 @@ using Orleans.Transactions;
 [assembly: GenerateSerializer(typeof(TransactionsConfiguration))]
 [assembly: GenerateSerializer(typeof(LogRecord<>))]
 [assembly: GenerateSerializer(typeof(TransactionalStateRecord<>))]
+[assembly: GenerateSerializer(typeof(PendingTransactionState<>))]
+[assembly: GenerateSerializer(typeof(TransactionalStorageLoadResponse<>))]

--- a/src/Orleans.Transactions/State/NamedTransactionalStateStorageFactory.cs
+++ b/src/Orleans.Transactions/State/NamedTransactionalStateStorageFactory.cs
@@ -28,8 +28,9 @@ namespace Orleans.Transactions
                 ? this.context.ActivationServices.GetService<IStorageProvider>()
                 : this.context.ActivationServices.GetServiceByName<IStorageProvider>(storageName);
             if (storageProvider != null) return new TransactionalStateStorageProviderWrapper<TState>(storageProvider, context);
-
-            throw new InvalidOperationException($"Transactional storage {storageName} was not found.");
+            throw (string.IsNullOrEmpty(storageName))
+                ? new InvalidOperationException($"No default {nameof(ITransactionalStateStorageFactory)} nor {nameof(IStorageProvider)} was found while attempting to create transactional state storage.")
+                : new InvalidOperationException($"No {nameof(ITransactionalStateStorageFactory)} nor {nameof(IStorageProvider)} with the name {storageName} was found while attempting to create transactional state storage.");
         }
     }
 }

--- a/src/Orleans.Transactions/State/NamedTransactionalStateStorageFactory.cs
+++ b/src/Orleans.Transactions/State/NamedTransactionalStateStorageFactory.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+using Orleans.Storage;
+
+namespace Orleans.Transactions
+{
+    public class NamedTransactionalStateStorageFactory : INamedTransactionalStateStorageFactory
+    {
+        private readonly IGrainActivationContext context;
+
+        public NamedTransactionalStateStorageFactory(IGrainActivationContext context)
+        {
+            this.context = context;
+        }
+        public ITransactionalStateStorage<TState> Create<TState>(string storageName)
+            where TState : class, new()
+        {
+            // Try to get ITransactionalStateStorage from factory
+            ITransactionalStateStorageFactory factory = string.IsNullOrEmpty(storageName)
+                ? this.context.ActivationServices.GetService<ITransactionalStateStorageFactory>()
+                : this.context.ActivationServices.GetServiceByName<ITransactionalStateStorageFactory>(storageName);
+            if (factory != null) return factory.Create<TState>();
+
+            // Else try to get storage provider and wrap it
+            IStorageProvider storageProvider = string.IsNullOrEmpty(storageName)
+                ? this.context.ActivationServices.GetService<IStorageProvider>()
+                : this.context.ActivationServices.GetServiceByName<IStorageProvider>(storageName);
+            if (storageProvider != null) return new TransactionalStateStorageProviderWrapper<TState>(storageProvider, context);
+
+            throw new InvalidOperationException($"Transactional storage {storageName} was not found.");
+        }
+    }
+}

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -483,7 +483,6 @@ namespace Orleans.Transactions
             return $"{this.context.GrainInstance}.{this.config.StateName}";
         }
 
-        [Serializable]
         private class Metadata
         {
             private static readonly JsonSerializerSettings settings = new JsonSerializerSettings

--- a/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using Orleans.Transactions.Abstractions;
+using Orleans.Core;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace Orleans.Transactions
+{
+    internal class TransactionalStateStorageProviderWrapper<TState> : ITransactionalStateStorage<TState>
+        where TState : class, new()
+    {
+        private readonly IStorageProvider storageProvider;
+        private readonly IGrainActivationContext context;
+        private readonly ConcurrentDictionary<string, IStorage<TransactionalStateRecord<TState>>> stateStorages;
+
+        public TransactionalStateStorageProviderWrapper(IStorageProvider storageProvider, IGrainActivationContext context)
+        {
+            this.storageProvider = storageProvider;
+            this.context = context;
+            this.stateStorages = new ConcurrentDictionary<string, IStorage<TransactionalStateRecord<TState>>>();
+        }
+
+        public async Task<TransactionalStorageLoadResponse<TState>> Load(string stateName)
+        {
+            IStorage<TransactionalStateRecord<TState>> stateStorage = GetStateStorage(stateName);
+            await stateStorage.ReadStateAsync();
+            return new TransactionalStorageLoadResponse<TState>(stateStorage.Etag, stateStorage.State.CommittedState, stateStorage.State.Metadata, stateStorage.State.PendingStates);
+        }
+
+        public async Task<string> Persist(string stateName, string expectedETag, string metadata, List<PendingTransactionState<TState>> statesToPrepare)
+        {
+            IStorage<TransactionalStateRecord<TState>> stateStorage = GetStateStorage(stateName);
+            if (stateStorage.Etag != expectedETag)
+                throw new ArgumentException(nameof(expectedETag), "Etag does not match");
+            stateStorage.State.Metadata = metadata;
+            foreach(PendingTransactionState<TState> pendingState in statesToPrepare.Where(s => !stateStorage.State.PendingStates.Contains(s)))
+            {
+                stateStorage.State.PendingStates.Add(pendingState);
+            }
+            await stateStorage.WriteStateAsync();
+            return stateStorage.Etag;
+        }
+
+        public async Task<string> Confirm(string stateName, string expectedETag, string metadata, string transactionIdToCommit)
+        {
+            IStorage<TransactionalStateRecord<TState>> stateStorage = GetStateStorage(stateName);
+            if (stateStorage.Etag != expectedETag)
+                throw new ArgumentException(nameof(expectedETag), "Etag does not match");
+            stateStorage.State.Metadata = metadata;
+            PendingTransactionState<TState> committedState = stateStorage.State.PendingStates.FirstOrDefault(pending => transactionIdToCommit == pending.TransactionId);
+            if (committedState != null)
+            {
+                stateStorage.State.CommittedTransactionId = committedState.TransactionId;
+                stateStorage.State.CommittedState = committedState.State;
+                stateStorage.State.PendingStates = stateStorage.State.PendingStates.Where(pending => pending.SequenceId > committedState.SequenceId).ToList();
+            }
+            await stateStorage.WriteStateAsync();
+            return stateStorage.Etag;
+        }
+
+        private IStorage<TransactionalStateRecord<TState>> GetStateStorage(string stateName)
+        {
+            return this.stateStorages.GetOrAdd(stateName, name => new StateStorageBridge<TransactionalStateRecord<TState>>(name, this.context.GrainInstance.GrainReference, storageProvider));
+        }
+    }
+
+    [Serializable]
+    public class TransactionalStateRecord<TState>
+        where TState : class, new()
+    {
+        public TState CommittedState { get; set; } = new TState();
+
+        public string CommittedTransactionId { get; set; }
+
+        public string Metadata { get; set; }
+
+        public List<PendingTransactionState<TState>> PendingStates { get; set; } = new List<PendingTransactionState<TState>>();
+    }
+}

--- a/test/Orleans.Transactions.Tests/Grains/SingleStateTransactionalGrain.cs
+++ b/test/Orleans.Transactions.Tests/Grains/SingleStateTransactionalGrain.cs
@@ -15,7 +15,7 @@ namespace Orleans.Transactions.Tests
         private readonly ITransactionalState<GrainData> data;
 
         public SingleStateTransactionalGrain(
-            [TransactionalState(TransactionTestConstants.TransactionStore)]
+            [TransactionalState("data", TransactionTestConstants.TransactionStore)]
             ITransactionalState<GrainData> data)
         {
             this.data = data;

--- a/test/Orleans.Transactions.Tests/Grains/TransactionOrchestrationGrain.cs
+++ b/test/Orleans.Transactions.Tests/Grains/TransactionOrchestrationGrain.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 using Orleans.Providers;
 using Orleans.Transactions.Abstractions;
+using Orleans.Transactions;
 
 namespace Orleans.Transactions.Tests
 {


### PR DESCRIPTION
Added a storage abstraction tuned towards the transaction state transactional resource.
If a storage specific or application specific implementation is not provided, the transactional state storage will default to using storage providers.