### PR TITLE
[Abstractions] Move SiloAddress to Abstractions

### DIFF
--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -82,7 +82,7 @@ namespace Orleans
 
         internal SiloAddress SiloAddress
         {
-            get { return Runtime?.SiloAddress ?? SiloAddress.Zero; }
+            get { return Runtime?.SiloAddress ?? SiloAddressFactory.Zero; }
         }
 
         /// <summary>

--- a/src/Orleans/IDs/SiloAddressFactory.cs
+++ b/src/Orleans/IDs/SiloAddressFactory.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Net;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.Runtime
+{
+    public static class SiloAddressFactory
+    {
+        private static readonly TimeSpan internCacheCleanupInterval = TimeSpan.Zero;
+        private static readonly Interner<SiloAddress, SiloAddress> siloAddressInterningCache;
+        private static readonly IPEndPoint localEndpoint = new IPEndPoint(ClusterConfiguration.GetLocalIPAddress(), 0); // non loopback local ip.
+        private const int INTERN_CACHE_INITIAL_SIZE = InternerConstants.SIZE_MEDIUM;
+        private static readonly DateTime epoch = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private const char SEPARATOR = '@';
+
+        /// <summary> Special constant value to indicate an empty SiloAddress. </summary>
+        public static SiloAddress Zero { get; private set; }
+
+        static SiloAddressFactory()
+        {
+            SiloAddressFactory.siloAddressInterningCache = new Interner<SiloAddress, SiloAddress>(SiloAddressFactory.INTERN_CACHE_INITIAL_SIZE, SiloAddressFactory.internCacheCleanupInterval);
+            var sa = new SiloAddress(new IPEndPoint(0, 0), 0);
+            SiloAddressFactory.Zero = SiloAddressFactory.siloAddressInterningCache.Intern(sa, sa);
+        }
+
+        /// <summary> Allocate a new silo generation number. </summary>
+        /// <returns>A new silo generation number.</returns>
+        public static int AllocateNewGeneration()
+        {
+            long elapsed = (DateTime.UtcNow.Ticks - epoch.Ticks) / TimeSpan.TicksPerSecond;
+            return unchecked((int)elapsed); // Unchecked to truncate any bits beyond the lower 32
+        }
+
+        /// <summary>
+        /// Factory for creating new SiloAddresses for silo on this machine with specified generation number.
+        /// </summary>
+        /// <param name="gen">Generation number of the silo.</param>
+        /// <returns>SiloAddress object initialized with the non-loopback local IP address and the specified silo generation.</returns>
+        public static SiloAddress NewLocalAddress(int gen)
+        {
+            return New(localEndpoint, gen);
+        }
+
+        /// <summary>
+        /// Factory for creating new SiloAddresses with specified IP endpoint address and silo generation number.
+        /// </summary>
+        /// <param name="ep">IP endpoint address of the silo.</param>
+        /// <param name="gen">Generation number of the silo.</param>
+        /// <returns>SiloAddress object initialized with specified address and silo generation.</returns>
+        public static SiloAddress New(IPEndPoint ep, int gen)
+        {
+            var sa = new SiloAddress(ep, gen);
+            return siloAddressInterningCache.Intern(sa, sa);
+        }
+
+        /// <summary>
+        /// Return this SiloAddress in a standard string form, suitable for later use with the <c>FromParsableString</c> method.
+        /// </summary>
+        /// <returns>SiloAddress in a standard string format.</returns>
+        public static string ToParsableString(this SiloAddress @this)
+        {
+            // This must be the "inverse" of FromParsableString, and must be the same across all silos in a deployment.
+            // Basically, this should never change unless the data content of SiloAddress changes
+
+            return String.Format("{0}:{1}@{2}", @this.Endpoint.Address, @this.Endpoint.Port, @this.Generation);
+        }
+
+        /// <summary>
+        /// Create a new SiloAddress object by parsing string in a standard form returned from <c>ToParsableString</c> method.
+        /// </summary>
+        /// <param name="addr">String containing the SiloAddress info to be parsed.</param>
+        /// <returns>New SiloAddress object created from the input data.</returns>
+        public static SiloAddress FromParsableString(string addr)
+        {
+            // This must be the "inverse" of ToParsableString, and must be the same across all silos in a deployment.
+            // Basically, this should never change unless the data content of SiloAddress changes
+
+            // First is the IPEndpoint; then '@'; then the generation
+            int atSign = addr.LastIndexOf(SEPARATOR);
+            if (atSign < 0)
+            {
+                throw new FormatException("Invalid string SiloAddress: " + addr);
+            }
+            var epString = addr.Substring(0, atSign);
+            var genString = addr.Substring(atSign + 1);
+            // IPEndpoint is the host, then ':', then the port
+            int lastColon = epString.LastIndexOf(':');
+            if (lastColon < 0) throw new FormatException("Invalid string SiloAddress: " + addr);
+
+            var hostString = epString.Substring(0, lastColon);
+            var portString = epString.Substring(lastColon + 1);
+            var host = IPAddress.Parse(hostString);
+            int port = Int32.Parse(portString);
+            return SiloAddressFactory.New(new IPEndPoint(host, port), Int32.Parse(genString));
+        }
+    }
+}

--- a/src/Orleans/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans/Messaging/ProxiedMessageCenter.cs
@@ -107,7 +107,7 @@ namespace Orleans.Messaging
             this.loggerFactory = loggerFactory;
             this.SerializationManager = serializationManager;
             lockable = new object();
-            MyAddress = SiloAddress.New(new IPEndPoint(localAddress, 0), gen);
+            MyAddress = SiloAddressFactory.New(new IPEndPoint(localAddress, 0), gen);
             ClientId = clientId;
             this.RuntimeClient = runtimeClient;
             this.messageFactory = messageFactory;

