### PR TITLE
Change symbol type to full from the default portable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <!-- We use full (Windows PDBs) until cross platform support for source link will get better -->
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <!-- FSharp SDK overrides -->


### PR DESCRIPTION
Microsoft Symbol Servers does not support Portable PDBs yet, but Source Link supports Windows PDBs, so to get the full debugging experience straight from consumed NuGet packages we're changing to this format.

Since the Source Link support on other platform IDEs are not in a good shape, we'll not affect the xplat developer's in a bad way.

Once Microsoft Symbol Servers will support Portable PDBs we'll move back to it.