### PR TITLE
Add build dependency to Orleans.CodeGeneration.Build.Bootstrap for codegen-enabled projects

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,17 @@
 <Project Condition=" '$(OrleansBuildTimeCodeGen)' == 'true' ">
   <!-- Begin Orleans: Without these lines the project won't build properly -->
   <!-- Set path to code generator -->
+  <ItemGroup>
+    <ProjectReference Include="$(SourceRoot)/src/BootstrapBuild/Orleans.CodeGeneration.Build/Orleans.CodeGeneration.Build.Bootstrap.csproj" Condition=" '$(OrleansBuildTimeCodeGen)' == 'true' ">
+      <Project>{F7D70028-7E3B-48E3-92B9-DB889AE5ABD1}</Project>
+      <Name>Orleans.CodeGeneration.Build.Bootstrap</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <!-- Workaround. See: https://github.com/dotnet/sdk/issues/939#issuecomment-284641613 -->
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <UndefineProperties>TargetFramework</UndefineProperties>
+      <!-- /Workaround -->
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(OrleansBuildTimeCodeGen)' == 'true' ">
     <OrleansCodeGeneratorAssembly>$(SourceRoot)Bootstrap/$(Configuration)/Orleans.CodeGeneration.Build.exe</OrleansCodeGeneratorAssembly>
   </PropertyGroup>

--- a/Orleans.sln
+++ b/Orleans.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4CD3AA9E-D937-48CA-BB6C-158E12257D23}"
 EndProject
@@ -55,9 +55,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestInterfaces", "test\TestInterfaces\TestInterfaces.csproj", "{2D1FDB2E-9E12-4453-BFF7-7F726D754791}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestGrainInterfaces", "test\TestGrainInterfaces\TestGrainInterfaces.csproj", "{CC76035A-056B-43F3-8FFB-92DE66A19305}"
-	ProjectSection(ProjectDependencies) = postProject
-		{F7D70028-7E3B-48E3-92B9-DB889AE5ABD1} = {F7D70028-7E3B-48E3-92B9-DB889AE5ABD1}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestGrains", "test\TestGrains\TestGrains.csproj", "{B84A0977-EF3A-44B0-B4EF-CE68B387AE63}"
 EndProject

--- a/Orleans.sln
+++ b/Orleans.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4CD3AA9E-D937-48CA-BB6C-158E12257D23}"
 EndProject
@@ -55,6 +55,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestInterfaces", "test\TestInterfaces\TestInterfaces.csproj", "{2D1FDB2E-9E12-4453-BFF7-7F726D754791}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestGrainInterfaces", "test\TestGrainInterfaces\TestGrainInterfaces.csproj", "{CC76035A-056B-43F3-8FFB-92DE66A19305}"
+	ProjectSection(ProjectDependencies) = postProject
+		{F7D70028-7E3B-48E3-92B9-DB889AE5ABD1} = {F7D70028-7E3B-48E3-92B9-DB889AE5ABD1}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestGrains", "test\TestGrains\TestGrains.csproj", "{B84A0977-EF3A-44B0-B4EF-CE68B387AE63}"
 EndProject


### PR DESCRIPTION
Since we now allow grain projects to only reference Core.Abstractions (https://github.com/dotnet/orleans/pull/3548), the codegenator is not always pre-built be the time we want to run codegen on the project.

This fixes the failure we are sometimes seeing in CI of this nature:
```
error MSB3073: The command ""D:\j\workspace\functional_pr---83d31c72\Bootstrap/Release/Orleans.CodeGeneration.Build.exe" "@obj\Release\net461\win10-x64\codegen\TestGrainInterfaces.orleans.g.args.txt"" exited with code 9009. [D:\j\workspace\functional_pr---83d31c72\test\TestGrainInterfaces\TestGrainInterfaces.csproj]
```