### PR TITLE
Service Fabric: ensure all silos reach a terminal state.

### DIFF
--- a/src/Orleans.Membership.ServiceFabric/FabricMembershipOracle.cs
+++ b/src/Orleans.Membership.ServiceFabric/FabricMembershipOracle.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Orleans.ServiceFabric
         private readonly Dictionary<SiloAddress, SiloEntry> silos = new Dictionary<SiloAddress, SiloEntry>();
         private readonly ConcurrentDictionary<ISiloStatusListener, ISiloStatusListener> subscribers =
             new ConcurrentDictionary<ISiloStatusListener, ISiloStatusListener>();
-
         private readonly AutoResetEvent notificationEvent = new AutoResetEvent(false);
         private readonly BlockingCollection<StatusChangeNotification> notifications = new BlockingCollection<StatusChangeNotification>();
         private readonly TimeSpan refreshPeriod = TimeSpan.FromSeconds(5);
@@ -27,6 +26,7 @@ namespace Microsoft.Orleans.ServiceFabric
         private readonly GlobalConfiguration globalConfig;
         private readonly IFabricServiceSiloResolver fabricServiceSiloResolver;
         private readonly ILogger log;
+        private readonly UnknownSiloMonitor unknownSiloMonitor;
 
         // Cached collection of active silos.
         private volatile Dictionary<SiloAddress, SiloStatus> activeSilosCache;
@@ -47,48 +47,38 @@ namespace Microsoft.Orleans.ServiceFabric
         /// <param name="globalConfig">The cluster configuration.</param>
         /// <param name="fabricServiceSiloResolver">The service resolver which this instance will use.</param>
         /// <param name="logger">The logger.</param>
+        /// <param name="unknownSiloMonitor">The unknown silo monitor.</param>
         public FabricMembershipOracle(
             ILocalSiloDetails localSiloDetails,
             GlobalConfiguration globalConfig,
             IFabricServiceSiloResolver fabricServiceSiloResolver,
-            ILogger<FabricMembershipOracle> logger)
+            ILogger<FabricMembershipOracle> logger,
+            UnknownSiloMonitor unknownSiloMonitor)
         {
             this.log = logger;
             this.localSiloDetails = localSiloDetails;
             this.globalConfig = globalConfig;
             this.fabricServiceSiloResolver = fabricServiceSiloResolver;
+            this.unknownSiloMonitor = unknownSiloMonitor;
             this.silos[this.SiloAddress] = new SiloEntry(SiloStatus.Created, this.SiloName);
         }
 
-        /// <summary>
-        /// Status of this silo.
-        /// </summary>
+        /// <inheritdoc />
         public SiloStatus CurrentStatus => this.GetApproximateSiloStatus(this.SiloAddress);
 
-        /// <summary>
-        /// Address of this silo.
-        /// </summary>
+        /// <inheritdoc />
         public SiloAddress SiloAddress => this.localSiloDetails.SiloAddress;
 
-        /// <summary>
-        /// Name of this silo.
-        /// </summary>
+        /// <inheritdoc />
         public string SiloName => this.localSiloDetails.Name;
 
-        /// <summary>
-        /// Returns a value indicating the health of this instance.
-        /// </summary>
-        /// <param name="lastCheckTime">The last time which this participant's health was checked.</param>
-        /// <returns><see langword="true"/> if the participant is healthy, <see langword="false"/> otherwise.</returns>
+        /// <inheritdoc />
         public bool CheckHealth(DateTime lastCheckTime)
         {
             return this.lastRefreshTime.Add(this.refreshPeriod + this.refreshPeriod) > DateTime.UtcNow;
         }
 
-        /// <summary>
-        /// Get a list of silos that are designated to function as gateways.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc />
         public IReadOnlyList<SiloAddress> GetApproximateMultiClusterGateways()
         {
             var result = this.multiClusterSilosCache;
@@ -117,28 +107,20 @@ namespace Microsoft.Orleans.ServiceFabric
             return result;
         }
 
-        /// <summary>
-        /// Get the status of a given silo. 
-        /// This method returns an approximate view on the status of a given silo. 
-        /// In particular, this oracle may think the given silo is alive, while it may already have failed.
-        /// If this oracle thinks the given silo is dead, it has been authoritatively told so by ISiloDirectory.
-        /// </summary>
-        /// <param name="siloAddress">A silo whose status we are interested in.</param>
-        /// <returns>The status of a given silo.</returns>
+        /// <inheritdoc />
         public SiloStatus GetApproximateSiloStatus(SiloAddress siloAddress)
         {
-            SiloStatus status;
             var allSilos = this.GetApproximateSiloStatuses(onlyActive: false);
-            var exists = allSilos.TryGetValue(siloAddress, out status);
+            var exists = allSilos.TryGetValue(siloAddress, out var status);
+            if (!exists)
+            {
+                this.unknownSiloMonitor.ReportUnknownSilo(siloAddress);
+            }
+
             return exists ? status : SiloStatus.None;
         }
 
-        /// <summary>
-        /// Get the statuses of all silo. 
-        /// This method returns an approximate view on the statuses of all silo.
-        /// </summary>
-        /// <param name="onlyActive">Include only silo who are currently considered to be active. If false, include all.</param>
-        /// <returns>A list of silo statuses.</returns>
+        /// <inheritdoc />
         public Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false)
         {
             if (onlyActive)
@@ -170,10 +152,7 @@ namespace Microsoft.Orleans.ServiceFabric
             }
         }
 
-        /// <summary>
-        /// Determine if the current silo is dead.
-        /// </summary>
-        /// <returns>The silo so ask about.</returns>
+        /// <inheritdoc />
         public bool IsDeadSilo(SiloAddress address)
         {
             if (address.Equals(this.SiloAddress)) return false;
@@ -181,21 +160,16 @@ namespace Microsoft.Orleans.ServiceFabric
             return status == SiloStatus.Dead;
         }
 
