### PR TITLE
Remove unused Orleans.CodeGenerator project references

### DIFF
--- a/src/Orleans.Client/Orleans.Client.csproj
+++ b/src/Orleans.Client/Orleans.Client.csproj
@@ -18,6 +18,5 @@
     <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
     <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
-    <ProjectReference Include="..\Orleans.CodeGeneration\Orleans.CodeGeneration.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Orleans.PowerShell/Orleans.PowerShell.csproj
+++ b/src/Orleans.PowerShell/Orleans.PowerShell.csproj
@@ -26,7 +26,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
-    <ProjectReference Include="..\Orleans.CodeGeneration\Orleans.CodeGeneration.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.Server/Orleans.Server.csproj
+++ b/src/Orleans.Server/Orleans.Server.csproj
@@ -19,6 +19,5 @@
     <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
     <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
     <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />
-    <ProjectReference Include="..\Orleans.CodeGeneration\Orleans.CodeGeneration.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Since there is no runtime code generation happening now, we are not building the Orleans.CodeGenerator nuget package and there is no need to reference that outside of the build time codegenerator.