### PR TITLE
Make OnSetupState overrideable.

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -325,7 +325,7 @@ namespace Orleans
             Stopwatch sw = Stopwatch.StartNew();
             try
             {
-                await this.ReadStateAsync();
+                await this.OnSetupStateAsync();
                 sw.Stop();
                 // TODO: find a way to reenable StorageStatisticsGroup here
                 //StorageStatisticsGroup.OnStorageActivate(grainTypeName, sw.Elapsed);
@@ -337,6 +337,11 @@ namespace Orleans
                 //StorageStatisticsGroup.OnStorageActivateError(grainTypeName);
                 throw;
             }
+        }
+        
+        protected virtual Task OnSetupStateAsync()
+        {
+            return this.ReadStateAsync();
         }
     }
 }


### PR DESCRIPTION
I would like to catch errors in the initial setup of the state.

I have not found an easy way in the current implementation. Instead I had to make a V2 Grain:

https://gist.github.com/SebastianStehle/21cf042385ed61fd8cdcda8dd8b6682f