### PR TITLE
Add SourceLink support for easier debugging of nuget packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
     <RepositoryUrl>https://github.com/dotnet/Orleans</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
+    <IncludeSource>false</IncludeSource>
   </PropertyGroup>
 
   <!-- Common compile parameters -->
@@ -93,6 +93,9 @@
     <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
     <XunitSkippableFactVersion>1.3.3</XunitSkippableFactVersion>
     <xUnitVersion>2.3.0</xUnitVersion>
+
+    <!-- Tooling related packages -->
+    <SourceLinkVersion>2.5.0</SourceLinkVersion>
   </PropertyGroup>
 
   <!-- Versioning properties -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
     <RepositoryUrl>https://github.com/dotnet/Orleans</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>false</IncludeSource>
+    <IncludeSource>true</IncludeSource>
   </PropertyGroup>
 
   <!-- Common compile parameters -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,4 +8,10 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
+
+  <!-- Configure source link: https://github.com/ctaggart/SourceLink -->
+  <PropertyGroup>
+    <SourceLinkCreate>true</SourceLinkCreate>
+    <SourceLinkOriginUrl>https://github.com/dotnet/orleans</SourceLinkOriginUrl>
+  </PropertyGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,7 +5,7 @@
 
   <Import Project="$(_ParentDirectoryBuildTargetsPath)" Condition="Exists('$(_ParentDirectoryBuildTargetsPath)')"/>
 
-  <ItemGroup Condition="'$(IsPackable)'=='true' and '$(SourceLinkCreate)'=='true' and $(IncludeBuildOutput)'=='true'">
+  <ItemGroup Condition="'$(IsPackable)'=='true' and '$(SourceLinkCreate)'=='true' and '$(IncludeBuildOutput)'=='true'">
     <PackageReference Include="SourceLink.Create.CommandLine" Version="$(SourceLinkVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <_ParentDirectoryBuildTargetsPath Condition="'$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('..', '$(_DirectoryBuildTargetsFile)'))</_ParentDirectoryBuildTargetsPath>
+  </PropertyGroup>
+
+  <Import Project="$(_ParentDirectoryBuildTargetsPath)" Condition="Exists('$(_ParentDirectoryBuildTargetsPath)')"/>
+
+  <ItemGroup Condition="'$(IsPackable)'=='true' and '$(SourceLinkCreate)'=='true' and $(IncludeBuildOutput)'=='true'">
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="$(SourceLinkVersion)" PrivateAssets="all" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR enables the [SourceLink](https://github.com/ctaggart/SourceLink) feature or Portable PDBs, which enables the debugging of Orleans code from consumed NuGet packages.

A blog about source link debugging configuration for AspNetCore 2.0 can be found [here](https://www.stevejgordon.co.uk/debugging-asp-net-core-2-source).