### PR TITLE
Fixed duplicate stream message cache monitoring bug.

### DIFF
--- a/src/OrleansProviders/Streams/Common/Monitors/PeriodicAction.cs
+++ b/src/OrleansProviders/Streams/Common/Monitors/PeriodicAction.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Orleans.Providers.Streams.Common
+{
+    internal class PeriodicAction
+    {
+        private readonly Action action;
+        private readonly TimeSpan period;
+        private DateTime nextUtc;
+
+        public PeriodicAction(TimeSpan period, Action action, DateTime? start = null)
+        {
+            this.period = period;
+            this.nextUtc = start ?? DateTime.UtcNow + period;
+            this.action = action;
+        }
+
+        public bool TryAction(DateTime nowUtc)
+        {
+            if (nowUtc < this.nextUtc) return false;
+            this.nextUtc = nowUtc + this.period;
+            this.action();
+            return true;
+        }
+    }
+}

--- a/src/OrleansProviders/Streams/Common/PooledCache/ChronologicalEvictionStrategy.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ChronologicalEvictionStrategy.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Orleans.Runtime;
-using System.Threading;
 
 namespace Orleans.Providers.Streams.Common
 {
@@ -20,8 +19,8 @@ namespace Orleans.Providers.Streams.Common
         /// </summary>
         protected readonly Queue<FixedSizeBuffer> inUseBuffers;
         private FixedSizeBuffer currentBuffer;
-        private ICacheMonitor cacheMonitor;
-        private Timer timer;
+        private readonly ICacheMonitor cacheMonitor;
+        private readonly PeriodicAction periodicMonitoring;
         private long cacheSizeInByte;
 
         /// <summary>
@@ -38,18 +37,22 @@ namespace Orleans.Providers.Streams.Common
             this.logger = logger;
             this.timePurge = timePurage;
             this.inUseBuffers = new Queue<FixedSizeBuffer>();
+
+            // monitoring
             this.cacheMonitor = cacheMonitor;
-            if (cacheMonitor != null && monitorWriteInterval.HasValue)
+            if (this.cacheMonitor != null && monitorWriteInterval.HasValue)
             {
-                this.timer = new Timer(this.ReportCacheSize, null, monitorWriteInterval.Value, monitorWriteInterval.Value);
+                this.periodicMonitoring = new PeriodicAction(monitorWriteInterval.Value, this.ReportCacheSize);
             }
+
             this.cacheSizeInByte = 0;
         }
 
-        private void ReportCacheSize(object state)
+        private void ReportCacheSize()
         {
             this.cacheMonitor.ReportCacheSize(this.cacheSizeInByte);
         }
+
         /// <summary>
         /// Get block pool block id for message
         /// </summary>
@@ -96,8 +99,14 @@ namespace Orleans.Providers.Streams.Common
             this.cacheMonitor?.TrackMemoryAllocated(newBlock.SizeInByte);
         }
 
-        /// <inheritdoc />
         public void PerformPurge(DateTime nowUtc)
