### PR TITLE
AddApplicationPartsFromReferences includes the specified assembly

### DIFF
--- a/src/Orleans.Core/ApplicationParts/ApplicationPartManagerExtensions.cs
+++ b/src/Orleans.Core/ApplicationParts/ApplicationPartManagerExtensions.cs
@@ -125,6 +125,7 @@ namespace Orleans.Hosting
             }
 
             var processedAssemblies = new HashSet<Assembly>();
+            processedAssemblies.Add(assembly);
             LoadReferencedAssemblies(assembly, processedAssemblies);
 
             foreach (var asm in processedAssemblies)

--- a/src/Orleans.Runtime/Hosting/SiloBuilderApplicationPartExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/SiloBuilderApplicationPartExtensions.cs
@@ -33,7 +33,7 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="assembly">The assembly</param>
-        public static IClientBuilder AddApplicationPartsFromReferences(this IClientBuilder builder, Assembly assembly)
+        public static ISiloHostBuilder AddApplicationPartsFromReferences(this ISiloHostBuilder builder, Assembly assembly)
         {
             builder.GetApplicationPartManager().AddApplicationPartsFromReferences(assembly);
             return builder;


### PR DESCRIPTION
- AddApplicationPartsFromReferences was not adding the specified assembly as a part, but it should, so it's doing that now.
- Fix extension method to target ISiloHostBuilder