### PR TITLE
Collapse DeploymentId with ClusterId

### DIFF
--- a/src/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -28,7 +28,7 @@ namespace Orleans.Runtime.MembershipService
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<AzureBasedMembershipTable>();
             this.options = membershipOptions.Value;
-            this.deploymentId = globalConfiguration.DeploymentId;
+            this.deploymentId = globalConfiguration.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -22,13 +22,13 @@ namespace Orleans.Runtime.MembershipService
         private readonly ILoggerFactory loggerFactory;
         private OrleansSiloInstanceManager tableManager;
         private readonly AzureTableMembershipOptions options;
-        private readonly string deploymentId;
+        private readonly string clusterId;
         public AzureBasedMembershipTable(ILoggerFactory loggerFactory, IOptions<AzureTableMembershipOptions> membershipOptions, GlobalConfiguration globalConfiguration)
         {
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<AzureBasedMembershipTable>();
             this.options = membershipOptions.Value;
-            this.deploymentId = globalConfiguration.ClusterId;
+            this.clusterId = globalConfiguration.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
@@ -37,7 +37,7 @@ namespace Orleans.Runtime.MembershipService
             LogFormatter.SetExceptionDecoder(typeof(StorageException), AzureStorageUtils.PrintStorageException);
 
             tableManager = await OrleansSiloInstanceManager.GetManager(
-                this.deploymentId, options.ConnectionString, this.loggerFactory);
+                this.clusterId, options.ConnectionString, this.loggerFactory);
 
             // even if I am not the one who created the table, 
             // try to insert an initial table version if it is not already there,
@@ -50,9 +50,9 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        public Task DeleteMembershipTableEntries(string deploymentId)
+        public Task DeleteMembershipTableEntries(string clusterId)
         {
-            return tableManager.DeleteTableEntries(deploymentId);
+            return tableManager.DeleteTableEntries(clusterId);
         }
 
         public async Task<MembershipTableData> ReadRow(SiloAddress key)

--- a/src/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
+++ b/src/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
@@ -20,7 +20,7 @@ namespace Orleans.AzureUtils
         public AzureGatewayListProvider(ILoggerFactory loggerFactory, IOptions<AzureTableGatewayListProviderOptions> options, ClientConfiguration clientConfiguration)
         {
             this.loggerFactory = loggerFactory;
-            this.deploymentId = clientConfiguration.DeploymentId;
+            this.deploymentId = clientConfiguration.ClusterId;
             this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
             this.options = options.Value;
         }

