### PR TITLE
Minimal silo lifecycle

### DIFF
--- a/src/Orleans.Core.Abstractions/Lifecycle/IGrainLifecycle.cs
+++ b/src/Orleans.Core.Abstractions/Lifecycle/IGrainLifecycle.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿
 namespace Orleans.Runtime
 {
     public interface IGrainLifecycle : ILifecycleObservable

--- a/src/Orleans.Core.Abstractions/Runtime/GrainLifecycleStage.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainLifecycleStage.cs
@@ -12,11 +12,11 @@
         /// <summary>
         /// Setup grain state prior to activation 
         /// </summary>
-        SetupState = 1<<10,  
+        SetupState = (1 << 10),  
 
         /// <summary>
         /// Activate grain
         /// </summary>
-        Activate = SetupState + 1<<10,
+        Activate = SetupState + (1 << 10)
     }
 }

--- a/src/Orleans.Core.Abstractions/Runtime/GrainLifecycleStage.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainLifecycleStage.cs
@@ -12,11 +12,11 @@
         /// <summary>
         /// Setup grain state prior to activation 
         /// </summary>
-        SetupState = (1 << 10),  
+        SetupState = 1000,  
 
         /// <summary>
         /// Activate grain
         /// </summary>
-        Activate = SetupState + (1 << 10)
+        Activate = 2000
     }
 }

--- a/src/Orleans.Core/Lifecycle/LifecycleObservable.cs
+++ b/src/Orleans.Core/Lifecycle/LifecycleObservable.cs
@@ -15,7 +15,7 @@ namespace Orleans
     /// - Once started, no other observers can be subscribed.
     /// - OnStart starts stages in order until first failure or cancelation.
     /// - OnStop stops states in reverse order starting from highest started stage.
-    /// - OnStop stops all stages regardless of errors unless canceled.
+    /// - OnStop stops all stages regardless of errors even if canceled canceled.
     /// </summary>
     public class LifecycleObservable : ILifecycleObservable, ILifecycleObserver
     {
@@ -67,10 +67,6 @@ namespace Orleans
                 this.highStage = observerGroup.Key;
                 try
                 {
-                    if (ct.IsCancellationRequested)
-                    {
-                        throw new OrleansLifecycleCanceledException("Lifecycle stop canceled by request");
-                    }
                     await Task.WhenAll(observerGroup.Select(orderedObserver => WrapExecution(ct, orderedObserver.Observer.OnStop)));
                 }
                 catch (Exception ex)

--- a/src/Orleans.Core/Lifecycle/LifecycleObservable.cs
+++ b/src/Orleans.Core/Lifecycle/LifecycleObservable.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 
 namespace Orleans
@@ -10,12 +11,12 @@ namespace Orleans
     public class LifecycleObservable : ILifecycleObservable, ILifecycleObserver
     {
         private readonly ConcurrentDictionary<object, OrderedObserver> subscribers;
-        private readonly Logger logger;
+        private readonly ILogger logger;
         private int highStage;
 
-        public LifecycleObservable(Logger logger)
+        public LifecycleObservable(ILoggerFactory loggerFactory)
         {
-            this.logger = logger?.GetLogger(GetType().Name);
+            this.logger = loggerFactory?.CreateLogger(GetType().FullName);
             this.subscribers = new ConcurrentDictionary<object, OrderedObserver>();
         }
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -192,7 +192,7 @@ namespace Orleans.Runtime
             if (null == collector) throw new ArgumentNullException(nameof(collector));
 
             logger = new LoggerWrapper<ActivationData>(loggerFactory);
-            this.lifecycle = new GrainLifecycle(logger);
+            this.lifecycle = new GrainLifecycle(loggerFactory);
             this.maxRequestProcessingTime = maxRequestProcessingTime;
             this.maxWarningRequestProcessingTime = maxWarningRequestProcessingTime;
             this.nodeConfiguration = nodeConfiguration;

--- a/src/Orleans.Runtime/Catalog/GrainLifecycle.cs
+++ b/src/Orleans.Runtime/Catalog/GrainLifecycle.cs
@@ -1,9 +1,11 @@
 ﻿
+using Microsoft.Extensions.Logging;
+
 namespace Orleans.Runtime
 {
     internal class GrainLifecycle : LifecycleObservable, IGrainLifecycle
     {
-        public GrainLifecycle(Logger logger) : base(logger)
+        public GrainLifecycle(ILoggerFactory loggerFactory) : base(loggerFactory)
         {
         }
     }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -20,13 +20,14 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using System.Threading;
 
 namespace Orleans.Runtime
 {
     /// <summary>
     /// Internal class for system grains to get access to runtime object
     /// </summary>
-    internal class InsideRuntimeClient : ISiloRuntimeClient
+    internal class InsideRuntimeClient : ISiloRuntimeClient, ILifecycleParticipant<ISiloLifecycle>
     {
         private readonly ILogger logger;
         private readonly Logger callbackDataLogger;
@@ -688,7 +689,7 @@ namespace Orleans.Runtime
 
         #endregion
 
-        internal void Stop()
+        private Task OnRuntimeInitializeStop(CancellationToken tc)
         {
             lock (disposables)
             {
@@ -704,11 +705,14 @@ namespace Orleans.Runtime
                     }
                 }
             }
+            return Task.CompletedTask;
         }
 
-        internal void Start()
+        private Task OnRuntimeInitializeStart(CancellationToken tc)
         {
+            typeManager.Start();
             GrainTypeResolver = typeManager.GetTypeCodeMap();
+            return Task.CompletedTask;
         }
 
         public IGrainTypeResolver GrainTypeResolver { get; private set; }
@@ -801,6 +805,11 @@ namespace Orleans.Runtime
             throw new ArgumentException(
                 $"Provider extension handler type {handlerType} was not found in the type manager",
                 nameof(handlerType));
+        }
+
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(SiloLifecycleStage.RuntimeInitialize, OnRuntimeInitializeStart, OnRuntimeInitializeStop);
         }
     }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -48,6 +48,7 @@ namespace Orleans.Hosting
 
             // Register system services.
             services.TryAddSingleton<ISiloHost, SiloWrapper>();
