### PR TITLE
Add ArgumentNullException in Grain

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -114,6 +114,9 @@ namespace Orleans
         /// <seealso cref="IDisposable"/>
         protected virtual IDisposable RegisterTimer(Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
         {
+            if (asyncCallback == null) 
+                throw new ArgumentNullException(nameof(asyncCallback));
+
             EnsureRuntime();
             return Runtime.TimerRegistry.RegisterTimer(this, asyncCallback, state, dueTime, period);
         }
@@ -131,10 +134,10 @@ namespace Orleans
         /// <returns>Promise for Reminder handle.</returns>
         protected virtual Task<IGrainReminder> RegisterOrUpdateReminder(string reminderName, TimeSpan dueTime, TimeSpan period)
         {
+            if (string.IsNullOrWhiteSpace(reminderName))
+                throw new ArgumentNullException(nameof(reminderName));
             if (!(this is IRemindable))
-            {
-                throw new InvalidOperationException(string.Format("Grain {0} is not 'IRemindable'. A grain should implement IRemindable to use the persistent reminder service", IdentityString));
-            }
+                throw new InvalidOperationException($"Grain {IdentityString} is not 'IRemindable'. A grain should implement IRemindable to use the persistent reminder service");
 
             EnsureRuntime();
             return Runtime.ReminderRegistry.RegisterOrUpdateReminder(reminderName, dueTime, period);
@@ -147,6 +150,9 @@ namespace Orleans
         /// <returns>Completion promise for this operation.</returns>
         protected virtual Task UnregisterReminder(IGrainReminder reminder)
         {
+            if (reminder == null)
+                throw new ArgumentNullException(nameof(reminder));
+
             EnsureRuntime();
             return Runtime.ReminderRegistry.UnregisterReminder(reminder);
         }
@@ -158,6 +164,9 @@ namespace Orleans
         /// <returns>Promise for Reminder handle.</returns>
         protected virtual Task<IGrainReminder> GetReminder(string reminderName)
         {
+            if (string.IsNullOrWhiteSpace(reminderName))
+                throw new ArgumentNullException(nameof(reminderName));
+
             EnsureRuntime();
             return Runtime.ReminderRegistry.GetReminder(reminderName);
         }
@@ -175,7 +184,8 @@ namespace Orleans
         protected virtual IStreamProvider GetStreamProvider(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
+                
             EnsureRuntime();
             return this.ServiceProvider.GetServiceByName<IStreamProvider>(name);
         }


### PR DESCRIPTION
I guess `ArgumentNullException` is more suitable exception instead of `NullReferenceException` for case when developer does mistake and call Grain methods by passing null 