### PR TITLE
Move configuration to typed options

### DIFF
--- a/src/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -23,12 +23,12 @@ namespace Orleans.Runtime.MembershipService
         private OrleansSiloInstanceManager tableManager;
         private readonly AzureTableMembershipOptions options;
         private readonly string clusterId;
-        public AzureBasedMembershipTable(ILoggerFactory loggerFactory, IOptions<AzureTableMembershipOptions> membershipOptions, GlobalConfiguration globalConfiguration)
+        public AzureBasedMembershipTable(ILoggerFactory loggerFactory, IOptions<AzureTableMembershipOptions> membershipOptions, IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<AzureBasedMembershipTable>();
             this.options = membershipOptions.Value;
-            this.clusterId = globalConfiguration.ClusterId;
+            this.clusterId = siloIdentityOptions.Value.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -23,12 +23,12 @@ namespace Orleans.Runtime.MembershipService
         private OrleansSiloInstanceManager tableManager;
         private readonly AzureTableMembershipOptions options;
         private readonly string clusterId;
-        public AzureBasedMembershipTable(ILoggerFactory loggerFactory, IOptions<AzureTableMembershipOptions> membershipOptions, IOptions<SiloIdentityOptions> siloIdentityOptions)
+        public AzureBasedMembershipTable(ILoggerFactory loggerFactory, IOptions<AzureTableMembershipOptions> membershipOptions, IOptions<SiloOptions> siloOptions)
         {
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<AzureBasedMembershipTable>();
             this.options = membershipOptions.Value;
-            this.clusterId = siloIdentityOptions.Value.ClusterId;
+            this.clusterId = siloOptions.Value.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -24,9 +24,9 @@ namespace Orleans.Runtime.Membership
         private readonly string clusterId;
 
         public ConsulBasedMembershipTable(ILogger<ConsulBasedMembershipTable> logger,
-            IOptions<ConsulMembershipOptions> membershipTableOptions, IOptions<SiloIdentityOptions> siloIdentityOptions)
+            IOptions<ConsulMembershipOptions> membershipTableOptions, IOptions<SiloOptions> siloOptions)
         {
-            this.clusterId = siloIdentityOptions.Value.ClusterId;
+            this.clusterId = siloOptions.Value.ClusterId;
             this._logger = logger;
             this.membershipTableOptions = membershipTableOptions.Value;
             _consulClient =

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -24,9 +24,9 @@ namespace Orleans.Runtime.Membership
         private readonly string clusterId;
 
         public ConsulBasedMembershipTable(ILogger<ConsulBasedMembershipTable> logger,
-            IOptions<ConsulMembershipOptions> membershipTableOptions, GlobalConfiguration globalConfiguration)
+            IOptions<ConsulMembershipOptions> membershipTableOptions, IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
-            this.clusterId = globalConfiguration.ClusterId;
+            this.clusterId = siloIdentityOptions.Value.ClusterId;
             this._logger = logger;
             this.membershipTableOptions = membershipTableOptions.Value;
             _consulClient =

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -56,12 +56,12 @@ namespace Orleans.Runtime.Membership
         /// </summary>
         private string rootConnectionString;
         
-        public ZooKeeperBasedMembershipTable(ILogger<ZooKeeperBasedMembershipTable> logger, IOptions<ZooKeeperMembershipOptions> membershipTableOptions, GlobalConfiguration globalConfiguration)
+        public ZooKeeperBasedMembershipTable(ILogger<ZooKeeperBasedMembershipTable> logger, IOptions<ZooKeeperMembershipOptions> membershipTableOptions, IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
             this.logger = logger;
             var options = membershipTableOptions.Value;
             watcher = new ZooKeeperWatcher(logger);
-            InitConfig(options.ConnectionString, globalConfiguration.ClusterId);
+            InitConfig(options.ConnectionString, siloIdentityOptions.Value.ClusterId);
         }
 
         /// <summary>

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -56,12 +56,12 @@ namespace Orleans.Runtime.Membership
         /// </summary>
         private string rootConnectionString;
         
-        public ZooKeeperBasedMembershipTable(ILogger<ZooKeeperBasedMembershipTable> logger, IOptions<ZooKeeperMembershipOptions> membershipTableOptions, IOptions<SiloIdentityOptions> siloIdentityOptions)
+        public ZooKeeperBasedMembershipTable(ILogger<ZooKeeperBasedMembershipTable> logger, IOptions<ZooKeeperMembershipOptions> membershipTableOptions, IOptions<SiloOptions> siloOptions)
         {
             this.logger = logger;
             var options = membershipTableOptions.Value;
             watcher = new ZooKeeperWatcher(logger);
-            InitConfig(options.ConnectionString, siloIdentityOptions.Value.ClusterId);
+            InitConfig(options.ConnectionString, siloOptions.Value.ClusterId);
         }
 
         /// <summary>

--- a/src/Orleans.Core/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core/Configuration/GlobalConfiguration.cs
@@ -827,9 +827,9 @@ namespace Orleans.Runtime.Configuration
                             ServiceId = ConfigUtilities.ParseGuid(child.GetAttribute("ServiceId"),
                                 "Invalid Guid value for the ServiceId attribute on the Azure element");
                         }
-                        if (child.HasAttribute("ClusterId"))
+                        if (child.HasAttribute("DeploymentId"))
                         {
-                            this.ClusterId = child.GetAttribute("ClusterId");
+                            this.ClusterId = child.GetAttribute("DeploymentId");
                         }
                         if (child.HasAttribute(Constants.DATA_CONNECTION_STRING_NAME))
                         {

--- a/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Options for configuring multi-cluster support
+    /// </summary>
+    public class MultiClusterOptions
+    {
+        /// <summary>
+        /// Whether this cluster is configured to be part of a multicluster network
+        /// </summary>
+        public bool HasMultiClusterNetwork { get; set; } = false;
+
+        /// <summary>
+        ///A list of cluster ids, to be used if no multicluster configuration is found in gossip channels.
+        /// </summary>
+        public IList<string> DefaultMultiCluster { get; set; } = new List<string>();
+
+        /// <summary>
+        /// The maximum number of silos per cluster should be designated to serve as gateways.
+        /// </summary>
+        public int MaxMultiClusterGateways { get; set; } = 10;
+
+        /// <summary>
+        /// The time between background gossips.
+        /// </summary>
+        public TimeSpan BackgroundGossipInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Whether to use the global single instance protocol as the default
+        /// multicluster registration strategy.
+        /// </summary>
+        public bool UseGlobalSingleInstanceByDefault { get; set; } = true;
+
+        /// <summary>
+        /// The number of quick retries before going into DOUBTFUL state.
+        /// </summary>
+        public int GlobalSingleInstanceNumberRetries { get; set; } = 10;
+
+        /// <summary>
+        /// The time between the slow retries for DOUBTFUL activations.
+        /// </summary>
+        public TimeSpan GlobalSingleInstanceRetryInterval { get; set; } = TimeSpan.FromSeconds(30);
+    }
+}

--- a/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
@@ -9,12 +9,12 @@ namespace Orleans.Hosting
     public class MultiClusterOptions
     {
         /// <summary>
-        /// Whether this cluster is configured to be part of a multicluster network
+        /// Whether this cluster is configured to be part of a multi-cluster network
         /// </summary>
         public bool HasMultiClusterNetwork { get; set; } = false;
 
         /// <summary>
-        ///A list of cluster ids, to be used if no multicluster configuration is found in gossip channels.
+        ///A list of cluster ids, to be used if no multi-cluster configuration is found in gossip channels.
         /// </summary>
         public IList<string> DefaultMultiCluster { get; set; } = new List<string>();
 
@@ -30,7 +30,7 @@ namespace Orleans.Hosting
 
         /// <summary>
         /// Whether to use the global single instance protocol as the default
-        /// multicluster registration strategy.
+        /// multi-cluster registration strategy.
         /// </summary>
         public bool UseGlobalSingleInstanceByDefault { get; set; } = true;
 

--- a/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
@@ -539,7 +539,7 @@ namespace Orleans.EventSourcing.Common
 
             if (notificationTracker != null)
             {
-                var remoteInstances = Services.RegistrationStrategy.GetRemoteInstances(newConfig, Services.MyClusterId).ToList();
+                var remoteInstances = Services.RegistrationStrategy.GetRemoteInstances(newConfig.Clusters, Services.MyClusterId).ToList();
                 notificationTracker.UpdateNotificationTargets(remoteInstances);
             }
         }
@@ -869,7 +869,7 @@ namespace Orleans.EventSourcing.Common
         /// <param name="exclude">if non-null, exclude this cluster id from the notification</param>
         protected void BroadcastNotification(INotificationMessage msg, string exclude = null)
         {
-            var remoteinstances = Services.RegistrationStrategy.GetRemoteInstances(Configuration, Services.MyClusterId);
+            var remoteinstances = Services.RegistrationStrategy.GetRemoteInstances(Configuration.Clusters, Services.MyClusterId);
 
             // if there is only one cluster, don't send notifications.
             if (remoteinstances.Count() == 0)

--- a/src/Orleans.Runtime/Core/ManagementGrain.cs
+++ b/src/Orleans.Runtime/Core/ManagementGrain.cs
@@ -23,7 +23,7 @@ namespace Orleans.Runtime.Management
     [OneInstancePerCluster]
     internal class ManagementGrain : Grain, IManagementGrain
     {
-        private readonly SiloIdentityOptions siloIdentityOptions;
+        private readonly SiloOptions siloOptions;
         private readonly IMultiClusterOracle multiClusterOracle;
         private readonly IInternalGrainFactory internalGrainFactory;
         private readonly ISiloStatusOracle siloStatusOracle;
@@ -33,7 +33,7 @@ namespace Orleans.Runtime.Management
         private ILogger logger;
 
         public ManagementGrain(
-            IOptions<SiloIdentityOptions> siloIdentityOptions,
+            IOptions<SiloOptions> siloOptions,
             IMultiClusterOracle multiClusterOracle,
             IInternalGrainFactory internalGrainFactory,
             ISiloStatusOracle siloStatusOracle,
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.Management
             GrainTypeManager grainTypeManager, 
             IVersionStore versionStore)
         {
-            this.siloIdentityOptions = siloIdentityOptions.Value;
+            this.siloOptions = siloOptions.Value;
             this.multiClusterOracle = multiClusterOracle;
             this.internalGrainFactory = internalGrainFactory;
             this.siloStatusOracle = siloStatusOracle;
@@ -426,7 +426,7 @@ namespace Orleans.Runtime.Management
 
         private IMultiClusterOracle GetMultiClusterOracle()
         {
-            if (!this.siloIdentityOptions.HasMultiClusterNetwork)
+            if (!this.siloOptions.HasMultiClusterNetwork)
                 throw new OrleansException("No multicluster network configured");
             return this.multiClusterOracle;
         }

--- a/src/Orleans.Runtime/Core/ManagementGrain.cs
+++ b/src/Orleans.Runtime/Core/ManagementGrain.cs
@@ -7,6 +7,7 @@ using System.Xml;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Orleans.Hosting;
 using Orleans.MultiCluster;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.MembershipService;
@@ -23,7 +24,7 @@ namespace Orleans.Runtime.Management
     [OneInstancePerCluster]
     internal class ManagementGrain : Grain, IManagementGrain
     {
-        private readonly SiloOptions siloOptions;
+        private readonly MultiClusterOptions multiClusterOptions;
         private readonly IMultiClusterOracle multiClusterOracle;
         private readonly IInternalGrainFactory internalGrainFactory;
         private readonly ISiloStatusOracle siloStatusOracle;
@@ -33,7 +34,7 @@ namespace Orleans.Runtime.Management
         private ILogger logger;
 
         public ManagementGrain(
-            IOptions<SiloOptions> siloOptions,
+            IOptions<MultiClusterOptions> multiClusterOptions,
             IMultiClusterOracle multiClusterOracle,
             IInternalGrainFactory internalGrainFactory,
             ISiloStatusOracle siloStatusOracle,
@@ -41,7 +42,7 @@ namespace Orleans.Runtime.Management
             GrainTypeManager grainTypeManager, 
             IVersionStore versionStore)
         {
-            this.siloOptions = siloOptions.Value;
+            this.multiClusterOptions = multiClusterOptions.Value;
             this.multiClusterOracle = multiClusterOracle;
             this.internalGrainFactory = internalGrainFactory;
             this.siloStatusOracle = siloStatusOracle;
@@ -426,7 +427,7 @@ namespace Orleans.Runtime.Management
 
         private IMultiClusterOracle GetMultiClusterOracle()
         {
-            if (!this.siloOptions.HasMultiClusterNetwork)
+            if (!this.multiClusterOptions.HasMultiClusterNetwork)
                 throw new OrleansException("No multicluster network configured");
             return this.multiClusterOracle;
         }

--- a/src/Orleans.Runtime/Core/ManagementGrain.cs
+++ b/src/Orleans.Runtime/Core/ManagementGrain.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.MultiCluster;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.MembershipService;
@@ -22,7 +23,7 @@ namespace Orleans.Runtime.Management
     [OneInstancePerCluster]
     internal class ManagementGrain : Grain, IManagementGrain
     {
-        private readonly GlobalConfiguration globalConfig;
+        private readonly SiloIdentityOptions siloIdentityOptions;
         private readonly IMultiClusterOracle multiClusterOracle;
         private readonly IInternalGrainFactory internalGrainFactory;
         private readonly ISiloStatusOracle siloStatusOracle;
@@ -32,7 +33,7 @@ namespace Orleans.Runtime.Management
         private ILogger logger;
 
         public ManagementGrain(
-            GlobalConfiguration globalConfig,
+            IOptions<SiloIdentityOptions> siloIdentityOptions,
             IMultiClusterOracle multiClusterOracle,
             IInternalGrainFactory internalGrainFactory,
             ISiloStatusOracle siloStatusOracle,
@@ -40,7 +41,7 @@ namespace Orleans.Runtime.Management
             GrainTypeManager grainTypeManager, 
             IVersionStore versionStore)
         {
-            this.globalConfig = globalConfig;
+            this.siloIdentityOptions = siloIdentityOptions.Value;
             this.multiClusterOracle = multiClusterOracle;
             this.internalGrainFactory = internalGrainFactory;
             this.siloStatusOracle = siloStatusOracle;
@@ -425,7 +426,7 @@ namespace Orleans.Runtime.Management
 
         private IMultiClusterOracle GetMultiClusterOracle()
         {
-            if (!this.globalConfig.HasMultiClusterNetwork)
+            if (!this.siloIdentityOptions.HasMultiClusterNetwork)
                 throw new OrleansException("No multicluster network configured");
             return this.multiClusterOracle;
         }

--- a/src/Orleans.Runtime/Counters/SiloStatisticsManager.cs
+++ b/src/Orleans.Runtime/Counters/SiloStatisticsManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
 
@@ -13,8 +14,9 @@ namespace Orleans.Runtime.Counters
         private CountersStatistics countersPublisher;
         internal SiloPerformanceMetrics MetricsTable;
         private readonly Logger logger;
+        private SiloIdentityOptions siloIdentityOptions;
 
-        public SiloStatisticsManager(SiloInitializationParameters initializationParams, SerializationManager serializationManager, ITelemetryProducer telemetryProducer, ILoggerFactory loggerFactory)
+        public SiloStatisticsManager(SiloInitializationParameters initializationParams, SerializationManager serializationManager, ITelemetryProducer telemetryProducer, ILoggerFactory loggerFactory, IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
             MessagingStatisticsGroup.Init(true);
             MessagingProcessingStatisticsGroup.Init();
@@ -33,6 +35,7 @@ namespace Orleans.Runtime.Counters
                 "Defaults/LoadShedding",
                 () => this.MetricsTable.NodeConfig = initializationParams.NodeConfig,
                 false);
+            this.siloIdentityOptions = siloIdentityOptions.Value;
         }
 
         internal async Task SetSiloMetricsTableDataManager(Silo silo, NodeConfiguration nodeConfig)
@@ -57,7 +60,7 @@ namespace Orleans.Runtime.Counters
                 {
                     var gateway = nodeConfig.IsGatewayNode ? nodeConfig.ProxyGatewayEndpoint : null;
                     configurableMetricsDataPublisher.AddConfiguration(
-                        silo.GlobalConfig.ClusterId, true, silo.Name, silo.SiloAddress, gateway, nodeConfig.DNSHostName);
+                        this.siloIdentityOptions.ClusterId, true, this.siloIdentityOptions.SiloName, silo.SiloAddress, gateway, nodeConfig.DNSHostName);
                 }
                 MetricsTable.MetricsDataPublisher = metricsDataPublisher;
             }
@@ -66,7 +69,7 @@ namespace Orleans.Runtime.Counters
                 // Hook up to publish silo metrics to Azure storage table
                 var gateway = nodeConfig.IsGatewayNode ? nodeConfig.ProxyGatewayEndpoint : null;
                 var metricsDataPublisher = AssemblyLoader.LoadAndCreateInstance<ISiloMetricsDataPublisher>(Constants.ORLEANS_AZURE_UTILS_DLL, logger, silo.Services);
-                await metricsDataPublisher.Init(silo.GlobalConfig.ClusterId, silo.GlobalConfig.DataConnectionString, silo.SiloAddress, silo.Name, gateway, nodeConfig.DNSHostName);
+                await metricsDataPublisher.Init(this.siloIdentityOptions.ClusterId, silo.GlobalConfig.DataConnectionString, silo.SiloAddress, this.siloIdentityOptions.SiloName, gateway, nodeConfig.DNSHostName);
                 MetricsTable.MetricsDataPublisher = metricsDataPublisher;
             }
             // else no metrics
@@ -96,26 +99,27 @@ namespace Orleans.Runtime.Counters
                 {
                     var gateway = nodeConfig.IsGatewayNode ? nodeConfig.ProxyGatewayEndpoint : null;
                     configurableStatsDataPublisher.AddConfiguration(
-                        silo.GlobalConfig.ClusterId, true, silo.Name, silo.SiloAddress, gateway, nodeConfig.DNSHostName);
+                        this.siloIdentityOptions.ClusterId, true, this.siloIdentityOptions.SiloName, silo.SiloAddress, gateway, nodeConfig.DNSHostName);
                 }
                 logStatistics.StatsTablePublisher = statsDataPublisher;
             }
             else if (useAzureTable)
             {
                 var statsDataPublisher = AssemblyLoader.LoadAndCreateInstance<IStatisticsPublisher>(Constants.ORLEANS_AZURE_UTILS_DLL, logger, silo.Services);
-                await statsDataPublisher.Init(true, silo.GlobalConfig.DataConnectionString, silo.GlobalConfig.ClusterId, silo.SiloAddress.ToLongString(), silo.Name, nodeConfig.DNSHostName);
+                await statsDataPublisher.Init(true, silo.GlobalConfig.DataConnectionString, this.siloIdentityOptions.ClusterId, silo.SiloAddress.ToLongString(), this.siloIdentityOptions.SiloName, nodeConfig.DNSHostName);
                 logStatistics.StatsTablePublisher = statsDataPublisher;
             }
             // else no stats
         }
 
-        private static bool ShouldUseExternalMetricsProvider(
+        private bool ShouldUseExternalMetricsProvider(
             Silo silo,
             IStatisticsConfiguration nodeConfig,
             out bool useAzureTable)
         {
+            // TODO: use DI to configure this and don't rely on GlobalConfiguration nor NodeConfiguration
             useAzureTable = silo.GlobalConfig.LivenessType == GlobalConfiguration.LivenessProviderType.AzureTable
-                                 && !string.IsNullOrEmpty(silo.GlobalConfig.ClusterId)
+                                 && !string.IsNullOrEmpty(this.siloIdentityOptions.ClusterId)
                                  && !string.IsNullOrEmpty(silo.GlobalConfig.DataConnectionString);
 
             return !string.IsNullOrEmpty(nodeConfig.StatisticsProviderName);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -102,12 +102,13 @@ namespace Orleans.Runtime.GrainDirectory
             RegistrarManager registrarManager,
             ExecutorService executorService,
             IOptions<DevelopmentMembershipOptions> developmentMembershipOptions,
+            IOptions<SiloIdentityOptions> siloIdentityOptions,
             ILoggerFactory loggerFactory)
         {
             this.log = new LoggerWrapper<LocalGrainDirectory>(loggerFactory);
             var globalConfig = clusterConfig.Globals;
 
-            var clusterId = globalConfig.HasMultiClusterNetwork ? globalConfig.ClusterId : null;
+            var clusterId = siloIdentityOptions.Value.HasMultiClusterNetwork ? siloIdentityOptions.Value.ClusterId : null;
             MyAddress = siloDetails.SiloAddress;
 
             Scheduler = scheduler;
@@ -133,7 +134,7 @@ namespace Orleans.Runtime.GrainDirectory
                     grainFactory, 
                     executorService,
                     loggerFactory);
-            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig, grainFactory, multiClusterOracle, executorService, loggerFactory);
+            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig, grainFactory, multiClusterOracle, executorService, siloIdentityOptions, loggerFactory);
 
             var primarySiloEndPoint = developmentMembershipOptions.Value.PrimarySiloEndPoint;
             if (primarySiloEndPoint != null)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -102,13 +102,13 @@ namespace Orleans.Runtime.GrainDirectory
             RegistrarManager registrarManager,
             ExecutorService executorService,
             IOptions<DevelopmentMembershipOptions> developmentMembershipOptions,
