### PR TITLE
Re-enable intellisense for generated code

### DIFF
--- a/src/ClientGenerator/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
+++ b/src/ClientGenerator/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
@@ -54,4 +54,12 @@
       <Output TaskParameter="Outputs" ItemName="FileWrites" />
     </Exec>
   </Target>
+  
+  <Target Name="IncludeCodegenOutputDuringDesignTimeBuild"
+        BeforeTargets="AssignTargetPaths"
+        Condition="'$(CodeGeneratorEnabled)' != 'true' and Exists('$(OutputFileName)')">
+    <ItemGroup>
+      <Compile Include="$(OutputFileName)"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/ClientGenerator/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
+++ b/src/ClientGenerator/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
@@ -60,6 +60,7 @@
         Condition="'$(CodeGeneratorEnabled)' != 'true' and Exists('$(OutputFileName)')">
     <ItemGroup>
       <Compile Include="$(OutputFileName)"/>
+      <FileWrites Include="$(OutputFileName)"/>
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
When `CodeGeneratorEnabled` is `true`, we also include `OutputFile` as a `<Compile>` item, so this just makes sure that it's always included as long as it exists.

Result is that users can navigate to generated code in Visual Studio and presumably other IDEs.