### PR TITLE
Turn off console logging on tests

### DIFF
--- a/src/OrleansTestingHost/OrleansTestingHost.csproj
+++ b/src/OrleansTestingHost/OrleansTestingHost.csproj
@@ -15,7 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrleansTestingHost/Utils/TestingUtils.cs
+++ b/src/OrleansTestingHost/Utils/TestingUtils.cs
@@ -17,22 +17,18 @@ namespace Orleans.TestingHost.Utils
     public static class TestingUtils
     {
         /// <summary>
-        /// Configure <paramref name="builder"/> with a ConsoleLoggerProvider and a TraceSourceLoggerProvider which logs to <paramref name="filePath"/>
-        /// This is to restore legacy default behavior of LogManager, which configure LogManager with a FileTelemetryConsumer and ConsoleTelemetryConsumer
+        /// Configure <paramref name="builder"/> with a <see cref="FileLoggerProvider"/> which logs to <paramref name="filePath"/>
         /// by default;
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="filePath"></param>
         public static void ConfigureDefaultLoggingBuilder(ILoggingBuilder builder, string filePath)
         {
-            if (ConsoleText.IsConsoleAvailable)
-                builder.AddConsole();
             builder.AddFile(filePath);
         }
 
         /// <summary>
-        /// Create the default logger factory, which would create <see cref="Microsoft.Extensions.Logging.ILogger"/>> that writes logs to <paramref name="filePath"/> and console.
-        /// This is to restore legacy default behavior of LogManager, which configure LogManager with a FileTelemetryConsumer and ConsoleTelemetryConsumer
+        /// Create the default logger factory, which would configure logger factory with a <see cref="FileLoggerProvider"/> that writes logs to <paramref name="filePath"/> and console.
         /// by default;
         /// </summary>
         /// <param name="filePath">the logger file path</param>
@@ -43,8 +39,7 @@ namespace Orleans.TestingHost.Utils
         }
 
         /// <summary>
-        /// Create the default logger factory, which would create <see cref="Microsoft.Extensions.Logging.ILogger"/>> that writes logs to <paramref name="filePath"/> and console.
-        /// This is to restore legacy default behavior of LogManager, which configure LogManager with a FileTelemetryConsumer and ConsoleTelemetryConsumer
+        /// Create the default logger factory, which would configure logger factory with a <see cref="FileLoggerProvider"/> that writes logs to <paramref name="filePath"/> and console.
         /// by default;
         /// </summary>
         /// <param name="filePath">the logger file path</param>
@@ -54,8 +49,6 @@ namespace Orleans.TestingHost.Utils
         {
             var factory = new LoggerFactory(new List<ILoggerProvider>(), filters);
             factory.AddProvider(new FileLoggerProvider(filePath));
-            if (ConsoleText.IsConsoleAvailable)
-                factory.AddConsole();
             return factory;
         }
 


### PR DESCRIPTION
Make `DefaultSiloBuilderFactory` to be just configured with a `FileLoggerProvider`. Orleans tests are just configured with a FileLoggerProvider also. 

If user want to turn on console logging on TestCluster, they can configure it through `ISiloBuilder` or `IClientBuilder` and `ISiloBuilderFactory`. Or they can turn on `TraceToConsole` in `TestClusterOptions`, if we bring this feature back using #3486 