### PR TITLE
[Abstractions] Update to .NET Standard 2.0 and move base Orleans exception

### DIFF
--- a/src/Orleans.Core.Abstractions/Exceptions/OrleansException.cs
+++ b/src/Orleans.Core.Abstractions/Exceptions/OrleansException.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// An exception class used by the Orleans runtime for reporting errors.
+    /// </summary>
+    /// <remarks>
+    /// This is also the base class for any more specific exceptions 
+    /// raised by the Orleans runtime.
+    /// </remarks>
+    [Serializable]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1058:TypesShouldNotExtendCertainBaseTypes")]
+    public class OrleansException : Exception
+    {
+        public OrleansException() : base("Unexpected error.") { }
+
+        public OrleansException(string message) : base(message) { }
+
+        public OrleansException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected OrleansException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
+++ b/src/Orleans.Core.Abstractions/Orleans.Core.Abstractions.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.Orleans.Core.Abstractions</AssemblyName>
     <RootNamespace>Orleans</RootNamespace>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.net standard < 2.0 does not have the exception constructor with serialization stuff, so I had to update the target framework