### PR TITLE
Clear transaction context in top level transaction

### DIFF
--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -468,14 +468,12 @@ namespace Orleans.Runtime
                         this.transactionAgent.Value.Abort(TransactionContext.GetTransactionInfo(), abortException);
                     }
                 }
-                catch (Exception) { }
                 finally
                 {
                     TransactionContext.Clear();
+                    if (message.Direction != Message.Directions.OneWay)
+                        SafeSendExceptionResponse(message, exc2);
                 }
-
-                if (message.Direction != Message.Directions.OneWay)
-                    SafeSendExceptionResponse(message, exc2);
             }
             finally
             {

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -411,6 +411,7 @@ namespace Orleans.Runtime
 
                     if (message.Direction != Message.Directions.OneWay)
                     {
+                        TransactionContext.Clear();
                         SafeSendExceptionResponse(message, exc1);
                     }
                     return;
@@ -430,6 +431,7 @@ namespace Orleans.Runtime
 
                     if (message.Direction != Message.Directions.OneWay)
                     {
+                        TransactionContext.Clear();
                         SafeSendExceptionResponse(message, abortException);
                     }
 
@@ -440,6 +442,7 @@ namespace Orleans.Runtime
                 {
                     // This request started the transaction, so we try to commit before returning.
                     await this.transactionAgent.Value.Commit(transactionInfo);
+                    TransactionContext.Clear();
                 }
 
                 if (message.Direction == Message.Directions.OneWay) return;
@@ -449,21 +452,30 @@ namespace Orleans.Runtime
             catch (Exception exc2)
             {
                 logger.Warn(ErrorCode.Runtime_Error_100329, "Exception during Invoke of message: " + message, exc2);
+
+                try
+                {
+                    if (exc2 is OrleansTransactionInDoubtException)
+                    {
+                        this.logger.LogError(exc2, "Transaction failed due to in doubt transaction");
+                    }
+                    else if (TransactionContext.GetTransactionInfo() != null)
+                    {
+                        // Must abort the transaction on exceptions
+                        TransactionContext.GetTransactionInfo().IsAborted = true;
+                        var abortException = (exc2 as OrleansTransactionAbortedException) ??
+                            new OrleansTransactionAbortedException(TransactionContext.GetTransactionInfo().TransactionId, exc2);
+                        this.transactionAgent.Value.Abort(TransactionContext.GetTransactionInfo(), abortException);
+                    }
+                }
+                catch (Exception) { }
+                finally
+                {
+                    TransactionContext.Clear();
+                }
+
                 if (message.Direction != Message.Directions.OneWay)
                     SafeSendExceptionResponse(message, exc2);
-
-                if (exc2 is OrleansTransactionInDoubtException)
-                {
-                    this.logger.LogError(exc2, "Transaction failed due to in doubt transaction");
-                }
-                else if (TransactionContext.GetTransactionInfo() != null)
-                {
-                    // Must abort the transaction on exceptions
-                    TransactionContext.GetTransactionInfo().IsAborted = true;
-                    var abortException = (exc2 as OrleansTransactionAbortedException) ?? 
-                        new OrleansTransactionAbortedException(TransactionContext.GetTransactionInfo().TransactionId, exc2);
-                    this.transactionAgent.Value.Abort(TransactionContext.GetTransactionInfo(), abortException);
-                }
             }
             finally
             {


### PR DESCRIPTION
Clear transaction context in top level transaction to prevent context from being passed back to the caller.

Context returned to the caller created a dependency on the transaction assembly for Orleans clients.  That assembly should be silo only.
