### PR TITLE
CodeGen: Check reference to Orleans.dll earlier

### DIFF
--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -230,14 +230,23 @@ namespace Orleans.CodeGeneration
                 // STEP 3 : Dump useful info for debugging
                 Console.WriteLine($"Orleans-CodeGen - Options {Environment.NewLine}\tInputLib={options.InputAssembly.FullName}{Environment.NewLine}\tOutputFileName={options.OutputFileName}");
 
+                bool referencesOrleans = options.InputAssembly.Name.Equals("Orleans.dll");
                 if (options.ReferencedAssemblies != null)
                 {
                     Console.WriteLine("Orleans-CodeGen - Using referenced libraries:");
-                    foreach (string assembly in options.ReferencedAssemblies) Console.WriteLine("\t{0} => {1}", Path.GetFileName(assembly), assembly);
+                    foreach (string assembly in options.ReferencedAssemblies)
+                    {
+                        var fileName = Path.GetFileName(assembly);
+                        Console.WriteLine("\t{0} => {1}", fileName, assembly);
+                        if (fileName != null && fileName.Equals("Orleans.dll")) referencesOrleans = true;
+                    }
                 }
 
-                // STEP 5 : Finally call code generation
-                if (!CreateGrainClientAssembly(options)) return -1;
+                if (referencesOrleans)
+                {
+                    // STEP 5 : Finally call code generation
+                    if (!CreateGrainClientAssembly(options)) return -1;
+                }
 
                 // DONE!
                 return 0;

--- a/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
+++ b/src/OrleansCodeGenerator/RoslynCodeGenerator.cs
@@ -225,7 +225,9 @@ namespace Orleans.CodeGenerator
         public string GenerateSourceForAssembly(Assembly input)
         {
             RegisterGeneratedCodeTargets(input);
-            if (!ShouldGenerateCodeForAssembly(input))
+
+            if (input.GetCustomAttribute<GeneratedCodeAttribute>() != null
+                || input.GetCustomAttribute<SkipCodeGenerationAttribute>() != null)
             {
                 return string.Empty;
             }


### PR DESCRIPTION
During build-time code generation, perform an early check that an assembly references Orleans.dll and avoid the existing check.