--- a/src/Orleans/Runtime/GrainReference.cs
+++ b/src/Orleans/Runtime/GrainReference.cs
@@ -408,7 +408,7 @@ namespace Orleans.Runtime
             {
                 grainIdStr = trimmed.Substring(grainIdIndex, systemTargetIndex - grainIdIndex).Trim();
                 string systemTargetStr = trimmed.Substring(systemTargetIndex + (SYSTEM_TARGET_STR + "=").Length);
-                SiloAddress siloAddress = SiloAddress.FromParsableString(systemTargetStr);
+                SiloAddress siloAddress = SiloAddressFactory.FromParsableString(systemTargetStr);
                 return FromGrainId(GrainId.FromParsableString(grainIdStr), runtime, null, siloAddress);
             }
             else
@@ -449,7 +449,7 @@ namespace Orleans.Runtime
             if (IsSystemTarget)
             {
                 var siloAddressStr = info.GetString("SystemTargetSilo");
-                SystemTargetSilo = SiloAddress.FromParsableString(siloAddressStr);
+                SystemTargetSilo = SiloAddressFactory.FromParsableString(siloAddressStr);
             }
             if (IsObserverReference)
             {

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -255,7 +255,7 @@ namespace Orleans
             await this.gatewayListProvider.InitializeGatewayListProvider(config)
                                .WithTimeout(initTimeout);
 
-            var generation = -SiloAddress.AllocateNewGeneration(); // Client generations are negative
+            var generation = -SiloAddressFactory.AllocateNewGeneration(); // Client generations are negative
             transport = ActivatorUtilities.CreateInstance<ProxiedMessageCenter>(this.ServiceProvider, localAddress, generation, handshakeClientId);
             transport.Start();
             CurrentActivationAddress = ActivationAddress.NewActivationAddress(transport.MyAddress, handshakeClientId);

--- a/src/Orleans/Serialization/BinaryTokenStreamReader.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamReader.cs
@@ -461,7 +461,7 @@ namespace Orleans.Serialization
         {
             var ep = ReadIPEndPoint();
             var gen = ReadInt();
-            return SiloAddress.New(ep, gen);
+            return SiloAddressFactory.New(ep, gen);
         }
 
         /// <summary> Read an <c>GrainId</c> value from the stream. </summary>
@@ -519,7 +519,7 @@ namespace Orleans.Serialization
             var grain = ReadGrainId();
             var act = ReadActivationId();
 
-            if (silo.Equals(SiloAddress.Zero))
+            if (silo.Equals(SiloAddressFactory.Zero))
                 silo = null;
 
             if (act.Equals(ActivationId.Zero))

--- a/src/Orleans/Serialization/BinaryTokenStreamWriter.cs
+++ b/src/Orleans/Serialization/BinaryTokenStreamWriter.cs
@@ -453,7 +453,7 @@ namespace Orleans.Serialization
         /// <summary> Write a <c>ActivationAddress</c> value to the stream. </summary>
         internal void Write(ActivationAddress addr)
         {
-            Write(addr.Silo ?? SiloAddress.Zero);
+            Write(addr.Silo ?? SiloAddressFactory.Zero);
 
             // GrainId must not be null
             Write(addr.Grain);

--- a/src/Orleans/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans/Serialization/OrleansJsonSerializer.cs
@@ -235,7 +235,7 @@ namespace Orleans.Serialization
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             JObject jo = JObject.Load(reader);
-            SiloAddress addr = SiloAddress.FromParsableString(jo["SiloAddress"].ToObject<string>());
+            SiloAddress addr = SiloAddressFactory.FromParsableString(jo["SiloAddress"].ToObject<string>());
             return addr;
         }
     }

--- a/src/Orleans/Utils/Utils.cs
+++ b/src/Orleans/Utils/Utils.cs
@@ -148,7 +148,7 @@ namespace Orleans.Runtime
             switch (uri.Scheme)
             {
                 case "gwy.tcp":
-                    return SiloAddress.New(uri.ToIPEndPoint(), uri.Segments.Length > 1 ? int.Parse(uri.Segments[1]) : 0);
+                    return SiloAddressFactory.New(uri.ToIPEndPoint(), uri.Segments.Length > 1 ? int.Parse(uri.Segments[1]) : 0);
             }
             return null;
         }

