### PR TITLE
Added more checks to RequestContext_LegacyActivityId_Simple

### DIFF
--- a/test/TestGrains/RequestContextTestGrain.cs
+++ b/test/TestGrains/RequestContextTestGrain.cs
@@ -40,7 +40,7 @@ namespace UnitTests.Grains
 
         public Task<Guid> E2ELegacyActivityId()
         {
-            if (!RequestContext.PropagateActivityId) throw new OrleansException("ActivityId Propegation is not enabled on silo.");
+            if (!RequestContext.PropagateActivityId) throw new InvalidOperationException("ActivityId propagation is not enabled on silo.");
             return Task.FromResult(Trace.CorrelationManager.ActivityId);
         }
 

--- a/test/TestGrains/RequestContextTestGrain.cs
+++ b/test/TestGrains/RequestContextTestGrain.cs
@@ -40,6 +40,7 @@ namespace UnitTests.Grains
 
         public Task<Guid> E2ELegacyActivityId()
         {
+            if (!RequestContext.PropagateActivityId) throw new OrleansException("ActivityId Propegation is not enabled on silo.");
             return Task.FromResult(Trace.CorrelationManager.ActivityId);
         }
 

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -70,6 +70,7 @@ namespace UnitTests.General
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
             Trace.CorrelationManager.ActivityId = activityId;
+            Assert.True(RequestContext.PropagateActivityId); // "Verify activityId propagation is enabled."
             Guid result = await grain.E2ELegacyActivityId();
             Assert.Equal(activityId, result);  // "E2E ActivityId not propagated correctly"
         }


### PR DESCRIPTION
RequestContextTests_Silo.RequestContext_LegacyActivityId_Simple seems to be failing intermittently.  It's unclear if the issue is on the client or silo side.  This PR adds more checks to the test to help identify root cause, as the issue does not reproduce locally.
