### PR TITLE
Bugfix - In-memory lease provider

### DIFF
--- a/src/OrleansRuntime/Development/InMemoryLeaseProvider.cs
+++ b/src/OrleansRuntime/Development/InMemoryLeaseProvider.cs
@@ -118,9 +118,18 @@ namespace Orleans.Runtime.Development
 
         private class Lease
         {
-            public DateTime ExpiredUtc { get; set; }
-            public string Token => ExpiredUtc.Ticks.ToString();
+            private DateTime expiredUtc;
+
+            public DateTime ExpiredUtc
+            {
+                get { return expiredUtc; }
+                set
+                {
+                    expiredUtc = value;
+                    Token = Guid.NewGuid().ToString();
+                }
+            }
+            public string Token { get; private set; }
         }
     }
-
 }


### PR DESCRIPTION
Bugfix - In-memory lease provider used timestamp as token, which failed to be unique in some fast running tests.

The fix is to always generate a new guid for the token.