### PR TITLE
Include OptionsBuilder.Configure<TDep> extension methods

### DIFF
--- a/src/Orleans.Core/Hosting/Options/ConfigureNamedOptions.cs
+++ b/src/Orleans.Core/Hosting/Options/ConfigureNamedOptions.cs
@@ -1,0 +1,327 @@
+// Code from https://github.com/aspnet/Options/blob/edc21af4166574ecd45d8f8dbd381dfec044f367/src/Microsoft.Extensions.Options/ConfigureNamedOptions.cs
+// This will be removed and superseded Mirosoft.Extensions.Options v2.1.0.0 once it ships.
+
+using System;
+using Microsoft.Extensions.Options;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Implementation of IConfigureNamedOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep"></typeparam>
+    internal class ConfigureNamedOptions<TOptions, TDep> : IConfigureNamedOptions<TOptions>
+        where TOptions : class
+        where TDep : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency">A dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public ConfigureNamedOptions(string name, TDep dependency, Action<TOptions, TDep> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency = dependency;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep> Action { get; }
+
+        public TDep Dependency { get; }
+
+        public virtual void Configure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency);
+            }
+        }
+
+        public void Configure(TOptions options) => Configure(Options.DefaultName, options);
+    }
+
+    /// <summary>
+    /// Implementation of IConfigureNamedOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep1"></typeparam>
+    /// <typeparam name="TDep2"></typeparam>
+    internal class ConfigureNamedOptions<TOptions, TDep1, TDep2> : IConfigureNamedOptions<TOptions>
+        where TOptions : class
+        where TDep1 : class
+        where TDep2 : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency">A dependency.</param>
+        /// <param name="dependency2">A second dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public ConfigureNamedOptions(string name, TDep1 dependency, TDep2 dependency2, Action<TOptions, TDep1, TDep2> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency1 = dependency;
+            Dependency2 = dependency2;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep1, TDep2> Action { get; }
+
+        public TDep1 Dependency1 { get; }
+
+        public TDep2 Dependency2 { get; }
+
+        public virtual void Configure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency1, Dependency2);
+            }
+        }
+
+        public void Configure(TOptions options) => Configure(Options.DefaultName, options);
+    }
+
+    /// <summary>
+    /// Implementation of IConfigureNamedOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep1"></typeparam>
+    /// <typeparam name="TDep2"></typeparam>
+    /// <typeparam name="TDep3"></typeparam>
+    internal class ConfigureNamedOptions<TOptions, TDep1, TDep2, TDep3> : IConfigureNamedOptions<TOptions>
+        where TOptions : class
+        where TDep1 : class
+        where TDep2 : class
+        where TDep3 : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency">A dependency.</param>
+        /// <param name="dependency2">A second dependency.</param>
+        /// <param name="dependency3">A third dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public ConfigureNamedOptions(string name, TDep1 dependency, TDep2 dependency2, TDep3 dependency3, Action<TOptions, TDep1, TDep2, TDep3> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency1 = dependency;
+            Dependency2 = dependency2;
+            Dependency3 = dependency3;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep1, TDep2, TDep3> Action { get; }
+
+        public TDep1 Dependency1 { get; }
+
+        public TDep2 Dependency2 { get; }
+
+        public TDep3 Dependency3 { get; }
+
+
+        public virtual void Configure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency1, Dependency2, Dependency3);
+            }
+        }
+
+        public void Configure(TOptions options) => Configure(Options.DefaultName, options);
+    }
+
+    /// <summary>
+    /// Implementation of IConfigureNamedOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep1"></typeparam>
+    /// <typeparam name="TDep2"></typeparam>
+    /// <typeparam name="TDep3"></typeparam>
+    /// <typeparam name="TDep4"></typeparam>
+    internal class ConfigureNamedOptions<TOptions, TDep1, TDep2, TDep3, TDep4> : IConfigureNamedOptions<TOptions>
+        where TOptions : class
+        where TDep1 : class
+        where TDep2 : class
+        where TDep3 : class
+        where TDep4 : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency1">A dependency.</param>
+        /// <param name="dependency2">A second dependency.</param>
+        /// <param name="dependency3">A third dependency.</param>
+        /// <param name="dependency4">A fourth dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public ConfigureNamedOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, TDep4 dependency4, Action<TOptions, TDep1, TDep2, TDep3, TDep4> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency1 = dependency1;
+            Dependency2 = dependency2;
+            Dependency3 = dependency3;
+            Dependency4 = dependency4;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep1, TDep2, TDep3, TDep4> Action { get; }
+
+        public TDep1 Dependency1 { get; }
+
+        public TDep2 Dependency2 { get; }
+
+        public TDep3 Dependency3 { get; }
+
+        public TDep4 Dependency4 { get; }
+
+
+        public virtual void Configure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency1, Dependency2, Dependency3, Dependency4);
+            }
+        }
+
+        public void Configure(TOptions options) => Configure(Options.DefaultName, options);
+    }
+
+    /// <summary>
+    /// Implementation of IConfigureNamedOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep1"></typeparam>
+    /// <typeparam name="TDep2"></typeparam>
+    /// <typeparam name="TDep3"></typeparam>
+    /// <typeparam name="TDep4"></typeparam>
+    /// <typeparam name="TDep5"></typeparam>
+    internal class ConfigureNamedOptions<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> : IConfigureNamedOptions<TOptions>
+        where TOptions : class
+        where TDep1 : class
+        where TDep2 : class
+        where TDep3 : class
+        where TDep4 : class
+        where TDep5 : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency1">A dependency.</param>
+        /// <param name="dependency2">A second dependency.</param>
+        /// <param name="dependency3">A third dependency.</param>
+        /// <param name="dependency4">A fourth dependency.</param>
+        /// <param name="dependency5">A fifth dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public ConfigureNamedOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, TDep4 dependency4, TDep5 dependency5, Action<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency1 = dependency1;
+            Dependency2 = dependency2;
+            Dependency3 = dependency3;
+            Dependency4 = dependency4;
+            Dependency5 = dependency5;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> Action { get; }
+
+        public TDep1 Dependency1 { get; }
+
+        public TDep2 Dependency2 { get; }
+
+        public TDep3 Dependency3 { get; }
+
+        public TDep4 Dependency4 { get; }
+
+        public TDep5 Dependency5 { get; }
+
+
+        public virtual void Configure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency1, Dependency2, Dependency3, Dependency4, Dependency5);
+            }
+        }
+
+        public void Configure(TOptions options) => Configure(Options.DefaultName, options);
+    }
+
+}

