### PR TITLE
In memory Lease provider (for development/test)

### DIFF
--- a/src/OrleansRuntime/Development/DevelopmentSiloBuilderExtensions.cs
+++ b/src/OrleansRuntime/Development/DevelopmentSiloBuilderExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Orleans.Hosting;
+using Orleans.LeaseProviders;
+
+namespace Orleans.Runtime.Development
+{
+    public static class DevelopmentSiloBuilderExtensions
+    {
+        /// <summary>
+        /// Configure silo with test/developement features.
+        /// NOT FOR PRODUCTION USE - dev/test only
+        /// </summary>
+        public static ISiloBuilder UseInMemoryLeaseProvider(this ISiloBuilder builder)
+        {
+            return builder.ConfigureServices(UseInMemoryLeaseProvider);
+        }
+
+        private static void UseInMemoryLeaseProvider(IServiceCollection services)
+        {
+            services.AddTransient<ILeaseProvider, InMemoryLeaseProvider>();
+        }
+    }
+}

--- a/src/OrleansRuntime/Development/InMemoryLeaseProvider.cs
+++ b/src/OrleansRuntime/Development/InMemoryLeaseProvider.cs
@@ -1,0 +1,121 @@
+﻿using Orleans.LeaseProviders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.Development
+{
+    public class InMemoryLeaseProvider : ILeaseProvider
+    {
+        private readonly IDevelopmentLeaseProviderGrain leaseProvider;
+
+        public InMemoryLeaseProvider(IGrainFactory grainFactory)
+        {
+            this.leaseProvider = grainFactory.GetGrain<IDevelopmentLeaseProviderGrain>(0);
+        }
+
+        public async Task<AcquireLeaseResult[]> Acquire(string category, LeaseRequest[] leaseRequests)
+        {
+            try
+            {
+                return await this.leaseProvider.Acquire(category, leaseRequests);
+            } catch(Exception ex)
+            {
+                return leaseRequests.Select(request => new AcquireLeaseResult(null, ResponseCode.TransientFailure, ex)).ToArray();
+            }
+        }
+
+        public Task Release(string category, AcquiredLease[] acquiredLeases)
+        {
+            return this.leaseProvider.Release(category, acquiredLeases);
+        }
+
+        public async Task<AcquireLeaseResult[]> Renew(string category, AcquiredLease[] acquiredLeases)
+        {
+            try
+            {
+                return await this.leaseProvider.Renew(category, acquiredLeases);
+            }
+            catch (Exception ex)
+            {
+                return acquiredLeases.Select(request => new AcquireLeaseResult(null, ResponseCode.TransientFailure, ex)).ToArray();
+            }
+        }
+    }
+
+    public interface IDevelopmentLeaseProviderGrain : ILeaseProvider, IGrainWithIntegerKey
+    {
+    }
+
+    public class DevelopmentLeaseProviderGrain : Grain, IDevelopmentLeaseProviderGrain
+    {
+        private readonly Dictionary<Tuple<string, string>, Lease> leases = new Dictionary<Tuple<string, string>, Lease>();
+
+        public Task<AcquireLeaseResult[]> Acquire(string category, LeaseRequest[] leaseRequests)
+        {
+            return Task.FromResult(leaseRequests.Select(request => Acquire(category, request)).ToArray());
+        }
+
+        public Task Release(string category, AcquiredLease[] acquiredLeases)
+        {
+            foreach(AcquiredLease lease in acquiredLeases)
+            {
+                Release(category, lease);
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task<AcquireLeaseResult[]> Renew(string category, AcquiredLease[] acquiredLeases)
+        {
+            return Task.FromResult(acquiredLeases.Select(lease => Renew(category, lease)).ToArray());
+        }
+
+        private AcquireLeaseResult Acquire(string category, LeaseRequest leaseRequest)
+        {
+            DateTime now = DateTime.UtcNow;
+            Lease lease = this.leases.GetValueOrAddNew(Tuple.Create(category, leaseRequest.ResourceKey));
+            if(lease.ExpiredUtc < now)
+            {
+                lease.ExpiredUtc = now + leaseRequest.Duration;
+                return new AcquireLeaseResult(new AcquiredLease(leaseRequest.ResourceKey, leaseRequest.Duration, lease.Token, now), ResponseCode.OK, null);
+            }
+            return new AcquireLeaseResult(null, ResponseCode.LeaseNotAvailable, new OrleansException("Lease not available"));
+        }
+
+        private void Release(string category, AcquiredLease acquiredLease)
+        {
+            Tuple<string,string> leaseKey = Tuple.Create(category, acquiredLease.ResourceKey);
+            if (this.leases.TryGetValue(leaseKey, out Lease lease) && lease.Token == acquiredLease.Token)
+            {
+                leases.Remove(leaseKey);
+            }
+        }
+
+        private AcquireLeaseResult Renew(string category, AcquiredLease acquiredLease)
+        {
+            DateTime now = DateTime.UtcNow;
+            // if lease exists, and we have the right token, and lease has not expired, renew.
+            if (this.leases.TryGetValue(Tuple.Create(category, acquiredLease.ResourceKey), out Lease lease))
+            {
+                // check token
+                if (lease.Token != acquiredLease.Token)
+                {
+                    return new AcquireLeaseResult(null, ResponseCode.InvalidToken, new OrleansException("Invalid token provided, caller is not the owner."));
+                }
+                // we don't care if lease has expired or not as long was owner has not changed.
+                lease.ExpiredUtc = now + acquiredLease.Duration;
+                return new AcquireLeaseResult(new AcquiredLease(acquiredLease.ResourceKey, acquiredLease.Duration, lease.Token, now), ResponseCode.OK, null);
+            }
+            // else try an aquire
+            return Acquire(category, new LeaseRequest { ResourceKey = acquiredLease.ResourceKey, Duration = acquiredLease.Duration } );
+        }
+
+        private class Lease
+        {
+            public DateTime ExpiredUtc { get; set; }
+            public string Token => ExpiredUtc.Ticks.ToString();
+        }
+    }
+
+}

--- a/test/DefaultCluster.Tests/Lease/GoldenPathInMemoryLeaseProviderTests.cs
+++ b/test/DefaultCluster.Tests/Lease/GoldenPathInMemoryLeaseProviderTests.cs
@@ -1,0 +1,27 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+using Orleans.Runtime.Development;
+using Orleans.TestingHost;
+using TestExtensions;
+using TestExtensions.Runners;
+
+namespace DefaultCluster.Tests
+{
+    [TestCategory("BVT"), TestCategory("Functional"), TestCategory("Lease")]
+    public class GoldenPathInMemoryLeaseProviderTests : GoldenPathLeaseProviderTestRunner, IClassFixture<GoldenPathInMemoryLeaseProviderTests.Fixture>
+    {
+        public GoldenPathInMemoryLeaseProviderTests(Fixture fixture, ITestOutputHelper output)
+            : base(new InMemoryLeaseProvider(fixture.GrainFactory), output)
+        {
+        }
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override TestCluster CreateTestCluster()
+            {
+                var options = new TestClusterOptions();
+                return new TestCluster(options);
+            }
+        }
+    }
+}

--- a/test/TestExtensions/Runners/GoldenPathLeaseProviderTestRunner.cs
+++ b/test/TestExtensions/Runners/GoldenPathLeaseProviderTestRunner.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Orleans.LeaseProviders;
+
+namespace TestExtensions.Runners
+{
+    public class GoldenPathLeaseProviderTestRunner
+    {
+        private const string LeaseCategory = "TestLeaseCategory";
+
+        private readonly ILeaseProvider leaseProvider;
+        private readonly ITestOutputHelper output;
+
+        protected GoldenPathLeaseProviderTestRunner(ILeaseProvider leaseProvider, ITestOutputHelper output)
+        {
+            this.leaseProvider = leaseProvider;
+            this.output = output;
+        }
+
+        [SkippableFact]
+        public async Task ProviderCanAcquireLeases()
+        {
+            var leaseRequests = new List<LeaseRequest>() {
+                new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15)), new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15))
+            };
+            //acquire
+            AcquireLeaseResult[] results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
+            for (int i = 0; i < results.Length; i++)
+            {
+                var result = results[i];
+                Assert.Equal(ResponseCode.OK, result.StatusCode);
+                Assert.NotNull(result.AcquiredLease);
+                Assert.Equal(leaseRequests[i].ResourceKey, result.AcquiredLease.ResourceKey);
+            };
+        }
+
+        [SkippableFact]
+        public async Task ProviderCanReleaseLeases()
+        {
+            var leaseRequests = new List<LeaseRequest>() {
+                new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15)), new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15))
+            };
+            //acquire
+            var results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
+            //release
+            await this.leaseProvider.Release(LeaseCategory, results.Select(result => result.AcquiredLease).ToArray());
+        }
+
+        [SkippableFact]
+        public async Task ProviderCanRenewLeases()
+        {
+            var leaseRequests = new List<LeaseRequest>() {
+                new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15)), new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15))
+            };
+            //acquire
+            var acquireResults = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
+            //renew
+            var renewResults = await this.leaseProvider.Renew(LeaseCategory, acquireResults.Select(result => result.AcquiredLease).ToArray());
+            for (int i = 0; i < renewResults.Count(); i++)
+            {
+                var result = renewResults[i];
+                Assert.Equal(ResponseCode.OK, result.StatusCode);
+                Assert.NotNull(result.AcquiredLease);
+                Assert.Equal(leaseRequests[i].ResourceKey, result.AcquiredLease.ResourceKey);
+            };
+        }
+
+        [SkippableFact]
+        public async Task Provider_TryAcquireLeaseWhichBelongToOtherEntity_Return_LeaseNotAvailable()
+        {
+            var resourceId = Guid.NewGuid().ToString();
+            var leaseRequests = new List<LeaseRequest>() {
+                new LeaseRequest(resourceId, TimeSpan.FromSeconds(15)), new LeaseRequest(resourceId, TimeSpan.FromSeconds(15))
+            };
+            //two entity tries to acquire lease on the same release
+            var results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
+            //one attempt succeeded and one attemp failed
+            Assert.Contains(results, result => result.StatusCode == ResponseCode.OK);
+            Assert.Contains(results, result => result.StatusCode == ResponseCode.LeaseNotAvailable);
+        }
+
+        [SkippableFact]
+        public async Task Provider_TryRenewLeaseWithWrongToken_Return_InvalidToken()
+        {
+            var leaseRequests = new List<LeaseRequest>() {
+                new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15)), new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15))
+            };
+            //acquire
+            var results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
+            var acquiredLeaseWithWrongToken = results.Select(result => new AcquiredLease(result.AcquiredLease.ResourceKey, result.AcquiredLease.Duration, Guid.NewGuid().ToString(), result.AcquiredLease.StartTimeUtc));
+            //renew with wrong token
+            var renewResults = await this.leaseProvider.Renew(LeaseCategory, acquiredLeaseWithWrongToken.ToArray());
+            for (int i = 0; i < renewResults.Count(); i++)
+            {
+                var result = renewResults[i];
+                Assert.Equal(ResponseCode.InvalidToken, result.StatusCode);
+                Assert.Null(result.AcquiredLease);
+            }
+        }
+
+        [SkippableFact]
+        public async Task Provider_LifeCycle_Acqurie_Renew_Release_ShouldBeAbleToAcquireLeaseOnTheSameResourceAfterRelease()
+        {
+            var resourceId = Guid.NewGuid().ToString();
+            var leaseRequests = new List<LeaseRequest>() {
+                new LeaseRequest(resourceId, TimeSpan.FromSeconds(15))
+            };
+
+            //acquire first time
+            var acquireResults1 = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
+            //renew
+            var renewResults = await this.leaseProvider.Renew(LeaseCategory, acquireResults1.Select(result => result.AcquiredLease).ToArray());
+            for (int i = 0; i < renewResults.Count(); i++)
+            {
+                var result = renewResults[i];
+                Assert.Equal(ResponseCode.OK, result.StatusCode);
+                Assert.NotNull(result.AcquiredLease);
+                Assert.Equal(leaseRequests[i].ResourceKey, result.AcquiredLease.ResourceKey);
+            }
+            //release
+            await this.leaseProvider.Release(LeaseCategory, renewResults.Select(result => result.AcquiredLease).ToArray());
+
+            //acquire second time, acquire lease on the same resource after their leases got released
+            var acquireResults2 = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
+            for (int i = 0; i < acquireResults2.Count(); i++)
+            {
+                var result = acquireResults2[i];
+                Assert.Equal(ResponseCode.OK, result.StatusCode);
+                Assert.NotNull(result.AcquiredLease);
+                Assert.Equal(leaseRequests[i].ResourceKey, result.AcquiredLease.ResourceKey);
+                //token in two leases should be different
+                Assert.NotEqual(acquireResults1[i].AcquiredLease.Token, result.AcquiredLease.Token);
+            }
+        }
+
+    }
+}

