### PR TITLE
Fix null reference exceptions on not started AsynchQueueAgent usage attempt

### DIFF
--- a/src/Orleans.Core/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ProxiedMessageCenter.cs
@@ -271,13 +271,17 @@ namespace Orleans.Messaging
             if (startRequired)
             {
                 gatewayConnection.Start();
+            }
+            else
+            {
+                gatewayConnection.WaitInitialization();
+            }
 
-                if (!gatewayConnection.IsLive)
-                {
-                    // if failed to start Gateway connection (failed to connect), try sending this msg to another Gateway.
-                    RejectOrResend(msg);
-                    return;
-                }
+            if (!gatewayConnection.IsLive)
+            {
+                // if failed to start Gateway connection (failed to connect), try sending this msg to another Gateway.
+                RejectOrResend(msg);
+                return;
             }
 
             try

--- a/src/Orleans.Core/Runtime/AsynchAgent.cs
+++ b/src/Orleans.Core/Runtime/AsynchAgent.cs
@@ -55,7 +55,6 @@ namespace Orleans.Runtime
 
             this.executorService = executorService;
             AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
-            EnsureExecutorInitialized();
 
 #if TRACK_DETAILED_STATS
             if (StatisticsCollector.CollectThreadTimeTrackingStats)

--- a/src/Orleans.Core/Runtime/AsynchQueueAgent.cs
+++ b/src/Orleans.Core/Runtime/AsynchQueueAgent.cs
@@ -19,6 +19,11 @@ namespace Orleans.Runtime
 
         public void QueueRequest(T request)
         {
+            if (State == ThreadState.Stopped)
+            {
+                throw new InvalidOperationException("Not started agent usage attempt");
+            }
+
             executor.QueueWorkItem(ProcessAction, request);
         }
 

--- a/src/Orleans.Core/Runtime/AsynchQueueAgent.cs
+++ b/src/Orleans.Core/Runtime/AsynchQueueAgent.cs
@@ -19,9 +19,9 @@ namespace Orleans.Runtime
 
         public void QueueRequest(T request)
         {
-            if (State == ThreadState.Stopped)
+            if (State != ThreadState.Running)
             {
-                throw new InvalidOperationException("Not started agent usage attempt");
+                throw new InvalidOperationException("Not running agent usage attempt");
             }
 
             executor.QueueWorkItem(ProcessAction, request);


### PR DESCRIPTION
After merge of https://github.com/dotnet/orleans/pull/3683 the null reference exceptions started to appear in `ProxiedMessageCenter.SendMessage` method. ([test fail 1](
https://ci.dot.net/job/dotnet_orleans/job/master/job/functional_prtest/654/consoleFull), [test fail 2](https://ci.dot.net/job/dotnet_orleans/job/master/job/functional_prtest/664/consoleFull )) 
Their cause seems to be in race condition between [adding](https://github.com/dotnet/orleans/blob/master/src/Orleans.Core/Messaging/ProxiedMessageCenter.cs#L194) of just created `GatewayConnection` (which is `AsynchQueueAgent`) to the list of connections, and [it's start](https://github.com/dotnet/orleans/blob/master/src/Orleans.Core/Messaging/ProxiedMessageCenter.cs#L273) , thus dictionary contains not ready to use connection for duration of it's `Start` method.
