### PR TITLE
Implement IKeyedServiceCollection in StreamProviderManager and remove it from GrainRuntime

### DIFF
--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -173,18 +173,12 @@ namespace Orleans
             return Runtime.ReminderRegistry.GetReminders();
         }
 
-        protected virtual IEnumerable<IStreamProvider> GetStreamProviders()
-        {
-            EnsureRuntime();
-            return Runtime.StreamProviderManager.GetStreamProviders();
-        }
-
         protected virtual IStreamProvider GetStreamProvider(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentNullException("name");
             EnsureRuntime();
-            return Runtime.StreamProviderManager.GetProvider(name) as IStreamProvider;
+            return this.ServiceProvider.GetServiceByName<IStreamProvider>(name);
         }
 
         /// <summary>

--- a/src/Orleans/Runtime/IGrainRuntime.cs
+++ b/src/Orleans/Runtime/IGrainRuntime.cs
@@ -31,8 +31,6 @@ namespace Orleans.Runtime
 
         IReminderRegistry ReminderRegistry { get; }
 
-        IStreamProviderManager StreamProviderManager { get; }
-
         IServiceProvider ServiceProvider { get; }
 
         //TODO: Mark it as [Obsolete] after all runtime has migrated

--- a/src/Orleans/Streams/Providers/StreamProviderManager.cs
+++ b/src/Orleans/Streams/Providers/StreamProviderManager.cs
@@ -5,10 +5,11 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Providers;
 using Orleans.Runtime.Configuration;
+using Orleans.Runtime;
 
 namespace Orleans.Streams
 {
-    internal class StreamProviderManager : IStreamProviderManager
+    internal class StreamProviderManager : IStreamProviderManager, IKeyedServiceCollection<string, IStreamProvider>
     {
         private ProviderLoader<IStreamProviderImpl> appStreamProviders;
         public StreamProviderManager(LoadedProviderTypeLoaders loadedProviderTypeLoaders, ILoggerFactory loggerFactory)
@@ -89,6 +90,11 @@ namespace Orleans.Streams
         public IProvider GetProvider(string name)
         {
             return appStreamProviders.GetProvider(name);
+        }
+
+        public IStreamProvider GetService(IServiceProvider services, string key)
+        {
+            return GetProvider(key) as IStreamProvider;
         }
     }
 }

--- a/src/OrleansRuntime/Core/GrainRuntime.cs
+++ b/src/OrleansRuntime/Core/GrainRuntime.cs
@@ -16,7 +16,6 @@ namespace Orleans.Runtime
             IGrainFactory grainFactory,
             ITimerRegistry timerRegistry,
             IReminderRegistry reminderRegistry,
-            IStreamProviderManager streamProviderManager,
             IServiceProvider serviceProvider,
             ISiloRuntimeClient runtimeClient,
             ILoggerFactory loggerFactory)
@@ -28,7 +27,6 @@ namespace Orleans.Runtime
             GrainFactory = grainFactory;
             TimerRegistry = timerRegistry;
             ReminderRegistry = reminderRegistry;
-            StreamProviderManager = streamProviderManager;
             ServiceProvider = serviceProvider;
             this.loggerFactory = loggerFactory;
         }
@@ -44,8 +42,6 @@ namespace Orleans.Runtime
         public ITimerRegistry TimerRegistry { get; }
         
         public IReminderRegistry ReminderRegistry { get; }
-        
-        public IStreamProviderManager StreamProviderManager { get; }
 
         public IServiceProvider ServiceProvider { get; }
 

--- a/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
+++ b/src/OrleansRuntime/Hosting/DefaultSiloServices.cs
@@ -111,7 +111,9 @@ namespace Orleans.Hosting
             services.TryAddSingleton<SerializationManager>();
             services.TryAddSingleton<ITimerRegistry, TimerRegistry>();
             services.TryAddSingleton<IReminderRegistry, ReminderRegistry>();
-            services.TryAddSingleton<IStreamProviderManager, StreamProviderManager>();
+            services.TryAddSingleton<StreamProviderManager>();
+            services.AddFromExisting<IStreamProviderManager, StreamProviderManager>();
+            services.TryAddFromExisting<IKeyedServiceCollection<string, IStreamProvider>, StreamProviderManager>(); // as named services
             services.AddFromExisting<IProviderManager, IStreamProviderManager>();
             services.TryAddSingleton<GrainRuntime>();
             services.TryAddSingleton<IGrainRuntime, GrainRuntime>();

--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -771,7 +771,7 @@ namespace Orleans.Runtime
                 // 9:
                 SafeExecute(() =>
                 {                
-                    var siloStreamProviderManager = (StreamProviderManager) runtimeClient.CurrentStreamProviderManager;
+                    var siloStreamProviderManager = (StreamProviderManager) StreamProviderManager;
                     scheduler.QueueTask(() => siloStreamProviderManager.CloseProviders(), providerManagerSystemTarget.SchedulingContext)
                             .WaitWithThrow(initTimeout);
                 });

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -685,7 +685,7 @@ namespace UnitTests.SchedulerTests
             {
                 SiloAddress = SiloAddressUtils.NewLocalSiloAddress(23)
             };
-            var grain = NonReentrentStressGrainWithoutState.Create(grainId, new GrainRuntime(new GlobalConfiguration(), silo, null, null, null, null, null, null, NullLoggerFactory.Instance));
+            var grain = NonReentrentStressGrainWithoutState.Create(grainId, new GrainRuntime(new GlobalConfiguration(), silo, null, null, null, null, null, NullLoggerFactory.Instance));
             await grain.OnActivateAsync();
 
             Task wrapped = null;

--- a/test/TestInternalGrains/StreamingGrain.cs
+++ b/test/TestInternalGrains/StreamingGrain.cs
@@ -898,7 +898,8 @@ namespace UnitTests.Grains
             _observers = new Dictionary<string, IConsumerObserver>();
             // discuss: Note that we need to know the provider that will be used in advance. I think it would be beneficial if we specified the provider as an argument to ImplicitConsumerActivationAttribute.
 
-            var activeStreamProviders = Runtime.StreamProviderManager.GetStreamProviders().Select(x => x.Name).ToList();
+            var providerManager = (StreamProviderManager) Runtime.ServiceProvider.GetService(typeof(StreamProviderManager));
+            var activeStreamProviders = providerManager.GetStreamProviders().Select(x => x.Name).ToList();
             await Task.WhenAll(activeStreamProviders.Select(stream => BecomeConsumer(this.GetPrimaryKey(), stream, "TestNamespace1")));
         }
 


### PR DESCRIPTION
`IStreamProviderManager` is depending on too many elements, so we don't want to pull it into Abstraction.

The modification proposed here is to use `IKeyedServiceCollection , like it is done for the `StorageProviderManager`.