### PR TITLE
Remove internal usage of Logger in extension projects and remove Initialize(Logger) from IExternalSerializer

### DIFF
--- a/src/Orleans.Core/Serialization/BinaryFormatterSerializer.cs
+++ b/src/Orleans.Core/Serialization/BinaryFormatterSerializer.cs
@@ -4,18 +4,11 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
-using Orleans.Runtime;
 
 namespace Orleans.Serialization
 {
     public class BinaryFormatterSerializer : IExternalSerializer
     {
-        private Logger logger;
-        public void Initialize(Logger logger)
-        {
-            this.logger = logger;
-        }
-
         public bool IsSupportedType(Type itemType)
         {
             return itemType.GetTypeInfo().IsSerializable;

--- a/src/Orleans.Core/Serialization/IExternalSerializer.cs
+++ b/src/Orleans.Core/Serialization/IExternalSerializer.cs
@@ -1,5 +1,4 @@
 using System;
-using Orleans.Runtime;
 
 namespace Orleans.Serialization
 {
@@ -12,12 +11,6 @@ namespace Orleans.Serialization
     /// </summary>
     public interface IExternalSerializer
     {
-        /// <summary>
-        /// Initializes the external serializer. Called once when the serialization manager creates 
-        /// an instance of this type
-        /// </summary>
-        void Initialize(Logger logger);
-
         /// <summary>
         /// Informs the serialization manager whether this serializer supports the type for serialization.
         /// </summary>

--- a/src/Orleans.Core/Serialization/ILBasedSerializer.cs
+++ b/src/Orleans.Core/Serialization/ILBasedSerializer.cs
@@ -75,14 +75,6 @@
         }
 
         /// <summary>
-        /// Initializes the external serializer. Called once when the serialization manager creates 
-        /// an instance of this type
-        /// </summary>
-        public void Initialize(Logger logger)
-        {
-        }
-
-        /// <summary>
         /// Informs the serialization manager whether this serializer supports the type for serialization.
         /// </summary>
         /// <param name="t">The type of the item to be serialized</param>

--- a/src/Orleans.Core/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans.Core/Serialization/OrleansJsonSerializer.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Net;
-using System.Reflection;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Orleans.CodeGeneration;
 using Orleans.Runtime;
 
 namespace Orleans.Serialization
@@ -19,7 +15,6 @@ namespace Orleans.Serialization
         public const string IndentJsonProperty = "IndentJSON";
         public const string TypeNameHandlingProperty = "TypeNameHandling";
         private readonly JsonSerializerSettings settings;
-        private Logger logger;
 
         public OrleansJsonSerializer(SerializationManager serializationManager, IGrainFactory grainFactory)
         {
@@ -94,12 +89,6 @@ namespace Orleans.Serialization
                 }
             }
             return settings;
-        }
-
-        /// <inheritdoc />
-        public void Initialize(Logger logger)
-        {
-            this.logger = logger;
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -1620,8 +1620,6 @@ namespace Orleans.Serialization
             {
                 serializer = new BinaryFormatterSerializer();
             }
-
-            serializer.Initialize(this.logger);
             return serializer;
         }
 
@@ -1784,8 +1782,7 @@ namespace Orleans.Serialization
                 {
                     try
                     {
-                        var serializer = Activator.CreateInstance(typeInfo.AsType()) as IExternalSerializer;
-                        serializer.Initialize(logger);
+                        var serializer = ActivatorUtilities.CreateInstance(serviceProvider, typeInfo.AsType()) as IExternalSerializer;
                         externalSerializers.Add(serializer);
                     }
                     catch (Exception exception)

--- a/src/Orleans.Serialization.Protobuf/ProtobufSerializer.cs
+++ b/src/Orleans.Serialization.Protobuf/ProtobufSerializer.cs
@@ -2,7 +2,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using Google.Protobuf;
-using Orleans.Runtime;
+using Microsoft.Extensions.Logging;
 
 namespace Orleans.Serialization
 {
@@ -12,17 +12,6 @@ namespace Orleans.Serialization
     public class ProtobufSerializer : IExternalSerializer
     {
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, MessageParser> Parsers = new ConcurrentDictionary<RuntimeTypeHandle, MessageParser>();
-
-        private Logger logger;
-
-        /// <summary>
-        /// Initializes the external serializer
-        /// </summary>
-        /// <param name="logger">The logger to use to capture any serialization events</param>
-        public void Initialize(Logger logger)
-        {
-            this.logger = logger;
-        }
 
         /// <summary>
         /// Determines whether this serializer has the ability to serialize a particular type.

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -1097,10 +1097,6 @@ namespace UnitTests.Serialization
 
         public class SupportsNothingSerializer : IExternalSerializer
         {
-            public void Initialize(Logger logger)
-            {
-            }
-
             public bool IsSupportedType(Type itemType) => false;
 
             public object DeepCopy(object source, ICopyContext context)

--- a/test/NonSilo.Tests/SerializationTests/ConfigurationTests/SerializationProviderTests.cs
+++ b/test/NonSilo.Tests/SerializationTests/ConfigurationTests/SerializationProviderTests.cs
@@ -84,7 +84,7 @@ namespace UnitTests.Serialization
 
         public static bool DeepCopyCalled { get; set; }
 
-        public void Initialize(Logger logger)
+        public AbstractFakeSerializer()
         {
             Initialized = true;
         }

--- a/test/TestExtensions/SerializationTestEnvironment.cs
+++ b/test/TestExtensions/SerializationTestEnvironment.cs
@@ -7,6 +7,7 @@ using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using Orleans.TestingHost;
 
 namespace TestExtensions
 {
@@ -15,11 +16,7 @@ namespace TestExtensions
         public SerializationTestEnvironment(ClientConfiguration config = null)
         {
             if (config == null) config = this.DefaultConfig();
-            this.Client = new ClientBuilder()
-                .UseConfiguration(config)
-                .AddApplicationPartsFromAppDomain()
-                .AddApplicationPartsFromBasePath()
-                .Build();
+            this.Client = TestClusterOptions.DefaultClientBuilderFactory(config).Build();
             this.RuntimeClient = this.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();
         }
 

--- a/test/TestGrains/MessageSerializationGrain.cs
+++ b/test/TestGrains/MessageSerializationGrain.cs
@@ -58,10 +58,6 @@
     {
         public const string FailureMessage = "Can't do it, sorry.";
 
-        public void Initialize(Logger logger)
-        {
-        }
-
         public bool IsSupportedType(Type itemType) => itemType == typeof(SimpleType);
 
         public object DeepCopy(object source, ICopyContext context)

--- a/test/TestInternalGrains/SerializationTestTypes.cs
+++ b/test/TestInternalGrains/SerializationTestTypes.cs
@@ -125,10 +125,6 @@ namespace UnitTests.Grains
             IsSupportedTypeCalled = DeepCopyCalled = SerializeCalled = DeserializeCalled = false;
         }
 
-        public void Initialize(Logger logger)
-        {
-        }
-
         public bool IsSupportedType(Type itemType)
         {
             IsSupportedTypeCalled = true;
@@ -168,10 +164,6 @@ namespace UnitTests.Grains
         public static void Reset()
         {
             IsSupportedTypeCalled = DeepCopyCalled = SerializeCalled = DeserializeCalled = false;
-        }
-
-        public void Initialize(Logger logger)
-        {
         }
 
         public bool IsSupportedType(Type itemType)

--- a/test/Tester/FakeSerializer.cs
+++ b/test/Tester/FakeSerializer.cs
@@ -21,7 +21,7 @@ namespace Tester.Serialization
 
         public static bool DeepCopyCalled { get; set; }
 
-        public void Initialize(Logger logger)
+        public FakeSerializer()
         {
             Initialized = true;
         }


### PR DESCRIPTION
- Remove internal usage of Logger in extension projects
- Remove `Initialize(Logger logger)` method from `IExternalSerializer` interface 