--- a/src/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
+++ b/src/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
@@ -12,7 +12,7 @@ namespace Orleans.AzureUtils
     internal class AzureGatewayListProvider : IGatewayListProvider
     {
         private OrleansSiloInstanceManager siloInstanceManager;
-        private readonly string deploymentId;
+        private readonly string clusterId;
         private readonly AzureTableGatewayListProviderOptions options;
         private readonly ILoggerFactory loggerFactory;
         private readonly TimeSpan maxStaleness;
@@ -20,7 +20,7 @@ namespace Orleans.AzureUtils
         public AzureGatewayListProvider(ILoggerFactory loggerFactory, IOptions<AzureTableGatewayListProviderOptions> options, ClientConfiguration clientConfiguration)
         {
             this.loggerFactory = loggerFactory;
-            this.deploymentId = clientConfiguration.ClusterId;
+            this.clusterId = clientConfiguration.ClusterId;
             this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
             this.options = options.Value;
         }
@@ -29,7 +29,7 @@ namespace Orleans.AzureUtils
 
         public async Task InitializeGatewayListProvider()
         {
-            siloInstanceManager = await OrleansSiloInstanceManager.GetManager(this.deploymentId, this.options.ConnectionString, this.loggerFactory);
+            siloInstanceManager = await OrleansSiloInstanceManager.GetManager(this.clusterId, this.options.ConnectionString, this.loggerFactory);
         }
         // no caching
         public Task<IList<Uri>> GetGateways()

--- a/src/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -30,17 +30,17 @@ namespace Orleans.AzureUtils
 
         public string DeploymentId { get; private set; }
 
-        private OrleansSiloInstanceManager(string deploymentId, string storageConnectionString, ILoggerFactory loggerFactory)
+        private OrleansSiloInstanceManager(string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)
         {
-            DeploymentId = deploymentId;
+            DeploymentId = clusterId;
             logger = loggerFactory.CreateLogger<OrleansSiloInstanceManager>();
             storage = new AzureTableDataManager<SiloInstanceTableEntry>(
                 INSTANCE_TABLE_NAME, storageConnectionString, loggerFactory);
         }
 
-        public static async Task<OrleansSiloInstanceManager> GetManager(string deploymentId, string storageConnectionString, ILoggerFactory loggerFactory)
+        public static async Task<OrleansSiloInstanceManager> GetManager(string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)
         {
-            var instance = new OrleansSiloInstanceManager(deploymentId, storageConnectionString, loggerFactory);
+            var instance = new OrleansSiloInstanceManager(clusterId, storageConnectionString, loggerFactory);
             try
             {
                 await instance.storage.InitTableAsync()
@@ -187,11 +187,11 @@ namespace Orleans.AzureUtils
             return storage.ReadSingleTableEntryAsync(partitionKey, rowKey);
         }
 
-        internal async Task<int> DeleteTableEntries(string deploymentId)
+        internal async Task<int> DeleteTableEntries(string clusterId)
         {
-            if (deploymentId == null) throw new ArgumentNullException("deploymentId");
+            if (clusterId == null) throw new ArgumentNullException(nameof(clusterId));
 
-            var entries = await storage.ReadAllTableEntriesForPartitionAsync(deploymentId);
+            var entries = await storage.ReadAllTableEntriesForPartitionAsync(clusterId);
             var entriesList = new List<Tuple<SiloInstanceTableEntry, string>>(entries);
             if (entriesList.Count <= AzureTableDefaultPolicies.MAX_BULK_UPDATE_ROWS)
             {

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -21,12 +21,12 @@ namespace Orleans.Runtime.Membership
         private ILogger _logger;
         private readonly ConsulClient _consulClient;
         private readonly ConsulMembershipOptions membershipTableOptions;
-        private readonly string deploymentId;
+        private readonly string clusterId;
 
         public ConsulBasedMembershipTable(ILogger<ConsulBasedMembershipTable> logger,
             IOptions<ConsulMembershipOptions> membershipTableOptions, GlobalConfiguration globalConfiguration)
         {
-            this.deploymentId = globalConfiguration.ClusterId;
+            this.clusterId = globalConfiguration.ClusterId;
             this._logger = logger;
             this.membershipTableOptions = membershipTableOptions.Value;
             _consulClient =
@@ -57,15 +57,15 @@ namespace Orleans.Runtime.Membership
 
         public Task<MembershipTableData> ReadAll()
         {
-            return ReadAll(this._consulClient, this.deploymentId, this._logger);
+            return ReadAll(this._consulClient, this.clusterId, this._logger);
         }
 
-        public static async Task<MembershipTableData> ReadAll(ConsulClient consulClient, string deploymentId, ILogger logger)
+        public static async Task<MembershipTableData> ReadAll(ConsulClient consulClient, string clusterId, ILogger logger)
         {
-            var deploymentKVAddresses = await consulClient.KV.List(ConsulSiloRegistrationAssembler.ParseDeploymentKVPrefix(deploymentId));
+            var deploymentKVAddresses = await consulClient.KV.List(ConsulSiloRegistrationAssembler.ParseDeploymentKVPrefix(clusterId));
             if (deploymentKVAddresses.Response == null)
             {
-                logger.Debug("Could not find any silo registrations for deployment {0}.", deploymentId);
+                logger.Debug("Could not find any silo registrations for deployment {0}.", clusterId);
                 return new MembershipTableData(_tableVersion);
             }
 
@@ -75,7 +75,7 @@ namespace Orleans.Runtime.Membership
                 .Select(siloKV =>
                 {
                     var iAmAliveKV = deploymentKVAddresses.Response.Where(kv => kv.Key.Equals(ConsulSiloRegistrationAssembler.ParseSiloIAmAliveKey(siloKV.Key), StringComparison.OrdinalIgnoreCase)).SingleOrDefault();
-                    return ConsulSiloRegistrationAssembler.FromKVPairs(deploymentId, siloKV, iAmAliveKV);
+                    return ConsulSiloRegistrationAssembler.FromKVPairs(clusterId, siloKV, iAmAliveKV);
                 }).ToArray();
 
             return AssembleMembershipTableData(allSiloRegistrations);
@@ -86,7 +86,7 @@ namespace Orleans.Runtime.Membership
             try
             {
                 //Use "0" as the eTag then Consul KV CAS will treat the operation as an insert and return false if the KV already exiats.
-                var consulSiloRegistration = ConsulSiloRegistrationAssembler.FromMembershipEntry(this.deploymentId, entry, "0");
+                var consulSiloRegistration = ConsulSiloRegistrationAssembler.FromMembershipEntry(this.clusterId, entry, "0");
                 var insertKV = ConsulSiloRegistrationAssembler.ToKVPair(consulSiloRegistration);
 
                 var tryUpdate = await _consulClient.KV.CAS(insertKV);
@@ -110,7 +110,7 @@ namespace Orleans.Runtime.Membership
             //Update Silo Liveness
             try
             {
-                var siloRegistration = ConsulSiloRegistrationAssembler.FromMembershipEntry(this.deploymentId, entry, etag);
+                var siloRegistration = ConsulSiloRegistrationAssembler.FromMembershipEntry(this.clusterId, entry, etag);
                 var updateKV = ConsulSiloRegistrationAssembler.ToKVPair(siloRegistration);
 
                 //If the KV.CAS() call returns false then the update failed
@@ -133,25 +133,25 @@ namespace Orleans.Runtime.Membership
 
         public async Task UpdateIAmAlive(MembershipEntry entry)
         {
-            var iAmAliveKV = ConsulSiloRegistrationAssembler.ToIAmAliveKVPair(this.deploymentId, entry.SiloAddress, entry.IAmAliveTime);
+            var iAmAliveKV = ConsulSiloRegistrationAssembler.ToIAmAliveKVPair(this.clusterId, entry.SiloAddress, entry.IAmAliveTime);
             await _consulClient.KV.Put(iAmAliveKV);
         }
 
-        public async Task DeleteMembershipTableEntries(String deploymentId)
+        public async Task DeleteMembershipTableEntries(String clusterId)
         {
-            await _consulClient.KV.DeleteTree(ConsulSiloRegistrationAssembler.ParseDeploymentKVPrefix(this.deploymentId));
+            await _consulClient.KV.DeleteTree(ConsulSiloRegistrationAssembler.ParseDeploymentKVPrefix(this.clusterId));
         }
 
         private async Task<ConsulSiloRegistration> GetConsulSiloRegistration(SiloAddress siloAddress)
         {
-            var siloKey = ConsulSiloRegistrationAssembler.ParseDeploymentSiloKey(this.deploymentId, siloAddress);
+            var siloKey = ConsulSiloRegistrationAssembler.ParseDeploymentSiloKey(this.clusterId, siloAddress);
             var siloKVEntry = await _consulClient.KV.List(siloKey);
             if (siloKVEntry.Response == null) return null;
 
             var siloKV = siloKVEntry.Response.Single(KV => KV.Key.Equals(siloKey, StringComparison.OrdinalIgnoreCase));
             var iAmAliveKV = siloKVEntry.Response.SingleOrDefault(KV => KV.Key.Equals(ConsulSiloRegistrationAssembler.ParseSiloIAmAliveKey(siloKey), StringComparison.OrdinalIgnoreCase));
 
-            var siloRegistration = ConsulSiloRegistrationAssembler.FromKVPairs(this.deploymentId, siloKV, iAmAliveKV);
+            var siloRegistration = ConsulSiloRegistrationAssembler.FromKVPairs(this.clusterId, siloKV, iAmAliveKV);
 
             return siloRegistration;
         }

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -26,7 +26,7 @@ namespace Orleans.Runtime.Membership
         public ConsulBasedMembershipTable(ILogger<ConsulBasedMembershipTable> logger,
             IOptions<ConsulMembershipOptions> membershipTableOptions, GlobalConfiguration globalConfiguration)
         {
-            this.deploymentId = globalConfiguration.DeploymentId;
+            this.deploymentId = globalConfiguration.ClusterId;
             this._logger = logger;
             this.membershipTableOptions = membershipTableOptions.Value;
             _consulClient =

--- a/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
@@ -14,14 +14,14 @@ namespace Orleans.Runtime.Membership
     public class ConsulGatewayListProvider : IGatewayListProvider
     {
         private ConsulClient consulClient;
-        private string deploymentId;
+        private string clusterId;
         private ILogger logger;
         private readonly ConsulGatewayListProviderOptions options;
         private readonly TimeSpan maxStaleness;
         public ConsulGatewayListProvider(ILogger<ConsulGatewayListProvider> logger, ClientConfiguration clientConfig, IOptions<ConsulGatewayListProviderOptions> options)
         {
             this.logger = logger;
-            this.deploymentId = clientConfig.ClusterId;
+            this.clusterId = clientConfig.ClusterId;
             this.maxStaleness = clientConfig.GatewayListRefreshPeriod;
             this.options = options.Value;
         }
@@ -45,7 +45,7 @@ namespace Orleans.Runtime.Membership
 
         public async Task<IList<Uri>> GetGateways()
         {
-            var membershipTableData = await ConsulBasedMembershipTable.ReadAll(this.consulClient, this.deploymentId, this.logger);
+            var membershipTableData = await ConsulBasedMembershipTable.ReadAll(this.consulClient, this.clusterId, this.logger);
             if (membershipTableData == null) return new List<Uri>();
 
             return membershipTableData.Members.Select(e => e.Item1).

--- a/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
@@ -21,7 +21,7 @@ namespace Orleans.Runtime.Membership
         public ConsulGatewayListProvider(ILogger<ConsulGatewayListProvider> logger, ClientConfiguration clientConfig, IOptions<ConsulGatewayListProviderOptions> options)
         {
             this.logger = logger;
-            this.deploymentId = clientConfig.DeploymentId;
+            this.deploymentId = clientConfig.ClusterId;
             this.maxStaleness = clientConfig.GatewayListRefreshPeriod;
             this.options = options.Value;
         }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -50,7 +50,7 @@ namespace Orleans.Runtime.Membership
         /// <summary>
         /// the node name for this deployment. for eg. /ClusterId
         /// </summary>
-        private string deploymentPath;
+        private string clusterPath;
         /// <summary>
         /// The root connection string. for eg. "192.168.1.1,192.168.1.2"
         /// </summary>
@@ -79,22 +79,22 @@ namespace Orleans.Runtime.Membership
             {
                 try
                 {
-                    await zk.createAsync(deploymentPath, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-                    await zk.sync(deploymentPath);
+                    await zk.createAsync(this.clusterPath, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                    await zk.sync(this.clusterPath);
                     //if we got here we know that we've just created the deployment path with version=0
-                    this.logger.Info("Created new deployment path: " + deploymentPath);
+                    this.logger.Info("Created new deployment path: " + this.clusterPath);
                 }
                 catch (KeeperException.NodeExistsException)
                 {
-                    this.logger.Debug("Deployment path already exists: " + deploymentPath);
+                    this.logger.Debug("Deployment path already exists: " + this.clusterPath);
                 }
             });
         }
 
-        private void InitConfig(string dataConnectionString, string deploymentId)
+        private void InitConfig(string dataConnectionString, string clusterId)
         {
-            deploymentPath = "/" + deploymentId;
-            deploymentConnectionString = dataConnectionString + deploymentPath;
+            this.clusterPath = "/" + clusterId;
+            deploymentConnectionString = dataConnectionString + this.clusterPath;
             rootConnectionString = dataConnectionString;
         }
 
@@ -242,11 +242,11 @@ namespace Orleans.Runtime.Membership
         }
 
         /// <summary>
-        /// Deletes all table entries of the given deploymentId
+        /// Deletes all table entries of the given clusterId
         /// </summary>
-        public Task DeleteMembershipTableEntries(string deploymentId)
+        public Task DeleteMembershipTableEntries(string clusterId)
         {
-            string pathToDelete = "/" + deploymentId;
+            string pathToDelete = "/" + clusterId;
             return UsingZookeeper(rootConnectionString, async zk =>
             {
                 await ZKUtil.deleteRecursiveAsync(zk, pathToDelete);

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -44,11 +44,11 @@ namespace Orleans.Runtime.Membership
         private ZooKeeperWatcher watcher;
 
         /// <summary>
-        /// The deployment connection string. for eg. "192.168.1.1,192.168.1.2/DeploymentId"
+        /// The deployment connection string. for eg. "192.168.1.1,192.168.1.2/ClusterId"
         /// </summary>
         private string deploymentConnectionString;
         /// <summary>
-        /// the node name for this deployment. for eg. /DeploymentId
+        /// the node name for this deployment. for eg. /ClusterId
         /// </summary>
         private string deploymentPath;
         /// <summary>
@@ -61,20 +61,20 @@ namespace Orleans.Runtime.Membership
             this.logger = logger;
             var options = membershipTableOptions.Value;
             watcher = new ZooKeeperWatcher(logger);
-            InitConfig(options.ConnectionString, globalConfiguration.DeploymentId);
+            InitConfig(options.ConnectionString, globalConfiguration.ClusterId);
         }
 
         /// <summary>
         /// Initializes the ZooKeeper based membership table.
         /// </summary>
-        /// <param name="tryInitPath">if set to true, we'll try to create a node named "/DeploymentId"</param>
+        /// <param name="tryInitPath">if set to true, we'll try to create a node named "/ClusterId"</param>
         /// <returns></returns>
         public async Task InitializeMembershipTable(bool tryInitPath)
         {
             // even if I am not the one who created the path, 
             // try to insert an initial path if it is not already there,
             // so we always have the path, before this silo starts working.
-            // note that when a zookeeper connection adds /DeploymentId to the connection string, the nodes are relative
+            // note that when a zookeeper connection adds /ClusterId to the connection string, the nodes are relative
             await UsingZookeeper(rootConnectionString, async zk =>
             {
                 try

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
@@ -16,12 +16,12 @@ namespace Orleans.Runtime.Membership
     {
         private ZooKeeperWatcher watcher;
         /// <summary>
-        /// the node name for this deployment. for eg. /DeploymentId
+        /// the node name for this deployment. for eg. /ClusterId
         /// </summary>
         private string deploymentPath;
 
         /// <summary>
-        /// The deployment connection string. for eg. "192.168.1.1,192.168.1.2/DeploymentId"
+        /// The deployment connection string. for eg. "192.168.1.1,192.168.1.2/ClusterId"
         /// </summary>
         private string deploymentConnectionString;
         private TimeSpan maxStaleness;

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
@@ -30,7 +30,7 @@ namespace Orleans.Runtime.Membership
         {
             watcher = new ZooKeeperWatcher(logger);
 
-            deploymentPath = "/" + clientConfiguration.DeploymentId;
+            deploymentPath = "/" + clientConfiguration.ClusterId;
             deploymentConnectionString = options.Value.ConnectionString + deploymentPath;
             maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
         }

--- a/src/Orleans.Core/Configuration/ClientConfiguration.cs
+++ b/src/Orleans.Core/Configuration/ClientConfiguration.cs
@@ -64,13 +64,24 @@ namespace Orleans.Runtime.Configuration
         public GatewayProviderType GatewayProvider { get; set; }
 
         /// <summary>
-        /// Specifies a unique identifier of this deployment.
+        /// Specifies a unique identifier for this cluster.
         /// If the silos are deployed on Azure (run as workers roles), deployment id is set automatically by Azure runtime, 
         /// accessible to the role via RoleEnvironment.DeploymentId static variable and is passed to the silo automatically by the role via config. 
         /// So if the silos are run as Azure roles this variable should not be specified in the OrleansConfiguration.xml (it will be overwritten if specified).
         /// If the silos are deployed on the cluster and not as Azure roles, this variable should be set by a deployment script in the OrleansConfiguration.xml file.
         /// </summary>
-        public string DeploymentId { get; set; }
+        public string ClusterId { get; set; }
+
+        /// <summary>
+        /// Deployment Id.
+        /// </summary>
+        [Obsolete("DeploymentId is the same as ClusterId.")]
+        public string DeploymentId
+        {
+            get => this.ClusterId;
+            set => this.ClusterId = value;
+        }
+
         /// <summary>
         /// Specifies the connection string for the gateway provider.
         /// If the silos are deployed on Azure (run as workers roles), DataConnectionString may be specified via RoleEnvironment.GetConfigurationSettingValue("DataConnectionString");
@@ -136,7 +147,7 @@ namespace Orleans.Runtime.Configuration
         { 
             get { 
                 return GatewayProvider == GatewayProviderType.AzureTable 
-                       && !String.IsNullOrWhiteSpace(DeploymentId) 
+                       && !String.IsNullOrWhiteSpace(this.ClusterId) 
                        && !String.IsNullOrWhiteSpace(DataConnectionString); 
             } 
         }
@@ -148,7 +159,7 @@ namespace Orleans.Runtime.Configuration
             get
             {
                 return GatewayProvider == GatewayProviderType.SqlServer
-                && !String.IsNullOrWhiteSpace(DeploymentId)
+                && !String.IsNullOrWhiteSpace(this.ClusterId)
                 && !String.IsNullOrWhiteSpace(DataConnectionString);
             }
         }
@@ -170,7 +181,7 @@ namespace Orleans.Runtime.Configuration
             NetInterface = null;
             Port = 0;
             DNSHostName = Dns.GetHostName();
-            DeploymentId = "";
+            this.ClusterId = "";
             DataConnectionString = "";
             // Assume the ado invariant is for sql server storage if not explicitly specified
             AdoInvariant = Constants.INVARIANT_NAME_SQL_SERVER;
@@ -234,7 +245,7 @@ namespace Orleans.Runtime.Configuration
                             }
                             if (child.HasAttribute("DeploymentId"))
                             {
-                                DeploymentId = child.GetAttribute("DeploymentId");
+                                this.ClusterId = child.GetAttribute("DeploymentId");
                             }
                             if (child.HasAttribute(Constants.DATA_CONNECTION_STRING_NAME))
                             {
@@ -454,10 +465,10 @@ namespace Orleans.Runtime.Configuration
                 sb.Append("   Preferred Gateway Address: ").AppendLine(Gateways[PreferedGatewayIndex].ToString());
             }
             sb.Append("   GatewayListRefreshPeriod: ").Append(GatewayListRefreshPeriod).AppendLine();
-            if (!String.IsNullOrEmpty(DeploymentId) || !String.IsNullOrEmpty(DataConnectionString))
+            if (!String.IsNullOrEmpty(this.ClusterId) || !String.IsNullOrEmpty(DataConnectionString))
             {
                 sb.Append("   Azure:").AppendLine();
-                sb.Append("      DeploymentId: ").Append(DeploymentId).AppendLine();
+                sb.Append("      ClusterId: ").Append(this.ClusterId).AppendLine();
                 string dataConnectionInfo = ConfigUtilities.RedactConnectionStringInfo(DataConnectionString); // Don't print Azure account keys in log files
                 sb.Append("      DataConnectionString: ").Append(dataConnectionInfo).AppendLine();
             }
@@ -522,7 +533,7 @@ namespace Orleans.Runtime.Configuration
                     break;
                 case GatewayProviderType.SqlServer:
                     if (!UseSqlSystemStore)
-                        throw new ArgumentException("Config specifies SqlServer based GatewayProviderType, but DeploymentId or DataConnectionString are not specified or not complete.", "GatewayProvider");
+                        throw new ArgumentException("Config specifies SqlServer based GatewayProviderType, but ClusterId or DataConnectionString are not specified or not complete.", "GatewayProvider");
                     break;
                 case GatewayProviderType.ZooKeeper:
                     break;

--- a/src/Orleans.Core/Configuration/ClientConfiguration.cs
+++ b/src/Orleans.Core/Configuration/ClientConfiguration.cs
@@ -73,7 +73,7 @@ namespace Orleans.Runtime.Configuration
         public string ClusterId { get; set; }
 
         /// <summary>
-        /// Deployment Id.
+        /// Deployment Id. This is the same as ClusterId and has been deprecated in favor of it.
         /// </summary>
         [Obsolete("DeploymentId is the same as ClusterId.")]
         public string DeploymentId

--- a/src/Orleans.Core/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core/Configuration/GlobalConfiguration.cs
@@ -222,7 +222,7 @@ namespace Orleans.Runtime.Configuration
         public string ClusterId { get; set; }
 
         /// <summary>
-        /// Deployment Id.
+        /// Deployment Id. This is the same as ClusterId and has been deprecated in favor of it.
         /// </summary>
         [Obsolete("DeploymentId is the same as ClusterId.")]
         public string DeploymentId

--- a/src/Orleans.Core/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core/Configuration/GlobalConfiguration.cs
@@ -827,9 +827,9 @@ namespace Orleans.Runtime.Configuration
                             ServiceId = ConfigUtilities.ParseGuid(child.GetAttribute("ServiceId"),
                                 "Invalid Guid value for the ServiceId attribute on the Azure element");
                         }
-                        if (child.HasAttribute("DeploymentId"))
+                        if (child.HasAttribute("ClusterId"))
                         {
-                            this.ClusterId = child.GetAttribute("DeploymentId");
+                            this.ClusterId = child.GetAttribute("ClusterId");
                         }
                         if (child.HasAttribute(Constants.DATA_CONNECTION_STRING_NAME))
                         {

--- a/src/Orleans.Core/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core/Configuration/GlobalConfiguration.cs
@@ -215,41 +215,28 @@ namespace Orleans.Runtime.Configuration
         public Guid ServiceId { get; set; }
 
         /// <summary>
+        /// Cluster identity. Silos with the same cluster identity will join together. 
+        /// When deploying different versions of the application simultaneously, be sure to change the ID if they should not join the same logical cluster.
+        /// In a multi-cluster network, the cluster ID must be unique for each cluster.
+        /// </summary>
+        public string ClusterId { get; set; }
+
+        /// <summary>
         /// Deployment Id.
         /// </summary>
-        public string DeploymentId { get; set; }
+        [Obsolete("DeploymentId is the same as ClusterId.")]
+        public string DeploymentId
+        {
+            get => this.ClusterId;
+            set => this.ClusterId = value;
+        }
 
         #region MultiClusterNetwork
-
-        private string clusterId;
 
         /// <summary>
         /// Whether this cluster is configured to be part of a multicluster network
         /// </summary>
-        public bool HasMultiClusterNetwork
-        {
-            get
-            {
-                return !(string.IsNullOrEmpty(this.clusterId));
-            }
-        }
-
-        /// <summary>
-        /// Cluster id (one per deployment, unique across all the deployments/clusters)
-        /// </summary>
-        public string ClusterId
-        {
-            get
-            {
-                var configuredId = this.HasMultiClusterNetwork ? this.clusterId : this.DeploymentId;
-                return string.IsNullOrEmpty(configuredId) ? DefaultClusterId : configuredId;
-            }
-
-            set
-            {
-                this.clusterId = value;
-            }
-        }
+        public bool HasMultiClusterNetwork { get; set; }
 
         /// <summary>
         ///A list of cluster ids, to be used if no multicluster configuration is found in gossip channels.
@@ -503,7 +490,7 @@ namespace Orleans.Runtime.Configuration
             }
         }
 
-        internal bool RunsInAzure { get { return UseAzureSystemStore && !String.IsNullOrWhiteSpace(DeploymentId); } }
+        internal bool RunsInAzure { get { return UseAzureSystemStore && !String.IsNullOrWhiteSpace(this.ClusterId); } }
 
         private static readonly TimeSpan DEFAULT_LIVENESS_PROBE_TIMEOUT = TimeSpan.FromSeconds(10);
         private static readonly TimeSpan DEFAULT_LIVENESS_TABLE_REFRESH_TIMEOUT = TimeSpan.FromSeconds(60);
@@ -571,7 +558,7 @@ namespace Orleans.Runtime.Configuration
             GlobalSingleInstanceNumberRetries = DEFAULT_GLOBAL_SINGLE_INSTANCE_NUMBER_RETRIES;
             ExpectedClusterSizeConfigValue = new ConfigValue<int>(DEFAULT_LIVENESS_EXPECTED_CLUSTER_SIZE, true);
             ServiceId = Guid.Empty;
-            DeploymentId = "";
+            this.ClusterId = "";
             DataConnectionString = "";
 
             // Assume the ado invariant is for sql server storage if not explicitly specified
@@ -612,7 +599,7 @@ namespace Orleans.Runtime.Configuration
             var sb = new StringBuilder();
             sb.AppendFormat("   System Ids:").AppendLine();
             sb.AppendFormat("      ServiceId: {0}", ServiceId).AppendLine();
-            sb.AppendFormat("      DeploymentId: {0}", DeploymentId).AppendLine();
+            sb.AppendFormat("      ClusterId: {0}", this.ClusterId).AppendLine();
             sb.Append("   Subnet: ").Append(Subnet == null ? "" : Subnet.ToStrings(x => x.ToString(CultureInfo.InvariantCulture), ".")).AppendLine();
             sb.Append("   Seed nodes: ");
             bool first = true;
@@ -842,7 +829,7 @@ namespace Orleans.Runtime.Configuration
                         }
                         if (child.HasAttribute("DeploymentId"))
                         {
-                            DeploymentId = child.GetAttribute("DeploymentId");
+                            this.ClusterId = child.GetAttribute("DeploymentId");
                         }
                         if (child.HasAttribute(Constants.DATA_CONNECTION_STRING_NAME))
                         {
@@ -890,6 +877,7 @@ namespace Orleans.Runtime.Configuration
                         }
                         break;
                     case "MultiClusterNetwork":
+                        HasMultiClusterNetwork = true;
                         ClusterId = child.GetAttribute("ClusterId");
 
                         // we always trim cluster ids to avoid surprises when parsing comma-separated lists

--- a/src/Orleans.Core/Configuration/OrleansConfiguration.xsd
+++ b/src/Orleans.Core/Configuration/OrleansConfiguration.xsd
@@ -347,7 +347,7 @@
     <xs:attribute name="DeploymentId" type="xs:string" use="optional">
       <xs:annotation>
         <xs:documentation>
-          Specifies a unique identifier of this deployment.
+          Specifies a unique identifier of this cluster.
           If the silos are deployed on Azure (run as workers roles), deployment id is set automatically by Azure runtime,
           accessible to the role via RoleEnvironment.ClusterId static variable and is passed to the silo automatically by the role via config.
           So if the silos are run as Azure roles this variable should not be specified in the OrleansConfiguration.xml (it will be overwritten if specified).

--- a/src/Orleans.Core/Configuration/OrleansConfiguration.xsd
+++ b/src/Orleans.Core/Configuration/OrleansConfiguration.xsd
@@ -349,7 +349,7 @@
         <xs:documentation>
           Specifies a unique identifier of this deployment.
           If the silos are deployed on Azure (run as workers roles), deployment id is set automatically by Azure runtime,
-          accessible to the role via RoleEnvironment.DeploymentId static variable and is passed to the silo automatically by the role via config.
+          accessible to the role via RoleEnvironment.ClusterId static variable and is passed to the silo automatically by the role via config.
           So if the silos are run as Azure roles this variable should not be specified in the OrleansConfiguration.xml (it will be overwritten if specified).
           If the silos are deployed on the cluster and not as Azure roles, this variable should be set by a deployment script in the OrleansConmfiguration.xml file.
         </xs:documentation>

--- a/src/Orleans.Core/Statistics/ClientStatisticsManager.cs
+++ b/src/Orleans.Core/Statistics/ClientStatisticsManager.cs
@@ -54,7 +54,7 @@ namespace Orleans.Runtime
                 if (configurableMetricsDataPublisher != null)
                 {
                     configurableMetricsDataPublisher.AddConfiguration(
-                        config.DeploymentId, config.DNSHostName, clientId.ToString(), transport.MyAddress.Endpoint.Address);
+                        config.ClusterId, config.DNSHostName, clientId.ToString(), transport.MyAddress.Endpoint.Address);
                 }
                 tableStatistics = new ClientTableStatistics(transport, metricsDataPublisher, runtimeStats, this.loggerFactory)
                 {
@@ -83,7 +83,7 @@ namespace Orleans.Runtime
                 else if (config.UseAzureSystemStore)
                 {
                     var statsDataPublisher = AssemblyLoader.LoadAndCreateInstance<IStatisticsPublisher>(Constants.ORLEANS_AZURE_UTILS_DLL, logger, this.serviceProvider);
-                    await statsDataPublisher.Init(false, config.DataConnectionString, config.DeploymentId,
+                    await statsDataPublisher.Init(false, config.DataConnectionString, config.ClusterId,
                         transport.MyAddress.Endpoint.ToString(), clientId.ToParsableString(), config.DNSHostName);
                     logStatistics.StatsTablePublisher = statsDataPublisher;
                 }

--- a/src/Orleans.Core/Statistics/IPerformanceMetrics.cs
+++ b/src/Orleans.Core/Statistics/IPerformanceMetrics.cs
@@ -107,13 +107,13 @@ namespace Orleans.Runtime
 
     public interface ISiloMetricsDataPublisher
     {
-        Task Init(string deploymentId, string storageConnectionString, SiloAddress siloAddress, string siloName, IPEndPoint gateway, string hostName);
+        Task Init(string clusterId, string storageConnectionString, SiloAddress siloAddress, string siloName, IPEndPoint gateway, string hostName);
         Task ReportMetrics(ISiloPerformanceMetrics metricsData);
     }
 
     public interface IConfigurableSiloMetricsDataPublisher : ISiloMetricsDataPublisher
     {
-        void AddConfiguration(string deploymentId, bool isSilo, string siloName, SiloAddress address, System.Net.IPEndPoint gateway, string hostName);
+        void AddConfiguration(string clusterId, bool isSilo, string siloName, SiloAddress address, System.Net.IPEndPoint gateway, string hostName);
     }
 
     public interface IClientMetricsDataPublisher
@@ -124,18 +124,18 @@ namespace Orleans.Runtime
 
     public interface IConfigurableClientMetricsDataPublisher : IClientMetricsDataPublisher
     {
-        void AddConfiguration(string deploymentId, string hostName, string clientId, System.Net.IPAddress address);
+        void AddConfiguration(string clusterId, string hostName, string clientId, System.Net.IPAddress address);
     }
 
     public interface IStatisticsPublisher
     {
         Task ReportStats(List<ICounter> statsCounters);
-        Task Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName, string hostName);
+        Task Init(bool isSilo, string storageConnectionString, string clusterId, string address, string siloName, string hostName);
     }
 
     public interface IConfigurableStatisticsPublisher : IStatisticsPublisher
     {
-        void AddConfiguration(string deploymentId, bool isSilo, string siloName, SiloAddress address, System.Net.IPEndPoint gateway, string hostName);
+        void AddConfiguration(string clusterId, bool isSilo, string siloName, SiloAddress address, System.Net.IPEndPoint gateway, string hostName);
     }
 
     /// <summary>

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 
 namespace Orleans
 {
@@ -21,9 +20,9 @@ namespace Orleans
         Task InitializeMembershipTable(bool tryInitTableVersion);
 
         /// <summary>
-        /// Deletes all table entries of the given deploymentId
+        /// Deletes all table entries of the given clusterId
         /// </summary>
-        Task DeleteMembershipTableEntries(string deploymentId);
+        Task DeleteMembershipTableEntries(string clusterId);
 
         /// <summary>
         /// Atomically reads the Membership Table information about a given silo.

--- a/src/Orleans.Runtime/Counters/SiloStatisticsManager.cs
+++ b/src/Orleans.Runtime/Counters/SiloStatisticsManager.cs
@@ -57,7 +57,7 @@ namespace Orleans.Runtime.Counters
                 {
                     var gateway = nodeConfig.IsGatewayNode ? nodeConfig.ProxyGatewayEndpoint : null;
                     configurableMetricsDataPublisher.AddConfiguration(
-                        silo.GlobalConfig.DeploymentId, true, silo.Name, silo.SiloAddress, gateway, nodeConfig.DNSHostName);
+                        silo.GlobalConfig.ClusterId, true, silo.Name, silo.SiloAddress, gateway, nodeConfig.DNSHostName);
                 }
                 MetricsTable.MetricsDataPublisher = metricsDataPublisher;
             }
@@ -66,7 +66,7 @@ namespace Orleans.Runtime.Counters
                 // Hook up to publish silo metrics to Azure storage table
                 var gateway = nodeConfig.IsGatewayNode ? nodeConfig.ProxyGatewayEndpoint : null;
                 var metricsDataPublisher = AssemblyLoader.LoadAndCreateInstance<ISiloMetricsDataPublisher>(Constants.ORLEANS_AZURE_UTILS_DLL, logger, silo.Services);
-                await metricsDataPublisher.Init(silo.GlobalConfig.DeploymentId, silo.GlobalConfig.DataConnectionString, silo.SiloAddress, silo.Name, gateway, nodeConfig.DNSHostName);
+                await metricsDataPublisher.Init(silo.GlobalConfig.ClusterId, silo.GlobalConfig.DataConnectionString, silo.SiloAddress, silo.Name, gateway, nodeConfig.DNSHostName);
                 MetricsTable.MetricsDataPublisher = metricsDataPublisher;
             }
             // else no metrics
@@ -96,14 +96,14 @@ namespace Orleans.Runtime.Counters
                 {
                     var gateway = nodeConfig.IsGatewayNode ? nodeConfig.ProxyGatewayEndpoint : null;
                     configurableStatsDataPublisher.AddConfiguration(
-                        silo.GlobalConfig.DeploymentId, true, silo.Name, silo.SiloAddress, gateway, nodeConfig.DNSHostName);
+                        silo.GlobalConfig.ClusterId, true, silo.Name, silo.SiloAddress, gateway, nodeConfig.DNSHostName);
                 }
                 logStatistics.StatsTablePublisher = statsDataPublisher;
             }
             else if (useAzureTable)
             {
                 var statsDataPublisher = AssemblyLoader.LoadAndCreateInstance<IStatisticsPublisher>(Constants.ORLEANS_AZURE_UTILS_DLL, logger, silo.Services);
-                await statsDataPublisher.Init(true, silo.GlobalConfig.DataConnectionString, silo.GlobalConfig.DeploymentId, silo.SiloAddress.ToLongString(), silo.Name, nodeConfig.DNSHostName);
+                await statsDataPublisher.Init(true, silo.GlobalConfig.DataConnectionString, silo.GlobalConfig.ClusterId, silo.SiloAddress.ToLongString(), silo.Name, nodeConfig.DNSHostName);
                 logStatistics.StatsTablePublisher = statsDataPublisher;
             }
             // else no stats
@@ -115,7 +115,7 @@ namespace Orleans.Runtime.Counters
             out bool useAzureTable)
         {
             useAzureTable = silo.GlobalConfig.LivenessType == GlobalConfiguration.LivenessProviderType.AzureTable
-                                 && !string.IsNullOrEmpty(silo.GlobalConfig.DeploymentId)
+                                 && !string.IsNullOrEmpty(silo.GlobalConfig.ClusterId)
                                  && !string.IsNullOrEmpty(silo.GlobalConfig.DataConnectionString);
 
             return !string.IsNullOrEmpty(nodeConfig.StatisticsProviderName);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -848,8 +848,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public Task<AddressesAndTag> LookupInCluster(GrainId grainId, string clusterId)
         {
-            if (clusterId == null)
-                throw new ArgumentNullException("clusterId");
+            if (clusterId == null) throw new ArgumentNullException(nameof(clusterId));
 
             if (clusterId == ClusterId)
             {

--- a/src/Orleans.Runtime/MembershipService/GrainBasedMembershipTable.cs
+++ b/src/Orleans.Runtime/MembershipService/GrainBasedMembershipTable.cs
@@ -87,7 +87,7 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        public Task DeleteMembershipTableEntries(string deploymentId) => this.grain.DeleteMembershipTableEntries(deploymentId);
+        public Task DeleteMembershipTableEntries(string clusterId) => this.grain.DeleteMembershipTableEntries(clusterId);
 
         public Task<MembershipTableData> ReadRow(SiloAddress key) => this.grain.ReadRow(key);
 
@@ -127,9 +127,9 @@ namespace Orleans.Runtime.MembershipService
             return Task.CompletedTask;
         }
 
-        public Task DeleteMembershipTableEntries(string deploymentId)
+        public Task DeleteMembershipTableEntries(string clusterId)
         {
-            logger.Info("DeleteMembershipTableEntries {0}", deploymentId);
+            logger.Info("DeleteMembershipTableEntries {0}", clusterId);
             table = null;
             return Task.CompletedTask;
         }

--- a/src/Orleans.Runtime/Silo/SiloHost.cs
+++ b/src/Orleans.Runtime/Silo/SiloHost.cs
@@ -44,7 +44,7 @@ namespace Orleans.Runtime.Host
         /// </remarks>
         public bool ConfigLoaded { get; private set; }
 
-        /// <summary> Deployment Id (if any) for the cluster this silo is running in. </summary>
+        /// <summary> Cluster Id (if any) for the cluster this silo is running in. </summary>
         public string DeploymentId { get; set; }
 
         /// <summary> Whether this silo started successfully and is currently running. </summary>
@@ -329,14 +329,14 @@ namespace Orleans.Runtime.Host
         /// as well as the connection string to use the silo system data, 
         /// such as the cluster membership table..
         /// </summary>
-        /// <param name="deploymentId">ClusterId this silo is part of.</param>
+        /// <param name="clusterId">ClusterId this silo is part of.</param>
         /// <param name="connectionString">Azure connection string to use the silo system data.</param>
-        public void SetDeploymentId(string deploymentId, string connectionString)
+        public void SetDeploymentId(string clusterId, string connectionString)
         {
             logger.Info(ErrorCode.SiloSetDeploymentId, "Setting Deployment Id to {0} and data connection string to {1}",
-                deploymentId, ConfigUtilities.RedactConnectionStringInfo(connectionString));
+                clusterId, ConfigUtilities.RedactConnectionStringInfo(connectionString));
 
-            Config.Globals.ClusterId = deploymentId;
+            Config.Globals.ClusterId = clusterId;
             Config.Globals.DataConnectionString = connectionString;
         }
 

--- a/src/Orleans.Runtime/Silo/SiloHost.cs
+++ b/src/Orleans.Runtime/Silo/SiloHost.cs
@@ -325,18 +325,18 @@ namespace Orleans.Runtime.Host
         }
 
         /// <summary>
-        /// Set the DeploymentId for this silo, 
+        /// Set the ClusterId for this silo, 
         /// as well as the connection string to use the silo system data, 
         /// such as the cluster membership table..
         /// </summary>
-        /// <param name="deploymentId">DeploymentId this silo is part of.</param>
+        /// <param name="deploymentId">ClusterId this silo is part of.</param>
         /// <param name="connectionString">Azure connection string to use the silo system data.</param>
         public void SetDeploymentId(string deploymentId, string connectionString)
         {
             logger.Info(ErrorCode.SiloSetDeploymentId, "Setting Deployment Id to {0} and data connection string to {1}",
                 deploymentId, ConfigUtilities.RedactConnectionStringInfo(connectionString));
 
-            Config.Globals.DeploymentId = deploymentId;
+            Config.Globals.ClusterId = deploymentId;
             Config.Globals.DataConnectionString = connectionString;
         }
 
@@ -509,7 +509,7 @@ namespace Orleans.Runtime.Host
             Config = config;
 
             if (!String.IsNullOrEmpty(DeploymentId))
-                Config.Globals.DeploymentId = DeploymentId;
+                Config.Globals.ClusterId = DeploymentId;
 
             if (string.IsNullOrWhiteSpace(Name))
                 throw new ArgumentException("SiloName not defined - cannot initialize config");

--- a/src/Orleans.Runtime/Versions/GrainVersionStore.cs
+++ b/src/Orleans.Runtime/Versions/GrainVersionStore.cs
@@ -23,7 +23,7 @@ namespace Orleans.Runtime.Versions
         public GrainVersionStore(IInternalGrainFactory grainFactory, GlobalConfiguration configuration)
         {
             this.grainFactory = grainFactory;
-            this.deploymentId = configuration.DeploymentId;
+            this.deploymentId = configuration.ClusterId;
             this.IsEnabled = false;
         }
 

--- a/src/Orleans.Runtime/Versions/GrainVersionStore.cs
+++ b/src/Orleans.Runtime/Versions/GrainVersionStore.cs
@@ -15,15 +15,15 @@ namespace Orleans.Runtime.Versions
     internal class GrainVersionStore : IVersionStore
     {
         private readonly IInternalGrainFactory grainFactory;
-        private readonly string deploymentId;
-        private IVersionStoreGrain StoreGrain => this.grainFactory.GetGrain<IVersionStoreGrain>(this.deploymentId);
+        private readonly string clusterId;
+        private IVersionStoreGrain StoreGrain => this.grainFactory.GetGrain<IVersionStoreGrain>(this.clusterId);
 
         public bool IsEnabled { get; private set; }
 
         public GrainVersionStore(IInternalGrainFactory grainFactory, GlobalConfiguration configuration)
         {
             this.grainFactory = grainFactory;
-            this.deploymentId = configuration.ClusterId;
+            this.clusterId = configuration.ClusterId;
             this.IsEnabled = false;
         }
 

--- a/src/Orleans.TestingHost/DefaultSiloBuilderFactory.cs
+++ b/src/Orleans.TestingHost/DefaultSiloBuilderFactory.cs
@@ -20,7 +20,7 @@ namespace Orleans.TestingHost
                 .AddApplicationPartsFromAppDomain()
                 .UseConfiguration(clusterConfiguration)
                 .ConfigureLogging(loggingBuilder => TestingUtils.ConfigureDefaultLoggingBuilder(loggingBuilder,
-                    TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
         }
     }
 }

--- a/src/Orleans.TestingHost/Extensions/TestConfigurationExtensions.cs
+++ b/src/Orleans.TestingHost/Extensions/TestConfigurationExtensions.cs
@@ -41,7 +41,7 @@ namespace Orleans.TestingHost.Extensions
                 throw new ArgumentNullException(nameof(clientConfiguration));
             }
 
-            AdjustProvidersDeploymentId(clientConfiguration.ProviderConfigurations, "DeploymentId", clientConfiguration.DeploymentId);
+            AdjustProvidersDeploymentId(clientConfiguration.ProviderConfigurations, "DeploymentId", clientConfiguration.ClusterId);
             if (string.IsNullOrEmpty(clientConfiguration.DataConnectionString))
             {
                 if (dataConnectionStringFallback != null)

--- a/src/Orleans.TestingHost/Extensions/TestConfigurationExtensions.cs
+++ b/src/Orleans.TestingHost/Extensions/TestConfigurationExtensions.cs
@@ -20,7 +20,7 @@ namespace Orleans.TestingHost.Extensions
             {
                 throw new ArgumentNullException(nameof(clusterConfig));
             }
-            AdjustProvidersDeploymentId(clusterConfig.Globals.ProviderConfigurations, "DeploymentId", clusterConfig.Globals.DeploymentId);
+            AdjustProvidersDeploymentId(clusterConfig.Globals.ProviderConfigurations, "DeploymentId", clusterConfig.Globals.ClusterId);
             if (string.IsNullOrEmpty(clusterConfig.Globals.DataConnectionString))
             {
                 if (dataConnectionStringFallback != null)

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -56,7 +56,7 @@ namespace Orleans.TestingHost
         /// <summary>
         /// ClusterId of the cluster
         /// </summary>
-        public string DeploymentId => this.ClusterConfiguration.Globals.ClusterId;
+        public string ClusterId => this.ClusterConfiguration.Globals.ClusterId;
 
         /// <summary>
         /// The internal client interface.

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -54,9 +54,9 @@ namespace Orleans.TestingHost
         private readonly StringBuilder log = new StringBuilder();
 
         /// <summary>
-        /// DeploymentId of the cluster
+        /// ClusterId of the cluster
         /// </summary>
-        public string DeploymentId => this.ClusterConfiguration.Globals.DeploymentId;
+        public string DeploymentId => this.ClusterConfiguration.Globals.ClusterId;
 
         /// <summary>
         /// The internal client interface.

--- a/src/Orleans.TestingHost/TestClusterOptions.cs
+++ b/src/Orleans.TestingHost/TestClusterOptions.cs
@@ -154,7 +154,7 @@ namespace Orleans.TestingHost
                 .AddApplicationPartsFromAppDomain()
                 .AddApplicationPartsFromBasePath()
                 .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder,
-                    TestingUtils.CreateTraceFileName(config.ClientName, config.DeploymentId)));
+                    TestingUtils.CreateTraceFileName(config.ClientName, config.ClusterId)));
 
         /// <summary>
         /// Factory delegate to create a client builder which will be used to build the <see cref="TestCluster"/> client. 
@@ -260,7 +260,7 @@ namespace Orleans.TestingHost
 
             config.DataConnectionString = clusterConfig.Globals.DataConnectionString;
             config.AdoInvariant = clusterConfig.Globals.AdoInvariant;
-            config.DeploymentId = clusterConfig.Globals.ClusterId;
+            config.ClusterId = clusterConfig.Globals.ClusterId;
             config.PropagateActivityId = clusterConfig.Defaults.PropagateActivityId;
             // If a debugger is attached, override the timeout setting
             config.ResponseTimeout = Debugger.IsAttached

--- a/src/Orleans.TestingHost/TestClusterOptions.cs
+++ b/src/Orleans.TestingHost/TestClusterOptions.cs
@@ -170,7 +170,7 @@ namespace Orleans.TestingHost
         public static ClusterConfiguration BuildClusterConfiguration(int baseSiloPort, int baseGatewayPort, int silosCount, FallbackOptions extendedOptions)
         {
             var config = ClusterConfiguration.LocalhostPrimarySilo(baseSiloPort, baseGatewayPort);
-            config.Globals.DeploymentId = CreateDeploymentId(baseSiloPort);
+            config.Globals.ClusterId = CreateDeploymentId(baseSiloPort);
 
             AddNodeConfiguration(config, Silo.SiloType.Primary, 0, baseSiloPort, baseGatewayPort);
             for (short instanceNumber = 1; instanceNumber < silosCount; instanceNumber++)
@@ -260,7 +260,7 @@ namespace Orleans.TestingHost
 
             config.DataConnectionString = clusterConfig.Globals.DataConnectionString;
             config.AdoInvariant = clusterConfig.Globals.AdoInvariant;
-            config.DeploymentId = clusterConfig.Globals.DeploymentId;
+            config.DeploymentId = clusterConfig.Globals.ClusterId;
             config.PropagateActivityId = clusterConfig.Defaults.PropagateActivityId;
             // If a debugger is attached, override the timeout setting
             config.ResponseTimeout = Debugger.IsAttached

--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -30,9 +30,9 @@ namespace Orleans.TestingHost.Utils
         /// Create trace file name for a specific node or client in a specific deployment
         /// </summary>
         /// <param name="nodeName"></param>
-        /// <param name="deploymentId"></param>
+        /// <param name="clusterId"></param>
         /// <returns></returns>
-        public static string CreateTraceFileName(string nodeName, string deploymentId)
+        public static string CreateTraceFileName(string nodeName, string clusterId)
         {
             const string traceFileFolder = "logs";
 
@@ -41,7 +41,7 @@ namespace Orleans.TestingHost.Utils
                 Directory.CreateDirectory(traceFileFolder);
             }
 
-            var traceFileName = $"{traceFileFolder}\\{deploymentId}_{nodeName}.log";
+            var traceFileName = $"{traceFileFolder}\\{clusterId}_{nodeName}.log";
 
             return traceFileName;
         }

--- a/src/OrleansAWSUtils/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/OrleansAWSUtils/Membership/DynamoDBGatewayListProvider.cs
@@ -28,7 +28,7 @@ namespace Orleans.Runtime.Membership
         {
             this.loggerFactory = loggerFactory;
             this.options = options.Value;
-            this.deploymentId = clientConfiguration.DeploymentId;
+            this.deploymentId = clientConfiguration.ClusterId;
             this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
         }
 

--- a/src/OrleansAWSUtils/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/OrleansAWSUtils/Membership/DynamoDBGatewayListProvider.cs
@@ -19,7 +19,7 @@ namespace Orleans.Runtime.Membership
         private const string TABLE_NAME_DEFAULT_VALUE = "OrleansSiloInstances";
 
         private DynamoDBStorage storage;
-        private string deploymentId;
+        private string clusterId;
         private readonly string INSTANCE_STATUS_ACTIVE = ((int)SiloStatus.Active).ToString();
         private readonly ILoggerFactory loggerFactory;
         private readonly DynamoDBGatewayListProviderOptions options;
@@ -28,7 +28,7 @@ namespace Orleans.Runtime.Membership
         {
             this.loggerFactory = loggerFactory;
             this.options = options.Value;
-            this.deploymentId = clientConfiguration.ClusterId;
+            this.clusterId = clientConfiguration.ClusterId;
             this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
         }
 
@@ -54,7 +54,7 @@ namespace Orleans.Runtime.Membership
         {
             var expressionValues = new Dictionary<string, AttributeValue>
             {
-                { $":{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}", new AttributeValue(deploymentId) },
+                { $":{SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME}", new AttributeValue(this.clusterId) },
                 { $":{SiloInstanceRecord.STATUS_PROPERTY_NAME}", new AttributeValue { N = INSTANCE_STATUS_ACTIVE } },
                 { $":{SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME}", new AttributeValue { N = "0"} }
             };

--- a/src/OrleansAWSUtils/Membership/DynamoDBMembershipTable.cs
+++ b/src/OrleansAWSUtils/Membership/DynamoDBMembershipTable.cs
@@ -32,7 +32,7 @@ namespace Orleans.Runtime.MembershipService
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<DynamoDBMembershipTable>();
             this.options = options.Value;
-            this.deploymentId = globalConfiguration.DeploymentId;
+            this.deploymentId = globalConfiguration.ClusterId;
         }
 
         public Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/OrleansAWSUtils/Reminders/DynamoDBReminderTable.cs
+++ b/src/OrleansAWSUtils/Reminders/DynamoDBReminderTable.cs
@@ -56,7 +56,7 @@ namespace OrleansAWSUtils.Reminders
         /// <returns></returns>
         public Task Init(GlobalConfiguration config)
         {
-            deploymentId = config.DeploymentId;
+            deploymentId = config.ClusterId;
             serviceId = config.ServiceId;
 
             storage = new DynamoDBStorage(config.DataConnectionStringForReminders, loggerFactory);

--- a/src/OrleansAWSUtils/Reminders/DynamoDBReminderTable.cs
+++ b/src/OrleansAWSUtils/Reminders/DynamoDBReminderTable.cs
@@ -17,7 +17,6 @@ namespace OrleansAWSUtils.Reminders
     public class DynamoDBReminderTable : IReminderTable
     {
         private readonly IGrainReferenceConverter grainReferenceConverter;
-        private const string DEPLOYMENT_ID_PROPERTY_NAME = "DeploymentId";
         private const string GRAIN_REFERENCE_PROPERTY_NAME = "GrainReference";
         private const string REMINDER_NAME_PROPERTY_NAME = "ReminderName";
         private const string SERVICE_ID_PROPERTY_NAME = "ServiceId";
@@ -34,7 +33,6 @@ namespace OrleansAWSUtils.Reminders
         private ILogger logger;
         private readonly ILoggerFactory loggerFactory;
         private DynamoDBStorage storage;
-        private string deploymentId;
         private Guid serviceId;
 
         /// <summary>
@@ -56,7 +54,6 @@ namespace OrleansAWSUtils.Reminders
         /// <returns></returns>
         public Task Init(GlobalConfiguration config)
         {
-            deploymentId = config.ClusterId;
             serviceId = config.ServiceId;
 
             storage = new DynamoDBStorage(config.DataConnectionStringForReminders, loggerFactory);

--- a/src/OrleansAWSUtils/Storage/SQSStorage.cs
+++ b/src/OrleansAWSUtils/Storage/SQSStorage.cs
@@ -42,10 +42,10 @@ namespace OrleansAWSUtils.Storage
         /// <param name="loggerFactory">logger factory to use</param>
         /// <param name="queueName">The name of the queue</param>
         /// <param name="connectionString">The connection string</param>
-        /// <param name="deploymentId">The cluster deployment Id</param>
-        public SQSStorage(ILoggerFactory loggerFactory, string queueName, string connectionString, string deploymentId = "")
+        /// <param name="clusterId">The cluster Id</param>
+        public SQSStorage(ILoggerFactory loggerFactory, string queueName, string connectionString, string clusterId = "")
         {
-            QueueName = string.IsNullOrWhiteSpace(deploymentId) ? queueName : $"{deploymentId}-{queueName}";
+            QueueName = string.IsNullOrWhiteSpace(clusterId) ? queueName : $"{clusterId}-{queueName}";
             ParseDataConnectionString(connectionString);
             Logger = loggerFactory.CreateLogger<SQSStorage>();
             CreateClient();

--- a/src/OrleansAWSUtils/Streams/SQSAdapterReceiver.cs
+++ b/src/OrleansAWSUtils/Streams/SQSAdapterReceiver.cs
@@ -26,13 +26,13 @@ namespace OrleansAWSUtils.Streams
 
         public QueueId Id { get; private set; }
 
-        public static IQueueAdapterReceiver Create(SerializationManager serializationManager, ILoggerFactory loggerFactory, QueueId queueId, string dataConnectionString, string deploymentId)
+        public static IQueueAdapterReceiver Create(SerializationManager serializationManager, ILoggerFactory loggerFactory, QueueId queueId, string dataConnectionString, string clusterId)
         {
             if (queueId == null) throw new ArgumentNullException("queueId");
             if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
-            if (string.IsNullOrEmpty(deploymentId)) throw new ArgumentNullException("deploymentId");
+            if (string.IsNullOrEmpty(clusterId)) throw new ArgumentNullException(nameof(clusterId));
 
-            var queue = new SQSStorage(loggerFactory, queueId.ToString(), dataConnectionString, deploymentId);
+            var queue = new SQSStorage(loggerFactory, queueId.ToString(), dataConnectionString, clusterId);
             return new SQSAdapterReceiver(serializationManager, loggerFactory, queueId, queue);
         }
 

--- a/src/OrleansAWSUtils/Streams/SQSStreamProviderUtils.cs
+++ b/src/OrleansAWSUtils/Streams/SQSStreamProviderUtils.cs
@@ -13,12 +13,12 @@ namespace OrleansAWSUtils.Streams
     public class SQSStreamProviderUtils
     {
         /// <summary>
-        /// Async method to delete all used queques, for specific provider and deploymentId
+        /// Async method to delete all used queques, for specific provider and clusterId
         /// </summary>
         /// <returns> Task object for this async method </returns>
-        public static async Task DeleteAllUsedQueues(string providerName, string deploymentId, string storageConnectionString, ILoggerFactory loggerFactory)
+        public static async Task DeleteAllUsedQueues(string providerName, string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)
         {
-            if (deploymentId != null)
+            if (clusterId != null)
             {
                 var queueMapper = new HashRingBasedStreamQueueMapper(SQSAdapterFactory.NumQueuesDefaultValue, providerName);
                 List<QueueId> allQueues = queueMapper.GetAllQueues().ToList();
@@ -26,7 +26,7 @@ namespace OrleansAWSUtils.Streams
                 var deleteTasks = new List<Task>();
                 foreach (var queueId in allQueues)
                 {
-                    var manager = new SQSStorage(loggerFactory, queueId.ToString(), storageConnectionString, deploymentId);
+                    var manager = new SQSStorage(loggerFactory, queueId.ToString(), storageConnectionString, clusterId);
                     manager.InitQueueAsync().Wait();
                     deleteTasks.Add(manager.DeleteQueue());
                 }

--- a/src/OrleansAzureUtils/Hosting/AzureClient.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureClient.cs
@@ -170,7 +170,7 @@ namespace Orleans.Runtime.Host
             var deploymentId = config.DeploymentId;
             var connectionString = config.DataConnectionString;
             if (String.IsNullOrEmpty(deploymentId))
-                throw new ArgumentException("Cannot connect to Azure silos with null deploymentId", "config.DeploymentId");
+                throw new ArgumentException("Cannot connect to Azure silos with null deploymentId", "config.ClusterId");
             
             if (String.IsNullOrEmpty(connectionString))
                 throw new ArgumentException("Cannot connect to Azure silos with null connectionString", "config.DataConnectionString");
@@ -201,8 +201,8 @@ namespace Orleans.Runtime.Host
             if (initSucceeded) return;
 
             OrleansException err;
-            err = lastException != null ? new OrleansException(String.Format("Could not Initialize Client for DeploymentId={0}. Last exception={1}",
-                deploymentId, lastException.Message), lastException) : new OrleansException(String.Format("Could not Initialize Client for DeploymentId={0}.", deploymentId));
+            err = lastException != null ? new OrleansException(String.Format("Could not Initialize Client for ClusterId={0}. Last exception={1}",
+                deploymentId, lastException.Message), lastException) : new OrleansException(String.Format("Could not Initialize Client for ClusterId={0}.", deploymentId));
             Trace.TraceError("Error starting Orleans Azure client application -- {0} -- bailing. {1}", err.Message, LogFormatter.PrintException(err));
             throw err;
         }

--- a/src/OrleansAzureUtils/Hosting/AzureClient.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureClient.cs
@@ -89,7 +89,7 @@ namespace Orleans.Runtime.Host
             var config = new ClientConfiguration
             {
                 GatewayProvider = ClientConfiguration.GatewayProviderType.AzureTable,
-                DeploymentId = GetDeploymentId(),
+                ClusterId = GetDeploymentId(),
                 DataConnectionString = GetDataConnectionString(),
             };
             
@@ -131,7 +131,7 @@ namespace Orleans.Runtime.Host
             Trace.TraceInformation("Overriding Orleans client config from Azure runtime environment.");
             try
             {
-                config.DeploymentId = GetDeploymentId();
+                config.ClusterId = GetDeploymentId();
                 config.DataConnectionString = GetDataConnectionString();
                 config.GatewayProvider = ClientConfiguration.GatewayProviderType.AzureTable;
             }
@@ -167,7 +167,7 @@ namespace Orleans.Runtime.Host
 
             //// Find endpoint info for the gateway to this Orleans silo cluster
             //Trace.WriteLine("Searching for Orleans gateway silo via Orleans instance table...");
-            var deploymentId = config.DeploymentId;
+            var deploymentId = config.ClusterId;
             var connectionString = config.DataConnectionString;
             if (String.IsNullOrEmpty(deploymentId))
                 throw new ArgumentException("Cannot connect to Azure silos with null deploymentId", "config.ClusterId");

--- a/src/OrleansAzureUtils/Hosting/AzureClient.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureClient.cs
@@ -167,9 +167,9 @@ namespace Orleans.Runtime.Host
 
             //// Find endpoint info for the gateway to this Orleans silo cluster
             //Trace.WriteLine("Searching for Orleans gateway silo via Orleans instance table...");
-            var deploymentId = config.ClusterId;
+            var clusterId = config.ClusterId;
             var connectionString = config.DataConnectionString;
-            if (String.IsNullOrEmpty(deploymentId))
+            if (String.IsNullOrEmpty(clusterId))
                 throw new ArgumentException("Cannot connect to Azure silos with null deploymentId", "config.ClusterId");
             
             if (String.IsNullOrEmpty(connectionString))
@@ -194,7 +194,7 @@ namespace Orleans.Runtime.Host
                     Trace.TraceError("Client.Initialize failed with exc -- {0}. Will try again", exc.Message);
                 }
                 // Pause to let Primary silo start up and register
-                Trace.TraceInformation("Pausing {0} awaiting silo and gateways registration for Deployment={1}", StartupRetryPause, deploymentId);
+                Trace.TraceInformation("Pausing {0} awaiting silo and gateways registration for Deployment={1}", StartupRetryPause, clusterId);
                 Thread.Sleep(StartupRetryPause);
             }
             
@@ -202,7 +202,7 @@ namespace Orleans.Runtime.Host
 
             OrleansException err;
             err = lastException != null ? new OrleansException(String.Format("Could not Initialize Client for ClusterId={0}. Last exception={1}",
-                deploymentId, lastException.Message), lastException) : new OrleansException(String.Format("Could not Initialize Client for ClusterId={0}.", deploymentId));
+                clusterId, lastException.Message), lastException) : new OrleansException(String.Format("Could not Initialize Client for ClusterId={0}.", clusterId));
             Trace.TraceError("Error starting Orleans Azure client application -- {0} -- bailing. {1}", err.Message, LogFormatter.PrintException(err));
             throw err;
         }

--- a/src/OrleansAzureUtils/Hosting/AzureSilo.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureSilo.cs
@@ -100,7 +100,7 @@ namespace Orleans.Runtime.Host
         {
             if (config.Globals.LivenessType == GlobalConfiguration.LivenessProviderType.AzureTable)
             {
-                string deploymentId = config.Globals.DeploymentId ?? serviceRuntimeWrapper.DeploymentId;
+                string deploymentId = config.Globals.ClusterId ?? serviceRuntimeWrapper.DeploymentId;
                 string connectionString = config.Globals.DataConnectionString ??
                                           serviceRuntimeWrapper.GetConfigurationSettingValue(DataConnectionConfigurationSettingName);
 
@@ -136,7 +136,7 @@ namespace Orleans.Runtime.Host
             var config = new ClusterConfiguration();
 
             config.Globals.LivenessType = GlobalConfiguration.LivenessProviderType.AzureTable;
-            config.Globals.DeploymentId = serviceRuntimeWrapper.DeploymentId;
+            config.Globals.ClusterId = serviceRuntimeWrapper.DeploymentId;
             try
             {
                 config.Globals.DataConnectionString = serviceRuntimeWrapper.GetConfigurationSettingValue(AzureConstants.DataConnectionConfigurationSettingName);
@@ -161,7 +161,7 @@ namespace Orleans.Runtime.Host
         /// <summary>
         /// Initialize this Orleans silo for execution. Config data will be read from silo config file as normal
         /// </summary>
-        /// <param name="deploymentId">Azure DeploymentId this silo is running under. If null, defaults to the value from the configuration.</param>
+        /// <param name="deploymentId">Azure ClusterId this silo is running under. If null, defaults to the value from the configuration.</param>
 		/// <param name="connectionString">Azure DataConnectionString. If null, defaults to the DataConnectionString setting from the Azure configuration for this role.</param>
         /// <returns><c>true</c> is the silo startup was successful</returns>
         public bool Start(string deploymentId = null, string connectionString = null)
@@ -187,7 +187,7 @@ namespace Orleans.Runtime.Host
         /// Initialize this Orleans silo for execution with the specified Azure deploymentId
         /// </summary>
         /// <param name="config">If null, Config data will be read from silo config file as normal, otherwise use the specified config data.</param>
-        /// <param name="deploymentId">Azure DeploymentId this silo is running under</param>
+        /// <param name="deploymentId">Azure ClusterId this silo is running under</param>
 		/// <param name="connectionString">Azure DataConnectionString. If null, defaults to the DataConnectionString setting from the Azure configuration for this role.</param>
         /// <returns><c>true</c> if the silo startup was successful</returns>
         internal bool Start(ClusterConfiguration config, string deploymentId, string connectionString)
@@ -222,11 +222,11 @@ namespace Orleans.Runtime.Host
             // Bootstrap this Orleans silo instance
 
             // If deploymentId was not direclty provided, take the value in the config. If it is not 
-            // in the config too, just take the DeploymentId from Azure
+            // in the config too, just take the ClusterId from Azure
             if (deploymentId == null)
-                deploymentId = string.IsNullOrWhiteSpace(host.Config.Globals.DeploymentId)
+                deploymentId = string.IsNullOrWhiteSpace(host.Config.Globals.ClusterId)
                     ? serviceRuntimeWrapper.DeploymentId
-                    : host.Config.Globals.DeploymentId;
+                    : host.Config.Globals.ClusterId;
 
             myEntry = new SiloInstanceTableEntry
             {

--- a/src/OrleansAzureUtils/Hosting/AzureSilo.cs
+++ b/src/OrleansAzureUtils/Hosting/AzureSilo.cs
@@ -100,13 +100,13 @@ namespace Orleans.Runtime.Host
         {
             if (config.Globals.LivenessType == GlobalConfiguration.LivenessProviderType.AzureTable)
             {
-                string deploymentId = config.Globals.ClusterId ?? serviceRuntimeWrapper.DeploymentId;
+                string clusterId = config.Globals.ClusterId ?? serviceRuntimeWrapper.DeploymentId;
                 string connectionString = config.Globals.DataConnectionString ??
                                           serviceRuntimeWrapper.GetConfigurationSettingValue(DataConnectionConfigurationSettingName);
 
                 try
                 {
-                    var manager = siloInstanceManager ?? await OrleansSiloInstanceManager.GetManager(deploymentId, connectionString, loggerFactory);
+                    var manager = siloInstanceManager ?? await OrleansSiloInstanceManager.GetManager(clusterId, connectionString, loggerFactory);
                     var instances = await manager.DumpSiloInstanceTable();
                     logger.Debug(instances);
                 }
@@ -184,16 +184,16 @@ namespace Orleans.Runtime.Host
         }
 
         /// <summary>
-        /// Initialize this Orleans silo for execution with the specified Azure deploymentId
+        /// Initialize this Orleans silo for execution with the specified Azure clusterId
         /// </summary>
         /// <param name="config">If null, Config data will be read from silo config file as normal, otherwise use the specified config data.</param>
-        /// <param name="deploymentId">Azure ClusterId this silo is running under</param>
+        /// <param name="clusterId">Azure ClusterId this silo is running under</param>
 		/// <param name="connectionString">Azure DataConnectionString. If null, defaults to the DataConnectionString setting from the Azure configuration for this role.</param>
         /// <returns><c>true</c> if the silo startup was successful</returns>
-        internal bool Start(ClusterConfiguration config, string deploymentId, string connectionString)
+        internal bool Start(ClusterConfiguration config, string clusterId, string connectionString)
         {
-            if (config != null && deploymentId != null)
-                throw new ArgumentException("Cannot use config and deploymentId on the same time");
+            if (config != null && clusterId != null)
+                throw new ArgumentException("Cannot use config and clusterId on the same time");
 
             // Program ident
             Trace.TraceInformation("Starting {0} v{1}", this.GetType().FullName, RuntimeVersion.Current);
@@ -221,16 +221,16 @@ namespace Orleans.Runtime.Host
 
             // Bootstrap this Orleans silo instance
 
-            // If deploymentId was not direclty provided, take the value in the config. If it is not 
+            // If clusterId was not direclty provided, take the value in the config. If it is not 
             // in the config too, just take the ClusterId from Azure
-            if (deploymentId == null)
-                deploymentId = string.IsNullOrWhiteSpace(host.Config.Globals.ClusterId)
+            if (clusterId == null)
+                clusterId = string.IsNullOrWhiteSpace(host.Config.Globals.ClusterId)
                     ? serviceRuntimeWrapper.DeploymentId
                     : host.Config.Globals.ClusterId;
 
             myEntry = new SiloInstanceTableEntry
             {
-                DeploymentId = deploymentId,
+                DeploymentId = clusterId,
                 Address = myEndpoint.Address.ToString(),
                 Port = myEndpoint.Port.ToString(CultureInfo.InvariantCulture),
                 Generation = generation.ToString(CultureInfo.InvariantCulture),
@@ -244,7 +244,7 @@ namespace Orleans.Runtime.Host
                 FaultZone = serviceRuntimeWrapper.FaultDomain.ToString(CultureInfo.InvariantCulture),
                 StartTime = LogFormatter.PrintDate(DateTime.UtcNow),
 
-                PartitionKey = deploymentId,
+                PartitionKey = clusterId,
                 RowKey = myEndpoint.Address + "-" + myEndpoint.Port + "-" + generation
             };
 
@@ -254,7 +254,7 @@ namespace Orleans.Runtime.Host
             try
             {
                 siloInstanceManager = OrleansSiloInstanceManager.GetManager(
-                    deploymentId, connectionString, this.loggerFactory).WithTimeout(AzureTableDefaultPolicies.TableCreationTimeout).Result;
+                    clusterId, connectionString, this.loggerFactory).WithTimeout(AzureTableDefaultPolicies.TableCreationTimeout).Result;
             }
             catch (Exception exc)
             {
@@ -276,7 +276,7 @@ namespace Orleans.Runtime.Host
             siloInstanceManager.RegisterSiloInstance(myEntry);
 
             // Initialize this Orleans silo instance
-            host.SetDeploymentId(deploymentId, connectionString);
+            host.SetDeploymentId(clusterId, connectionString);
             host.SetSiloEndpoint(myEndpoint, generation);
             host.SetProxyEndpoint(proxyEndpoint);
 

--- a/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
+++ b/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
@@ -92,7 +92,7 @@ namespace Orleans.Runtime.Configuration
         /// <param name="providerName">The provider name</param>
         /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
         /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
-        /// <param name="deploymentId">The deployment ID used for partitioning. If none is specified, the provider will use the same DeploymentId as the Cluster.</param>
+        /// <param name="deploymentId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
         /// <param name="cacheSize">The cache size.</param>
         /// <param name="startupState">The startup state of the persistent stream provider.</param>
         /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>
@@ -109,7 +109,7 @@ namespace Orleans.Runtime.Configuration
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
-            deploymentId = deploymentId ?? config.Globals.DeploymentId;
+            deploymentId = deploymentId ?? config.Globals.ClusterId;
             var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
 #pragma warning disable 618
             config.Globals.RegisterStreamProvider<AzureQueueStreamProvider>(providerName, properties);
@@ -123,7 +123,7 @@ namespace Orleans.Runtime.Configuration
         /// <param name="providerName">The provider name</param>
         /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
         /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
-        /// <param name="deploymentId">The deployment ID used for partitioning. If none is specified, the provider will use the same DeploymentId as the Cluster.</param>
+        /// <param name="deploymentId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
         /// <param name="cacheSize">The cache size.</param>
         /// <param name="startupState">The startup state of the persistent stream provider.</param>
         /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>
@@ -140,7 +140,7 @@ namespace Orleans.Runtime.Configuration
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
-            deploymentId = deploymentId ?? config.Globals.DeploymentId;
+            deploymentId = deploymentId ?? config.Globals.ClusterId;
             var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
             config.Globals.RegisterStreamProvider<AzureQueueStreamProviderV2>(providerName, properties);
         }
@@ -152,7 +152,7 @@ namespace Orleans.Runtime.Configuration
         /// <param name="providerName">The provider name</param>
         /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
         /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
-        /// <param name="deploymentId">The deployment ID used for partitioning. If none is specified, the provider will use the same DeploymentId as the Cluster.</param>
+        /// <param name="deploymentId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
         /// <param name="cacheSize">The cache size.</param>
         /// <param name="startupState">The startup state of the persistent stream provider.</param>
         /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>
@@ -183,7 +183,7 @@ namespace Orleans.Runtime.Configuration
         /// <param name="providerName">The provider name</param>
         /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
         /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
-        /// <param name="deploymentId">The deployment ID used for partitioning. If none is specified, the provider will use the same DeploymentId as the Cluster.</param>
+        /// <param name="deploymentId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
         /// <param name="cacheSize">The cache size.</param>
         /// <param name="startupState">The startup state of the persistent stream provider.</param>
         /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>

--- a/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
+++ b/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
@@ -92,7 +92,7 @@ namespace Orleans.Runtime.Configuration
         /// <param name="providerName">The provider name</param>
         /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
         /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
-        /// <param name="deploymentId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
+        /// <param name="clusterId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
         /// <param name="cacheSize">The cache size.</param>
         /// <param name="startupState">The startup state of the persistent stream provider.</param>
         /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>
@@ -101,7 +101,7 @@ namespace Orleans.Runtime.Configuration
             string providerName,
             string connectionString = null,
             int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
-            string deploymentId = null,
+            string clusterId = null,
             int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
 #pragma warning disable CS0618 // Type or member is obsolete
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
@@ -109,8 +109,8 @@ namespace Orleans.Runtime.Configuration
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
-            deploymentId = deploymentId ?? config.Globals.ClusterId;
-            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
+            clusterId = clusterId ?? config.Globals.ClusterId;
+            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, clusterId, cacheSize, startupState, persistentStreamProviderConfig);
 #pragma warning disable 618
             config.Globals.RegisterStreamProvider<AzureQueueStreamProvider>(providerName, properties);
 #pragma warning restore 618
@@ -123,7 +123,7 @@ namespace Orleans.Runtime.Configuration
         /// <param name="providerName">The provider name</param>
         /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
         /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
-        /// <param name="deploymentId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
+        /// <param name="clusterId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
         /// <param name="cacheSize">The cache size.</param>
         /// <param name="startupState">The startup state of the persistent stream provider.</param>
         /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>
@@ -132,7 +132,7 @@ namespace Orleans.Runtime.Configuration
             string providerName,
             string connectionString = null,
             int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
-            string deploymentId = null,
+            string clusterId = null,
             int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
 #pragma warning disable 618
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
@@ -140,8 +140,8 @@ namespace Orleans.Runtime.Configuration
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
-            deploymentId = deploymentId ?? config.Globals.ClusterId;
-            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
+            clusterId = clusterId ?? config.Globals.ClusterId;
+            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, clusterId, cacheSize, startupState, persistentStreamProviderConfig);
             config.Globals.RegisterStreamProvider<AzureQueueStreamProviderV2>(providerName, properties);
         }
 
@@ -152,7 +152,7 @@ namespace Orleans.Runtime.Configuration
         /// <param name="providerName">The provider name</param>
         /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
         /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
-        /// <param name="deploymentId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
+        /// <param name="clusterId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
         /// <param name="cacheSize">The cache size.</param>
         /// <param name="startupState">The startup state of the persistent stream provider.</param>
         /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>
@@ -161,7 +161,7 @@ namespace Orleans.Runtime.Configuration
             string providerName,
             string connectionString = null,
             int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
-            string deploymentId = null,
+            string clusterId = null,
             int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
 #pragma warning disable 618
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
@@ -169,8 +169,8 @@ namespace Orleans.Runtime.Configuration
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
-            deploymentId = deploymentId ?? config.ClusterId;
-            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
+            clusterId = clusterId ?? config.ClusterId;
+            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, clusterId, cacheSize, startupState, persistentStreamProviderConfig);
 #pragma warning disable 618
             config.RegisterStreamProvider<AzureQueueStreamProvider>(providerName, properties);
 #pragma warning restore 618
@@ -183,7 +183,7 @@ namespace Orleans.Runtime.Configuration
         /// <param name="providerName">The provider name</param>
         /// <param name="connectionString">The azure storage connection string. If none is provided, it will use the same as in the Globals configuration.</param>
         /// <param name="numberOfQueues">The number of queues to use as partitions.</param>
-        /// <param name="deploymentId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
+        /// <param name="clusterId">The ClusterId used for partitioning. If none is specified, the provider will use the same ClusterId as the Cluster.</param>
         /// <param name="cacheSize">The cache size.</param>
         /// <param name="startupState">The startup state of the persistent stream provider.</param>
         /// <param name="persistentStreamProviderConfig">Settings related to all persistent stream providers.</param>
@@ -192,7 +192,7 @@ namespace Orleans.Runtime.Configuration
             string providerName,
             string connectionString = null,
             int numberOfQueues = AzureQueueAdapterConstants.NumQueuesDefaultValue,
-            string deploymentId = null,
+            string clusterId = null,
             int cacheSize = AzureQueueAdapterConstants.CacheSizeDefaultValue,
 #pragma warning disable 618
             PersistentStreamProviderState startupState = AzureQueueStreamProvider.StartupStateDefaultValue,
@@ -200,8 +200,8 @@ namespace Orleans.Runtime.Configuration
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
-            deploymentId = deploymentId ?? config.ClusterId;
-            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
+            clusterId = clusterId ?? config.ClusterId;
+            var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, clusterId, cacheSize, startupState, persistentStreamProviderConfig);
             config.RegisterStreamProvider<AzureQueueStreamProviderV2>(providerName, properties);
         }
 

--- a/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
+++ b/src/OrleansAzureUtils/Providers/AzureConfigurationExtensions.cs
@@ -169,7 +169,7 @@ namespace Orleans.Runtime.Configuration
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
-            deploymentId = deploymentId ?? config.DeploymentId;
+            deploymentId = deploymentId ?? config.ClusterId;
             var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
 #pragma warning disable 618
             config.RegisterStreamProvider<AzureQueueStreamProvider>(providerName, properties);
@@ -200,7 +200,7 @@ namespace Orleans.Runtime.Configuration
             PersistentStreamProviderConfig persistentStreamProviderConfig = null)
         {
             connectionString = GetConnectionString(connectionString, config);
-            deploymentId = deploymentId ?? config.DeploymentId;
+            deploymentId = deploymentId ?? config.ClusterId;
             var properties = GetAzureQueueStreamProviderProperties(providerName, connectionString, numberOfQueues, deploymentId, cacheSize, startupState, persistentStreamProviderConfig);
             config.RegisterStreamProvider<AzureQueueStreamProviderV2>(providerName, properties);
         }

--- a/src/OrleansAzureUtils/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
+++ b/src/OrleansAzureUtils/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
@@ -16,7 +16,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
     {
         private static readonly Func<TEntity> DefaultCreateEntity = () => new TEntity();
         private readonly SerializationManager serializationManager;
-        private readonly string deploymentId;
+        private readonly string clusterId;
         private readonly Orleans.AzureUtils.AzureTableDataManager<TEntity> dataManager;
         private readonly Func<TEntity> createEntity;
 
@@ -26,15 +26,15 @@ namespace Orleans.Providers.Streams.PersistentStreams
         /// <param name="serializationManager"></param>
         /// <param name="loggerFactory">logger factory to use</param>
         /// <param name="faultOnFailure"></param>
-        /// <param name="deploymentId"></param>
+        /// <param name="clusterId"></param>
         /// <param name="tableName"></param>
         /// <param name="storageConnectionString"></param>
         /// <param name="createEntity"></param>
-        public AzureTableStorageStreamFailureHandler(SerializationManager serializationManager, ILoggerFactory loggerFactory, bool faultOnFailure, string deploymentId, string tableName, string storageConnectionString, Func<TEntity> createEntity = null)
+        public AzureTableStorageStreamFailureHandler(SerializationManager serializationManager, ILoggerFactory loggerFactory, bool faultOnFailure, string clusterId, string tableName, string storageConnectionString, Func<TEntity> createEntity = null)
         {
-            if (string.IsNullOrEmpty(deploymentId))
+            if (string.IsNullOrEmpty(clusterId))
             {
-                throw new ArgumentNullException("deploymentId");
+                throw new ArgumentNullException(nameof(clusterId));
             }
             if (string.IsNullOrEmpty(tableName))
             {
@@ -45,7 +45,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
                 throw new ArgumentNullException("storageConnectionString");
             }
             this.serializationManager = serializationManager;
-            this.deploymentId = deploymentId;
+            this.clusterId = clusterId;
             ShouldFaultSubsriptionOnError = faultOnFailure;
             this.createEntity = createEntity ?? DefaultCreateEntity;
             dataManager = new AzureTableDataManager<TEntity>(tableName, storageConnectionString, loggerFactory);
@@ -115,7 +115,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
             failureEntity.StreamGuid = streamIdentity.Guid;
             failureEntity.StreamNamespace = streamIdentity.Namespace;
             failureEntity.SetSequenceToken(this.serializationManager, sequenceToken);
-            failureEntity.SetPartitionKey(deploymentId);
+            failureEntity.SetPartitionKey(this.clusterId);
             failureEntity.SetRowkey();
             await dataManager.CreateTableEntryAsync(failureEntity);
         }

--- a/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
+++ b/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
@@ -23,7 +23,7 @@ namespace Orleans.Runtime.ReminderService
 
         public async Task Init(GlobalConfiguration config)
         {
-            remTableManager = await RemindersTableManager.GetManager(config.ServiceId, config.DeploymentId, config.DataConnectionStringForReminders, this.loggerFactory);
+            remTableManager = await RemindersTableManager.GetManager(config.ServiceId, config.ClusterId, config.DataConnectionStringForReminders, this.loggerFactory);
         }
 
         #region Utility methods

--- a/src/OrleansAzureUtils/Storage/ClientMetricsTableDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/ClientMetricsTableDataManager.cs
@@ -74,7 +74,7 @@ namespace Orleans.AzureUtils
 
         async Task IClientMetricsDataPublisher.Init(ClientConfiguration config, IPAddress address, string clientId)
         {
-            deploymentId = config.DeploymentId;
+            deploymentId = config.ClusterId;
             this.clientId = clientId;
             this.address = address;
             myHostName = config.DNSHostName;

--- a/src/OrleansAzureUtils/Storage/RemindersTableManager.cs
+++ b/src/OrleansAzureUtils/Storage/RemindersTableManager.cs
@@ -83,12 +83,12 @@ namespace Orleans.Runtime.ReminderService
 
         private static readonly TimeSpan initTimeout = AzureTableDefaultPolicies.TableCreationTimeout;
 
-        public static async Task<RemindersTableManager> GetManager(Guid serviceId, string deploymentId, string storageConnectionString, ILoggerFactory loggerFactory)
+        public static async Task<RemindersTableManager> GetManager(Guid serviceId, string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)
         {
-            var singleton = new RemindersTableManager(serviceId, deploymentId, storageConnectionString, loggerFactory);
+            var singleton = new RemindersTableManager(serviceId, clusterId, storageConnectionString, loggerFactory);
             try
             {
-                singleton.Logger.Info("Creating RemindersTableManager for service id {0} and deploymentId {1}.", serviceId, deploymentId);
+                singleton.Logger.Info("Creating RemindersTableManager for service id {0} and clusterId {1}.", serviceId, clusterId);
                 await singleton.InitTableAsync()
                     .WithTimeout(initTimeout);
             }
@@ -107,10 +107,10 @@ namespace Orleans.Runtime.ReminderService
             return singleton;
         }
 
-        private RemindersTableManager(Guid serviceId, string deploymentId, string storageConnectionString, ILoggerFactory loggerFactory)
+        private RemindersTableManager(Guid serviceId, string clusterId, string storageConnectionString, ILoggerFactory loggerFactory)
             : base(REMINDERS_TABLE_NAME, storageConnectionString, loggerFactory)
         {
-            DeploymentId = deploymentId;
+            DeploymentId = clusterId;
             ServiceId = serviceId;
         }
 

--- a/src/OrleansAzureUtils/Storage/SiloMetricsTableDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/SiloMetricsTableDataManager.cs
@@ -81,9 +81,9 @@ namespace Orleans.AzureUtils
             logger = loggerFactory.CreateLogger<SiloMetricsTableDataManager>();
         }
 
-        public async Task Init(string deploymentId, string storageConnectionString, SiloAddress siloAddress, string siloName, IPEndPoint gateway, string hostName)
+        public async Task Init(string clusterId, string storageConnectionString, SiloAddress siloAddress, string siloName, IPEndPoint gateway, string hostName)
         {
-            this.deploymentId = deploymentId;
+            this.deploymentId = clusterId;
             this.siloAddress = siloAddress;
             this.siloName = siloName;
             this.gateway = gateway;

--- a/src/OrleansAzureUtils/Storage/StatsTableDataManager.cs
+++ b/src/OrleansAzureUtils/Storage/StatsTableDataManager.cs
@@ -73,9 +73,9 @@ namespace Orleans.AzureUtils
             this.logger = this.loggerFactory.CreateLogger<StatsTableDataManager>();
         }
 
-        async Task IStatisticsPublisher.Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName, string hostName)
+        async Task IStatisticsPublisher.Init(bool isSilo, string storageConnectionString, string clusterId, string address, string siloName, string hostName)
         {
-            this.deploymentId = deploymentId;
+            this.deploymentId = clusterId;
             this.address = address;
             name = siloName;
             myHostName = hostName;

--- a/src/OrleansSQLUtils/Messaging/SqlGatewayListProvider.cs
+++ b/src/OrleansSQLUtils/Messaging/SqlGatewayListProvider.cs
@@ -25,7 +25,7 @@ namespace Orleans.Runtime.Membership
             this.logger = logger;
             this.grainReferenceConverter = grainReferenceConverter;
             this.options = options.Value;
-            deploymentId = clientConfiguration.DeploymentId;
+            deploymentId = clientConfiguration.ClusterId;
             this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
         }
 

--- a/src/OrleansSQLUtils/Messaging/SqlGatewayListProvider.cs
+++ b/src/OrleansSQLUtils/Messaging/SqlGatewayListProvider.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime.Membership
     public class SqlGatewayListProvider : IGatewayListProvider
     {
         private readonly ILogger logger;
-        private string deploymentId;
+        private string clusterId;
         private readonly SqlGatewayListProviderOptions options;
         private RelationalOrleansQueries orleansQueries;
         private readonly IGrainReferenceConverter grainReferenceConverter;
@@ -25,7 +25,7 @@ namespace Orleans.Runtime.Membership
             this.logger = logger;
             this.grainReferenceConverter = grainReferenceConverter;
             this.options = options.Value;
-            deploymentId = clientConfiguration.ClusterId;
+            this.clusterId = clientConfiguration.ClusterId;
             this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
         }
 
@@ -50,7 +50,7 @@ namespace Orleans.Runtime.Membership
             if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("SqlMembershipTable.GetGateways called.");
             try
             {
-                return await orleansQueries.ActiveGatewaysAsync(deploymentId);
+                return await orleansQueries.ActiveGatewaysAsync(this.clusterId);
             }
             catch (Exception ex)
             {

--- a/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
+++ b/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
@@ -11,7 +11,7 @@ namespace Orleans.Runtime.MembershipService
     public class SqlMembershipTable: IMembershipTable
     {
         private readonly IGrainReferenceConverter grainReferenceConverter;
-        private string deploymentId;        
+        private string clusterId;        
         private ILogger logger;
         private RelationalOrleansQueries orleansQueries;
         private readonly SqlMembershipOptions membershipTableOptions;
@@ -20,7 +20,7 @@ namespace Orleans.Runtime.MembershipService
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = logger;
             this.membershipTableOptions = membershipTableoptions.Value;
-            deploymentId = globalConfig.ClusterId;
+            this.clusterId = globalConfig.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
@@ -50,7 +50,7 @@ namespace Orleans.Runtime.MembershipService
             if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(string.Format("SqlMembershipTable.ReadRow called with key: {0}.", key));
             try
             {
-                return await orleansQueries.MembershipReadRowAsync(deploymentId, key);                
+                return await orleansQueries.MembershipReadRowAsync(this.clusterId, key);                
             }
             catch(Exception ex)
             {
@@ -65,7 +65,7 @@ namespace Orleans.Runtime.MembershipService
             if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("SqlMembershipTable.ReadAll called.");
             try
             {
-                return await orleansQueries.MembershipReadAllAsync(deploymentId);                
+                return await orleansQueries.MembershipReadAllAsync(this.clusterId);                
             }
             catch(Exception ex)
             {
@@ -97,7 +97,7 @@ namespace Orleans.Runtime.MembershipService
 
             try
             {
-                return await orleansQueries.InsertMembershipRowAsync(deploymentId, entry, tableVersion.VersionEtag);
+                return await orleansQueries.InsertMembershipRowAsync(this.clusterId, entry, tableVersion.VersionEtag);
             }
             catch(Exception ex)
             {
@@ -129,7 +129,7 @@ namespace Orleans.Runtime.MembershipService
 
             try
             {
-                return await orleansQueries.UpdateMembershipRowAsync(deploymentId, entry, tableVersion.VersionEtag);                                
+                return await orleansQueries.UpdateMembershipRowAsync(this.clusterId, entry, tableVersion.VersionEtag);                                
             }
             catch(Exception ex)
             {
@@ -149,7 +149,7 @@ namespace Orleans.Runtime.MembershipService
             }
             try
             {
-                await orleansQueries.UpdateIAmAliveTimeAsync(deploymentId, entry.SiloAddress, entry.IAmAliveTime);
+                await orleansQueries.UpdateIAmAliveTimeAsync(this.clusterId, entry.SiloAddress, entry.IAmAliveTime);
             }
             catch(Exception ex)
             {
@@ -159,12 +159,12 @@ namespace Orleans.Runtime.MembershipService
         }
 
 
-        public async Task DeleteMembershipTableEntries(string deploymentId)
+        public async Task DeleteMembershipTableEntries(string clusterId)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(string.Format("IMembershipTable.DeleteMembershipTableEntries called with deploymentId {0}.", deploymentId));
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(string.Format("IMembershipTable.DeleteMembershipTableEntries called with clusterId {0}.", clusterId));
             try
             {
-                await orleansQueries.DeleteMembershipTableEntriesAsync(deploymentId);
+                await orleansQueries.DeleteMembershipTableEntriesAsync(clusterId);
             }
             catch(Exception ex)
             {
@@ -178,7 +178,7 @@ namespace Orleans.Runtime.MembershipService
         {
             try
             {
-                return await orleansQueries.InsertMembershipVersionRowAsync(deploymentId);
+                return await orleansQueries.InsertMembershipVersionRowAsync(this.clusterId);
             }
             catch(Exception ex)
             {

--- a/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
+++ b/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
@@ -20,7 +20,7 @@ namespace Orleans.Runtime.MembershipService
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = logger;
             this.membershipTableOptions = membershipTableoptions.Value;
-            deploymentId = globalConfig.DeploymentId;
+            deploymentId = globalConfig.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/OrleansSQLUtils/Storage/SqlStatisticsPublisher.cs
+++ b/src/OrleansSQLUtils/Storage/SqlStatisticsPublisher.cs
@@ -67,13 +67,13 @@ namespace Orleans.Providers.SqlServer
         /// <summary>
         /// Adds configuration parameters
         /// </summary>
-        /// <param name="deployment">Deployment ID</param>
+        /// <param name="clusterId">Deployment ID</param>
         /// <param name="hostName">Host name</param>
         /// <param name="client">Client ID</param>
         /// <param name="address">IP address</param>
-        public void AddConfiguration(string deployment, string hostName, string client, IPAddress address)
+        public void AddConfiguration(string clusterId, string hostName, string client, IPAddress address)
         {
-            deploymentId = deployment;
+            deploymentId = clusterId;
             isSilo = false;
             this.hostName = hostName;
             clientId = client;
@@ -84,15 +84,15 @@ namespace Orleans.Providers.SqlServer
         /// <summary>
         /// Adds configuration parameters
         /// </summary>
-        /// <param name="deployment">Deployment ID</param>
+        /// <param name="clusterId">Deployment ID</param>
         /// <param name="silo">Silo name</param>
         /// <param name="siloId">Silo ID</param>
         /// <param name="address">Silo address</param>
         /// <param name="gatewayAddress">Client gateway address</param>
         /// <param name="hostName">Host name</param>
-        public void AddConfiguration(string deployment, bool silo, string siloId, SiloAddress address, IPEndPoint gatewayAddress, string hostName)
+        public void AddConfiguration(string clusterId, bool silo, string siloId, SiloAddress address, IPEndPoint gatewayAddress, string hostName)
         {
-            deploymentId = deployment;
+            deploymentId = clusterId;
             isSilo = silo;
             siloName = siloId;
             siloAddress = address;
@@ -129,7 +129,7 @@ namespace Orleans.Providers.SqlServer
         }
 
 
-        Task ISiloMetricsDataPublisher.Init(string deploymentId, string storageConnectionString, SiloAddress siloAddress, string siloName, IPEndPoint gateway, string hostName)
+        Task ISiloMetricsDataPublisher.Init(string clusterId, string storageConnectionString, SiloAddress siloAddress, string siloName, IPEndPoint gateway, string hostName)
         {
             return Task.CompletedTask;
         }
@@ -154,7 +154,7 @@ namespace Orleans.Providers.SqlServer
         }
 
 
-        Task IStatisticsPublisher.Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName, string hostName)
+        Task IStatisticsPublisher.Init(bool isSilo, string storageConnectionString, string clusterId, string address, string siloName, string hostName)
         {
             return Task.CompletedTask;
         }

--- a/test/AWSUtils.Tests/LivenessTests.cs
+++ b/test/AWSUtils.Tests/LivenessTests.cs
@@ -89,7 +89,7 @@ namespace AWSUtils.Tests.Liveness
                     {
                         options.ConnectionString = ConnectionString;
                     })
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
         }
 

--- a/test/AWSUtils.Tests/LivenessTests.cs
+++ b/test/AWSUtils.Tests/LivenessTests.cs
@@ -77,7 +77,7 @@ namespace AWSUtils.Tests.Liveness
                LegacyDynamoDBGatewayListProviderConfigurator.ParseDataConnectionString(ConnectionString, gatewayOptions);
             })
             .AddApplicationPartsFromAppDomain()
-            .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(config.ClientName, config.DeploymentId)));
+            .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(config.ClientName, config.ClusterId)));
         public class SiloBuilderFactory : ISiloBuilderFactory
         {
             public ISiloHostBuilder CreateSiloBuilder(string siloName, ClusterConfiguration clusterConfiguration)

--- a/test/AWSUtils.Tests/StorageTests/Base_PersistenceGrainTests_AWSStore.cs
+++ b/test/AWSUtils.Tests/StorageTests/Base_PersistenceGrainTests_AWSStore.cs
@@ -263,9 +263,9 @@ namespace AWSUtils.Tests.StorageTests
         protected async Task Grain_AWSStore_SiloRestart()
         {
             var initialServiceId = this.HostedCluster.ClusterConfiguration.Globals.ServiceId;
-            var initialDeploymentId = this.HostedCluster.DeploymentId;
+            var initialDeploymentId = this.HostedCluster.ClusterId;
 
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
 
             Guid id = Guid.NewGuid();
             IAWSStorageTestGrain grain = this.fixture.GrainFactory.GetGrain<IAWSStorageTestGrain>(id);
@@ -285,9 +285,9 @@ namespace AWSUtils.Tests.StorageTests
 
             output.WriteLine("Silos restarted");
 
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
             Assert.Equal(initialServiceId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);  // "ServiceId same after restart."
-            Assert.Equal(initialDeploymentId, this.HostedCluster.DeploymentId);  // "ClusterId same after restart."
+            Assert.Equal(initialDeploymentId, this.HostedCluster.ClusterId);  // "ClusterId same after restart."
 
             val = await grain.GetValue();
             Assert.Equal(1, val);  // "Value after Write-1"

--- a/test/AWSUtils.Tests/StorageTests/Base_PersistenceGrainTests_AWSStore.cs
+++ b/test/AWSUtils.Tests/StorageTests/Base_PersistenceGrainTests_AWSStore.cs
@@ -265,7 +265,7 @@ namespace AWSUtils.Tests.StorageTests
             var initialServiceId = this.HostedCluster.ClusterConfiguration.Globals.ServiceId;
             var initialDeploymentId = this.HostedCluster.DeploymentId;
 
-            output.WriteLine("DeploymentId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
 
             Guid id = Guid.NewGuid();
             IAWSStorageTestGrain grain = this.fixture.GrainFactory.GetGrain<IAWSStorageTestGrain>(id);
@@ -285,9 +285,9 @@ namespace AWSUtils.Tests.StorageTests
 
             output.WriteLine("Silos restarted");
 
-            output.WriteLine("DeploymentId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
             Assert.Equal(initialServiceId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);  // "ServiceId same after restart."
-            Assert.Equal(initialDeploymentId, this.HostedCluster.DeploymentId);  // "DeploymentId same after restart."
+            Assert.Equal(initialDeploymentId, this.HostedCluster.DeploymentId);  // "ClusterId same after restart."
 
             val = await grain.GetValue();
             Assert.Equal(1, val);  // "Value after Write-1"

--- a/test/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
@@ -28,7 +28,7 @@ namespace AWSUtils.Tests.Streaming
         private readonly TestEnvironmentFixture fixture;
         private const int NumBatches = 20;
         private const int NumMessagesPerBatch = 20;
-        private readonly string deploymentId;
+        private readonly string clusterId;
         public static readonly string SQS_STREAM_PROVIDER_NAME = "SQSAdapterTests";
 
         private static readonly SafeRandom Random = new SafeRandom();
@@ -42,12 +42,12 @@ namespace AWSUtils.Tests.Streaming
 
             this.output = output;
             this.fixture = fixture;
-            this.deploymentId = MakeDeploymentId();
+            this.clusterId = MakeClusterId();
         }
 
         public void Dispose()
         {
-            SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, deploymentId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
+            SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, this.clusterId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
         }
 
         [SkippableFact]
@@ -56,7 +56,7 @@ namespace AWSUtils.Tests.Streaming
             var properties = new Dictionary<string, string>
                 {
                     {SQSAdapterFactory.DataConnectionStringPropertyName, AWSTestConstants.DefaultSQSConnectionString},
-                    {SQSAdapterFactory.DeploymentIdPropertyName, deploymentId}
+                    {SQSAdapterFactory.DeploymentIdPropertyName, this.clusterId}
                 };
             var config = new ProviderConfiguration(properties, "type", "name");
 
@@ -191,9 +191,9 @@ namespace AWSUtils.Tests.Streaming
             }).ToList();
         }
 
-        internal static string MakeDeploymentId()
+        internal static string MakeClusterId()
         {
-            const string DeploymentIdFormat = "deployment-{0}";
+            const string DeploymentIdFormat = "cluster-{0}";
             string now = DateTime.UtcNow.ToString("yyyy-MM-dd-hh-mm-ss-ffff");
             return String.Format(DeploymentIdFormat, now);
         }

--- a/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
@@ -47,7 +47,7 @@ namespace AWSUtils.Tests.Streaming
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
 
             options.ClusterConfiguration.Globals.ClusterId = deploymentId;
-            options.ClientConfiguration.DeploymentId = deploymentId;
+            options.ClientConfiguration.ClusterId = deploymentId;
             options.ClusterConfiguration.Globals.ClientDropTimeout = TimeSpan.FromSeconds(5);
             options.ClientConfiguration.DataConnectionString = StorageConnectionString;
             options.ClusterConfiguration.Globals.DataConnectionString = StorageConnectionString;

--- a/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
@@ -58,7 +58,7 @@ namespace AWSUtils.Tests.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.DeploymentId;
+            var deploymentId = HostedCluster.ClusterId;
             base.Dispose();
             SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, deploymentId, StorageConnectionString, NullLoggerFactory.Instance).Wait();
         }