--- a/src/OrleansAWSUtils/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/OrleansAWSUtils/Membership/DynamoDBGatewayListProvider.cs
@@ -63,7 +63,7 @@ namespace Orleans.Runtime.MembershipService
             var records = await storage.ScanAsync<Uri>(TABLE_NAME_DEFAULT_VALUE, expressionValues,
                 expression, gateway =>
                 {
-                    return SiloAddress.New(
+                    return SiloAddressFactory.New(
                         new IPEndPoint(
                             IPAddress.Parse(gateway[SiloInstanceRecord.ADDRESS_PROPERTY_NAME].S),
                             int.Parse(gateway[SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME].N)),

--- a/src/OrleansAWSUtils/Membership/DynamoDBMembershipTable.cs
+++ b/src/OrleansAWSUtils/Membership/DynamoDBMembershipTable.cs
@@ -254,7 +254,7 @@ namespace Orleans.Runtime.MembershipService
 
             parse.ProxyPort = tableEntry.ProxyPort;
 
-            parse.SiloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Parse(tableEntry.Address), tableEntry.Port), tableEntry.Generation);
+            parse.SiloAddress = SiloAddressFactory.New(new IPEndPoint(IPAddress.Parse(tableEntry.Address), tableEntry.Port), tableEntry.Generation);
 
             if (!string.IsNullOrEmpty(tableEntry.SiloName))
             {
@@ -275,7 +275,7 @@ namespace Orleans.Runtime.MembershipService
                 string[] silos = tableEntry.SuspectingSilos.Split('|');
                 foreach (string silo in silos)
                 {
-                    suspectingSilos.Add(SiloAddress.FromParsableString(silo));
+                    suspectingSilos.Add(SiloAddressFactory.FromParsableString(silo));
                 }
             }
 

--- a/src/OrleansAWSUtils/Membership/SiloInstanceRecord.cs
+++ b/src/OrleansAWSUtils/Membership/SiloInstanceRecord.cs
@@ -109,7 +109,7 @@ namespace Orleans.Runtime.MembershipService
                 IPAddress address = IPAddress.Parse(addressStr);
                 int port = Int32.Parse(portStr);
                 int generation = Int32.Parse(genStr);
-                return SiloAddress.New(new IPEndPoint(address, port), generation);
+                return SiloAddressFactory.New(new IPEndPoint(address, port), generation);
             }
             catch (Exception exc)
             {

--- a/src/OrleansAzureUtils/Hosting/AzureSilo.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureSilo.cs
@@ -217,7 +217,7 @@ namespace Orleans.Runtime.Host
 
             host.SetSiloType(Silo.SiloType.Secondary);
 
-            int generation = SiloAddress.AllocateNewGeneration();
+            int generation = SiloAddressFactory.AllocateNewGeneration();
 
             // Bootstrap this Orleans silo instance
 

--- a/src/OrleansAzureUtils/MultiClusterNetwork/GossipTableInstanceManager.cs
+++ b/src/OrleansAzureUtils/MultiClusterNetwork/GossipTableInstanceManager.cs
@@ -71,7 +71,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
                 Port = Int32.Parse(segments[2]);
                 Generation = Int32.Parse(segments[3]);
 
-                this.SiloAddress = SiloAddress.New(new IPEndPoint(Address, Port), Generation);
+                this.SiloAddress = SiloAddressFactory.New(new IPEndPoint(Address, Port), Generation);
             }
             catch (Exception exc)
             {

--- a/src/OrleansAzureUtils/Storage/AzureBasedMembershipTable.cs
+++ b/src/OrleansAzureUtils/Storage/AzureBasedMembershipTable.cs
@@ -203,7 +203,7 @@ namespace Orleans.Runtime.MembershipService
             if (!string.IsNullOrEmpty(tableEntry.Generation))
                 int.TryParse(tableEntry.Generation, out gen);
 
-            parse.SiloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Parse(tableEntry.Address), port), gen);
+            parse.SiloAddress = SiloAddressFactory.New(new IPEndPoint(IPAddress.Parse(tableEntry.Address), port), gen);
 
             parse.RoleName = tableEntry.RoleName;
             if (!string.IsNullOrEmpty(tableEntry.SiloName))
@@ -235,7 +235,7 @@ namespace Orleans.Runtime.MembershipService
                 string[] silos = tableEntry.SuspectingSilos.Split('|');
                 foreach (string silo in silos)
                 {
-                    suspectingSilos.Add(SiloAddress.FromParsableString(silo));
+                    suspectingSilos.Add(SiloAddressFactory.FromParsableString(silo));
                 }
             }
 

--- a/src/OrleansAzureUtils/Storage/OrleansSiloInstanceManager.cs
+++ b/src/OrleansAzureUtils/Storage/OrleansSiloInstanceManager.cs
@@ -69,7 +69,7 @@ namespace Orleans.AzureUtils
                 IPAddress address = IPAddress.Parse(addressStr);
                 int port = Int32.Parse(portStr);
                 int generation = Int32.Parse(genStr);
-                return SiloAddress.New(new IPEndPoint(address, port), generation);
+                return SiloAddressFactory.New(new IPEndPoint(address, port), generation);
             }
             catch (Exception exc)
             {
@@ -218,7 +218,7 @@ namespace Orleans.AzureUtils
             if (!string.IsNullOrEmpty(gateway.Generation))
                 int.TryParse(gateway.Generation, out gen);
 
-            SiloAddress address = SiloAddress.New(new IPEndPoint(IPAddress.Parse(gateway.Address), proxyPort), gen);
+            SiloAddress address = SiloAddressFactory.New(new IPEndPoint(IPAddress.Parse(gateway.Address), proxyPort), gen);
             return address.ToGatewayUri();
         }
 

--- a/src/OrleansAzureUtils/Storage/StatsTableDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/StatsTableDataManager.cs
@@ -82,7 +82,7 @@ namespace Orleans.AzureUtils
             this.isSilo = isSilo;
             if (!this.isSilo)
             {
-                clientEpoch = SiloAddress.AllocateNewGeneration();
+                clientEpoch = SiloAddressFactory.AllocateNewGeneration();
             }
             counter = 0;
             var tableName = isSilo ? "OrleansSiloStatistics" : "OrleansClientStatistics";

--- a/src/OrleansConsulUtils/SerializableMembershipTypes.cs
+++ b/src/OrleansConsulUtils/SerializableMembershipTypes.cs
@@ -115,7 +115,7 @@ namespace Orleans.Runtime.Host
             var ret = JsonConvert.DeserializeObject<ConsulSiloRegistration>(Encoding.UTF8.GetString(siloKV.Value));
 
             var keyParts = siloKV.Key.Split(KeySeparator);
-            ret.Address = SiloAddress.FromParsableString(keyParts.Last());
+            ret.Address = SiloAddressFactory.FromParsableString(keyParts.Last());
             ret.DeploymentId = deploymentId;
             ret.LastIndex = siloKV.ModifyIndex;
 
@@ -170,7 +170,7 @@ namespace Orleans.Runtime.Host
                 Status = siloRegistration.Status,
                 ProxyPort = siloRegistration.ProxyPort,
                 StartTime = siloRegistration.StartTime,
-                SuspectTimes = siloRegistration.SuspectingSilos?.Select(silo => new Tuple<SiloAddress, DateTime>(SiloAddress.FromParsableString(silo.Id), silo.Time)).ToList(),
+                SuspectTimes = siloRegistration.SuspectingSilos?.Select(silo => new Tuple<SiloAddress, DateTime>(SiloAddressFactory.FromParsableString(silo.Id), silo.Time)).ToList(),
                 IAmAliveTime = siloRegistration.IAmAliveTime,
                 SiloName = siloRegistration.SiloName,
 

--- a/src/OrleansManager/Program.cs
+++ b/src/OrleansManager/Program.cs
@@ -336,7 +336,7 @@ namespace OrleansManager
 
         private static SiloAddress ParseSilo(string s)
         {
-            return SiloAddress.FromParsableString(s);
+            return SiloAddressFactory.FromParsableString(s);
         }
 
         public static void WriteStatus(string msg)

