### PR TITLE
Move configuration system to an IOptions based one

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,7 +56,7 @@
     <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>2.0.0</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>2.0.0</MicrosoftExtensionsConfigurationJsonVersion>
     <MicrosoftExtensionsConfigurationVersion>2.0.0</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsDependencyInjection>2.0.0</MicrosoftExtensionsDependencyInjection>
+    <MicrosoftExtensionsDependencyInjectionVersion>2.0.0</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsLoggingVersion>2.0.0</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsOptionsConfigurationExtensionsVersion>2.0.0</MicrosoftExtensionsOptionsConfigurationExtensionsVersion>
     <MicrosoftExtensionsOptionsVersion>2.0.0</MicrosoftExtensionsOptionsVersion>

--- a/src/ClientGenerator/ClientGenerator.cs
+++ b/src/ClientGenerator/ClientGenerator.cs
@@ -1,6 +1,3 @@
-using Microsoft.Extensions.Logging;
-using Orleans.Logging;
-
 namespace Orleans.CodeGeneration
 {
     using System;
@@ -8,9 +5,13 @@ namespace Orleans.CodeGeneration
     using System.IO;
     using System.Reflection;
     using Orleans.CodeGenerator;
+    using Orleans.Configuration;
+    using Orleans.Logging;
     using Orleans.Runtime;
     using Orleans.Serialization;
     using Orleans.Runtime.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
 
     /// <summary>
     /// Generates factory, grain reference, and invoker classes for grain interfaces.
@@ -126,9 +127,14 @@ namespace Orleans.CodeGeneration
             }
 
             var config = new ClusterConfiguration();
+            var serializationProviderOptions = Options.Create(new SerializationProviderOptions
+            {
+                SerializationProviders = config.Globals.SerializationProviders,
+                FallbackSerializationProvider = config.Globals.FallbackSerializationProvider
+            });
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(new FileLoggerProvider("ClientGenerator.log"));
-            var codeGenerator = new RoslynCodeGenerator(new SerializationManager(null, config.Globals, config.Defaults, loggerFactory), loggerFactory);
+            var codeGenerator = new RoslynCodeGenerator(new SerializationManager(null, serializationProviderOptions, config.Defaults, loggerFactory), loggerFactory);
 
             // Generate source
             ConsoleText.WriteStatus("Orleans-CodeGen - Generating file {0}", options.OutputFileName);

