### PR TITLE
Update xUnit to latest vertion (VS test discovery perf boost)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -93,7 +93,7 @@
     <BenchmarkDotNetVersion>0.10.9</BenchmarkDotNetVersion>
     <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
     <XunitSkippableFactVersion>1.3.3</XunitSkippableFactVersion>
-    <xUnitVersion>2.3.0-beta5-build3769</xUnitVersion>
+    <xUnitVersion>2.3.0-rc3-build3818</xUnitVersion>
   </PropertyGroup>
 
   <!-- Versioning properties -->

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -7,6 +7,8 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
     <!-- Needed for tests to force the generation of binding redirects -->
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>


### PR DESCRIPTION
Disable doc generation explicitly for tests and disable docgen warning