### PR TITLE
All_Small non-deterministic test failure fix

### DIFF
--- a/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
+++ b/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
@@ -38,7 +38,7 @@ namespace Tests.GeoClusterTests
             numGrains = 600;
             await RunWithTimeout("IndependentCreation", 5000, IndependentCreation);
             await RunWithTimeout("CreationRace", 10000, CreationRace);
-            await RunWithTimeout("ConflictResolution", 20000, ConflictResolution);
+            await RunWithTimeout("ConflictResolution", 25000, ConflictResolution);
         }
 
         /// <summary>


### PR DESCRIPTION
All_Small test is time sensitive, timeout raised for the conflict resolution part to make it pass on VSO