--- a/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
@@ -46,7 +46,7 @@ namespace AWSUtils.Tests.Streaming
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
 
-            options.ClusterConfiguration.Globals.DeploymentId = deploymentId;
+            options.ClusterConfiguration.Globals.ClusterId = deploymentId;
             options.ClientConfiguration.DeploymentId = deploymentId;
             options.ClusterConfiguration.Globals.ClientDropTimeout = TimeSpan.FromSeconds(5);
             options.ClientConfiguration.DataConnectionString = StorageConnectionString;

--- a/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
@@ -37,17 +37,17 @@ namespace AWSUtils.Tests.Streaming
                 throw new SkipException("Empty connection string");
             }
 
-            var deploymentId = Guid.NewGuid().ToString();
+            var clusterId = Guid.NewGuid().ToString();
             var streamConnectionString = new Dictionary<string, string>
                 {
                     { "DataConnectionString",  StorageConnectionString},
-                    { "DeploymentId",  deploymentId}
+                    { "DeploymentId",  clusterId}
                 };
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
 
-            options.ClusterConfiguration.Globals.ClusterId = deploymentId;
-            options.ClientConfiguration.ClusterId = deploymentId;
+            options.ClusterConfiguration.Globals.ClusterId = clusterId;
+            options.ClientConfiguration.ClusterId = clusterId;
             options.ClusterConfiguration.Globals.ClientDropTimeout = TimeSpan.FromSeconds(5);
             options.ClientConfiguration.DataConnectionString = StorageConnectionString;
             options.ClusterConfiguration.Globals.DataConnectionString = StorageConnectionString;
