### PR TITLE
Disambiguate different grain methods whose parameters have the same simple type name

### DIFF
--- a/test/TestGrainInterfaces/CodegenTestInterfaces.cs
+++ b/test/TestGrainInterfaces/CodegenTestInterfaces.cs
@@ -4,10 +4,35 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
 
-
 namespace UnitTests.GrainInterfaces
 {
     using Orleans.Concurrency;
+
+    namespace One
+    {
+        public class Command
+        {
+        }
+    }
+
+    namespace Two
+    {
+        public class Command
+        {
+        }
+    }
+
+    /// <summary>
+    /// Repro for https://github.com/dotnet/orleans/issues/3713.
+    /// Having multiple methods with the same name and same parameter type
+    /// name would cause a code generation failure because only one of the
+    /// methods would be implemented in the generated GrainReference.
+    /// </summary>
+    internal interface ISameNameParameterTypeGrain : IGrainWithIntegerKey
+    {
+        Task ExecuteCommand(One.Command command);
+        Task ExecuteCommand(Two.Command command);
+    }
 
     internal interface IInternalPingGrain : IGrainWithIntegerKey
     {


### PR DESCRIPTION
Fixes #3713.

Note that this changes the algorithm used to compute method ids, meaning that all existing applications would have to be recompiled and older versions will not be able to communicate with newer versions.

Since the next release is 2.0, I think it's ok to make this change now. This doesn't affect serialization of grain references.

Alternatively, I can partially undo this change so that method id computation is unchanged but at least users can explicitly disambiguate by using the `[MethodId(x)]` attribute (which will not work today).