### PR TITLE
Make Exceptions shallow copyable

### DIFF
--- a/src/Orleans.Core/Serialization/TypeUtilities.cs
+++ b/src/Orleans.Core/Serialization/TypeUtilities.cs
@@ -69,6 +69,12 @@ namespace Orleans.Serialization
                 return true;
             }
 
+            if (typeInfo.IsAssignableFrom(typeof(Exception)))
+            {
+                shallowCopyableTypes[t] = true;
+                return true;
+            }
+
             if (typeInfo.IsValueType && !typeInfo.IsGenericType && !typeInfo.IsGenericTypeDefinition)
             {
                 result = IsValueTypeFieldsShallowCopyable(typeInfo);

--- a/src/Orleans.Core/Serialization/TypeUtilities.cs
+++ b/src/Orleans.Core/Serialization/TypeUtilities.cs
@@ -69,7 +69,7 @@ namespace Orleans.Serialization
                 return true;
             }
 
-            if (typeInfo.IsAssignableFrom(typeof(Exception)))
+            if (typeof(Exception).IsAssignableFrom(typeInfo))
             {
                 shallowCopyableTypes[t] = true;
                 return true;

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -891,23 +891,30 @@ namespace UnitTests.Serialization
         public void SerializationTests_IsOrleansShallowCopyable(SerializerToUse serializerToUse)
         {
             var environment = InitializeSerializer(serializerToUse);
-            Type t = typeof(Dictionary<string, object>);
-            Assert.False(t.IsOrleansShallowCopyable(), $"IsOrleansShallowCopyable: {t.Name}");
+            var nonShallowCopyableTypes = new[]
+            {
+                typeof(Dictionary<string, object>),
+                typeof(Dictionary<string, int>)
+            };
 
-            t = typeof(Dictionary<string, int>);
-            Assert.False(t.IsOrleansShallowCopyable(), $"IsOrleansShallowCopyable: {t.Name}");
+            foreach (var nonShallowCopyableType in nonShallowCopyableTypes)
+            {
+                Assert.False(nonShallowCopyableType.IsOrleansShallowCopyable(), $"IsOrleansShallowCopyable: {nonShallowCopyableType.Name}");
+            }
 
-            t = typeof(int);
-            Assert.True(t.IsOrleansShallowCopyable(), $"IsOrleansShallowCopyable: {t.Name}");
+            var shallowCopyableTypes = new[]
+            {
+                typeof(int),
+                typeof(DateTime),
+                typeof(Immutable<Dictionary<string, object>>),
+                typeof(ShallowCopyableValueType),
+                typeof(Exception)
+            };
 
-            t = typeof(DateTime);
-            Assert.True(t.IsOrleansShallowCopyable(), $"IsOrleansShallowCopyable: {t.Name}");
-
-            t = typeof(Immutable<Dictionary<string, object>>);
-            Assert.True(t.IsOrleansShallowCopyable(), $"IsOrleansShallowCopyable: {t.Name}");
-
-            t = typeof(ShallowCopyableValueType);
-            Assert.True(t.IsOrleansShallowCopyable(), $"IsOrleansShallowCopyable: {t.Name}");
+            foreach (var shallowCopyableType in shallowCopyableTypes)
+            {
+                Assert.True(shallowCopyableType.IsOrleansShallowCopyable(), $"IsOrleansShallowCopyable: {shallowCopyableType.Name}");
+            }
         }
 
         public struct ShallowCopyableValueType

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -908,7 +908,7 @@ namespace UnitTests.Serialization
                 typeof(DateTime),
                 typeof(Immutable<Dictionary<string, object>>),
                 typeof(ShallowCopyableValueType),
-                typeof(Exception)
+                typeof(ArgumentNullException)
             };
 
             foreach (var shallowCopyableType in shallowCopyableTypes)


### PR DESCRIPTION
Addresses https://github.com/dotnet/orleans/issues/3640/

Change is to consider exceptions (immutable objects) as shallow copyable types. 