@@ -58,9 +58,9 @@ namespace AWSUtils.Tests.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.ClusterId;
             base.Dispose();
-            SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, deploymentId, StorageConnectionString, NullLoggerFactory.Instance).Wait();
+            SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, clusterId, StorageConnectionString, NullLoggerFactory.Instance).Wait();
         }
 
         [SkippableFact, TestCategory("AWS")]

--- a/test/AWSUtils.Tests/Streaming/SQSStreamTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSStreamTests.cs
@@ -74,7 +74,7 @@ namespace AWSUtils.Tests.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.DeploymentId;
+            var deploymentId = HostedCluster.ClusterId;
             base.Dispose();
             SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, deploymentId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
         }

--- a/test/AWSUtils.Tests/Streaming/SQSStreamTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSStreamTests.cs
@@ -74,9 +74,9 @@ namespace AWSUtils.Tests.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.ClusterId;
             base.Dispose();
-            SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, deploymentId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
+            SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, clusterId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
         }
 
         ////------------------------ One to One ----------------------//

--- a/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -38,7 +38,7 @@ namespace AWSUtils.Tests.Streaming
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
             
-            options.ClusterConfiguration.Globals.DeploymentId = deploymentId;
+            options.ClusterConfiguration.Globals.ClusterId = deploymentId;
             options.ClientConfiguration.DeploymentId = deploymentId;
             options.ClientConfiguration.DataConnectionString = StreamConnectionString;
             options.ClusterConfiguration.Globals.DataConnectionString = StreamConnectionString;