--- a/test/TestExtensions/TestExtensions.csproj
+++ b/test/TestExtensions/TestExtensions.csproj
@@ -7,8 +7,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonVersion)" />
+    <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.core" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.extensibility.execution" Version="$(xUnitVersion)" />
+    <PackageReference Include="Xunit.SkippableFact" Version="$(XunitSkippableFactVersion)" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TesterAzureUtils/Lease/AzureBlobLeaseProviderTests.cs
+++ b/test/TesterAzureUtils/Lease/AzureBlobLeaseProviderTests.cs
@@ -1,147 +1,22 @@
-﻿using Orleans.LeaseProviders;
-using Orleans.Runtime.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Xunit.Abstractions;
+using Orleans.LeaseProviders;
 using TestExtensions;
-using Xunit;
+using TestExtensions.Runners;
 
 namespace Tester.AzureUtils.Lease
 {
     [TestCategory("Functional"), TestCategory("Azure"), TestCategory("Lease")]
-    public class AzureBlobLeaseProviderTests : AzureStorageBasicTests
+    public class AzureBlobLeaseProviderTests : GoldenPathLeaseProviderTestRunner
     {
-        private const string LeaseCategory = "AzureBlobLeaseProviderTests";
-        private AzureBlobLeaseProvider leaseProvider;
-        public AzureBlobLeaseProviderTests()
-            :base()
-        {
-            var config = new AzureBlobLeaseProviderConfig()
+        public AzureBlobLeaseProviderTests(ITestOutputHelper output)
+            :base(new AzureBlobLeaseProvider(new AzureBlobLeaseProviderConfig()
             {
                 DataConnectionString = TestDefaultConfiguration.DataConnectionString,
                 BlobContainerName = "test-blob-container-name"
-            };
-            this.leaseProvider = new AzureBlobLeaseProvider(config);
-        }
-
-        [SkippableFact]
-        public async Task ProviderCanAcquireLeases()
+            }), output)
         {
-            var leaseRequests = new List<LeaseRequest>() {
-                new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15)), new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15))
-            };
-            //acquire
-            var results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
-            for(int i = 0; i < results.Count(); i++)
-            {
-                var result = results[i];
-                Assert.Equal(ResponseCode.OK, result.StatusCode);
-                Assert.NotNull(result.AcquiredLease);
-                Assert.Equal(leaseRequests[i].ResourceKey, result.AcquiredLease.ResourceKey);
-            };
+            TestUtils.CheckForAzureStorage();
         }
