### PR TITLE
Cleanup IMessagingConfiguration usage

### DIFF
--- a/src/Orleans/Messaging/GatewayConnection.cs
+++ b/src/Orleans/Messaging/GatewayConnection.cs
@@ -31,14 +31,17 @@ namespace Orleans.Messaging
         internal SiloAddress Silo { get; private set; }
 
         private readonly GatewayClientReceiver receiver;
+        private readonly TimeSpan openConnectionTimeout;
+
         internal Socket Socket { get; private set; }       // Shared by the receiver
 
         private DateTime lastConnect;
 
-        internal GatewayConnection(Uri address, ProxiedMessageCenter mc, MessageFactory messageFactory, ILoggerFactory loggerFactory)
+        internal GatewayConnection(Uri address, ProxiedMessageCenter mc, MessageFactory messageFactory, ILoggerFactory loggerFactory, TimeSpan openConnectionTimeout)
             : base("GatewayClientSender_" + address, mc.SerializationManager, loggerFactory)
         {
             this.messageFactory = messageFactory;
+            this.openConnectionTimeout = openConnectionTimeout;
             Address = address;
             MsgCenter = mc;
             receiver = new GatewayClientReceiver(this, mc.SerializationManager, loggerFactory);
@@ -167,7 +170,7 @@ namespace Orleans.Messaging
                         }
                         lastConnect = DateTime.UtcNow;
                         Socket = new Socket(Silo.Endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-                        SocketManager.Connect(Socket, Silo.Endpoint, MsgCenter.MessagingConfiguration.OpenConnectionTimeout);
+                        SocketManager.Connect(Socket, Silo.Endpoint, this.openConnectionTimeout);
                         NetworkingStatisticsGroup.OnOpenedGatewayDuplexSocket();
                         MsgCenter.OnGatewayConnectionOpen();
                         SocketManager.WriteConnectionPreamble(Socket, MsgCenter.ClientId);  // Identifies this client

--- a/src/Orleans/Messaging/IMessageCenter.cs
+++ b/src/Orleans/Messaging/IMessageCenter.cs
@@ -1,5 +1,4 @@
 using System.Threading;
-using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime
 {
@@ -20,7 +19,5 @@ namespace Orleans.Runtime
         int SendQueueLength { get; }
 
         int ReceiveQueueLength { get; }
-
-        IMessagingConfiguration MessagingConfiguration { get; }
     }
 }

--- a/src/Orleans/Messaging/SocketManager.cs
+++ b/src/Orleans/Messaging/SocketManager.cs
@@ -5,6 +5,8 @@ using System.Net.Sockets;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Configuration;
+using Orleans.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Runtime
 {
@@ -15,10 +17,11 @@ namespace Orleans.Runtime
         private ILogger logger;
         private const int MAX_SOCKETS = 200;
 
-        internal SocketManager(IMessagingConfiguration config, ILoggerFactory loggerFactory)
+        internal SocketManager(IOptions<MessagingOptions> options, ILoggerFactory loggerFactory)
         {
-            connectionTimeout = config.OpenConnectionTimeout;
-            cache = new LRU<IPEndPoint, Socket>(MAX_SOCKETS, config.MaxSocketAge, SendingSocketCreator);
+            var messagingOptions = options.Value;
+            connectionTimeout = messagingOptions.OpenConnectionTimeout;
+            cache = new LRU<IPEndPoint, Socket>(MAX_SOCKETS, messagingOptions.MaxSocketAge, SendingSocketCreator);
             this.logger = loggerFactory.CreateLogger<SocketManager>();
             cache.RaiseFlushEvent += FlushHandler;
         }

--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -647,7 +647,7 @@ namespace Orleans
                     context,
                     message,
                     unregisterCallback,
-                    config,
+                    this.clientMessagingOptions,
                     this.callBackDataLogger,
                     this.timerLogger);
                 callbacks.TryAdd(message.Id, callbackData);