--- a/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -39,7 +39,7 @@ namespace AWSUtils.Tests.Streaming
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
             
             options.ClusterConfiguration.Globals.ClusterId = deploymentId;
-            options.ClientConfiguration.DeploymentId = deploymentId;
+            options.ClientConfiguration.ClusterId = deploymentId;
             options.ClientConfiguration.DataConnectionString = StreamConnectionString;
             options.ClusterConfiguration.Globals.DataConnectionString = StreamConnectionString;
             options.ClusterConfiguration.Globals.RegisterStreamProvider<SQSStreamProvider>(SQSStreamProviderName, streamConnectionString);

--- a/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -54,7 +54,7 @@ namespace AWSUtils.Tests.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.DeploymentId;
+            var deploymentId = HostedCluster.ClusterId;
             base.Dispose();
             SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, deploymentId, StreamConnectionString, NullLoggerFactory.Instance).Wait();
         }

--- a/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -29,17 +29,17 @@ namespace AWSUtils.Tests.Streaming
                 throw new SkipException("Empty connection string");
             }
 
-            var deploymentId = Guid.NewGuid().ToString();
+            var clusterId = Guid.NewGuid().ToString();
             var streamConnectionString = new Dictionary<string, string>
                 {
                     { "DataConnectionString",  StreamConnectionString},
-                    { "DeploymentId",  deploymentId}
+                    { "DeploymentId",  clusterId}
                 };
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
             
