### PR TITLE
Move queuing logic from AsynchQueueAgent into Executor

### DIFF
--- a/src/Orleans.Core/Messaging/GatewayClientReceiver.cs
+++ b/src/Orleans.Core/Messaging/GatewayClientReceiver.cs
@@ -11,7 +11,7 @@ namespace Orleans.Messaging
     /// <summary>
     /// The Receiver class is used by the GatewayConnection to receive messages. It runs its own thread, but it performs all i/o operations synchronously.
     /// </summary>
-    internal class GatewayClientReceiver : AsynchAgent
+    internal class GatewayClientReceiver : SingleTaskAsynchAgent
     {
         private readonly GatewayConnection gatewayConnection;
         private readonly IncomingMessageBuffer buffer;

--- a/src/Orleans.Core/Messaging/GatewayConnection.cs
+++ b/src/Orleans.Core/Messaging/GatewayConnection.cs
@@ -28,6 +28,7 @@ namespace Orleans.Messaging
                 Silo = addr.ToSiloAddress();
             }
         }
+
         internal SiloAddress Silo { get; private set; }
 
         private readonly GatewayClientReceiver receiver;
@@ -72,7 +73,6 @@ namespace Orleans.Messaging
             IsLive = false;
             receiver.Stop();
             base.Stop();
-            DrainQueue(RerouteMessage);
             MsgCenter.RuntimeClient.BreakOutstandingMessagesToDeadSilo(Silo);
             Socket s;
             lock (Lockable)
@@ -83,6 +83,19 @@ namespace Orleans.Messaging
             if (s == null) return;
 
             CloseSocket(s);
+        }
+
+        protected override void Process(Message msg)
+        {
+            // not threadsafe check, but behavior is preserved
+            if (!IsLive)
+            {
+                RerouteMessage(msg);
+            }
+            else
+            {
+                base.Process(msg);
+            }
         }
 
         // passed the exact same socket on which it got SocketException. This way we prevent races between connect and disconnect.
@@ -98,7 +111,7 @@ namespace Orleans.Messaging
                     s = Socket;
                     Socket = null;
                     Log.Warn(ErrorCode.ProxyClient_MarkGatewayDisconnected, String.Format("Marking gateway at address {0} as Disconnected", Address));
-                    if ( MsgCenter != null && MsgCenter.GatewayManager != null)
+                    if (MsgCenter != null && MsgCenter.GatewayManager != null)
                         // We need a refresh...
                         MsgCenter.GatewayManager.ExpediteUpdateLiveGatewaysSnapshot();
                 }

