### PR TITLE
CodeGen: Allow per-project log level configuration

### DIFF
--- a/src/Orleans.CodeGeneration.Build/CodeGenOptions.cs
+++ b/src/Orleans.CodeGeneration.Build/CodeGenOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Extensions.Logging;
 
 namespace Orleans.CodeGeneration
 {
@@ -12,5 +13,6 @@ namespace Orleans.CodeGeneration
         public List<string> ReferencedAssemblies = new List<string>();
 
         public string OutputFileName;
+        public LogLevel LogLevel { get; set; } = LogLevel.Warning;
     }
 }

--- a/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
+++ b/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
@@ -68,12 +68,12 @@ namespace Orleans.CodeGeneration
             return !string.IsNullOrWhiteSpace(generatedCode);
         }
 
-        private static string GenerateSourceForAssembly(Assembly grainAssembly)
+        private static string GenerateSourceForAssembly(Assembly grainAssembly, LogLevel logLevel)
         {
             using (var loggerFactory = new LoggerFactory())
             {
                 var config = new ClusterConfiguration();
-                loggerFactory.AddConsole(LogLevel.Warning);
+                loggerFactory.AddConsole(logLevel);
                 var serializationProviderOptions = Options.Create(
                     new SerializationProviderOptions
                     {
@@ -171,7 +171,7 @@ namespace Orleans.CodeGeneration
                 AppDomain.CurrentDomain.AssemblyResolve += refResolver.ResolveAssembly;
 #endif
 
-                return GenerateSourceForAssembly(refResolver.Assembly);
+                return GenerateSourceForAssembly(refResolver.Assembly, options.LogLevel);
             }
             finally
             {

--- a/src/Orleans.CodeGeneration.Build/Program.cs
+++ b/src/Orleans.CodeGeneration.Build/Program.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Orleans.CodeGeneration
 {
@@ -67,6 +69,18 @@ namespace Orleans.CodeGeneration
                             var outfile = arg.Substring(arg.IndexOf(':') + 1);
                             AssertWellFormed(outfile);
                             options.OutputFileName = outfile;
+                        }
+                        else if (arg.StartsWith("/loglevel:"))
+                        {
+                            var levelString = arg.Substring(arg.IndexOf(':') + 1);
+                            if (!Enum.TryParse(ignoreCase: true, value: levelString, result: out LogLevel level))
+                            {
+                                var validValues = string.Join(", ", Enum.GetNames(typeof(LogLevel)).Select(v => v.ToString()));
+                                Console.WriteLine($"ERROR: \"{levelString}\" is not a valid log level. Valid values are {validValues}");
+                                return 1;
+                            }
+
+                            options.LogLevel = level;
                         }
                     }
                     else

--- a/src/Orleans.CodeGeneration.Build/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
+++ b/src/Orleans.CodeGeneration.Build/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
@@ -30,6 +30,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <OrleansCodeGenLogLevel Condition="'$(OrleansCodeGenLogLevel)' == ''">Warning</OrleansCodeGenLogLevel>
     <CodeGenDirectory Condition="'$([System.IO.Path]::IsPathRooted($(IntermediateOutputPath)))' == 'true'">$(IntermediateOutputPath)</CodeGenDirectory>
     <CodeGenDirectory Condition="'$(CodeGenDirectory)' == ''">$(ProjectDir)$(IntermediateOutputPath)</CodeGenDirectory>
     <OutputFileName>$(CodeGenDirectory)$(TargetName).orleans.g.cs</OutputFileName>
@@ -56,6 +57,7 @@
     <ItemGroup>
       <CodeGenArgs Include="/in:$(InputAssembly)"/>
       <CodeGenArgs Include="/out:$(OutputFileName)"/>
+      <CodeGenArgs Include="/loglevel:$(OrleansCodeGenLogLevel)"/>
       <CodeGenArgs Include="@(ReferencePath->'/r:%(Identity)')"/>
     </ItemGroup>
     <MSBuild


### PR DESCRIPTION
Adds a property which can be set in user's .csproj files to configure the log level of the build-time code generator. Log levels are defined in the `LogLevel` enum from `Microsoft.Extensions.Logging`. If the user specifies an invalid log level, they'll see a message like this in the build log: `error : "Trakjjkjkce" is not a valid log level. Valid values are Trace, Debug, Information, Warning, Error, Critical, None` and the build will fail. Default level is `Warning`.

Example, to set log to `Trace`.
```xml
<PropertyGroup>
    <OrleansCodeGenLogLevel>Trace</OrleansCodeGenLogLevel>
</PropertyGroup>
```