### PR TITLE
CodeGen: do not generate KnownTypes for nested private or compiler-generated classes

### DIFF
--- a/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
+++ b/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
@@ -368,8 +368,10 @@ namespace Orleans.CodeGenerator
 
             foreach (var type in this.typeCollector.EncounteredTypes)
             {
+                // Skip types which can not or should not be referenced.
                 if (!IsAssemblyReferenced(type)) continue;
-                
+                if (type.IsNestedPrivate) continue;
+                if (type.GetCustomAttribute<CompilerGeneratedAttribute>() != null) continue;
                 if (type.GetCustomAttribute<GeneratedCodeAttribute>() != null) continue;
 
                 var qualifiedTypeName = RuntimeTypeNameFormatter.Format(type);

--- a/test/TestGrains/MultipleGenericParameterInterfaceImpl.cs
+++ b/test/TestGrains/MultipleGenericParameterInterfaceImpl.cs
@@ -7,18 +7,21 @@ using System.Threading.Tasks;
 
 namespace UnitTests.Grains
 {
-    interface IFactory<TInput, TOutput>
-    {
-        Task<TOutput> Product(TInput input);
-    }
-
-    class Factory
+    public class CodeGenTestPoco
     {
         public int SomeProperty { get; set; }
     }
 
-    class AFactory : Factory, IFactory<int, double>
+    // This class forms a code generation test case.
+    // If the code generator does generate any code for the async state machine in the Product
+    // method, it must generate valid C# syntax. See: https://github.com/dotnet/orleans/pull/3639
+    public class FeaturePopulatorCodeGenTestClass : CodeGenTestPoco, FeaturePopulatorCodeGenTestClass.IFactory<int, double>
     {
+        public interface IFactory<TInput, TOutput>
+        {
+            Task<TOutput> Product(TInput input);
+        }
+
         async Task<double> IFactory<int, double>.Product(int input)
         {
             await Task.Delay(100);


### PR DESCRIPTION
Follow-on from #3639.

These classes either can't or shouldn't be referenced, so we should not generate code referring to them.