--- a/src/Orleans.Core/Messaging/GatewayConnection.cs
+++ b/src/Orleans.Core/Messaging/GatewayConnection.cs
@@ -87,7 +87,6 @@ namespace Orleans.Messaging
 
         protected override void Process(Message msg)
         {
-            // not threadsafe check, but behavior is preserved
             if (!IsLive)
             {
                 RerouteMessage(msg);

--- a/src/Orleans.Core/Messaging/GatewayConnection.cs
+++ b/src/Orleans.Core/Messaging/GatewayConnection.cs
@@ -12,7 +12,7 @@ namespace Orleans.Messaging
     /// 
     /// Note that both sends and receives are synchronous.
     /// </summary>
-    internal class GatewayConnection : OutgoingMessageSender
+    internal class GatewayConnection : OutgoingMessageSender, IQueueDrainable
     {
         private readonly MessageFactory messageFactory;
         internal bool IsLive { get; private set; }
@@ -87,6 +87,7 @@ namespace Orleans.Messaging
 
         protected override void Process(Message msg)
         {
+            // After stop GatewayConnection needs to reroute not yet sent messages to another gateway 
             if (!IsLive)
             {
                 RerouteMessage(msg);

--- a/src/Orleans.Core/Messaging/IOutgoingMessage.cs
+++ b/src/Orleans.Core/Messaging/IOutgoingMessage.cs
@@ -6,7 +6,7 @@ namespace Orleans.Runtime
     // Used for Client -> gateway and Silo <-> Silo messeging
     // Message implements ITimeInterval to be able to measure different time intervals in the lifecycle of a message,
     // such as time in queue...
-    internal interface IOutgoingMessage : ITimeInterval
+    internal interface IOutgoingMessage
     {
         bool IsSameDestination(IOutgoingMessage other);
     }
@@ -23,26 +23,6 @@ namespace Orleans.Runtime
         {
             var otherTuple = (OutgoingClientMessage)other;
             return otherTuple != null && this.Item1.Equals(otherTuple.Item1);
-        }
-
-        public void Start()
-        {
-            this.Item2.Start();
-        }
-
-        public void Stop()
-        {
-            this.Item2.Stop();
-        }
-
-        public void Restart()
-        {
-            this.Item2.Start();
-        }
-
-        public TimeSpan Elapsed
-        {
-            get { return this.Item2.Elapsed; }
         }
     }
 }

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -675,30 +675,6 @@ namespace Orleans.Runtime
             return msg != null && Object.Equals(TargetSilo, msg.TargetSilo);
         }
 
-        // For statistical measuring of time spent in queues.
-        private ITimeInterval timeInterval;
-
-        public void Start()
-        {
-            timeInterval = TimeIntervalFactory.CreateTimeInterval(true);
-            timeInterval.Start();
-        }
-
-        public void Stop()
-        {
-            timeInterval.Stop();
-        }
-
-        public void Restart()
-        {
-            timeInterval.Restart();
-        }
-
-        public TimeSpan Elapsed
-        {
-            get { return timeInterval.Elapsed; }
-        }
-
         public static Message CreatePromptExceptionResponse(Message request, Exception exception)
         {
             return new Message

--- a/src/Orleans.Core/Runtime/AsynchAgent.cs
+++ b/src/Orleans.Core/Runtime/AsynchAgent.cs
@@ -14,7 +14,8 @@ namespace Orleans.Runtime
             IgnoreFault     // Allow the agent to stop if it faults, but take no other action (other than logging)
         }
 
-        protected readonly IExecutor executor;
+        protected readonly ExecutorService executorService;
+        protected IExecutor executor;
         protected CancellationTokenSource Cts;
         protected object Lockable;
         protected Logger Log;
@@ -52,7 +53,7 @@ namespace Orleans.Runtime
             OnFault = FaultBehavior.IgnoreFault;
             Log = new LoggerWrapper(Name, loggerFactory);
 
-            executor = executorService.GetExecutor(new GetExecutorRequest(GetType(), Name, Cts));
+            this.executorService = executorService;
             AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
 
 #if TRACK_DETAILED_STATS
@@ -93,6 +94,8 @@ namespace Orleans.Runtime
                 {
                     return;
                 }
+
+                executor = executorService.GetExecutor(new GetExecutorRequest(GetType(), Name, Cts));
 
                 if (State == ThreadState.Stopped)
                 {

--- a/src/Orleans.Core/Runtime/AsynchAgent.cs
+++ b/src/Orleans.Core/Runtime/AsynchAgent.cs
@@ -153,11 +153,6 @@ namespace Orleans.Runtime
                 Cts.Dispose();
                 Cts = null;
             }
-
-            if (executor is IDisposable disposableExecutor)
-            {
-                disposableExecutor.Dispose();
-            }
         }
 
 #endregion

--- a/src/Orleans.Core/Runtime/AsynchQueueAgent.cs
+++ b/src/Orleans.Core/Runtime/AsynchQueueAgent.cs
@@ -1,145 +1,43 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime
 {
-    internal abstract class AsynchQueueAgent<T> : AsynchAgent, IDisposable where T : IOutgoingMessage
+    internal abstract class AsynchQueueAgent<T> : AsynchAgent where T : IOutgoingMessage
     {
-        private BlockingCollection<T> requestQueue;
-        private QueueTrackingStatistic queueTracking;
-
         protected AsynchQueueAgent(string nameSuffix, ExecutorService executorService, ILoggerFactory loggerFactory)
             : base(nameSuffix, executorService, loggerFactory)
         {
-            requestQueue = new BlockingCollection<T>();
-            if (StatisticsCollector.CollectQueueStats)
-            {
-                queueTracking = new QueueTrackingStatistic(base.Name);
-            }
+            ProcessAction = state => Process((T)state);
         }
+
+        public WaitCallback ProcessAction { get; }
 
         public void QueueRequest(T request)
         {
-            if (requestQueue==null)
-            {
-                return;
-            }
-
-#if TRACK_DETAILED_STATS
-            if (StatisticsCollector.CollectQueueStats)
-            {
-                queueTracking.OnEnQueueRequest(1, requestQueue.Count, request);
-            }
-#endif
-
-            requestQueue.Add(request);
+            executor.QueueWorkItem(ProcessAction, request);
         }
 
         protected abstract void Process(T request);
 
-        protected override void Run()
-        {
-#if TRACK_DETAILED_STATS
-            if (StatisticsCollector.CollectThreadTimeTrackingStats)
-            {
-                threadTracking.OnStartExecution();
-                queueTracking.OnStartExecution();
-            }
-#endif
-            try
-            {
-                RunNonBatching();
-            }
-            finally
-            {
-#if TRACK_DETAILED_STATS
-                if (StatisticsCollector.CollectThreadTimeTrackingStats)
-                {
-                    threadTracking.OnStopExecution();
-                    queueTracking.OnStopExecution();
-                }
-#endif
-            }
-        }
-
-
-        protected void RunNonBatching()
-        {            
-            while (true)
-            {
-                if (Cts == null || Cts.IsCancellationRequested)
-                {
-                    return;
-                }
-                T request;
-                try
-                {
-                    request = requestQueue.Take();
-                }
-                catch (InvalidOperationException)
-                {
-                    Log.Info(ErrorCode.Runtime_Error_100312, "Stop request processed");
-                    break;
-                }
-#if TRACK_DETAILED_STATS
-                if (StatisticsCollector.CollectQueueStats)
-                {
-                    queueTracking.OnDeQueueRequest(request);
-                }
-                if (StatisticsCollector.CollectThreadTimeTrackingStats)
-                {
-                    threadTracking.OnStartProcessing();
-                }
-#endif
-                Process(request);
-#if TRACK_DETAILED_STATS
-                if (StatisticsCollector.CollectThreadTimeTrackingStats)
-                {
-                    threadTracking.OnStopProcessing();
-                    threadTracking.IncrementNumberOfProcessed();
-                }
-#endif
-            }
-        }
-
         public override void Stop()
         {
-#if TRACK_DETAILED_STATS
-            if (StatisticsCollector.CollectThreadTimeTrackingStats)
-            {
-                threadTracking.OnStopExecution();
-            }
-#endif
-            requestQueue?.CompleteAdding();
+            //   requestQueue?.CompleteAdding(); - ensured by CTS usage
             base.Stop();
         }
 
-        protected void DrainQueue(Action<T> action)
-        {
-            T request;
-            while (requestQueue.TryTake(out request))
-            {
-                action(request);
-            }
-        }
-
-        public virtual int Count
-        {
-            get
-            {
-                return requestQueue.Count;
-            }
-        }
+        public int Count => executor.WorkQueueLength;
 
         #region IDisposable Members
 
         protected override void Dispose(bool disposing)
         {
             if (!disposing) return;
-            
+
 #if TRACK_DETAILED_STATS
             if (StatisticsCollector.CollectThreadTimeTrackingStats)
             {
@@ -147,9 +45,6 @@ namespace Orleans.Runtime
             }
 #endif
             base.Dispose(disposing);
-
-            requestQueue?.Dispose();
-            requestQueue = null;
         }
 
         #endregion

--- a/src/Orleans.Core/Runtime/AsynchQueueAgent.cs
+++ b/src/Orleans.Core/Runtime/AsynchQueueAgent.cs
@@ -23,30 +23,7 @@ namespace Orleans.Runtime
         }
 
         protected abstract void Process(T request);
-
-        public override void Stop()
-        {
-            //   requestQueue?.CompleteAdding(); - ensured by CTS usage
-            base.Stop();
-        }
-
-        public int Count => executor.WorkQueueLength;
-
-        #region IDisposable Members
-
-        protected override void Dispose(bool disposing)
-        {
-            if (!disposing) return;
-
-#if TRACK_DETAILED_STATS
-            if (StatisticsCollector.CollectThreadTimeTrackingStats)
-            {
-                threadTracking.OnStopExecution();
-            }
-#endif
-            base.Dispose(disposing);
-        }
-
-        #endregion
+        
+        public int Count => executor.WorkQueueCount;
     }
 }

