### PR TITLE
Remove internal usage of Logger from AWsUtils

### DIFF
--- a/src/Orleans.Core/Logging/LoggerWrapper.cs
+++ b/src/Orleans.Core/Logging/LoggerWrapper.cs
@@ -39,6 +39,15 @@ namespace Orleans.Runtime
         private readonly Severity maxSeverityLevel;
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
+
+        public LoggerWrapper(ILogger logger, string name, ILoggerFactory loggerFactory)
+        {
+            this.logger = logger;
+            this.name = name;
+            this.loggerFactory = loggerFactory;
+            this.maxSeverityLevel = FindSeverityForLogger(this.logger);
+        }
+
         public LoggerWrapper(string name, ILoggerFactory loggerFactory)
         {
             this.name = Name;

--- a/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
+++ b/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
@@ -14,6 +14,7 @@ using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using OrleansAWSUtils.Storage;
 using Microsoft.Extensions.Logging;
+using Orleans.Runtime.Configuration;
 
 namespace Orleans.Storage
 {
@@ -61,6 +62,7 @@ namespace Orleans.Storage
         /// </summary>
         public Logger Log { get; private set; }
 
+        private ILogger logger;
         private DynamoDBStorage storage;
         private SerializationManager serializationManager;
 
@@ -86,9 +88,10 @@ namespace Orleans.Storage
 
             isDeleteStateOnClear = config.Properties.ContainsKey(DELETE_ON_CLEAR_PROPERTY_NAME) &&
                 "true".Equals(config.Properties[DELETE_ON_CLEAR_PROPERTY_NAME], StringComparison.OrdinalIgnoreCase);
-
-            Log = providerRuntime.GetLogger("Storage.AWSDynamoDBStorage." + id);
-
+            var loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
+            var loggerName = $"{this.GetType().FullName}.{name}";
+            Log = new LoggerWrapper(loggerName, loggerFactory);
+            logger = loggerFactory.CreateLogger(loggerName);
             var initMsg = string.Format("Init: Name={0} ServiceId={1} Table={2} DeleteStateOnClear={3}",
                 Name, serviceId, tableName, isDeleteStateOnClear);
 
@@ -100,7 +103,7 @@ namespace Orleans.Storage
 
             initMsg = string.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 
-            Log.Info(ErrorCode.StorageProviderBase, "AWS DynamoDB Provider: {0}", initMsg);
+            logger.Info(ErrorCode.StorageProviderBase, "AWS DynamoDB Provider: {0}", initMsg);
 
             storage = new DynamoDBStorage(config.Properties[DATA_CONNECTION_STRING_PROPERTY_NAME], providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>());
             return storage.InitializeTable(tableName,
@@ -114,11 +117,6 @@ namespace Orleans.Storage
                     new AttributeDefinition { AttributeName = GRAIN_REFERENCE_PROPERTY_NAME, AttributeType = ScalarAttributeType.S },
                     new AttributeDefinition { AttributeName = GRAIN_TYPE_PROPERTY_NAME, AttributeType = ScalarAttributeType.S }
                 });
-        }
-
-        internal void InitLogger(Logger logger)
-        {
-            Log = logger;
         }
 
         /// <summary> Shutdown this storage provider. </summary>
