### PR TITLE
Enhance error handling on GetDefinedTypes

### DIFF
--- a/src/Orleans.CodeGeneration.Build/AssemblyResolver.cs
+++ b/src/Orleans.CodeGeneration.Build/AssemblyResolver.cs
@@ -22,7 +22,8 @@ namespace Orleans.CodeGeneration
         /// Needs to be public so can be serialized accross the the app domain.
         /// </summary>
         public Dictionary<string, string> ReferenceAssemblyPaths { get; } = new Dictionary<string, string>();
-        
+
+        private readonly bool usedByCodeGenerator;
         private readonly ICompilationAssemblyResolver assemblyResolver;
 
         private readonly DependencyContext dependencyContext;
@@ -31,10 +32,14 @@ namespace Orleans.CodeGeneration
         private readonly AssemblyLoadContext loadContext;
 #endif
 
-        public AssemblyResolver(string path, List<string> referencedAssemblies)
+        public AssemblyResolver(string path, List<string> referencedAssemblies, bool usedByCodeGenerator = false)
         {
-            if (Path.GetFileName(path) == "Orleans.Core.dll")  this.Assembly = typeof(RuntimeVersion).Assembly;
-            else this.Assembly = Assembly.LoadFrom(path);
+            this.usedByCodeGenerator = usedByCodeGenerator;
+
+            if (Path.GetFileName(path) == "Orleans.Core.dll")
+                this.Assembly = typeof(RuntimeVersion).Assembly;
+            else
+                this.Assembly = Assembly.LoadFrom(path);
 
             this.dependencyContext = DependencyContext.Load(this.Assembly);
             this.resolverRependencyContext = DependencyContext.Load(typeof(AssemblyResolver).Assembly);
@@ -48,16 +53,27 @@ namespace Orleans.CodeGeneration
                     new PackageCompilationAssemblyResolver()
                 });
 
-            AppDomain.CurrentDomain.AssemblyResolve += this.ResolveAssembly;
 #if NETCOREAPP2_0
             this.loadContext = AssemblyLoadContext.GetLoadContext(this.Assembly);
-            this.loadContext.Resolving += this.AssemblyLoadContextResolving;
-            if (this.loadContext != AssemblyLoadContext.Default)
+
+            if (this.loadContext == AssemblyLoadContext.Default)
             {
-                AssemblyLoadContext.Default.Resolving += this.AssemblyLoadContextResolving;
+                if (!this.usedByCodeGenerator)
+                {
+                    AssemblyLoadContext.Default.Resolving += this.AssemblyLoadContextResolving;
+                }
+            }
+            else
+            {
+                this.loadContext.Resolving += this.AssemblyLoadContextResolving;
+            }
+#else
+            if (!this.usedByCodeGenerator)
+            {
+                AppDomain.CurrentDomain.AssemblyResolve += this.ResolveAssembly;
             }
 #endif
-            
+
             foreach (var assemblyPath in referencedAssemblies)
             {
                 var libName = Path.GetFileNameWithoutExtension(assemblyPath);
@@ -71,13 +87,23 @@ namespace Orleans.CodeGeneration
 
         public void Dispose()
         {
-            AppDomain.CurrentDomain.AssemblyResolve -= this.ResolveAssembly;
-
 #if NETCOREAPP2_0
-            this.loadContext.Resolving -= this.AssemblyLoadContextResolving;
-            if (this.loadContext != AssemblyLoadContext.Default)
+
+            if (this.loadContext == AssemblyLoadContext.Default)
             {
-                AssemblyLoadContext.Default.Resolving -= this.AssemblyLoadContextResolving;
+                if (!this.usedByCodeGenerator)
+                {
+                    AssemblyLoadContext.Default.Resolving -= this.AssemblyLoadContextResolving;
+                }
+            }
+            else
+            {
+                this.loadContext.Resolving -= this.AssemblyLoadContextResolving;
+            }
+#else
+            if (!this.usedByCodeGenerator)
+            {
+                AppDomain.CurrentDomain.AssemblyResolve -= this.ResolveAssembly;
             }
 #endif
         }
@@ -92,15 +118,16 @@ namespace Orleans.CodeGeneration
         /// </returns>
         public Assembly ResolveAssembly(object sender, ResolveEventArgs args)
         {
+            var context = default(AssemblyLoadContext);
+
 #if NETCOREAPP2_0
-            var context = AssemblyLoadContext.GetLoadContext(args.RequestingAssembly);
-#else
-            AssemblyLoadContext context = null;
+            context = AssemblyLoadContext.GetLoadContext(args.RequestingAssembly);
 #endif
+
             return this.AssemblyLoadContextResolving(context, new AssemblyName(args.Name));
         }
 
-        public Assembly AssemblyLoadContextResolving(AssemblyLoadContext context, AssemblyName name)
+            public Assembly AssemblyLoadContextResolving(AssemblyLoadContext context, AssemblyName name)
         {
             // Attempt to resolve the library from one of the dependency contexts.
             var library = this.resolverRependencyContext?.RuntimeLibraries?.FirstOrDefault(NamesMatch)
@@ -127,20 +154,27 @@ namespace Orleans.CodeGeneration
                 }
             }
 