--- a/src/Orleans/Configuration/Legacy/LegacyConfigurationExtensions.cs
+++ b/src/Orleans/Configuration/Legacy/LegacyConfigurationExtensions.cs
@@ -7,7 +7,7 @@ namespace Orleans.Configuration
 {
     public static class LegacyConfigurationExtensions
     {
-        public static IServiceCollection AddLegacySiloConfigurationSupport(this IServiceCollection services)
+        public static IServiceCollection AddLegacyClusterConfigurationSupport(this IServiceCollection services)
         {
             // Global configuration
 

--- a/src/Orleans/Configuration/Legacy/LegacyConfigurationExtensions.cs
+++ b/src/Orleans/Configuration/Legacy/LegacyConfigurationExtensions.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime.Configuration;
+using System;
+
+namespace Orleans.Configuration
+{
+    public static class LegacyConfigurationExtensions
+    {
+        public static IServiceCollection AddLegacySiloConfigurationSupport(this IServiceCollection services)
+        {
+            // Global configuration
+
+            services.Configure<ClusterConfiguration, SiloMessagingOptions>((configuration, options) =>
+            {
+                CopyCommonMessagingOptions(configuration.Globals, options);
+
+                options.SiloSenderQueues = configuration.Globals.SiloSenderQueues;
+                options.GatewaySenderQueues = configuration.Globals.GatewaySenderQueues;
+                options.MaxForwardCount = configuration.Globals.MaxForwardCount;
+                options.ClientDropTimeout = configuration.Globals.ClientDropTimeout;
+            });
+
+            services.Configure<ClusterConfiguration, SerializationProviderOptions>((configuration, options) =>
+            {
+                options.SerializationProviders = configuration.Globals.SerializationProviders;
+                options.FallbackSerializationProvider = configuration.Globals.FallbackSerializationProvider;
+            });
+
+            return services;
+        }
+
+        public static IServiceCollection AddLegacyClientConfigurationSupport(this IServiceCollection services)
+        {
+            // Global configuration
+
+            services.Configure<ClientConfiguration, ClientMessagingOptions>((configuration, options) =>
+            {
+                CopyCommonMessagingOptions(configuration, options);
+
+                options.ClientSenderBuckets = configuration.ClientSenderBuckets;
+            });
+
+            services.Configure<ClientConfiguration, SerializationProviderOptions>((configuration, options) =>
+            {
+                options.SerializationProviders = configuration.SerializationProviders;
+                options.FallbackSerializationProvider = configuration.FallbackSerializationProvider;
+            });
+
+            return services;
+        }
+
+        private static void CopyCommonMessagingOptions(IMessagingConfiguration configuration, MessagingOptions options)
+        {
+            options.OpenConnectionTimeout = configuration.OpenConnectionTimeout;
+            options.ResponseTimeout = configuration.ResponseTimeout;
+            options.MaxResendCount = configuration.MaxResendCount;
+            options.ResendOnTimeout = configuration.ResendOnTimeout;
+            options.MaxSocketAge = configuration.MaxSocketAge;
+            options.DropExpiredMessages = configuration.DropExpiredMessages;
+            options.BufferPoolBufferSize = configuration.BufferPoolBufferSize;
+            options.BufferPoolMaxSize = configuration.BufferPoolMaxSize;
+            options.BufferPoolPreallocationSize = configuration.BufferPoolPreallocationSize;
+        }
+
+        private static void Configure<TConfiguration, TOptions>(this IServiceCollection services, Action<TConfiguration, TOptions> configureOptions) where TOptions : class
+        {
+            services.AddSingleton<IConfigureOptions<TOptions>>(serviceProvider =>
+            {
+                var configuration = serviceProvider.GetRequiredService<TConfiguration>();
+
+                return new ConfigureOptions<TOptions>(options => configureOptions(configuration, options));
+            });
+        }
+    }
+}

--- a/src/Orleans/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans/Configuration/MessagingConfiguration.cs
@@ -121,8 +121,6 @@ namespace Orleans.Runtime.Configuration
 
         public List<TypeInfo> SerializationProviders { get; private set; }
         public TypeInfo FallbackSerializationProvider { get; set; }
-        internal double RejectionInjectionRate { get; set; }
-        internal double MessageLossInjectionRate { get; set; }
 
         private static readonly TimeSpan DEFAULT_MAX_SOCKET_AGE = TimeSpan.MaxValue;
         internal const int DEFAULT_MAX_FORWARD_COUNT = 2;
@@ -135,7 +133,6 @@ namespace Orleans.Runtime.Configuration
         private const int DEFAULT_BUFFER_POOL_MAX_SIZE = 10000;
         private const int DEFAULT_BUFFER_POOL_PREALLOCATION_SIZE = 250;
         private const bool DEFAULT_DROP_EXPIRED_MESSAGES = true;
-        private const double DEFAULT_ERROR_INJECTION_RATE = 0.0;
 
         private readonly bool isSiloConfig;
 
@@ -162,14 +159,10 @@ namespace Orleans.Runtime.Configuration
             if (isSiloConfig)
             {
                 MaxForwardCount = DEFAULT_MAX_FORWARD_COUNT;
-                RejectionInjectionRate = DEFAULT_ERROR_INJECTION_RATE;
-                MessageLossInjectionRate = DEFAULT_ERROR_INJECTION_RATE;
             }
             else
             {
                 MaxForwardCount = 0;
-                RejectionInjectionRate = 0.0;
-                MessageLossInjectionRate = 0.0;
             }
             SerializationProviders = new List<TypeInfo>();
         }

--- a/src/Orleans/Configuration/Options/ClientMessagingOptions.cs
+++ b/src/Orleans/Configuration/Options/ClientMessagingOptions.cs
@@ -1,0 +1,17 @@
+﻿namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Specifies global messaging options that are client related.
+    /// </summary>
+    public class ClientMessagingOptions : MessagingOptions
+    {
+        /// <summary>
+        ///  The ClientSenderBuckets attribute specifies the total number of grain buckets used by the client in client-to-gateway communication
+        ///  protocol. In this protocol, grains are mapped to buckets and buckets are mapped to gateway connections, in order to enable stickiness
+        ///  of grain to gateway (messages to the same grain go to the same gateway, while evenly spreading grains across gateways).
+        ///  This number should be about 10 to 100 times larger than the expected number of gateway connections.
+        ///  If this attribute is not specified, then Math.Pow(2, 13) is used.
+        /// </summary>
+        public int ClientSenderBuckets { get; set; } = 8192;
+    }
+}

--- a/src/Orleans/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans/Configuration/Options/MessagingOptions.cs
@@ -1,0 +1,60 @@
+﻿using Orleans.Runtime;
+using System;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Specifies global messaging options that are common to client and silo.
+    /// </summary>
+    public class MessagingOptions
+    {
+        /// <summary>
+        /// The OpenConnectionTimeout attribute specifies the timeout before a connection open is assumed to have failed
+        /// </summary>
+        public TimeSpan OpenConnectionTimeout { get; set; } = Constants.DEFAULT_OPENCONNECTION_TIMEOUT;
+
+        /// <summary>
+        /// The ResponseTimeout attribute specifies the default timeout before a request is assumed to have failed.
+        /// </summary>
+        public TimeSpan ResponseTimeout { get; set; } = Constants.DEFAULT_RESPONSE_TIMEOUT;
+
+        /// <summary>
+        /// The MaxResendCount attribute specifies the maximal number of resends of the same message.
+        /// </summary>
+        public int MaxResendCount { get; set; }
+
+        /// <summary>
+        /// The ResendOnTimeout attribute specifies whether the message should be automaticaly resend by the runtime when it times out on the sender.
+        /// Default is false.
+        /// </summary>
+        public bool ResendOnTimeout { get; set; }
+
+        /// <summary>
+        /// The MaxSocketAge attribute specifies how long to keep an open socket before it is closed.
+        /// Default is TimeSpan.MaxValue (never close sockets automatically, unles they were broken).
+        /// </summary>
+        public TimeSpan MaxSocketAge { get; set; } = TimeSpan.MaxValue;
+
+        /// <summary>
+        /// The DropExpiredMessages attribute specifies whether the message should be dropped if it has expired, that is if it was not delivered 
+        /// to the destination before it has timed out on the sender.
+        /// Default is true.
+        /// </summary>
+        public bool DropExpiredMessages { get; set; } = true;
+
+        /// <summary>
+        /// The size of a buffer in the messaging buffer pool.
+        /// </summary>
+        public int BufferPoolBufferSize { get; set; } = 4 * 1024;
+
+        /// <summary>
+        /// The maximum size of the messaging buffer pool.
+        /// </summary>
+        public int BufferPoolMaxSize { get; set; } = 10000;
+
+        /// <summary>
+        /// The initial size of the messaging buffer pool that is pre-allocated.
+        /// </summary>
+        public int BufferPoolPreallocationSize { get; set; } = 250;
+    }
+}

