### PR TITLE
Improve samples: remove misleading code to configure ServicePointManager

### DIFF
--- a/Samples/AzureWebSample/OrleansAzureSilos/WorkerRole.cs
+++ b/Samples/AzureWebSample/OrleansAzureSilos/WorkerRole.cs
@@ -22,9 +22,6 @@ namespace Orleans.Azure.Silos
             Trace.WriteLine("OrleansAzureSilos-OnStart called", "Information");
             Trace.WriteLine("OrleansAzureSilos-OnStart Initializing config", "Information");
 
-            // Set the maximum number of concurrent connections 
-            ServicePointManager.DefaultConnectionLimit = 12;
-
             // For information on handling configuration changes see the MSDN topic at http://go.microsoft.com/fwlink/?LinkId=166357.
             RoleEnvironment.Changing += RoleEnvironmentChanging;
             SetupEnvironmentChangeHandlers();

--- a/Samples/GPSTracker/GPSTracker.Web/WebRole.cs
+++ b/Samples/GPSTracker/GPSTracker.Web/WebRole.cs
@@ -11,9 +11,6 @@ namespace GPSTracker.Web
 
         public override bool OnStart()
         {
-            // Set the maximum number of concurrent connections 
-            ServicePointManager.DefaultConnectionLimit = 12;
-
             Trace.WriteLine("Starting Role Entry Point");
 
             silo = new AzureSilo();

--- a/Samples/HelloGeoSample/Orleans.Silos/WorkerRole.cs
+++ b/Samples/HelloGeoSample/Orleans.Silos/WorkerRole.cs
@@ -24,9 +24,6 @@ namespace Orleans.Azure.Silos
 
             Trace.WriteLine("OrleansAzureSilos-OnStart Initializing config", "Information");
 
-            // Set the maximum number of concurrent connections 
-            ServicePointManager.DefaultConnectionLimit = 12;
-
             // For information on handling configuration changes see the MSDN topic at http://go.microsoft.com/fwlink/?LinkId=166357.
             RoleEnvironment.Changing += RoleEnvironmentChanging;
             SetupEnvironmentChangeHandlers();

--- a/Samples/ReplicatedChatGrainSample/Orleans.Silos/WorkerRole.cs
+++ b/Samples/ReplicatedChatGrainSample/Orleans.Silos/WorkerRole.cs
@@ -24,9 +24,6 @@ namespace Orleans.Azure.Silos
 
             Trace.WriteLine("OrleansAzureSilos-OnStart Initializing config", "Information");
 
-            // Set the maximum number of concurrent connections 
-            ServicePointManager.DefaultConnectionLimit = 12;
-
             // For information on handling configuration changes see the MSDN topic at http://go.microsoft.com/fwlink/?LinkId=166357.
             RoleEnvironment.Changing += RoleEnvironmentChanging;
             SetupEnvironmentChangeHandlers();

--- a/Samples/ReplicatedEventSample/Orleans.Silos/WorkerRole.cs
+++ b/Samples/ReplicatedEventSample/Orleans.Silos/WorkerRole.cs
@@ -24,9 +24,6 @@ namespace Orleans.Azure.Silos
 
             Trace.WriteLine("OrleansAzureSilos-OnStart Initializing config", "Information");
 
-            // Set the maximum number of concurrent connections 
-            ServicePointManager.DefaultConnectionLimit = 12;
-
             // For information on handling configuration changes see the MSDN topic at http://go.microsoft.com/fwlink/?LinkId=166357.
             RoleEnvironment.Changing += RoleEnvironmentChanging;
             SetupEnvironmentChangeHandlers();

--- a/Samples/TicTacToe/OrleansXO.WorkerRole/WorkerRole.cs
+++ b/Samples/TicTacToe/OrleansXO.WorkerRole/WorkerRole.cs
@@ -11,9 +11,6 @@ namespace OrleansXO.WorkerRole
 
         public override bool OnStart()
         {
-            // Set the maximum number of concurrent connections 
-            ServicePointManager.DefaultConnectionLimit = 12;
-
             // Do other silo initialization – for example: Azure diagnostics, etc
             
             // For information on handling configuration changes


### PR DESCRIPTION
- remove misleading code in samples to configure ServicePointManager
- [ServicePointManager.DefaultConnectionLimit gets set in Silo initialization](https://github.com/dotnet/orleans/blob/1591fd13a2868336bd111d01251f20aba503dbf3/src/Orleans.Runtime/Silo/Silo.cs#L657) with value from
  ClusterConfiguration.Defaults.DefaultConnectionLimit (defaults to 200)