+            services.TryAddSingleton<SiloLifecycle>();
 
             services.PostConfigure<SiloMessagingOptions>(options =>
             {
@@ -131,6 +132,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<InsideRuntimeClient>();
             services.TryAddFromExisting<IRuntimeClient, InsideRuntimeClient>();
             services.TryAddFromExisting<ISiloRuntimeClient, InsideRuntimeClient>();
+            services.TryAddFromExisting<ILifecycleParticipant<ISiloLifecycle>, InsideRuntimeClient>();
             services.TryAddSingleton<MultiClusterGossipChannelFactory>();
             services.TryAddSingleton<MultiClusterOracle>();
             services.TryAddSingleton<MultiClusterRegistrationStrategyManager>();

--- a/src/Orleans.Runtime/Hosting/Generic/SiloWrapper.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloWrapper.cs
@@ -23,29 +23,15 @@ namespace Orleans.Hosting
         public Task Stopped { get; }
 
         /// <inheritdoc />
-        public async Task StartAsync(CancellationToken cancellationToken)
+        public Task StartAsync(CancellationToken cancellationToken)
         {
-            if (!cancellationToken.IsCancellationRequested)
-            {
-                this.silo.Start();
-            }
-
-            // Await to avoid compiler warnings.
-            await Task.CompletedTask;
+            return this.silo.StartAsync(cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task StopAsync(CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                this.silo.Stop();
-            }
-            else
-            {
-                this.silo.Shutdown();
-            }
-
+            await silo.StopAsync(cancellationToken);
             await this.Stopped;
         }
 

--- a/src/Orleans.Runtime/Lifecycle/ISiloLifecycle.cs
+++ b/src/Orleans.Runtime/Lifecycle/ISiloLifecycle.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Orleans.Runtime
+{
+    public interface ISiloLifecycle : ILifecycleObservable
+    {
+    }
+}

--- a/src/Orleans.Runtime/Lifecycle/SiloLifecycle.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloLifecycle.cs
@@ -1,0 +1,12 @@
+﻿
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.Runtime
+{
+    internal class SiloLifecycle : LifecycleObservable, ISiloLifecycle
+    {
+        public SiloLifecycle(ILoggerFactory loggerFactory) : base(loggerFactory)
+        {
+        }
+    }
+}

--- a/src/Orleans.Runtime/Lifecycle/SiloLifecycleExtensions.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloLifecycleExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime
+{
+    public static class SiloLifecycleExtensions
+    {
+        public static IDisposable Subscribe(this ISiloLifecycle observable, SiloLifecycleStage stage, ILifecycleObserver observer)
+        {
+            return observable.Subscribe((int)stage, observer);
+        }
+
+        public static IDisposable Subscribe(this ISiloLifecycle observable, SiloLifecycleStage stage, Func<CancellationToken, Task> onStart, Func<CancellationToken, Task> onStop)
+        {
+            return observable.Subscribe((int)stage, onStart, onStop);
+        }
+
+        public static IDisposable Subscribe(this ISiloLifecycle observable, SiloLifecycleStage stage, Func<CancellationToken, Task> onStart)
+        {
+            return observable.Subscribe((int)stage, onStart);
+        }
+    }
+}

--- a/src/Orleans.Runtime/Lifecycle/SiloLifecycleStage.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloLifecycleStage.cs
@@ -9,21 +9,21 @@ namespace Orleans.Runtime
         /// <summary>
         /// Initialize silo runtime
         /// </summary>
-        RuntimeInitialize = (1 << 10),
+        RuntimeInitialize = 1000,
 
         /// <summary>
         /// Start runtime services
         /// </summary>
-        RuntimeServices = RuntimeInitialize + (1 << 10),
+        RuntimeServices = 2000,
 
         /// <summary>
         /// Start application layer services
         /// </summary>
-        ApplicationServices = RuntimeServices + (1 << 10),
+        ApplicationServices = 3000,
 
         /// <summary>
         /// Silo is active and available to service requests
         /// </summary>
-        SiloActive = ApplicationServices + (1 << 10),
+        SiloActive = 4000,
     }
 }

--- a/src/Orleans.Runtime/Lifecycle/SiloLifecycleStage.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloLifecycleStage.cs
@@ -9,21 +9,21 @@ namespace Orleans.Runtime
         /// <summary>
         /// Initialize silo runtime
         /// </summary>
-        RuntimeInitialize = 1 << 10,
+        RuntimeInitialize = (1 << 10),
 
         /// <summary>
         /// Start runtime services
         /// </summary>
-        RuntimeServices = RuntimeInitialize + 1 << 10,
+        RuntimeServices = RuntimeInitialize + (1 << 10),
 
         /// <summary>
         /// Start application layer services
         /// </summary>
-        ApplicationServices = RuntimeServices + 1 << 10,
+        ApplicationServices = RuntimeServices + (1 << 10),
 
         /// <summary>
         /// Silo is active and available to service requests
         /// </summary>
-        SiloActive = ApplicationServices + 1 << 10,
+        SiloActive = ApplicationServices + (1 << 10),
     }
 }

