### PR TITLE
Re-enable multi-cluster setting in tests that require it

### DIFF
--- a/test/TestServiceFabric/FabricMembershipOracleTests.cs
+++ b/test/TestServiceFabric/FabricMembershipOracleTests.cs
@@ -38,6 +38,7 @@ namespace TestServiceFabric
 
             this.resolver = new MockResolver();
             var globalConfig = new ClusterConfiguration().Globals;
+            globalConfig.HasMultiClusterNetwork = true;
             globalConfig.MaxMultiClusterGateways = 2;
             globalConfig.ClusterId = "MegaGoodCluster";
 

--- a/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -146,6 +146,7 @@ namespace Tests.GeoClusterTests
                     // configure multi-cluster network
                     config.Globals.ServiceId = globalServiceId;
                     config.Globals.ClusterId = clusterId;
+                    config.Globals.HasMultiClusterNetwork = true;
                     config.Globals.MaxMultiClusterGateways = 2;
                     config.Globals.DefaultMultiCluster = null;
 


### PR DESCRIPTION
Previously it was inferred only if ClusterId was set. Now ClusterId is always set (as it was collapsed with DeploymentId), so there is an explicit setting for multi-cluster.