-            options.ClusterConfiguration.Globals.ClusterId = deploymentId;
-            options.ClientConfiguration.ClusterId = deploymentId;
+            options.ClusterConfiguration.Globals.ClusterId = clusterId;
+            options.ClientConfiguration.ClusterId = clusterId;
             options.ClientConfiguration.DataConnectionString = StreamConnectionString;
             options.ClusterConfiguration.Globals.DataConnectionString = StreamConnectionString;
             options.ClusterConfiguration.Globals.RegisterStreamProvider<SQSStreamProvider>(SQSStreamProviderName, streamConnectionString);
@@ -54,9 +54,9 @@ namespace AWSUtils.Tests.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.ClusterId;
             base.Dispose();
-            SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, deploymentId, StreamConnectionString, NullLoggerFactory.Instance).Wait();
+            SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, clusterId, StreamConnectionString, NullLoggerFactory.Instance).Wait();
         }
 
         [SkippableFact, TestCategory("AWS")]

--- a/test/Benchmarks/Benchmarks/Transactions/TransactionBenchmark.cs
+++ b/test/Benchmarks/Benchmarks/Transactions/TransactionBenchmark.cs
@@ -77,7 +77,7 @@ namespace Benchmarks.Transactions
             {
                 return new SiloHostBuilder().ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)))
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)))
                     .UseInClusterTransactionManager(new TransactionsConfiguration())
                     .UseInMemoryTransactionLog()
                     .UseTransactionalState();

--- a/test/Consul.Tests/LivenessTests.cs
+++ b/test/Consul.Tests/LivenessTests.cs
@@ -50,7 +50,7 @@ namespace Consul.Tests
                     {
                         options.Address = new Uri(ConsulTestUtils.CONSUL_ENDPOINT);
                     })
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
         }
 

--- a/test/Consul.Tests/LivenessTests.cs
+++ b/test/Consul.Tests/LivenessTests.cs
@@ -37,7 +37,7 @@ namespace Consul.Tests
                 gatewayOptions.Address = new Uri(ConsulTestUtils.CONSUL_ENDPOINT);;
             })
             .AddApplicationPartsFromAppDomain()
-            .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(config.ClientName, config.DeploymentId)));
+            .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(config.ClientName, config.ClusterId)));
 
         public class SiloBuilderFactory : ISiloBuilderFactory
         {

--- a/test/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
+++ b/test/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
@@ -36,7 +36,7 @@ namespace GoogleUtils.Tests.Streaming
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
             
-            options.ClusterConfiguration.Globals.DeploymentId = GoogleTestUtils.ProjectId;
+            options.ClusterConfiguration.Globals.ClusterId = GoogleTestUtils.ProjectId;
             options.ClientConfiguration.DeploymentId = GoogleTestUtils.ProjectId;
             options.ClientConfiguration.RegisterStreamProvider<PubSubStreamProvider>(PROVIDER_NAME, providerSettings);
             options.ClusterConfiguration.Globals.RegisterStreamProvider<PubSubStreamProvider>(PROVIDER_NAME, providerSettings);

--- a/test/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
+++ b/test/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
@@ -37,7 +37,7 @@ namespace GoogleUtils.Tests.Streaming
             options.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
             
             options.ClusterConfiguration.Globals.ClusterId = GoogleTestUtils.ProjectId;
-            options.ClientConfiguration.DeploymentId = GoogleTestUtils.ProjectId;
+            options.ClientConfiguration.ClusterId = GoogleTestUtils.ProjectId;
             options.ClientConfiguration.RegisterStreamProvider<PubSubStreamProvider>(PROVIDER_NAME, providerSettings);
             options.ClusterConfiguration.Globals.RegisterStreamProvider<PubSubStreamProvider>(PROVIDER_NAME, providerSettings);
             return new TestCluster(options);

--- a/test/NonSilo.Tests/ConfigTests.cs
+++ b/test/NonSilo.Tests/ConfigTests.cs
@@ -772,7 +772,7 @@ namespace UnitTests
 
             var config = new ClientConfiguration();
 
-            config.DeploymentId = deploymentId;
+            config.ClusterId = deploymentId;
             config.DataConnectionString = "UseDevelopmentStorage=true";
             config.GatewayProvider = ClientConfiguration.GatewayProviderType.AzureTable;
 

--- a/test/NonSilo.Tests/ConfigTests.cs
+++ b/test/NonSilo.Tests/ConfigTests.cs
@@ -741,7 +741,7 @@ namespace UnitTests
             Assert.Equal(GlobalConfiguration.LivenessProviderType.AzureTable, siloConfig.Globals.LivenessType); // LivenessType
             Assert.Equal(GlobalConfiguration.ReminderServiceProviderType.AzureTable, siloConfig.Globals.ReminderServiceType); // ReminderServiceType
 
-            Assert.Equal(deploymentId, siloConfig.Globals.DeploymentId); // DeploymentId
+            Assert.Equal(deploymentId, siloConfig.Globals.ClusterId); // ClusterId
             Assert.Equal(connectionString, siloConfig.Globals.DataConnectionString); // DataConnectionString
 
             Assert.True(siloConfig.Globals.UseAzureSystemStore, "Should be using Azure storage");

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -714,7 +714,7 @@ namespace UnitTests.SchedulerTests
             var orleansConfig = new ClusterConfiguration();
             orleansConfig.StandardLoad();
             NodeConfiguration config = orleansConfig.CreateNodeConfigurationForSilo("Primary");
-            var loggerFactory = TestingUtils.CreateDefaultLoggerFactory(TestingUtils.CreateTraceFileName(config.SiloName, orleansConfig.Globals.DeploymentId), filters);
+            var loggerFactory = TestingUtils.CreateDefaultLoggerFactory(TestingUtils.CreateTraceFileName(config.SiloName, orleansConfig.Globals.ClusterId), filters);
             StatisticsCollector.Initialize(StatisticsLevel.Info);
             SchedulerStatisticsGroup.Init(loggerFactory);
             return loggerFactory;

--- a/test/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -32,11 +32,11 @@ namespace Orleans.Transactions.Azure.Tests
                 return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)))
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)))
                     .UseInClusterTransactionManager(new TransactionsConfiguration())
                     .UseAzureTransactionLog(new AzureTransactionLogConfiguration() {
                         // TODO: Find better way for test isolation.  Possibly different partition keys.
-                        TableName = $"TransactionLog{((uint)clusterConfiguration.Globals.DeploymentId.GetHashCode())%100000}",
+                        TableName = $"TransactionLog{((uint)clusterConfiguration.Globals.ClusterId.GetHashCode())%100000}",
                         ConnectionString = TestDefaultConfiguration.DataConnectionString})
                     .UseTransactionalState();
             }

