### PR TITLE
Fix serialization of fields types from strong named assemblies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -95,6 +95,7 @@
     <FluentAssertionsVersion>4.19.4</FluentAssertionsVersion>
     <XunitSkippableFactVersion>1.3.3</XunitSkippableFactVersion>
     <xUnitVersion>2.3.0</xUnitVersion>
+    <NodaTimeVersion>2.2.2</NodaTimeVersion>
 
     <!-- Tooling related packages -->
     <SourceLinkVersion>2.5.0</SourceLinkVersion>

--- a/src/Orleans.Core.Abstractions/Serialization/FieldUtils.cs
+++ b/src/Orleans.Core.Abstractions/Serialization/FieldUtils.cs
@@ -45,7 +45,7 @@ namespace Orleans.Serialization
                 field.Name + "Get",
                 field.FieldType,
                 parameterTypes,
-                field.FieldType.GetTypeInfo().Module,
+                typeof(FieldUtils).Module,
                 true);
 
             // Emit IL to return the value of the Transaction property.
@@ -104,7 +104,7 @@ namespace Orleans.Serialization
             }
 
             // Create a method to hold the generated IL.
-            var method = new DynamicMethod(field.Name + "Set", null, parameterTypes, field.FieldType.GetTypeInfo().Module, true);
+            var method = new DynamicMethod(field.Name + "Set", null, parameterTypes, typeof(FieldUtils).Module, true);
 
             // Emit IL to return the value of the Transaction property.
             var emitter = method.GetILGenerator();

--- a/test/DefaultCluster.Tests/DefaultCluster.Tests.csproj
+++ b/test/DefaultCluster.Tests/DefaultCluster.Tests.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="Xunit.SkippableFact" Version="$(XunitSkippableFactVersion)" />
+    <PackageReference Include="NodaTime" Version="$(NodaTimeVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DefaultCluster.Tests/SerializationTests/SerializationTests.cs
+++ b/test/DefaultCluster.Tests/SerializationTests/SerializationTests.cs
@@ -1,4 +1,6 @@
-﻿using Orleans.Serialization;
+﻿using System;
+using NodaTime;
+using Orleans.Serialization;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
@@ -50,6 +52,31 @@ namespace DefaultCluster.Tests
 
             Assert.IsAssignableFrom<ValueTypeTestData>(copy);
             Assert.Equal<int>(4, ((ValueTypeTestData)copy).GetValue());
+        }
+
+        [Serializable]
+        public class NodaTimeTestPoco
+        {
+            public LocalDate Date { get; }
+
+            public NodaTimeTestPoco(LocalDate date)
+            {
+                this.Date = date;
+            }
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/dotnet/orleans/issues/2979.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Serialization")]
+        public void Serialization_NodaTime()
+        {
+            var data = new NodaTimeTestPoco(new LocalDate(2010, 10, 14));
+
+            object obj = this.HostedCluster.SerializationManager.RoundTripSerializationForTesting(data);
+
+            Assert.IsAssignableFrom<NodaTimeTestPoco>(obj);
+            Assert.Equal<LocalDate>(new LocalDate(2010, 10, 14), ((NodaTimeTestPoco)obj).Date);
         }
     }
 }


### PR DESCRIPTION
Fixes #2979

Associates DynamicMethods for private field getters & setters with the (non-strong-named) Orleans assembly instead of the (possibly strong-named) assembly containing the type or the field type.

From [these docs](https://docs.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/security-issues-in-reflection-emit), under the *Dynamic Methods Associated with Existing Assemblies*  section:
> In addition, you can use a constructor that specifies the ability to skip the visibility checks of the JIT compiler. **Doing so gives your dynamic method access to all types and members in all assemblies, regardless of access level.**

So we're associating the `DynamicMethod` with the module emitting it and specifying that visibility checks should be skipped.