### PR TITLE
Remove runtime codegen NuGet package.

### DIFF
--- a/src/Orleans.CodeGeneration/Orleans.CodeGeneration.csproj
+++ b/src/Orleans.CodeGeneration/Orleans.CodeGeneration.csproj
@@ -1,13 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Microsoft.Orleans.OrleansCodeGenerator</PackageId>
-    <Title>Microsoft Orleans Code Generation</Title>
-    <Description>Runtime and compile-time code generation support for Microsoft Orleans.</Description>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <AssemblyName>Orleans.CodeGeneration</AssemblyName>
     <RootNamespace>OrleansCodeGenerator</RootNamespace>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We don't support runtime code generation any longer, so there's no use having this NuGet package for the time being.

In the future, we may add another NuGet package which adds a form of runtime codegen which works with the `ApplicationPartManager` and runs only once, before client/silo initialization begins.