--- a/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/OrleansRuntime/GrainDirectory/LocalGrainDirectory.cs
@@ -132,7 +132,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             if (globalConfig.SeedNodes.Count > 0)
             {
-                seed = globalConfig.SeedNodes.Contains(MyAddress.Endpoint) ? MyAddress : SiloAddress.New(globalConfig.SeedNodes[0], 0);
+                seed = globalConfig.SeedNodes.Contains(MyAddress.Endpoint) ? MyAddress : SiloAddressFactory.New(globalConfig.SeedNodes[0], 0);
             }
 
             stopPreparationResolver = new TaskCompletionSource<bool>();

--- a/src/OrleansRuntime/Messaging/Gateway.cs
+++ b/src/OrleansRuntime/Messaging/Gateway.cs
@@ -51,7 +51,7 @@ namespace Orleans.Runtime.Messaging
             clients = new ConcurrentDictionary<GrainId, ClientState>();
             clientSockets = new ConcurrentDictionary<Socket, ClientState>();
             clientsReplyRoutingCache = new ClientsReplyRoutingCache(messageCenter.MessagingConfiguration);
-            this.gatewayAddress = SiloAddress.New(nodeConfig.ProxyGatewayEndpoint, 0);
+            this.gatewayAddress = SiloAddressFactory.New(nodeConfig.ProxyGatewayEndpoint, 0);
             lockable = new object();
         }
 

--- a/src/OrleansRuntime/Messaging/MessageCenter.cs
+++ b/src/OrleansRuntime/Messaging/MessageCenter.cs
@@ -69,7 +69,7 @@ namespace Orleans.Runtime.Messaging
 
             SocketManager = new SocketManager(config, this.loggerFactory);
             ima = new IncomingMessageAcceptor(this, here, SocketDirection.SiloToSilo, this.messageFactory, this.serializationManager, this.loggerFactory);
-            MyAddress = SiloAddress.New((IPEndPoint)ima.AcceptingSocket.LocalEndPoint, generation);
+            MyAddress = SiloAddressFactory.New((IPEndPoint)ima.AcceptingSocket.LocalEndPoint, generation);
             MessagingConfiguration = config;
             InboundQueue = new InboundMessageQueue(this.loggerFactory);
             OutboundQueue = new OutboundMessageQueue(this, config, this.serializationManager, this.loggerFactory);

--- a/src/OrleansRuntime/Silo/SiloInitializationParameters.cs
+++ b/src/OrleansRuntime/Silo/SiloInitializationParameters.cs
@@ -58,10 +58,10 @@ namespace Orleans.Runtime
 
             if (this.NodeConfig.Generation == 0)
             {
-                this.NodeConfig.Generation = SiloAddress.AllocateNewGeneration();
+                this.NodeConfig.Generation = SiloAddressFactory.AllocateNewGeneration();
             }
 
-            this.SiloAddress = SiloAddress.New(this.NodeConfig.Endpoint, this.NodeConfig.Generation);
+            this.SiloAddress = SiloAddressFactory.New(this.NodeConfig.Endpoint, this.NodeConfig.Generation);
             this.Type = this.NodeConfig.IsPrimaryNode ? Silo.SiloType.Primary : Silo.SiloType.Secondary;
         }
 

--- a/src/OrleansSQLUtils/Storage/DbStoredQueries.cs
+++ b/src/OrleansSQLUtils/Storage/DbStoredQueries.cs
@@ -177,7 +177,7 @@ namespace OrleansSQLUtils.Storage
                         entry.SuspectTimes.AddRange(suspectingSilos.Split('|').Select(s =>
                         {
                             var split = s.Split(',');
-                            return new Tuple<SiloAddress, DateTime>(SiloAddress.FromParsableString(split[0]),
+                            return new Tuple<SiloAddress, DateTime>(SiloAddressFactory.FromParsableString(split[0]),
                                 LogFormatter.ParseDate(split[1]));
                         }));
                     }
@@ -221,7 +221,7 @@ namespace OrleansSQLUtils.Storage
                 int port = record.GetValue<int>(portName);
                 int generation = record.GetValue<int>(nameof(Columns.Generation));
                 string address = record.GetValue<string>(nameof(Columns.Address));
-                var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Parse(address), port), generation);
+                var siloAddress = SiloAddressFactory.New(new IPEndPoint(IPAddress.Parse(address), port), generation);
                 return siloAddress;
             }
 

--- a/src/OrleansSQLUtils/Storage/SqlStatisticsPublisher.cs
+++ b/src/OrleansSQLUtils/Storage/SqlStatisticsPublisher.cs
@@ -77,7 +77,7 @@ namespace Orleans.Providers.SqlServer
             this.hostName = hostName;
             clientId = client;
             clientAddress = address;
-            generation = SiloAddress.AllocateNewGeneration();
+            generation = SiloAddressFactory.AllocateNewGeneration();
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Orleans.Providers.SqlServer
             this.hostName = hostName;
             if(!isSilo)
             {
-                generation = SiloAddress.AllocateNewGeneration();
+                generation = SiloAddressFactory.AllocateNewGeneration();
             }
         }
 

--- a/src/OrleansServiceFabricUtils/Models/FabricSiloInfo.cs
+++ b/src/OrleansServiceFabricUtils/Models/FabricSiloInfo.cs
@@ -19,8 +19,8 @@
         public FabricSiloInfo(NodeConfiguration config)
         {
             this.Name = config.SiloName;
-            this.Silo = SiloAddress.New(config.Endpoint, config.Generation).ToParsableString();
-            this.Gateway = SiloAddress.New(config.ProxyGatewayEndpoint, config.Generation).ToParsableString();
+            this.Silo = SiloAddressFactory.New(config.Endpoint, config.Generation).ToParsableString();
+            this.Gateway = SiloAddressFactory.New(config.ProxyGatewayEndpoint, config.Generation).ToParsableString();
         }
 
         /// <summary>
