### PR TITLE
Service Fabric: Async shutdown support for CloseAsync

### DIFF
--- a/src/Orleans.Membership.ServiceFabric/OrleansCommunicationListener.cs
+++ b/src/Orleans.Membership.ServiceFabric/OrleansCommunicationListener.cs
@@ -118,8 +118,7 @@ namespace Microsoft.Orleans.ServiceFabric
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>
         public Task CloseAsync(CancellationToken cancellationToken)
         {
-            this.SiloHost.Stop();
-            return Task.CompletedTask;
+            return this.SiloHost.ShutdownAsync(cancellationToken);
         }
 
         /// <summary>

--- a/src/Orleans.Membership.ServiceFabric/Utilities/ISiloHost.cs
+++ b/src/Orleans.Membership.ServiceFabric/Utilities/ISiloHost.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Microsoft.Orleans.ServiceFabric.Utilities
 {
     using System;
@@ -25,5 +28,10 @@ namespace Microsoft.Orleans.ServiceFabric.Utilities
         /// Stops the silo.
         /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Shuts down the silo (async).
+        /// </summary>
+        Task ShutdownAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Orleans.Membership.ServiceFabric/Utilities/SiloHostWrapper.cs
+++ b/src/Orleans.Membership.ServiceFabric/Utilities/SiloHostWrapper.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Orleans.ServiceFabric.Utilities
@@ -23,6 +26,21 @@ namespace Microsoft.Orleans.ServiceFabric.Utilities
             try
             {
                 this.host?.StopOrleansSilo();
+            }
+            catch
+            {
+                // Ignore.
+            }
+
+            this.host?.UnInitializeOrleansSilo();
+        }
+
+        public async Task ShutdownAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (this.host != null)
+                    await this.host.ShutdownOrleansSiloAsync(cancellationToken);
             }
             catch
             {


### PR DESCRIPTION
This is my suggestion to fix two things

1) Service Fabric CloseAsync expects us to wait async for shutdown so we don't block. I added async shutdown code paths, using a thread to do the actual shutdown, and waiting for the terminated wait event to fire. I picked thread here because that's what the other, existing event triggered background shutdown seemed to be doing as well.

2) Service Fabric integration should in my opinion call shutdown instead of stop on the silo, so that OnDeactivateAsync for grains gets called when SF moves/scales/messes with the silo service in general.