--- a/src/OrleansRuntime/Core/InsideRuntimeClient.cs
+++ b/src/OrleansRuntime/Core/InsideRuntimeClient.cs
@@ -18,6 +18,8 @@ using Orleans.Streams;
 using Orleans.Transactions;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 
 namespace Orleans.Runtime
 {
@@ -31,6 +33,7 @@ namespace Orleans.Runtime
         private readonly ILogger timerLogger;
         private readonly ILogger invokeExceptionLogger;
         private readonly ILoggerFactory loggerFactory;
+        private readonly SiloMessagingOptions messagingOptions;
         private readonly List<IDisposable> disposables;
         private readonly ConcurrentDictionary<CorrelationId, CallbackData> callbacks;
         private readonly Func<Message, bool> tryResendMessage;
@@ -59,7 +62,8 @@ namespace Orleans.Runtime
             MessageFactory messageFactory,
             IEnumerable<IGrainCallFilter> registeredInterceptors,
             Factory<ITransactionAgent> transactionAgent,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            IOptions<SiloMessagingOptions> messagingOptions)
         {
             this.ServiceProvider = serviceProvider;
             this.SerializationManager = serializationManager;
@@ -79,6 +83,7 @@ namespace Orleans.Runtime
             this.logger = loggerFactory.CreateLogger<InsideRuntimeClient>();
             this.invokeExceptionLogger =loggerFactory.CreateLogger($"{typeof(Grain).FullName}.InvokeException");
             this.loggerFactory = loggerFactory;
+            this.messagingOptions = messagingOptions.Value;
             this.callbackDataLogger = new LoggerWrapper<CallbackData>(loggerFactory);
             this.timerLogger = loggerFactory.CreateLogger<SafeTimer>();
         }
@@ -208,7 +213,7 @@ namespace Orleans.Runtime
                     context,
                     message,
                     unregisterCallback,
-                    Config.Globals,
+                    messagingOptions,
                     this.callbackDataLogger,
                     this.timerLogger);
                 callbacks.TryAdd(message.Id, callbackData);

