### PR TITLE
Remove cref attribute in inheritdoc comments

### DIFF
--- a/src/Orleans.Core.Abstractions/Streams/Predicates/RegexStreamNamespacePredicate.cs
+++ b/src/Orleans.Core.Abstractions/Streams/Predicates/RegexStreamNamespacePredicate.cs
@@ -21,7 +21,7 @@ namespace Orleans.Streams
             this.regex = regex;
         }
 
-        /// <inheritdoc cref="IStreamNamespacePredicate"/>
+        /// <inheritdoc />
         public bool IsMatch(string streamNameSpace)
         {
             return regex.IsMatch(streamNameSpace);

--- a/src/Orleans.Core/Logging/FileLogger.cs
+++ b/src/Orleans.Core/Logging/FileLogger.cs
@@ -134,18 +134,19 @@ namespace Orleans.Logging
             this.output = output;
         }
 
-        /// <inheritdoc cref="ILogger"/>
+        /// <inheritdoc />
         public IDisposable BeginScope<TState>(TState state)
         {
             //TODO: implemente scope 
             return NullScope.Instance;
         }
-        /// <inheritdoc cref="ILogger"/>
+
+        /// <inheritdoc />
         public bool IsEnabled(LogLevel logLevel)
         {
             return true;
         }
-        /// <inheritdoc cref="ILogger"/>
+        /// <inheritdoc />
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             this.output.Log(logLevel, eventId, state, exception, formatter, this.category);

--- a/src/Orleans.EventSourcing/JournaledGrain.cs
+++ b/src/Orleans.EventSourcing/JournaledGrain.cs
@@ -236,7 +236,7 @@ namespace Orleans.EventSourcing
         }
 
 
-        /// <inheritdoc cref="ILogConsistencyDiagnostics.UnresolvedConnectionIssues"/>
+        /// <inheritdoc />
         protected IEnumerable<ConnectionIssue> UnresolvedConnectionIssues
         {
             get
@@ -245,19 +245,19 @@ namespace Orleans.EventSourcing
             }
         }
 
-        /// <inheritdoc cref="ILogConsistencyDiagnostics.EnableStatsCollection"/>
+        /// <inheritdoc />
         protected void EnableStatsCollection()
         {
             LogViewAdaptor.EnableStatsCollection();
         }
 
-        /// <inheritdoc cref="ILogConsistencyDiagnostics.DisableStatsCollection"/>
+        /// <inheritdoc />
         protected void DisableStatsCollection()
         {
             LogViewAdaptor.DisableStatsCollection();
         }
 
-        /// <inheritdoc cref="ILogConsistencyDiagnostics.GetStats"/>
+        /// <inheritdoc />
         protected LogConsistencyStatistics GetStats()
         {
             return LogViewAdaptor.GetStats();

--- a/src/Orleans.Logging.Legacy/EventBulkingLoggerProvider.cs
+++ b/src/Orleans.Logging.Legacy/EventBulkingLoggerProvider.cs
@@ -26,13 +26,13 @@ namespace Orleans.Logging.Legacy
             this.bulkingConfig = bulkingConfig == null? new EventBulkingOptions() : bulkingConfig;
         }
 
-        /// <inheritdoc cref="ILoggerProvider"/>
+        /// <inheritdoc />
         public ILogger CreateLogger(string categoryName)
         {
             return new EventBulkingDecoratorLogger(this.bulkingConfig, provider.CreateLogger(categoryName));
         }
 