-            IOptions<SiloIdentityOptions> siloIdentityOptions,
+            IOptions<SiloOptions> siloOptions,
             ILoggerFactory loggerFactory)
         {
             this.log = new LoggerWrapper<LocalGrainDirectory>(loggerFactory);
             var globalConfig = clusterConfig.Globals;
 
-            var clusterId = siloIdentityOptions.Value.HasMultiClusterNetwork ? siloIdentityOptions.Value.ClusterId : null;
+            var clusterId = siloOptions.Value.HasMultiClusterNetwork ? siloOptions.Value.ClusterId : null;
             MyAddress = siloDetails.SiloAddress;
 
             Scheduler = scheduler;
@@ -134,7 +134,7 @@ namespace Orleans.Runtime.GrainDirectory
                     grainFactory, 
                     executorService,
                     loggerFactory);
-            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig, grainFactory, multiClusterOracle, executorService, siloIdentityOptions, loggerFactory);
+            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig, grainFactory, multiClusterOracle, executorService, siloOptions, loggerFactory);
 
             var primarySiloEndPoint = developmentMembershipOptions.Value.PrimarySiloEndPoint;
             if (primarySiloEndPoint != null)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -103,12 +103,13 @@ namespace Orleans.Runtime.GrainDirectory
             ExecutorService executorService,
             IOptions<DevelopmentMembershipOptions> developmentMembershipOptions,
             IOptions<SiloOptions> siloOptions,