--- a/src/OrleansRuntime/Messaging/Gateway.cs
+++ b/src/OrleansRuntime/Messaging/Gateway.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.Logging;
 using Orleans.Messaging;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using Orleans.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Runtime.Messaging
 {
@@ -35,22 +37,23 @@ namespace Orleans.Runtime.Messaging
 
         private readonly Logger logger;
         private readonly ILoggerFactory loggerFactory;
-        private IMessagingConfiguration MessagingConfiguration { get { return messageCenter.MessagingConfiguration; } }
+        private readonly SiloMessagingOptions messagingOptions;
         
-        public Gateway(MessageCenter msgCtr, NodeConfiguration nodeConfig, MessageFactory messageFactory, SerializationManager serializationManager, GlobalConfiguration globalConfig, ILoggerFactory loggerFactory)
+        public Gateway(MessageCenter msgCtr, NodeConfiguration nodeConfig, MessageFactory messageFactory, SerializationManager serializationManager, GlobalConfiguration globalConfig, ILoggerFactory loggerFactory, IOptions<SiloMessagingOptions> options)
         {
+            this.messagingOptions = options.Value;
             this.loggerFactory = loggerFactory;
             messageCenter = msgCtr;
             this.messageFactory = messageFactory;
             this.logger = new LoggerWrapper<Gateway>(this.loggerFactory);
             this.serializationManager = serializationManager;
             acceptor = new GatewayAcceptor(msgCtr, this, nodeConfig.ProxyGatewayEndpoint, this.messageFactory, this.serializationManager, globalConfig, loggerFactory);
-            senders = new Lazy<GatewaySender>[messageCenter.MessagingConfiguration.GatewaySenderQueues];
+            senders = new Lazy<GatewaySender>[messagingOptions.GatewaySenderQueues];
             nextGatewaySenderToUseForRoundRobin = 0;
-            dropper = new GatewayClientCleanupAgent(this, loggerFactory);
+            dropper = new GatewayClientCleanupAgent(this, loggerFactory, messagingOptions.ClientDropTimeout);
             clients = new ConcurrentDictionary<GrainId, ClientState>();
             clientSockets = new ConcurrentDictionary<Socket, ClientState>();
-            clientsReplyRoutingCache = new ClientsReplyRoutingCache(messageCenter.MessagingConfiguration);
+            clientsReplyRoutingCache = new ClientsReplyRoutingCache(messagingOptions.ResponseTimeout);
             this.gatewayAddress = SiloAddress.New(nodeConfig.ProxyGatewayEndpoint, 0);
             lockable = new object();
         }
@@ -110,7 +113,7 @@ namespace Orleans.Runtime.Messaging
                 {
                     int gatewayToUse = nextGatewaySenderToUseForRoundRobin % senders.Length;
                     nextGatewaySenderToUseForRoundRobin++; // under Gateway lock
-                    clientState = new ClientState(clientId, gatewayToUse, MessagingConfiguration.ClientDropTimeout);
+                    clientState = new ClientState(clientId, gatewayToUse, messagingOptions.ClientDropTimeout);
                     clients[clientId] = clientState;
                     MessagingStatisticsGroup.ConnectedClientCount.Increment();
                 }
@@ -284,11 +287,13 @@ namespace Orleans.Runtime.Messaging
         private class GatewayClientCleanupAgent : AsynchAgent
         {
             private readonly Gateway gateway;
+            private readonly TimeSpan clientDropTimeout;
 
-            internal GatewayClientCleanupAgent(Gateway gateway, ILoggerFactory loggerFactory)
+            internal GatewayClientCleanupAgent(Gateway gateway, ILoggerFactory loggerFactory, TimeSpan clientDropTimeout)
                 :base(loggerFactory)
             {
                 this.gateway = gateway;
+                this.clientDropTimeout = clientDropTimeout;
             }
 
             #region Overrides of AsynchAgent
@@ -299,7 +304,7 @@ namespace Orleans.Runtime.Messaging
                 {
                     gateway.DropDisconnectedClients();
                     gateway.DropExpiredRoutingCachedEntries();
-                    Thread.Sleep(gateway.MessagingConfiguration.ClientDropTimeout);
+                    Thread.Sleep(clientDropTimeout);
                 }
             }
 
@@ -316,10 +321,10 @@ namespace Orleans.Runtime.Messaging
             private readonly ConcurrentDictionary<GrainId, Tuple<SiloAddress, DateTime>> clientRoutes;
             private readonly TimeSpan TIME_BEFORE_ROUTE_CACHED_ENTRY_EXPIRES;
 
-            internal ClientsReplyRoutingCache(IMessagingConfiguration messagingConfiguration)
+            internal ClientsReplyRoutingCache(TimeSpan responseTimeout)
             {
                 clientRoutes = new ConcurrentDictionary<GrainId, Tuple<SiloAddress, DateTime>>();
-                TIME_BEFORE_ROUTE_CACHED_ENTRY_EXPIRES = messagingConfiguration.ResponseTimeout.Multiply(5);
+                TIME_BEFORE_ROUTE_CACHED_ENTRY_EXPIRES = responseTimeout.Multiply(5);
             }
 
             internal void RecordClientRoute(GrainId client, SiloAddress gateway)

--- a/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
+++ b/src/OrleansRuntime/Messaging/OutboundMessageQueue.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using Orleans.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Runtime.Messaging
 {
@@ -29,12 +31,12 @@ namespace Orleans.Runtime.Messaging
 
         internal const string QUEUED_TIME_METADATA = "QueuedTime";
 
-        internal OutboundMessageQueue(MessageCenter mc, IMessagingConfiguration config, SerializationManager serializationManager, ILoggerFactory loggerFactory)
+        internal OutboundMessageQueue(MessageCenter mc, IOptions<SiloMessagingOptions> options, SerializationManager serializationManager, ILoggerFactory loggerFactory)
         {
             messageCenter = mc;
             pingSender = new SiloMessageSender("PingSender", messageCenter, serializationManager, loggerFactory);
             systemSender = new SiloMessageSender("SystemSender", messageCenter, serializationManager, loggerFactory);
-            senders = new Lazy<SiloMessageSender>[config.SiloSenderQueues];
+            senders = new Lazy<SiloMessageSender>[options.Value.SiloSenderQueues];
 
             for (int i = 0; i < senders.Length; i++)
             {


### PR DESCRIPTION
- Remove references to IMessagingConfiguration interface
- Remove IMessagingconfiguration dependency in various classes like GatewayConnection, IMessageCenter, ProxiedMessageCenter
- Pass or store single property from options where only it was the only purpose of storing the whole configuration class in field variable