### PR TITLE
Rename Box/Unbox to ToUntypedTask/ToTypedTask & cleanup OrleansTaskExtensions

### DIFF
--- a/src/Orleans.Core/CodeGeneration/GenericMethodInvoker.cs
+++ b/src/Orleans.Core/CodeGeneration/GenericMethodInvoker.cs
@@ -124,7 +124,8 @@ namespace Orleans.CodeGeneration
         /// <returns>A suitable conversion method.</returns>
         private static MethodInfo GetTaskConversionMethod(Type taskType)
         {
-            if (taskType == typeof(Task)) return TypeUtils.Method((Task task) => task.Box());
+            if (taskType == typeof(Task)) return TypeUtils.Method((Task task) => task.ToUntypedTask());
+            if (taskType == typeof(Task<object>)) return TypeUtils.Method((Task<object> task) => task.ToUntypedTask());
             if (taskType == typeof(void)) return TypeUtils.Property(() => Task.CompletedTask).GetMethod;
 
             if (taskType.GetGenericTypeDefinition() != typeof(Task<>))
@@ -133,7 +134,7 @@ namespace Orleans.CodeGeneration
             var methods = typeof(OrleansTaskExtentions).GetMethods(BindingFlags.Static | BindingFlags.Public);
             foreach (var method in methods)
             {
-                if (method.Name != nameof(OrleansTaskExtentions.Box) || !method.ContainsGenericParameters) continue;
+                if (method.Name != nameof(OrleansTaskExtentions.ToUntypedTask) || !method.ContainsGenericParameters) continue;
                 return method.MakeGenericMethod(innerType);
             }
 

--- a/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs
@@ -77,7 +77,7 @@ namespace Orleans.Runtime
             }
 
             resultTask = OrleansTaskExtentions.ConvertTaskViaTcs(resultTask);
-            return resultTask.Unbox<T>();
+            return resultTask.ToTypedTask<T>();
         }
 
         public TGrainInterface Convert<TGrainInterface>(IAddressable grain)


### PR DESCRIPTION
This is a follow-on from #3559 which I almost forgot about. I didn't include these changes in that PR to keep things simple.

Box & Unbox are unintuitive names and OrleansTaskExtensions could use a little cleanup.

Low pri