### PR TITLE
Remove static UnobservedExceptionsHandlerClass and detach from client library

### DIFF
--- a/src/Orleans.Core/Async/UnobservedExceptionsHandler.cs
+++ b/src/Orleans.Core/Async/UnobservedExceptionsHandler.cs
@@ -6,17 +6,18 @@ namespace Orleans
 {
     using Orleans.Runtime;
 
-    internal class UnobservedExceptionsHandlerClass
+    internal class UnobservedExceptionsHandler
     {
-        private static readonly Object lockObject = new Object();
-        private static ILogger logger;
-        private static UnobservedExceptionDelegate unobservedExceptionHandler;
-        private static readonly bool alreadySubscribedToTplEvent = false;
+        private readonly Object lockObject = new Object();
+        private ILogger logger;
+        private UnobservedExceptionDelegate unobservedExceptionHandler;
+        private readonly bool alreadySubscribedToTplEvent = false;
 
         internal delegate void UnobservedExceptionDelegate(ISchedulingContext context, Exception exception);
         
-        static UnobservedExceptionsHandlerClass()
+        public UnobservedExceptionsHandler(ILogger<UnobservedExceptionsHandler> logger)
         {
+            this.logger = logger;
             lock (lockObject)
             {
                 if (!alreadySubscribedToTplEvent)
@@ -27,12 +28,8 @@ namespace Orleans
             }
         }
 
-        internal static void InitLogger(ILoggerFactory loggerFactory)
-        {
-            logger = loggerFactory.CreateLogger<UnobservedExceptionsHandlerClass>();
-        }
 
-        internal static bool TrySetUnobservedExceptionHandler(UnobservedExceptionDelegate handler)
+        internal bool TrySetUnobservedExceptionHandler(UnobservedExceptionDelegate handler)
         {
             if (handler == null) throw new ArgumentNullException(nameof(handler));
             lock (lockObject)
@@ -48,7 +45,7 @@ namespace Orleans
             return true;
         }
 
-        internal static void ResetUnobservedExceptionHandler()
+        internal void ResetUnobservedExceptionHandler()
         {
             lock (lockObject)
             {
@@ -56,7 +53,7 @@ namespace Orleans
             }
         }
 
-        private static void InternalUnobservedTaskExceptionHandler(object sender, UnobservedTaskExceptionEventArgs e)
+        private void InternalUnobservedTaskExceptionHandler(object sender, UnobservedTaskExceptionEventArgs e)
         {
             var aggrException = e.Exception;
             var baseException = aggrException.GetBaseException();

--- a/src/Orleans.Core/Configuration/ApplicationConfiguration.cs
+++ b/src/Orleans.Core/Configuration/ApplicationConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using System.Xml;
+using Microsoft.Extensions.Logging;
 
 
 namespace Orleans.Runtime.Configuration
@@ -202,7 +203,7 @@ namespace Orleans.Runtime.Configuration
             if (timeSpan < TimeSpan.Zero) throw new ArgumentOutOfRangeException(paramName);
         }
 
-        internal void ValidateConfiguration(Logger logger)
+        internal void ValidateConfiguration(ILogger logger)
         {
             foreach (GrainTypeConfiguration config in classSpecific.Values)
             {
@@ -342,7 +343,7 @@ namespace Orleans.Runtime.Configuration
             throw new InvalidOperationException(string.Format("empty GrainTypeConfiguration for {0}", fullTypeName == null ? "defaults" : fullTypeName));
         }
 
-        internal void ValidateConfiguration(Logger logger)
+        internal void ValidateConfiguration(ILogger logger)
         {
             if (AreDefaults) return;
 

--- a/src/Orleans.Core/Core/ClientBuilder.cs
+++ b/src/Orleans.Core/Core/ClientBuilder.cs
@@ -114,7 +114,6 @@ namespace Orleans
             services.TryAddSingleton<IInternalClusterClient, ClusterClient>();
             services.TryAddFromExisting<IClusterClient, IInternalClusterClient>();
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
-            services.TryAddSingleton<UnobservedExceptionsHandler>();
             // Application parts
             var parts = context.GetApplicationPartManager();
             services.TryAddSingleton<ApplicationPartManager>(parts);

--- a/src/Orleans.Core/Core/ClientBuilder.cs
+++ b/src/Orleans.Core/Core/ClientBuilder.cs
@@ -114,7 +114,7 @@ namespace Orleans
             services.TryAddSingleton<IInternalClusterClient, ClusterClient>();
             services.TryAddFromExisting<IClusterClient, IInternalClusterClient>();
             services.TryAddSingleton<ITypeResolver, CachedTypeResolver>();
-
+            services.TryAddSingleton<UnobservedExceptionsHandler>();
             // Application parts
             var parts = context.GetApplicationPartManager();
             services.TryAddSingleton<ApplicationPartManager>(parts);

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -76,7 +76,7 @@ namespace Orleans.Hosting
             services.TryAddTransient(typeof(IStreamSubscriptionObserver<>), typeof(StreamSubscriptionObserverProxy<>));
 
             services.TryAddSingleton<ProviderManagerSystemTarget>();
-            services.TryAddSingleton<UnobservedExceptionsHandler>();
+            services.TryAddSingleton<UnobservedExceptionsHandler>(sp => ActivatorUtilities.CreateInstance<UnobservedExceptionsHandler>(sp, Silo.UnobservedExceptionDelegate));
             services.TryAddSingleton<StatisticsProviderManager>();
             services.AddFromExisting<IProviderManager, StatisticsProviderManager>();
 

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -76,7 +76,7 @@ namespace Orleans.Hosting
             services.TryAddTransient(typeof(IStreamSubscriptionObserver<>), typeof(StreamSubscriptionObserverProxy<>));
 
             services.TryAddSingleton<ProviderManagerSystemTarget>();
-            services.TryAddSingleton<UnobservedExceptionsHandler>(sp => ActivatorUtilities.CreateInstance<UnobservedExceptionsHandler>(sp, Silo.UnobservedExceptionDelegate));
+            services.TryAddSingleton<SiloUnobservedExceptionsHandler>();
             services.TryAddSingleton<StatisticsProviderManager>();
             services.AddFromExisting<IProviderManager, StatisticsProviderManager>();
 

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -76,7 +76,7 @@ namespace Orleans.Hosting
             services.TryAddTransient(typeof(IStreamSubscriptionObserver<>), typeof(StreamSubscriptionObserverProxy<>));
 
             services.TryAddSingleton<ProviderManagerSystemTarget>();
-
+            services.TryAddSingleton<UnobservedExceptionsHandler>();
             services.TryAddSingleton<StatisticsProviderManager>();
             services.AddFromExisting<IProviderManager, StatisticsProviderManager>();
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -829,7 +829,7 @@ namespace Orleans.Runtime
             SafeExecute(messageCenter.Stop);
             SafeExecute(siloStatistics.Stop);
 
-            this.unobservedExceptionsHandler.ResetUnobservedExceptionHandler();
+            SafeExecute(this.unobservedExceptionsHandler.Dispose);
 
             SafeExecute(() => this.SystemStatus = SystemStatus.Terminated);
             SafeExecute(() => AppDomain.CurrentDomain.UnhandledException -= this.DomainUnobservedExceptionHandler);

--- a/src/Orleans.Runtime/Silo/SiloHost.cs
+++ b/src/Orleans.Runtime/Silo/SiloHost.cs
@@ -114,9 +114,7 @@ namespace Orleans.Runtime.Host
         /// </summary>
         public void UnInitializeOrleansSilo()
         {
-            var unObservedExceptionHandler = this.orleans?.Services?.GetService<UnobservedExceptionsHandler>();
-            if(unObservedExceptionHandler != null)
-                Utils.SafeExecute(unObservedExceptionHandler.Dispose);
+            //currently an empty method, keep this method for backward-compatibility
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Silo/SiloHost.cs
+++ b/src/Orleans.Runtime/Silo/SiloHost.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 using Orleans.Logging;
 using System.Threading.Tasks;
 using Orleans.Runtime.Configuration;
-
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Orleans.Runtime.Host
 {
@@ -114,7 +114,7 @@ namespace Orleans.Runtime.Host
         /// </summary>
         public void UnInitializeOrleansSilo()
         {
-            Utils.SafeExecute(UnobservedExceptionsHandlerClass.ResetUnobservedExceptionHandler);
+            Utils.SafeExecute(this.orleans.Services.GetService<UnobservedExceptionsHandler>().ResetUnobservedExceptionHandler);
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Silo/SiloHost.cs
+++ b/src/Orleans.Runtime/Silo/SiloHost.cs
@@ -114,7 +114,9 @@ namespace Orleans.Runtime.Host
         /// </summary>
         public void UnInitializeOrleansSilo()
         {
-            Utils.SafeExecute(this.orleans.Services.GetService<UnobservedExceptionsHandler>().ResetUnobservedExceptionHandler);
+            var unObservedExceptionHandler = this.orleans?.Services?.GetService<UnobservedExceptionsHandler>();
+            if(unObservedExceptionHandler != null)
+                Utils.SafeExecute(unObservedExceptionHandler.ResetUnobservedExceptionHandler);
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Silo/SiloHost.cs
+++ b/src/Orleans.Runtime/Silo/SiloHost.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime.Host
         {
             var unObservedExceptionHandler = this.orleans?.Services?.GetService<UnobservedExceptionsHandler>();
             if(unObservedExceptionHandler != null)
-                Utils.SafeExecute(unObservedExceptionHandler.ResetUnobservedExceptionHandler);
+                Utils.SafeExecute(unObservedExceptionHandler.Dispose);
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Utilities/SiloUnobservedExceptionsHandler.cs
+++ b/src/Orleans.Runtime/Utilities/SiloUnobservedExceptionsHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Orleans.Runtime
 {
-    internal static class ServiceProviderExtensions
+    internal static class SiloUnobservedExceptionsHandlerServiceProviderExtensions
     {
         public static void InitializeSiloUnobservedExceptionsHandler(this IServiceProvider services)
         {
@@ -42,12 +42,12 @@ namespace Orleans.Runtime
             {
                 if (e.Observed)
                 {
-                    logger.Info(ErrorCode.Runtime_Error_100311, "UnobservedExceptionsHandlerClass caught an UnobservedTaskException which was successfully observed and recovered from. BaseException = {0}. Exception = {1}",
+                    logger.Info(ErrorCode.Runtime_Error_100311, "Silo caught an UnobservedTaskException which was successfully observed and recovered from. BaseException = {0}. Exception = {1}",
                             baseException.Message, LogFormatter.PrintException(aggrException));
                 }
                 else
                 {
-                    var errorStr = String.Format("UnobservedExceptionsHandlerClass Caught an UnobservedTaskException event sent by {0}. Exception = {1}",
+                    var errorStr = String.Format("Silo Caught an UnobservedTaskException event sent by {0}. Exception = {1}",
                             OrleansTaskExtentions.ToString((Task)sender), LogFormatter.PrintException(aggrException));
                     logger.Error(ErrorCode.Runtime_Error_100005, errorStr);
                     logger.Error(ErrorCode.Runtime_Error_100006, "Exception remained UnObserved!!! The subsequent behavior depends on the ThrowUnobservedTaskExceptions setting in app config and .NET version.");


### PR DESCRIPTION
PR for issue #3293 . 
This PR makes interception of unhandled exceptions non-static, as well as it doesn't listen to unobserved task exceptions in the client library (as the client is not a hosting runtime).
Still may need another PR to make interception of unhandled exceptions completely optional on the Silo too, if that's desired.