--- a/src/Orleans/Configuration/Options/SerializationProviderOptions.cs
+++ b/src/Orleans/Configuration/Options/SerializationProviderOptions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Specifies serialization provider and fallback serializer options.
+    /// </summary>
+    public class SerializationProviderOptions
+    {
+        public List<TypeInfo> SerializationProviders { get; set; }
+        public TypeInfo FallbackSerializationProvider { get; set; }
+    }
+}

--- a/src/Orleans/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans/Configuration/Options/SiloMessagingOptions.cs
@@ -13,14 +13,14 @@ namespace Orleans.Configuration
         /// messages (requests, responses, and notifications) to other silos.
         /// If this attribute is not specified, then System.Environment.ProcessorCount is used.
         /// </summary>
-        public int SiloSenderQueues { get; set; } = Environment.ProcessorCount;
+        public int SiloSenderQueues { get; set; }
 
         /// <summary>
         /// The GatewaySenderQueues attribute specifies the number of parallel queues and attendant threads used by the silo Gateway to send outbound
         ///  messages (requests, responses, and notifications) to clients that are connected to it.
         ///  If this attribute is not specified, then System.Environment.ProcessorCount is used.
         /// </summary>
-        public int GatewaySenderQueues { get; set; } = Environment.ProcessorCount;
+        public int GatewaySenderQueues { get; set; }
 
         /// <summary>
         /// The MaxForwardCount attribute specifies the maximal number of times a message is being forwared from one silo to another.

--- a/src/Orleans/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans/Configuration/Options/SiloMessagingOptions.cs
@@ -1,0 +1,37 @@
+﻿using Orleans.Runtime;
+using System;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Specifies global messaging options that are silo related.
+    /// </summary>
+    public class SiloMessagingOptions : MessagingOptions
+    {
+        /// <summary>
+        /// The SiloSenderQueues attribute specifies the number of parallel queues and attendant threads used by the silo to send outbound
+        /// messages (requests, responses, and notifications) to other silos.
+        /// If this attribute is not specified, then System.Environment.ProcessorCount is used.
+        /// </summary>
+        public int SiloSenderQueues { get; set; } = Environment.ProcessorCount;
+
+        /// <summary>
+        /// The GatewaySenderQueues attribute specifies the number of parallel queues and attendant threads used by the silo Gateway to send outbound
+        ///  messages (requests, responses, and notifications) to clients that are connected to it.
+        ///  If this attribute is not specified, then System.Environment.ProcessorCount is used.
+        /// </summary>
+        public int GatewaySenderQueues { get; set; } = Environment.ProcessorCount;
+
+        /// <summary>
+        /// The MaxForwardCount attribute specifies the maximal number of times a message is being forwared from one silo to another.
+        /// Forwarding is used internally by the tuntime as a recovery mechanism when silos fail and the membership is unstable.
+        /// In such times the messages might not be routed correctly to destination, and runtime attempts to forward such messages a number of times before rejecting them.
+        /// </summary>
+        public int MaxForwardCount { get; set; } = 2;
+
+        /// <summary>
+        ///  This is the period of time a gateway will wait before dropping a disconnected client.
+        /// </summary>
+        public TimeSpan ClientDropTimeout { get; set; } = Constants.DEFAULT_CLIENT_DROP_TIMEOUT;
+    }
+}