-        /// <summary>
-        /// Determine if the current silo is valid for creating new activations on or for directory lookups.
-        /// </summary>
-        /// <returns>The silo so ask about.</returns>
+        /// <inheritdoc />
         public bool IsFunctionalDirectory(SiloAddress siloAddress)
         {
             if (siloAddress.Equals(this.SiloAddress)) return true;
 
             var status = this.GetApproximateSiloStatus(siloAddress);
-            return !status.IsTerminating();
+            return !status.IsUnavailable();
         }
 
-        /// <summary>
-        /// Start this oracle. Will register this silo in the SiloDirectory with SiloStatus.Starting status.
-        /// </summary>
+        /// <inheritdoc />
         public Task Start()
         {
             // Start processing notifications.
@@ -203,7 +177,7 @@ namespace Microsoft.Orleans.ServiceFabric
                 this.ProcessNotifications,
                 CancellationToken.None,
                 TaskCreationOptions.None,
-                TaskScheduler.Current);
+                TaskScheduler.Current).Ignore();
 
             this.timer = new Timer(
                 self => ((FabricMembershipOracle)self).RefreshAsync().Ignore(),
@@ -213,39 +187,32 @@ namespace Microsoft.Orleans.ServiceFabric
             this.fabricServiceSiloResolver.Subscribe(this);
             this.RefreshAsync().Ignore();
             this.UpdateStatus(SiloStatus.Joining);
+            
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Turns this oracle into an Active state. Will update this silo in the SiloDirectory with SiloStatus.Active status.
-        /// </summary>
+        /// <inheritdoc />
         public Task BecomeActive()
         {
             this.UpdateStatus(SiloStatus.Active);
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// ShutDown this oracle. Will update this silo in the SiloDirectory with SiloStatus.ShuttingDown status. 
-        /// </summary>
+        /// <inheritdoc />
         public Task ShutDown()
         {
             this.UpdateStatus(SiloStatus.ShuttingDown);
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Stop this oracle. Will update this silo in the SiloDirectory with SiloStatus.Stopping status. 
-        /// </summary>
+        /// <inheritdoc />
         public Task Stop()
         {
             this.UpdateStatus(SiloStatus.Stopping);
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Completely kill this oracle. Will update this silo in the SiloDirectory with SiloStatus.Dead status. 
-        /// </summary>
+        /// <inheritdoc />
         public Task KillMyself()
         {
             this.UpdateStatus(SiloStatus.Dead);
@@ -253,46 +220,34 @@ namespace Microsoft.Orleans.ServiceFabric
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Get the name of a silo. 
-        /// Silo name is assumed to be static and does not change across restarts of the same silo.
-        /// </summary>
-        /// <param name="siloAddress">A silo whose name we are interested in.</param>
-        /// <param name="siloName">A silo name.</param>
-        /// <returns>TTrue if could return the requested name, false otherwise.</returns>
+        /// <inheritdoc />
         public bool TryGetSiloName(SiloAddress siloAddress, out string siloName)
         {
-            SiloEntry entry;
-            var result = this.silos.TryGetValue(siloAddress, out entry);
+            var result = this.silos.TryGetValue(siloAddress, out var entry);
             siloName = entry?.Name;
+            if (!result)
+            {
+                this.unknownSiloMonitor.ReportUnknownSilo(siloAddress);
+            }
+
             return result;
         }
 
-        /// <summary>
-        /// Subscribe to status events about all silos. 
-        /// </summary>
-        /// <param name="observer">An observer async interface to receive silo status notifications.</param>
-        /// <returns>bool value indicating that subscription succeeded or not.</returns>
+        /// <inheritdoc />
         public bool SubscribeToSiloStatusEvents(ISiloStatusListener observer)
         {
             this.subscribers[observer] = observer;
             return true;
         }
 
-        /// <summary>
-        /// UnSubscribe from status events about all silos. 
-        /// </summary>
-        /// <returns>bool value indicating that subscription succeeded or not.</returns>
+        /// <inheritdoc />
         public bool UnSubscribeFromSiloStatusEvents(ISiloStatusListener observer)
         {
             this.subscribers.TryRemove(observer, out observer);
             return true;
         }
 
-        /// <summary>
-        /// Notifies this instance of an update to one or more partitions.
-        /// </summary>
-        /// <param name="partitions">The updated set of partitions.</param>
+        /// <inheritdoc />
         public void OnUpdate(FabricSiloInfo[] partitions)
         {
             var hasChanges = false;
@@ -302,8 +257,7 @@ namespace Microsoft.Orleans.ServiceFabric
                 {
                     // Update the silo if it was not previously seen or if the existing entry's status
                     // does not match the updated status.
-                    SiloEntry existing;
-                    if (this.silos.TryGetValue(updatedSilo.SiloAddress, out existing))
+                    if (this.silos.TryGetValue(updatedSilo.SiloAddress, out var existing))
                     {
                         // Mark the existing silo as being refreshed.
                         existing.Refreshed = true;
@@ -319,14 +273,13 @@ namespace Microsoft.Orleans.ServiceFabric
                     {
                         // Add the new silo.
                         this.notifications.Add(new StatusChangeNotification(updatedSilo.SiloAddress, SiloStatus.Active));
-                        var siloEntry = new SiloEntry(SiloStatus.Active, updatedSilo.Name)
+                        this.silos[updatedSilo.SiloAddress] = new SiloEntry(SiloStatus.Active, updatedSilo.Name)
                         {
                             Refreshed = true
                         };
-                        this.silos[updatedSilo.SiloAddress] = siloEntry;
                         hasChanges = true;
 
-                        this.log.Info($"Silo {updatedSilo.SiloAddress} ({siloEntry.Name}) transitioned from {SiloStatus.None} to {siloEntry.Status}.");
+                        this.log.Info($"Silo {updatedSilo.SiloAddress} ({updatedSilo.Name}) transitioned from {SiloStatus.None} to {SiloStatus.Active}.");
                     }
                 }
 
@@ -349,14 +302,31 @@ namespace Microsoft.Orleans.ServiceFabric
                     // Reset the refresh flag.
                     silo.Value.Refreshed = false;
                 }
-            }
 
-            // If anything was updated, clear the cache before notifying clients.
-            if (hasChanges)
-            {
                 // Clear the caches.
                 this.ClearCaches();
 
+                // Determine dead silos which this silo has seen queries for but have never been seen in an update from Service Fabric.
+                var singleton = this.fabricServiceSiloResolver.IsSingletonPartition.HasValue && this.fabricServiceSiloResolver.IsSingletonPartition.Value;
+                foreach (var deadSilo in this.unknownSiloMonitor.DetermineDeadSilos(this.GetApproximateSiloStatuses(true), singleton))
+                {
+                    if (this.silos.TryGetValue(deadSilo, out var entry))
+                    {
+                        entry.Status = SiloStatus.Dead;
+                    }
+                    else
+                    {
+                        this.silos[deadSilo] = new SiloEntry(SiloStatus.Dead, "unknown");
+                    }
+
+                    this.notifications.Add(new StatusChangeNotification(deadSilo, SiloStatus.Dead));
+                    hasChanges = true;
+                }
+            }
+            
+            // If anything was updated, clear the cache before notifying clients.
+            if (hasChanges)
+            {
                 this.log.Info($"Current cluster members: {string.Join(", ", this.GetApproximateSiloStatuses(true))}");
 
                 // Notify all subscribers.
@@ -379,8 +349,7 @@ namespace Microsoft.Orleans.ServiceFabric
             while (!this.notifications.IsAddingCompleted)
             {
                 await this.notificationEvent.WaitAsync(TimeSpan.FromMinutes(1));
-                StatusChangeNotification notification;
-                while (this.notifications.TryTake(out notification))
+                while (this.notifications.TryTake(out var notification))
                 {
                     foreach (var subscriber in this.subscribers.Values)
                     {
@@ -445,7 +414,7 @@ namespace Microsoft.Orleans.ServiceFabric
             }
         }
 
-        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+        /// <inheritdoc />
         public void Dispose()
         {
             this.StopInternal();

--- a/src/Orleans.Membership.ServiceFabric/FabricMembershipOracle.cs
+++ b/src/Orleans.Membership.ServiceFabric/FabricMembershipOracle.cs
@@ -307,8 +307,7 @@ namespace Microsoft.Orleans.ServiceFabric
                 this.ClearCaches();
 
                 // Determine dead silos which this silo has seen queries for but have never been seen in an update from Service Fabric.
-                var singleton = this.fabricServiceSiloResolver.IsSingletonPartition.HasValue && this.fabricServiceSiloResolver.IsSingletonPartition.Value;
-                foreach (var deadSilo in this.unknownSiloMonitor.DetermineDeadSilos(this.GetApproximateSiloStatuses(true), singleton))
+                foreach (var deadSilo in this.unknownSiloMonitor.DetermineDeadSilos(this.GetApproximateSiloStatuses(true)))
                 {
                     if (this.silos.TryGetValue(deadSilo, out var entry))
                     {

--- a/src/Orleans.Membership.ServiceFabric/FabricServiceSiloResolver.cs
+++ b/src/Orleans.Membership.ServiceFabric/FabricServiceSiloResolver.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Fabric;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -47,9 +46,6 @@ namespace Microsoft.Orleans.ServiceFabric
         }
 
         /// <inheritdoc />
-        public bool? IsSingletonPartition { get; private set; }
-
-        /// <inheritdoc />
         public void Subscribe(IFabricServiceStatusListener handler)
         {
             this.subscribers.TryAdd(handler, handler);
@@ -69,7 +65,6 @@ namespace Microsoft.Orleans.ServiceFabric
             lock (this.updateLock)
             {
                 this.silos = result;
-                this.IsSingletonPartition = this.silos.FirstOrDefault()?.Partition.Kind == ServicePartitionKind.Singleton;
 
                 // Register for update notifications for each partition.
                 var oldRegistrations = this.changeHandlerRegistrations;

--- a/src/Orleans.Membership.ServiceFabric/IFabricServiceSiloResolver.cs
+++ b/src/Orleans.Membership.ServiceFabric/IFabricServiceSiloResolver.cs
@@ -5,6 +5,14 @@ namespace Microsoft.Orleans.ServiceFabric
     internal interface IFabricServiceSiloResolver
     {
         /// <summary>
+        /// Gets a value indicating whether or not this service exists in a singleton partition.
+        /// </summary>
+        /// <remarks>
+        /// If the result is null, the value is not yet determined.
+        /// </remarks>
+        bool? IsSingletonPartition { get; }
+
+        /// <summary>
         /// Subscribes the provided handler for update notifications.
         /// </summary>
         /// <param name="handler">The update notification handler.</param>

--- a/src/Orleans.Membership.ServiceFabric/IFabricServiceSiloResolver.cs
+++ b/src/Orleans.Membership.ServiceFabric/IFabricServiceSiloResolver.cs
@@ -5,14 +5,6 @@ namespace Microsoft.Orleans.ServiceFabric
     internal interface IFabricServiceSiloResolver
     {
         /// <summary>
-        /// Gets a value indicating whether or not this service exists in a singleton partition.
-        /// </summary>
-        /// <remarks>
-        /// If the result is null, the value is not yet determined.
-        /// </remarks>
-        bool? IsSingletonPartition { get; }
-
-        /// <summary>
         /// Subscribes the provided handler for update notifications.
         /// </summary>
         /// <param name="handler">The update notification handler.</param>

--- a/src/Orleans.Membership.ServiceFabric/OrleansCommunicationListener.cs
+++ b/src/Orleans.Membership.ServiceFabric/OrleansCommunicationListener.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Fabric.Description;
-using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 
 namespace Microsoft.Orleans.ServiceFabric

--- a/src/Orleans.Membership.ServiceFabric/OrleansServiceFabricExtensions.cs
+++ b/src/Orleans.Membership.ServiceFabric/OrleansServiceFabricExtensions.cs
@@ -29,22 +29,10 @@ namespace Microsoft.Orleans.ServiceFabric
             StatefulService service)
         {
             AddStandardServices(serviceCollection);
-
-            // Use Service Fabric for cluster membership.
-            serviceCollection.AddSingleton<IFabricServiceSiloResolver>(
-                sp =>
-                    new FabricServiceSiloResolver(
-                        service.Context.ServiceName,
-                        sp.GetService<IFabricQueryManager>(),
-                        sp.GetService<ILoggerFactory>()));
-            serviceCollection.AddSingleton<IMembershipOracle, FabricMembershipOracle>();
-            serviceCollection.AddSingleton<IGatewayListProvider, FabricGatewayProvider>();
-
-            serviceCollection.AddSingleton<ISiloStatusOracle>(provider => provider.GetService<IMembershipOracle>());
+            AddSiloServices(serviceCollection, service.Context);
 
             // In order to support local, replicated persistence, the state manager must be registered.
             serviceCollection.AddTransient(_ => service.StateManager);
-            serviceCollection.AddTransient<ServiceContext>(_ => service.Context);
 
             return serviceCollection;
         }
@@ -60,20 +48,7 @@ namespace Microsoft.Orleans.ServiceFabric
             StatelessService service)
         {
             AddStandardServices(serviceCollection);
-
-            // Use Service Fabric for cluster membership.
-            serviceCollection.AddSingleton<IFabricServiceSiloResolver>(
-                sp =>
-                    new FabricServiceSiloResolver(
-                        service.Context.ServiceName,
-                        sp.GetService<IFabricQueryManager>(),
-                        sp.GetService<ILoggerFactory>()));
-            serviceCollection.AddSingleton<IMembershipOracle, FabricMembershipOracle>();
-
-            serviceCollection.AddSingleton<ISiloStatusOracle>(provider => provider.GetService<IMembershipOracle>());
-
-            serviceCollection.AddSingleton<IGatewayListProvider, FabricGatewayProvider>();
-            serviceCollection.AddTransient<ServiceContext>(_ => service.Context);
+            AddSiloServices(serviceCollection, service.Context);
 
             return serviceCollection;
         }
@@ -119,12 +94,37 @@ namespace Microsoft.Orleans.ServiceFabric
             return clientBuilder;
         }
 
+        /// <summary>
+        /// Adds services which are common between silos and clients.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
         private static void AddStandardServices(IServiceCollection serviceCollection)
         {
             serviceCollection.AddSingleton<FabricClient>();
             serviceCollection.AddSingleton<CreateFabricClientDelegate>(sp => () => sp.GetRequiredService<FabricClient>());
             serviceCollection.AddSingleton<IServicePartitionResolver, ServicePartitionResolver>();
             serviceCollection.AddSingleton<IFabricQueryManager, FabricQueryManager>();
+        }
+
+        /// <summary>
+        /// Adds services which are required by Service Fabric silos.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="context">The service context.</param>
+        private static void AddSiloServices(IServiceCollection services, ServiceContext context)
+        {
+            // Use Service Fabric for cluster membership.
+            services.AddSingleton<IFabricServiceSiloResolver>(
+                sp =>
+                    new FabricServiceSiloResolver(
+                        context.ServiceName,
+                        sp.GetService<IFabricQueryManager>(),
+                        sp.GetService<ILoggerFactory>()));
+            services.AddSingleton<IMembershipOracle, FabricMembershipOracle>();
+            services.AddSingleton<IGatewayListProvider, FabricGatewayProvider>();
+            services.AddSingleton<ISiloStatusOracle>(provider => provider.GetService<IMembershipOracle>());
+            services.AddSingleton<ServiceContext>(context);
+            services.AddSingleton<UnknownSiloMonitor>();
         }
     }
 }

--- a/src/Orleans.Membership.ServiceFabric/ServiceFabricMembershipOptions.cs
+++ b/src/Orleans.Membership.ServiceFabric/ServiceFabricMembershipOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Microsoft.Orleans.ServiceFabric
+{
+    /// <summary>
+    /// Options for Service Fabric cluster membership.
+    /// </summary>
+    public class ServiceFabricMembershipOptions
+    {
+        /// <summary>
+        /// Gets or sets the period of time before unknown silos are considered dead.
+        /// </summary>
+        public TimeSpan UnknownSiloRemovalPeriod { get; set; } = TimeSpan.FromMinutes(1);
+    }
+}

--- a/src/Orleans.Membership.ServiceFabric/UnknownSiloMonitor.cs
+++ b/src/Orleans.Membership.ServiceFabric/UnknownSiloMonitor.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+
+namespace Microsoft.Orleans.ServiceFabric
+{
+    /// <summary>
+    /// Monitors cluster changes for information about silos which are defunct and have not been reported as functional by Service Fabric.
+    /// </summary>
+    internal class UnknownSiloMonitor
+    {
+        /// <summary>
+        /// Collection of unknown silos.
+        /// </summary>
+        private readonly ConcurrentDictionary<SiloAddress, DateTime> unknownSilos = new ConcurrentDictionary<SiloAddress, DateTime>();
+        private readonly ServiceFabricMembershipOptions options;
+        private readonly ILogger<UnknownSiloMonitor> log;
+
+        public UnknownSiloMonitor(IOptions<ServiceFabricMembershipOptions> options, ILogger<UnknownSiloMonitor> log)
+        {
+            this.options = options.Value;
+            this.log = log;
+        }
+
+        /// <summary>
+        /// Gets or sets the delegate used to retrieve the current time.
+        /// </summary>
+        /// <remarks>
+        /// This is exposed for testing purposes.
+        /// The accuracy of this method
+        /// </remarks>
+        internal Func<DateTime> GetDateTime { get; set; } = () => DateTime.UtcNow;
+        
+        /// <summary>
+        /// Adds an unknown silo to monitor.
+        /// </summary>
+        /// <param name="siloAddress">The silo address.</param>
+        /// <returns><see langword="true"/> if the silo was added as an unknown silo, <see langword="false"/> otherwise.</returns>
+        public void ReportUnknownSilo(SiloAddress siloAddress)
+        {
+            if (this.unknownSilos.TryAdd(siloAddress, this.GetDateTime()))
+            {
+                this.log.Info($"Recording unknown silo {siloAddress}.");
+            }
+        }
+
+        /// <summary>
+        /// Finds dead silos which were previously in an unknown state.
+        /// </summary>
+        /// <param name="allKnownSilos">The collection of all known silos, including dead silos.</param>
+        /// <param name="isSingletonPartition">Whether or not this service is running inside of a singleton partition.</param>
+        /// <returns>A collection of dead silos.</returns>
+        public IEnumerable<SiloAddress> DetermineDeadSilos(Dictionary<SiloAddress, SiloStatus> allKnownSilos, bool isSingletonPartition)
+        {
+            if (this.unknownSilos.Count == 0) return Array.Empty<SiloAddress>();
+            
+            // The latest generation for each silo endpoint.
+            var latestGenerations = new Dictionary<IPEndPoint, int>();
+
+            // All known silos can be removed from the unknown list as long as their status is valid.
+            foreach (var known in allKnownSilos)
+            {
+                if (known.Value == SiloStatus.None) continue;
+                var address = known.Key;
+                var endpoint = address.Endpoint;
+                if (!latestGenerations.TryGetValue(endpoint, out var knownGeneration) || knownGeneration < address.Generation)
+                {
+                    latestGenerations[endpoint] = address.Generation;
+                }
+                
+                // Unknown silos are not removed from the collection until they have been confirmed in the collection of known silos.
+                if (this.unknownSilos.TryRemove(address, out var _))
+                {
+                    this.log.Info($"Previously unknown silo {address} has transitioned to state {known.Value}.");
+                }
+            }
+            
+            var updates = new List<SiloAddress>();
+            foreach (var pair in this.unknownSilos)
+            {
+                var unknownSilo = pair.Key;
+
+                // If a known silo exists on the endpoint with a higher generation, the old silo must be dead.
+                if (latestGenerations.TryGetValue(unknownSilo.Endpoint, out var knownGeneration) && knownGeneration > unknownSilo.Generation)
+                {
+                    this.log.Info($"Previously unknown silo {unknownSilo} was superseded by later generation on same endpoint {SiloAddress.New(unknownSilo.Endpoint, knownGeneration)}.");
+                    updates.Add(unknownSilo);
+                }
+
+                // If this is a singleton partition, then any silo with a given address (excluding port) and a higher generation indicates that the
+                // unknown silo is dead.
+                if (isSingletonPartition)
+                {
+                    foreach (var knownSilo in latestGenerations)
+                    {
+                        if (unknownSilo.Endpoint.Address.Equals(knownSilo.Key.Address) && knownSilo.Value > unknownSilo.Generation)
+                        {
+                            this.log.Info($"Previously unknown silo {unknownSilo} was superseded by {knownSilo}.");
+                            updates.Add(unknownSilo);
+                        }
+                    }
+                }
+
+                // Silos which have been in an unknown state for more than configured maximum allowed time are automatically considered dead.
+                if (this.GetDateTime() - pair.Value > this.options.UnknownSiloRemovalPeriod)
+                {
+                    this.log.Info($"Previously unknown silo {unknownSilo} declared dead after {this.options.UnknownSiloRemovalPeriod.TotalSeconds} seconds.");
+                    updates.Add(unknownSilo);
+                }
+            }
+
+            if (this.unknownSilos.Count == 0 && updates.Count == 0)
+            {
+                this.log.Info("All unknown silos have been identified.");
+            }
+
+            return updates;
+        }
+    }
+}

--- a/src/Orleans.Membership.ServiceFabric/UnknownSiloMonitor.cs
+++ b/src/Orleans.Membership.ServiceFabric/UnknownSiloMonitor.cs
@@ -52,9 +52,8 @@ namespace Microsoft.Orleans.ServiceFabric
         /// Finds dead silos which were previously in an unknown state.
         /// </summary>
         /// <param name="allKnownSilos">The collection of all known silos, including dead silos.</param>
-        /// <param name="isSingletonPartition">Whether or not this service is running inside of a singleton partition.</param>
         /// <returns>A collection of dead silos.</returns>
-        public IEnumerable<SiloAddress> DetermineDeadSilos(Dictionary<SiloAddress, SiloStatus> allKnownSilos, bool isSingletonPartition)
+        public IEnumerable<SiloAddress> DetermineDeadSilos(Dictionary<SiloAddress, SiloStatus> allKnownSilos)
         {
             if (this.unknownSilos.Count == 0) return Array.Empty<SiloAddress>();
             
@@ -90,21 +89,7 @@ namespace Microsoft.Orleans.ServiceFabric
                     this.log.Info($"Previously unknown silo {unknownSilo} was superseded by later generation on same endpoint {SiloAddress.New(unknownSilo.Endpoint, knownGeneration)}.");
                     updates.Add(unknownSilo);
                 }
-
-                // If this is a singleton partition, then any silo with a given address (excluding port) and a higher generation indicates that the
-                // unknown silo is dead.
-                if (isSingletonPartition)
-                {
-                    foreach (var knownSilo in latestGenerations)
-                    {
-                        if (unknownSilo.Endpoint.Address.Equals(knownSilo.Key.Address) && knownSilo.Value > unknownSilo.Generation)
-                        {
-                            this.log.Info($"Previously unknown silo {unknownSilo} was superseded by {knownSilo}.");
-                            updates.Add(unknownSilo);
-                        }
-                    }
-                }
-
+                
                 // Silos which have been in an unknown state for more than configured maximum allowed time are automatically considered dead.
                 if (this.GetDateTime() - pair.Value > this.options.UnknownSiloRemovalPeriod)
                 {

--- a/src/Orleans.Membership.ServiceFabric/Utilities/ErrorCode.cs
+++ b/src/Orleans.Membership.ServiceFabric/Utilities/ErrorCode.cs
@@ -14,5 +14,6 @@ namespace Microsoft.Orleans.ServiceFabric.Utilities
         ServiceFabric_Resolver_PartitionNotFound = ServiceFabricBase + 5,
         ServiceFabric_Resolver_PartitionResolutionException = ServiceFabricBase + 6,
         ServiceFabric_MembershipOracle_EncounteredUndeadSilo = ServiceFabricBase + 7,
+        ServiceFabric_MembershipOracle_PartitionResolutionException = ServiceFabricBase + 8,
     }
 }

--- a/test/TestServiceFabric/FabricMembershipOracleTests.cs
+++ b/test/TestServiceFabric/FabricMembershipOracleTests.cs
@@ -333,8 +333,6 @@ namespace TestServiceFabric
 
             public int RefreshCalled { get; private set; }
 
-            public bool? IsSingletonPartition => true;
-
             public void Subscribe(IFabricServiceStatusListener handler)
             {
                 this.Handlers.Add(handler);

--- a/test/TestServiceFabric/FabricMembershipOracleTests.cs
+++ b/test/TestServiceFabric/FabricMembershipOracleTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Orleans.ServiceFabric;
 using Microsoft.Orleans.ServiceFabric.Models;
 using Orleans.Runtime;
@@ -24,6 +24,9 @@ namespace TestServiceFabric
 
         private ITestOutputHelper Output { get; }
         private readonly FabricMembershipOracle oracle;
+        private readonly UnknownSiloMonitor unknownSiloMonitor;
+        private readonly ServiceFabricMembershipOptions fabricMembershipOptions;
+
         public FabricMembershipOracleTests(ITestOutputHelper output)
         {
             this.Output = output;
@@ -38,11 +41,16 @@ namespace TestServiceFabric
             globalConfig.MaxMultiClusterGateways = 2;
             globalConfig.ClusterId = "MegaGoodCluster";
 
+            this.fabricMembershipOptions = new ServiceFabricMembershipOptions();
+            this.unknownSiloMonitor = new UnknownSiloMonitor(
+                new OptionsWrapper<ServiceFabricMembershipOptions>(this.fabricMembershipOptions),
+                new TestOutputLogger<UnknownSiloMonitor>(this.Output));
             this.oracle = new FabricMembershipOracle(
                 this.siloDetails,
                 globalConfig,
                 this.resolver,
-                new NullLogger<FabricMembershipOracle>());
+                new NullLogger<FabricMembershipOracle>(),
+                this.unknownSiloMonitor);
         }
 
         [Fact]
@@ -80,8 +88,7 @@ namespace TestServiceFabric
         {
             Assert.Equal(this.siloDetails.SiloAddress, this.oracle.SiloAddress);
             Assert.Equal(this.siloDetails.Name, this.oracle.SiloName);
-            string actualName;
-            Assert.True(this.oracle.TryGetSiloName(this.siloDetails.SiloAddress, out actualName));
+            Assert.True(this.oracle.TryGetSiloName(this.siloDetails.SiloAddress, out var actualName));
             Assert.Equal(this.siloDetails.Name, actualName);
         }
 
@@ -184,6 +191,75 @@ namespace TestServiceFabric
             Assert.Contains(this.siloDetails.SiloAddress, multiClusters);
         }
 
+        /// <summary>
+        /// Tests that unknown silos are accounted for when updates occur.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        /// <remarks>
+        /// This is an integration test between <see cref="FabricMembershipOracle"/> and <see cref="UnknownSiloMonitorTests"/>.
+        /// </remarks>
+        [Fact]
+        public async Task UnknownSilosAreAccountedForDuringUpdate()
+        {
+            var now = new[] {DateTime.UtcNow};
+            this.unknownSiloMonitor.GetDateTime = () => now[0];
+
+            var listener = new MockStatusListener();
+            this.oracle.SubscribeToSiloStatusEvents(listener);
+            await this.oracle.Start();
+            await this.oracle.BecomeActive();
+
+            var silos = new[]
+            {
+                CreateSiloInfo(
+                    SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 1), 1),
+                    SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 2), 1),
+                    "HappyNewSilo"),
+                CreateSiloInfo(
+                    SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 3), 2),
+                    SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 4), 2),
+                    "OtherNewSilo"),
+            };
+
+            this.resolver.Notify(silos);
+            listener.WaitForVersion(4);
+            Assert.Equal(3, listener.Silos.Count);
+
+            // Query for an unknown silo. Doing so should result in the silo being recorded as unknown.
+            var unknownSilo1 = SiloAddress.New(new IPEndPoint(IPAddress.Parse("1.1.1.1"), 3), 3);
+            Assert.Equal(SiloStatus.None, this.oracle.GetApproximateSiloStatus(unknownSilo1));
+            this.resolver.Notify(silos);
+
+            // The status should not have changed.
+            Assert.Equal(SiloStatus.None, this.oracle.GetApproximateSiloStatus(unknownSilo1));
+
+            now[0] += this.fabricMembershipOptions.UnknownSiloRemovalPeriod + TimeSpan.FromMilliseconds(1);
+            this.resolver.Notify(silos);
+            listener.WaitForVersion(5);
+
+            // After the delay, the silo should be declared dead.
+            Assert.Equal(SiloStatus.Dead, this.oracle.GetApproximateSiloStatus(unknownSilo1));
+            
+            // Query for another unknown silo using a different mechanism.
+            var unknownSilo2 = SiloAddress.New(new IPEndPoint(IPAddress.Parse("2.2.2.2"), 4), 4);
+            Assert.False(this.oracle.IsFunctionalDirectory(unknownSilo2));
+
+            // Report a new silo with the same endpoint as the unknown silo but a higher generation. 
+            silos = new[]
+            {
+                silos[0],
+                silos[1],
+                CreateSiloInfo(
+                    SiloAddress.New(new IPEndPoint(IPAddress.Parse("2.2.2.2"), 4), 5),
+                    SiloAddress.Zero,
+                    "TippyTop")
+            };
+
+            this.resolver.Notify(silos);
+            listener.WaitForVersion(6);
+            Assert.True(this.oracle.IsDeadSilo(unknownSilo2));
+        }
+
         private class MockSiloDetails : ILocalSiloDetails
         {
             public string Name { get; set; }
@@ -223,8 +299,7 @@ namespace TestServiceFabric
 
             public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
             {
-                SiloStatus existingStatus;
-                if (this.Silos.TryGetValue(updatedSilo, out existingStatus))
+                if (this.Silos.TryGetValue(updatedSilo, out var existingStatus))
                 {
                     if (existingStatus == status) throw new InvalidOperationException($"Silo {updatedSilo} already has status {status}.");
                 }
@@ -257,6 +332,8 @@ namespace TestServiceFabric
             public HashSet<IFabricServiceStatusListener> Handlers { get; } = new HashSet<IFabricServiceStatusListener>();
 
             public int RefreshCalled { get; private set; }
+
+            public bool? IsSingletonPartition => true;
 
             public void Subscribe(IFabricServiceStatusListener handler)
             {

--- a/test/TestServiceFabric/TestOutputLogger.cs
+++ b/test/TestServiceFabric/TestOutputLogger.cs
@@ -1,23 +1,28 @@
 using System;
-using Orleans.Runtime;
 using Xunit.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions.Internal;
 namespace TestServiceFabric
 {
+    public class TestOutputLogger<TCategoryName> : TestOutputLogger, ILogger<TCategoryName>
+    {
+        public TestOutputLogger(ITestOutputHelper output, LogLevel level = LogLevel.Information) : base(output, nameof(TCategoryName), level)
+        {
+        }
+    }
+
     public class TestOutputLogger : ILogger
     {
+        private readonly LogLevel minLevel;
 
-        public string LoggerName { get; set; }
-
-        public string Name => this.LoggerName;
-        private LogLevel logLevel;
         public TestOutputLogger(ITestOutputHelper output, string name = null, LogLevel level = LogLevel.Information)
         {
             this.Output = output;
-            this.LoggerName = name ?? nameof(TestOutputLogger);
-            this.logLevel = level;
+            this.Name = name ?? nameof(TestOutputLogger);
+            this.minLevel = level;
         }
+
+        public string Name { get; }
 
         public IDisposable BeginScope<TState>(TState state)
         {
@@ -28,7 +33,7 @@ namespace TestServiceFabric
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            return logLevel > this.logLevel;
+            return logLevel > this.minLevel;
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,

--- a/test/TestServiceFabric/UnknownSiloMonitorTests.cs
+++ b/test/TestServiceFabric/UnknownSiloMonitorTests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Orleans.ServiceFabric;
+using Orleans.Runtime;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TestServiceFabric
+{
+    /// <summary>
+    /// Tests for <see cref="UnknownSiloMonitor"/>.
+    /// </summary>
+    [TestCategory("ServiceFabric"), TestCategory("BVT")]
+    public class UnknownSiloMonitorTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public UnknownSiloMonitorTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        private ILogger<UnknownSiloMonitor> Logger => new TestOutputLogger<UnknownSiloMonitor>(this.output);
+
+        /// <summary>
+        /// Tests that unknown silos are declared dead after a configured period of time.
+        /// </summary>
+        /// <param name="singletonPartition">
+        /// Whether or not the service is running in a singleton Service Fabric partition.
+        /// </param>
+        [Theory]
+        [InlineData(true), InlineData(false)]
+        public void SiloEventuallyBecomesDead(bool singletonPartition)
+        {
+            var now = new[] { DateTime.UtcNow };
+            var options = new ServiceFabricMembershipOptions();
+            var monitor = new UnknownSiloMonitor(new OptionsWrapper<ServiceFabricMembershipOptions>(options), this.Logger)
+            {
+                GetDateTime = () => now[0]
+            };
+
+            var knownSilos = new Dictionary<SiloAddress, SiloStatus>
+            {
+                [NewSiloAddress("2.2.2.2", 9030, 2)] = SiloStatus.Active
+            };
+
+            // Report a silo as having an unknown status.
+            var deadSilo = NewSiloAddress("1.1.1.1", 9030, 1000);
+            monitor.ReportUnknownSilo(deadSilo);
+
+            // No time has passed and the set of known silos contains no information about the reported silo,
+            // therefore we expect no reports even after running multiple times.
+            Assert.Empty(monitor.DetermineDeadSilos(knownSilos, singletonPartition));
+            Assert.Empty(monitor.DetermineDeadSilos(knownSilos, singletonPartition));
+
+            // Advance passed the expiration time.
+            now[0] += options.UnknownSiloRemovalPeriod + TimeSpan.FromMilliseconds(1);
+
+            // The silo should be declared dead by the monitor.
+            Assert.Contains(deadSilo, monitor.DetermineDeadSilos(knownSilos, singletonPartition));
+        }
+
+        /// <summary>
+        /// Tests that unknown silos are declared dead when a silo supersedes it on the same endpoint.
+        /// </summary>
+        /// <param name="singletonPartition">
+        /// Whether or not the service is running in a singleton Service Fabric partition.
+        /// </param>
+        [Theory]
+        [InlineData(true), InlineData(false)]
+        public void SiloDeclaredDeadWhenSupersededOnSameEndpoint(bool singletonPartition)
+        {
+            var now = new[] { DateTime.UtcNow };
+            var options = new ServiceFabricMembershipOptions();
+            var monitor = new UnknownSiloMonitor(new OptionsWrapper<ServiceFabricMembershipOptions>(options), this.Logger)
+            {
+                GetDateTime = () => now[0]
+            };
+
+            var knownSilos = new Dictionary<SiloAddress, SiloStatus>();
+
+            // Report a silo as having an unknown status.
+            var deadSilo = NewSiloAddress("1.1.1.1", 9030, 1000);
+            monitor.ReportUnknownSilo(deadSilo);
+            Assert.Empty(monitor.DetermineDeadSilos(knownSilos, singletonPartition));
+
+            // Create a silo with the same IP and port but a lower generation.
+            var predecessorSilo = NewSiloAddress("1.1.1.1", 9030, 500);
+            knownSilos[predecessorSilo] = SiloStatus.Active;
+            Assert.Empty(monitor.DetermineDeadSilos(knownSilos, singletonPartition));
+
+            knownSilos[predecessorSilo] = SiloStatus.Dead;
+            Assert.Empty(monitor.DetermineDeadSilos(knownSilos, singletonPartition));
+
+            // Create a silo with the same IP and port but a higher generation.
+            var supersedingSilo = NewSiloAddress("1.1.1.1", 9030, 2000);
+
+            // A status of None is equivalent to no status, so no declarations should be made.
+            knownSilos[supersedingSilo] = SiloStatus.None;
+            Assert.Empty(monitor.DetermineDeadSilos(knownSilos, singletonPartition));
+
+            // The silo should be declared dead by the monitor even if the newer silo is dead.
+            knownSilos[supersedingSilo] = SiloStatus.Dead;
+            Assert.Contains(deadSilo, monitor.DetermineDeadSilos(knownSilos, singletonPartition));
+
+            // The silo should be declared dead by the monitor.
+            knownSilos[supersedingSilo] = SiloStatus.Active;
+            Assert.Contains(deadSilo, monitor.DetermineDeadSilos(knownSilos, singletonPartition));
+        }
+
+        /// <summary>
+        /// Tests that unknown silos are declared dead when a silo supersedes it on the same IP address but different port if
+        /// the service has a singleton partition.
+        /// </summary>
+        [Fact]
+        public void SiloDeclaredDeadWhenSupersededOnSameAddress()
+        {
+            var now = new[] { DateTime.UtcNow };
+            var options = new ServiceFabricMembershipOptions();
+            var monitor = new UnknownSiloMonitor(new OptionsWrapper<ServiceFabricMembershipOptions>(options), this.Logger)
+            {
+                GetDateTime = () => now[0]
+            };
+
+            var deadSilo = NewSiloAddress("1.1.1.1", 1111, 1000);
+            var supersedingSilo = NewSiloAddress("1.1.1.1", 9999, 2000);
+            var knownSilos = new Dictionary<SiloAddress, SiloStatus>
+            {
+                [supersedingSilo] = SiloStatus.Active
+            };
+
+            // Report a silo as having an unknown status.
+            monitor.ReportUnknownSilo(deadSilo);
+
+            // The silo is declared dead only if the partition is a singleton.
+            Assert.Empty(monitor.DetermineDeadSilos(knownSilos, false));
+            Assert.Contains(deadSilo, monitor.DetermineDeadSilos(knownSilos, true));
+        }
+
+        private static SiloAddress NewSiloAddress(string ip, ushort port, int generation) =>
+            SiloAddress.New(new IPEndPoint(IPAddress.Parse(ip), port), generation);
+    }
+}


### PR DESCRIPTION
Unlike other membership providers, the Service Fabric provider does not record a total set of all silos which ever attempted to join a cluster. Because of this, there are cases where a silo might query the membership oracle for silos which were never before seen by the oracle.

This PR adds an `UnknownSiloMonitor` which attempts to alleviate issues which arise because of this. It records queries for the status of unknown silos and tracks those silos until:
* The silo is determined to be alive by a membership update
* The silos is determined to be dead because:
  * A silo with the same IP:Port exists with a later generation
  * A silo with the same IP (but different port) exists with a later generation in a singleton partition (max 1 silo per IP) **Note: this won't work on development clusters since all nodes share an IP**
  * A period of time passes, defaulting to 1 minute and configurable using the Options subsystem via `ServiceFabricMembershipOptions`.

Additionally, this PR improves the logic around querying Service Fabric for cluster membership changes. Previously it's possible that membership queries were returning cached results. By caching the results of previous queries and passing those cached results to subsequent queries we tell SF to avoid returning a cached result. If this performs poorly then we should consider increasing the polling interval from 5 seconds.