--- a/test/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
+++ b/test/Orleans.Transactions.Tests/Memory/MemoryTransactionsFixture.cs
@@ -26,7 +26,7 @@ namespace Orleans.Transactions.Tests
                 return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)))
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)))
                     .UseInClusterTransactionManager(new TransactionsConfiguration())
                     .UseInMemoryTransactionLog()
                     .UseTransactionalState();

--- a/test/TestExtensions/DefaultClusterFixture.cs
+++ b/test/TestExtensions/DefaultClusterFixture.cs
@@ -22,7 +22,7 @@ namespace TestExtensions
                 return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
-                    .ConfigureLogging(loggingBuilder => TestingUtils.ConfigureDefaultLoggingBuilder(loggingBuilder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(loggingBuilder => TestingUtils.ConfigureDefaultLoggingBuilder(loggingBuilder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
         }
     }

--- a/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/GatewayConnectionTests.cs
@@ -67,7 +67,7 @@ namespace Tester.ClientConnectionTests
                 }))
                 .ConfigureServices(services => services.AddFromExisting<IGatewayListProvider, TestGatewayManager>())
                 .AddApplicationPartsFromBasePath()
-                .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(configuration.ClientName, configuration.DeploymentId)));
+                .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(configuration.ClientName, configuration.ClusterId)));
         }
 
         public GatewayConnectionTests()

--- a/test/Tester/DependencyInjectionGrainTests.cs
+++ b/test/Tester/DependencyInjectionGrainTests.cs
@@ -37,7 +37,7 @@ namespace UnitTests.General
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)
-                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
                 }
             }
 

--- a/test/Tester/EventSourcingTests/EventSourcingClusterFixture.cs
+++ b/test/Tester/EventSourcingTests/EventSourcingClusterFixture.cs
@@ -48,7 +48,7 @@ namespace Tester.EventSourcingTests
                 return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
-                    .ConfigureLogging(builder => ConfigureLogging(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(builder => ConfigureLogging(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
 
             private void ConfigureLogging(ILoggingBuilder builder, string filePath)

--- a/test/Tester/GrainActivatorTests.cs
+++ b/test/Tester/GrainActivatorTests.cs
@@ -38,7 +38,7 @@ namespace UnitTests.General
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)
-                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
                 }
             }
 

--- a/test/Tester/GrainCallFilterTests.cs
+++ b/test/Tester/GrainCallFilterTests.cs
@@ -42,7 +42,7 @@ namespace UnitTests.General
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)
-                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
                 }
             }
             

--- a/test/Tester/GrainServiceTests/GrainServiceTests.cs
+++ b/test/Tester/GrainServiceTests/GrainServiceTests.cs
@@ -36,7 +36,7 @@ namespace Tester
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)
-                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
                 }
 
             }

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -26,7 +26,7 @@ namespace UnitTests.MembershipTests
 
         protected async Task Do_Liveness_OracleTest_1()
         {
-            output.WriteLine("ClusterId= {0}", this.HostedCluster.DeploymentId);
+            output.WriteLine("ClusterId= {0}", this.HostedCluster.ClusterId);
 
             SiloHandle silo3 = this.HostedCluster.StartAdditionalSilo();
 

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -26,7 +26,7 @@ namespace UnitTests.MembershipTests
 
         protected async Task Do_Liveness_OracleTest_1()
         {
-            output.WriteLine("DeploymentId= {0}", this.HostedCluster.DeploymentId);
+            output.WriteLine("ClusterId= {0}", this.HostedCluster.DeploymentId);
 
             SiloHandle silo3 = this.HostedCluster.StartAdditionalSilo();
 

--- a/test/Tester/Placement/CustomPlacementTests.cs
+++ b/test/Tester/Placement/CustomPlacementTests.cs
@@ -44,7 +44,7 @@ namespace Tester.CustomPlacementTests
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
                         .ConfigureServices(ConfigureServices)
-                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                        .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
                 }
             }
 

--- a/test/Tester/StorageFacet/StorageFacetTests.cs
+++ b/test/Tester/StorageFacet/StorageFacetTests.cs
@@ -33,7 +33,7 @@ namespace Tester
                     var builder = new SiloHostBuilder()
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
-                        .ConfigureLogging(loggingBuilder => TestingUtils.ConfigureDefaultLoggingBuilder(loggingBuilder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                        .ConfigureLogging(loggingBuilder => TestingUtils.ConfigureDefaultLoggingBuilder(loggingBuilder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
 
                     // Setup storage feature infrastructure.
                     // - Setup infrastructure.

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -52,7 +52,7 @@ namespace Tester.StreamingTests
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
                     .ConfigureServices(ConfigureServices)
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
 
             private void ConfigureServices(IServiceCollection services)

--- a/test/TesterAzureUtils/AzureGossipTableTests.cs
+++ b/test/TesterAzureUtils/AzureGossipTableTests.cs
@@ -18,9 +18,6 @@ namespace Tester.AzureUtils
         private readonly Logger logger;
 
         private Guid globalServiceId; //this should be the same for all clusters. Use this as partition key.
-        //this should be unique per cluster. Can we use deployment id? 
-        //problem with only using deployment id is that it is not known before deployment and hence not in the config file.
-        private string deploymentId;
         private SiloAddress siloAddress1;
         private SiloAddress siloAddress2;
         private static readonly TimeSpan timeout = TimeSpan.FromMinutes(1);
@@ -32,7 +29,6 @@ namespace Tester.AzureUtils
             logger = new LoggerWrapper<AzureGossipTableTests>(loggerFactory);
         
             globalServiceId = Guid.NewGuid();
-            deploymentId = "test-" + globalServiceId;
 
             IPAddress ip;
             if (!IPAddress.TryParse("127.0.0.1", out ip))
@@ -45,13 +41,12 @@ namespace Tester.AzureUtils
             IPEndPoint ep2 = new IPEndPoint(ip, 21112);
             siloAddress2 = SiloAddress.New(ep2, 0);
 
-            logger.Info("DeploymentId={0}", deploymentId);
+            logger.Info("Global ServiceId={0}", globalServiceId);
 
             GlobalConfiguration config = new GlobalConfiguration
             {
                 ServiceId = globalServiceId,
                 ClusterId = "0",
-                DeploymentId = deploymentId,
                 DataConnectionString = TestDefaultConfiguration.DataConnectionString
             };
 

--- a/test/TesterAzureUtils/AzureQueueDataManagerTests.cs
+++ b/test/TesterAzureUtils/AzureQueueDataManagerTests.cs
@@ -24,7 +24,7 @@ namespace Tester.AzureUtils
         public AzureQueueDataManagerTests()
         {
             ClientConfiguration config = new ClientConfiguration();
-            var loggerFactory = TestingUtils.CreateDefaultLoggerFactory(TestingUtils.CreateTraceFileName(config.ClientName, config.DeploymentId));
+            var loggerFactory = TestingUtils.CreateDefaultLoggerFactory(TestingUtils.CreateTraceFileName(config.ClientName, config.ClusterId));
             logger = loggerFactory.CreateLogger<AzureQueueDataManagerTests>();
             this.loggerFactory = loggerFactory;
         }

--- a/test/TesterAzureUtils/Lease/LeaseBasedQueueBalancerTests.cs
+++ b/test/TesterAzureUtils/Lease/LeaseBasedQueueBalancerTests.cs
@@ -55,7 +55,7 @@ namespace Tester.AzureUtils.Lease
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
                     .ConfigureServices(ConfigureServices)
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
         }
 

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
@@ -308,7 +308,7 @@ namespace Tester.AzureUtils.Persistence
         {
             var initialServiceId = this.HostedCluster.ClusterConfiguration.Globals.ServiceId;
 
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
 
             Guid id = Guid.NewGuid();
             IAzureStorageTestGrain grain = this.GrainFactory.GetGrain<IAzureStorageTestGrain>(id);
@@ -328,7 +328,7 @@ namespace Tester.AzureUtils.Persistence
 
             output.WriteLine("Silos restarted");
 
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
             Assert.Equal(initialServiceId,  this.HostedCluster.ClusterConfiguration.Globals.ServiceId);  // "ServiceId same after restart."
             
             val = await grain.GetValue();

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
@@ -65,7 +65,7 @@ namespace Tester.AzureUtils.Persistence
                 gatewayOptions.ConnectionString = TestDefaultConfiguration.DataConnectionString;
             })
             .AddApplicationPartsFromAppDomain()
-            .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(config.ClientName, config.DeploymentId)));
+            .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(config.ClientName, config.ClusterId)));
 
         public static IProviderConfiguration GetNamedProviderConfigForShardedProvider(IEnumerable<KeyValuePair<string, IProviderConfiguration>> providers, string providerName)
         {

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
@@ -55,7 +55,7 @@ namespace Tester.AzureUtils.Persistence
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.MaxStorageBusyRetries = 3;
                     })
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
         }
 
@@ -308,7 +308,7 @@ namespace Tester.AzureUtils.Persistence
         {
             var initialServiceId = this.HostedCluster.ClusterConfiguration.Globals.ServiceId;
 
-            output.WriteLine("DeploymentId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
 
             Guid id = Guid.NewGuid();
             IAzureStorageTestGrain grain = this.GrainFactory.GetGrain<IAzureStorageTestGrain>(id);
@@ -328,7 +328,7 @@ namespace Tester.AzureUtils.Persistence
 
             output.WriteLine("Silos restarted");
 
-            output.WriteLine("DeploymentId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
             Assert.Equal(initialServiceId,  this.HostedCluster.ClusterConfiguration.Globals.ServiceId);  // "ServiceId same after restart."
             
             val = await grain.GetValue();

--- a/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -62,31 +62,31 @@ namespace Tester.AzureUtils.TimerTests
         [SkippableFact, TestCategory("ReminderService")]
         public async Task Reminders_AzureTable_InsertNewRowAndReadBack()
         {
-            string deploymentId = NewDeploymentId();
+            string clusterId = NewClusterId();
             IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory);
             var config = new GlobalConfiguration()
             {
                 ServiceId = ServiceId,
-                ClusterId = deploymentId,
+                ClusterId = clusterId,
                 DataConnectionString = TestDefaultConfiguration.DataConnectionString
             };
             await table.Init(config);
 
             ReminderEntry[] rows = (await GetAllRows(table)).ToArray();
-            Assert.Empty(rows); // "The reminder table (sid={0}, did={1}) was not empty.", ServiceId, deploymentId);
+            Assert.Empty(rows); // "The reminder table (sid={0}, did={1}) was not empty.", ServiceId, clusterId);
 
             ReminderEntry expected = NewReminderEntry();
             await table.UpsertRow(expected);
             rows = (await GetAllRows(table)).ToArray();
 
-            Assert.Single(rows); // "The reminder table (sid={0}, did={1}) did not contain the correct number of rows (1).", ServiceId, deploymentId);
+            Assert.Single(rows); // "The reminder table (sid={0}, did={1}) did not contain the correct number of rows (1).", ServiceId, clusterId);
             ReminderEntry actual = rows[0];
-            Assert.Equal(expected.GrainRef,  actual.GrainRef); // "The newly inserted reminder table (sid={0}, did={1}) row did not contain the expected grain reference.", ServiceId, deploymentId);
-            Assert.Equal(expected.ReminderName,  actual.ReminderName); // "The newly inserted reminder table (sid={0}, did={1}) row did not have the expected reminder name.", ServiceId, deploymentId);
-            Assert.Equal(expected.Period,  actual.Period); // "The newly inserted reminder table (sid={0}, did={1}) row did not have the expected period.", ServiceId, deploymentId);
+            Assert.Equal(expected.GrainRef,  actual.GrainRef); // "The newly inserted reminder table (sid={0}, did={1}) row did not contain the expected grain reference.", ServiceId, clusterId);
+            Assert.Equal(expected.ReminderName,  actual.ReminderName); // "The newly inserted reminder table (sid={0}, did={1}) row did not have the expected reminder name.", ServiceId, clusterId);
+            Assert.Equal(expected.Period,  actual.Period); // "The newly inserted reminder table (sid={0}, did={1}) row did not have the expected period.", ServiceId, clusterId);
             // the following assertion fails but i don't know why yet-- the timestamps appear identical in the error message. it's not really a priority to hunt down the reason, however, because i have high confidence it is working well enough for the moment.
-            /*Assert.Equal(expected.StartAt,  actual.StartAt); // "The newly inserted reminder table (sid={0}, did={1}) row did not contain the correct start time.", ServiceId, deploymentId);*/
-            Assert.False(string.IsNullOrWhiteSpace(actual.ETag), $"The newly inserted reminder table (sid={ServiceId}, did={deploymentId}) row contains an invalid etag.");
+            /*Assert.Equal(expected.StartAt,  actual.StartAt); // "The newly inserted reminder table (sid={0}, did={1}) row did not contain the correct start time.", ServiceId, clusterId);*/
+            Assert.False(string.IsNullOrWhiteSpace(actual.ETag), $"The newly inserted reminder table (sid={ServiceId}, did={clusterId}) row contains an invalid etag.");
         }
 
         private async Task TestTableInsertRate(IReminderTable reminderTable, double numOfInserts)
@@ -144,7 +144,7 @@ namespace Tester.AzureUtils.TimerTests
                 };
         }
 
-        private string NewDeploymentId()
+        private string NewClusterId()
         {
             return string.Format("ReminderTest.{0}", Guid.NewGuid());
         }

--- a/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -50,7 +50,7 @@ namespace Tester.AzureUtils.TimerTests
             var config = new GlobalConfiguration()
             {
                 ServiceId = ServiceId,
-                DeploymentId = "TMSLocalTesting",
+                ClusterId = "TMSLocalTesting",
                 DataConnectionString = TestDefaultConfiguration.DataConnectionString
             };
             await table.Init(config);
@@ -67,7 +67,7 @@ namespace Tester.AzureUtils.TimerTests
             var config = new GlobalConfiguration()
             {
                 ServiceId = ServiceId,
-                DeploymentId = deploymentId,
+                ClusterId = deploymentId,
                 DataConnectionString = TestDefaultConfiguration.DataConnectionString
             };
             await table.Init(config);

--- a/test/TesterAzureUtils/SiloInstanceTableManagerTests.cs
+++ b/test/TesterAzureUtils/SiloInstanceTableManagerTests.cs
@@ -48,7 +48,7 @@ namespace Tester.AzureUtils
             generation = SiloAddress.AllocateNewGeneration();
             siloAddress = SiloAddressUtils.NewLocalSiloAddress(generation);
 
-            output.WriteLine("DeploymentId={0} Generation={1}", deploymentId, generation);
+            output.WriteLine("ClusterId={0} Generation={1}", deploymentId, generation);
 
             output.WriteLine("Initializing SiloInstanceManager");
             manager = OrleansSiloInstanceManager.GetManager(deploymentId, TestDefaultConfiguration.DataConnectionString, fixture.LoggerFactory)

--- a/test/TesterAzureUtils/SiloInstanceTableManagerTests.cs
+++ b/test/TesterAzureUtils/SiloInstanceTableManagerTests.cs
@@ -33,7 +33,7 @@ namespace Tester.AzureUtils
             }
         }
 
-        private string deploymentId;
+        private string clusterId;
         private int generation;
         private SiloAddress siloAddress;
         private SiloInstanceTableEntry myEntry;
@@ -44,14 +44,14 @@ namespace Tester.AzureUtils
         {
             TestUtils.CheckForAzureStorage();
             this.output = output;
-            deploymentId = "test-" + Guid.NewGuid();
+            this.clusterId = "test-" + Guid.NewGuid();
             generation = SiloAddress.AllocateNewGeneration();
             siloAddress = SiloAddressUtils.NewLocalSiloAddress(generation);
 
-            output.WriteLine("ClusterId={0} Generation={1}", deploymentId, generation);
+            output.WriteLine("ClusterId={0} Generation={1}", this.clusterId, generation);
 
             output.WriteLine("Initializing SiloInstanceManager");
-            manager = OrleansSiloInstanceManager.GetManager(deploymentId, TestDefaultConfiguration.DataConnectionString, fixture.LoggerFactory)
+            manager = OrleansSiloInstanceManager.GetManager(this.clusterId, TestDefaultConfiguration.DataConnectionString, fixture.LoggerFactory)
                 .WaitForResultWithThrow(SiloInstanceTableTestConstants.Timeout);
         }
 
@@ -64,7 +64,7 @@ namespace Tester.AzureUtils
 
                 output.WriteLine("TestCleanup Timeout={0}", timeout);
 
-                manager.DeleteTableEntries(deploymentId).WaitWithThrow(timeout);
+                manager.DeleteTableEntries(this.clusterId).WaitWithThrow(timeout);
 
                 output.WriteLine("TestCleanup -  Finished");
                 manager = null;
@@ -206,7 +206,7 @@ namespace Tester.AzureUtils
 
         private void RegisterSiloInstance()
         {
-            string partitionKey = deploymentId;
+            string partitionKey = this.clusterId;
             string rowKey = SiloInstanceTableEntry.ConstructRowKey(siloAddress);
 
             IPEndPoint myEndpoint = siloAddress.Endpoint;
@@ -216,7 +216,7 @@ namespace Tester.AzureUtils
                 PartitionKey = partitionKey,
                 RowKey = rowKey,
 
-                DeploymentId = deploymentId,
+                DeploymentId = this.clusterId,
                 Address = myEndpoint.Address.ToString(),
                 Port = myEndpoint.Port.ToString(CultureInfo.InvariantCulture),
                 Generation = generation.ToString(CultureInfo.InvariantCulture),
@@ -238,7 +238,7 @@ namespace Tester.AzureUtils
 
         private async Task<Tuple<SiloInstanceTableEntry, string>> FindSiloEntry(SiloAddress siloAddr)
         {
-            string partitionKey = deploymentId;
+            string partitionKey = this.clusterId;
             string rowKey = SiloInstanceTableEntry.ConstructRowKey(siloAddr);
 
             output.WriteLine("FindSiloEntry for SiloAddress={0} PartitionKey={1} RowKey={2}", siloAddr, partitionKey, rowKey);

--- a/test/TesterAzureUtils/Streaming/AQClientStreamTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQClientStreamTests.cs
@@ -42,9 +42,9 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.ClusterId;
             base.Dispose();
-            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AQStreamProviderName, deploymentId,
+            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AQStreamProviderName, clusterId,
                 TestDefaultConfiguration.DataConnectionString).Wait();
             TestAzureTableStorageStreamFailureHandler.DeleteAll().Wait();
         }