-        /// <inheritdoc cref="IDisposable"/>
+        /// <inheritdoc />
         public void Dispose()
         {
             provider.Dispose();

--- a/src/Orleans.Logging.Legacy/LegacyOrleansLogger.cs
+++ b/src/Orleans.Logging.Legacy/LegacyOrleansLogger.cs
@@ -58,7 +58,7 @@ namespace Orleans.Logging.Legacy
 
         /// <summary>
         /// Log a message. Current logger supports legacy event bulking feature. Message bulking feature will only log eventId code appearance count
-        /// if certain event appear more than <see cref="EventBulkingOptions.BulkEventLimit"/>> in <see cref="EventBulkingOptions.BulkEventInterval"/>
+        /// if certain event appear more than <see cref="EventBulkingOptions.BulkEventLimit" /> in <see cref="EventBulkingOptions.BulkEventInterval"/>
         /// </summary>
         /// <typeparam name="TState"></typeparam>
         /// <param name="logLevel"></param>

--- a/src/Orleans.Membership.Consul/LegacyConsulMembershipConfigurator.cs
+++ b/src/Orleans.Membership.Consul/LegacyConsulMembershipConfigurator.cs
@@ -5,7 +5,7 @@ using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.MembershipService
 {
-    /// <inheritdoc cref="ILegacyMembershipConfigurator"/>
+    /// <inheritdoc />
     public class LegacyConsulMembershipConfigurator : ILegacyMembershipConfigurator
     {
         public void ConfigureServices(GlobalConfiguration configuration, IServiceCollection services)

--- a/src/Orleans.Membership.ZooKeeper/LegacyZooKeeperMembershipConfigurator.cs
+++ b/src/Orleans.Membership.ZooKeeper/LegacyZooKeeperMembershipConfigurator.cs
@@ -5,7 +5,7 @@ using Orleans.Hosting;
 
 namespace OrleansZooKeeperUtils
 {
-    /// <inheritdoc cref="ILegacyMembershipConfigurator"/>
+    /// <inheritdoc />
     public class LegacyZooKeeperMembershipConfigurator : ILegacyMembershipConfigurator
     {
         public void ConfigureServices(GlobalConfiguration configuration, IServiceCollection services)

--- a/src/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
+++ b/src/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionDataGenerator.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Extensions.Logging;
-using static Microsoft.Azure.EventHubs.EventData;
 using Orleans.Runtime;
 using Orleans.Serialization;
-using Orleans.ServiceBus.Providers;
 using Orleans.Streams;
 
 namespace Orleans.ServiceBus.Providers.Testing
@@ -18,12 +14,12 @@ namespace Orleans.ServiceBus.Providers.Testing
     /// </summary>
     public class SimpleStreamEventDataGenerator : IStreamDataGenerator<EventData>
     {
-        /// <inheritdoc cref="IEventHubReceiver"/>
+        /// <inheritdoc />
         public IStreamIdentity StreamId { get; set; }
 
-        /// <inheritdoc cref="IEventHubReceiver"/>
+        /// <inheritdoc />
         public IIntCounter SequenceNumberCounter { set; private get; }
-        /// <inheritdoc cref="IEventHubReceiver"/>
+        /// <inheritdoc />
         public bool ShouldProduce { private get; set; }
 
         private ILogger logger;
@@ -45,7 +41,7 @@ namespace Orleans.ServiceBus.Providers.Testing
             this.serializationManager = serializationManager;
         }
 
-        /// <inheritdoc cref="IStreamDataGenerator{T}"/>
+        /// <inheritdoc />
         public bool TryReadEvents(int maxCount, out IEnumerable<EventData> events)
         {
             if (!this.ShouldProduce)
@@ -112,7 +108,7 @@ namespace Orleans.ServiceBus.Providers.Testing
             this.serializationManager = serializationManager;
             this.settings = settings;
         }
-        /// <inheritdoc cref="IStreamDataGeneratingController"/>>
+        /// <inheritdoc />
         public void AddDataGeneratorForStream(IStreamIdentity streamId)
         {
             var generator = (IStreamDataGenerator<EventData>)Activator.CreateInstance(settings.StreamDataGeneratorType,
@@ -121,7 +117,7 @@ namespace Orleans.ServiceBus.Providers.Testing
             this.logger.Info($"Data generator set up on stream {streamId.Namespace}-{streamId.Guid.ToString()}.");
             this.generators.Add(generator);
         }
-        /// <inheritdoc cref="IStreamDataGeneratingController"/>>
+        /// <inheritdoc />
         public void StopProducingOnStream(IStreamIdentity streamId)
         {
             this.generators.ForEach(generator => {
@@ -132,7 +128,7 @@ namespace Orleans.ServiceBus.Providers.Testing
                 }
             });
         }
-        /// <inheritdoc cref="IDataGenerator{T}"/>>
+        /// <inheritdoc />
         public bool TryReadEvents(int maxCount, out IEnumerable<EventData> events)
         {
             if (this.generators.Count == 0)

--- a/src/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
+++ b/src/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
@@ -23,7 +23,7 @@ namespace Orleans.ServiceBus.Providers.Testing
         {
             this.generator = generator;
         }
-        /// <inheritdoc cref="IEventHubReceiver"/>
+        /// <inheritdoc />
         public async Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
         {
             IEnumerable<EventData> events;
@@ -38,19 +38,19 @@ namespace Orleans.ServiceBus.Providers.Testing
             return new List<EventData>().AsEnumerable();
         }
 
-        /// <inheritdoc cref="IEventHubReceiver"/>
+        /// <inheritdoc />
         public void StopProducingOnStream(IStreamIdentity streamId)
         {
             (this.generator as IStreamDataGeneratingController)?.StopProducingOnStream(streamId);
         }
 
-        /// <inheritdoc cref="IEventHubReceiver"/>
+        /// <inheritdoc />
         public void ConfigureDataGeneratorForStream(IStreamIdentity streamId)
         {
             (this.generator as IStreamDataGeneratingController)?.AddDataGeneratorForStream(streamId);
         }
 
-        /// <inheritdoc cref="IEventHubReceiver"/>
+        /// <inheritdoc />
         public Task CloseAsync()
         {
             return Task.CompletedTask;

--- a/src/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
+++ b/src/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubDataAdapter.cs
@@ -181,13 +181,13 @@ namespace Orleans.ServiceBus.Providers
             this.bufferPool = bufferPool;
         }
 
-        /// <inheritdoc cref="ICacheDataAdapter{TQueueMessage,TCachedMessage}"/>
+        /// <inheritdoc />
         public DateTime? GetMessageEnqueueTimeUtc(ref CachedEventHubMessage message)
         {
             return message.EnqueueTimeUtc;
         }
 
-        /// <inheritdoc cref="ICacheDataAdapter{TQueueMessage,TCachedMessage}"/>
+        /// <inheritdoc />
         public DateTime? GetMessageDequeueTimeUtc(ref CachedEventHubMessage message)
         {
             return message.DequeueTimeUtc;

--- a/src/OrleansAWSUtils/Membership/LegacyDynamoDBMembershipConfigurator.cs
+++ b/src/OrleansAWSUtils/Membership/LegacyDynamoDBMembershipConfigurator.cs
@@ -4,7 +4,7 @@ using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.MembershipService
 {
-    /// <inheritdoc cref="ILegacyMembershipConfigurator"/>
+    /// <inheritdoc />
     public class LegacyDynamoDBMembershipConfigurator : ILegacyMembershipConfigurator
     {
         public void ConfigureServices(GlobalConfiguration configuration, IServiceCollection services)

--- a/src/OrleansAzureUtils/Storage/LegacyAzureMembershipConfigurator.cs
+++ b/src/OrleansAzureUtils/Storage/LegacyAzureMembershipConfigurator.cs
@@ -4,7 +4,7 @@ using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.MembershipService
 {
-    /// <inheritdoc cref="ILegacyMembershipConfigurator"/>
+    /// <inheritdoc />
     public class LegacyAzureTableMembershipConfigurator : ILegacyMembershipConfigurator
     {
         public void ConfigureServices(GlobalConfiguration configuration, IServiceCollection services)

--- a/src/OrleansProviders/Streams/Common/Monitors/DefaultBlockPoolMonitor.cs
+++ b/src/OrleansProviders/Streams/Common/Monitors/DefaultBlockPoolMonitor.cs
@@ -29,7 +29,7 @@ namespace Orleans.Providers.Streams.Common
                 {"HostName", dimensions.NodeConfig.HostNameOrIPAddress }
             };
         }
-        /// <inheritdoc cref="IBlockPoolMonitor"/>
+        /// <inheritdoc />
         public void Report(long totalMemoryInByte, long availableMemoryInByte, long claimedMemoryInByte)
         {
             this.TelemetryProducer.TrackMetric("TotalMemoryInByte", totalMemoryInByte, this.LogProperties);
@@ -37,13 +37,13 @@ namespace Orleans.Providers.Streams.Common
             this.TelemetryProducer.TrackMetric("ClaimedMemoryInByte", claimedMemoryInByte, this.LogProperties);
         }
 
-        /// <inheritdoc cref="IBlockPoolMonitor"/>
+        /// <inheritdoc />
         public void TrackMemoryReleased(long releasedMemoryInByte)
         {
             this.TelemetryProducer.TrackMetric("ReleasedMemoryInByte", releasedMemoryInByte, this.LogProperties);
         }
 
-        /// <inheritdoc cref="IBlockPoolMonitor"/>
+        /// <inheritdoc />
         public void TrackMemoryAllocated(long allocatedMemoryInByte)
         {
             this.TelemetryProducer.TrackMetric("AllocatedMemoryInByte", allocatedMemoryInByte, this.LogProperties);

--- a/src/OrleansProviders/Streams/Common/Monitors/DefaultCacheMonitor.cs
+++ b/src/OrleansProviders/Streams/Common/Monitors/DefaultCacheMonitor.cs
@@ -29,7 +29,7 @@ namespace Orleans.Providers.Streams.Common
                 {"HostName", dimensions.NodeConfig.HostNameOrIPAddress}
             };
         }
-        /// <inheritdoc cref="ICacheMonitor"/>
+        /// <inheritdoc />
         public void TrackCachePressureMonitorStatusChange(string pressureMonitorType, bool underPressure, double? cachePressureContributionCount, double? currentPressure,
             double? flowControlThreshold)
         {
@@ -40,13 +40,13 @@ namespace Orleans.Providers.Streams.Common
                 this.TelemetryProducer.TrackMetric($"{pressureMonitorType}-CurrentPressure", currentPressure.Value, this.LogProperties);
         }
 
-        /// <inheritdoc cref="ICacheMonitor"/>
+        /// <inheritdoc />
         public void ReportCacheSize(long totalCacheSizeInByte)
         {
             this.TelemetryProducer.TrackMetric("TotalCacheSizeInByte", totalCacheSizeInByte, this.LogProperties);
         }
 
-        /// <inheritdoc cref="ICacheMonitor"/>
+        /// <inheritdoc />
         public void ReportMessageStatistics(DateTime? oldestMessageEnqueueTimeUtc, DateTime? oldestMessageDequeueTimeUtc, DateTime? newestMessageEnqueueTimeUtc, long totalMessageCount)
         {
             if (oldestMessageEnqueueTimeUtc.HasValue && newestMessageEnqueueTimeUtc.HasValue)
@@ -58,25 +58,25 @@ namespace Orleans.Providers.Streams.Common
             this.TelemetryProducer.TrackMetric("TotalMessageCount", totalMessageCount, this.LogProperties);
         }
 
-        /// <inheritdoc cref="ICacheMonitor"/>
+        /// <inheritdoc />
         public void TrackMemoryAllocated(int memoryInByte)
         {
             this.TelemetryProducer.TrackMetric("MemoryAllocatedInByte", memoryInByte, this.LogProperties);
         }
 
-        /// <inheritdoc cref="ICacheMonitor"/>
+        /// <inheritdoc />
         public void TrackMemoryReleased(int memoryInByte)
         {
             this.TelemetryProducer.TrackMetric("MemoryReleasedInByte", memoryInByte, this.LogProperties);
         }
 
-        /// <inheritdoc cref="ICacheMonitor"/>
+        /// <inheritdoc />
         public void TrackMessagesAdded(long mesageAdded)
         {
             this.TelemetryProducer.TrackMetric("MessageAdded", mesageAdded, this.LogProperties);
         }
 
-        /// <inheritdoc cref="ICacheMonitor"/>
+        /// <inheritdoc />
         public void TrackMessagesPurged(long messagePurged)
         {
             this.TelemetryProducer.TrackMetric("MessagePurged", messagePurged, this.LogProperties);

--- a/src/OrleansSQLUtils/Messaging/LegacySqlMembershipConfigurator.cs
+++ b/src/OrleansSQLUtils/Messaging/LegacySqlMembershipConfigurator.cs
@@ -5,7 +5,7 @@ using Orleans.Hosting;
 
 namespace OrleansSQLUtils
 {
-    /// <inheritdoc cref="ILegacyMembershipConfigurator"/>
+    /// <inheritdoc />
     public class LegacySqlMembershipConfigurator : ILegacyMembershipConfigurator
     {
         public void ConfigureServices(GlobalConfiguration configuration, IServiceCollection services)


### PR DESCRIPTION
It is not needed, and most of these usages are incorrect as they just refer to the type but not the correct member in that base type.