+            IOptions<MultiClusterOptions> multiClusterOptions,
             ILoggerFactory loggerFactory)
         {
             this.log = new LoggerWrapper<LocalGrainDirectory>(loggerFactory);
             var globalConfig = clusterConfig.Globals;
 
-            var clusterId = siloOptions.Value.HasMultiClusterNetwork ? siloOptions.Value.ClusterId : null;
+            var clusterId = multiClusterOptions.Value.HasMultiClusterNetwork ? siloOptions.Value.ClusterId : null;
             MyAddress = siloDetails.SiloAddress;
 
             Scheduler = scheduler;
@@ -134,7 +135,7 @@ namespace Orleans.Runtime.GrainDirectory
                     grainFactory, 
                     executorService,
                     loggerFactory);
-            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig, grainFactory, multiClusterOracle, executorService, siloOptions, loggerFactory);
+            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig, grainFactory, multiClusterOracle, executorService, siloOptions, multiClusterOptions, loggerFactory);
 
             var primarySiloEndPoint = developmentMembershipOptions.Value.PrimarySiloEndPoint;
             if (primarySiloEndPoint != null)

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
@@ -30,8 +30,17 @@ namespace Orleans.Runtime.GrainDirectory
         // maintainer periodically takes and processes this list.
         private List<GrainId> doubtfulGrains = new List<GrainId>();
 
-        public GlobalSingleInstanceActivationMaintainer(LocalGrainDirectory router, Logger logger, GlobalConfiguration config, IInternalGrainFactory grainFactory, IMultiClusterOracle multiClusterOracle, ExecutorService executorService, IOptions<SiloOptions> siloOptions, IOptions<MultiClusterOptions> multiClusterOptions, ILoggerFactory loggerFactory)
-            :base(executorService, loggerFactory)
+        public GlobalSingleInstanceActivationMaintainer(
+            LocalGrainDirectory router,
+            Logger logger,
+            GlobalConfiguration config,
+            IInternalGrainFactory grainFactory,
+            IMultiClusterOracle multiClusterOracle,
+            ExecutorService executorService,
+            IOptions<SiloOptions> siloOptions,
+            IOptions<MultiClusterOptions> multiClusterOptions,
+            ILoggerFactory loggerFactory)
+            : base(executorService, loggerFactory)
         {
             this.router = router;
             this.logger = logger;

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.GrainDirectory;
 using Orleans.SystemTargetInterfaces;
 using Orleans.Runtime.Configuration;
@@ -16,12 +16,12 @@ namespace Orleans.Runtime.GrainDirectory
     internal class GlobalSingleInstanceActivationMaintainer : SingleTaskAsynchAgent
     {
         private readonly object lockable = new object();
-        private readonly GlobalConfiguration config;
         private readonly LocalGrainDirectory router;
         private readonly Logger logger;
         private readonly IInternalGrainFactory grainFactory;
         private readonly TimeSpan period;
         private readonly IMultiClusterOracle multiClusterOracle;
+        private readonly SiloIdentityOptions siloIdentityOptions;
 
         // scanning the entire directory for doubtful activations is too slow.
         // therefore, we maintain a list of potentially doubtful activations on the side.
@@ -35,14 +35,15 @@ namespace Orleans.Runtime.GrainDirectory
             IInternalGrainFactory grainFactory,
             IMultiClusterOracle multiClusterOracle,
             ExecutorService executorService,
+            IOptions<SiloIdentityOptions> siloIdentityOptions,
             ILoggerFactory loggerFactory)
             :base(executorService, loggerFactory)
         {
             this.router = router;
             this.logger = logger;
             this.grainFactory = grainFactory;
-            this.config = config;
             this.multiClusterOracle = multiClusterOracle;
+            this.siloIdentityOptions = siloIdentityOptions.Value;
             this.period = config.GlobalSingleInstanceRetryInterval;
             logger.Verbose("GSIP:M GlobalSingleInstanceActivationMaintainer Started, Period = {0}", period);
         }
@@ -82,10 +83,10 @@ namespace Orleans.Runtime.GrainDirectory
         // the following method runs for the whole lifetime of the silo, doing the periodic maintenance
         protected override async void Run()
         {
-            if (!this.config.HasMultiClusterNetwork)
+            if (!this.siloIdentityOptions.HasMultiClusterNetwork)
                 return;
 
-            var myClusterId = this.config.ClusterId;
+            var myClusterId = this.siloIdentityOptions.ClusterId;
 
             while (router.Running)
             {
@@ -193,7 +194,7 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     var clusterGatewayAddress = this.multiClusterOracle.GetRandomClusterGateway(remotecluster);
                     var clusterGrainDir = this.grainFactory.GetSystemTarget<IClusterGrainDirectory>(Constants.ClusterDirectoryServiceId, clusterGatewayAddress);
-                    var r = await clusterGrainDir.ProcessActivationRequestBatch(addresses.Select(a => a.Grain).ToArray(), this.config.ClusterId);
+                    var r = await clusterGrainDir.ProcessActivationRequestBatch(addresses.Select(a => a.Grain).ToArray(), this.siloIdentityOptions.ClusterId);
                     batchResponses.Add(r);
                 }
                 catch (Exception e)

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.GrainDirectory;
+using Orleans.Hosting;
 using Orleans.SystemTargetInterfaces;
 using OutcomeState = Orleans.Runtime.GrainDirectory.GlobalSingleInstanceResponseOutcome.OutcomeState;
 using Orleans.Runtime.Configuration;
@@ -40,7 +41,8 @@ namespace Orleans.Runtime.GrainDirectory
             GlobalConfiguration config,
             IInternalGrainFactory grainFactory,
             IMultiClusterOracle multiClusterOracle,
-            IOptions<SiloOptions> siloOptions)
+            IOptions<SiloOptions> siloOptions,
+            IOptions<MultiClusterOptions> multiClusterOptions)
         {
             this.directoryPartition = localDirectory.DirectoryPartition;
             this.logger = logger;
@@ -48,7 +50,7 @@ namespace Orleans.Runtime.GrainDirectory
             this.numRetries = config.GlobalSingleInstanceNumberRetries;
             this.grainFactory = grainFactory;
             this.multiClusterOracle = multiClusterOracle;
-            this.hasMultiClusterNetwork = siloOptions.Value.HasMultiClusterNetwork;
+            this.hasMultiClusterNetwork = multiClusterOptions.Value.HasMultiClusterNetwork;
             this.clusterId = siloOptions.Value.ClusterId;
         }
 

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.GrainDirectory;
 using Orleans.SystemTargetInterfaces;
 using OutcomeState = Orleans.Runtime.GrainDirectory.GlobalSingleInstanceResponseOutcome.OutcomeState;
@@ -38,7 +39,8 @@ namespace Orleans.Runtime.GrainDirectory
             GlobalSingleInstanceActivationMaintainer gsiActivationMaintainer,
             GlobalConfiguration config,
             IInternalGrainFactory grainFactory,
-            IMultiClusterOracle multiClusterOracle)
+            IMultiClusterOracle multiClusterOracle,
+            IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
             this.directoryPartition = localDirectory.DirectoryPartition;
             this.logger = logger;
@@ -46,8 +48,8 @@ namespace Orleans.Runtime.GrainDirectory
             this.numRetries = config.GlobalSingleInstanceNumberRetries;
             this.grainFactory = grainFactory;
             this.multiClusterOracle = multiClusterOracle;
-            this.hasMultiClusterNetwork = config.HasMultiClusterNetwork;
-            this.clusterId = config.ClusterId;
+            this.hasMultiClusterNetwork = siloIdentityOptions.Value.HasMultiClusterNetwork;
+            this.clusterId = siloIdentityOptions.Value.ClusterId;
         }
 
         public bool IsSynchronous { get { return false; } }

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.GrainDirectory
             GlobalConfiguration config,
             IInternalGrainFactory grainFactory,
             IMultiClusterOracle multiClusterOracle,
-            IOptions<SiloIdentityOptions> siloIdentityOptions)
+            IOptions<SiloOptions> siloOptions)
         {
             this.directoryPartition = localDirectory.DirectoryPartition;
             this.logger = logger;
@@ -48,8 +48,8 @@ namespace Orleans.Runtime.GrainDirectory
             this.numRetries = config.GlobalSingleInstanceNumberRetries;
             this.grainFactory = grainFactory;
             this.multiClusterOracle = multiClusterOracle;
-            this.hasMultiClusterNetwork = siloIdentityOptions.Value.HasMultiClusterNetwork;
-            this.clusterId = siloIdentityOptions.Value.ClusterId;
+            this.hasMultiClusterNetwork = siloOptions.Value.HasMultiClusterNetwork;
+            this.clusterId = siloOptions.Value.ClusterId;
         }
 
         public bool IsSynchronous { get { return false; } }

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistrationStrategy.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistrationStrategy.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
-using Orleans.Runtime.Configuration;
-using Orleans.MultiCluster;
 using Microsoft.Extensions.Options;