--- a/test/TesterAzureUtils/Streaming/AQClientStreamTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQClientStreamTests.cs
@@ -42,7 +42,7 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.DeploymentId;
+            var deploymentId = HostedCluster.ClusterId;
             base.Dispose();
             AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AQStreamProviderName, deploymentId,
                 TestDefaultConfiguration.DataConnectionString).Wait();

--- a/test/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
@@ -16,7 +16,7 @@ namespace Tester.AzureUtils.Streaming
     [TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
     public class StreamFilteringTests_AQ : StreamFilteringTestsBase, IClassFixture<StreamFilteringTests_AQ.Fixture>, IDisposable
     {
-        private readonly string deploymentId;
+        private readonly string clusterId;
         public class Fixture : BaseAzureTestClusterFixture
         {
             public const string StreamProvider = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
@@ -32,9 +32,9 @@ namespace Tester.AzureUtils.Streaming
 
             public override void Dispose()
             {
-                var deploymentId = this.HostedCluster?.ClusterId;
+                var clusterId = this.HostedCluster?.ClusterId;
                 base.Dispose();
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProvider, deploymentId, TestDefaultConfiguration.DataConnectionString)
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProvider, clusterId, TestDefaultConfiguration.DataConnectionString)
                     .Wait();
             }
         }
@@ -42,7 +42,7 @@ namespace Tester.AzureUtils.Streaming
         public StreamFilteringTests_AQ(Fixture fixture) : base(fixture)
         {
             fixture.EnsurePreconditionsMet();
-            this.deploymentId = fixture.HostedCluster.ClusterId;
+            this.clusterId = fixture.HostedCluster.ClusterId;
             streamProviderName = Fixture.StreamProvider;
         }
 
@@ -50,7 +50,7 @@ namespace Tester.AzureUtils.Streaming
         {
                 AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(NullLoggerFactory.Instance, 
                     streamProviderName,
-                    this.deploymentId,
+                    this.clusterId,
                     TestDefaultConfiguration.DataConnectionString).Wait();
             }
 

--- a/test/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
@@ -32,7 +32,7 @@ namespace Tester.AzureUtils.Streaming
 
             public override void Dispose()
             {
-                var deploymentId = this.HostedCluster?.DeploymentId;
+                var deploymentId = this.HostedCluster?.ClusterId;
                 base.Dispose();
                 AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProvider, deploymentId, TestDefaultConfiguration.DataConnectionString)
                     .Wait();
@@ -42,7 +42,7 @@ namespace Tester.AzureUtils.Streaming
         public StreamFilteringTests_AQ(Fixture fixture) : base(fixture)
         {
             fixture.EnsurePreconditionsMet();
-            this.deploymentId = fixture.HostedCluster.DeploymentId;
+            this.deploymentId = fixture.HostedCluster.ClusterId;
             streamProviderName = Fixture.StreamProvider;
         }
 

--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -45,9 +45,9 @@ namespace Tester.AzureUtils.Streaming
         
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.ClusterId;
             base.Dispose();
-            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
         }
 
         ////------------------------ One to One ----------------------//

--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -45,7 +45,7 @@ namespace Tester.AzureUtils.Streaming
         
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.DeploymentId;
+            var deploymentId = HostedCluster.ClusterId;
             base.Dispose();
             AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
         }

--- a/test/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
@@ -36,7 +36,7 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.DeploymentId;
+            var deploymentId = HostedCluster.ClusterId;
             base.Dispose();
             AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AQStreamProviderName, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
         }

--- a/test/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
@@ -36,9 +36,9 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.ClusterId;
             base.Dispose();
-            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AQStreamProviderName, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AQStreamProviderName, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
         }
         
         [SkippableFact, TestCategory("Functional")]

--- a/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -30,7 +30,7 @@ namespace Tester.AzureUtils.Streaming
         private readonly TestEnvironmentFixture fixture;
         private const int NumBatches = 20;
         private const int NumMessagesPerBatch = 20;
-        private string deploymentId;
+        private string clusterId;
         public static readonly string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AQAdapterTests";
         private readonly ILoggerFactory loggerFactory;
         private static readonly SafeRandom Random = new SafeRandom();
@@ -39,14 +39,14 @@ namespace Tester.AzureUtils.Streaming
         {
             this.output = output;
             this.fixture = fixture;
-            this.deploymentId = MakeDeploymentId();
+            this.clusterId = MakeClusterId();
             this.loggerFactory = this.fixture.Services.GetService<ILoggerFactory>();
             BufferPool.InitGlobalBufferPool(Options.Create(new SiloMessagingOptions()));
         }
         
         public void Dispose()
         {
-            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(this.loggerFactory, AZURE_QUEUE_STREAM_PROVIDER_NAME, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(this.loggerFactory, AZURE_QUEUE_STREAM_PROVIDER_NAME, this.clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
         }
 
         [SkippableFact, TestCategory("Functional"), TestCategory("Halo")]
@@ -55,7 +55,7 @@ namespace Tester.AzureUtils.Streaming
             var properties = new Dictionary<string, string>
                 {
                     {AzureQueueAdapterConstants.DataConnectionStringPropertyName, TestDefaultConfiguration.DataConnectionString},
-                    {AzureQueueAdapterConstants.DeploymentIdPropertyName, deploymentId},
+                    {AzureQueueAdapterConstants.DeploymentIdPropertyName, this.clusterId},
                     {AzureQueueAdapterConstants.MessageVisibilityTimeoutPropertyName, "00:00:30" }
                 };
             var config = new ProviderConfiguration(properties, "type", "name");
@@ -191,9 +191,9 @@ namespace Tester.AzureUtils.Streaming
             }).ToList();
         }
 
-        internal static string MakeDeploymentId()
+        internal static string MakeClusterId()
         {
-            const string DeploymentIdFormat = "deployment-{0}";
+            const string DeploymentIdFormat = "cluster-{0}";
             string now = DateTime.UtcNow.ToString("yyyy-MM-dd-hh-mm-ss-ffff");
             return String.Format(DeploymentIdFormat, now);
         }

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -48,11 +48,11 @@ namespace UnitTests.HaloTests.Streaming
 
             public override void Dispose()
             {
-                var deploymentId = this.HostedCluster?.ClusterId;
+                var clusterId = this.HostedCluster?.ClusterId;
                 base.Dispose();
-                if (deploymentId != null)
+                if (clusterId != null)
                 {
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AzureQueueStreamProviderName, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AzureQueueStreamProviderName, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
                 }
             }
         }
@@ -76,10 +76,10 @@ namespace UnitTests.HaloTests.Streaming
 
         public void Dispose()
         {
-            var deploymentId = this.HostedCluster?.ClusterId;
-            if (deploymentId != null && _streamProvider != null && _streamProvider.Equals(AzureQueueStreamProviderName))
+            var clusterId = this.HostedCluster?.ClusterId;
+            if (clusterId != null && _streamProvider != null && _streamProvider.Equals(AzureQueueStreamProviderName))
             {
-                AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(this.loggerFactory, _streamProvider, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+                AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(this.loggerFactory, _streamProvider, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
             }
         }
 

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -48,7 +48,7 @@ namespace UnitTests.HaloTests.Streaming
 
             public override void Dispose()
             {
-                var deploymentId = this.HostedCluster?.DeploymentId;
+                var deploymentId = this.HostedCluster?.ClusterId;
                 base.Dispose();
                 if (deploymentId != null)
                 {
@@ -76,7 +76,7 @@ namespace UnitTests.HaloTests.Streaming
 
         public void Dispose()
         {
-            var deploymentId = this.HostedCluster?.DeploymentId;
+            var deploymentId = this.HostedCluster?.ClusterId;
             if (deploymentId != null && _streamProvider != null && _streamProvider.Equals(AzureQueueStreamProviderName))
             {
                 AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(this.loggerFactory, _streamProvider, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();

--- a/test/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
@@ -33,10 +33,10 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster?.ClusterId;
-            if (deploymentId != null)
+            var clusterId = HostedCluster?.ClusterId;
+            if (clusterId != null)
             {
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProvider, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProvider, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
             }
         }
 

--- a/test/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
@@ -33,7 +33,7 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var deploymentId = HostedCluster?.DeploymentId;
+            var deploymentId = HostedCluster?.ClusterId;
             if (deploymentId != null)
             {
                 AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProvider, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -108,7 +108,7 @@ namespace UnitTests.Streaming.Reliability
             }
             Task.WhenAll(promises).Wait();
 #endif
-            var deploymentId = HostedCluster.DeploymentId;
+            var deploymentId = HostedCluster.ClusterId;
             base.Dispose();
             if (_streamProviderName != null && _streamProviderName.Equals(AZURE_QUEUE_STREAM_PROVIDER_NAME))
             {

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -71,7 +71,7 @@ namespace UnitTests.Streaming.Reliability
                 gatewayOptions.ConnectionString = TestDefaultConfiguration.DataConnectionString;
             })
             .AddApplicationPartsFromAppDomain()
-            .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(config.ClientName, config.DeploymentId)));
+            .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(config.ClientName, config.ClusterId)));
 
         public class SiloBuilderFactory : ISiloBuilderFactory
         {

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -108,11 +108,11 @@ namespace UnitTests.Streaming.Reliability
             }
             Task.WhenAll(promises).Wait();
 #endif
-            var deploymentId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.ClusterId;
             base.Dispose();
             if (_streamProviderName != null && _streamProviderName.Equals(AZURE_QUEUE_STREAM_PROVIDER_NAME))
             {
-                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, _streamProviderName, deploymentId, TestDefaultConfiguration.DataConnectionString).Wait();
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, _streamProviderName, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
             }
         }
 

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -85,7 +85,7 @@ namespace UnitTests.Streaming.Reliability
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.MaxStorageBusyRetries = 3;
                     })
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
         }
 

--- a/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
@@ -53,7 +53,7 @@ namespace Tests.GeoClusterTests
                     return new SiloHostBuilder()
                         .ConfigureSiloName(siloName)
                         .UseConfiguration(clusterConfiguration)
-                        .ConfigureServices(services => ConfigureLogging(services, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                        .ConfigureServices(services => ConfigureLogging(services, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
                 }
 
                 private void ConfigureLogging(IServiceCollection services, string filePath)

--- a/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -170,7 +170,7 @@ namespace Tests.GeoClusterTests
                 return new SiloHostBuilder()
                     .ConfigureSiloName(siloName)
                     .UseConfiguration(clusterConfiguration)
-                    .ConfigureLogging(builder => ConfigureLogging(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(builder => ConfigureLogging(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
 
             private void ConfigureLogging(ILoggingBuilder builder, string filePath)

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -66,7 +66,7 @@ namespace UnitTests.MembershipTests
 
             clientConfiguration = new ClientConfiguration
             {
-                DeploymentId = globalConfiguration.ClusterId,
+                ClusterId = globalConfiguration.ClusterId,
                 AdoInvariant = globalConfiguration.AdoInvariant,
                 DataConnectionString = globalConfiguration.DataConnectionString
             };

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -50,13 +50,13 @@ namespace UnitTests.MembershipTests
 
             deploymentId = "test-" + Guid.NewGuid();
 
-            logger.Info("DeploymentId={0}", deploymentId);
+            logger.Info("ClusterId={0}", deploymentId);
 
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
             this.connectionString = fixture.ConnectionString;
             globalConfiguration = new GlobalConfiguration
             {
-                DeploymentId = deploymentId,
+                ClusterId = deploymentId,
                 AdoInvariant = GetAdoInvariant(),
                 DataConnectionString = fixture.ConnectionString
             };
@@ -66,7 +66,7 @@ namespace UnitTests.MembershipTests
 
             clientConfiguration = new ClientConfiguration
             {
-                DeploymentId = globalConfiguration.DeploymentId,
+                DeploymentId = globalConfiguration.ClusterId,
                 AdoInvariant = globalConfiguration.AdoInvariant,
                 DataConnectionString = globalConfiguration.DataConnectionString
             };

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -36,7 +36,7 @@ namespace UnitTests.MembershipTests
         private readonly Logger logger;
         private readonly IMembershipTable membershipTable;
         private readonly IGatewayListProvider gatewayListProvider;
-        protected readonly string deploymentId;
+        protected readonly string clusterId;
         protected readonly string connectionString;
         protected ILoggerFactory loggerFactory;
         protected GlobalConfiguration globalConfiguration;
@@ -48,15 +48,15 @@ namespace UnitTests.MembershipTests
             loggerFactory = TestingUtils.CreateDefaultLoggerFactory($"{this.GetType()}.log", filters);
             logger = new LoggerWrapper<MembershipTableTestsBase>(loggerFactory);
 
-            deploymentId = "test-" + Guid.NewGuid();
+            this.clusterId = "test-" + Guid.NewGuid();
 
-            logger.Info("ClusterId={0}", deploymentId);
+            logger.Info("ClusterId={0}", this.clusterId);
 
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
             this.connectionString = fixture.ConnectionString;
             globalConfiguration = new GlobalConfiguration
             {
-                ClusterId = deploymentId,
+                ClusterId = this.clusterId,
                 AdoInvariant = GetAdoInvariant(),
                 DataConnectionString = fixture.ConnectionString
             };
@@ -85,7 +85,7 @@ namespace UnitTests.MembershipTests
         {
             if (membershipTable != null && SiloInstanceTableTestConstants.DeleteEntriesAfterTest)
             {
-                membershipTable.DeleteMembershipTableEntries(deploymentId).Wait();
+                membershipTable.DeleteMembershipTableEntries(this.clusterId).Wait();
             }
             this.loggerFactory.Dispose();
         }

--- a/test/TesterInternal/MockStatsCollectors.cs
+++ b/test/TesterInternal/MockStatsCollectors.cs
@@ -76,7 +76,7 @@ namespace UnitTests.Stats
             return Task.CompletedTask;
         }
 
-        public Task Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName,
+        public Task Init(bool isSilo, string storageConnectionString, string clusterId, string address, string siloName,
             string hostName)
         {
             return Task.CompletedTask;
@@ -110,7 +110,7 @@ namespace UnitTests.Stats
             return Task.CompletedTask;
         }
 
-        public Task Init(string deploymentId, string storageConnectionString, SiloAddress siloAddress, string siloName,
+        public Task Init(string clusterId, string storageConnectionString, SiloAddress siloAddress, string siloName,
             IPEndPoint gateway, string hostName)
         {
             throw new NotImplementedException();
@@ -129,7 +129,7 @@ namespace UnitTests.Stats
             return Task.CompletedTask;
         }
 
-        public Task Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName,
+        public Task Init(bool isSilo, string storageConnectionString, string clusterId, string address, string siloName,
             string hostName)
         {
             return Task.CompletedTask;

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -31,16 +31,16 @@ namespace UnitTests.RemindersTest
             this.ClusterFixture = clusterFixture;
             logger = loggerFactory.CreateLogger<ReminderTableTestsBase>();
             var serviceId = Guid.NewGuid();
-            var deploymentId = "test-" + serviceId;
+            var clusterId = "test-" + serviceId;
 
-            logger.Info("ClusterId={0}", deploymentId);
+            logger.Info("ClusterId={0}", clusterId);
 
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
 
             var globalConfiguration = new GlobalConfiguration
             {
                 ServiceId = serviceId,
-                ClusterId = deploymentId,
+                ClusterId = clusterId,
                 AdoInvariantForReminders = GetAdoInvariant(),
                 DataConnectionStringForReminders = fixture.ConnectionString
             };

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -33,14 +33,14 @@ namespace UnitTests.RemindersTest
             var serviceId = Guid.NewGuid();
             var deploymentId = "test-" + serviceId;
 
-            logger.Info("DeploymentId={0}", deploymentId);
+            logger.Info("ClusterId={0}", deploymentId);
 
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
 
             var globalConfiguration = new GlobalConfiguration
             {
                 ServiceId = serviceId,
-                DeploymentId = deploymentId,
+                ClusterId = deploymentId,
                 AdoInvariantForReminders = GetAdoInvariant(),
                 DataConnectionStringForReminders = fixture.ConnectionString
             };

--- a/test/TesterInternal/StreamProvidersTests.cs
+++ b/test/TesterInternal/StreamProvidersTests.cs
@@ -87,7 +87,7 @@ namespace UnitTests.Streaming
 
             output.WriteLine("..... Silos restarted");
 
-            output.WriteLine("DeploymentId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
 
             Assert.Equal(ServiceId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);  // "ServiceId same after restart."
 

--- a/test/TesterInternal/StreamProvidersTests.cs
+++ b/test/TesterInternal/StreamProvidersTests.cs
@@ -87,7 +87,7 @@ namespace UnitTests.Streaming
 
             output.WriteLine("..... Silos restarted");
 
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.DeploymentId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);
 
             Assert.Equal(ServiceId, this.HostedCluster.ClusterConfiguration.Globals.ServiceId);  // "ServiceId same after restart."
 

--- a/test/TesterInternal/TimerTests/ReminderTests_Base.cs
+++ b/test/TesterInternal/TimerTests/ReminderTests_Base.cs
@@ -51,7 +51,7 @@ namespace UnitTests.TimerTests
             filters.AddFilter("Reminder", LogLevel.Trace);
 #endif
 
-            log = new LoggerWrapper<ReminderTests_Base>(TestingUtils.CreateDefaultLoggerFactory(TestingUtils.CreateTraceFileName(configuration.ClientName, configuration.DeploymentId), filters));
+            log = new LoggerWrapper<ReminderTests_Base>(TestingUtils.CreateDefaultLoggerFactory(TestingUtils.CreateTraceFileName(configuration.ClientName, configuration.ClusterId), filters));
         }
 
         public IGrainFactory GrainFactory { get; }

--- a/test/TesterZooKeeperUtils/LivenessTests.cs
+++ b/test/TesterZooKeeperUtils/LivenessTests.cs
@@ -39,7 +39,7 @@ namespace Tester.ZooKeeperUtils
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     })
-                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                    .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
         }
 

--- a/test/Versions/TestVersionGrains/VersionGrainsSiloBuilderfactory.cs
+++ b/test/Versions/TestVersionGrains/VersionGrainsSiloBuilderfactory.cs
@@ -22,7 +22,7 @@ namespace TestVersionGrains
                 .ConfigureServices(this.ConfigureServices)
                 .AddApplicationPartsFromAppDomain()
                 .AddApplicationPartsFromBasePath()
-                .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.DeploymentId)));
+                .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
         }
 
         private void ConfigureServices(IServiceCollection services)


### PR DESCRIPTION
Related to #3694 
Rename most usages of `DeploymentId` to `ClusterId`. This pass should be mostly back-compat.
I did not modify the providers that write a `DeploymentId` column to storage, as this would break in non-trivial ways, nor did I change the legacy configuration objects that parse the `DeploymentId` value (for both the main cluster id, as well as provider specific configuration that uses `DeploymentId` today). We plan to keep those object as legacy anyway, the new config system would use ClusterId as the new name for their strongly typed options.

Note to reviewers, I did split into a few commits that are probably easier to review in isolation, as they are doing similar things.