### PR TITLE
[Abstractions] Remove dependency of IStorageProvider in Grain<T>

### DIFF
--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -328,20 +328,20 @@ namespace Orleans
         {
             if (ct.IsCancellationRequested)
                 return;
-            IStorageProvider storageProvider = this.GetStorageProvider(this.ServiceProvider);
-            string grainTypeName = this.GetType().FullName;
-            this.storage = new StateStorageBridge<TGrainState>(grainTypeName, this.GrainReference, storageProvider);
+            this.storage = this.Runtime.GetStateStorageBridge(this);
             Stopwatch sw = Stopwatch.StartNew();
             try
             {
                 await this.ReadStateAsync();
                 sw.Stop();
-                StorageStatisticsGroup.OnStorageActivate(grainTypeName, sw.Elapsed);
+                // TODO: find a way to reenable StorageStatisticsGroup here
+                //StorageStatisticsGroup.OnStorageActivate(grainTypeName, sw.Elapsed);
             }
             catch (Exception)
             {
                 sw.Stop();
-                StorageStatisticsGroup.OnStorageActivateError(grainTypeName);
+                // TODO: find a way to reenable StorageStatisticsGroup here
+                //StorageStatisticsGroup.OnStorageActivateError(grainTypeName);
                 throw;
             }
         }

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -328,7 +328,7 @@ namespace Orleans
         {
             if (ct.IsCancellationRequested)
                 return;
-            this.storage = this.Runtime.GetStateStorageBridge<TGrainState>(this);
+            this.storage = this.Runtime.GetStorage<TGrainState>(this);
             Stopwatch sw = Stopwatch.StartNew();
             try
             {

--- a/src/Orleans/Core/Grain.cs
+++ b/src/Orleans/Core/Grain.cs
@@ -328,7 +328,7 @@ namespace Orleans
         {
             if (ct.IsCancellationRequested)
                 return;
-            this.storage = this.Runtime.GetStateStorageBridge(this);
+            this.storage = this.Runtime.GetStateStorageBridge<TGrainState>(this);
             Stopwatch sw = Stopwatch.StartNew();
             try
             {

--- a/src/Orleans/Runtime/IGrainRuntime.cs
+++ b/src/Orleans/Runtime/IGrainRuntime.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Orleans.Core;
 using Orleans.Streams;
 using Orleans.Timers;
 
@@ -41,5 +42,7 @@ namespace Orleans.Runtime
         void DeactivateOnIdle(Grain grain);
 
         void DelayDeactivation(Grain grain, TimeSpan timeSpan);
+
+        IStorage<TGrainState> GetStateStorageBridge<TGrainState>(Grain<TGrainState> grain) where TGrainState : new();
     }
 }

--- a/src/Orleans/Runtime/IGrainRuntime.cs
+++ b/src/Orleans/Runtime/IGrainRuntime.cs
@@ -43,6 +43,6 @@ namespace Orleans.Runtime
 
         void DelayDeactivation(Grain grain, TimeSpan timeSpan);
 
-        IStorage<TGrainState> GetStateStorageBridge<TGrainState>(Grain<TGrainState> grain) where TGrainState : new();
+        IStorage<TGrainState> GetStateStorageBridge<TGrainState>(Grain grain) where TGrainState : new();
     }
 }

--- a/src/Orleans/Runtime/IGrainRuntime.cs
+++ b/src/Orleans/Runtime/IGrainRuntime.cs
@@ -43,6 +43,6 @@ namespace Orleans.Runtime
 
         void DelayDeactivation(Grain grain, TimeSpan timeSpan);
 
-        IStorage<TGrainState> GetStateStorageBridge<TGrainState>(Grain grain) where TGrainState : new();
+        IStorage<TGrainState> GetStorage<TGrainState>(Grain grain) where TGrainState : new();
     }
 }

--- a/src/OrleansRuntime/Core/GrainRuntime.cs
+++ b/src/OrleansRuntime/Core/GrainRuntime.cs
@@ -66,7 +66,7 @@ namespace Orleans.Runtime
             grain.Data.DelayDeactivation(timeSpan);
         }
 
-        public IStorage<TGrainState> GetStateStorageBridge<TGrainState>(Grain<TGrainState> grain) where TGrainState : new()
+        public IStorage<TGrainState> GetStateStorageBridge<TGrainState>(Grain grain) where TGrainState : new()
         {
             IStorageProvider storageProvider = grain.GetStorageProvider(ServiceProvider);
             string grainTypeName = grain.GetType().FullName;

--- a/src/OrleansRuntime/Core/GrainRuntime.cs
+++ b/src/OrleansRuntime/Core/GrainRuntime.cs
@@ -66,7 +66,7 @@ namespace Orleans.Runtime
             grain.Data.DelayDeactivation(timeSpan);
         }
 
-        public IStorage<TGrainState> GetStateStorageBridge<TGrainState>(Grain grain) where TGrainState : new()
+        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain) where TGrainState : new()
         {
             IStorageProvider storageProvider = grain.GetStorageProvider(ServiceProvider);
             string grainTypeName = grain.GetType().FullName;

--- a/src/OrleansRuntime/Core/GrainRuntime.cs
+++ b/src/OrleansRuntime/Core/GrainRuntime.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
+using Orleans.Core;
 using Orleans.Runtime.Configuration;
 using Orleans.Streams;
 using Orleans.Timers;
+using Orleans.Storage;
 
 namespace Orleans.Runtime
 {
@@ -62,6 +64,13 @@ namespace Orleans.Runtime
         public void DelayDeactivation(Grain grain, TimeSpan timeSpan)
         {
             grain.Data.DelayDeactivation(timeSpan);
+        }
+
+        public IStorage<TGrainState> GetStateStorageBridge<TGrainState>(Grain<TGrainState> grain) where TGrainState : new()
+        {
+            IStorageProvider storageProvider = grain.GetStorageProvider(ServiceProvider);
+            string grainTypeName = this.GetType().FullName;
+            return new StateStorageBridge<TGrainState>(grainTypeName, grain.GrainReference, storageProvider);
         }
     }
 }

--- a/src/OrleansRuntime/Core/GrainRuntime.cs
+++ b/src/OrleansRuntime/Core/GrainRuntime.cs
@@ -69,7 +69,7 @@ namespace Orleans.Runtime
         public IStorage<TGrainState> GetStateStorageBridge<TGrainState>(Grain<TGrainState> grain) where TGrainState : new()
         {
             IStorageProvider storageProvider = grain.GetStorageProvider(ServiceProvider);
-            string grainTypeName = this.GetType().FullName;
+            string grainTypeName = grain.GetType().FullName;
             return new StateStorageBridge<TGrainState>(grainTypeName, grain.GrainReference, storageProvider);
         }
     }


### PR DESCRIPTION
Move logic to construct the storage bridge in the `GrainRuntime` to remove some dependencies in `Grain<T>`.

I chose to use `GrainRuntime` since it was already there. But if the opposition is strong, I could introduce a new factory for that.