### PR TITLE
Add metrics to monitor transaction agent batch calls

### DIFF
--- a/src/Orleans.Core/Utils/PeriodicAction.cs
+++ b/src/Orleans.Core/Utils/PeriodicAction.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Orleans.Providers.Streams.Common
+namespace Orleans
 {
     internal class PeriodicAction
     {

--- a/src/Orleans.Runtime/Transactions/TransactionAgent.cs
+++ b/src/Orleans.Runtime/Transactions/TransactionAgent.cs
@@ -1,13 +1,99 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Concurrency;
+using Orleans.Runtime.Configuration;
+using DateTime = System.DateTime;
 
 namespace Orleans.Transactions
 {
+    internal class TransactionAgentMetrics
+    {
+        //TPS in current monitor window
+        private const string BatchStartTransanctionsDeltaTPS = "TransactionAgent.BatchStartTransactions.Delta.TPS";
+        //avg latency in current monitor window
+        private const string AvgBatchStartTransactionsDeltaLatency = "TransactionAgent.BatchStartTransactions.Delta.AvgLatency";
+        private const string BatchCommitTransactionsDeltaTPS = "TransactionAgent.BatchCommitTransactions.Delta.TPS";
+        private const string AvgBatchCommitTransactionsDeltaLatency = "TransactionAgent.BatchCommitTransactions.Delta.AvgLatency";
+
+        internal int BatchStartTransactionsRequestCounter { get; set; }
+
+        internal int BatchCommitTransactionsRequestsCounter { get; set; }
+        private TimeSpan batchStartTransactionsRequestLatencyCounter = TimeSpan.Zero;
+        internal TimeSpan BatchStartTransactionsRequestLatencyCounter
+        {
+            get { return batchStartTransactionsRequestLatencyCounter; }
+            set
+            {
+                batchStartTransactionsRequestLatencyCounter = value;
+                this.periodicMonitor.TryAction(DateTime.UtcNow);
+            }
+        }
+        private TimeSpan batchCommitTransactionsRequestLatencyCounter = TimeSpan.Zero;
+
+        internal TimeSpan BatchCommitTransactionsRequestLatencyCounter
+        {
+            get { return batchCommitTransactionsRequestLatencyCounter; }
+            set
+            {
+                batchCommitTransactionsRequestLatencyCounter = value;
+                this.periodicMonitor.TryAction(DateTime.UtcNow);
+            }
+        }
+        private DateTime lastReportTime = DateTime.UtcNow;
+        private ITelemetryProducer telemetryProducer;
+        private PeriodicAction periodicMonitor;
+
+        public TransactionAgentMetrics(ITelemetryProducer producer, TimeSpan interval)
+        {
+            this.telemetryProducer = producer;
+            this.periodicMonitor = new PeriodicAction(interval, this.ReportMetrics);
+        }
+
+        private void ResetCounters(DateTime lastReportTimeStamp)
+        {
+            //record last report time stamp
+            lastReportTime = lastReportTimeStamp;
+            this.BatchStartTransactionsRequestCounter = 0;
+            this.BatchCommitTransactionsRequestsCounter = 0;
+            this.batchStartTransactionsRequestLatencyCounter = TimeSpan.Zero;
+            this.batchCommitTransactionsRequestLatencyCounter = TimeSpan.Zero;
+        }
+
+        private void ReportMetrics()
+        {
+            var now = DateTime.UtcNow;
+           
+            //batch start metrics
+            var batchStartTransactionTPS = BatchStartTransactionsRequestCounter / (now - lastReportTime).TotalSeconds;
+            this.telemetryProducer.TrackMetric(BatchStartTransanctionsDeltaTPS, batchStartTransactionTPS);
+            if (BatchStartTransactionsRequestCounter > 0)
+            {
+                var avgBatchStartTransactionLatency = batchStartTransactionsRequestLatencyCounter.Divide(BatchStartTransactionsRequestCounter);
+                this.telemetryProducer.TrackMetric(AvgBatchStartTransactionsDeltaLatency,
+                    avgBatchStartTransactionLatency);
+            }
+
+            //batch commit metrics
+            var batchCommitTransactionTPS = BatchCommitTransactionsRequestsCounter / (now - lastReportTime).TotalSeconds;
+            this.telemetryProducer.TrackMetric(BatchCommitTransactionsDeltaTPS, batchCommitTransactionTPS);
+            if (BatchCommitTransactionsRequestsCounter > 0)
+            {
+                var avgBatchCommitTransactionLatency =
+                batchCommitTransactionsRequestLatencyCounter.Divide(BatchCommitTransactionsRequestsCounter);
+                this.telemetryProducer.TrackMetric(AvgBatchCommitTransactionsDeltaLatency,
+                    avgBatchCommitTransactionLatency);
+
+            }
+            
+            this.ResetCounters(now);
+        }
+    }
+
     [Reentrant]
     internal class TransactionAgent : SystemTarget, ITransactionAgent, ITransactionAgentSystemTarget
     {
@@ -30,7 +116,9 @@ namespace Orleans.Transactions
 
         public long ReadOnlyTransactionId { get; private set; }
 
-        public TransactionAgent(ILocalSiloDetails siloDetails, ITransactionManagerService tmService, ILoggerFactory loggerFactory)
+        //metrics related
+        private TransactionAgentMetrics metrics;
+        public TransactionAgent(ILocalSiloDetails siloDetails, ITransactionManagerService tmService, ILoggerFactory loggerFactory, ITelemetryProducer telemetryProducer, Factory<NodeConfiguration> getNodeConfig)
             : base(Constants.TransactionAgentSystemTargetId, siloDetails.SiloAddress, loggerFactory)
         {
             logger = loggerFactory.CreateLogger<TransactionAgent>();
@@ -45,6 +133,7 @@ namespace Orleans.Transactions
             transactionCommitQueue = new ConcurrentQueue<TransactionInfo>();
             commitCompletions = new ConcurrentDictionary<long, TaskCompletionSource<bool>>();
             outstandingCommits = new HashSet<long>();
+            this.metrics = new TransactionAgentMetrics(telemetryProducer, getNodeConfig().StatisticsMetricsTableWriteInterval);
         }
 
         #region ITransactionAgent
@@ -194,68 +283,7 @@ namespace Orleans.Transactions
                 {
                     logger.Debug(ErrorCode.Transactions_SendingTMRequest, "Calling TM to commit {0} transactions", committingTransactions.Count);
 
-                    commitTransactionsTask = this.tmService.CommitTransactions(committingTransactions, outstandingCommits).ContinueWith(
-                        async commitRequest =>
-                        {
-                            try
-                            {
-                                var commitResponse = await commitRequest;
-                                var commitResults = commitResponse.CommitResult;
-
-                                // reply to clients with the outcomes we received from the TM.
-                                foreach (var completedId in commitResults.Keys)
-                                {
-                                    outstandingCommits.Remove(completedId);
-
-                                    TaskCompletionSource<bool> completion;
-                                    if (commitCompletions.TryRemove(completedId, out completion))
-                                    {
-                                        if (commitResults[completedId].Success)
-                                        {
-                                            TransactionsStatisticsGroup.OnTransactionCommitted();
-                                            completion.SetResult(true);
-                                        }
-                                        else
-                                        {
-                                            if (commitResults[completedId].AbortingException != null)
-                                            {
-                                                TransactionsStatisticsGroup.OnTransactionAborted();
-                                                completion.SetException(commitResults[completedId].AbortingException);
-                                            }
-                                            else
-                                            {
-                                                TransactionsStatisticsGroup.OnTransactionInDoubt();
-                                                completion.SetException(new OrleansTransactionInDoubtException(completedId));
-                                            }
-                                        }
-                                    }
-                                }
-
-                                // Refresh cached values using new values from TM.
-                                this.ReadOnlyTransactionId = Math.Max(this.ReadOnlyTransactionId, commitResponse.ReadOnlyTransactionId);
-                                this.abortLowerBound = Math.Max(this.abortLowerBound, commitResponse.AbortLowerBound);
-                                logger.Debug(ErrorCode.Transactions_ReceivedTMResponse, "{0} transactions committed. readOnlyTransactionId {1}, abortLowerBound {2}", committingTransactions.Count, ReadOnlyTransactionId, abortLowerBound);
-                            }
-                            catch (Exception e)
-                            {
-                                logger.Error(ErrorCode.Transactions_TMError, "TM Error", e);
-                                
-                                // Propagate the exception to every transaction in the request.
-                                foreach (var tx in committingTransactions)
-                                {
-                                    TransactionsStatisticsGroup.OnTransactionInDoubt();
-                                    
-                                    TaskCompletionSource<bool> completion;
-                                    if (commitCompletions.TryRemove(tx.TransactionId, out completion))
-                                    {
-                                        outstandingCommits.Remove(tx.TransactionId);
-                                        completion.SetException(new OrleansTransactionInDoubtException(tx.TransactionId));
-                                    }
-                                }
-                            }
-
-                            committingTransactions.Clear();
-                        });
+                    commitTransactionsTask = this.CommitTransactions(committingTransactions, outstandingCommits);
 
                     // Removed transactions below the abort lower bound.
                     if (this.abortLowerBound != initialAbortLowerBound)
@@ -274,11 +302,87 @@ namespace Orleans.Transactions
 
         }
 
-        private async Task StartTransactions(List<TimeSpan> startingTransactions, List<TaskCompletionSource<long>> startCompletions)
+        private async Task CommitTransactions(List<TransactionInfo> committingTransactions,
+            HashSet<long> outstandingCommits)
         {
+            var stopWatch = Stopwatch.StartNew();
             try
             {
+                metrics.BatchCommitTransactionsRequestsCounter++;
+                var commitResponse = await this.tmService.CommitTransactions(committingTransactions, outstandingCommits);
+                metrics.BatchCommitTransactionsRequestLatencyCounter += stopWatch.Elapsed;
+                stopWatch.Stop();
+                var commitResults = commitResponse.CommitResult;
+
+                // reply to clients with the outcomes we received from the TM.
+                foreach (var completedId in commitResults.Keys)
+                {
+                    outstandingCommits.Remove(completedId);
+
+                    TaskCompletionSource<bool> completion;
+                    if (commitCompletions.TryRemove(completedId, out completion))
+                    {
+                        if (commitResults[completedId].Success)
+                        {
+                            TransactionsStatisticsGroup.OnTransactionCommitted();
+                            completion.SetResult(true);
+                        }
+                        else
+                        {
+                            if (commitResults[completedId].AbortingException != null)
+                            {
+                                TransactionsStatisticsGroup.OnTransactionAborted();
+                                completion.SetException(commitResults[completedId].AbortingException);
+                            }
+                            else
+                            {
+                                TransactionsStatisticsGroup.OnTransactionInDoubt();
+                                completion.SetException(new OrleansTransactionInDoubtException(completedId));
+                            }
+                        }
+                    }
+                }
+
+                // Refresh cached values using new values from TM.
+                this.ReadOnlyTransactionId = Math.Max(this.ReadOnlyTransactionId,
+                    commitResponse.ReadOnlyTransactionId);
+                this.abortLowerBound = Math.Max(this.abortLowerBound, commitResponse.AbortLowerBound);
+                logger.Debug(ErrorCode.Transactions_ReceivedTMResponse,
+                    "{0} transactions committed. readOnlyTransactionId {1}, abortLowerBound {2}",
+                    committingTransactions.Count, ReadOnlyTransactionId, abortLowerBound);
+            }
+            catch (Exception e)
+            {
+                metrics.BatchCommitTransactionsRequestLatencyCounter += stopWatch.Elapsed;
+                stopWatch.Stop();
+                logger.Error(ErrorCode.Transactions_TMError, "TM Error", e);
+                // Propagate the exception to every transaction in the request.
+                foreach (var tx in committingTransactions)
+                {
+                    TransactionsStatisticsGroup.OnTransactionInDoubt();
+
+                    TaskCompletionSource<bool> completion;
+                    if (commitCompletions.TryRemove(tx.TransactionId, out completion))
+                    {
+                        outstandingCommits.Remove(tx.TransactionId);
+                        completion.SetException(new OrleansTransactionInDoubtException(tx.TransactionId));
+                    }
+                }
+            }
+
+            committingTransactions.Clear();
+                
+        }
+
+        private async Task StartTransactions(List<TimeSpan> startingTransactions, List<TaskCompletionSource<long>> startCompletions)
+        {
+            var stopWatch = Stopwatch.StartNew();
+            try
+            {
+                metrics.BatchStartTransactionsRequestCounter++;
                 StartTransactionsResponse startResponse = await this.tmService.StartTransactions(startingTransactions);
+                metrics.BatchStartTransactionsRequestLatencyCounter += stopWatch.Elapsed;
+                stopWatch.Stop();
                 List<long> startedIds = startResponse.TransactionId;
 
                 // reply to clients with results
@@ -295,8 +399,10 @@ namespace Orleans.Transactions
             }
             catch (Exception e)
             {
+                metrics.BatchStartTransactionsRequestLatencyCounter += stopWatch.Elapsed;
+                stopWatch.Stop();
                 logger.Error(ErrorCode.Transactions_TMError, "Transaction manager failed to start transactions.", e);
-
+                
                 foreach (var completion in startCompletions)
                 {
                     TransactionsStatisticsGroup.OnTransactionStartFailed();


### PR DESCRIPTION
Add metrics to monitor transaction agent batch TM calls
Metric monitor configured through NodeConfig.StatisticsMetricsTableWriteInterval as reporting frequency 