--- a/src/Orleans.Core/Hosting/Options/OptionsBuilder.cs
+++ b/src/Orleans.Core/Hosting/Options/OptionsBuilder.cs
@@ -1,4 +1,4 @@
-// Code from https://github.com/aspnet/Options/blob/fe3f1b15811958acfa0be7eb88656d4bd5943834/src/Microsoft.Extensions.Options/OptionsBuilder.cs
+// Code from https://github.com/aspnet/Options/blob/edc21af4166574ecd45d8f8dbd381dfec044f367/src/Microsoft.Extensions.Options/OptionsBuilder.cs
 // This will be removed and superseded Mirosoft.Extensions.Options v2.1.0.0 once it ships.
 
 using System;
@@ -55,6 +55,99 @@ namespace Orleans.Hosting
             return this;
         }
 
+        public virtual OptionsBuilder<TOptions> Configure<TDep>(Action<TOptions, TDep> configureOptions)
+            where TDep : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IConfigureOptions<TOptions>>(sp =>
+                new ConfigureNamedOptions<TOptions, TDep>(Name, sp.GetRequiredService<TDep>(), configureOptions));
+            return this;
+        }
+
+        public virtual OptionsBuilder<TOptions> Configure<TDep1, TDep2>(Action<TOptions, TDep1, TDep2> configureOptions)
+            where TDep1 : class
+            where TDep2 : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IConfigureOptions<TOptions>>(sp =>
+                new ConfigureNamedOptions<TOptions, TDep1, TDep2>(Name, sp.GetRequiredService<TDep1>(), sp.GetRequiredService<TDep2>(), configureOptions));
+            return this;
+        }
+
+        public virtual OptionsBuilder<TOptions> Configure<TDep1, TDep2, TDep3>(Action<TOptions, TDep1, TDep2, TDep3> configureOptions)
+            where TDep1 : class
+            where TDep2 : class
+            where TDep3 : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IConfigureOptions<TOptions>>(
+                sp => new ConfigureNamedOptions<TOptions, TDep1, TDep2, TDep3>(
+                    Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    sp.GetRequiredService<TDep3>(),
+                    configureOptions));
+            return this;
+        }
+
+        public virtual OptionsBuilder<TOptions> Configure<TDep1, TDep2, TDep3, TDep4>(Action<TOptions, TDep1, TDep2, TDep3, TDep4> configureOptions)
+            where TDep1 : class
+            where TDep2 : class
+            where TDep3 : class
+            where TDep4 : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IConfigureOptions<TOptions>>(
+                sp => new ConfigureNamedOptions<TOptions, TDep1, TDep2, TDep3, TDep4>(
+                    Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    sp.GetRequiredService<TDep3>(),
+                    sp.GetRequiredService<TDep4>(),
+                    configureOptions));
+            return this;
+        }
+
+        public virtual OptionsBuilder<TOptions> Configure<TDep1, TDep2, TDep3, TDep4, TDep5>(Action<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> configureOptions)
+            where TDep1 : class
+            where TDep2 : class
+            where TDep3 : class
+            where TDep4 : class
+            where TDep5 : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IConfigureOptions<TOptions>>(
+                sp => new ConfigureNamedOptions<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5>(
+                    Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    sp.GetRequiredService<TDep3>(),
+                    sp.GetRequiredService<TDep4>(),
+                    sp.GetRequiredService<TDep5>(),
+                    configureOptions));
+            return this;
+        }
+
         /// <summary>
         /// Registers an action used to configure a particular type of options.
         /// Note: These are run after all <seealso cref="Configure(Action{TOptions})"/>.
