### PR TITLE
Build only one configuration in Build.cmd

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -3,6 +3,7 @@ setlocal
 
 SET CMDHOME=%~dp0.
 if "%BUILD_FLAGS%"=="" SET BUILD_FLAGS=/m:1 /v:m
+if not defined BuildConfiguration SET BuildConfiguration=Debug
 
 :: Clear the 'Platform' env variable for this session, as it's a per-project setting within the build, and
 :: misleading value (such as 'MCD' in HP PCs) may lead to build breakage (issue: #69).
@@ -56,63 +57,38 @@ SET TOOLS_PACKAGES_PATH=%CMDHOME%\packages
 SET SOLUTION=%CMDHOME%\Orleans.sln
 
 :: Set DateTime suffix for debug builds
-for /f %%i in ('powershell -NoProfile -ExecutionPolicy ByPass Get-Date -format "{yyyyMMddHHmm}"') do set DATE_SUFFIX=%%i
+if "%BuildConfiguration%" == "Debug" (
+    for /f %%i in ('powershell -NoProfile -ExecutionPolicy ByPass Get-Date -format "{yyyyMMddHHmm}"') do set DATE_SUFFIX=%%i
+	SET AdditionalConfigurationProperties=";VersionDateSuffix=%DATE_SUFFIX%"
+)
 
 if "%1" == "Pack" GOTO :Package
 
 @echo ===== Building %SOLUTION% =====
+SET STEP="Download build tools"
 call %_dotnet% restore "%CMDHOME%\Build\Tools.csproj" --packages %TOOLS_PACKAGES_PATH%
 
-@echo Build Debug ==============================
+@echo Build %BuildConfiguration% ==============================
+SET STEP="Restore %BuildConfiguration%"
 
-SET CURRENT_CONFIGURATION=Debug
-
-call %_dotnet% restore %BUILD_FLAGS% /bl:%CURRENT_CONFIGURATION%-Restore.binlog /p:Configuration=%CURRENT_CONFIGURATION% "%SOLUTION%"
+call %_dotnet% restore %BUILD_FLAGS% /bl:%BuildConfiguration%-Restore.binlog /p:Configuration=%BuildConfiguration%%AdditionalConfigurationProperties% "%SOLUTION%"
 @if ERRORLEVEL 1 GOTO :ErrorStop
-@echo RESTORE ok for %CURRENT_CONFIGURATION% %SOLUTION%
+@echo "RESTORE ok for %BuildConfiguration% %SOLUTION%"
 
-call %_dotnet% build %BUILD_FLAGS% /bl:%CURRENT_CONFIGURATION%-Build.binlog /p:Configuration=%CURRENT_CONFIGURATION% "%SOLUTION%"
+SET STEP="Build %BuildConfiguration%"
+call %_dotnet% build --no-restore %BUILD_FLAGS% /bl:%BuildConfiguration%-Build.binlog /p:Configuration=%BuildConfiguration%%AdditionalConfigurationProperties% "%SOLUTION%"
 @if ERRORLEVEL 1 GOTO :ErrorStop
-@echo BUILD ok for %CURRENT_CONFIGURATION% %SOLUTION%
+@echo "BUILD ok for %BuildConfiguration% %SOLUTION%"
 
-call %_dotnet% pack --no-build %BUILD_FLAGS% /bl:%CURRENT_CONFIGURATION%-Pack.binlog /p:Configuration=%CURRENT_CONFIGURATION%;VersionDateSuffix=%DATE_SUFFIX% "%SOLUTION%"
-@if ERRORLEVEL 1 GOTO :ErrorStop
-@echo PACKAGE ok for %CURRENT_CONFIGURATION% %SOLUTION%
-
-@echo Build Release ============================
-
-SET CURRENT_CONFIGURATION=Release
-
-call %_dotnet% restore %BUILD_FLAGS% /bl:%CURRENT_CONFIGURATION%-Restore.binlog /p:Configuration=%CURRENT_CONFIGURATION% "%SOLUTION%"
-@if ERRORLEVEL 1 GOTO :ErrorStop
-@echo RESTORE ok for %CURRENT_CONFIGURATION% %SOLUTION%
-
-call %_dotnet% build %BUILD_FLAGS% /bl:%CURRENT_CONFIGURATION%-Build.binlog /p:Configuration=%CURRENT_CONFIGURATION% "%SOLUTION%"
-@if ERRORLEVEL 1 GOTO :ErrorStop                                    
-@echo BUILD ok for %CURRENT_CONFIGURATION% %SOLUTION%
-
-call %_dotnet% pack --no-build %BUILD_FLAGS% /bl:%CURRENT_CONFIGURATION%-Pack.binlog /p:Configuration=%CURRENT_CONFIGURATION% "%SOLUTION%"
-@if ERRORLEVEL 1 GOTO :ErrorStop                                    
-@echo PACKAGE ok for %CURRENT_CONFIGURATION% %SOLUTION%
-
-goto :BuildFinished
 
 :Package
-@echo Package Debug ============================
+@echo Package BuildConfiguration ============================
+SET STEP="Pack %BuildConfiguration%"
 
-SET CURRENT_CONFIGURATION=Debug
-
-call %_dotnet% pack --no-build %BUILD_FLAGS% /bl:%CURRENT_CONFIGURATION%-Pack.binlog /p:Configuration=%CURRENT_CONFIGURATION%;VersionDateSuffix=%DATE_SUFFIX% "%SOLUTION%"
+call %_dotnet% pack --no-build --no-restore %BUILD_FLAGS% /bl:%BuildConfiguration%-Pack.binlog /p:Configuration=%BuildConfiguration%%AdditionalConfigurationProperties% "%SOLUTION%"
 @if ERRORLEVEL 1 GOTO :ErrorStop
-@echo PACKAGE ok for %CURRENT_CONFIGURATION% %SOLUTION%
+@echo "PACKAGE ok for %BuildConfiguration% %SOLUTION%"
 
-@echo Package Release ============================
-
-SET CURRENT_CONFIGURATION=Release
-
-call %_dotnet% pack --no-build %BUILD_FLAGS% /bl:%CURRENT_CONFIGURATION%-Pack.binlog /p:Configuration=%CURRENT_CONFIGURATION% "%SOLUTION%"
-@if ERRORLEVEL 1 GOTO :ErrorStop                                    
-@echo PACKAGE ok for %CURRENT_CONFIGURATION% %SOLUTION%
 
 :BuildFinished
 @echo ===== Build succeeded for %SOLUTION% =====
@@ -120,7 +96,7 @@ call %_dotnet% pack --no-build %BUILD_FLAGS% /bl:%CURRENT_CONFIGURATION%-Pack.bi
 
 :ErrorStop
 set RC=%ERRORLEVEL%
-if "%STEP%" == "" set STEP=%CURRENT_CONFIGURATION%
+if "%STEP%" == "" set STEP=%BuildConfiguration%
 @echo ===== Build FAILED for %SOLUTION% -- %STEP% with error %RC% - CANNOT CONTINUE =====
 exit /B %RC%
 :EOF

--- a/Test.cmd
+++ b/Test.cmd
@@ -1,7 +1,7 @@
 @if not defined _echo @echo off
 setlocal
 
-SET CONFIGURATION=Release
+if not defined BuildConfiguration SET BuildConfiguration=Debug
 
 SET CMDHOME=%~dp0
 @REM Remove trailing backslash \
@@ -10,11 +10,11 @@ set CMDHOME=%CMDHOME:~0,-1%
 pushd "%CMDHOME%"
 @cd
 
-SET TestResultDir=%CMDHOME%\Binaries\%CONFIGURATION%\TestResults
+SET TestResultDir=%CMDHOME%\Binaries\%BuildConfiguration%\TestResults
 
 if not exist %TestResultDir% md %TestResultDir%
 
-SET _Directory=bin\%CONFIGURATION%\net461\win10-x64
+SET _Directory=bin\%BuildConfiguration%\net461\win10-x64
 
 rem copy Versioning dlls to the appropriate place to make Versioning tests pass.
 if not exist %CMDHOME%\test\Tester\%_Directory%\TestVersionGrainsV1\ mkdir %CMDHOME%\test\Tester\%_Directory%\TestVersionGrainsV1

--- a/netci.groovy
+++ b/netci.groovy
@@ -13,7 +13,7 @@ def branch = GithubBranchName
 
         def newJob = job(Utilities.getFullJobName(project, newJobName, isPR)) {
             steps {
-                batchFile("call Build.cmd && SET OrleansDataConnectionString= && ${testScript}")
+                batchFile("SET BuildConfiguration=Release&& call Build.cmd && SET OrleansDataConnectionString= && ${testScript}")
             }
         }
 


### PR DESCRIPTION
Build only 1 configuration instead of both Debug and Release in Build.cmd
Default local development environment to Debug, but CI environment to Release.