### PR TITLE
Initialize primary node and seed information when the silo is about to start

### DIFF
--- a/src/Orleans.Core/Configuration/ClusterConfiguration.cs
+++ b/src/Orleans.Core/Configuration/ClusterConfiguration.cs
@@ -185,15 +185,9 @@ namespace Orleans.Runtime.Configuration
             {
                 var n = new NodeConfiguration(Defaults);
                 n.Load(ParseXml(new StringReader(p.Value)));
-                InitNodeSettingsFromGlobals(n);
+                n.InitNodeSettingsFromGlobals(this);
                 Overrides[n.SiloName] = n;
             }
-        }
-
-        private void InitNodeSettingsFromGlobals(NodeConfiguration n)
-        {
-            if (n.Endpoint.Equals(this.PrimaryNode)) n.IsPrimaryNode = true;
-            if (Globals.SeedNodes.Contains(n.Endpoint)) n.IsSeedNode = true;
         }
 
         /// <summary>Loads the configuration from a file</summary>
@@ -226,7 +220,7 @@ namespace Orleans.Runtime.Configuration
         public NodeConfiguration CreateNodeConfigurationForSilo(string siloName)
         {
             var siloNode = new NodeConfiguration(Defaults) { SiloName = siloName };
-            InitNodeSettingsFromGlobals(siloNode);
+            siloNode.InitNodeSettingsFromGlobals(this);
             Overrides[siloName] = siloNode;
             return siloNode;
         }

--- a/src/Orleans.Core/Configuration/NodeConfiguration.cs
+++ b/src/Orleans.Core/Configuration/NodeConfiguration.cs
@@ -333,6 +333,12 @@ namespace Orleans.Runtime.Configuration
             return sb.ToString();
         }
 
+        internal void InitNodeSettingsFromGlobals(ClusterConfiguration clusterConfiguration)
+        {
+            this.IsPrimaryNode = this.Endpoint.Equals(clusterConfiguration.PrimaryNode);
+            this.IsSeedNode = clusterConfiguration.Globals.SeedNodes.Contains(this.Endpoint);
+        }
+
         internal void Load(XmlElement root)
         {
             SiloName = root.LocalName.Equals("Override") ? root.GetAttribute("Node") : DEFAULT_NODE_NAME;

--- a/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
+++ b/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
@@ -61,6 +61,7 @@ namespace Orleans.Runtime
                 this.NodeConfig.Generation = SiloAddress.AllocateNewGeneration();
             }
 
+            this.NodeConfig.InitNodeSettingsFromGlobals(config);
             this.SiloAddress = SiloAddress.New(this.NodeConfig.Endpoint, this.NodeConfig.Generation);
             this.Type = this.NodeConfig.IsPrimaryNode ? Silo.SiloType.Primary : Silo.SiloType.Secondary;
         }


### PR DESCRIPTION
The information was set only when initially building the node, but not updated if the Endpoint changed. This way it could be stale (and it was in many cases) by the time the silo starts