@@ -68,6 +161,99 @@ namespace Orleans.Hosting
             }
 
             Services.AddSingleton<IPostConfigureOptions<TOptions>>(new PostConfigureOptions<TOptions>(Name, configureOptions));
+            return this;
+        }
+
+        public virtual OptionsBuilder<TOptions> PostConfigure<TDep>(Action<TOptions, TDep> configureOptions)
+            where TDep : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IPostConfigureOptions<TOptions>>(sp =>
+                new PostConfigureOptions<TOptions, TDep>(Name, sp.GetRequiredService<TDep>(), configureOptions));
+            return this;
+        }
+
+        public virtual OptionsBuilder<TOptions> PostConfigure<TDep1, TDep2>(Action<TOptions, TDep1, TDep2> configureOptions)
+            where TDep1 : class
+            where TDep2 : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IPostConfigureOptions<TOptions>>(sp =>
+                new PostConfigureOptions<TOptions, TDep1, TDep2>(Name, sp.GetRequiredService<TDep1>(), sp.GetRequiredService<TDep2>(), configureOptions));
+            return this;
+        }
+
+        public virtual OptionsBuilder<TOptions> PostConfigure<TDep1, TDep2, TDep3>(Action<TOptions, TDep1, TDep2, TDep3> configureOptions)
+            where TDep1 : class
+            where TDep2 : class
+            where TDep3 : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IPostConfigureOptions<TOptions>>(
+                sp => new PostConfigureOptions<TOptions, TDep1, TDep2, TDep3>(
+                    Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    sp.GetRequiredService<TDep3>(),
+                    configureOptions));
+            return this;
+        }
+
+        public virtual OptionsBuilder<TOptions> PostConfigure<TDep1, TDep2, TDep3, TDep4>(Action<TOptions, TDep1, TDep2, TDep3, TDep4> configureOptions)
+            where TDep1 : class
+            where TDep2 : class
+            where TDep3 : class
+            where TDep4 : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IPostConfigureOptions<TOptions>>(
+                sp => new PostConfigureOptions<TOptions, TDep1, TDep2, TDep3, TDep4>(
+                    Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    sp.GetRequiredService<TDep3>(),
+                    sp.GetRequiredService<TDep4>(),
+                    configureOptions));
+            return this;
+        }
+
+        public virtual OptionsBuilder<TOptions> PostConfigure<TDep1, TDep2, TDep3, TDep4, TDep5>(Action<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> configureOptions)
+            where TDep1 : class
+            where TDep2 : class
+            where TDep3 : class
+            where TDep4 : class
+            where TDep5 : class
+        {
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            Services.AddTransient<IPostConfigureOptions<TOptions>>(
+                sp => new PostConfigureOptions<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5>(
+                    Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    sp.GetRequiredService<TDep3>(),
+                    sp.GetRequiredService<TDep4>(),
+                    sp.GetRequiredService<TDep5>(),
+                    configureOptions));
             return this;
         }
     }