--- a/src/Orleans/Core/ClientBuilder.cs
+++ b/src/Orleans/Core/ClientBuilder.cs
@@ -37,6 +37,8 @@ namespace Orleans
                 {
                     services.TryAddSingleton(this.clientConfiguration ?? ClientConfiguration.StandardLoad());
                     services.TryAddFromExisting<IMessagingConfiguration, ClientConfiguration>();
+                    // register legacy logging to new options mapping for Client options
+                    services.AddLegacyClientConfigurationSupport();
                     services.TryAddFromExisting<ITraceConfiguration, ClientConfiguration>();
                 });
             this.serviceProviderBuilder.ConfigureServices(AddDefaultServices);

--- a/src/Orleans/Core/ClientBuilder.cs
+++ b/src/Orleans/Core/ClientBuilder.cs
@@ -37,7 +37,7 @@ namespace Orleans
                 {
                     services.TryAddSingleton(this.clientConfiguration ?? ClientConfiguration.StandardLoad());
                     services.TryAddFromExisting<IMessagingConfiguration, ClientConfiguration>();
-                    // register legacy logging to new options mapping for Client options
+                    // register legacy configuration to new options mapping for Client options
                     services.AddLegacyClientConfigurationSupport();
                     services.TryAddFromExisting<ITraceConfiguration, ClientConfiguration>();
                 });

--- a/src/Orleans/Messaging/BufferPool.cs
+++ b/src/Orleans/Messaging/BufferPool.cs
@@ -2,7 +2,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
-using Orleans.Runtime.Configuration;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 
 namespace Orleans.Runtime
 {
@@ -38,9 +39,9 @@ namespace Orleans.Runtime
             private set;
         }
 
-        internal static void InitGlobalBufferPool(IMessagingConfiguration config)
+        internal static void InitGlobalBufferPool(IOptions<MessagingOptions> messagingConfigurationOptions)
         {
-            GlobalPool = new BufferPool(config.BufferPoolBufferSize, config.BufferPoolMaxSize, config.BufferPoolPreallocationSize, "Global");
+            GlobalPool = new BufferPool(messagingConfigurationOptions.Value.BufferPoolBufferSize, messagingConfigurationOptions.Value.BufferPoolMaxSize, messagingConfigurationOptions.Value.BufferPoolPreallocationSize, "Global");
         }
 
         /// <summary>

--- a/src/Orleans/Messaging/BufferPool.cs
+++ b/src/Orleans/Messaging/BufferPool.cs
@@ -39,9 +39,11 @@ namespace Orleans.Runtime
             private set;
         }
 
-        internal static void InitGlobalBufferPool(IOptions<MessagingOptions> messagingConfigurationOptions)
+        internal static void InitGlobalBufferPool(IOptions<MessagingOptions> messagingOptions)
         {
-            GlobalPool = new BufferPool(messagingConfigurationOptions.Value.BufferPoolBufferSize, messagingConfigurationOptions.Value.BufferPoolMaxSize, messagingConfigurationOptions.Value.BufferPoolPreallocationSize, "Global");
+            var messagingOptionsValue = messagingOptions.Value;
+
+            GlobalPool = new BufferPool(messagingOptionsValue.BufferPoolBufferSize, messagingOptionsValue.BufferPoolMaxSize, messagingOptionsValue.BufferPoolPreallocationSize, "Global");
         }
 
         /// <summary>

--- a/src/Orleans/Messaging/GatewayConnection.cs
+++ b/src/Orleans/Messaging/GatewayConnection.cs
@@ -36,7 +36,7 @@ namespace Orleans.Messaging
         private DateTime lastConnect;
 
         internal GatewayConnection(Uri address, ProxiedMessageCenter mc, MessageFactory messageFactory, ILoggerFactory loggerFactory)
-            : base("GatewayClientSender_" + address, mc.MessagingConfiguration, mc.SerializationManager, loggerFactory)
+            : base("GatewayClientSender_" + address, mc.SerializationManager, loggerFactory)
         {
             this.messageFactory = messageFactory;
             Address = address;

--- a/src/Orleans/Messaging/Message.cs
+++ b/src/Orleans/Messaging/Message.cs
@@ -300,9 +300,9 @@ namespace Orleans.Runtime
             }
         }
 
-        public bool IsExpirableMessage(IMessagingConfiguration config)
+        public bool IsExpirableMessage(bool dropExpiredMessages)
         {
-            if (!config.DropExpiredMessages) return false;
+            if (!dropExpiredMessages) return false;
 
             GrainId id = TargetGrain;
             if (id == null) return false;
@@ -342,9 +342,9 @@ namespace Orleans.Runtime
         }
 
         // Resends are used by the sender, usualy due to en error to send or due to a transient rejection.