@@ -50,13 +50,13 @@
         /// Gets the parsed silo address.
         /// </summary>
         [JsonIgnore]
-        public SiloAddress SiloAddress => string.IsNullOrWhiteSpace(this.Silo) ? null : SiloAddress.FromParsableString(this.Silo);
+        public SiloAddress SiloAddress => string.IsNullOrWhiteSpace(this.Silo) ? null : SiloAddressFactory.FromParsableString(this.Silo);
 
         /// <summary>
         /// Gets the parsed gateway address.
         /// </summary>
         [JsonIgnore]
-        public SiloAddress GatewayAddress => string.IsNullOrWhiteSpace(this.Gateway) ? null : SiloAddress.FromParsableString(this.Gateway);
+        public SiloAddress GatewayAddress => string.IsNullOrWhiteSpace(this.Gateway) ? null : SiloAddressFactory.FromParsableString(this.Gateway);
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/OrleansServiceFabricUtils/OrleansCommunicationListener.cs
+++ b/src/OrleansServiceFabricUtils/OrleansCommunicationListener.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Orleans.ServiceFabric
                 // Start the silo.
                 if (this.configuration.Defaults.Generation == 0)
                 {
-                    this.configuration.Defaults.Generation = SiloAddress.AllocateNewGeneration();
+                    this.configuration.Defaults.Generation = SiloAddressFactory.AllocateNewGeneration();
                 }
 
                 this.SiloHost.Start(this.SiloName, this.configuration);

--- a/src/OrleansTestingHost/SiloHandle.cs
+++ b/src/OrleansTestingHost/SiloHandle.cs
@@ -20,7 +20,7 @@ namespace Orleans.TestingHost
         public SiloAddress SiloAddress { get; set; }
 
         /// <summary>Get the proxy address of the silo</summary>
-        public SiloAddress ProxyAddress => SiloAddress.New(this.NodeConfiguration.ProxyGatewayEndpoint, 0);
+        public SiloAddress ProxyAddress => SiloAddressFactory.New(this.NodeConfiguration.ProxyGatewayEndpoint, 0);
 
         /// <summary>Gets whether the remote silo is expected to be active</summary>
         public abstract bool IsActive { get; }

--- a/src/OrleansZooKeeperUtils/MembershipSerializerSettings.cs
+++ b/src/OrleansZooKeeperUtils/MembershipSerializerSettings.cs
@@ -77,7 +77,7 @@ namespace Orleans.Runtime.Host
             {
                 JObject jo = JObject.Load(reader);
                 string seStr = jo["SiloAddress"].ToObject<string>(serializer);
-                return SiloAddress.FromParsableString(seStr);
+                return SiloAddressFactory.FromParsableString(seStr);
             }
         }
     }

--- a/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
+++ b/src/OrleansZooKeeperUtils/ZooKeeperBasedMembershipTable.cs
@@ -154,7 +154,7 @@ namespace Orleans.Runtime.Host
                 var childrenResult = await zk.getChildrenAsync("/");//get all the child nodes (without the data)
 
                 var childrenTasks = //get the data from each child node
-                    childrenResult.Children.Select(child => GetRow(zk, SiloAddress.FromParsableString(child))).ToList();
+                    childrenResult.Children.Select(child => GetRow(zk, SiloAddressFactory.FromParsableString(child))).ToList();
 
                 var childrenTaskResults = await Task.WhenAll(childrenTasks);
 

--- a/test/AWSUtils.Tests/MembershipTests/SiloInstanceRecordTests.cs
+++ b/test/AWSUtils.Tests/MembershipTests/SiloInstanceRecordTests.cs
@@ -13,7 +13,7 @@ namespace AWSUtils.Tests.MembershipTests
         [Fact]
         public void GetKeysTest()
         {
-            SiloAddress address = SiloAddress.New(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 12345), 67890); 
+            SiloAddress address = SiloAddressFactory.New(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 12345), 67890); 
             var instanceRecord = new SiloInstanceRecord
             {
                 DeploymentId = "deploymentID",

--- a/test/NonSilo.Tests/General/Identifiertests.cs
+++ b/test/NonSilo.Tests/General/Identifiertests.cs
@@ -60,7 +60,7 @@ namespace UnitTests.General
             Assert.Equal(testGrain, sGrain); // Should be equivalent GrainId object
             Assert.Same(testGrain, sGrain); // Should be same / intern'ed GrainId object
 
-            ActivationId testActivation = ActivationId.GetSystemActivation(testGrain, SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 2456), 0));
+            ActivationId testActivation = ActivationId.GetSystemActivation(testGrain, SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 2456), 0));
             output.WriteLine("Testing ActivationID " + testActivation);
             Assert.True(testActivation.IsSystem); // System activation ID is not flagged as a system ID
         }
@@ -343,8 +343,8 @@ namespace UnitTests.General
         public void Interning_SiloAddress()
         {
             //string addrStr1 = "1.2.3.4@11111@1";
-            SiloAddress a1 = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
-            SiloAddress a2 = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
+            SiloAddress a1 = SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
+            SiloAddress a2 = SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
             Assert.Equal(a1, a2); // Should be equal SiloAddress's
             Assert.Same(a1, a2); // Should be same / intern'ed SiloAddress object
 
@@ -359,8 +359,8 @@ namespace UnitTests.General
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void Interning_SiloAddress2()
         {
-            SiloAddress a1 = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
-            SiloAddress a2 = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 2222), 12345);
+            SiloAddress a1 = SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
+            SiloAddress a2 = SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 2222), 12345);
             Assert.NotEqual(a1, a2); // Should not be equal SiloAddress's
             Assert.NotSame(a1, a2); // Should not be same / intern'ed SiloAddress object
         }
@@ -368,7 +368,7 @@ namespace UnitTests.General
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void Interning_SiloAddress_Serialization()
         {
-            SiloAddress a1 = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
+            SiloAddress a1 = SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 1111), 12345);
 
             // Round-trip through Serializer
             SiloAddress a3 = (SiloAddress)this.environment.SerializationManager.RoundTripSerializationForTesting(a1);