-            if (this.ReferenceAssemblyPaths.TryGetValue(name.FullName, out string path))
+            if (this.ReferenceAssemblyPaths.TryGetValue(name.FullName, out var pathByFullName))
             {
-                var assembly = TryLoadAssemblyFromPath(path);
+                var assembly = TryLoadAssemblyFromPath(pathByFullName);
                 if (assembly != null) return assembly;
             }
 
-            if (this.ReferenceAssemblyPaths.TryGetValue(name.Name, out path))
+            if (this.ReferenceAssemblyPaths.TryGetValue(name.Name, out var pathByName))
             {
-                var assembly = TryLoadAssemblyFromPath(path);
-                if (assembly != null) return assembly;
+                //
+                // Only try to load it if the resolved path is different than from before
+                //
+
+                if (String.Compare(pathByFullName, pathByName, StringComparison.OrdinalIgnoreCase) != 0)
+                {
+                    var assembly = TryLoadAssemblyFromPath(pathByName);
+                    if (assembly != null) return assembly;
+                }
             }
-                
+
             return null;
-            
+
             bool NamesMatch(RuntimeLibrary runtime)
             {
                 return string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase);

--- a/src/Orleans.CodeGeneration.Build/AssemblyResolver.cs
+++ b/src/Orleans.CodeGeneration.Build/AssemblyResolver.cs
@@ -23,7 +23,7 @@ namespace Orleans.CodeGeneration
         /// </summary>
         public Dictionary<string, string> ReferenceAssemblyPaths { get; } = new Dictionary<string, string>();
 
-        private readonly bool usedByCodeGenerator;
+        private readonly bool installDefaultResolveHandler;
         private readonly ICompilationAssemblyResolver assemblyResolver;
 
         private readonly DependencyContext dependencyContext;
@@ -32,9 +32,9 @@ namespace Orleans.CodeGeneration
         private readonly AssemblyLoadContext loadContext;
 #endif
 