-        public bool MayResend(IMessagingConfiguration config)
+        public bool MayResend(int maxResendCount)
         {
-            return ResendCount < config.MaxResendCount;
+            return ResendCount < maxResendCount;
         }
 
         // Forwardings are used by the receiver, usualy when it cannot process the message and forwars it to another silo to perform the processing

--- a/src/Orleans/Messaging/OutgoingMessageSender.cs
+++ b/src/Orleans/Messaging/OutgoingMessageSender.cs
@@ -21,8 +21,8 @@ namespace Orleans.Messaging
     {
         private readonly SerializationManager serializationManager;
 
-        internal OutgoingMessageSender(string nameSuffix, IMessagingConfiguration config, SerializationManager serializationManager, ILoggerFactory loggerFactory)
-            : base(nameSuffix, config, loggerFactory)
+        internal OutgoingMessageSender(string nameSuffix, SerializationManager serializationManager, ILoggerFactory loggerFactory)
+            : base(nameSuffix, loggerFactory)
         {
             this.serializationManager = serializationManager;
         }

--- a/src/Orleans/Orleans.csproj
+++ b/src/Orleans/Orleans.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjection)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />

--- a/src/Orleans/Runtime/AsynchQueueAgent.cs
+++ b/src/Orleans/Runtime/AsynchQueueAgent.cs
@@ -8,14 +8,12 @@ namespace Orleans.Runtime
 {
     internal abstract class AsynchQueueAgent<T> : AsynchAgent, IDisposable where T : IOutgoingMessage
     {
-        private readonly IMessagingConfiguration config;
         private BlockingCollection<T> requestQueue;
         private QueueTrackingStatistic queueTracking;
 
-        protected AsynchQueueAgent(string nameSuffix, IMessagingConfiguration cfg, ILoggerFactory loggerFactory)
+        protected AsynchQueueAgent(string nameSuffix, ILoggerFactory loggerFactory)
             : base(nameSuffix, loggerFactory)
         {
-            config = cfg;
             requestQueue = new BlockingCollection<T>();
             if (StatisticsCollector.CollectQueueStats)
             {

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -29,7 +29,7 @@ namespace Orleans
         private Logger callBackDataLogger;
         private ILogger timerLogger;
         private ClientConfiguration config;
-        private IOptions<ClientMessagingOptions> clientMessagingOptions;
+        private ClientMessagingOptions clientMessagingOptions;
 
         private readonly ConcurrentDictionary<CorrelationId, CallbackData> callbacks;
         private readonly ConcurrentDictionary<GuidId, LocalObjectData> localObjects;
@@ -132,7 +132,10 @@ namespace Orleans
             this.messageFactory = this.ServiceProvider.GetService<MessageFactory>();
 
             this.config = this.ServiceProvider.GetRequiredService<ClientConfiguration>();
-            this.clientMessagingOptions = this.ServiceProvider.GetRequiredService<IOptions<ClientMessagingOptions>>();
+
+            var resolvedClientMessagingOptions = this.ServiceProvider.GetRequiredService<IOptions<ClientMessagingOptions>>();
+            this.clientMessagingOptions = resolvedClientMessagingOptions.Value;
+
             this.GrainReferenceRuntime = this.ServiceProvider.GetRequiredService<IGrainReferenceRuntime>();
 
             this.ServiceProvider.GetService<TelemetryManager>()?.AddFromConfiguration(this.ServiceProvider, config.TelemetryConfiguration);
@@ -141,8 +144,7 @@ namespace Orleans
             this.assemblyProcessor = this.ServiceProvider.GetRequiredService<AssemblyProcessor>();
             this.assemblyProcessor.Initialize();
 
-            BufferPool.InitGlobalBufferPool(clientMessagingOptions);
-
+            BufferPool.InitGlobalBufferPool(resolvedClientMessagingOptions);
 
             try
             {

--- a/src/Orleans/Serialization/SerializationManager.cs
+++ b/src/Orleans/Serialization/SerializationManager.cs
@@ -142,7 +142,10 @@ namespace Orleans.Serialization
             logger = new LoggerWrapper<SerializationManager>(loggerFactory);
             this.serviceProvider = serviceProvider;
             RegisterBuiltInSerializers();
-            fallbackSerializer = GetFallbackSerializer(serviceProvider, serializatonProviderOptions.Value.FallbackSerializationProvider);
+
+            var serializatonProviderOptionsValue = serializatonProviderOptions.Value;
+
+            fallbackSerializer = GetFallbackSerializer(serviceProvider, serializatonProviderOptionsValue.FallbackSerializationProvider);
 
             if (StatisticsCollector.CollectSerializationStats)
             {
@@ -176,7 +179,7 @@ namespace Orleans.Serialization
                 FallbackCopiesTimeStatistic = CounterStatistic.FindOrCreate(StatisticNames.SERIALIZATION_BODY_FALLBACK_DEEPCOPY_MILLIS, storeFallback).AddValueConverter(Utils.TicksToMilliSeconds);
             }
 
-            RegisterSerializationProviders(serializatonProviderOptions.Value.SerializationProviders);
+            RegisterSerializationProviders(serializatonProviderOptionsValue.SerializationProviders);
         }
 
         internal void RegisterBuiltInSerializers()

--- a/src/OrleansRuntime/Core/Dispatcher.cs
+++ b/src/OrleansRuntime/Core/Dispatcher.cs
@@ -29,9 +29,6 @@ namespace Orleans.Runtime
         private readonly MessageFactory messagefactory;
         private readonly SerializationManager serializationManager;
         private readonly CompatibilityDirectorManager compatibilityDirectorManager;
-        private readonly double rejectionInjectionRate;
-        private readonly bool errorInjection;
-        private readonly double errorInjectionRate;
         private readonly SafeRandom random;
         private readonly ILogger invokeWorkItemLogger;
         private readonly ILoggerFactory loggerFactory;
@@ -59,10 +56,6 @@ namespace Orleans.Runtime
             this.serializationManager = serializationManager;
             this.compatibilityDirectorManager = compatibilityDirectorManager;
             logger = new LoggerWrapper<Dispatcher>(loggerFactory);
-            rejectionInjectionRate = config.Globals.RejectionInjectionRate;
-            double messageLossInjectionRate = config.Globals.MessageLossInjectionRate;
-            errorInjection = rejectionInjectionRate > 0.0d || messageLossInjectionRate > 0.0d;
-            errorInjectionRate = rejectionInjectionRate + messageLossInjectionRate;
             random = new SafeRandom();
         }
 
@@ -94,14 +87,6 @@ namespace Orleans.Runtime
             {
                 MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedError(message, "ReceiveMessage on system target.");
                 throw new InvalidOperationException("Dispatcher was called ReceiveMessage on system target for " + message);
-            }
-
-            if (errorInjection && ShouldInjectError(message))
-            {
-                if (logger.IsVerbose) logger.Verbose(ErrorCode.Dispatcher_InjectingRejection, "Injecting a rejection");
-                MessagingProcessingStatisticsGroup.OnDispatcherMessageProcessedError(message, "ErrorInjection");
-                RejectMessage(message, Message.RejectionTypes.Unrecoverable, null, "Injected rejection");                
-                return;
             }
 
             try
@@ -571,7 +556,7 @@ namespace Orleans.Runtime
 
         internal bool TryResendMessage(Message message)
         {
-            if (!message.MayResend(this.config.Globals)) return false;
+            if (!message.MayResend(this.config.Globals.MaxResendCount)) return false;
 
             message.ResendCount = message.ResendCount + 1;
             MessagingProcessingStatisticsGroup.OnIgcMessageResend(message);
@@ -850,23 +835,6 @@ namespace Orleans.Runtime
                 runLoop = true;
             }
             while (runLoop);
-        }
-
-        private bool ShouldInjectError(Message message)
-        {
-            if (!errorInjection || message.Direction != Message.Directions.Request) return false;
-
-            double r = random.NextDouble() * 100;
-            if (!(r < errorInjectionRate)) return false;
-
-            if (r < rejectionInjectionRate)
-            {
-                return true;
-            }
-
-            if (logger.IsVerbose) logger.Verbose(ErrorCode.Dispatcher_InjectingMessageLoss, "Injecting a message loss");
-            // else do nothing and intentionally drop message on the floor to inject a message loss
-            return true;
         }
 
         #endregion

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -197,7 +197,7 @@ namespace Orleans.Runtime
             if (context == null && !oneWay)
                 logger.Warn(ErrorCode.IGC_SendRequest_NullContext, "Null context {0}: {1}", message, Utils.GetStackTrace());
 
-            if (message.IsExpirableMessage(Config.Globals))
+            if (message.IsExpirableMessage(Config.Globals.DropExpiredMessages))
                 message.TimeToLive = ResponseTimeout;
 
             if (!oneWay)

--- a/src/OrleansRuntime/Counters/SiloStatisticsManager.cs
+++ b/src/OrleansRuntime/Counters/SiloStatisticsManager.cs
@@ -19,7 +19,7 @@ namespace Orleans.Runtime.Counters
             MessagingStatisticsGroup.Init(true);
             MessagingProcessingStatisticsGroup.Init();
             NetworkingStatisticsGroup.Init(true);
-            ApplicationRequestsStatisticsGroup.Init(initializationParams.GlobalConfig.ResponseTimeout);
+            ApplicationRequestsStatisticsGroup.Init(initializationParams.ClusterConfig.Globals.ResponseTimeout);
             SchedulerStatisticsGroup.Init(loggerFactory);
             StorageStatisticsGroup.Init();
             TransactionsStatisticsGroup.Init();

--- a/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
+++ b/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.CodeGeneration;
@@ -47,7 +46,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ISilo, SiloWrapper>();
             services.TryAddFromExisting<ILocalSiloDetails, SiloInitializationParameters>();
             services.TryAddSingleton(sp => sp.GetRequiredService<SiloInitializationParameters>().ClusterConfig);
-            services.TryAddSingleton(sp => sp.GetRequiredService<SiloInitializationParameters>().GlobalConfig);
+            services.TryAddSingleton(sp => sp.GetRequiredService<SiloInitializationParameters>().ClusterConfig.Globals);
             services.TryAddTransient(sp => sp.GetRequiredService<SiloInitializationParameters>().NodeConfig);
             services.TryAddSingleton<Factory<NodeConfiguration>>(
                 sp =>
@@ -56,6 +55,8 @@ namespace Orleans.Hosting
                     return () => initializationParams.NodeConfig;
                 });
             services.TryAddFromExisting<IMessagingConfiguration, GlobalConfiguration>();
+            // register legacy logging to new options mapping for Silo options
+            services.AddLegacySiloConfigurationSupport();
             services.TryAddFromExisting<ITraceConfiguration, NodeConfiguration>();
             services.TryAddSingleton<TelemetryManager>();
             services.TryAddFromExisting<ITelemetryProducer, TelemetryManager>();
@@ -114,7 +115,6 @@ namespace Orleans.Hosting
             services.TryAddFromExisting<ICorePerformanceMetrics, ISiloPerformanceMetrics>();
             services.TryAddSingleton<SiloAssemblyLoader>();
             services.TryAddSingleton<GrainTypeManager>();
-            services.TryAddFromExisting<IMessagingConfiguration, GlobalConfiguration>();
             services.TryAddSingleton<MessageCenter>();
             services.TryAddFromExisting<IMessageCenter, MessageCenter>();
             services.TryAddFromExisting<ISiloMessageCenter, MessageCenter>();

--- a/src/OrleansRuntime/Messaging/Gateway.cs
+++ b/src/OrleansRuntime/Messaging/Gateway.cs
@@ -363,7 +363,7 @@ namespace Orleans.Runtime.Messaging
             private readonly CounterStatistic gatewaySends;
             private readonly SerializationManager serializationManager;
             internal GatewaySender(string name, Gateway gateway, MessageFactory messageFactory, SerializationManager serializationManager, ILoggerFactory loggerFactory)
-                : base(name, gateway.MessagingConfiguration, loggerFactory)
+                : base(name, loggerFactory)
             {
                 this.gateway = gateway;
                 this.messageFactory = messageFactory;

--- a/src/OrleansRuntime/Messaging/SiloMessageSender.cs
+++ b/src/OrleansRuntime/Messaging/SiloMessageSender.cs
@@ -19,7 +19,7 @@ namespace Orleans.Runtime.Messaging
 
         
         internal SiloMessageSender(string nameSuffix, MessageCenter msgCtr, SerializationManager serializationManager, ILoggerFactory loggerFactory)
-            : base(nameSuffix, msgCtr.MessagingConfiguration, serializationManager, loggerFactory)
+            : base(nameSuffix, serializationManager, loggerFactory)
         {
             messageCenter = msgCtr;
             lastConnectionFailure = new Dictionary<SiloAddress, DateTime>();

--- a/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/OrleansRuntime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
             this.grainFactory = grainFactory;
             if (siloDetails == null) throw new ArgumentNullException(nameof(siloDetails));
 
-            var config = siloDetails.GlobalConfig;
+            var config = siloDetails.ClusterConfig.Globals;
             logger = new LoggerWrapper<MultiClusterOracle>(loggerFactory);
             localData = new MultiClusterOracleData(logger, grainFactory);
             clusterId = config.ClusterId;

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -33,6 +33,8 @@ using Orleans.Streams;
 using Orleans.Transactions;
 using Orleans.Runtime.Versions;
 using Orleans.Versions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 
 namespace Orleans.Runtime
 {
@@ -97,7 +99,7 @@ namespace Orleans.Runtime
         public SiloType Type => this.initializationParams.Type;
         internal string Name => this.initializationParams.Name;
         internal ClusterConfiguration OrleansConfig => this.initializationParams.ClusterConfig;
-        internal GlobalConfiguration GlobalConfig => this.initializationParams.GlobalConfig;
+        internal GlobalConfiguration GlobalConfig => this.initializationParams.ClusterConfig.Globals;
         internal NodeConfiguration LocalConfig => this.initializationParams.NodeConfig;
         internal OrleansTaskScheduler LocalScheduler { get { return scheduler; } }
         internal GrainTypeManager LocalGrainTypeManager { get { return grainTypeManager; } }
@@ -202,7 +204,8 @@ namespace Orleans.Runtime
             this.assemblyProcessor = this.Services.GetRequiredService<AssemblyProcessor>();
             this.assemblyProcessor.Initialize();
 
-            BufferPool.InitGlobalBufferPool(GlobalConfig);
+            var siloMessagingOptions = this.Services.GetRequiredService<IOptions<SiloMessagingOptions>>();
+            BufferPool.InitGlobalBufferPool(siloMessagingOptions);
             //init logger for UnobservedExceptionsHandlerClass
             UnobservedExceptionsHandlerClass.InitLogger(this.loggerFactory);
             if (!UnobservedExceptionsHandlerClass.TrySetUnobservedExceptionHandler(UnobservedExceptionHandler))

--- a/src/OrleansRuntime/Silo/SiloInitializationParameters.cs
+++ b/src/OrleansRuntime/Silo/SiloInitializationParameters.cs
@@ -81,11 +81,6 @@ namespace Orleans.Runtime
         public ClusterConfiguration ClusterConfig { get; }
 
         /// <summary>
-        /// Gets the global configuration.
-        /// </summary>
-        public GlobalConfiguration GlobalConfig => this.ClusterConfig.Globals;
-
-        /// <summary>
         /// Gets the node configuration.
         /// </summary>
         public NodeConfiguration NodeConfig { get; private set; }

--- a/test/NonSilo.Tests/OrleansRuntime/ExceptionsTests.cs
+++ b/test/NonSilo.Tests/OrleansRuntime/ExceptionsTests.cs
@@ -1,6 +1,6 @@
-
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
 using Xunit;
@@ -15,7 +15,7 @@ namespace UnitTests.OrleansRuntime
         public ExceptionsTests(TestEnvironmentFixture fixture)
         {
             this.fixture = fixture;
-            BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
+            BufferPool.InitGlobalBufferPool(Options.Create(new ClientMessagingOptions()));
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]

--- a/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -17,6 +17,8 @@ using TestExtensions;
 using Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 
 namespace Tester.AzureUtils.Streaming
 {
@@ -39,7 +41,7 @@ namespace Tester.AzureUtils.Streaming
             this.fixture = fixture;
             this.deploymentId = MakeDeploymentId();
             this.loggerFactory = this.fixture.Services.GetService<ILoggerFactory>();
-            BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
+            BufferPool.InitGlobalBufferPool(Options.Create(new SiloMessagingOptions()));
         }
         
         public void Dispose()

--- a/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
+++ b/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
@@ -8,6 +8,8 @@ using Orleans.Runtime.ConsistentRing;
 using Orleans.Streams;
 using Xunit;
 using Xunit.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 
 namespace UnitTests.LivenessTests
 {
@@ -19,7 +21,7 @@ namespace UnitTests.LivenessTests
         {
             public Fixture()
             {
-                BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
+                BufferPool.InitGlobalBufferPool(Options.Create(new SiloMessagingOptions()));
             }
         }
 

--- a/test/TesterInternal/StorageTests/HierarchicalKeyStoreTests.cs
+++ b/test/TesterInternal/StorageTests/HierarchicalKeyStoreTests.cs
@@ -6,6 +6,8 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Storage;
 using Xunit;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 
 namespace UnitTests.StorageTests
 {
@@ -15,7 +17,7 @@ namespace UnitTests.StorageTests
         {
             public Fixture()
             {
-                BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
+                BufferPool.InitGlobalBufferPool(Options.Create(new SiloMessagingOptions()));
                 ClientConfiguration cfg = ClientConfiguration.LoadFromFile("ClientConfigurationForTesting.xml");
             }
         }


### PR DESCRIPTION
This PR is first of the n PRs which will add IOptions based configuration system for Orleans 2.0, replacing the old one.

The first class that was added is the divided version of IMessagingConfiguration. It is separated into its Client and Silo counterparts, SerializationProviderOptions was extracted into a separate class.

For easier transition LegacyConfigurationExtensions adds 1-1 extension method to support the mapping of old configuration objects to their IOptions counterpart for client and silo.

That is not a goal of the OR to replace every reference to IMessagingConfiguration and MessagingConfiguration, those changes will be applied incrementally to the codebase.

After the full migration of the old configuration system, the configuration classes and legacy support extension methods will be moved to the Microsoft.Orleans.Configuration.Legacy NuGet package.

- Add MessagingOptions classes
- Add IOption support for MessagingOptions classes
- Update SerializationManager to consume IOptions<SerializationProviderOptions>
- Update BufferPool to consume IOptions<MessagingOptions>
- Add Version suffix to MicrosoftExtensionsDependencyInjection
- Remove unused properties from MessagingConfiguration and their usages
- Remove MessagingConfiguration dependency from Message class
- Remove unused MessagingConfiguration private field from AsynchQueueAgent class
- Update OutsideRuntimeClient.ConsumeServices to use the ServiceProvider property consistently
- Remove redundant Globals property from SiloInitializatonParameters since it is accessible through the ClusterConfig property
- Add extension methods to simplify the support of legacy configuration objects