@@ -135,7 +133,7 @@ namespace Orleans.Storage
             if (storage == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string partitionKey = GetKeyString(grainReference);
-            if (Log.IsVerbose3) Log.Verbose3(ErrorCode.StorageProviderBase, "Reading: GrainType={0} Pk={1} Grainid={2} from Table={3}", grainType, partitionKey, grainReference, tableName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.StorageProviderBase, "Reading: GrainType={0} Pk={1} Grainid={2} from Table={3}", grainType, partitionKey, grainReference, tableName);
             string rowKey = AWSUtils.ValidateDynamoDBRowKey(grainType);
 
             var record = await storage.ReadSingleEntryAsync(tableName,
@@ -188,7 +186,7 @@ namespace Orleans.Storage
             }
             catch (Exception exc)
             {
-                Log.Error(ErrorCode.StorageProviderBase, string.Format("Error Writing: GrainType={0} Grainid={1} ETag={2} to Table={3} Exception={4}",
+                logger.Error(ErrorCode.StorageProviderBase, string.Format("Error Writing: GrainType={0} Grainid={1} ETag={2} to Table={3} Exception={4}",
                     grainType, grainReference, grainState.ETag, tableName, exc.Message), exc);
                 throw;
             }
@@ -261,7 +259,7 @@ namespace Orleans.Storage
             if (storage == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string partitionKey = GetKeyString(grainReference);
-            if (Log.IsVerbose3) Log.Verbose3(ErrorCode.StorageProviderBase, "Clearing: GrainType={0} Pk={1} Grainid={2} ETag={3} DeleteStateOnClear={4} from Table={5}", grainType, partitionKey, grainReference, grainState.ETag, isDeleteStateOnClear, tableName);
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(ErrorCode.StorageProviderBase, "Clearing: GrainType={0} Pk={1} Grainid={2} ETag={3} DeleteStateOnClear={4} from Table={5}", grainType, partitionKey, grainReference, grainState.ETag, isDeleteStateOnClear, tableName);
             string rowKey = AWSUtils.ValidateDynamoDBRowKey(grainType);
             var record = new GrainStateRecord { GrainReference = partitionKey, ETag = string.IsNullOrWhiteSpace(grainState.ETag) ? 0 : int.Parse(grainState.ETag), GrainType = rowKey };
 
@@ -285,7 +283,7 @@ namespace Orleans.Storage
             }
             catch (Exception exc)
             {
-                Log.Error(ErrorCode.StorageProviderBase, string.Format("Error {0}: GrainType={1} Grainid={2} ETag={3} from Table={4} Exception={5}",
+                logger.Error(ErrorCode.StorageProviderBase, string.Format("Error {0}: GrainType={1} Grainid={2} ETag={3} from Table={4} Exception={5}",
                     operation, grainType, grainReference, grainState.ETag, tableName, exc.Message), exc);
                 throw;
             }
@@ -342,7 +340,7 @@ namespace Orleans.Storage
                     sb.AppendFormat("Data Value={0} Type={1}", dataValue, dataValue.GetType());
                 }
 
-                Log.Error(0, sb.ToString(), exc);
+                logger.Error(0, sb.ToString(), exc);
                 throw new AggregateException(sb.ToString(), exc);
             }
 
@@ -358,7 +356,7 @@ namespace Orleans.Storage
                 entity.StringState = JsonConvert.SerializeObject(grainState, jsonSettings);
                 dataSize = STRING_STATE_PROPERTY_NAME.Length + entity.StringState.Length;
 
-                if (Log.IsVerbose3) Log.Verbose3("Writing JSON data size = {0} for grain id = Partition={1} / Row={2}",
+                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Writing JSON data size = {0} for grain id = Partition={1} / Row={2}",
                     dataSize, entity.GrainReference, entity.GrainType);
             }
             else
@@ -367,7 +365,7 @@ namespace Orleans.Storage
                 entity.BinaryState = this.serializationManager.SerializeToByteArray(grainState);
                 dataSize = BINARY_STATE_PROPERTY_NAME.Length + entity.BinaryState.Length;
 
-                if (Log.IsVerbose3) Log.Verbose3("Writing binary data size = {0} for grain id = Partition={1} / Row={2}",
+                if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("Writing binary data size = {0} for grain id = Partition={1} / Row={2}",
                     dataSize, entity.GrainReference, entity.GrainType);
             }
 

--- a/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
+++ b/src/OrleansAWSUtils/Storage/Provider/DynamoDBStorageProvider.cs
@@ -45,8 +45,6 @@ namespace Orleans.Storage
         private const string ETAG_PROPERTY_NAME = "ETag";
         private const string CURRENT_ETAG_ALIAS = ":currentETag";
         private string tableName;
-        private static int counter;
-        private readonly int id;
         private string serviceId;
         private bool isDeleteStateOnClear = false;
         private bool useJsonFormat;
@@ -72,7 +70,6 @@ namespace Orleans.Storage
         public DynamoDBStorageProvider()
         {
             tableName = TABLE_NAME_DEFAULT_VALUE;
-            id = Interlocked.Increment(ref counter);
         }
 
         /// <summary> Initialization function for this storage provider. </summary>
@@ -90,8 +87,8 @@ namespace Orleans.Storage
                 "true".Equals(config.Properties[DELETE_ON_CLEAR_PROPERTY_NAME], StringComparison.OrdinalIgnoreCase);
             var loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
             var loggerName = $"{this.GetType().FullName}.{name}";
-            Log = new LoggerWrapper(loggerName, loggerFactory);
             logger = loggerFactory.CreateLogger(loggerName);
+            Log = new LoggerWrapper(logger, loggerName, loggerFactory);
             var initMsg = string.Format("Init: Name={0} ServiceId={1} Table={2} DeleteStateOnClear={3}",
                 Name, serviceId, tableName, isDeleteStateOnClear);
 

--- a/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureBlobStorage.cs
@@ -70,7 +70,7 @@ namespace Orleans.Storage
             var loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
             var loggerName = $"{this.GetType().FullName}.{name}";
             this.logger = loggerFactory.CreateLogger(loggerName);
-            Log = new LoggerWrapper(loggerName, loggerFactory);
+            Log = new LoggerWrapper(logger, loggerName, loggerFactory);
 
             try
             {

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -108,7 +108,7 @@ namespace Orleans.Storage
             var loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
             var loggerName = $"{this.GetType().FullName}.{Name}";
             logger = loggerFactory.CreateLogger(loggerName);
-            Log = new LoggerWrapper(loggerName, loggerFactory);
+            Log = new LoggerWrapper(logger, loggerName, loggerFactory);
             var initMsg = string.Format("Init: Name={0} ServiceId={1} Table={2} DeleteStateOnClear={3}",
                 Name, serviceId, tableName, isDeleteStateOnClear);
 

--- a/test/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
+++ b/test/AWSUtils.Tests/StorageTests/PersistenceGrainTests_AWSDynamoDBStore.cs
@@ -20,6 +20,7 @@ namespace AWSUtils.Tests.StorageTests
     [TestCategory("Persistence"), TestCategory("AWS"), TestCategory("DynamoDb")]
     public class PersistenceGrainTests_AWSDynamoDBStore : Base_PersistenceGrainTests_AWSStore, IClassFixture<PersistenceGrainTests_AWSDynamoDBStore.Fixture>
     {
+        private static string DataConnectionString = $"Service={AWSTestConstants.Service}";
         public class Fixture : TestExtensions.BaseTestClusterFixture
         {
             protected override TestCluster CreateTestCluster()
@@ -27,7 +28,7 @@ namespace AWSUtils.Tests.StorageTests
                 if (AWSTestConstants.IsDynamoDbAvailable)
                 {
                     Guid serviceId = Guid.NewGuid();
-                    string dataConnectionString = $"Service={AWSTestConstants.Service}";
+                    string dataConnectionString = DataConnectionString;
                     var options = new TestClusterOptions(initialSilosCount: 4);
 
 
@@ -173,7 +174,7 @@ namespace AWSUtils.Tests.StorageTests
             var initialState = new GrainStateContainingGrainReferences { Grain = grain };
             var entity = new GrainStateRecord();
             var storage = await InitDynamoDBTableStorageProvider(
-                this.HostedCluster.ServiceProvider.GetRequiredService<IProviderRuntime>(), "dynamoDB");
+                this.HostedCluster.ServiceProvider.GetRequiredService<IProviderRuntime>(), "TestTable");
             storage.ConvertToStorageFormat(initialState, entity);
             var convertedState = new GrainStateContainingGrainReferences();
             convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity);
@@ -200,7 +201,7 @@ namespace AWSUtils.Tests.StorageTests
             var entity = new GrainStateRecord();
             var storage =
                 await InitDynamoDBTableStorageProvider(
-                    this.HostedCluster.ServiceProvider.GetRequiredService<IProviderRuntime>(), "dynamoDB");
+                    this.HostedCluster.ServiceProvider.GetRequiredService<IProviderRuntime>(), "TestTable");
             storage.ConvertToStorageFormat(initialState, entity);
             var convertedState = (GrainStateContainingGrainReferences)storage.ConvertFromStorageFormat(entity);
             Assert.NotNull(convertedState);
@@ -219,7 +220,7 @@ namespace AWSUtils.Tests.StorageTests
         {
             Dictionary<string, string> providerCfgProps = new Dictionary<string, string>();
             var store = new DynamoDBStorageProvider();
-            providerCfgProps["DataConnectionString"] = TestDefaultConfiguration.DataConnectionString;
+            providerCfgProps["DataConnectionString"] = DataConnectionString;
             var cfg = new ProviderConfiguration(providerCfgProps, null);
             await store.Init(storageName, runtime, cfg);
             return store;


### PR DESCRIPTION
braindead PR to remove internal usage of Orleans.Runtime.Logger from AwsUtils, except for usage of Logger in `IStorageProvider` interface, which can be addressed in another PR. 