-        public AssemblyResolver(string path, List<string> referencedAssemblies, bool usedByCodeGenerator = false)
+        public AssemblyResolver(string path, List<string> referencedAssemblies, bool installDefaultResolveHandler = true)
         {
-            this.usedByCodeGenerator = usedByCodeGenerator;
+            this.installDefaultResolveHandler = installDefaultResolveHandler;
 
             if (Path.GetFileName(path) == "Orleans.Core.dll")
                 this.Assembly = typeof(RuntimeVersion).Assembly;
@@ -58,7 +58,7 @@ namespace Orleans.CodeGeneration
 
             if (this.loadContext == AssemblyLoadContext.Default)
             {
-                if (!this.usedByCodeGenerator)
+                if (this.installDefaultResolveHandler)
                 {
                     AssemblyLoadContext.Default.Resolving += this.AssemblyLoadContextResolving;
                 }
@@ -68,7 +68,7 @@ namespace Orleans.CodeGeneration
                 this.loadContext.Resolving += this.AssemblyLoadContextResolving;
             }
 #else
-            if (!this.usedByCodeGenerator)
+            if (this.installDefaultResolveHandler)
             {
                 AppDomain.CurrentDomain.AssemblyResolve += this.ResolveAssembly;
             }
@@ -91,7 +91,7 @@ namespace Orleans.CodeGeneration
 
             if (this.loadContext == AssemblyLoadContext.Default)
             {
-                if (!this.usedByCodeGenerator)
+                if (this.installDefaultResolveHandler)
                 {
                     AssemblyLoadContext.Default.Resolving -= this.AssemblyLoadContextResolving;
                 }
@@ -101,7 +101,7 @@ namespace Orleans.CodeGeneration
                 this.loadContext.Resolving -= this.AssemblyLoadContextResolving;
             }
 #else
-            if (!this.usedByCodeGenerator)
+            if (this.installDefaultResolveHandler)
             {
                 AppDomain.CurrentDomain.AssemblyResolve -= this.ResolveAssembly;
             }

--- a/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
+++ b/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
@@ -158,7 +158,7 @@ namespace Orleans.CodeGeneration
             var referencedAssemblies = options.ReferencedAssemblies;
 
             // Set up assembly resolver
-            var refResolver = new AssemblyResolver(inputAssembly, referencedAssemblies, true);
+            var refResolver = new AssemblyResolver(inputAssembly, referencedAssemblies, false);
 
             try
             {

--- a/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
+++ b/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
@@ -158,14 +158,15 @@ namespace Orleans.CodeGeneration
             var referencedAssemblies = options.ReferencedAssemblies;
 
             // Set up assembly resolver
-            var refResolver = new AssemblyResolver(inputAssembly, referencedAssemblies);
+            var refResolver = new AssemblyResolver(inputAssembly, referencedAssemblies, true);
 
             try
             {
                 // Set up assembly resolution.
-                AppDomain.CurrentDomain.AssemblyResolve += refResolver.ResolveAssembly;
 #if NETCOREAPP2_0
                 AssemblyLoadContext.Default.Resolving += refResolver.AssemblyLoadContextResolving;
+#else
+                AppDomain.CurrentDomain.AssemblyResolve += refResolver.ResolveAssembly;
 #endif
 
                 return GenerateSourceForAssembly(refResolver.Assembly);
@@ -173,9 +174,10 @@ namespace Orleans.CodeGeneration
             finally
             {
                 refResolver.Dispose();
-                AppDomain.CurrentDomain.AssemblyResolve -= refResolver.ResolveAssembly;
 #if NETCOREAPP2_0
                 AssemblyLoadContext.Default.Resolving -= refResolver.AssemblyLoadContextResolving;
+#else
+                AppDomain.CurrentDomain.AssemblyResolve -= refResolver.ResolveAssembly;
 #endif
             }
         }

--- a/src/Orleans.Core/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/TypeUtils.cs
@@ -569,9 +569,7 @@ namespace Orleans.Runtime
 
                         if (logger != null && logger.IsWarning)
                         {
-                            var badImageFormatExceptionCount = typeLoadException.LoaderExceptions.Count(ex => ex as BadImageFormatException != null);
-
-                            if (typeLoadException.LoaderExceptions.Count() != badImageFormatExceptionCount)
+                            if (typeLoadException.LoaderExceptions.Any(ex => !(ex is BadImageFormatException)) || logger.IsVerbose)
                             {
                                 var message =
                                     $"Exception loading types from assembly '{assembly.FullName}': {LogFormatter.PrintException(exception)}.";

--- a/src/Orleans.Core/CodeGeneration/TypeUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/TypeUtils.cs
@@ -174,7 +174,7 @@ namespace Orleans.Runtime
             {
                 return GetParameterizedTemplateName(GetSimpleTypeName(typeInfo, fullName), typeInfo, applyRecursively, fullName);
             }
-            
+
             var t = typeInfo.AsType();
             if (fullName != null && fullName(t) == true)
             {
@@ -190,7 +190,7 @@ namespace Orleans.Runtime
                 fullName = tt => false;
 
             if (!typeInfo.IsGenericType) return baseName;
-            
+
             string s = baseName;
             s += "<";
             bool first = true;
@@ -401,7 +401,7 @@ namespace Orleans.Runtime
             }
 
             if (grainType == type || grainChevronType == type) return false;
-            
+
             if (!grainType.IsAssignableFrom(type)) return false;
 
             // exclude generated classes.
@@ -504,7 +504,7 @@ namespace Orleans.Runtime
 
             return generalType.IsAssignableFrom(type) && TypeHasAttribute(type, typeof(MethodInvokerAttribute));
         }
-        
+
 
         private static readonly Lazy<bool> canUseReflectionOnly = new Lazy<bool>(() =>
         {
@@ -556,24 +556,45 @@ namespace Orleans.Runtime
             }
             catch (Exception exception)
             {
+                var typeLoadException = exception as ReflectionTypeLoadException;
+
+                if (typeLoadException != null)
+                {
+                    if (typeLoadException.LoaderExceptions != null)
+                    {
+                        //
+                        // If we've only BadImageFormatExceptions in LoaderExceptions, then it's ok to not to log, otherwise log
+                        // as a warning.
+                        //
+
+                        if (logger != null && logger.IsWarning)
+                        {
+                            var badImageFormatExceptionCount = typeLoadException.LoaderExceptions.Count(ex => ex as BadImageFormatException != null);
+
+                            if (typeLoadException.LoaderExceptions.Count() != badImageFormatExceptionCount)
+                            {
+                                var message =
+                                    $"Exception loading types from assembly '{assembly.FullName}': {LogFormatter.PrintException(exception)}.";
+                                logger.Warn(ErrorCode.Loader_TypeLoadError_5, message, exception);
+                            }
+                        }
+                    }
+
+                    return typeLoadException.Types?.Where(type => type != null).Select(type => type.GetTypeInfo()) ??
+                           Enumerable.Empty<TypeInfo>();
+                }
+
                 if (logger != null && logger.IsWarning)
                 {
                     var message =
                         $"Exception loading types from assembly '{assembly.FullName}': {LogFormatter.PrintException(exception)}.";
                     logger.Warn(ErrorCode.Loader_TypeLoadError_5, message, exception);
                 }
-                
-                var typeLoadException = exception as ReflectionTypeLoadException;
-                if (typeLoadException != null)
-                {
-                    return typeLoadException.Types?.Where(type => type != null).Select(type => type.GetTypeInfo()) ??
-                           Enumerable.Empty<TypeInfo>();
-                }
 
                 return Enumerable.Empty<TypeInfo>();
             }
         }
-        
+
         /// <summary>
         /// Returns a value indicating whether or not the provided <paramref name="methodInfo"/> is a grain method.
         /// </summary>
@@ -879,7 +900,7 @@ namespace Orleans.Runtime
 
             throw new ArgumentException("Expression type unsupported.");
         }
-        
+
         /// <summary>
         /// Returns the <see cref="PropertyInfo"/> for the simple member access in the provided <paramref name="expression"/>.
         /// </summary>


### PR DESCRIPTION
Enhance the error message we produce in case of an assembly loading error in a call to GetDefinedTypes. Fixes #3619