@@ -406,10 +406,10 @@ namespace UnitTests.General
         [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("Identifiers")]
         public void SiloAddress_ToFrom_ParsableString()
         {
-            SiloAddress address1 = SiloAddress.NewLocalAddress(12345);
+            SiloAddress address1 = SiloAddressFactory.NewLocalAddress(12345);
 
             string addressStr1 = address1.ToParsableString();
-            SiloAddress addressObj1 = SiloAddress.FromParsableString(addressStr1);
+            SiloAddress addressObj1 = SiloAddressFactory.FromParsableString(addressStr1);
 
             output.WriteLine("Convert -- From: {0} Got result string: '{1}' object: {2}",
                 address1, addressStr1, addressObj1);
@@ -418,7 +418,7 @@ namespace UnitTests.General
 
             //const string addressStr2 = "127.0.0.1-11111-144611139";
             const string addressStr2 = "127.0.0.1:11111@144611139";
-            SiloAddress addressObj2 = SiloAddress.FromParsableString(addressStr2);
+            SiloAddress addressObj2 = SiloAddressFactory.FromParsableString(addressStr2);
             string addressStr2Out = addressObj2.ToParsableString();
 
             output.WriteLine("Convert -- From: {0} Got result string: '{1}' object: {2}",
@@ -448,7 +448,7 @@ namespace UnitTests.General
             TestGrainReference(grainRef);
 
             GrainId systemTragetGrainId = GrainId.NewSystemTargetGrainIdByTypeCode(2);
-            grainRef = GrainReference.FromGrainId(systemTragetGrainId, null, null, SiloAddress.NewLocalAddress(1));
+            grainRef = GrainReference.FromGrainId(systemTragetGrainId, null, null, SiloAddressFactory.NewLocalAddress(1));
             this.environment.GrainFactory.BindGrainReference(grainRef);
             TestGrainReference(grainRef);
 

--- a/test/NonSilo.Tests/General/RingTests_Standalone.cs
+++ b/test/NonSilo.Tests/General/RingTests_Standalone.cs
@@ -102,7 +102,7 @@ namespace UnitTests.General
 
             for (int i = 1; i <= n; i++)
             {
-                SiloAddress addr = SiloAddress.NewLocalAddress(i);
+                SiloAddress addr = SiloAddressFactory.NewLocalAddress(i);
                 rings.Add(addr, new ConsistentRingProvider(addr, NullLoggerFactory.Instance));
             }
             return rings;

--- a/test/NonSilo.Tests/OrleansRuntime/ExceptionsTests.cs
+++ b/test/NonSilo.Tests/OrleansRuntime/ExceptionsTests.cs
@@ -21,7 +21,7 @@ namespace UnitTests.OrleansRuntime
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_Exception_DotNet()
         {
-            var activationAddress = ActivationAddress.NewActivationAddress(SiloAddress.NewLocalAddress(12345), GrainId.NewId());
+            var activationAddress = ActivationAddress.NewActivationAddress(SiloAddressFactory.NewLocalAddress(12345), GrainId.NewId());
            
             var original = new Catalog.NonExistentActivationException("Some message", activationAddress, false);
             var output = TestingUtils.RoundTripDotNetSerializer(original, this.fixture.GrainFactory, this.fixture.SerializationManager);
@@ -34,7 +34,7 @@ namespace UnitTests.OrleansRuntime
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_Exception_Orleans()
         {
-            var activationAddress = ActivationAddress.NewActivationAddress(SiloAddress.NewLocalAddress(12345), GrainId.NewId());
+            var activationAddress = ActivationAddress.NewActivationAddress(SiloAddressFactory.NewLocalAddress(12345), GrainId.NewId());
 
             var original = new Catalog.NonExistentActivationException("Some message", activationAddress, false);
             var output = this.fixture.SerializationManager.RoundTripSerializationForTesting(original);

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -683,7 +683,7 @@ namespace UnitTests.SchedulerTests
             var grainId = GrainId.GetGrainId(0, Guid.NewGuid());
             var silo = new MockSiloDetails
             {
-                SiloAddress = SiloAddress.NewLocalAddress(23)
+                SiloAddress = SiloAddressFactory.NewLocalAddress(23)
             };
             var grain = NonReentrentStressGrainWithoutState.Create(grainId, new GrainRuntime(new GlobalConfiguration(), silo, null, null, null, null, null, null, NullLoggerFactory.Instance));
             await grain.OnActivateAsync();

--- a/test/NonSilo.Tests/SerializerTests/MessageSerializerTests.cs
+++ b/test/NonSilo.Tests/SerializerTests/MessageSerializerTests.cs
@@ -76,8 +76,8 @@ namespace NonSilo.Tests.UnitTests.SerializerTests
             InvokeMethodRequest request = new InvokeMethodRequest(0, 2, 0, null);
             Message resp = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None);
             resp.Id = new CorrelationId();
-            resp.SendingSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 200), 0);
-            resp.TargetSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 300), 0);
+            resp.SendingSilo = SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 200), 0);
+            resp.TargetSilo = SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 300), 0);
             resp.SendingGrain = GrainId.NewId();
             resp.TargetGrain = GrainId.NewId();
             resp.IsAlwaysInterleave = true;

--- a/test/TestInternalGrains/StressTestGrain.cs
+++ b/test/TestInternalGrains/StressTestGrain.cs
@@ -66,7 +66,7 @@ namespace UnitTests.Grains
                 var reply = new List<Tuple<SiloAddress, ActivationId>>();
                 for (int i = 0; i < 10; i++)
                 {
-                    reply.Add(new Tuple<SiloAddress, ActivationId>(SiloAddress.NewLocalAddress(0), ActivationId.NewId()));
+                    reply.Add(new Tuple<SiloAddress, ActivationId>(SiloAddressFactory.NewLocalAddress(0), ActivationId.NewId()));
                 }
                 list.Add(new Tuple<GrainId, int, List<Tuple<SiloAddress, ActivationId>>>(id, 3, reply));
             }