+        {
+            PerformPurgeInternal(nowUtc);
+            this.periodicMonitoring?.TryAction(nowUtc);
+        }
+
+        /// <inheritdoc />
+        public void PerformPurgeInternal(DateTime nowUtc)
         {
             //if the cache is empty, then nothing to purge, return
             if (this.PurgeObservable.IsEmpty)

--- a/src/OrleansProviders/Streams/Common/PooledCache/ChronologicalEvictionStrategy.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/ChronologicalEvictionStrategy.cs
@@ -29,7 +29,7 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="logger"></param>
         /// <param name="timePurage"></param>
         /// <param name="cacheMonitor"></param>
-        /// <param name="monitorWriteInterval"></param>
+        /// <param name="monitorWriteInterval">"Interval to write periodic statistics.  Only triggered for active caches.</param>
         protected ChronologicalEvictionStrategy(Logger logger, TimePurgePredicate timePurage, ICacheMonitor cacheMonitor, TimeSpan? monitorWriteInterval)
         {
             if (logger == null) throw new ArgumentException(nameof(logger));
@@ -99,14 +99,14 @@ namespace Orleans.Providers.Streams.Common
             this.cacheMonitor?.TrackMemoryAllocated(newBlock.SizeInByte);
         }
 
+        /// <inheritdoc />
         public void PerformPurge(DateTime nowUtc)
         {
             PerformPurgeInternal(nowUtc);
             this.periodicMonitoring?.TryAction(nowUtc);
         }
 
-        /// <inheritdoc />
-        public void PerformPurgeInternal(DateTime nowUtc)
+        private void PerformPurgeInternal(DateTime nowUtc)
         {
             //if the cache is empty, then nothing to purge, return
             if (this.PurgeObservable.IsEmpty)

--- a/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
@@ -74,7 +74,7 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="comparer"></param>
         /// <param name="logger"></param>
         /// <param name="cacheMonitor"></param>
-        /// <param name="cacheMonitorWriteInterval">cache monitor write interval</param>
+        /// <param name="cacheMonitorWriteInterval">cache monitor write interval.  Only triggered for active caches.</param>
         public PooledQueueCache(ICacheDataAdapter<TQueueMessage, TCachedMessage> cacheDataAdapter, ICacheDataComparer<TCachedMessage> comparer, Logger logger, ICacheMonitor cacheMonitor, TimeSpan? cacheMonitorWriteInterval)
         {
             if (cacheDataAdapter == null)

--- a/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
+++ b/src/OrleansProviders/Streams/Common/PooledCache/PooledQueueCache.cs
@@ -1,11 +1,9 @@
 ﻿
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Orleans.Runtime;
 using Orleans.Streams;
-using System.Threading;
 
 namespace Orleans.Providers.Streams.Common
 {
@@ -35,8 +33,8 @@ namespace Orleans.Providers.Streams.Common
         private readonly ICacheDataComparer<TCachedMessage> comparer;
         private readonly Logger logger;
         private readonly ICacheMonitor cacheMonitor;
+        private readonly PeriodicAction periodicMonitoring;
         private int itemCount;
-        private Timer timer;
         /// <summary>
         /// Cached message most recently added
         /// </summary>
@@ -101,9 +99,8 @@ namespace Orleans.Providers.Streams.Common
 
             if (this.cacheMonitor != null && cacheMonitorWriteInterval.HasValue)
             {
-                this.timer = new Timer(this.ReportCacheMessageStatistics, null, cacheMonitorWriteInterval.Value, cacheMonitorWriteInterval.Value);
+                this.periodicMonitoring = new PeriodicAction(cacheMonitorWriteInterval.Value, this.ReportCacheMessageStatistics);
             }
-           
         }
 
         /// <summary>
@@ -125,7 +122,7 @@ namespace Orleans.Providers.Streams.Common
             return cursor;
         }
 
-        private void ReportCacheMessageStatistics(object state)
+        private void ReportCacheMessageStatistics()
         {
             if (this.IsEmpty)
             {
@@ -316,16 +313,11 @@ namespace Orleans.Providers.Streams.Common
                 streamPosisions.Add(this.Add(message, dequeueTime));
             }
             this.cacheMonitor?.TrackMessagesAdded(messages.Count);
+            periodicMonitoring?.TryAction(dequeueTime);
             return streamPosisions;
         }
 
-        /// <summary>
-        /// Add a queue message to the cache
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="dequeueTimeUtc"></param>
-        /// <returns></returns>
-        public StreamPosition Add(TQueueMessage message, DateTime dequeueTimeUtc)
+        private StreamPosition Add(TQueueMessage message, DateTime dequeueTimeUtc)
         {
             if (message == null)
             {

--- a/src/OrleansProviders/Streams/Common/RecoverableStreamProviderSettings.cs
+++ b/src/OrleansProviders/Streams/Common/RecoverableStreamProviderSettings.cs
@@ -49,6 +49,7 @@ namespace Orleans.Providers.Streams.Common
 
         /// <summary>
         /// Statistic monitor write interval
+        /// Statistics generation is triggered by activity.  Interval will be ignored when streams are inactive.
         /// </summary>
         public TimeSpan StatisticMonitorWriteInterval { get; set; } = DefaultStatisticMonitorWriteInterval;
 

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -7,6 +7,7 @@ using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Streams;
 using static System.String;
+using System.Linq;
 
 namespace Orleans.Providers.Streams.Generator
 {
@@ -230,11 +231,10 @@ namespace Orleans.Providers.Streams.Generator
         /// <param name="messages"></param>
         public void AddToCache(IList<IBatchContainer> messages)
         {
-            DateTime dequeueTimeUtc = DateTime.UtcNow;
-            foreach (IBatchContainer container in messages)
-            {
-                cache.Add(container as GeneratedBatchContainer, dequeueTimeUtc);
-            }
+            List<GeneratedBatchContainer> generatedMessages = messages
+                .Cast<GeneratedBatchContainer>()
+                .ToList();
+            cache.Add(generatedMessages, DateTime.UtcNow);
         }
 
         /// <summary>

--- a/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
+++ b/src/OrleansProviders/Streams/Generator/GeneratorPooledCache.cs
@@ -25,7 +25,7 @@ namespace Orleans.Providers.Streams.Generator
         /// <param name="logger"></param>
         /// <param name="serializationManager"></param>
         /// <param name="cacheMonitor"></param>
-        /// <param name="monitorWriteInterval"></param>
+        /// <param name="monitorWriteInterval">monitor write interval.  Only triggered for active caches.</param>
         public GeneratorPooledCache(IObjectPool<FixedSizeBuffer> bufferPool, Logger logger, SerializationManager serializationManager, ICacheMonitor cacheMonitor, TimeSpan? monitorWriteInterval)
         {
             var dataAdapter = new CacheDataAdapter(bufferPool, serializationManager);

--- a/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
@@ -219,12 +219,11 @@ namespace Orleans.Providers
         /// <param name="messages"></param>
         public void AddToCache(IList<IBatchContainer> messages)
         {
-            DateTime dequeueTimeUtc = DateTime.UtcNow;
-            foreach (IBatchContainer container in messages)
-            {
-                MemoryBatchContainer<TSerializer> memoryBatchContainer = (MemoryBatchContainer<TSerializer>) container;
-                cache.Add(memoryBatchContainer.MessageData, dequeueTimeUtc);
-            }
+            List<MemoryMessageData> memoryMessages = messages
+                .Cast<MemoryBatchContainer<TSerializer>>()
+                .Select(container => container.MessageData)
+                .ToList();
+            cache.Add(memoryMessages, DateTime.UtcNow);
         }
 
         /// <summary>

--- a/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
+++ b/src/OrleansProviders/Streams/Memory/MemoryPooledCache.cs
@@ -25,7 +25,7 @@ namespace Orleans.Providers
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="cacheMonitor"></param>
-        /// <param name="monitorWriteInterval"></param>
+        /// <param name="monitorWriteInterval">monitor write interval.  Only triggered for active caches.</param>
         public MemoryPooledCache(IObjectPool<FixedSizeBuffer> bufferPool, TimePurgePredicate purgePredicate, Logger logger, TSerializer serializer, ICacheMonitor cacheMonitor, TimeSpan? monitorWriteInterval)
         {
             var dataAdapter = new CacheDataAdapter(bufferPool, serializer);

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubCacheEvictionStrategy.cs
@@ -15,9 +15,9 @@ namespace Orleans.ServiceBus.Providers
         /// Constructor
         /// </summary>
         /// <param name="logger"></param>
-        /// <param name="cacheMonitor"></param>
-        /// <param name="monitorWriteInterval"></param>
         /// <param name="timePurage"></param>
+        /// <param name="cacheMonitor"></param>
+        /// <param name="monitorWriteInterval">monitor write interval.  Only triggered for active caches.</param>
         public EventHubCacheEvictionStrategy(Logger logger, TimePurgePredicate timePurage, ICacheMonitor cacheMonitor, TimeSpan? monitorWriteInterval)
             : base(logger.GetLogger(LogName), timePurage, cacheMonitor, monitorWriteInterval)
         {

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -125,16 +125,6 @@ namespace Orleans.ServiceBus.Providers
         }
 
         /// <summary>
-        /// Add an Eventhub EventData to the cache
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="dequeueTimeUtc"></param>
-        /// <returns></returns>
-        public StreamPosition Add(EventData message, DateTime dequeueTimeUtc)
-        {
-            return cache.Add(message, dequeueTimeUtc);
-        }
-        /// <summary>
         /// Add a list of EventHub EventData to the cache.
         /// </summary>
         /// <param name="messages"></param>

--- a/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/OrleansServiceBus/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -20,14 +20,6 @@ namespace Orleans.ServiceBus.Providers
         List<StreamPosition> Add(List<EventData> message, DateTime dequeueTimeUtc);
 
         /// <summary>
-        /// Add an EventHub EventData to the cache.
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="dequeueTimeUtc"></param>
-        /// <returns></returns>
-        StreamPosition Add(EventData message, DateTime dequeueTimeUtc);
-
-        /// <summary>
         /// Get a cursor into the cache to read events from a stream.
         /// </summary>
         /// <param name="streamIdentity"></param>

--- a/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/ServiceBus.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -223,25 +223,28 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             }
             return itemCount;
         }
+
         private async Task AddDataIntoCache(EventHubQueueCacheForTesting cache, int count)
         {
             await Task.Delay(10);
-            int sequenceNumber = 0;
-            while (count > 0)
-            {
-                count--;
-                //just to make compiler happy
-                byte[] ignore = { 12, 23 };
-                var eventData = new EventData(ignore);
-                DateTime now = DateTime.UtcNow;
-                var offSet = Guid.NewGuid().ToString() + now.ToString();
-                eventData.SetOffset(offSet);
-                //set sequence number
-                eventData.SetSequenceNumber(sequenceNumber++);
-                //set enqueue time
-                eventData.SetEnqueuedTimeUtc(now);
-                cache.Add(eventData, DateTime.UtcNow);
-            }
+            List<EventData> messages = Enumerable.Range(0, count)
+                .Select(i => MakeEventData(i))
+                .ToList();
+            cache.Add(messages, DateTime.UtcNow);
+        }
+
+        private EventData MakeEventData(long sequenceNumber)
+        {
+            byte[] ignore = { 12, 23 };
+            var eventData = new EventData(ignore);
+            DateTime now = DateTime.UtcNow;
+            var offSet = Guid.NewGuid().ToString() + now.ToString();
+            eventData.SetOffset(offSet);
+            //set sequence number
+            eventData.SetSequenceNumber(sequenceNumber);
+            //set enqueue time
+            eventData.SetEnqueuedTimeUtc(now);
+            return eventData;
         }
 
         private NodeConfiguration GetNodeConfiguration()

--- a/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/TesterInternal/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -286,7 +286,7 @@ namespace UnitTests.OrleansRuntime.Streams
                     SequenceNumber = sequenceNumber + i
                 })
                 .ToList();
-                cache.Add(messages, DateTime.UtcNow);
+                cache.Add(moreMessages, DateTime.UtcNow);
                 sequenceNumber += MessagesPerBuffer;
 
                 // walk all the events in the stream using the cursor


### PR DESCRIPTION
Problems:
- Monitoring for message caches used timers which were not being cleaned up when caches were no longer in use.  This lead to duplicate monitoring calls on disposed caches.
- Caches not disposed, but not active, continue to periodically log state metrics.

Fix
- Clean up caches correctly on receiver shutdown and reinitialize (due to failure).
- No longer rely on timers to log periodically, instead allow activity to drive periotic metrics logging.  This removes the need to dispose of timers, and eliminates state metrics from inactive caches.