--- a/src/Orleans.Core/Hosting/Options/PostConfigureOptions.cs
+++ b/src/Orleans.Core/Hosting/Options/PostConfigureOptions.cs
@@ -1,0 +1,327 @@
+// Code from https://github.com/aspnet/Options/blob/edc21af4166574ecd45d8f8dbd381dfec044f367/src/Microsoft.Extensions.Options/PostConfigureOptions.cs
+// This will be removed and superseded Mirosoft.Extensions.Options v2.1.0.0 once it ships.
+
+using System;
+using Microsoft.Extensions.Options;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Implementation of IPostConfigureOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep"></typeparam>
+    internal class PostConfigureOptions<TOptions, TDep> : IPostConfigureOptions<TOptions>
+        where TOptions : class
+        where TDep : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency">A dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public PostConfigureOptions(string name, TDep dependency, Action<TOptions, TDep> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency = dependency;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep> Action { get; }
+
+        public TDep Dependency { get; }
+
+        public virtual void PostConfigure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency);
+            }
+        }
+
+        public void PostConfigure(TOptions options) => PostConfigure(Options.DefaultName, options);
+    }
+
+    /// <summary>
+    /// Implementation of IPostConfigureOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep1"></typeparam>
+    /// <typeparam name="TDep2"></typeparam>
+    internal class PostConfigureOptions<TOptions, TDep1, TDep2> : IPostConfigureOptions<TOptions>
+        where TOptions : class
+        where TDep1 : class
+        where TDep2 : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency">A dependency.</param>
+        /// <param name="dependency2">A second dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public PostConfigureOptions(string name, TDep1 dependency, TDep2 dependency2, Action<TOptions, TDep1, TDep2> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency1 = dependency;
+            Dependency2 = dependency2;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep1, TDep2> Action { get; }
+
+        public TDep1 Dependency1 { get; }
+
+        public TDep2 Dependency2 { get; }
+
+        public virtual void PostConfigure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency1, Dependency2);
+            }
+        }
+
+        public void PostConfigure(TOptions options) => PostConfigure(Options.DefaultName, options);
+    }
+
+    /// <summary>
+    /// Implementation of IPostConfigureOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep1"></typeparam>
+    /// <typeparam name="TDep2"></typeparam>
+    /// <typeparam name="TDep3"></typeparam>
+    internal class PostConfigureOptions<TOptions, TDep1, TDep2, TDep3> : IPostConfigureOptions<TOptions>
+        where TOptions : class
+        where TDep1 : class
+        where TDep2 : class
+        where TDep3 : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency">A dependency.</param>
+        /// <param name="dependency2">A second dependency.</param>
+        /// <param name="dependency3">A third dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public PostConfigureOptions(string name, TDep1 dependency, TDep2 dependency2, TDep3 dependency3, Action<TOptions, TDep1, TDep2, TDep3> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency1 = dependency;
+            Dependency2 = dependency2;
+            Dependency3 = dependency3;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep1, TDep2, TDep3> Action { get; }
+
+        public TDep1 Dependency1 { get; }
+
+        public TDep2 Dependency2 { get; }
+
+        public TDep3 Dependency3 { get; }
+
+
+        public virtual void PostConfigure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency1, Dependency2, Dependency3);
+            }
+        }
+
+        public void PostConfigure(TOptions options) => PostConfigure(Options.DefaultName, options);
+    }
+
+    /// <summary>
+    /// Implementation of IPostConfigureOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep1"></typeparam>
+    /// <typeparam name="TDep2"></typeparam>
+    /// <typeparam name="TDep3"></typeparam>
+    /// <typeparam name="TDep4"></typeparam>
+    internal class PostConfigureOptions<TOptions, TDep1, TDep2, TDep3, TDep4> : IPostConfigureOptions<TOptions>
+        where TOptions : class
+        where TDep1 : class
+        where TDep2 : class
+        where TDep3 : class
+        where TDep4 : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency1">A dependency.</param>
+        /// <param name="dependency2">A second dependency.</param>
+        /// <param name="dependency3">A third dependency.</param>
+        /// <param name="dependency4">A fourth dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public PostConfigureOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, TDep4 dependency4, Action<TOptions, TDep1, TDep2, TDep3, TDep4> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency1 = dependency1;
+            Dependency2 = dependency2;
+            Dependency3 = dependency3;
+            Dependency4 = dependency4;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep1, TDep2, TDep3, TDep4> Action { get; }
+
+        public TDep1 Dependency1 { get; }
+
+        public TDep2 Dependency2 { get; }
+
+        public TDep3 Dependency3 { get; }
+
+        public TDep4 Dependency4 { get; }
+
+
+        public virtual void PostConfigure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency1, Dependency2, Dependency3, Dependency4);
+            }
+        }
+
+        public void PostConfigure(TOptions options) => PostConfigure(Options.DefaultName, options);
+    }
+
+    /// <summary>
+    /// Implementation of IPostConfigureOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TDep1"></typeparam>
+    /// <typeparam name="TDep2"></typeparam>
+    /// <typeparam name="TDep3"></typeparam>
+    /// <typeparam name="TDep4"></typeparam>
+    /// <typeparam name="TDep5"></typeparam>
+    internal class PostConfigureOptions<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> : IPostConfigureOptions<TOptions>
+        where TOptions : class
+        where TDep1 : class
+        where TDep2 : class
+        where TDep3 : class
+        where TDep4 : class
+        where TDep5 : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="dependency1">A dependency.</param>
+        /// <param name="dependency2">A second dependency.</param>
+        /// <param name="dependency3">A third dependency.</param>
+        /// <param name="dependency4">A fourth dependency.</param>
+        /// <param name="dependency5">A fifth dependency.</param>
+        /// <param name="action">The action to register.</param>
+        public PostConfigureOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, TDep4 dependency4, TDep5 dependency5, Action<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> action)
+        {
+            Name = name;
+            Action = action;
+            Dependency1 = dependency1;
+            Dependency2 = dependency2;
+            Dependency3 = dependency3;
+            Dependency4 = dependency4;
+            Dependency5 = dependency5;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> Action { get; }
+
+        public TDep1 Dependency1 { get; }
+
+        public TDep2 Dependency2 { get; }
+
+        public TDep3 Dependency3 { get; }
+
+        public TDep4 Dependency4 { get; }
+
+        public TDep5 Dependency5 { get; }
+
+
+        public virtual void PostConfigure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options, Dependency1, Dependency2, Dependency3, Dependency4, Dependency5);
+            }
+        }
+
+        public void PostConfigure(TOptions options) => PostConfigure(Options.DefaultName, options);
+    }
+
+}

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -36,8 +36,8 @@ namespace Orleans.Hosting
                 });
             services.TryAddFromExisting<IMessagingConfiguration, GlobalConfiguration>();
 