-
-        [SkippableFact]
-        public async Task ProviderCanReleaseLeases()
-        {
-            var leaseRequests = new List<LeaseRequest>() {
-                new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15)), new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15))
-            };
-            //acquire
-            var results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
-            //release
-            await this.leaseProvider.Release(LeaseCategory, results.Select(result => result.AcquiredLease).ToArray());
-        }
-
-        [SkippableFact]
-        public async Task ProviderCanRenewLeases()
-        {
-            var leaseRequests = new List<LeaseRequest>() {
-                new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15)), new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15))
-            };
-            //acquire
-            var acquireResults = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
-            //renew
-            var renewResults = await this.leaseProvider.Renew(LeaseCategory, acquireResults.Select(result => result.AcquiredLease).ToArray());
-            for (int i = 0; i < renewResults.Count(); i++)
-            {
-                var result = renewResults[i];
-                Assert.Equal(ResponseCode.OK, result.StatusCode);
-                Assert.NotNull(result.AcquiredLease);
-                Assert.Equal(leaseRequests[i].ResourceKey, result.AcquiredLease.ResourceKey);
-            };
-        }
-
-        [SkippableFact]
-        public async Task Provider_TryAcquireLeaseWhichBelongToOtherEntity_Return_LeaseNotAvailable()
-        {
-            var resourceId = Guid.NewGuid().ToString();
-            var leaseRequests = new List<LeaseRequest>() {
-                new LeaseRequest(resourceId, TimeSpan.FromSeconds(15)), new LeaseRequest(resourceId, TimeSpan.FromSeconds(15))
-            };
-            //two entity tries to acquire lease on the same release
-            var results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
-            //one attempt succeeded and one attemp failed
-            Assert.Contains(results, result => result.StatusCode == ResponseCode.OK);
-            Assert.Contains(results, result => result.StatusCode == ResponseCode.LeaseNotAvailable);
-        }
-
-        [SkippableFact]
-        public async Task Provider_TryRenewLeaseWithWrongToken_Return_InvalidToken()
-        {
-            var leaseRequests = new List<LeaseRequest>() {
-                new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15)), new LeaseRequest(Guid.NewGuid().ToString(), TimeSpan.FromSeconds(15))
-            };
-            //acquire
-            var results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
-            var acquiredLeaseWithWrongToken = results.Select(result => new AcquiredLease(result.AcquiredLease.ResourceKey, result.AcquiredLease.Duration, Guid.NewGuid().ToString(), result.AcquiredLease.StartTimeUtc));
-            //renew with wrong token
-            var renewResults = await this.leaseProvider.Renew(LeaseCategory, acquiredLeaseWithWrongToken.ToArray());
-            for (int i = 0; i < renewResults.Count(); i++)
-            {
-                var result = renewResults[i];
-                Assert.Equal(ResponseCode.InvalidToken, result.StatusCode);
-                Assert.Null(result.AcquiredLease);
-            }
-        }
-
-        [SkippableFact]
-        public async Task Provider_LifeCycle_Acqurie_Renew_Release_ShouldBeAbleToAcquireLeaseOnTheSameResourceAfterRelease()
-        {
-            var resourceId = Guid.NewGuid().ToString();
-            var leaseRequests = new List<LeaseRequest>() {
-                new LeaseRequest(resourceId, TimeSpan.FromSeconds(15))
-            };
-
-            //acquire first time
-            var acquireResults1 = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
-            //renew
-            var renewResults = await this.leaseProvider.Renew(LeaseCategory, acquireResults1.Select(result => result.AcquiredLease).ToArray());
-            for (int i = 0; i < renewResults.Count(); i++)
-            {
-                var result = renewResults[i];
-                Assert.Equal(ResponseCode.OK, result.StatusCode);
-                Assert.NotNull(result.AcquiredLease);
-                Assert.Equal(leaseRequests[i].ResourceKey, result.AcquiredLease.ResourceKey);
-            }
-            //release
-            await this.leaseProvider.Release(LeaseCategory, renewResults.Select(result => result.AcquiredLease).ToArray());
-
-            //acquire second time, acquire lease on the same resource after their leases got released
-            var acquireResults2 = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
-            for (int i = 0; i < acquireResults2.Count(); i++)
-            {
-                var result = acquireResults2[i];
-                Assert.Equal(ResponseCode.OK, result.StatusCode);
-                Assert.NotNull(result.AcquiredLease);
-                Assert.Equal(leaseRequests[i].ResourceKey, result.AcquiredLease.ResourceKey);
-                //token in two leases should be different
-                Assert.NotEqual(acquireResults1[i].AcquiredLease.Token, result.AcquiredLease.Token);
-            }
-        }
-
     }
 }
 

