### PR TITLE
Remove internal usage of Logger in AzureUtils

### DIFF
--- a/src/OrleansAzureUtils/Hosting/AzureSilo.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureSilo.cs
@@ -48,7 +48,7 @@ namespace Orleans.Runtime.Host
         private SiloHost host;
         private OrleansSiloInstanceManager siloInstanceManager;
         private SiloInstanceTableEntry myEntry;
-        private readonly Logger logger;
+        private readonly ILogger logger;
         private readonly IServiceRuntimeWrapper serviceRuntimeWrapper;
         //TODO: hook this up with SiloBuilder when SiloBuilder supports create AzureSilo
         private static ILoggerFactory DefaultLoggerFactory = CreateDefaultLoggerFactory("AzureSilo.log");
@@ -88,7 +88,7 @@ namespace Orleans.Runtime.Host
             MaxRetries = AzureConstants.MAX_RETRIES;  // 120 x 5s = Total: 10 minutes
 
             this.loggerFactory = loggerFactory;
-            logger = new LoggerWrapper<AzureSilo>(loggerFactory);
+            logger = loggerFactory.CreateLogger<AzureSilo>();
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Orleans.Runtime.Host
                 {
                     var manager = siloInstanceManager ?? await OrleansSiloInstanceManager.GetManager(deploymentId, connectionString, loggerFactory);
                     var instances = await manager.DumpSiloInstanceTable();
-                    logger.Verbose(instances);
+                    logger.Debug(instances);
                 }
                 catch (Exception exc)
                 {

--- a/src/OrleansAzureUtils/MultiClusterNetwork/AzureTableBasedGossipChannel.cs
+++ b/src/OrleansAzureUtils/MultiClusterNetwork/AzureTableBasedGossipChannel.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
     /// </summary>
     internal class AzureTableBasedGossipChannel : IGossipChannel
     {
-        private Logger logger;
+        private ILogger logger;
         private GossipTableInstanceManager tableManager;
         private static int sequenceNumber;
 
@@ -24,15 +24,15 @@ namespace Orleans.Runtime.MultiClusterNetwork
         public AzureTableBasedGossipChannel(ILoggerFactory loggerFactory)
         {
             Name = "AzureTableBasedGossipChannel-" + ++sequenceNumber;
-            logger = new LoggerWrapper<AzureTableBasedGossipChannel>(loggerFactory);
+            logger = loggerFactory.CreateLogger<AzureTableBasedGossipChannel>();
             this.loggerFactory = loggerFactory;
         }
 
         public async Task Initialize(Guid serviceid, string connectionstring)
         {
 
-            logger.Info("Initializing Gossip Channel for ServiceId={0} using connection: {1}, SeverityLevel={2}",
-                serviceid, ConfigUtilities.RedactConnectionStringInfo(connectionstring), logger.SeverityLevel);
+            logger.Info("Initializing Gossip Channel for ServiceId={0} using connection: {1}",
+                serviceid, ConfigUtilities.RedactConnectionStringInfo(connectionstring));
 
             tableManager = await GossipTableInstanceManager.GetManager(serviceid, connectionstring, this.loggerFactory);
         }
@@ -49,7 +49,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
 
         public async Task Publish(MultiClusterData data)
         {
-            logger.Verbose("-Publish data:{0}", data);
+            logger.Debug("-Publish data:{0}", data);
             // this is (almost) always called with just one item in data to be written back
             // so we are o.k. with doing individual tasks for each storage read and write
 
@@ -75,7 +75,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
 
         public async Task<MultiClusterData> Synchronize(MultiClusterData pushed)
         {
-            logger.Verbose("-Synchronize pushed:{0}", pushed);
+            logger.Debug("-Synchronize pushed:{0}", pushed);
 
             try
             {
@@ -115,7 +115,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
                 }
                 var delta = new MultiClusterData(gw, configDeltaTask.Result);
 
-                logger.Verbose("-Synchronize pulled delta:{0}", delta);
+                logger.Debug("-Synchronize pulled delta:{0}", delta);
 
                 return delta;
             }

--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json;
@@ -11,6 +12,7 @@ using Orleans.Providers.Azure;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Orleans.Storage
 {
@@ -56,6 +58,7 @@ namespace Orleans.Storage
         /// <see cref="IStorageProvider.Log"/>
         public Logger Log { get; private set; }
 
+        private ILogger logger;
         /// <summary> Name of this storage provider instance. </summary>
         /// <see cref="IProvider.Name"/>
         public string Name { get; private set; }
@@ -64,7 +67,9 @@ namespace Orleans.Storage
         /// <see cref="IProvider.Init"/>
         public async Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
         {
-            Log = providerRuntime.GetLogger("Storage.AzureBlobStorage");
+            var loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
+            this.logger = loggerFactory.CreateLogger<AzureBlobStorage>();
+            Log = new LoggerWrapper(this.GetType().FullName, loggerFactory);
 
             try
             {
@@ -80,12 +85,12 @@ namespace Orleans.Storage
                 container = blobClient.GetContainerReference(containerName);
                 await container.CreateIfNotExistsAsync().ConfigureAwait(false);
 
-                Log.Info((int)AzureProviderErrorCode.AzureBlobProvider_InitProvider, "Init: Name={0} ServiceId={1} {2}", name, providerRuntime.ServiceId.ToString(), string.Join(" ", FormatPropertyMessage(config)));
-                Log.Info((int)AzureProviderErrorCode.AzureBlobProvider_ParamConnectionString, "AzureBlobStorage Provider is using DataConnectionString: {0}", ConfigUtilities.RedactConnectionStringInfo(config.Properties["DataConnectionString"]));
+                logger.Info((int)AzureProviderErrorCode.AzureBlobProvider_InitProvider, "Init: Name={0} ServiceId={1} {2}", name, providerRuntime.ServiceId.ToString(), string.Join(" ", FormatPropertyMessage(config)));
+                logger.Info((int)AzureProviderErrorCode.AzureBlobProvider_ParamConnectionString, "AzureBlobStorage Provider is using DataConnectionString: {0}", ConfigUtilities.RedactConnectionStringInfo(config.Properties["DataConnectionString"]));
             }
             catch (Exception ex)
             {
-                Log.Error((int)AzureProviderErrorCode.AzureBlobProvider_InitProvider, ex.ToString(), ex);
+                logger.Error((int)AzureProviderErrorCode.AzureBlobProvider_InitProvider, ex.ToString(), ex);
                 throw;
             }
         }
@@ -119,7 +124,7 @@ namespace Orleans.Storage
         public async Task ReadStateAsync(string grainType, GrainReference grainId, IGrainState grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
-            if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Reading, "Reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+            if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Reading, "Reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
 
             try
             {
@@ -133,29 +138,29 @@ namespace Orleans.Storage
                 }
                 catch (StorageException exception) when (exception.IsBlobNotFound())
                 {
-                    if (this.Log.IsVerbose2) this.Log.Verbose2((int)AzureProviderErrorCode.AzureBlobProvider_BlobNotFound, "BlobNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                    if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_BlobNotFound, "BlobNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
                     return;
                 }
                 catch (StorageException exception) when (exception.IsContainerNotFound())
                 {
-                    if (this.Log.IsVerbose2) this.Log.Verbose2((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "ContainerNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                    if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "ContainerNotFound reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
                     return;
                 }
 
                 if (string.IsNullOrWhiteSpace(json))
                 {
-                    if (this.Log.IsVerbose2) this.Log.Verbose2((int)AzureProviderErrorCode.AzureBlobProvider_BlobEmpty, "BlobEmpty reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                    if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_BlobEmpty, "BlobEmpty reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
                     return;
                 }
 
                 grainState.State = JsonConvert.DeserializeObject(json, grainState.State.GetType(), jsonSettings);
                 grainState.ETag = blob.Properties.ETag;
 
-                if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Read: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Read: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
             }
             catch (Exception ex)
             {
-                Log.Error((int)AzureProviderErrorCode.AzureBlobProvider_ReadError,
+                logger.Error((int)AzureProviderErrorCode.AzureBlobProvider_ReadError,
                     string.Format("Error reading: GrainType={0} Grainid={1} ETag={2} from BlobName={3} in Container={4} Exception={5}", grainType, grainId, grainState.ETag, blobName, container.Name, ex.Message),
                     ex);
 
@@ -175,7 +180,7 @@ namespace Orleans.Storage
             var blobName = GetBlobName(grainType, grainId);
             try
             {
-                if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Writing, "Writing: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_Writing, "Writing: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
 
                 var json = JsonConvert.SerializeObject(grainState.State, jsonSettings);
 
@@ -184,11 +189,11 @@ namespace Orleans.Storage
 
                 await WriteStateAndCreateContainerIfNotExists(grainType, grainId, grainState, json, blob);
 
-                if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Written: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Storage_DataRead, "Written: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
             }
             catch (Exception ex)
             {
-                Log.Error((int)AzureProviderErrorCode.AzureBlobProvider_WriteError,
+                logger.Error((int)AzureProviderErrorCode.AzureBlobProvider_WriteError,
                     string.Format("Error writing: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4} Exception={5}", grainType, grainId, grainState.ETag, blobName, container.Name, ex.Message),
                     ex);
 
@@ -203,7 +208,7 @@ namespace Orleans.Storage
             var blobName = GetBlobName(grainType, grainId);
             try
             {
-                if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_ClearingData, "Clearing: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_ClearingData, "Clearing: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blobName, container.Name);
 
                 var blob = container.GetBlockBlobReference(blobName);
 
@@ -212,11 +217,11 @@ namespace Orleans.Storage
 
                 grainState.ETag = null;
 
-                if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_Cleared, "Cleared: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4}", grainType, grainId, blob.Properties.ETag, blobName, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_Cleared, "Cleared: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4}", grainType, grainId, blob.Properties.ETag, blobName, container.Name);
             }
             catch (Exception ex)
             {
-                Log.Error((int)AzureProviderErrorCode.AzureBlobProvider_ClearError,
+                logger.Error((int)AzureProviderErrorCode.AzureBlobProvider_ClearError,
                   string.Format("Error clearing: GrainType={0} Grainid={1} ETag={2} BlobName={3} in Container={4} Exception={5}", grainType, grainId, grainState.ETag, blobName, container.Name, ex.Message),
                   ex);
 
@@ -236,7 +241,7 @@ namespace Orleans.Storage
             catch (StorageException exception) when (exception.IsContainerNotFound())
             {
                 // if the container does not exist, create it, and make another attempt
-                if (this.Log.IsVerbose3) this.Log.Verbose3((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "Creating container: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blob.Name, container.Name);
+                if (this.logger.IsEnabled(LogLevel.Trace)) this.logger.Trace((int)AzureProviderErrorCode.AzureBlobProvider_ContainerNotFound, "Creating container: GrainType={0} Grainid={1} ETag={2} to BlobName={3} in Container={4}", grainType, grainId, grainState.ETag, blob.Name, container.Name);
                 await container.CreateIfNotExistsAsync().ConfigureAwait(false);
 
                 await WriteStateAndCreateContainerIfNotExists(grainType, grainId, grainState, json, blob).ConfigureAwait(false);

--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -68,8 +68,9 @@ namespace Orleans.Storage
         public async Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
         {
             var loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
-            this.logger = loggerFactory.CreateLogger<AzureBlobStorage>();
-            Log = new LoggerWrapper(this.GetType().FullName, loggerFactory);
+            var loggerName = $"{this.GetType().FullName}.{name}";
+            this.logger = loggerFactory.CreateLogger(loggerName);
+            Log = new LoggerWrapper(loggerName, loggerFactory);
 
             try
             {

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -110,7 +110,7 @@ namespace Orleans.Storage
             isDeleteStateOnClear = config.Properties.ContainsKey(DeleteOnClearPropertyName) &&
                 "true".Equals(config.Properties[DeleteOnClearPropertyName], StringComparison.OrdinalIgnoreCase);
             var loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
-            var loggerName = this.GetType().FullName + id;
+            var loggerName = $"{this.GetType().FullName}.{Name}";
             logger = loggerFactory.CreateLogger(loggerName);
             Log = new LoggerWrapper(loggerName, loggerFactory);
             var initMsg = string.Format("Init: Name={0} ServiceId={1} Table={2} DeleteStateOnClear={3}",

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -15,6 +15,7 @@ using Orleans.Providers.Azure;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Orleans.Storage
 {
@@ -82,6 +83,7 @@ namespace Orleans.Storage
         /// <see cref="IStorageProvider.Log"/>
         public Logger Log { get; private set; }
 
+        private ILogger logger;
         /// <summary> Default constructor </summary>
         public AzureTableStorage()
         {
@@ -107,9 +109,10 @@ namespace Orleans.Storage
 
             isDeleteStateOnClear = config.Properties.ContainsKey(DeleteOnClearPropertyName) &&
                 "true".Equals(config.Properties[DeleteOnClearPropertyName], StringComparison.OrdinalIgnoreCase);
-
-            Log = providerRuntime.GetLogger("Storage.AzureTableStorage." + id);
-
+            var loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
+            var loggerName = this.GetType().FullName + id;
+            logger = loggerFactory.CreateLogger(loggerName);
+            Log = new LoggerWrapper(loggerName, loggerFactory);
             var initMsg = string.Format("Init: Name={0} ServiceId={1} Table={2} DeleteStateOnClear={3}",
                 Name, serviceId, tableName, isDeleteStateOnClear);
 
@@ -120,16 +123,10 @@ namespace Orleans.Storage
             this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.serializationManager, grainFactory), config);
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 
-            Log.Info((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, initMsg);
-            Log.Info((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, "AzureTableStorage Provider is using DataConnectionString: {0}", ConfigUtilities.RedactConnectionStringInfo(dataConnectionString));
+            this.logger.Info((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, initMsg);
+            logger.Info((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, "AzureTableStorage Provider is using DataConnectionString: {0}", ConfigUtilities.RedactConnectionStringInfo(dataConnectionString));
             tableDataManager = new GrainStateTableDataManager(tableName, dataConnectionString, loggerFactory);
             return tableDataManager.InitTableAsync();
-        }
-
-        // Internal method to initialize for testing
-        internal void InitLogger(Logger logger)
-        {
-            Log = logger;
         }
 
         /// <summary> Shutdown this storage provider. </summary>
@@ -147,7 +144,7 @@ namespace Orleans.Storage
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainReference);
-            if (Log.IsVerbose3) Log.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_ReadingData, "Reading: GrainType={0} Pk={1} Grainid={2} from Table={3}", grainType, pk, grainReference, tableName);
+            if(logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_ReadingData, "Reading: GrainType={0} Pk={1} Grainid={2} from Table={3}", grainType, pk, grainReference, tableName);
             string partitionKey = pk;
             string rowKey = grainType;
             GrainStateRecord record = await tableDataManager.Read(partitionKey, rowKey).ConfigureAwait(false);
@@ -172,8 +169,8 @@ namespace Orleans.Storage
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainReference);
-            if (Log.IsVerbose3)
-                Log.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Writing: GrainType={0} Pk={1} Grainid={2} ETag={3} to Table={4}", grainType, pk, grainReference, grainState.ETag, tableName);
+            if (logger.IsEnabled(LogLevel.Trace))
+                logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Writing: GrainType={0} Pk={1} Grainid={2} ETag={3} to Table={4}", grainType, pk, grainReference, grainState.ETag, tableName);
 
             var entity = new DynamicTableEntity(pk, grainType);
             ConvertToStorageFormat(grainState.State, entity);
@@ -185,7 +182,7 @@ namespace Orleans.Storage
             }
             catch (Exception exc)
             {
-                Log.Error((int)AzureProviderErrorCode.AzureTableProvider_WriteError,
+                logger.Error((int)AzureProviderErrorCode.AzureTableProvider_WriteError,
                     $"Error Writing: GrainType={grainType} Grainid={grainReference} ETag={grainState.ETag} to Table={tableName} Exception={exc.Message}", exc);
                 throw;
             }
@@ -203,7 +200,7 @@ namespace Orleans.Storage
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainReference);
-            if (Log.IsVerbose3) Log.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Clearing: GrainType={0} Pk={1} Grainid={2} ETag={3} DeleteStateOnClear={4} from Table={5}", grainType, pk, grainReference, grainState.ETag, isDeleteStateOnClear, tableName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_WritingData, "Clearing: GrainType={0} Pk={1} Grainid={2} ETag={3} DeleteStateOnClear={4} from Table={5}", grainType, pk, grainReference, grainState.ETag, isDeleteStateOnClear, tableName);
             var entity = new DynamicTableEntity(pk, grainType);
             var record = new GrainStateRecord { Entity = entity, ETag = grainState.ETag };
             string operation = "Clearing";
@@ -223,7 +220,7 @@ namespace Orleans.Storage
             }
             catch (Exception exc)
             {
-                Log.Error((int)AzureProviderErrorCode.AzureTableProvider_DeleteError, string.Format("Error {0}: GrainType={1} Grainid={2} ETag={3} from Table={4} Exception={5}",
+                logger.Error((int)AzureProviderErrorCode.AzureTableProvider_DeleteError, string.Format("Error {0}: GrainType={1} Grainid={2} ETag={3} from Table={4} Exception={5}",
                     operation, grainType, grainReference, grainState.ETag, tableName, exc.Message), exc);
                 throw;
             }
@@ -262,7 +259,7 @@ namespace Orleans.Storage
                 // http://james.newtonking.com/json/help/index.html?topic=html/T_Newtonsoft_Json_JsonConvert.htm
                 string data = Newtonsoft.Json.JsonConvert.SerializeObject(grainState, jsonSettings);
 
-                if (Log.IsVerbose3) Log.Verbose3("Writing JSON data size = {0} for grain id = Partition={1} / Row={2}",
+                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Writing JSON data size = {0} for grain id = Partition={1} / Row={2}",
                     data.Length, entity.PartitionKey, entity.RowKey);
 
                 // each Unicode character takes 2 bytes
@@ -277,7 +274,7 @@ namespace Orleans.Storage
 
                 byte[] data = this.serializationManager.SerializeToByteArray(grainState);
 
-                if (Log.IsVerbose3) Log.Verbose3("Writing binary data size = {0} for grain id = Partition={1} / Row={2}",
+                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Writing binary data size = {0} for grain id = Partition={1} / Row={2}",
                     data.Length, entity.PartitionKey, entity.RowKey);
 
                 dataSize = data.Length;
@@ -300,7 +297,7 @@ namespace Orleans.Storage
             if (dataSize > maxDataSize)
             {
                 var msg = string.Format("Data too large to write to Azure table. Size={0} MaxSize={1}", dataSize, maxDataSize);
-                Log.Error(0, msg);
+                logger.Error(0, msg);
                 throw new ArgumentOutOfRangeException("GrainState.Size", msg);
             }
         }
@@ -448,7 +445,7 @@ namespace Orleans.Storage
                     sb.AppendFormat("Data Value={0} Type={1}", dataValue, dataValue.GetType());
                 }
 
-                Log.Error(0, sb.ToString(), exc);
+                logger.Error(0, sb.ToString(), exc);
                 throw new AggregateException(sb.ToString(), exc);
             }
 
@@ -471,11 +468,11 @@ namespace Orleans.Storage
         {
             public string TableName { get; private set; }
             private readonly AzureTableDataManager<DynamicTableEntity> tableManager;
-            private readonly Logger logger;
+            private readonly ILogger logger;
 
             public GrainStateTableDataManager(string tableName, string storageConnectionString, ILoggerFactory loggerFactory)
             {
-                this.logger = new LoggerWrapper<GrainStateTableDataManager>(loggerFactory);
+                this.logger = loggerFactory.CreateLogger<GrainStateTableDataManager>();
                 TableName = tableName;
                 tableManager = new AzureTableDataManager<DynamicTableEntity>(tableName, storageConnectionString, loggerFactory);
             }
@@ -487,25 +484,25 @@ namespace Orleans.Storage
 
             public async Task<GrainStateRecord> Read(string partitionKey, string rowKey)
             {
-                if (logger.IsVerbose3) logger.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_Storage_Reading, "Reading: PartitionKey={0} RowKey={1} from Table={2}", partitionKey, rowKey, TableName);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_Storage_Reading, "Reading: PartitionKey={0} RowKey={1} from Table={2}", partitionKey, rowKey, TableName);
                 try
                 {
                     Tuple<DynamicTableEntity, string> data = await tableManager.ReadSingleTableEntryAsync(partitionKey, rowKey).ConfigureAwait(false);
                     if (data == null || data.Item1 == null)
                     {
-                        if (logger.IsVerbose2) logger.Verbose2((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "DataNotFound reading: PartitionKey={0} RowKey={1} from Table={2}", partitionKey, rowKey, TableName);
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "DataNotFound reading: PartitionKey={0} RowKey={1} from Table={2}", partitionKey, rowKey, TableName);
                         return null;
                     }
                     DynamicTableEntity stateEntity = data.Item1;
                     var record = new GrainStateRecord { Entity = stateEntity, ETag = data.Item2 };
-                    if (logger.IsVerbose3) logger.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_Storage_DataRead, "Read: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", stateEntity.PartitionKey, stateEntity.RowKey, TableName, record.ETag);
+                    if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_Storage_DataRead, "Read: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", stateEntity.PartitionKey, stateEntity.RowKey, TableName, record.ETag);
                     return record;
                 }
                 catch (Exception exc)
                 {
                     if (AzureStorageUtils.TableStorageDataNotFound(exc))
                     {
-                        if (logger.IsVerbose2) logger.Verbose2((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "DataNotFound reading (exception): PartitionKey={0} RowKey={1} from Table={2} Exception={3}", partitionKey, rowKey, TableName, LogFormatter.PrintException(exc));
+                        if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_DataNotFound, "DataNotFound reading (exception): PartitionKey={0} RowKey={1} from Table={2} Exception={3}", partitionKey, rowKey, TableName, LogFormatter.PrintException(exc));
                         return null;  // No data
                     }
                     throw;
@@ -515,7 +512,7 @@ namespace Orleans.Storage
             public async Task Write(GrainStateRecord record)
             {
                 var entity = record.Entity;
-                if (logger.IsVerbose3) logger.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_Storage_Writing, "Writing: PartitionKey={0} RowKey={1} to Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_Storage_Writing, "Writing: PartitionKey={0} RowKey={1} to Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
                 string eTag = String.IsNullOrEmpty(record.ETag) ?
                     await tableManager.CreateTableEntryAsync(entity).ConfigureAwait(false) :
                     await tableManager.UpdateTableEntryAsync(entity, record.ETag).ConfigureAwait(false);
@@ -525,7 +522,7 @@ namespace Orleans.Storage
             public async Task Delete(GrainStateRecord record)
             {
                 var entity = record.Entity;
-                if (logger.IsVerbose3) logger.Verbose3((int)AzureProviderErrorCode.AzureTableProvider_Storage_Writing, "Deleting: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
+                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace((int)AzureProviderErrorCode.AzureTableProvider_Storage_Writing, "Deleting: PartitionKey={0} RowKey={1} from Table={2} with ETag={3}", entity.PartitionKey, entity.RowKey, TableName, record.ETag);
                 await tableManager.DeleteTableEntryAsync(entity, record.ETag).ConfigureAwait(false);
                 record.ETag = null;
             }

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -57,10 +57,7 @@ namespace Orleans.Storage
         private string serviceId;
         private GrainStateTableDataManager tableDataManager;
         private bool isDeleteStateOnClear;
-        private static int counter;
-        private readonly int id;
-
-        private ILoggerFactory loggerFactory;
+        
         // each property can hold 64KB of data and each entity can take 1MB in total, so 15 full properties take
         // 15 * 64 = 960 KB leaving room for the primary key, timestamp etc
         private const int MAX_DATA_CHUNK_SIZE = 64 * 1024;
@@ -88,7 +85,6 @@ namespace Orleans.Storage
         public AzureTableStorage()
         {
             tableName = TableNameDefaultValue;
-            id = Interlocked.Increment(ref counter);
         }
 
         /// <summary> Initialization function for this storage provider. </summary>
@@ -118,7 +114,6 @@ namespace Orleans.Storage
 
             if (config.Properties.ContainsKey(UseJsonFormatPropertyName))
                 useJsonFormat = "true".Equals(config.Properties[UseJsonFormatPropertyName], StringComparison.OrdinalIgnoreCase);
-            this.loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
             var grainFactory = providerRuntime.ServiceProvider.GetRequiredService<IGrainFactory>();
             this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.serializationManager, grainFactory), config);
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);

--- a/src/OrleansAzureUtils/Storage/AzureQueueDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/AzureQueueDataManager.cs
@@ -50,7 +50,7 @@ namespace Orleans.AzureUtils
 
         private string connectionString { get; set; }
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        private readonly Logger logger;
+        private readonly ILogger logger;
         private readonly TimeSpan? messageVisibilityTimeout;
         private readonly CloudQueueClient queueOperationsClient;
         private CloudQueue queue;
@@ -66,7 +66,7 @@ namespace Orleans.AzureUtils
         {
             AzureStorageUtils.ValidateQueueName(queueName);
 
-            logger = new LoggerWrapper<AzureQueueDataManager>(loggerFactory);
+            logger = loggerFactory.CreateLogger<AzureQueueDataManager>();
             QueueName = queueName;
             connectionString = storageConnectionString;
             messageVisibilityTimeout = visibilityTimeout;
@@ -90,7 +90,7 @@ namespace Orleans.AzureUtils
         {
             AzureStorageUtils.ValidateQueueName(queueName);
             
-            logger = new LoggerWrapper<AzureQueueDataManager>(loggerFactory);
+            logger = loggerFactory.CreateLogger<AzureQueueDataManager>();
             QueueName = deploymentId + "-" + queueName;
             AzureStorageUtils.ValidateQueueName(QueueName);
             connectionString = storageConnectionString;
@@ -137,7 +137,7 @@ namespace Orleans.AzureUtils
         public async Task DeleteQueue()
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsVerbose2) logger.Verbose2("Deleting queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Deleting queue: {0}", QueueName);
             try
             {
                 // that way we don't have first to create the queue to be able later to delete it.
@@ -163,7 +163,7 @@ namespace Orleans.AzureUtils
         public async Task ClearQueue()
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsVerbose2) logger.Verbose2("Clearing a queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Clearing a queue: {0}", QueueName);
             try
             {
                 // that way we don't have first to create the queue to be able later to delete it.
@@ -188,7 +188,7 @@ namespace Orleans.AzureUtils
         public async Task AddQueueMessage(CloudQueueMessage message)
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsVerbose2) logger.Verbose2("Adding message {0} to queue: {1}", message, QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Adding message {0} to queue: {1}", message, QueueName);
             try
             {
                 await queue.AddMessageAsync(message);
@@ -209,7 +209,7 @@ namespace Orleans.AzureUtils
         public async Task<CloudQueueMessage> PeekQueueMessage()
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsVerbose2) logger.Verbose2("Peeking a message from queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Peeking a message from queue: {0}", QueueName);
             try
             {
                 return await queue.PeekMessageAsync();
@@ -233,7 +233,7 @@ namespace Orleans.AzureUtils
         public async Task<CloudQueueMessage> GetQueueMessage()
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsVerbose2) logger.Verbose2("Getting a message from queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Getting a message from queue: {0}", QueueName);
             try
             {
                 //BeginGetMessage and EndGetMessage is not supported in netstandard, may be use GetMessageAsync
@@ -263,7 +263,7 @@ namespace Orleans.AzureUtils
             {
                 count = CloudQueueMessage.MaxNumberOfMessagesToPeek;
             }
-            if (logger.IsVerbose2) logger.Verbose2("Getting up to {0} messages from queue: {1}", count, QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Getting up to {0} messages from queue: {1}", count, QueueName);
             try
             {
                 return await queue.GetMessagesAsync(count, messageVisibilityTimeout, options: null, operationContext: null);
@@ -286,7 +286,7 @@ namespace Orleans.AzureUtils
         public async Task DeleteQueueMessage(CloudQueueMessage message)
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsVerbose2) logger.Verbose2("Deleting a message from queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Deleting a message from queue: {0}", QueueName);
             try
             {
                 await queue.DeleteMessageAsync(message.Id, message.PopReceipt);
@@ -314,7 +314,7 @@ namespace Orleans.AzureUtils
         public async Task<int> GetApproximateMessageCount()
         {
             var startTime = DateTime.UtcNow;
-            if (logger.IsVerbose2) logger.Verbose2("GetApproximateMessageCount a message from queue: {0}", QueueName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("GetApproximateMessageCount a message from queue: {0}", QueueName);
             try
             {
                 await queue.FetchAttributesAsync();

--- a/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
+++ b/src/OrleansAzureUtils/Storage/AzureStorageUtils.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Linq;
 using System.Net;
+using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Microsoft.WindowsAzure.Storage.Shared.Protocol;
 using Orleans.Runtime;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Orleans.AzureUtils
 {
@@ -185,7 +187,7 @@ namespace Orleans.AzureUtils
             string storageConnectionString,
             IRetryPolicy retryPolicy,
             TimeSpan timeout,
-            Logger logger)
+            ILogger logger)
         {
             try
             {
@@ -297,7 +299,7 @@ namespace Orleans.AzureUtils
                     message.AsString);
         }
 
-        internal static bool AnalyzeReadException(Exception exc, int iteration, string tableName, Logger logger)
+        internal static bool AnalyzeReadException(Exception exc, int iteration, string tableName, ILogger logger)
         {
             bool isLastErrorRetriable;
             var we = exc as WebException;
@@ -317,7 +319,7 @@ namespace Orleans.AzureUtils
                 {
                     if (StorageErrorCodeStrings.ResourceNotFound.Equals(restStatus))
                     {
-                        if (logger.IsVerbose) logger.Verbose(ErrorCode.AzureTable_DataNotFound,
+                        if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.AzureTable_DataNotFound,
                             "DataNotFound reading Azure storage table {0}:{1} HTTP status code={2} REST status code={3} Exception={4}",
                             tableName,
                             iteration == 0 ? "" : (" Repeat=" + iteration),

--- a/src/OrleansAzureUtils/Storage/AzureTableDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/AzureTableDataManager.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using Orleans.Runtime;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Orleans.AzureUtils
 {
@@ -24,7 +25,7 @@ namespace Orleans.AzureUtils
         public string TableName { get; private set; }
 
         /// <summary> Logger for this table manager instance. </summary>
-        protected internal Logger Logger { get; private set; }
+        protected internal ILogger Logger { get; private set; }
 
         /// <summary> Connection string for the Azure storage account used to host this table. </summary>
         protected string ConnectionString { get; set; }
@@ -41,7 +42,7 @@ namespace Orleans.AzureUtils
         /// <param name="loggerFactory">Logger factory to use.</param>
         public AzureTableDataManager(string tableName, string storageConnectionString, ILoggerFactory loggerFactory)
         {
-            Logger = new LoggerWrapper<AzureTableDataManager<T>>(loggerFactory);
+            Logger = loggerFactory.CreateLogger<AzureTableDataManager<T>>();
             TableName = tableName;
             ConnectionString = storageConnectionString;
 
@@ -136,7 +137,7 @@ namespace Orleans.AzureUtils
             const string operation = "CreateTableEntry";
             var startTime = DateTime.UtcNow;
 
-            if (Logger.IsVerbose2) Logger.Verbose2("Creating {0} table entry: {1}", TableName, data);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Creating {0} table entry: {1}", TableName, data);
 
             try
             {
@@ -173,7 +174,7 @@ namespace Orleans.AzureUtils
         {
             const string operation = "UpsertTableEntry";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsVerbose2) Logger.Verbose2("{0} entry {1} into table {2}", operation, data, TableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} entry {1} into table {2}", operation, data, TableName);
 
             try
             {
@@ -210,7 +211,7 @@ namespace Orleans.AzureUtils
         {
             const string operation = "MergeTableEntry";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsVerbose2) Logger.Verbose2("{0} entry {1} into table {2}", operation, data, TableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} entry {1} into table {2}", operation, data, TableName);
 
             try
             {
@@ -250,7 +251,7 @@ namespace Orleans.AzureUtils
         {
             const string operation = "UpdateTableEntryAsync";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsVerbose2) Logger.Verbose2("{0} table {1}  entry {2}", operation, TableName, data);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} table {1}  entry {2}", operation, TableName, data);
 
             try
             {
@@ -285,7 +286,7 @@ namespace Orleans.AzureUtils
         {            
             const string operation = "DeleteTableEntryAsync";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsVerbose2) Logger.Verbose2("{0} table {1}  entry {2}", operation, TableName, data);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} table {1}  entry {2}", operation, TableName, data);
 
             try
             {   
@@ -319,7 +320,7 @@ namespace Orleans.AzureUtils
         {
             const string operation = "ReadSingleTableEntryAsync";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsVerbose2) Logger.Verbose2("{0} table {1} partitionKey {2} rowKey = {3}", operation, TableName, partitionKey, rowKey);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} table {1} partitionKey {2} rowKey = {3}", operation, TableName, partitionKey, rowKey);
             T retrievedResult = default(T);
 
             try
@@ -338,7 +339,7 @@ namespace Orleans.AzureUtils
                 }
                 //The ETag of data is needed in further operations.                                        
                 if (retrievedResult != null) return new Tuple<T, string>(retrievedResult, retrievedResult.ETag);
-                if (Logger.IsVerbose) Logger.Verbose("Could not find table entry for PartitionKey={0} RowKey={1}", partitionKey, rowKey);
+                if (Logger.IsEnabled(LogLevel.Debug)) Logger.Debug("Could not find table entry for PartitionKey={0} RowKey={1}", partitionKey, rowKey);
                 return null;  // No data
             }
             finally
@@ -380,7 +381,7 @@ namespace Orleans.AzureUtils
         {
             const string operation = "DeleteTableEntries";
             var startTime = DateTime.UtcNow;
-            if (Logger.IsVerbose2) Logger.Verbose2("Deleting {0} table entries: {1}", TableName, Utils.EnumerableToString(collection));
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Deleting {0} table entries: {1}", TableName, Utils.EnumerableToString(collection));
 
             if (collection == null) throw new ArgumentNullException("collection");
 
@@ -510,7 +511,7 @@ namespace Orleans.AzureUtils
             }
 
             var startTime = DateTime.UtcNow;
-            if (Logger.IsVerbose2) Logger.Verbose2("Bulk inserting {0} entries to {1} table", collection.Count, TableName);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("Bulk inserting {0} entries to {1} table", collection.Count, TableName);
 
             try
             {
@@ -553,7 +554,7 @@ namespace Orleans.AzureUtils
             string data2Str = (data2 == null ? "null" : data2.ToString());
             var startTime = DateTime.UtcNow;
 
-            if (Logger.IsVerbose2) Logger.Verbose2("{0} into table {1} data1 {2} data2 {3}", operation, TableName, data1, data2Str);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} into table {1} data1 {2} data2 {3}", operation, TableName, data1, data2Str);
 
             try
             {                                
@@ -598,7 +599,7 @@ namespace Orleans.AzureUtils
             const string operation = "UpdateTableEntryConditionally";
             string data2Str = (data2 == null ? "null" : data2.ToString());
             var startTime = DateTime.UtcNow;
-            if (Logger.IsVerbose2) Logger.Verbose2("{0} table {1} data1 {2} data2 {3}", operation, TableName, data1, data2Str);
+            if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("{0} table {1} data1 {2} data2 {3}", operation, TableName, data1, data2Str);
 
             try
             {
@@ -691,7 +692,7 @@ namespace Orleans.AzureUtils
             if(AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus) && AzureStorageUtils.IsContentionError(httpStatusCode))
             {
                 // log at Verbose, since failure on conditional is not not an error. Will analyze and warn later, if required.
-                if(Logger.IsVerbose) Logger.Verbose(ErrorCode.AzureTable_13,
+                if(Logger.IsEnabled(LogLevel.Debug)) Logger.Debug(ErrorCode.AzureTable_13,
                     $"Intermediate Azure table write error {operation} to table {TableName} data1 {(data1 ?? "null")} data2 {(data2 ?? "null")}", exc);
 
             }

--- a/src/OrleansAzureUtils/Storage/RemindersTableManager.cs
+++ b/src/OrleansAzureUtils/Storage/RemindersTableManager.cs
@@ -198,7 +198,7 @@ namespace Orleans.Runtime.ReminderService
                 string restStatus;
                 if (AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus))
                 {
-                    if (Logger.IsVerbose2) Logger.Verbose2("UpsertRow failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
+                    if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("UpsertRow failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
                     if (AzureStorageUtils.IsContentionError(httpStatusCode)) return null; // false;
                 }
                 throw;
@@ -218,7 +218,7 @@ namespace Orleans.Runtime.ReminderService
                 string restStatus;
                 if (AzureStorageUtils.EvaluateException(exc, out httpStatusCode, out restStatus))
                 {
-                    if (Logger.IsVerbose2) Logger.Verbose2("DeleteReminderEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
+                    if (Logger.IsEnabled(LogLevel.Trace)) Logger.Trace("DeleteReminderEntryConditionally failed with httpStatusCode={0}, restStatus={1}", httpStatusCode, restStatus);
                     if (AzureStorageUtils.IsContentionError(httpStatusCode)) return false;
                 }
                 throw;

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableStore.cs
@@ -175,7 +175,6 @@ namespace Tester.AzureUtils.Persistence
             var initialState = new GrainStateContainingGrainReferences { Grain = grain };
             var entity = new DynamicTableEntity();
             var storage = new AzureTableStorage();
-            storage.InitLogger(logger);
             await storage.Init("AzStore", this.HostedCluster.ServiceProvider.GetRequiredService<ClientProviderRuntime>(), new ProviderConfiguration(providerProperties, null));
             storage.ConvertToStorageFormat(initialState, entity);
             var convertedState = new GrainStateContainingGrainReferences();
@@ -202,7 +201,6 @@ namespace Tester.AzureUtils.Persistence
             }
             var entity = new DynamicTableEntity();
             var storage = new AzureTableStorage();
-            storage.InitLogger(logger);
             await storage.Init("AzStore", this.HostedCluster.ServiceProvider.GetRequiredService<ClientProviderRuntime>(), new ProviderConfiguration(providerProperties, null));
             storage.ConvertToStorageFormat(initialState, entity);
             var convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity);

--- a/test/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -240,9 +240,6 @@ namespace Tester.AzureUtils.Persistence
             var storage = await InitAzureTableStorageProvider(useJson, testName);
             var initialState = state.State;
 
-            var logger = new LoggerWrapper<PersistenceProviderTests_Local>(TestingUtils.CreateDefaultLoggerFactory($"{this.GetType().Name}.log"));
-            storage.InitLogger(logger);
-
             var entity = new DynamicTableEntity();
 
             storage.ConvertToStorageFormat(initialState, entity);


### PR DESCRIPTION
Remove internal usage of Logger in AzureUtils.
There's still usage of Logger in public methods, which is non-trivia. We talked about marking them as obsolete or move them to a legacy package. This can be addressed in another PR. 