### PR TITLE
Set a timeout value for the synchronous socket read operations

### DIFF
--- a/src/Orleans.Core/Messaging/SocketManager.cs
+++ b/src/Orleans.Core/Messaging/SocketManager.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="address">The address to bind to.</param>
         /// <returns>The new socket, appropriately bound.</returns>
-        internal static Socket GetAcceptingSocketForEndpoint(IPEndPoint address)
+        internal Socket GetAcceptingSocketForEndpoint(IPEndPoint address)
         {
             var s = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             try
@@ -39,6 +39,10 @@ namespace Orleans.Runtime
                 // Prep the socket so it will reset on close
                 s.LingerState = new LingerOption(true, 0);
                 s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                // The following timeout is only effective when calling the synchronous
+                // Socket.Receive method. We should only use this method when we are reading
+                // the connection preamble
+                s.ReceiveTimeout = (int) this.connectionTimeout.TotalMilliseconds;
                 // And bind it to the address
                 s.Bind(address);
             }

--- a/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
+++ b/src/Orleans.Runtime/Messaging/IncomingMessageAcceptor.cs
@@ -56,7 +56,7 @@ namespace Orleans.Runtime.Messaging
             if (here == null)
                 listenAddress = MessageCenter.MyAddress.Endpoint;
 
-            AcceptingSocket = SocketManager.GetAcceptingSocketForEndpoint(listenAddress);
+            AcceptingSocket = MessageCenter.SocketManager.GetAcceptingSocketForEndpoint(listenAddress);
             Log.Info(ErrorCode.Messaging_IMA_OpenedListeningSocket, "Opened a listening socket at address " + AcceptingSocket.LocalEndPoint);
             OpenReceiveSockets = new HashSet<Socket>();
             OnFault = FaultBehavior.CrashOnFault;
@@ -584,7 +584,7 @@ namespace Orleans.Runtime.Messaging
             {
                 if (Log.IsVerbose) Log.Verbose("Restarting of the accepting socket");
                 SocketManager.CloseSocket(AcceptingSocket);
-                AcceptingSocket = SocketManager.GetAcceptingSocketForEndpoint(listenAddress);
+                AcceptingSocket = MessageCenter.SocketManager.GetAcceptingSocketForEndpoint(listenAddress);
                 AcceptingSocket.Listen(LISTEN_BACKLOG_SIZE);
                 StartAccept(null);
             }

--- a/test/Tester/ClientConnectionTests/StallConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/StallConnectionTests.cs
@@ -1,0 +1,68 @@
+﻿using Orleans.Runtime;
+using Orleans.TestingHost;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.ClientConnectionTests
+{
+    public class StallConnectionTests : TestClusterPerTest
+    {
+        public override TestCluster CreateTestCluster()
+        {
+            return new TestCluster(new TestClusterOptions(1));
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task ConnectToGwAfterStallConnectionOpened()
+        {
+            Socket stalledSocket;
+            var gwEndpoint = this.HostedCluster.Primary.NodeConfiguration.ProxyGatewayEndpoint;
+
+            // Close current client connection
+            await this.Client.Close();
+
+            // Stall connection to GW
+            using (stalledSocket = new Socket(gwEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+            {
+                await stalledSocket.ConnectAsync(gwEndpoint);
+
+                // Try to reconnect to GW
+                this.HostedCluster.InitializeClient();
+
+                stalledSocket.Disconnect(true);
+            }
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task SiloJoinAfterStallConnectionOpened()
+        {
+            Socket stalledSocket;
+            var siloEndpoint = this.HostedCluster.Primary.NodeConfiguration.Endpoint;
+
+            // Stall connection to GW
+            using (stalledSocket = new Socket(siloEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+            {
+                await stalledSocket.ConnectAsync(siloEndpoint);
+
+                // Try to add a new silo in the cluster
+                this.HostedCluster.StartAdditionalSilo();
+
+                // Wait for the silo to join the cluster
+                await this.HostedCluster.WaitForLivenessToStabilizeAsync();
+
+                var mgmtGrain = this.Client.GetGrain<IManagementGrain>(0);
+                var hosts = await mgmtGrain.GetHosts();
+
+                Assert.Equal(2, hosts.Count);
+
+                stalledSocket.Disconnect(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
First fix for #3715 

Basically reusing the connection timeout value from the configuration in the Socket configuration for synchronous call to `Socket.Receive` (when waiting connections preamble).

This do not interfere with the asynchronous receive that we do thereafter : https://msdn.microsoft.com/en-us/library/system.net.sockets.socket.receivetimeout(v=vs.110).aspx

> **Remarks**
> This option applies to synchronous Receive calls only