-            // Add legacy node configuration, based from the instance returned from the above registered factory
-            services.AddLegacyNodeConfigurationSupport();
+            services.AddOptions<StatisticsOptions>()
+                .Configure<NodeConfiguration>((options, nodeConfig) => LegacyConfigurationExtensions.CopyStatisticsOptions(nodeConfig, options));
 
             // Translate legacy configuration to new Options
             services.Configure<SiloMessagingOptions>(options =>
@@ -56,7 +56,7 @@ namespace Orleans.Hosting
                 options.FallbackSerializationProvider = configuration.Globals.FallbackSerializationProvider;
             });
 
-            services.Configure<IOptions<SiloIdentityOptions>, GrainClassOptions>((identityOptions, options) =>
+            services.AddOptions<GrainClassOptions>().Configure<IOptions<SiloIdentityOptions>>((options, identityOptions) =>
             {
                 var nodeConfig = configuration.GetOrCreateNodeConfigurationForSilo(identityOptions.Value.SiloName);
                 options.ExcludedGrainTypes.AddRange(nodeConfig.ExcludedGrainTypes);
@@ -64,35 +64,6 @@ namespace Orleans.Hosting
 
             LegacyMembershipConfigurator.ConfigureServices(configuration.Globals, services);
             return services;
-        }
-
-        internal static void Configure<TService, TOptions>(this IServiceCollection services, Action<TService, TOptions> configure) where TOptions : class
-        {
-            services.AddTransient<IConfigureOptions<TOptions>>(sp => new ServiceBasedConfigurator<TService, TOptions>(sp.GetRequiredService<TService>(), configure));
-        }
-
-        private static IServiceCollection AddLegacyNodeConfigurationSupport(this IServiceCollection services)
-        {
-            services.Configure<NodeConfiguration, StatisticsOptions>((configuration, options) =>
-            {
-                LegacyConfigurationExtensions.CopyStatisticsOptions(configuration, options);
-            });
-
-            return services;
-        }
-
-        private class ServiceBasedConfigurator<TService, TOptions> : IConfigureOptions<TOptions> where TOptions : class
-        {
-            private readonly Action<TService, TOptions> configure;
-            private readonly TService service;
-
-            public ServiceBasedConfigurator(TService service, Action<TService, TOptions> configure)
-            {
-                this.service = service;
-                this.configure = configure;
-            }
-
-            public void Configure(TOptions options) => this.configure(this.service, options);
         }
     }
 }


### PR DESCRIPTION
Replace our custom `ServiceBasedConfigurator` with a copy of Microsoft.Extensions.Options extension methods to fulfill the same goal. We can remove our copy once 2.1 of Options ship.

The copied code comes from this PR: https://github.com/aspnet/Options/pull/239

This addition will be even more useful in upcoming changes where I need to bring 2 dependencies instead of 1, so `ServiceBasedConfigurator` is not enough as it is.