--- a/test/TesterAzureUtils/Lease/AzureBlobLeaseProviderTests.cs
+++ b/test/TesterAzureUtils/Lease/AzureBlobLeaseProviderTests.cs
@@ -9,13 +9,18 @@ namespace Tester.AzureUtils.Lease
     public class AzureBlobLeaseProviderTests : GoldenPathLeaseProviderTestRunner
     {
         public AzureBlobLeaseProviderTests(ITestOutputHelper output)
-            :base(new AzureBlobLeaseProvider(new AzureBlobLeaseProviderConfig()
+            :base(CreateLeaseProvider(), output)
+        {
+        }
+
+        private static ILeaseProvider CreateLeaseProvider()
+        {
+            TestUtils.CheckForAzureStorage();
+            return new AzureBlobLeaseProvider(new AzureBlobLeaseProviderConfig()
             {
                 DataConnectionString = TestDefaultConfiguration.DataConnectionString,
                 BlobContainerName = "test-blob-container-name"
-            }), output)
-        {
-            TestUtils.CheckForAzureStorage();
+            });
         }
     }
 }


### PR DESCRIPTION
- Added in-memory lease provider for dev/test use.
- Moved lease provider tests to a test runner so lease provider implementation can be uniformly verified.
- Added tests for in-memory lease provider.