### PR TITLE
Add MaxSocketAge to OrleansConfiguration.xsd

### DIFF
--- a/src/Orleans.Core/Configuration/OrleansConfiguration.xsd
+++ b/src/Orleans.Core/Configuration/OrleansConfiguration.xsd
@@ -314,6 +314,14 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="MaxSocketAge" type="tns:TimeSpan" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The MaxSocketAge attribute specifies how long to keep an open socket before it is closed.
+          Default is TimeSpan.MaxValue (never close sockets automatically, unless they were broken).
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="SystemStoreConfiguration">


### PR DESCRIPTION
- [It's possible to specify `MaxSocketAge`](https://github.com/dotnet/orleans/blob/2c8e524a23d0f97fdb4476cab4716f70bac04270/src/Orleans.Core/Configuration/MessagingConfiguration.cs#L222-L226) in the `Messaging` element of `OrleansConfiguration.xml`. However this was missing from the xsd file. This PR just adds that element and [it's documentation](https://github.com/dotnet/orleans/blob/2c8e524a23d0f97fdb4476cab4716f70bac04270/src/Orleans.Core/Configuration/MessagingConfiguration.cs#L33-L36) to the xsd file.

- Using something like `<Messaging MaxSocketAge="230s"/>` in `Globals` in `OrleansConfiguration.xml` might be a way to workaround a problem of a router or firewall dropping an Orleans TCP connection without notification (no RST is sent and the connection just hangs around, Azure routers/firewalls are reported to behave in this way). There was a related issue #1545 which was never resolved. Perhaps enabling TCP keepalive for the sockets would be a better way to resolve #1545 than using the `MaxSocketAge` workaround?