--- a/test/TestServiceFabric/FabricMembershipOracleTests.cs
+++ b/test/TestServiceFabric/FabricMembershipOracleTests.cs
@@ -29,7 +29,7 @@ namespace TestServiceFabric
             this.siloDetails = new MockSiloDetails
             {
                 Name = Guid.NewGuid().ToString("N"),
-                SiloAddress = SiloAddress.NewLocalAddress(SiloAddress.AllocateNewGeneration())
+                SiloAddress = SiloAddressFactory.NewLocalAddress(SiloAddressFactory.AllocateNewGeneration())
             };
 
             this.resolver = new MockResolver();
@@ -125,12 +125,12 @@ namespace TestServiceFabric
             var silos = new[]
             {
                 CreateSiloInfo(
-                    SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1), 1),
-                    SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 2), 1),
+                    SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 1), 1),
+                    SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 2), 1),
                     "HappyNewSilo"),
                 CreateSiloInfo(
-                    SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 3), 2),
-                    SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 4), 2),
+                    SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 3), 2),
+                    SiloAddressFactory.New(new IPEndPoint(IPAddress.Loopback, 4), 2),
                     "OtherNewSilo"),
             };
             

--- a/test/Tester/GeoClusterTests/MultiClusterDataTests.cs
+++ b/test/Tester/GeoClusterTests/MultiClusterDataTests.cs
@@ -44,9 +44,9 @@ namespace Tester.GeoClusterTests
             IPAddress ip;
             Assert.True(IPAddress.TryParse("127.0.0.1", out ip));
             IPEndPoint ep1 = new IPEndPoint(ip, 21111);
-            var siloAddress1 = SiloAddress.New(ep1, 0);
+            var siloAddress1 = SiloAddressFactory.New(ep1, 0);
             IPEndPoint ep2 = new IPEndPoint(ip, 21112);
-            var siloAddress2 = SiloAddress.New(ep2, 0);
+            var siloAddress2 = SiloAddressFactory.New(ep2, 0);
 
             var G1 = new GatewayEntry()
             {

--- a/test/TesterAzureUtils/AzureGossipTableTests.cs
+++ b/test/TesterAzureUtils/AzureGossipTableTests.cs
@@ -41,9 +41,9 @@ namespace Tester.AzureUtils
                 return;
             }
             IPEndPoint ep1 = new IPEndPoint(ip, 21111);
-            siloAddress1 = SiloAddress.New(ep1, 0);
+            siloAddress1 = SiloAddressFactory.New(ep1, 0);
             IPEndPoint ep2 = new IPEndPoint(ip, 21112);
-            siloAddress2 = SiloAddress.New(ep2, 0);
+            siloAddress2 = SiloAddressFactory.New(ep2, 0);
 
             logger.Info("DeploymentId={0}", deploymentId);
 

--- a/test/TesterAzureUtils/SiloInstanceTableManagerTests.cs
+++ b/test/TesterAzureUtils/SiloInstanceTableManagerTests.cs
@@ -45,8 +45,8 @@ namespace Tester.AzureUtils
             TestUtils.CheckForAzureStorage();
             this.output = output;
             deploymentId = "test-" + Guid.NewGuid();
-            generation = SiloAddress.AllocateNewGeneration();
-            siloAddress = SiloAddress.NewLocalAddress(generation);
+            generation = SiloAddressFactory.AllocateNewGeneration();
+            siloAddress = SiloAddressFactory.NewLocalAddress(generation);
 
             output.WriteLine("DeploymentId={0} Generation={1}", deploymentId, generation);
 
@@ -190,7 +190,7 @@ namespace Tester.AzureUtils
 
             IPAddress address = IPAddress.Parse(ipAddress);
             IPEndPoint endpoint = new IPEndPoint(address, port);
-            SiloAddress siloAddress = SiloAddress.New(endpoint, generation);
+            SiloAddress siloAddress = SiloAddressFactory.New(endpoint, generation);
 
             string MembershipRowKey = SiloInstanceTableEntry.ConstructRowKey(siloAddress);
 