-using Orleans.Runtime;
+using Orleans.Hosting;
+using Orleans.MultiCluster;
 
 namespace Orleans.GrainDirectory
 {
-
     internal class MultiClusterRegistrationStrategyManager
     {
-        public MultiClusterRegistrationStrategyManager(GlobalConfiguration config, IOptions<SiloOptions> siloOptions)
+        public MultiClusterRegistrationStrategyManager(IOptions<MultiClusterOptions> multiClusterOptions)
         {
-            if (siloOptions.Value.HasMultiClusterNetwork && config.UseGlobalSingleInstanceByDefault)
+            var options = multiClusterOptions.Value;
+            if (options.HasMultiClusterNetwork && options.UseGlobalSingleInstanceByDefault)
             {
                 this.DefaultStrategy = GlobalSingleInstanceRegistration.Singleton;
             }

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistrationStrategy.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistrationStrategy.cs
@@ -3,16 +3,17 @@ using System.Linq;
 using System.Reflection;
 using Orleans.Runtime.Configuration;
 using Orleans.MultiCluster;
-using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
 
 namespace Orleans.GrainDirectory
 {
 
     internal class MultiClusterRegistrationStrategyManager
     {
-        public MultiClusterRegistrationStrategyManager(GlobalConfiguration config)
+        public MultiClusterRegistrationStrategyManager(GlobalConfiguration config, IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
-            if (config.HasMultiClusterNetwork && config.UseGlobalSingleInstanceByDefault)
+            if (siloIdentityOptions.Value.HasMultiClusterNetwork && config.UseGlobalSingleInstanceByDefault)
             {
                 this.DefaultStrategy = GlobalSingleInstanceRegistration.Singleton;
             }
@@ -41,14 +42,6 @@ namespace Orleans.GrainDirectory
                             typeof(MultiClusterRegistrationStrategy).Name,
                             grainClass.Name));
             }
-        }
-    }
-
-    public static class MultiClusterRegistrationStrategyExtensions
-    {
-        public static IEnumerable<string> GetRemoteInstances(this IMultiClusterRegistrationStrategy strategy, MultiClusterConfiguration configuration, string myClusterId)
-        {
-            return strategy.GetRemoteInstances(configuration.Clusters, myClusterId);
         }
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistrationStrategy.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistrationStrategy.cs
@@ -11,9 +11,9 @@ namespace Orleans.GrainDirectory
 
     internal class MultiClusterRegistrationStrategyManager
     {
-        public MultiClusterRegistrationStrategyManager(GlobalConfiguration config, IOptions<SiloIdentityOptions> siloIdentityOptions)
+        public MultiClusterRegistrationStrategyManager(GlobalConfiguration config, IOptions<SiloOptions> siloOptions)
         {
-            if (siloIdentityOptions.Value.HasMultiClusterNetwork && config.UseGlobalSingleInstanceByDefault)
+            if (siloOptions.Value.HasMultiClusterNetwork && config.UseGlobalSingleInstanceByDefault)
             {
                 this.DefaultStrategy = GlobalSingleInstanceRegistration.Singleton;
             }

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -24,7 +24,7 @@ namespace Orleans.Hosting
             {
                 if (!context.Properties.ContainsKey("OrleansServicesAdded"))
                 {
-                    services.PostConfigure<SiloIdentityOptions>(options => options.SiloName = options.SiloName
+                    services.PostConfigure<SiloOptions>(options => options.SiloName = options.SiloName
                                            ?? context.HostingEnvironment.ApplicationName
                                            ?? $"Silo_{Guid.NewGuid().ToString("N").Substring(0, 5)}");
 
@@ -45,7 +45,7 @@ namespace Orleans.Hosting
         /// <returns>The silo builder.</returns>
         public static ISiloHostBuilder ConfigureSiloName(this ISiloHostBuilder builder, string siloName)
         {
-            builder.Configure<SiloIdentityOptions>(options => options.SiloName = siloName);
+            builder.Configure<SiloOptions>(options => options.SiloName = siloName);
             return builder;
         }
 

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -52,7 +53,7 @@ namespace Orleans.Hosting
                 {
                     options.HasMultiClusterNetwork = true;
                     options.BackgroundGossipInterval = globals.BackgroundGossipInterval;
-                    options.DefaultMultiCluster = globals.DefaultMultiCluster.ToList();
+                    options.DefaultMultiCluster = globals.DefaultMultiCluster?.ToList() ?? new List<string>();
                     options.GlobalSingleInstanceNumberRetries = globals.GlobalSingleInstanceNumberRetries;
                     options.GlobalSingleInstanceRetryInterval = globals.GlobalSingleInstanceRetryInterval;
                     options.MaxMultiClusterGateways = globals.MaxMultiClusterGateways;

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -34,6 +34,22 @@ namespace Orleans.Hosting
                     var initializationParams = sp.GetRequiredService<SiloInitializationParameters>();
                     return () => initializationParams.NodeConfig;
                 });
+
+            services.Configure<SiloIdentityOptions>(options =>
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (string.IsNullOrWhiteSpace(options.ClusterId) && !string.IsNullOrWhiteSpace(configuration.Globals.DeploymentId))
+                {
+                    options.ClusterId = configuration.Globals.DeploymentId;
+                }
+
+                if (configuration.Globals.HasMultiClusterNetwork)
+                {
+                    options.HasMultiClusterNetwork = true;
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
+            });
+
             services.TryAddFromExisting<IMessagingConfiguration, GlobalConfiguration>();
 
             services.AddOptions<StatisticsOptions>()

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -35,7 +35,7 @@ namespace Orleans.Hosting
                     return () => initializationParams.NodeConfig;
                 });
 
-            services.Configure<SiloIdentityOptions>(options =>
+            services.Configure<SiloOptions>(options =>
             {
 #pragma warning disable CS0618 // Type or member is obsolete
                 if (string.IsNullOrWhiteSpace(options.ClusterId) && !string.IsNullOrWhiteSpace(configuration.Globals.DeploymentId))
@@ -74,9 +74,9 @@ namespace Orleans.Hosting
                 options.FallbackSerializationProvider = configuration.Globals.FallbackSerializationProvider;
             });
 
-            services.AddOptions<GrainClassOptions>().Configure<IOptions<SiloIdentityOptions>>((options, identityOptions) =>
+            services.AddOptions<GrainClassOptions>().Configure<IOptions<SiloOptions>>((options, siloOptions) =>
             {
-                var nodeConfig = configuration.GetOrCreateNodeConfigurationForSilo(identityOptions.Value.SiloName);
+                var nodeConfig = configuration.GetOrCreateNodeConfigurationForSilo(siloOptions.Value.SiloName);
                 options.ExcludedGrainTypes.AddRange(nodeConfig.ExcludedGrainTypes);
             });
 

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -42,12 +42,22 @@ namespace Orleans.Hosting
                 {
                     options.ClusterId = configuration.Globals.DeploymentId;
                 }
+#pragma warning restore CS0618 // Type or member is obsolete
+            });
 
-                if (configuration.Globals.HasMultiClusterNetwork)
+            services.Configure<MultiClusterOptions>(options =>
+            {
+                var globals = configuration.Globals;
+                if (globals.HasMultiClusterNetwork)
                 {
                     options.HasMultiClusterNetwork = true;
+                    options.BackgroundGossipInterval = globals.BackgroundGossipInterval;
+                    options.DefaultMultiCluster = globals.DefaultMultiCluster.ToList();
+                    options.GlobalSingleInstanceNumberRetries = globals.GlobalSingleInstanceNumberRetries;
+                    options.GlobalSingleInstanceRetryInterval = globals.GlobalSingleInstanceRetryInterval;
+                    options.MaxMultiClusterGateways = globals.MaxMultiClusterGateways;
+                    options.UseGlobalSingleInstanceByDefault = globals.UseGlobalSingleInstanceByDefault;
                 }
-#pragma warning restore CS0618 // Type or member is obsolete
             });
 
             services.TryAddFromExisting<IMessagingConfiguration, GlobalConfiguration>();

--- a/src/Orleans.Runtime/LogConsistency/ProtocolServices.cs
+++ b/src/Orleans.Runtime/LogConsistency/ProtocolServices.cs
@@ -8,6 +8,7 @@ using Orleans.LogConsistency;
 using Orleans.MultiCluster;
 using Orleans.SystemTargetInterfaces;
 using Orleans.GrainDirectory;
+using Orleans.Hosting;
 using Orleans.Serialization;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.MultiClusterNetwork;
@@ -38,6 +39,7 @@ namespace Orleans.Runtime.LogConsistency
         private readonly MultiClusterConfiguration pseudoMultiClusterConfiguration;
 
         private readonly SiloOptions siloOptions;
+        private readonly MultiClusterOptions multiClusterOptions;
 
         public ProtocolServices(
             Grain gr,
@@ -46,6 +48,7 @@ namespace Orleans.Runtime.LogConsistency
             SerializationManager serializationManager,
             IInternalGrainFactory grainFactory,
             IOptions<SiloOptions> siloOptions,
+            IOptions<MultiClusterOptions> multiClusterOptions,
             IMultiClusterOracle multiClusterOracle)
         {
             this.grain = gr;
@@ -55,8 +58,9 @@ namespace Orleans.Runtime.LogConsistency
             this.SerializationManager = serializationManager;
             this.multiClusterOracle = multiClusterOracle;
             this.siloOptions = siloOptions.Value;
+            this.multiClusterOptions = multiClusterOptions.Value;
 
-            if (!this.siloOptions.HasMultiClusterNetwork)
+            if (!this.multiClusterOptions.HasMultiClusterNetwork)
             {
                 // we are creating a default multi-cluster configuration containing exactly one cluster, this one.
                 this.pseudoMultiClusterConfiguration = PseudoMultiClusterConfigurations.FindOrCreate(
@@ -123,7 +127,7 @@ namespace Orleans.Runtime.LogConsistency
         /// <inheritdoc />
         public SerializationManager SerializationManager { get; }
 
-        public bool MultiClusterEnabled => this.siloOptions.HasMultiClusterNetwork;
+        public bool MultiClusterEnabled => this.multiClusterOptions.HasMultiClusterNetwork;
     
         public string MyClusterId
         {

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.Messaging;
 using Orleans.Runtime.Scheduler;
@@ -39,14 +40,15 @@ namespace Orleans.Runtime.MembershipService
         public SiloAddress SiloAddress { get { return membershipOracleData.MyAddress; } }
         private TimeSpan AllowedIAmAliveMissPeriod { get { return orleansConfig.Globals.IAmAliveTablePublishTimeout.Multiply(orleansConfig.Globals.NumMissedTableIAmAliveLimit); } }
         private readonly ILoggerFactory loggerFactory;
-        public MembershipOracle(ILocalSiloDetails siloDetails, ClusterConfiguration clusterConfiguration, NodeConfiguration nodeConfiguration, MembershipTableFactory membershipTableFactory, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory)
+
+        public MembershipOracle(ILocalSiloDetails siloDetails, ClusterConfiguration clusterConfiguration, NodeConfiguration nodeConfiguration, MembershipTableFactory membershipTableFactory, IInternalGrainFactory grainFactory, IOptions<SiloIdentityOptions> siloIdentityOptions, ILoggerFactory loggerFactory)
             : base(Constants.MembershipOracleId, siloDetails.SiloAddress, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
             this.membershipTableFactory = membershipTableFactory;
             this.grainFactory = grainFactory;
             logger = new LoggerWrapper<MembershipOracle>(loggerFactory);
-            membershipOracleData = new MembershipOracleData(siloDetails, nodeConfiguration, clusterConfiguration.Globals, logger);
+            membershipOracleData = new MembershipOracleData(siloDetails, nodeConfiguration, clusterConfiguration.Globals, logger, siloIdentityOptions.Value);
             probedSilos = new Dictionary<SiloAddress, int>();
             orleansConfig = clusterConfiguration;
             nodeConfig = nodeConfiguration;

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -41,14 +41,14 @@ namespace Orleans.Runtime.MembershipService
         private TimeSpan AllowedIAmAliveMissPeriod { get { return orleansConfig.Globals.IAmAliveTablePublishTimeout.Multiply(orleansConfig.Globals.NumMissedTableIAmAliveLimit); } }
         private readonly ILoggerFactory loggerFactory;
 
-        public MembershipOracle(ILocalSiloDetails siloDetails, ClusterConfiguration clusterConfiguration, NodeConfiguration nodeConfiguration, MembershipTableFactory membershipTableFactory, IInternalGrainFactory grainFactory, IOptions<SiloIdentityOptions> siloIdentityOptions, ILoggerFactory loggerFactory)
+        public MembershipOracle(ILocalSiloDetails siloDetails, ClusterConfiguration clusterConfiguration, NodeConfiguration nodeConfiguration, MembershipTableFactory membershipTableFactory, IInternalGrainFactory grainFactory, IOptions<SiloOptions> siloOptions, ILoggerFactory loggerFactory)
             : base(Constants.MembershipOracleId, siloDetails.SiloAddress, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
             this.membershipTableFactory = membershipTableFactory;
             this.grainFactory = grainFactory;
             logger = new LoggerWrapper<MembershipOracle>(loggerFactory);
-            membershipOracleData = new MembershipOracleData(siloDetails, nodeConfiguration, clusterConfiguration.Globals, logger, siloIdentityOptions.Value);
+            membershipOracleData = new MembershipOracleData(siloDetails, nodeConfiguration, clusterConfiguration.Globals, logger, siloOptions.Value);
             probedSilos = new Dictionary<SiloAddress, int>();
             orleansConfig = clusterConfiguration;
             nodeConfig = nodeConfiguration;

--- a/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracle.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Orleans.Hosting;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.Messaging;
 using Orleans.Runtime.Scheduler;
@@ -41,14 +42,14 @@ namespace Orleans.Runtime.MembershipService
         private TimeSpan AllowedIAmAliveMissPeriod { get { return orleansConfig.Globals.IAmAliveTablePublishTimeout.Multiply(orleansConfig.Globals.NumMissedTableIAmAliveLimit); } }
         private readonly ILoggerFactory loggerFactory;
 
-        public MembershipOracle(ILocalSiloDetails siloDetails, ClusterConfiguration clusterConfiguration, NodeConfiguration nodeConfiguration, MembershipTableFactory membershipTableFactory, IInternalGrainFactory grainFactory, IOptions<SiloOptions> siloOptions, ILoggerFactory loggerFactory)
+        public MembershipOracle(ILocalSiloDetails siloDetails, ClusterConfiguration clusterConfiguration, NodeConfiguration nodeConfiguration, MembershipTableFactory membershipTableFactory, IInternalGrainFactory grainFactory, IOptions<MultiClusterOptions> multiClusterOptions, ILoggerFactory loggerFactory)
             : base(Constants.MembershipOracleId, siloDetails.SiloAddress, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
             this.membershipTableFactory = membershipTableFactory;
             this.grainFactory = grainFactory;
             logger = new LoggerWrapper<MembershipOracle>(loggerFactory);
-            membershipOracleData = new MembershipOracleData(siloDetails, nodeConfiguration, clusterConfiguration.Globals, logger, siloOptions.Value);
+            membershipOracleData = new MembershipOracleData(siloDetails, nodeConfiguration, logger, multiClusterOptions.Value);
             probedSilos = new Dictionary<SiloAddress, int>();
             orleansConfig = clusterConfiguration;
             nodeConfig = nodeConfiguration;

--- a/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime.MembershipService
 
         private UpdateFaultCombo myFaultAndUpdateZones;
 
-        internal MembershipOracleData(ILocalSiloDetails siloDetails, NodeConfiguration nodeConfiguration, GlobalConfiguration globalConfig, Logger log)
+        internal MembershipOracleData(ILocalSiloDetails siloDetails, NodeConfiguration nodeConfiguration, GlobalConfiguration globalConfig, Logger log, SiloIdentityOptions siloIdentityOptions)
         {
             logger = log;
             localTable = new Dictionary<SiloAddress, MembershipEntry>();  
@@ -45,7 +45,7 @@ namespace Orleans.Runtime.MembershipService
             MyAddress = siloDetails.SiloAddress;
             MyHostname = nodeConfiguration.DNSHostName;
             SiloName = siloDetails.Name;
-            this.multiClusterActive = globalConfig.HasMultiClusterNetwork;
+            this.multiClusterActive = siloIdentityOptions.HasMultiClusterNetwork;
             this.maxMultiClusterGateways = globalConfig.MaxMultiClusterGateways;
             CurrentStatus = SiloStatus.Created;
             clusterSizeStatistic = IntValueStatistic.FindOrCreate(StatisticNames.MEMBERSHIP_ACTIVE_CLUSTER_SIZE, () => localTableCopyOnlyActive.Count);

--- a/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime.MembershipService
 
         private UpdateFaultCombo myFaultAndUpdateZones;
 
-        internal MembershipOracleData(ILocalSiloDetails siloDetails, NodeConfiguration nodeConfiguration, GlobalConfiguration globalConfig, Logger log, SiloIdentityOptions siloIdentityOptions)
+        internal MembershipOracleData(ILocalSiloDetails siloDetails, NodeConfiguration nodeConfiguration, GlobalConfiguration globalConfig, Logger log, SiloOptions siloOptions)
         {
             logger = log;
             localTable = new Dictionary<SiloAddress, MembershipEntry>();  
@@ -45,7 +45,7 @@ namespace Orleans.Runtime.MembershipService
             MyAddress = siloDetails.SiloAddress;
             MyHostname = nodeConfiguration.DNSHostName;
             SiloName = siloDetails.Name;
-            this.multiClusterActive = siloIdentityOptions.HasMultiClusterNetwork;
+            this.multiClusterActive = siloOptions.HasMultiClusterNetwork;
             this.maxMultiClusterGateways = globalConfig.MaxMultiClusterGateways;
             CurrentStatus = SiloStatus.Created;
             clusterSizeStatistic = IntValueStatistic.FindOrCreate(StatisticNames.MEMBERSHIP_ACTIVE_CLUSTER_SIZE, () => localTableCopyOnlyActive.Count);

--- a/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Orleans.Hosting;
 using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime.MembershipService
@@ -31,7 +32,7 @@ namespace Orleans.Runtime.MembershipService
 
         private UpdateFaultCombo myFaultAndUpdateZones;
 
-        internal MembershipOracleData(ILocalSiloDetails siloDetails, NodeConfiguration nodeConfiguration, GlobalConfiguration globalConfig, Logger log, SiloOptions siloOptions)
+        internal MembershipOracleData(ILocalSiloDetails siloDetails, NodeConfiguration nodeConfiguration, Logger log, MultiClusterOptions multiClusterOptions)
         {
             logger = log;
             localTable = new Dictionary<SiloAddress, MembershipEntry>();  
@@ -45,8 +46,8 @@ namespace Orleans.Runtime.MembershipService
             MyAddress = siloDetails.SiloAddress;
             MyHostname = nodeConfiguration.DNSHostName;
             SiloName = siloDetails.Name;
-            this.multiClusterActive = siloOptions.HasMultiClusterNetwork;
-            this.maxMultiClusterGateways = globalConfig.MaxMultiClusterGateways;
+            this.multiClusterActive = multiClusterOptions.HasMultiClusterNetwork;
+            this.maxMultiClusterGateways = multiClusterOptions.MaxMultiClusterGateways;
             CurrentStatus = SiloStatus.Created;
             clusterSizeStatistic = IntValueStatistic.FindOrCreate(StatisticNames.MEMBERSHIP_ACTIVE_CLUSTER_SIZE, () => localTableCopyOnlyActive.Count);
             clusterStatistic = StringValueStatistic.FindOrCreate(StatisticNames.MEMBERSHIP_ACTIVE_CLUSTER,

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ILoggerFactory loggerFactory;
         private readonly SiloMessagingOptions messagingOptions;
         
-        public Gateway(MessageCenter msgCtr, NodeConfiguration nodeConfig, MessageFactory messageFactory, SerializationManager serializationManager, ExecutorService executorService, GlobalConfiguration globalConfig, ILoggerFactory loggerFactory, IOptions<SiloMessagingOptions> options)
+        public Gateway(MessageCenter msgCtr, NodeConfiguration nodeConfig, MessageFactory messageFactory, SerializationManager serializationManager, ExecutorService executorService, GlobalConfiguration globalConfig, ILoggerFactory loggerFactory, IOptions<SiloMessagingOptions> options, IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
             this.messagingOptions = options.Value;
             this.loggerFactory = loggerFactory;
@@ -49,7 +49,7 @@ namespace Orleans.Runtime.Messaging
             this.logger = new LoggerWrapper<Gateway>(this.loggerFactory);
             this.serializationManager = serializationManager;
             this.executorService = executorService;
-            acceptor = new GatewayAcceptor(msgCtr,this, nodeConfig.ProxyGatewayEndpoint, this.messageFactory, this.serializationManager, globalConfig, executorService, loggerFactory);
+            acceptor = new GatewayAcceptor(msgCtr,this, nodeConfig.ProxyGatewayEndpoint, this.messageFactory, this.serializationManager, globalConfig, executorService, siloIdentityOptions, loggerFactory);
             senders = new Lazy<GatewaySender>[messagingOptions.GatewaySenderQueues];
             nextGatewaySenderToUseForRoundRobin = 0;
             dropper = new GatewayClientCleanupAgent(this, executorService, loggerFactory, messagingOptions.ClientDropTimeout);

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ILoggerFactory loggerFactory;
         private readonly SiloMessagingOptions messagingOptions;
         
-        public Gateway(MessageCenter msgCtr, NodeConfiguration nodeConfig, MessageFactory messageFactory, SerializationManager serializationManager, ExecutorService executorService, GlobalConfiguration globalConfig, ILoggerFactory loggerFactory, IOptions<SiloMessagingOptions> options, IOptions<SiloOptions> siloOptions)
+        public Gateway(MessageCenter msgCtr, NodeConfiguration nodeConfig, MessageFactory messageFactory, SerializationManager serializationManager, ExecutorService executorService, ILoggerFactory loggerFactory, IOptions<SiloMessagingOptions> options, IOptions<SiloOptions> siloOptions, IOptions<MultiClusterOptions> multiClusterOptions)
         {
             this.messagingOptions = options.Value;
             this.loggerFactory = loggerFactory;
@@ -49,7 +49,7 @@ namespace Orleans.Runtime.Messaging
             this.logger = new LoggerWrapper<Gateway>(this.loggerFactory);
             this.serializationManager = serializationManager;
             this.executorService = executorService;
-            acceptor = new GatewayAcceptor(msgCtr,this, nodeConfig.ProxyGatewayEndpoint, this.messageFactory, this.serializationManager, globalConfig, executorService, siloOptions, loggerFactory);
+            acceptor = new GatewayAcceptor(msgCtr,this, nodeConfig.ProxyGatewayEndpoint, this.messageFactory, this.serializationManager, executorService, siloOptions, multiClusterOptions, loggerFactory);
             senders = new Lazy<GatewaySender>[messagingOptions.GatewaySenderQueues];
             nextGatewaySenderToUseForRoundRobin = 0;
             dropper = new GatewayClientCleanupAgent(this, executorService, loggerFactory, messagingOptions.ClientDropTimeout);

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ILoggerFactory loggerFactory;
         private readonly SiloMessagingOptions messagingOptions;
         
-        public Gateway(MessageCenter msgCtr, NodeConfiguration nodeConfig, MessageFactory messageFactory, SerializationManager serializationManager, ExecutorService executorService, GlobalConfiguration globalConfig, ILoggerFactory loggerFactory, IOptions<SiloMessagingOptions> options, IOptions<SiloIdentityOptions> siloIdentityOptions)
+        public Gateway(MessageCenter msgCtr, NodeConfiguration nodeConfig, MessageFactory messageFactory, SerializationManager serializationManager, ExecutorService executorService, GlobalConfiguration globalConfig, ILoggerFactory loggerFactory, IOptions<SiloMessagingOptions> options, IOptions<SiloOptions> siloOptions)
         {
             this.messagingOptions = options.Value;
             this.loggerFactory = loggerFactory;
@@ -49,7 +49,7 @@ namespace Orleans.Runtime.Messaging
             this.logger = new LoggerWrapper<Gateway>(this.loggerFactory);
             this.serializationManager = serializationManager;
             this.executorService = executorService;
-            acceptor = new GatewayAcceptor(msgCtr,this, nodeConfig.ProxyGatewayEndpoint, this.messageFactory, this.serializationManager, globalConfig, executorService, siloIdentityOptions, loggerFactory);
+            acceptor = new GatewayAcceptor(msgCtr,this, nodeConfig.ProxyGatewayEndpoint, this.messageFactory, this.serializationManager, globalConfig, executorService, siloOptions, loggerFactory);
             senders = new Lazy<GatewaySender>[messagingOptions.GatewaySenderQueues];
             nextGatewaySenderToUseForRoundRobin = 0;
             dropper = new GatewayClientCleanupAgent(this, executorService, loggerFactory, messagingOptions.ClientDropTimeout);

--- a/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -32,7 +32,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
         private readonly IInternalGrainFactory grainFactory;
         private MultiClusterConfiguration injectedConfig;
         private readonly ILoggerFactory loggerFactory;
-        public MultiClusterOracle(SiloInitializationParameters siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory, IOptions<SiloIdentityOptions> siloIdentityOptions)
+        public MultiClusterOracle(SiloInitializationParameters siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory, IOptions<SiloOptions> siloOptions)
             : base(Constants.MultiClusterOracleId, siloDetails.SiloAddress, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
@@ -44,7 +44,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
             var config = siloDetails.ClusterConfig.Globals;
             logger = new LoggerWrapper<MultiClusterOracle>(loggerFactory);
             localData = new MultiClusterOracleData(logger, grainFactory);
-            clusterId = siloIdentityOptions.Value.ClusterId;
+            clusterId = siloOptions.Value.ClusterId;
             defaultMultiCluster = config.DefaultMultiCluster;
             random = new SafeRandom();
 

--- a/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.MultiCluster;
 
 namespace Orleans.Runtime.MultiClusterNetwork
@@ -31,7 +32,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
         private readonly IInternalGrainFactory grainFactory;
         private MultiClusterConfiguration injectedConfig;
         private readonly ILoggerFactory loggerFactory;
-        public MultiClusterOracle(SiloInitializationParameters siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory)
+        public MultiClusterOracle(SiloInitializationParameters siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory, IOptions<SiloIdentityOptions> siloIdentityOptions)
             : base(Constants.MultiClusterOracleId, siloDetails.SiloAddress, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
@@ -43,7 +44,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
             var config = siloDetails.ClusterConfig.Globals;
             logger = new LoggerWrapper<MultiClusterOracle>(loggerFactory);
             localData = new MultiClusterOracleData(logger, grainFactory);
-            clusterId = config.ClusterId;
+            clusterId = siloIdentityOptions.Value.ClusterId;
             defaultMultiCluster = config.DefaultMultiCluster;
             random = new SafeRandom();
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -59,6 +59,7 @@ namespace Orleans.Runtime
         }
 
         private readonly SiloInitializationParameters initializationParams;
+        private readonly SiloIdentityOptions siloIdentityOptions;
         private readonly ISiloMessageCenter messageCenter;
         private readonly OrleansTaskScheduler scheduler;
         private readonly LocalGrainDirectory localGrainDirectory;
@@ -269,8 +270,9 @@ namespace Orleans.Runtime
             incomingAgent = new IncomingMessageAgent(Message.Categories.Application, messageCenter, activationDirectory, scheduler, catalog.Dispatcher, messageFactory, executorService, this.loggerFactory);
 
             membershipOracle = Services.GetRequiredService<IMembershipOracle>();
+            this.siloIdentityOptions = Services.GetRequiredService<IOptions<SiloIdentityOptions>>().Value;
 
-            if (!this.GlobalConfig.HasMultiClusterNetwork)
+            if (!this.siloIdentityOptions.HasMultiClusterNetwork)
             {
                 logger.Info("Skip multicluster oracle creation (no multicluster network configured)");
             }
@@ -520,10 +522,10 @@ namespace Orleans.Runtime
                 .WithTimeout(this.initTimeout);
 
             //if running in multi cluster scenario, start the MultiClusterNetwork Oracle
-            if (GlobalConfig.HasMultiClusterNetwork) 
+            if (this.siloIdentityOptions.HasMultiClusterNetwork) 
             {
                 logger.Info("Starting multicluster oracle with my ServiceId={0} and ClusterId={1}.",
-                    GlobalConfig.ServiceId, GlobalConfig.ClusterId);
+                    GlobalConfig.ServiceId, this.siloIdentityOptions.ClusterId);
 
                 this.multiClusterOracleContext = (multiClusterOracle as SystemTarget)?.SchedulingContext ??
                                                           this.providerManagerSystemTarget.SchedulingContext;

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -59,7 +59,7 @@ namespace Orleans.Runtime
         }
 
         private readonly SiloInitializationParameters initializationParams;
-        private readonly SiloIdentityOptions siloIdentityOptions;
+        private readonly SiloOptions siloOptions;
         private readonly ISiloMessageCenter messageCenter;
         private readonly OrleansTaskScheduler scheduler;
         private readonly LocalGrainDirectory localGrainDirectory;
@@ -180,7 +180,7 @@ namespace Orleans.Runtime
                 serviceCollection.AddSingleton<Silo>(this);
                 serviceCollection.AddSingleton(initializationParams);
                 serviceCollection.AddLegacyClusterConfigurationSupport(config);
-                serviceCollection.Configure<SiloIdentityOptions>(options => options.SiloName = name);
+                serviceCollection.Configure<SiloOptions>(options => options.SiloName = name);
                 var hostContext = new HostBuilderContext(new Dictionary<object, object>());
                 DefaultSiloServices.AddDefaultServices(hostContext, serviceCollection);
 
@@ -270,9 +270,9 @@ namespace Orleans.Runtime
             incomingAgent = new IncomingMessageAgent(Message.Categories.Application, messageCenter, activationDirectory, scheduler, catalog.Dispatcher, messageFactory, executorService, this.loggerFactory);
 
             membershipOracle = Services.GetRequiredService<IMembershipOracle>();
-            this.siloIdentityOptions = Services.GetRequiredService<IOptions<SiloIdentityOptions>>().Value;
+            this.siloOptions = Services.GetRequiredService<IOptions<SiloOptions>>().Value;
 
-            if (!this.siloIdentityOptions.HasMultiClusterNetwork)
+            if (!this.siloOptions.HasMultiClusterNetwork)
             {
                 logger.Info("Skip multicluster oracle creation (no multicluster network configured)");
             }
@@ -522,10 +522,10 @@ namespace Orleans.Runtime
                 .WithTimeout(this.initTimeout);
 
             //if running in multi cluster scenario, start the MultiClusterNetwork Oracle
-            if (this.siloIdentityOptions.HasMultiClusterNetwork) 
+            if (this.siloOptions.HasMultiClusterNetwork) 
             {
                 logger.Info("Starting multicluster oracle with my ServiceId={0} and ClusterId={1}.",
-                    GlobalConfig.ServiceId, this.siloIdentityOptions.ClusterId);
+                    GlobalConfig.ServiceId, this.siloOptions.ClusterId);
 
                 this.multiClusterOracleContext = (multiClusterOracle as SystemTarget)?.SchedulingContext ??
                                                           this.providerManagerSystemTarget.SchedulingContext;

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -271,8 +271,9 @@ namespace Orleans.Runtime
 
             membershipOracle = Services.GetRequiredService<IMembershipOracle>();
             this.siloOptions = Services.GetRequiredService<IOptions<SiloOptions>>().Value;
+            var multiClusterOptions = Services.GetRequiredService<IOptions<MultiClusterOptions>>().Value;
 
-            if (!this.siloOptions.HasMultiClusterNetwork)
+            if (!multiClusterOptions.HasMultiClusterNetwork)
             {
                 logger.Info("Skip multicluster oracle creation (no multicluster network configured)");
             }
@@ -522,7 +523,7 @@ namespace Orleans.Runtime
                 .WithTimeout(this.initTimeout);
 
             //if running in multi cluster scenario, start the MultiClusterNetwork Oracle
-            if (this.siloOptions.HasMultiClusterNetwork) 
+            if (this.multiClusterOracle != null) 
             {
                 logger.Info("Starting multicluster oracle with my ServiceId={0} and ClusterId={1}.",
                     GlobalConfig.ServiceId, this.siloOptions.ClusterId);

--- a/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
+++ b/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
@@ -12,6 +12,16 @@ namespace Orleans.Runtime
         /// Gets or sets the silo name.
         /// </summary>
         public string SiloName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
+        /// </summary>
+        public string ClusterId { get; set; }
+
+        /// <summary>
+        /// Whether this cluster is configured to be part of a multicluster network
+        /// </summary>
+        public bool HasMultiClusterNetwork { get; set; }
     }
 
     /// <summary>

--- a/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
+++ b/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
@@ -18,10 +18,7 @@ namespace Orleans.Runtime
         /// </summary>
         public string ClusterId { get; set; }
 
-        /// <summary>
-        /// Whether this cluster is configured to be part of a multicluster network
-        /// </summary>
-        public bool HasMultiClusterNetwork { get; set; }
+        // TODO: add ServiceId.
     }
 
     /// <summary>

--- a/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
+++ b/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
@@ -6,7 +6,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// Silo identity configuration options.
     /// </summary>
-    public class SiloIdentityOptions
+    public class SiloOptions
     {
         /// <summary>
         /// Gets or sets the silo name.
@@ -32,12 +32,12 @@ namespace Orleans.Runtime
         /// <summary>
         /// Initializes a new instance of the <see cref="SiloInitializationParameters"/> class. 
         /// </summary>
-        /// <param name="identityOptions">The identity of this silo.</param>
+        /// <param name="siloOptions">The identity of this silo.</param>
         /// <param name="config">The cluster configuration.</param>
         public SiloInitializationParameters(
-            IOptions<SiloIdentityOptions> identityOptions,
+            IOptions<SiloOptions> siloOptions,
             ClusterConfiguration config) : this(
-            identityOptions.Value.SiloName,
+            siloOptions.Value.SiloName,
             config)
         {
         }

--- a/src/Orleans.Runtime/Versions/GrainVersionStore.cs
+++ b/src/Orleans.Runtime/Versions/GrainVersionStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Orleans.Runtime.Configuration;
 using Orleans.Storage;
 using Orleans.Versions;
@@ -20,10 +21,10 @@ namespace Orleans.Runtime.Versions
 
         public bool IsEnabled { get; private set; }
 
-        public GrainVersionStore(IInternalGrainFactory grainFactory, GlobalConfiguration configuration)
+        public GrainVersionStore(IInternalGrainFactory grainFactory, IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
             this.grainFactory = grainFactory;
-            this.clusterId = configuration.ClusterId;
+            this.clusterId = siloIdentityOptions.Value.ClusterId;
             this.IsEnabled = false;
         }
 

--- a/src/Orleans.Runtime/Versions/GrainVersionStore.cs
+++ b/src/Orleans.Runtime/Versions/GrainVersionStore.cs
@@ -21,10 +21,10 @@ namespace Orleans.Runtime.Versions
 
         public bool IsEnabled { get; private set; }
 
-        public GrainVersionStore(IInternalGrainFactory grainFactory, IOptions<SiloIdentityOptions> siloIdentityOptions)
+        public GrainVersionStore(IInternalGrainFactory grainFactory, IOptions<SiloOptions> siloOptions)
         {
             this.grainFactory = grainFactory;
-            this.clusterId = siloIdentityOptions.Value.ClusterId;
+            this.clusterId = siloOptions.Value.ClusterId;
             this.IsEnabled = false;
         }
 

--- a/src/OrleansAWSUtils/Membership/DynamoDBMembershipTable.cs
+++ b/src/OrleansAWSUtils/Membership/DynamoDBMembershipTable.cs
@@ -27,12 +27,12 @@ namespace Orleans.Runtime.MembershipService
         private DynamoDBStorage storage;
         private readonly DynamoDBMembershipOptions options;
         private readonly string clusterId;
-        public DynamoDBMembershipTable(ILoggerFactory loggerFactory, IOptions<DynamoDBMembershipOptions> options, GlobalConfiguration globalConfiguration)
+        public DynamoDBMembershipTable(ILoggerFactory loggerFactory, IOptions<DynamoDBMembershipOptions> options, IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<DynamoDBMembershipTable>();
             this.options = options.Value;
-            this.clusterId = globalConfiguration.ClusterId;
+            this.clusterId = siloIdentityOptions.Value.ClusterId;
         }
 
         public Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/OrleansAWSUtils/Membership/DynamoDBMembershipTable.cs
+++ b/src/OrleansAWSUtils/Membership/DynamoDBMembershipTable.cs
@@ -27,12 +27,12 @@ namespace Orleans.Runtime.MembershipService
         private DynamoDBStorage storage;
         private readonly DynamoDBMembershipOptions options;
         private readonly string clusterId;
-        public DynamoDBMembershipTable(ILoggerFactory loggerFactory, IOptions<DynamoDBMembershipOptions> options, IOptions<SiloIdentityOptions> siloIdentityOptions)
+        public DynamoDBMembershipTable(ILoggerFactory loggerFactory, IOptions<DynamoDBMembershipOptions> options, IOptions<SiloOptions> siloOptions)
         {
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<DynamoDBMembershipTable>();
             this.options = options.Value;
-            this.clusterId = siloIdentityOptions.Value.ClusterId;
+            this.clusterId = siloOptions.Value.ClusterId;
         }
 
         public Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
+++ b/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.Runtime.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Runtime.ReminderService
 {
@@ -11,19 +12,20 @@ namespace Orleans.Runtime.ReminderService
         private readonly IGrainReferenceConverter grainReferenceConverter;
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
+        private readonly SiloIdentityOptions siloIdentityOptions;
         private RemindersTableManager remTableManager;
 
-        public AzureBasedReminderTable(IGrainReferenceConverter grainReferenceConverter, ILoggerFactory loggerFactory)
+        public AzureBasedReminderTable(IGrainReferenceConverter grainReferenceConverter, ILoggerFactory loggerFactory, IOptions<SiloIdentityOptions> siloIdentityOptions)
         {
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = loggerFactory.CreateLogger<AzureBasedReminderTable>();
             this.loggerFactory = loggerFactory;
-
+            this.siloIdentityOptions = siloIdentityOptions.Value;
         }
 
         public async Task Init(GlobalConfiguration config)
         {
-            remTableManager = await RemindersTableManager.GetManager(config.ServiceId, config.ClusterId, config.DataConnectionStringForReminders, this.loggerFactory);
+            remTableManager = await RemindersTableManager.GetManager(config.ServiceId, this.siloIdentityOptions.ClusterId, config.DataConnectionStringForReminders, this.loggerFactory);
         }
 
         #region Utility methods

--- a/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
+++ b/src/OrleansAzureUtils/Storage/AzureBasedReminderTable.cs
@@ -12,20 +12,20 @@ namespace Orleans.Runtime.ReminderService
         private readonly IGrainReferenceConverter grainReferenceConverter;
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
-        private readonly SiloIdentityOptions siloIdentityOptions;
+        private readonly SiloOptions siloOptions;
         private RemindersTableManager remTableManager;
 
-        public AzureBasedReminderTable(IGrainReferenceConverter grainReferenceConverter, ILoggerFactory loggerFactory, IOptions<SiloIdentityOptions> siloIdentityOptions)
+        public AzureBasedReminderTable(IGrainReferenceConverter grainReferenceConverter, ILoggerFactory loggerFactory, IOptions<SiloOptions> siloOptions)
         {
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = loggerFactory.CreateLogger<AzureBasedReminderTable>();
             this.loggerFactory = loggerFactory;
-            this.siloIdentityOptions = siloIdentityOptions.Value;
+            this.siloOptions = siloOptions.Value;
         }
 
         public async Task Init(GlobalConfiguration config)
         {
-            remTableManager = await RemindersTableManager.GetManager(config.ServiceId, this.siloIdentityOptions.ClusterId, config.DataConnectionStringForReminders, this.loggerFactory);
+            remTableManager = await RemindersTableManager.GetManager(config.ServiceId, this.siloOptions.ClusterId, config.DataConnectionStringForReminders, this.loggerFactory);
         }
 
         #region Utility methods

--- a/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
+++ b/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
@@ -15,12 +15,12 @@ namespace Orleans.Runtime.MembershipService
         private ILogger logger;
         private RelationalOrleansQueries orleansQueries;
         private readonly SqlMembershipOptions membershipTableOptions;
-        public SqlMembershipTable(IGrainReferenceConverter grainReferenceConverter, GlobalConfiguration globalConfig, IOptions<SqlMembershipOptions> membershipTableoptions, ILogger<SqlMembershipTable> logger)
+        public SqlMembershipTable(IGrainReferenceConverter grainReferenceConverter, IOptions<SiloIdentityOptions> siloIdentityOptions, IOptions<SqlMembershipOptions> membershipTableoptions, ILogger<SqlMembershipTable> logger)
         {
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = logger;
             this.membershipTableOptions = membershipTableoptions.Value;
-            this.clusterId = globalConfig.ClusterId;
+            this.clusterId = siloIdentityOptions.Value.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
+++ b/src/OrleansSQLUtils/Messaging/SqlMembershipTable.cs
@@ -15,12 +15,12 @@ namespace Orleans.Runtime.MembershipService
         private ILogger logger;
         private RelationalOrleansQueries orleansQueries;
         private readonly SqlMembershipOptions membershipTableOptions;
-        public SqlMembershipTable(IGrainReferenceConverter grainReferenceConverter, IOptions<SiloIdentityOptions> siloIdentityOptions, IOptions<SqlMembershipOptions> membershipTableoptions, ILogger<SqlMembershipTable> logger)
+        public SqlMembershipTable(IGrainReferenceConverter grainReferenceConverter, IOptions<SiloOptions> siloOptions, IOptions<SqlMembershipOptions> membershipTableoptions, ILogger<SqlMembershipTable> logger)
         {
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = logger;
             this.membershipTableOptions = membershipTableoptions.Value;
-            this.clusterId = siloIdentityOptions.Value.ClusterId;
+            this.clusterId = siloOptions.Value.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -47,7 +47,7 @@ namespace AWSUtils.Tests.MembershipTests
             {
                 ConnectionString = this.connectionString,
             };
-            return new DynamoDBMembershipTable(this.loggerFactory, Options.Create<DynamoDBMembershipOptions>(options), this.globalConfiguration);
+            return new DynamoDBMembershipTable(this.loggerFactory, Options.Create(options), this.siloIdentityOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -47,7 +47,7 @@ namespace AWSUtils.Tests.MembershipTests
             {
                 ConnectionString = this.connectionString,
             };
-            return new DynamoDBMembershipTable(this.loggerFactory, Options.Create(options), this.siloIdentityOptions);
+            return new DynamoDBMembershipTable(this.loggerFactory, Options.Create(options), this.siloOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -42,7 +42,7 @@ namespace Consul.Tests
             {
                 Address = new Uri(this.connectionString)
             };
-            return new ConsulBasedMembershipTable(loggerFactory.CreateLogger<ConsulBasedMembershipTable>(), Options.Create<ConsulMembershipOptions>(options), this.globalConfiguration);
+            return new ConsulBasedMembershipTable(loggerFactory.CreateLogger<ConsulBasedMembershipTable>(), Options.Create(options), this.siloIdentityOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -42,7 +42,7 @@ namespace Consul.Tests
             {
                 Address = new Uri(this.connectionString)
             };
-            return new ConsulBasedMembershipTable(loggerFactory.CreateLogger<ConsulBasedMembershipTable>(), Options.Create(options), this.siloIdentityOptions);
+            return new ConsulBasedMembershipTable(loggerFactory.CreateLogger<ConsulBasedMembershipTable>(), Options.Create(options), this.siloOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterAzureUtils/AzureMembershipTableTests.cs
+++ b/test/TesterAzureUtils/AzureMembershipTableTests.cs
@@ -44,7 +44,7 @@ namespace Tester.AzureUtils
                 MaxStorageBusyRetries = 3,
                 ConnectionString = this.connectionString,
             };
-            return new AzureBasedMembershipTable(loggerFactory, Options.Create<AzureTableMembershipOptions>(options), this.globalConfiguration);
+            return new AzureBasedMembershipTable(loggerFactory, Options.Create(options), this.siloIdentityOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterAzureUtils/AzureMembershipTableTests.cs
+++ b/test/TesterAzureUtils/AzureMembershipTableTests.cs
@@ -44,7 +44,7 @@ namespace Tester.AzureUtils
                 MaxStorageBusyRetries = 3,
                 ConnectionString = this.connectionString,
             };
-            return new AzureBasedMembershipTable(loggerFactory, Options.Create(options), this.siloIdentityOptions);
+            return new AzureBasedMembershipTable(loggerFactory, Options.Create(options), this.siloOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterAzureUtils/AzureRemindersTableTests.cs
+++ b/test/TesterAzureUtils/AzureRemindersTableTests.cs
@@ -41,7 +41,7 @@ namespace UnitTests.RemindersTest
         protected override IReminderTable CreateRemindersTable()
         {
             TestUtils.CheckForAzureStorage();
-            return new AzureBasedReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(), loggerFactory, this.siloIdentityOptions);
+            return new AzureBasedReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(), loggerFactory, this.siloOptions);
         }
 
         protected override Task<string> GetConnectionString()

--- a/test/TesterAzureUtils/AzureRemindersTableTests.cs
+++ b/test/TesterAzureUtils/AzureRemindersTableTests.cs
@@ -41,7 +41,7 @@ namespace UnitTests.RemindersTest
         protected override IReminderTable CreateRemindersTable()
         {
             TestUtils.CheckForAzureStorage();
-            return new AzureBasedReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(), loggerFactory);
+            return new AzureBasedReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(), loggerFactory, this.siloIdentityOptions);
         }
 
         protected override Task<string> GetConnectionString()

--- a/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -47,8 +47,8 @@ namespace Tester.AzureUtils.TimerTests
         [SkippableFact, TestCategory("ReminderService"), TestCategory("Performance")]
         public async Task Reminders_AzureTable_InsertRate()
         {
-            var siloIdentityOptions = Options.Create(new SiloIdentityOptions { ClusterId = "TMSLocalTesting" });
-            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, siloIdentityOptions);
+            var siloOptions = Options.Create(new SiloOptions { ClusterId = "TMSLocalTesting" });
+            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, siloOptions);
             var config = new GlobalConfiguration()
             {
                 ServiceId = ServiceId,
@@ -64,8 +64,8 @@ namespace Tester.AzureUtils.TimerTests
         public async Task Reminders_AzureTable_InsertNewRowAndReadBack()
         {
             string clusterId = NewClusterId();
-            var siloIdentityOptions = Options.Create(new SiloIdentityOptions { ClusterId = clusterId });
-            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, siloIdentityOptions);
+            var siloOptions = Options.Create(new SiloOptions { ClusterId = clusterId });
+            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, siloOptions);
             var config = new GlobalConfiguration()
             {
                 ServiceId = ServiceId,

--- a/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -11,6 +11,7 @@ using TestExtensions;
 using Xunit;
 using Xunit.Abstractions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.TestingHost.Utils;
 
 // ReSharper disable InconsistentNaming
@@ -46,11 +47,11 @@ namespace Tester.AzureUtils.TimerTests
         [SkippableFact, TestCategory("ReminderService"), TestCategory("Performance")]
         public async Task Reminders_AzureTable_InsertRate()
         {
-            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory);
+            var siloIdentityOptions = Options.Create(new SiloIdentityOptions { ClusterId = "TMSLocalTesting" });
+            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, siloIdentityOptions);
             var config = new GlobalConfiguration()
             {
                 ServiceId = ServiceId,
-                ClusterId = "TMSLocalTesting",
                 DataConnectionString = TestDefaultConfiguration.DataConnectionString
             };
             await table.Init(config);
@@ -63,7 +64,8 @@ namespace Tester.AzureUtils.TimerTests
         public async Task Reminders_AzureTable_InsertNewRowAndReadBack()
         {
             string clusterId = NewClusterId();
-            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory);
+            var siloIdentityOptions = Options.Create(new SiloIdentityOptions { ClusterId = clusterId });
+            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, siloIdentityOptions);
             var config = new GlobalConfiguration()
             {
                 ServiceId = ServiceId,

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -40,7 +40,7 @@ namespace UnitTests.MembershipTests
         protected readonly string clusterId;
         protected readonly string connectionString;
         protected ILoggerFactory loggerFactory;
-        protected IOptions<SiloIdentityOptions> siloIdentityOptions;
+        protected IOptions<SiloOptions> siloOptions;
         protected const string testDatabaseName = "OrleansMembershipTest";//for relational storage
         protected readonly ClientConfiguration clientConfiguration;
         protected MembershipTableTestsBase(ConnectionStringFixture fixture, TestEnvironmentFixture environment, LoggerFilterOptions filters)
@@ -55,7 +55,7 @@ namespace UnitTests.MembershipTests
 
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
             this.connectionString = fixture.ConnectionString;
-            this.siloIdentityOptions = Options.Create(new SiloIdentityOptions() { ClusterId = this.clusterId });
+            this.siloOptions = Options.Create(new SiloOptions() { ClusterId = this.clusterId });
             var adoVariant = GetAdoInvariant();
 
             membershipTable = CreateMembershipTable(logger);

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -24,7 +24,7 @@ namespace UnitTests.RemindersTest
 
         private readonly IReminderTable remindersTable;
         protected ILoggerFactory loggerFactory;
-        protected IOptions<SiloIdentityOptions> siloIdentityOptions;
+        protected IOptions<SiloOptions> siloOptions;
         protected const string testDatabaseName = "OrleansReminderTest";//for relational storage
         
         protected ReminderTableTestsBase(ConnectionStringFixture fixture, TestEnvironmentFixture clusterFixture, LoggerFilterOptions filters)
@@ -36,7 +36,7 @@ namespace UnitTests.RemindersTest
             var clusterId = "test-" + serviceId;
 
             logger.Info("ClusterId={0}", clusterId);
-            siloIdentityOptions = Options.Create(new SiloIdentityOptions { ClusterId = clusterId });
+            siloOptions = Options.Create(new SiloOptions { ClusterId = clusterId });
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
 
             var globalConfiguration = new GlobalConfiguration

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -11,6 +11,7 @@ using TestExtensions;
 using UnitTests.MembershipTests;
 using Xunit;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.TestingHost.Utils;
 
 namespace UnitTests.RemindersTest
@@ -23,6 +24,7 @@ namespace UnitTests.RemindersTest
 
         private readonly IReminderTable remindersTable;
         protected ILoggerFactory loggerFactory;
+        protected IOptions<SiloIdentityOptions> siloIdentityOptions;
         protected const string testDatabaseName = "OrleansReminderTest";//for relational storage
         
         protected ReminderTableTestsBase(ConnectionStringFixture fixture, TestEnvironmentFixture clusterFixture, LoggerFilterOptions filters)
@@ -34,7 +36,7 @@ namespace UnitTests.RemindersTest
             var clusterId = "test-" + serviceId;
 
             logger.Info("ClusterId={0}", clusterId);
-
+            siloIdentityOptions = Options.Create(new SiloIdentityOptions { ClusterId = clusterId });
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
 
             var globalConfiguration = new GlobalConfiguration

--- a/test/TesterSQLUtils/MySqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/MySqlMembershipTableTests.cs
@@ -42,8 +42,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new SqlMembershipTable(this.GrainReferenceConverter, this.globalConfiguration, Options.Create<SqlMembershipOptions>(options),
-                loggerFactory.CreateLogger<SqlMembershipTable>());
+            return new SqlMembershipTable(this.GrainReferenceConverter, this.siloIdentityOptions, Options.Create(options), loggerFactory.CreateLogger<SqlMembershipTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterSQLUtils/MySqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/MySqlMembershipTableTests.cs
@@ -42,7 +42,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new SqlMembershipTable(this.GrainReferenceConverter, this.siloIdentityOptions, Options.Create(options), loggerFactory.CreateLogger<SqlMembershipTable>());
+            return new SqlMembershipTable(this.GrainReferenceConverter, this.siloOptions, Options.Create(options), loggerFactory.CreateLogger<SqlMembershipTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
@@ -39,7 +39,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new SqlMembershipTable(this.GrainReferenceConverter, this.siloIdentityOptions, Options.Create(options), this.loggerFactory.CreateLogger<SqlMembershipTable>());
+            return new SqlMembershipTable(this.GrainReferenceConverter, this.siloOptions, Options.Create(options), this.loggerFactory.CreateLogger<SqlMembershipTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
@@ -39,7 +39,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new SqlMembershipTable(this.GrainReferenceConverter, this.globalConfiguration, Options.Create<SqlMembershipOptions>(options), this.loggerFactory.CreateLogger<SqlMembershipTable>());
+            return new SqlMembershipTable(this.GrainReferenceConverter, this.siloIdentityOptions, Options.Create(options), this.loggerFactory.CreateLogger<SqlMembershipTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
+++ b/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
@@ -40,7 +40,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new SqlMembershipTable(this.GrainReferenceConverter, this.siloIdentityOptions, Options.Create(options),  this.loggerFactory.CreateLogger<SqlMembershipTable>());
+            return new SqlMembershipTable(this.GrainReferenceConverter, this.siloOptions, Options.Create(options),  this.loggerFactory.CreateLogger<SqlMembershipTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
+++ b/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
@@ -40,8 +40,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new SqlMembershipTable(this.GrainReferenceConverter, this.globalConfiguration,
-                Options.Create<SqlMembershipOptions>(options),  this.loggerFactory.CreateLogger<SqlMembershipTable>());
+            return new SqlMembershipTable(this.GrainReferenceConverter, this.siloIdentityOptions, Options.Create(options),  this.loggerFactory.CreateLogger<SqlMembershipTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
+++ b/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
@@ -72,7 +72,6 @@ namespace UnitTests.SqlStatisticsPublisherTests
 
         protected async Task SqlStatisticsPublisher_ReportMetrics_Silo()
         {
-
             var options = new SqlMembershipOptions()
             {
                 AdoInvariant = AdoInvariant,
@@ -80,7 +79,7 @@ namespace UnitTests.SqlStatisticsPublisherTests
             };
 
             IMembershipTable mbr = new SqlMembershipTable(this.environment.Services.GetRequiredService<IGrainReferenceConverter>(), 
-                this.environment.Services.GetRequiredService<GlobalConfiguration>(), Options.Create<SqlMembershipOptions>(options), 
+                this.environment.Services.GetRequiredService<IOptions<SiloIdentityOptions>>(), Options.Create(options), 
                 this.loggerFactory.CreateLogger<SqlMembershipTable>());
             await mbr.InitializeMembershipTable(true).WithTimeout(TimeSpan.FromMinutes(1));
             StatisticsPublisher.AddConfiguration("statisticsDeployment", true, "statisticsSiloId", SiloAddressUtils.NewLocalSiloAddress(0), new IPEndPoint(IPAddress.Loopback, 12345), "statisticsHostName");

--- a/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
+++ b/test/TesterSQLUtils/SqlStatisticsPublisherTests/SqlStatisticsPublisherTestsBase.cs
@@ -79,7 +79,7 @@ namespace UnitTests.SqlStatisticsPublisherTests
             };
 
             IMembershipTable mbr = new SqlMembershipTable(this.environment.Services.GetRequiredService<IGrainReferenceConverter>(), 
-                this.environment.Services.GetRequiredService<IOptions<SiloIdentityOptions>>(), Options.Create(options), 
+                this.environment.Services.GetRequiredService<IOptions<SiloOptions>>(), Options.Create(options), 
                 this.loggerFactory.CreateLogger<SqlMembershipTable>());
             await mbr.InitializeMembershipTable(true).WithTimeout(TimeSpan.FromMinutes(1));
             StatisticsPublisher.AddConfiguration("statisticsDeployment", true, "statisticsSiloId", SiloAddressUtils.NewLocalSiloAddress(0), new IPEndPoint(IPAddress.Loopback, 12345), "statisticsHostName");

--- a/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -37,7 +37,7 @@ namespace UnitTests.MembershipTests
             var options = new ZooKeeperMembershipOptions();
             options.ConnectionString = this.connectionString;
            
-            return new ZooKeeperBasedMembershipTable(this.Services.GetService<ILogger<ZooKeeperBasedMembershipTable>>(), Options.Create(options), this.siloIdentityOptions);
+            return new ZooKeeperBasedMembershipTable(this.Services.GetService<ILogger<ZooKeeperBasedMembershipTable>>(), Options.Create(options), this.siloOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)

--- a/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -37,8 +37,7 @@ namespace UnitTests.MembershipTests
             var options = new ZooKeeperMembershipOptions();
             options.ConnectionString = this.connectionString;
            
-            return new ZooKeeperBasedMembershipTable(this.Services.GetService<ILogger<ZooKeeperBasedMembershipTable>>(),
-               Options.Create<ZooKeeperMembershipOptions>(options), this.globalConfiguration);
+            return new ZooKeeperBasedMembershipTable(this.Services.GetService<ILogger<ZooKeeperBasedMembershipTable>>(), Options.Create(options), this.siloIdentityOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(Logger logger)


### PR DESCRIPTION
Rename `SiloIdentityOptions` to `SiloOptions`
Migrate `GlobalConfiguration.ClusterId` to `SiloOptions.ClusterId`
Migrate multi-cluster configuration in `GlobalConfiguration` to a new `MultiClusterOptions` type