### PR TITLE
Added a constructror to LogConsistentGrainBase and JournaledGrain

### DIFF
--- a/src/Orleans/LogConsistency/ILogConsistentGrain.cs
+++ b/src/Orleans/LogConsistency/ILogConsistentGrain.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Orleans.Concurrency;
 using Orleans.Runtime;
 using Orleans.Storage;
+using Orleans.Core;
 
 namespace Orleans.LogConsistency
 {
@@ -42,5 +43,17 @@ namespace Orleans.LogConsistency
     /// <typeparam name="TView">The type of the view</typeparam>
     public class LogConsistentGrainBase<TView> : Grain
     {
+        public LogConsistentGrainBase()
+        {
+        }
+
+        /// <summary>
+        /// This constructor is particularly useful for unit testing where test code can create a Grain and replace
+        /// the IGrainIdentity, IGrainRuntime and State with test doubles (mocks/stubs).
+        /// </summary>
+        protected LogConsistentGrainBase(IGrainIdentity identity, IGrainRuntime runtime)
+            :base(identity,runtime)
+        {
+        }
     }
 }

--- a/src/OrleansEventSourcing/JournaledGrain.cs
+++ b/src/OrleansEventSourcing/JournaledGrain.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.Storage;
+using Orleans.Core;
+using Orleans.Runtime;
 
 namespace Orleans.EventSourcing
 {
@@ -16,7 +18,16 @@ namespace Orleans.EventSourcing
     /// </summary>
     public abstract class JournaledGrain<TGrainState> : JournaledGrain<TGrainState, object>
         where TGrainState : class, new()
-    { }
+    {
+        protected JournaledGrain() { }
+
+        /// <summary>
+        /// This constructor is particularly useful for unit testing where test code can create a Grain and replace
+        /// the IGrainIdentity, IGrainRuntime and State with test doubles (mocks/stubs).
+        /// </summary>
+        protected JournaledGrain(IGrainIdentity identity, IGrainRuntime runtime)
+            : base(identity, runtime);
+    }
 
 
     /// <summary>
@@ -34,6 +45,13 @@ namespace Orleans.EventSourcing
         where TEventBase: class
     {
         protected JournaledGrain() { }
+
+        /// <summary>
+        /// This constructor is particularly useful for unit testing where test code can create a Grain and replace
+        /// the IGrainIdentity, IGrainRuntime and State with test doubles (mocks/stubs).
+        /// </summary>
+        protected JournaledGrain(IGrainIdentity identity, IGrainRuntime runtime)
+            : base(identity, runtime);
 
         /// <summary>
         /// Raise an event.


### PR DESCRIPTION
Essentially exposing the Grain's constructor to allow for unit testing JournaledGrain implementations