--- a/test/TesterInternal/GeoClusterTests/GatewaySelectionTest.cs
+++ b/test/TesterInternal/GeoClusterTests/GatewaySelectionTest.cs
@@ -17,18 +17,18 @@ namespace UnitTests.GeoClusterTests
         public void TestMultiClusterGatewaySelection()
         {
             var candidates = new SiloAddress[] {
-                SiloAddress.New(new IPEndPoint(0,0),0),
-                SiloAddress.New(new IPEndPoint(0,0),1),
-                SiloAddress.New(new IPEndPoint(0,1),0),
-                SiloAddress.New(new IPEndPoint(0,1),1),
-                SiloAddress.New(new IPEndPoint(0,234),1),
-                SiloAddress.New(new IPEndPoint(1,0),0),
-                SiloAddress.New(new IPEndPoint(1,0),1),
-                SiloAddress.New(new IPEndPoint(1,1),1),
-                SiloAddress.New(new IPEndPoint(1,234),1),
-                SiloAddress.New(new IPEndPoint(2,234),1),
-                SiloAddress.New(new IPEndPoint(3,234),1),
-                SiloAddress.New(new IPEndPoint(4,234),1),
+                SiloAddressFactory.New(new IPEndPoint(0,0),0),
+                SiloAddressFactory.New(new IPEndPoint(0,0),1),
+                SiloAddressFactory.New(new IPEndPoint(0,1),0),
+                SiloAddressFactory.New(new IPEndPoint(0,1),1),
+                SiloAddressFactory.New(new IPEndPoint(0,234),1),
+                SiloAddressFactory.New(new IPEndPoint(1,0),0),
+                SiloAddressFactory.New(new IPEndPoint(1,0),1),
+                SiloAddressFactory.New(new IPEndPoint(1,1),1),
+                SiloAddressFactory.New(new IPEndPoint(1,234),1),
+                SiloAddressFactory.New(new IPEndPoint(2,234),1),
+                SiloAddressFactory.New(new IPEndPoint(3,234),1),
+                SiloAddressFactory.New(new IPEndPoint(4,234),1),
             };
             
             Func<SiloAddress,UpdateFaultCombo> group = (SiloAddress a) => new UpdateFaultCombo(a.Endpoint.Port, a.Generation);

--- a/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
+++ b/test/TesterInternal/LivenessTests/ConsistentRingProviderTests.cs
@@ -31,28 +31,28 @@ namespace UnitTests.LivenessTests
         [Fact, TestCategory("Functional"), TestCategory("Liveness"), TestCategory("Ring"), TestCategory("RingStandalone")]
         public void ConsistentRingProvider_Test1()
         {
-            SiloAddress silo1 = SiloAddress.NewLocalAddress(0);
+            SiloAddress silo1 = SiloAddressFactory.NewLocalAddress(0);
             ConsistentRingProvider ring = new ConsistentRingProvider(silo1, NullLoggerFactory.Instance);
             output.WriteLine("Silo1 range: {0}. The whole ring is: {1}", ring.GetMyRange(), ring.ToString());
 
-            ring.AddServer(SiloAddress.NewLocalAddress(1));
+            ring.AddServer(SiloAddressFactory.NewLocalAddress(1));
             output.WriteLine("Silo1 range: {0}. The whole ring is: {1}", ring.GetMyRange(), ring.ToString());
 
-            ring.AddServer(SiloAddress.NewLocalAddress(2));
+            ring.AddServer(SiloAddressFactory.NewLocalAddress(2));
             output.WriteLine("Silo1 range: {0}. The whole ring is: {1}", ring.GetMyRange(), ring.ToString());
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Liveness"), TestCategory("Ring"), TestCategory("RingStandalone")]
         public void ConsistentRingProvider_Test2()
         {
-            SiloAddress silo1 = SiloAddress.NewLocalAddress(0);
+            SiloAddress silo1 = SiloAddressFactory.NewLocalAddress(0);
             VirtualBucketsRingProvider ring = new VirtualBucketsRingProvider(silo1, NullLoggerFactory.Instance, 30);
             //ring.logger.SetSeverityLevel(Severity.Warning);
             output.WriteLine("\n\n*** Silo1 range: {0}.\n*** The whole ring with 1 silo is:\n{1}\n\n", ring.GetMyRange(), ring.ToString());
 
             for (int i = 1; i <= 10; i++)
             {
-                ring.SiloStatusChangeNotification(SiloAddress.NewLocalAddress(i), SiloStatus.Active);
+                ring.SiloStatusChangeNotification(SiloAddressFactory.NewLocalAddress(i), SiloStatus.Active);
                 var range = RangeFactory.CreateEquallyDividedMultiRange(ring.GetMyRange(), 5);
                 output.WriteLine("\n\n*** Silo1 range: {0}. \n*** The whole ring with {1} silos is:\n{2}\n\n", range.ToCompactString(), i + 1, ring.ToString());
             }
@@ -66,13 +66,13 @@ namespace UnitTests.LivenessTests
             int NUM_AGENTS = 4;
 
             Random random = new Random();
-            SiloAddress silo1 = SiloAddress.NewLocalAddress(random.Next(100000));
+            SiloAddress silo1 = SiloAddressFactory.NewLocalAddress(random.Next(100000));
             VirtualBucketsRingProvider ring = new VirtualBucketsRingProvider(silo1, NullLoggerFactory.Instance, 50);
             //ring.logger.SetSeverityLevel(Severity.Warning);
             
             for (int i = 1; i <= NUM_SILOS - 1; i++)
             {
-                ring.SiloStatusChangeNotification(SiloAddress.NewLocalAddress(random.Next(100000)), SiloStatus.Active);
+                ring.SiloStatusChangeNotification(SiloAddressFactory.NewLocalAddress(random.Next(100000)), SiloStatus.Active);
             }
   
             IDictionary<SiloAddress, IRingRangeInternal> siloRanges = ring.GetRanges();

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -437,7 +437,7 @@ namespace UnitTests.MembershipTests
 
         private static SiloAddress CreateSiloAddressForTest()
         {
-            var siloAddress = SiloAddress.NewLocalAddress(Interlocked.Increment(ref generation));
+            var siloAddress = SiloAddressFactory.NewLocalAddress(Interlocked.Increment(ref generation));
             siloAddress.Endpoint.Port = 12345;
             return siloAddress;
         }

--- a/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
+++ b/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
@@ -79,7 +79,7 @@ namespace UnitTests.SqlStatisticsPublisherTests
 
             IMembershipTable mbr = new SqlMembershipTable(this.environment.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory.CreateLogger<SqlMembershipTable>());
             await mbr.InitializeMembershipTable(config, true).WithTimeout(TimeSpan.FromMinutes(1));
-            StatisticsPublisher.AddConfiguration("statisticsDeployment", true, "statisticsSiloId", SiloAddress.NewLocalAddress(0), new IPEndPoint(IPAddress.Loopback, 12345), "statisticsHostName");
+            StatisticsPublisher.AddConfiguration("statisticsDeployment", true, "statisticsSiloId", SiloAddressFactory.NewLocalAddress(0), new IPEndPoint(IPAddress.Loopback, 12345), "statisticsHostName");
             await RunParallel(10, () => StatisticsPublisher.ReportMetrics((ISiloPerformanceMetrics)new DummyPerformanceMetrics()));
         }
 


### PR DESCRIPTION
Following the same pattern as in #3467 

The only issue with this PR is that we cache the value returned by `GetConsistentHashCode()` and `GetUniformHashCodes` in this class, and these methods have dependencies that we want to avoid pulling in Abstractions.

As a temporary work-around, I marked the "cache members" as internal and set them in the `SiloAddressFactory` that is responsible for computing these values.

We could also compute these value when constructing the object; I don't think there will be a lot of performance hit, since, except in the client, we need theses values anyway.