--- a/src/Orleans.Core/Runtime/ExecutorService.cs
+++ b/src/Orleans.Core/Runtime/ExecutorService.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime
 {
     internal interface IExecutor
     {
-        void QueueWorkItem(WaitCallback callBack, object state = null);
+        void QueueWorkItem(WaitCallback callback, object state = null);
 
         int WorkQueueCount { get; }
     }

--- a/src/Orleans.Core/Runtime/QueuedExecutor.cs
+++ b/src/Orleans.Core/Runtime/QueuedExecutor.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Orleans.Runtime
+{
+    internal class QueuedExecutor : IExecutor, IDisposable
+    {
+        private QueueTrackingStatistic queueTracking;
+
+        private readonly BlockingCollection<QueueWorkItemCallback> workQueue = new BlockingCollection<QueueWorkItemCallback>();
+        private readonly CancellationTokenSource cancellationTokenSource;
+
+#if TRACK_DETAILED_STATS
+        internal protected ThreadTrackingStatistic threadTracking;
+#endif
+
+        public QueuedExecutor(string name, CancellationTokenSource cts)
+        {
+            if (StatisticsCollector.CollectQueueStats)
+            {
+                queueTracking = new QueueTrackingStatistic(name);
+            }
+
+#if TRACK_DETAILED_STATS
+            if (StatisticsCollector.CollectThreadTimeTrackingStats)
+            {
+                threadTracking = new ThreadTrackingStatistic(Name);
+            }
+#endif
+
+            cancellationTokenSource = cts;
+
+
+            new ThreadPerTaskExecutor(name).QueueWorkItem(_ => ProcessQueue());
+        }
+
+        public int WorkQueueLength => workQueue.Count;
+
+        public void QueueWorkItem(WaitCallback callBack, object state = null)
+        {
+#if TRACK_DETAILED_STATS
+            if (StatisticsCollector.CollectQueueStats)
+            {
+                queueTracking.OnEnQueueRequest(1, requestQueue.Count, request);
+            }
+#endif
+
+            workQueue.Add(new QueueWorkItemCallback(callBack, state));
+        }
+        
+        public void Dispose()
+        {
+            workQueue.Dispose();
+        }
+
+        protected void ProcessQueue()
+        {
+#if TRACK_DETAILED_STATS
+            if (StatisticsCollector.CollectThreadTimeTrackingStats)
+            {
+                queueTracking.OnStartExecution();
+            }
+#endif
+            try
+            {
+                RunNonBatching();
+            }
+            finally
+            {
+#if TRACK_DETAILED_STATS
+                if (StatisticsCollector.CollectThreadTimeTrackingStats)
+                {
+                    queueTracking.OnStopExecution();
+                }
+#endif
+            }
+        }
+
+
+        protected void RunNonBatching()
+        {
+            while (true)
+            {
+                if (cancellationTokenSource.IsCancellationRequested)
+                {
+#if TRACK_DETAILED_STATS
+            if (StatisticsCollector.CollectThreadTimeTrackingStats)
+            {
+                threadTracking.OnStopExecution();
+            }
+#endif
+                    return;
+                }
+
+                var workItem = workQueue.Take();
+#if TRACK_DETAILED_STATS
+                if (StatisticsCollector.CollectQueueStats)
+                {
+                    queueTracking.OnDeQueueRequest(request);
+                }
+                if (StatisticsCollector.CollectThreadTimeTrackingStats)
+                {
+                    threadTracking.OnStartProcessing();
+                }
+#endif
+                workItem.ExecuteWorkItem();
+#if TRACK_DETAILED_STATS
+                if (StatisticsCollector.CollectThreadTimeTrackingStats)
+                {
+                    threadTracking.OnStopProcessing();
+                    threadTracking.IncrementNumberOfProcessed();
+                }
+#endif
+            }
+        }
+
+        internal sealed class QueueWorkItemCallback
+        {
+            private readonly WaitCallback callback;
+
+            private readonly object state;
+
+            public QueueWorkItemCallback(WaitCallback callback, object state)
+            {
+                this.callback = callback;
+                this.state = state;
+            }
+
+            public void ExecuteWorkItem()
+            {
+                callback.Invoke(state);
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Runtime/QueuedExecutor.cs
+++ b/src/Orleans.Core/Runtime/QueuedExecutor.cs
@@ -4,7 +4,7 @@ using System.Threading;
 
 namespace Orleans.Runtime
 {
-    internal class QueuedExecutor : IExecutor, IDisposable
+    internal class QueuedExecutor : IExecutor
     {
         private QueueTrackingStatistic queueTracking;
 
@@ -112,11 +112,6 @@ namespace Orleans.Runtime
                 }
 #endif
             }
-        }
-
-        public void Dispose()
-        {
-            // workQueue.Dispose();
         }
         
         internal sealed class QueueWorkItemCallback : ITimeInterval

--- a/src/Orleans.Core/Runtime/QueuedExecutor.cs
+++ b/src/Orleans.Core/Runtime/QueuedExecutor.cs
@@ -49,11 +49,6 @@ namespace Orleans.Runtime
 
             workQueue.Add(workItemCallback);
         }
-        
-        public void Dispose()
-        {
-            workQueue.Dispose();
-        }
 
         protected void ProcessQueue()
         {
@@ -77,8 +72,7 @@ namespace Orleans.Runtime
 #endif
             }
         }
-
-
+        
         protected void RunNonBatching()
         {
             while (true)
@@ -120,6 +114,11 @@ namespace Orleans.Runtime
             }
         }
 
+        public void Dispose()
+        {
+            workQueue.Dispose();
+        }
+        
         internal sealed class QueueWorkItemCallback : ITimeInterval
         {
             private readonly WaitCallback callback;

--- a/src/Orleans.Core/Runtime/QueuedExecutor.cs
+++ b/src/Orleans.Core/Runtime/QueuedExecutor.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime
 
         public void Dispose()
         {
-            workQueue.Dispose();
+            // workQueue.Dispose();
         }
         
         internal sealed class QueueWorkItemCallback : ITimeInterval

--- a/src/Orleans.Core/Runtime/QueuedExecutor.cs
+++ b/src/Orleans.Core/Runtime/QueuedExecutor.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime
 
         public void Dispose()
         {
-            // workQueue.Dispose();
+            workQueue.Dispose();
         }
         
         internal sealed class QueueWorkItemCallback : ITimeInterval

--- a/src/Orleans.Core/Runtime/QueuedExecutor.cs
+++ b/src/Orleans.Core/Runtime/QueuedExecutor.cs
@@ -84,11 +84,12 @@ namespace Orleans.Runtime
         {
             while (true)
             {
-                if (!drainAfterCancel && cancellationTokenSource.IsCancellationRequested)
+                if (!drainAfterCancel && cancellationTokenSource.IsCancellationRequested ||
+                    workQueue.IsCompleted)
                 {
                     return;
                 }
-
+                
                 QueueWorkItemCallback workItem;
                 try
                 {

--- a/src/Orleans.Core/Runtime/QueuedExecutor.cs
+++ b/src/Orleans.Core/Runtime/QueuedExecutor.cs
@@ -37,9 +37,10 @@ namespace Orleans.Runtime
 
         public int WorkQueueCount => workQueue.Count;
 
-        public void QueueWorkItem(WaitCallback callBack, object state = null)
+        public void QueueWorkItem(WaitCallback callback, object state = null)
         {
-            var workItemCallback = new QueueWorkItemCallback(callBack, state);
+            var workItemCallback = new QueueWorkItemCallback(callback, state);
+
 #if TRACK_DETAILED_STATS
             if (StatisticsCollector.CollectQueueStats)
             {

--- a/src/Orleans.Core/Runtime/SingleTaskAsynchAgent.cs
+++ b/src/Orleans.Core/Runtime/SingleTaskAsynchAgent.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.Runtime
+{
+    internal abstract class SingleTaskAsynchAgent : AsynchAgent
+    {
+        protected SingleTaskAsynchAgent(string nameSuffix, ExecutorService executorService, ILoggerFactory loggerFactory) : base(nameSuffix, executorService, loggerFactory)
+        {
+        }
+
+        protected SingleTaskAsynchAgent(ExecutorService executorService, ILoggerFactory loggerFactory) : base(executorService, loggerFactory)
+        {
+        }
+
+        public override void OnStart()
+        {
+            executor.QueueWorkItem(_ => AgentThreadProc(this));
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        private void AgentThreadProc(Object obj)
+        {
+            var agent = obj as SingleTaskAsynchAgent;
+            if (agent == null)
+            {
+                throw new InvalidOperationException("Agent thread started with incorrect parameter type");
+            }
+
+            try
+            {
+                LogStatus(agent.Log, "Starting AsyncAgent {0} on managed thread {1}", agent.Name, Thread.CurrentThread.ManagedThreadId);
+                CounterStatistic.SetOrleansManagedThread(); // do it before using CounterStatistic.
+                CounterStatistic.FindOrCreate(new StatisticName(StatisticNames.RUNTIME_THREADS_ASYNC_AGENT_PERAGENTTYPE, agent.type)).Increment();
+                CounterStatistic.FindOrCreate(StatisticNames.RUNTIME_THREADS_ASYNC_AGENT_TOTAL_THREADS_CREATED).Increment();
+                agent.Run();
+            }
+            catch (Exception exc)
+            {
+                if (agent.State == ThreadState.Running) // If we're stopping, ignore exceptions
+                {
+                    var log = agent.Log;
+                    switch (agent.OnFault)
+                    {
+                        case FaultBehavior.CrashOnFault:
+                            Console.WriteLine(
+                                "The {0} agent has thrown an unhandled exception, {1}. The process will be terminated.",
+                                agent.Name, exc);
+                            log.Error(ErrorCode.Runtime_Error_100023,
+                                "AsynchAgent Run method has thrown an unhandled exception. The process will be terminated.",
+                                exc);
+                            log.Fail(ErrorCode.Runtime_Error_100024, "Terminating process because of an unhandled exception caught in AsynchAgent.Run.");
+                            break;
+                        case FaultBehavior.IgnoreFault:
+                            log.Error(ErrorCode.Runtime_Error_100025, "AsynchAgent Run method has thrown an unhandled exception. The agent will exit.",
+                                exc);
+                            agent.State = ThreadState.Stopped;
+                            break;
+                        case FaultBehavior.RestartOnFault:
+                            log.Error(ErrorCode.Runtime_Error_100026,
+                                "AsynchAgent Run method has thrown an unhandled exception. The agent will be restarted.",
+                                exc);
+                            agent.State = ThreadState.Stopped;
+                            try
+                            {
+                                agent.Start();
+                            }
+                            catch (Exception ex)
+                            {
+                                log.Error(ErrorCode.Runtime_Error_100027, "Unable to restart AsynchAgent", ex);
+                                agent.State = ThreadState.Stopped;
+                            }
+                            break;
+                    }
+                }
+            }
+            finally
+            {
+                CounterStatistic.FindOrCreate(new StatisticName(StatisticNames.RUNTIME_THREADS_ASYNC_AGENT_PERAGENTTYPE, agent.type)).DecrementBy(1);
+                agent.Log.Info(ErrorCode.Runtime_Error_100328, "Stopping AsyncAgent {0} that runs on managed thread {1}", agent.Name, Thread.CurrentThread.ManagedThreadId);
+            }
+        }
+
+        protected abstract void Run();
+
+        private static void LogStatus(Logger log, string msg, params object[] args)
+        {
+            if (IsStarting)
+            {
+                // Reduce log noise during silo startup
+                if (log.IsVerbose) log.Verbose(msg, args);
+            }
+            else
+            {
+                // Changes in agent threads during all operations aside for initial creation are usually important diag events.
+                log.Info(msg, args);
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Runtime/SingleTaskAsynchAgent.cs
+++ b/src/Orleans.Core/Runtime/SingleTaskAsynchAgent.cs
@@ -16,13 +16,13 @@ namespace Orleans.Runtime
 
         public override void OnStart()
         {
-            executor.QueueWorkItem(_ => AgentThreadProc(this));
+            executor.QueueWorkItem(_ => AgentThreadProc());
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        private void AgentThreadProc(Object obj)
+        private void AgentThreadProc()
         {
-            var agent = obj as SingleTaskAsynchAgent;
+            var agent = this;
             if (agent == null)
             {
                 throw new InvalidOperationException("Agent thread started with incorrect parameter type");

--- a/src/Orleans.Core/Runtime/ThreadPerTaskExecutor.cs
+++ b/src/Orleans.Core/Runtime/ThreadPerTaskExecutor.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading;
+
+namespace Orleans.Runtime
+{
+    internal class ThreadPerTaskExecutor : IExecutor
+    {
+        private readonly string name;
+
+        public ThreadPerTaskExecutor(string name)
+        {
+            this.name = name;
+        }
+        
+        public void QueueWorkItem(WaitCallback callBack, object state = null)
+        {
+            new Thread(() => callBack.Invoke(state))
+            {
+                IsBackground = true,
+                Name = name
+            }.Start();
+        }
+
+        public int WorkQueueLength => 0;
+    }
+}

--- a/src/Orleans.Core/Runtime/ThreadPerTaskExecutor.cs
+++ b/src/Orleans.Core/Runtime/ThreadPerTaskExecutor.cs
@@ -21,7 +21,7 @@ namespace Orleans.Runtime
 #endif
         }
 
-        public void QueueWorkItem(WaitCallback callBack, object state = null)
+        public void QueueWorkItem(WaitCallback callback, object state = null)
         {
             new Thread(() =>
             {
@@ -31,7 +31,7 @@ namespace Orleans.Runtime
                     threadTracking.OnStartExecution();
                 }
 #endif
-                callBack.Invoke(state);
+                callback.Invoke(state);
 
 #if TRACK_DETAILED_STATS
                 if (StatisticsCollector.CollectThreadTimeTrackingStats)

--- a/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs
@@ -8,7 +8,7 @@ using Orleans.Runtime.Scheduler;
 
 namespace Orleans.Runtime.GrainDirectory
 {
-    internal class AdaptiveDirectoryCacheMaintainer<TValue> : AsynchAgent
+    internal class AdaptiveDirectoryCacheMaintainer<TValue> : SingleTaskAsynchAgent
     {
         private static readonly TimeSpan SLEEP_TIME_BETWEEN_REFRESHES = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromMinutes(1); // this should be something like minTTL/4
 

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
@@ -13,7 +13,7 @@ using Orleans.Runtime.MultiClusterNetwork;
 
 namespace Orleans.Runtime.GrainDirectory
 {
-    internal class GlobalSingleInstanceActivationMaintainer : AsynchAgent
+    internal class GlobalSingleInstanceActivationMaintainer : SingleTaskAsynchAgent
     {
         private readonly object lockable = new object();
         private readonly GlobalConfiguration config;

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -286,7 +286,7 @@ namespace Orleans.Runtime.Messaging
         }
 
 
-        private class GatewayClientCleanupAgent : AsynchAgent
+        private class GatewayClientCleanupAgent : SingleTaskAsynchAgent
         {
             private readonly Gateway gateway;
             private readonly TimeSpan clientDropTimeout;

--- a/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
@@ -8,7 +8,7 @@ using Orleans.Serialization;
 
 namespace Orleans.Runtime.Messaging
 {
-    internal class IncomingMessageAcceptor : AsynchAgent
+    internal class IncomingMessageAcceptor : SingleTaskAsynchAgent
     {
         private readonly ConcurrentObjectPool<SaeaPoolWrapper> receiveEventArgsPool;
         private const int SocketBufferSize = 1024 * 128; // 128 kb

--- a/src/Orleans.Runtime/Messaging/IncomingMessageAgent.cs
+++ b/src/Orleans.Runtime/Messaging/IncomingMessageAgent.cs
@@ -5,7 +5,7 @@ using Orleans.Runtime.Scheduler;
 
 namespace Orleans.Runtime.Messaging
 {
-    internal class IncomingMessageAgent : AsynchAgent
+    internal class IncomingMessageAgent : SingleTaskAsynchAgent
     {
         private readonly IMessageCenter messageCenter;
         private readonly ActivationDirectory directory;

--- a/src/Orleans.Runtime/Messaging/IncomingMessageAgent.cs
+++ b/src/Orleans.Runtime/Messaging/IncomingMessageAgent.cs
@@ -42,48 +42,30 @@ namespace Orleans.Runtime.Messaging
 
         protected override void Run()
         {
-            try
+            CancellationToken ct = Cts.Token;
+            while (true)
             {
-#if TRACK_DETAILED_STATS
-                if (StatisticsCollector.CollectThreadTimeTrackingStats)
+                // Get an application message
+                var msg = messageCenter.WaitMessage(category, ct);
+                if (msg == null)
                 {
-                    threadTracking.OnStartExecution();
+                    if (Log.IsVerbose) Log.Verbose("Dequeued a null message, exiting");
+                    // Null return means cancelled
+                    break;
                 }
-#endif
-                CancellationToken ct = Cts.Token;
-                while (true)
-                {
-                    // Get an application message
-                    var msg = messageCenter.WaitMessage(category, ct);
-                    if (msg == null)
-                    {
-                        if (Log.IsVerbose) Log.Verbose("Dequeued a null message, exiting");
-                        // Null return means cancelled
-                        break;
-                    }
 
 #if TRACK_DETAILED_STATS
-                    if (StatisticsCollector.CollectThreadTimeTrackingStats)
-                    {
-                        threadTracking.OnStartProcessing();
-                    }
-#endif
-                    ReceiveMessage(msg);
-#if TRACK_DETAILED_STATS
-                    if (StatisticsCollector.CollectThreadTimeTrackingStats)
-                    {
-                        threadTracking.OnStopProcessing();
-                        threadTracking.IncrementNumberOfProcessed();
-                    }
-#endif
+                if (StatisticsCollector.CollectThreadTimeTrackingStats)
+                {
+                    threadTracking.OnStartProcessing();
                 }
-            }
-            finally
-            {
+#endif
+                ReceiveMessage(msg);
 #if TRACK_DETAILED_STATS
                 if (StatisticsCollector.CollectThreadTimeTrackingStats)
                 {
-                    threadTracking.OnStopExecution();
+                    threadTracking.OnStopProcessing();
+                    threadTracking.IncrementNumberOfProcessed();
                 }
 #endif
             }

--- a/src/Orleans.Runtime/Scheduler/WorkerPoolThread.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkerPoolThread.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Orleans.Runtime.Scheduler
 {
-    internal class WorkerPoolThread : AsynchAgent
+    internal class WorkerPoolThread : SingleTaskAsynchAgent
     {
         internal const int MAX_THREAD_COUNT_TO_REPLACE = 500;
         private const int MAX_CPU_USAGE_TO_REPLACE = 50;

--- a/src/Orleans.Runtime/Scheduler/WorkerPoolThread.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkerPoolThread.cs
@@ -116,13 +116,6 @@ namespace Orleans.Runtime.Scheduler
                 RuntimeContext.InitializeThread(scheduler);
                 
                 int noWorkCount = 0;
-                
-#if TRACK_DETAILED_STATS
-                if (StatisticsCollector.CollectThreadTimeTrackingStats)
-                {
-                    threadTracking.OnStartExecution();
-                }
-#endif
 
                 // Until we're cancelled...
                 while (!Cts.IsCancellationRequested)
@@ -273,13 +266,6 @@ namespace Orleans.Runtime.Scheduler
             {
                 if (!IsSystem)
                     pool.RecordLeavingThread(this);
-                
-#if TRACK_DETAILED_STATS
-                if (StatisticsCollector.CollectThreadTimeTrackingStats)
-                {
-                    threadTracking.OnStopExecution();
-                }
-#endif
                 CurrentWorkItem = null;
             }
         }

--- a/src/Orleans.Runtime/Silo/Watchdog.cs
+++ b/src/Orleans.Runtime/Silo/Watchdog.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace Orleans.Runtime
 {
 
-    internal class Watchdog : AsynchAgent
+    internal class Watchdog : SingleTaskAsynchAgent
     {
         private static readonly TimeSpan heartbeatPeriod = TimeSpan.FromMilliseconds(1000);
         private readonly TimeSpan healthCheckPeriod;

--- a/src/Orleans.Runtime/Silo/Watchdog.cs
+++ b/src/Orleans.Runtime/Silo/Watchdog.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 
-
 namespace Orleans.Runtime
 {
-
     internal class Watchdog : SingleTaskAsynchAgent
     {
         private static readonly TimeSpan heartbeatPeriod = TimeSpan.FromMilliseconds(1000);

--- a/test/NonSilo.Tests/AsynchAgentRestartTest.cs
+++ b/test/NonSilo.Tests/AsynchAgentRestartTest.cs
@@ -11,7 +11,7 @@ namespace UnitTests.MessageCenterTests
     {
         private readonly ITestOutputHelper output;
 
-        private class TestAgent : AsynchAgent
+        private class TestAgent : SingleTaskAsynchAgent
         {
             private readonly ITestOutputHelper output;
 


### PR DESCRIPTION
Continuation of https://github.com/dotnet/orleans/pull/3663


### Changes description:
 - Introduced `IExecutor` interface with work queuing API compatible to .NET `ThreadPool`.
-  `ExecutorService` now returns suitable executors based on stage type. In future  `ExecutionPlan` could be introduced, allowing fine grained control over executor - stage assignment.
 - Moved queuing logic (blocking collection, its processing loop and statistics gathering) from `AsynchQueueAgent` into newly created `QueuedExecutor`. It resulted in separation of descendants of `AsynchAgent` and `AsynchQueueAgent`, as the former one schedules single long running work on start, while the latter - multiple short running tasks during execution. Stages with single task were made inheritors of  new `SingleTaskAsynchAgent` which contains extracted from `AsynchAgent` thread processing logic.
 - Due to move of statistics gathering into executors - `Message` is no longer implements `ITimeInterval` which was used for calculation of time spent in queues. Instead this measure is now being tracked inside `QueuedExecutor`.

Unification with `WorkQueue ` is matter for a separate PR. 

Suggestions on better names are welcomed, such as `AsynchAgent` -> `StageDefinition` (this one could go into global rename / refactor PR after), `QueuedExecutor` -> `ThreadPoolExecutor`, etc.
