### PR TITLE
Fixing codegen when a type's name contains comma

### DIFF
--- a/src/Orleans.CodeGeneration/Utilities/StringExtensions.cs
+++ b/src/Orleans.CodeGeneration/Utilities/StringExtensions.cs
@@ -6,6 +6,7 @@ namespace Orleans.CodeGenerator.Utilities
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using System.IO;
 
     /// <summary>
     /// Extensions to the <see cref="string"/> class to support code generation.
@@ -25,7 +26,7 @@ namespace Orleans.CodeGenerator.Utilities
         {
             var syntaxToken = SyntaxFactory.Literal(
                 SyntaxFactory.TriviaList(),
-                @"""" + str + @"""",
+                @"@""" + str + @"""",
                 str,
                 SyntaxFactory.TriviaList());
             return SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, syntaxToken);

--- a/src/Orleans.CodeGeneration/Utilities/StringExtensions.cs
+++ b/src/Orleans.CodeGeneration/Utilities/StringExtensions.cs
@@ -6,7 +6,6 @@ namespace Orleans.CodeGenerator.Utilities
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using System.IO;
 
     /// <summary>
     /// Extensions to the <see cref="string"/> class to support code generation.

--- a/test/TestGrains/MultipleGenericParameterInterfaceImpl.cs
+++ b/test/TestGrains/MultipleGenericParameterInterfaceImpl.cs
@@ -1,0 +1,28 @@
+﻿using Orleans;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests.Grains
+{
+    interface IFactory<TInput, TOutput>
+    {
+        Task<TOutput> Product(TInput input);
+    }
+
+    class Factory
+    {
+        public int SomeProperty { get; set; }
+    }
+
+    class AFactory : Factory, IFactory<int, double>
+    {
+        async Task<double> IFactory<int, double>.Product(int input)
+        {
+            await Task.Delay(100);
+            return input;
+        }
+    }
+}


### PR DESCRIPTION
While Roslyn may generate some types that their names may contain ','.
For example, when implement an interface which has more than one generic parameters and the method is async.
When orleans codegen generating code, it produces some code like:
```c#
feature.AddKnownType("UnitTests.Grains.AFactory+<UnitTests-Grains-IFactory<System-Int32\,System-Double>-Product>d__0,TestGrains", "UnitTests.Grains.<UnitTests-Grains-IFactory<System-Int32\,System-Double>-Product>d__0");
```
The `\,` in the string literals will cause compiler errors. (unrecognized escape sequence)
Convert them to verbatim string literals will solve the issue.
```c#
feature.AddKnownType(@"UnitTests.Grains.AFactory+<UnitTests-Grains-IFactory<System-Int32\,System-Double>-Product>d__0,TestGrains", @"UnitTests.Grains.<UnitTests-Grains-IFactory<System-Int32\,System-Double>-Product>d__0");
```