### PR TITLE
fix null reference exception when unit testing grains that use streams

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -37,7 +37,7 @@ namespace Orleans
         /// </summary>
         protected IServiceProvider ServiceProvider 
         {
-            get { return Data.ServiceProvider ?? Runtime?.ServiceProvider; }
+            get { return Data?.ServiceProvider ?? Runtime?.ServiceProvider; }
         }
 
         internal IGrainIdentity Identity;


### PR DESCRIPTION
When unit testing a grain that uses streams a NullReferenceException will occur as the IActivationData on the grain will be null. This appears to be introduced with 2.0 beta 1. 

I have put a null check on the Grain IActivationData so that under unit testing scenarios it will defer to the injected IGrainRuntime to get a ServiceProvider.