--- a/src/Orleans.Runtime/Lifecycle/SiloLifecycleStage.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloLifecycleStage.cs
@@ -1,0 +1,29 @@
+﻿
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Stages of a silo's lifecycle.
+    /// </summary>
+    public enum SiloLifecycleStage
+    {
+        /// <summary>
+        /// Initialize silo runtime
+        /// </summary>
+        RuntimeInitialize = 1 << 10,
+
+        /// <summary>
+        /// Start runtime services
+        /// </summary>
+        RuntimeServices = RuntimeInitialize + 1 << 10,
+
+        /// <summary>
+        /// Start application layer services
+        /// </summary>
+        ApplicationServices = RuntimeServices + 1 << 10,
+
+        /// <summary>
+        /// Silo is active and available to service requests
+        /// </summary>
+        SiloActive = ApplicationServices + 1 << 10,
+    }
+}

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -687,7 +687,6 @@ namespace Orleans.Runtime
         /// </summary>
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            this.gracefully = !cancellationToken.IsCancellationRequested;
             string operation = gracefully ? "Shutdown()" : "Stop()";
             bool stopAlreadyInProgress = false;
             lock (lockable)

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
-using System.Reflection;
 using System.Runtime;
 using System.Text;
 using System.Threading;
@@ -11,6 +10,7 @@ using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.CodeGeneration;
 using Orleans.Core;
 using Orleans.Hosting;
@@ -33,7 +33,7 @@ using Orleans.Streams;
 using Orleans.Transactions;
 using Orleans.Runtime.Versions;
 using Orleans.Versions;
-using Microsoft.Extensions.Options;
+using Orleans.ApplicationParts;
 using Orleans.Configuration;
 using Orleans.Serialization;
 


### PR DESCRIPTION
Added staged startup of silo via Lifecycle.
This work is still primitive and minimal.
Stages are preliminary, and will need to be further refined.
We still need to modify components to interact direct with the lifecycle rather than requiring silo to know about and start all components.  Only component modified so far, for proof of concept purposes, is the InsideRuntimeClient.  These changes can be made in future passes.
