### PR TITLE
Support serialization lifecycle hooks

### DIFF
--- a/src/Orleans.CodeGeneration/SerializerGenerationManager.cs
+++ b/src/Orleans.CodeGeneration/SerializerGenerationManager.cs
@@ -153,6 +153,10 @@ namespace Orleans.CodeGenerator
                 RecordType(arg, targetAssembly);
             }
 
+            // Do not generate serializers for classes which require the use of serialization hooks.
+            // Instead, a fallback serializer which supports those hooks can be used.
+            if (DotNetSerializableUtilities.HasSerializationHookAttributes(t)) return false;
+
             return true;
         }
 

--- a/src/Orleans.Core/Serialization/BinaryFormatterISerializableSerializer.cs
+++ b/src/Orleans.Core/Serialization/BinaryFormatterISerializableSerializer.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Reflection;
 using System.Runtime.Serialization;
-using Orleans.Utilities;
 
 namespace Orleans.Serialization
 {
@@ -11,7 +9,6 @@ namespace Orleans.Serialization
     internal class BinaryFormatterISerializableSerializer : IKeyedSerializer
     {
         private static readonly Type SerializableType = typeof(ISerializable);
-        private static readonly Type[] SerializationConstructorParameterTypes = { typeof(SerializationInfo), typeof(StreamingContext) };
         
         private readonly BinaryFormatterSerializer serializer;
 
@@ -23,8 +20,7 @@ namespace Orleans.Serialization
         /// <inheritdoc />
         public bool IsSupportedType(Type itemType)
         {
-            return SerializableType.IsAssignableFrom(itemType)
-                   && HasSerializationConstructor(itemType);
+            return SerializableType.IsAssignableFrom(itemType) && DotNetSerializableUtilities.HasSerializationConstructor(itemType);
         }
 
         /// <inheritdoc />
@@ -38,14 +34,5 @@ namespace Orleans.Serialization
 
         /// <inheritdoc />
         public KeyedSerializerId SerializerId => KeyedSerializerId.BinaryFormatterISerializable;
-
-        private static bool HasSerializationConstructor(Type type)
-        {
-            return type.GetConstructor(
-                       BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                       null,
-                       SerializationConstructorParameterTypes,
-                       null) != null;
-        }
     }
 }

--- a/src/Orleans.Core/Serialization/DotNetSerializableUtilities.cs
+++ b/src/Orleans.Core/Serialization/DotNetSerializableUtilities.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Orleans.Serialization
+{
+    internal static class DotNetSerializableUtilities
+    {
+        private static readonly Type[] SerializationConstructorParameterTypes = { typeof(SerializationInfo), typeof(StreamingContext) };
+
+        public static bool HasSerializationConstructor(Type type)
+        {
+            return type.GetConstructor(
+                       BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                       null,
+                       SerializationConstructorParameterTypes,
+                       null) != null;
+        }
+
+        public static bool HasSerializationHookAttributes(Type type)
+        {
+            return type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                       .Any(m => m.GetCustomAttributes().Any(a =>
+                           a is OnSerializingAttribute ||
+                           a is OnSerializedAttribute ||
+                           a is OnDeserializingAttribute ||
+                           a is OnDeserializedAttribute));
+        }
+    }
+}

--- a/src/Orleans.Core/Serialization/ILSerializerGenerator.cs
+++ b/src/Orleans.Core/Serialization/ILSerializerGenerator.cs
@@ -62,7 +62,8 @@ namespace Orleans.Serialization
         /// <returns>A value indicating whether the provided <paramref name="type"/> is supported.</returns>
         public static bool IsSupportedType(Type type)
         {
-            return !type.IsAbstract && !type.IsInterface && !type.IsArray && !type.IsEnum && IsSupportedFieldType(type);
+            return !type.IsAbstract && !type.IsInterface && !type.IsArray && !type.IsEnum &&
+                   IsSupportedFieldType(type) && !DotNetSerializableUtilities.HasSerializationHookAttributes(type);
         }
 
         /// <summary>

--- a/src/Orleans.Core/Serialization/ILSerializerGenerator.cs
+++ b/src/Orleans.Core/Serialization/ILSerializerGenerator.cs
@@ -1,13 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Orleans.Runtime;
+
 namespace Orleans.Serialization
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using System.Reflection;
-
-    using Orleans.Runtime;
-
     internal class ILSerializerGenerator
     {
         private static readonly RuntimeTypeHandle IntPtrTypeHandle = typeof(IntPtr).TypeHandle;
@@ -23,11 +23,6 @@ namespace Orleans.Serialization
         private static readonly DeepCopier ImmutableTypeCopier = (obj, context) => obj;
 
         private static readonly ILFieldBuilder FieldBuilder = new ILFieldBuilder();
-
-        private static readonly Type OnDeserializedLifecycleType = typeof(IOnDeserialized);
-
-        private static readonly MethodInfo OnDeserializedMethod =
-            TypeUtils.Method((IOnDeserialized i) => i.OnDeserialized(default(ISerializerContext)));
 
         static ILSerializerGenerator()
         {
@@ -62,8 +57,7 @@ namespace Orleans.Serialization
         /// <returns>A value indicating whether the provided <paramref name="type"/> is supported.</returns>
         public static bool IsSupportedType(Type type)
         {
-            return !type.IsAbstract && !type.IsInterface && !type.IsArray && !type.IsEnum &&
-                   IsSupportedFieldType(type) && !DotNetSerializableUtilities.HasSerializationHookAttributes(type);
+            return !type.IsAbstract && !type.IsInterface && !type.IsArray && !type.IsEnum && IsSupportedFieldType(type);
         }
 
         /// <summary>
@@ -86,23 +80,24 @@ namespace Orleans.Serialization
         {
             try
             {
-                var serializationFields = this.GetFields(type, serializationFieldsFilter, fieldComparer);
-                List<FieldInfo> copyFields;
-                if (copyFieldsFilter == serializationFieldsFilter)
+                bool SerializationFieldFilter(FieldInfo field) => !field.IsNotSerialized() && (serializationFieldsFilter?.Invoke(field) ?? true);
+                var serializationFields = this.GetFields(type, SerializationFieldFilter, fieldComparer);
+
+                var callbacks = GetSerializationCallbacks(type);
+
+                DeepCopier copier;
+                if (type.IsOrleansShallowCopyable())
                 {
-                    copyFields = serializationFields;
+                    copier = ImmutableTypeCopier;
                 }
                 else
                 {
-                    copyFields = this.GetFields(type, copyFieldsFilter, fieldComparer);
+                    var copyFields = this.GetFields(type, copyFieldsFilter, fieldComparer);
+                    copier = this.EmitCopier(type, copyFields).CreateDelegate();
                 }
-                
-                DeepCopier copier;
-                if (type.IsOrleansShallowCopyable()) copier = ImmutableTypeCopier;
-                else copier = this.EmitCopier(type, copyFields).CreateDelegate();
 
-                var serializer = this.EmitSerializer(type, serializationFields);
-                var deserializer = this.EmitDeserializer(type, serializationFields);
+                var serializer = this.EmitSerializer(type, serializationFields, callbacks);
+                var deserializer = this.EmitDeserializer(type, serializationFields, callbacks);
                 return new SerializerMethods(
                     copier,
                     serializer.CreateDelegate(),
@@ -169,7 +164,8 @@ namespace Orleans.Serialization
             return il;
         }
 
-        private ILDelegateBuilder<Serializer> EmitSerializer(Type type, List<FieldInfo> fields)
+        private ILDelegateBuilder<Serializer> EmitSerializer(Type type, List<FieldInfo> fields,
+            SerializationCallbacks callbacks)
         {
             var il = new ILDelegateBuilder<Serializer>(
                 FieldBuilder,
@@ -179,10 +175,27 @@ namespace Orleans.Serialization
             // Declare local variables.
             var typedInput = il.DeclareLocal(type);
 
+            var streamingContext = default(ILDelegateBuilder<Serializer>.Local);
+            if (callbacks.OnSerializing != null || callbacks.OnSerialized != null)
+            {
+                streamingContext = il.DeclareLocal(typeof(StreamingContext));
+                il.LoadLocalAddress(streamingContext);
+                il.LoadConstant((int) StreamingContextStates.All);
+                il.LoadArgument(1);
+                il.Call(typeof(StreamingContext).GetConstructor(new[] {typeof(StreamingContextStates), typeof(object)}));
+            }
+
             // Set the typed input variable from the method parameter.
             il.LoadArgument(0);
             il.CastOrUnbox(type);
             il.StoreLocal(typedInput);
+
+            if (callbacks.OnSerializing != null)
+            {
+                il.LoadLocalAsReference(type, typedInput);
+                il.LoadLocal(streamingContext);
+                il.Call(callbacks.OnSerializing);
+            }
 
             // Serialize each field
             foreach (var field in fields)
@@ -220,16 +233,35 @@ namespace Orleans.Serialization
                 }
             }
 
+            if (callbacks.OnSerialized != null)
+            {
+                il.LoadLocalAsReference(type, typedInput);
+                il.LoadLocal(streamingContext);
+                il.Call(callbacks.OnSerialized);
+            }
+
             il.Return();
             return il;
         }
 
-        private ILDelegateBuilder<Deserializer> EmitDeserializer(Type type, List<FieldInfo> fields)
+        private ILDelegateBuilder<Deserializer> EmitDeserializer(Type type, List<FieldInfo> fields,
+            SerializationCallbacks callbacks)
         {
             var il = new ILDelegateBuilder<Deserializer>(
                 FieldBuilder,
                 type.Name + "Deserializer",
                 SerializationMethodInfos.DeserializerDelegate);
+
+            var streamingContext = default(ILDelegateBuilder<Deserializer>.Local);
+            if (callbacks.OnDeserializing != null || callbacks.OnDeserialized != null)
+            {
+                streamingContext = il.DeclareLocal(typeof(StreamingContext));
+                il.LoadLocalAddress(streamingContext);
+                il.LoadConstant((int) StreamingContextStates.All);
+                il.LoadArgument(1);
+                il.Call(typeof(StreamingContext).GetConstructor(new[]
+                    {typeof(StreamingContextStates), typeof(object)}));
+            }
 
             // Declare local variables.
             var result = il.DeclareLocal(type);
@@ -242,6 +274,13 @@ namespace Orleans.Serialization
             il.LoadLocal(result);
             il.BoxIfValueType(type);
             il.Call(SerializationMethodInfos.RecordObjectWhileDeserializing);
+
+            if (callbacks.OnDeserializing != null)
+            {
+                il.LoadLocalAsReference(type, result);
+                il.LoadLocal(streamingContext);
+                il.Call(callbacks.OnDeserializing);
+            }
 
             // Deserialize each field.
             foreach (var field in fields)
@@ -282,18 +321,105 @@ namespace Orleans.Serialization
                 }
             }
 
-            // If the type implements the IOnDeserialized lifecycle handler, call that method now.
-            if (OnDeserializedLifecycleType.IsAssignableFrom(type))
+            if (callbacks.OnDeserialized != null)
             {
-                il.LoadLocal(result);
+                il.LoadLocalAsReference(type, result);
+                il.LoadLocal(streamingContext);
+                il.Call(callbacks.OnDeserialized);
+            }
+
+            // If the type implements the IOnDeserialized lifecycle handler, call that method now.
+            if (typeof(IOnDeserialized).IsAssignableFrom(type))
+            {
+                il.LoadLocalAsReference(type, result);
                 il.LoadArgument(1);
-                il.Call(OnDeserializedMethod);
+                var concreteMethod = GetConcreteMethod(
+                    type,
+                    TypeUtils.Method((IOnDeserialized i) => i.OnDeserialized(default(ISerializerContext))));
+                il.Call(concreteMethod);
+            }
+
+            // If the type implements the IDeserializationCallback lifecycle handler, call that method now.
+            if (typeof(IDeserializationCallback).IsAssignableFrom(type))
+            {
+                il.LoadLocalAsReference(type, result);
+                il.LoadArgument(1);
+
+                var concreteMethod = GetConcreteMethod(
+                    type,
+                    TypeUtils.Method((IDeserializationCallback i) => i.OnDeserialization(default(object))));
+                il.Call(concreteMethod);
             }
 
             il.LoadLocal(result);
             il.BoxIfValueType(type);
             il.Return();
             return il;
+        }
+
+        private static MethodInfo GetConcreteMethod(Type type, MethodInfo interfaceMethod)
+        {
+            if (interfaceMethod == null) throw new ArgumentNullException(nameof(interfaceMethod));
+
+            var map = type.GetInterfaceMap(interfaceMethod.DeclaringType);
+            var concreteMethod = default(MethodInfo);
+            for (var i = 0; i < map.InterfaceMethods.Length; i++)
+            {
+                if (map.InterfaceMethods[i] == interfaceMethod)
+                {
+                    concreteMethod = map.TargetMethods[i];
+                    break;
+                }
+            }
+
+            if (concreteMethod == null)
+            {
+                throw new InvalidOperationException(
+                    $"Unable to find implementation of method {interfaceMethod.DeclaringType}.{interfaceMethod} on type {type} while generating serializer.");
+            }
+
+            return concreteMethod;
+        }
+
+        private SerializationCallbacks GetSerializationCallbacks(Type type)
+        {
+            var result = new SerializationCallbacks();
+            foreach (var method in type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                var parameters = method.GetParameters();
+                if (parameters.Length != 1) continue;
+                if (parameters[0].ParameterType != typeof(StreamingContext)) continue;
+
+                if (method.GetCustomAttribute<OnDeserializingAttribute>() != null)
+                {
+                    result.OnDeserializing = method;
+                }
+
+                if (method.GetCustomAttribute<OnDeserializedAttribute>() != null)
+                {
+                    result.OnDeserialized = method;
+                }
+
+                if (method.GetCustomAttribute<OnSerializingAttribute>() != null)
+                {
+                    result.OnSerializing = method;
+                }
+
+                if (method.GetCustomAttribute<OnSerializedAttribute>() != null)
+                {
+                    result.OnSerialized = method;
+                }
+            }
+
+            return result;
+        }
+
+        private class SerializationCallbacks
+        {
+            public MethodInfo OnDeserializing { get; set; }
+            public MethodInfo OnDeserialized { get; set; }
+            public MethodInfo OnSerializing { get; set; }
+            public MethodInfo OnSerialized { get; set; }
         }
 
         /// <summary>
@@ -312,8 +438,7 @@ namespace Orleans.Serialization
                 type.GetAllFields()
                     .Where(
                         field =>
-                            !field.IsNotSerialized()
-                            && !field.IsStatic
+                            !field.IsStatic
                             && IsSupportedFieldType(field.FieldType)
                             && (fieldFilter == null || fieldFilter(field)))
                     .ToList();

--- a/src/Orleans.Core/Serialization/IlDelegateBuilder.cs
+++ b/src/Orleans.Core/Serialization/IlDelegateBuilder.cs
@@ -28,7 +28,7 @@ namespace Orleans.Serialization
                 name,
                 returnType,
                 parameterTypes,
-                typeof(ILDelegateBuilder<>).GetTypeInfo().Module,
+                typeof(ILDelegateBuilder<>).Module,
                 true);
             this.il = this.dynamicMethod.GetILGenerator();
         }
@@ -248,6 +248,16 @@ namespace Orleans.Serialization
         }
 
         /// <summary>
+        /// Calls the specified method.
+        /// </summary>
+        /// <param name="method">The method to call.</param>
+        public void Call(ConstructorInfo method)
+        {
+            if (method.IsFinal || !method.IsVirtual) this.il.Emit(OpCodes.Call, method);
+            else this.il.Emit(OpCodes.Callvirt, method);
+        }
+
+        /// <summary>
         /// Returns from the current method.
         /// </summary>
         public void Return() => this.il.Emit(OpCodes.Ret);
@@ -329,7 +339,7 @@ namespace Orleans.Serialization
         /// <param name="local">The local.</param>
         public void LoadLocalAsReference(Type type, Local local)
         {
-            if (type.GetTypeInfo().IsValueType)
+            if (type.IsValueType)
             {
                 this.LoadLocalAddress(local);
             }
@@ -345,7 +355,7 @@ namespace Orleans.Serialization
         /// <param name="type">The type.</param>
         public void BoxIfValueType(Type type)
         {
-            if (type.GetTypeInfo().IsValueType)
+            if (type.IsValueType)
             {
                 this.Box(type);
             }
@@ -357,7 +367,7 @@ namespace Orleans.Serialization
         /// <param name="type">The type.</param>
         public void CastOrUnbox(Type type)
         {
-            if (type.GetTypeInfo().IsValueType)
+            if (type.IsValueType)
             {
                 this.UnboxAny(type);
             }
@@ -376,7 +386,7 @@ namespace Orleans.Serialization
         public void CreateInstance(Type type, Local local, MethodInfo getUninitializedObject)
         {
             var constructorInfo = type.GetConstructor(Type.EmptyTypes);
-            if (type.GetTypeInfo().IsValueType)
+            if (type.IsValueType)
             {
                 this.LoadLocalAddress(local);
                 this.InitObject(type);

--- a/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/BuiltInSerializerTests.cs
@@ -793,7 +793,7 @@ namespace UnitTests.Serialization
             GrainReference input = environment.InternalGrainFactory.GetGrain(grainId);
             Assert.True(input.IsBound);
 
-            object deserialized = DotNetSerializationLoop(input, environment.SerializationManager, environment.GrainFactory);
+            object deserialized = DotNetSerializationLoop(input, environment.SerializationManager);
             var grainRef = Assert.IsAssignableFrom<GrainReference>(deserialized); //GrainReference copied as wrong type
             Assert.True(grainRef.IsBound);
             Assert.Equal(grainId, grainRef.GrainId); //GrainId different after copy
@@ -811,7 +811,7 @@ namespace UnitTests.Serialization
             // Expected exception:
             // System.Runtime.Serialization.SerializationException: Type 'Echo.Grains.EchoTaskGrain' in Assembly 'UnitTestGrains, Version=1.0.0.0, Culture=neutral, PublicKeyToken=070f47935e3ed133' is not marked as serializable.
 
-            var exc = Assert.Throws<SerializationException>(() => DotNetSerializationLoop(input, environment.SerializationManager, environment.GrainFactory));
+            var exc = Assert.Throws<SerializationException>(() => DotNetSerializationLoop(input, environment.SerializationManager));
 
             Assert.Contains("is not marked as serializable", exc.Message);
         }
@@ -916,7 +916,7 @@ namespace UnitTests.Serialization
             public int AnotherValueType;
         }
 
-        internal object OrleansSerializationLoop(SerializationManager serializationManager, object input, bool includeWire = true)
+        internal static object OrleansSerializationLoop(SerializationManager serializationManager, object input, bool includeWire = true)
         {
             var copy = serializationManager.DeepCopy(input);
             if (includeWire)
@@ -926,7 +926,7 @@ namespace UnitTests.Serialization
             return copy;
         }
 
-        private object DotNetSerializationLoop(object input, SerializationManager serializationManager, IGrainFactory grainFactory)
+        internal static object DotNetSerializationLoop(object input, SerializationManager serializationManager)
         {
             byte[] bytes;
             object deserialized;
@@ -1162,8 +1162,7 @@ namespace UnitTests.Serialization
 
             var result2 = (SimpleISerializableObject)DotNetSerializationLoop(
                 input2,
-                environment.SerializationManager,
-                environment.GrainFactory);
+                environment.SerializationManager);
 
             Assert.Equal(input2.History, input.History);
             Assert.Equal(result2.History, result.History);
@@ -1203,8 +1202,7 @@ namespace UnitTests.Serialization
 
             var result2 = (SimpleISerializableStruct)DotNetSerializationLoop(
                 input2,
-                environment.SerializationManager,
-                environment.GrainFactory);
+                environment.SerializationManager);
 
             Assert.Equal(input2.History, input.History);
             Assert.Equal(result2.History, result.History);

--- a/test/NonSilo.Tests/Serialization/ILBasedSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/ILBasedSerializerTests.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.Serialization;
+using Orleans.Runtime;
 using Orleans.Serialization;
 using TestExtensions;
 using Xunit;
@@ -83,7 +87,7 @@ namespace UnitTests.Serialization
         /// Tests that <see cref="ILSerializerGenerator"/> does not serialize fields marked as [NonSerialized].
         /// </summary>
         [Fact]
-        public void ILSerialized_NonSerializedFields()
+        public void ILSerializer_NonSerializedFields()
         {
             var input = new FieldTest
             {
@@ -102,12 +106,223 @@ namespace UnitTests.Serialization
             {
                 StreamReader = new BinaryTokenStreamReader(writer.StreamWriter.ToByteArray())
             };
-            var deserialized = (FieldTest)serializers.Deserialize(input.GetType(), reader);
+            var deserialized = (FieldTest) serializers.Deserialize(input.GetType(), reader);
 
             Assert.Equal(input.One, deserialized.One);
             Assert.Equal(input.Two, deserialized.Two);
             Assert.NotEqual(input.NonSerializedInt, deserialized.NonSerializedInt);
             Assert.Equal(default(int), deserialized.NonSerializedInt);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="ILBasedSerializer"/> can correctly serialize objects which have serialization lifecycle hooks.
+        /// </summary>
+        [Fact]
+        public void ILSerializer_SerializesObjectWithHooks()
+        {
+            var input = new SimpleISerializableObject
+            {
+                Payload = "pyjamas"
+            };
+
+            // Verify that our behavior conforms to our expected behavior.
+            var result = SerializerLoop(input);
+            Assert.Equal(
+                new[]
+                {
+                    "default_ctor",
+                    "serializing",
+                    "serialized"
+                },
+                input.History);
+            Assert.Equal(2, input.Contexts.Count);
+            Assert.All(input.Contexts,
+                ctx => Assert.True(ctx.Context is ICopyContext || ctx.Context is ISerializationContext));
+
+            Assert.Equal(
+                new[]
+                {
+                    "default_ctor",
+                    "deserializing",
+                    "deserialized",
+                    "deserialization"
+                },
+                result.History);
+            Assert.Equal(input.Payload, result.Payload, StringComparer.Ordinal);
+            Assert.Equal(2, result.Contexts.Count);
+            Assert.All(result.Contexts, ctx => Assert.True(ctx.Context is IDeserializationContext));
+
+            // Verify that our behavior conforms to the behavior of BinaryFormatter.
+            var input2 = new SimpleISerializableObject
+            {
+                Payload = "pyjamas"
+            };
+
+            var result2 = (SimpleISerializableObject) BuiltInSerializerTests.DotNetSerializationLoop(
+                input2,
+                this.fixture.SerializationManager);
+
+            Assert.Equal(input2.History, input.History);
+            Assert.Equal(result2.History, result.History.Skip(1).ToList());
+        }
+
+        /// <summary>
+        /// Tests that <see cref="ILBasedSerializer"/> can correctly serialize structs which have serialization lifecycle hooks.
+        /// </summary>
+        [Fact]
+        public void ILSerializer_SerializesStructWithHooks()
+        {
+            var input = new SimpleISerializableStruct
+            {
+                Payload = "pyjamas"
+            };
+
+            // Verify that our behavior conforms to our expected behavior.
+            var result = SerializerLoop(input);
+            Assert.Equal(
+                new[]
+                {
+                    "deserializing",
+                    "deserialized",
+                    "deserialization"
+                },
+                result.History);
+            Assert.Equal(input.Payload, result.Payload, StringComparer.Ordinal);
+            Assert.Equal(2, result.Contexts.Count);
+            Assert.All(result.Contexts, ctx => Assert.True(ctx.Context is IDeserializationContext));
+
+            // Verify that our behavior conforms to the behavior of BinaryFormatter.
+            var input2 = new SimpleISerializableStruct
+            {
+                Payload = "pyjamas"
+            };
+
+            var result2 = (SimpleISerializableStruct) BuiltInSerializerTests.DotNetSerializationLoop(
+                input2,
+                this.fixture.SerializationManager);
+
+            Assert.Equal(input2.History, input.History);
+            Assert.Equal(result2.History, result.History);
+        }
+
+        private T SerializerLoop<T>(T input)
+        {
+            var serializer = new ILBasedSerializer(new CachedTypeResolver());
+            Assert.True(serializer.IsSupportedType(input.GetType()));
+            
+            var serializationContext =
+                new SerializationContext(this.fixture.SerializationManager)
+                {
+                    StreamWriter = new BinaryTokenStreamWriter()
+                };
+            serializer.Serialize(input, serializationContext, typeof(T));
+            var deserializationContext = new DeserializationContext(this.fixture.SerializationManager)
+            {
+                StreamReader = new BinaryTokenStreamReader(serializationContext.StreamWriter.ToBytes())
+            };
+
+            return (T) serializer.Deserialize(typeof(T), deserializationContext);
+        }
+
+        [Serializable]
+        public class SimpleISerializableObject : IDeserializationCallback
+        {
+            [NonSerialized]
+            private List<string> history;
+
+            [NonSerialized]
+            private List<StreamingContext> contexts;
+
+            public SimpleISerializableObject()
+            {
+                this.History.Add("default_ctor");
+            }
+            
+            public List<string> History => this.history ?? (this.history = new List<string>());
+            public List<StreamingContext> Contexts => this.contexts ?? (this.contexts = new List<StreamingContext>());
+
+            public string Payload { get; set; }
+            
+            [OnSerializing]
+            internal void OnSerializingMethod(StreamingContext context)
+            {
+                this.History.Add("serializing");
+                this.Contexts.Add(context);
+            }
+
+            [OnSerialized]
+            internal void OnSerializedMethod(StreamingContext context)
+            {
+                this.History.Add("serialized");
+                this.Contexts.Add(context);
+            }
+
+            [OnDeserializing]
+            internal void OnDeserializingMethod(StreamingContext context)
+            {
+                this.History.Add("deserializing");
+                this.Contexts.Add(context);
+            }
+
+            [OnDeserialized]
+            internal void OnDeserializedMethod(StreamingContext context)
+            {
+                this.History.Add("deserialized");
+                this.Contexts.Add(context);
+            }
+
+            void IDeserializationCallback.OnDeserialization(object sender)
+            {
+                this.History.Add("deserialization");
+            }
+        }
+
+        [Serializable]
+        public struct SimpleISerializableStruct : IDeserializationCallback
+        {
+            [NonSerialized]
+            private List<string> history;
+
+            [NonSerialized]
+            private List<StreamingContext> contexts;
+            
+            public List<string> History => this.history ?? (this.history = new List<string>());
+            public List<StreamingContext> Contexts => this.contexts ?? (this.contexts = new List<StreamingContext>());
+
+            public string Payload { get; set; }
+
+            [OnSerializing]
+            internal void OnSerializingMethod(StreamingContext context)
+            {
+                this.History.Add("serializing");
+                this.Contexts.Add(context);
+            }
+
+            [OnSerialized]
+            internal void OnSerializedMethod(StreamingContext context)
+            {
+                this.History.Add("serialized");
+                this.Contexts.Add(context);
+            }
+
+            [OnDeserializing]
+            internal void OnDeserializingMethod(StreamingContext context)
+            {
+                this.History.Add("deserializing");
+                this.Contexts.Add(context);
+            }
+
+            [OnDeserialized]
+            internal void OnDeserializedMethod(StreamingContext context)
+            {
+                this.History.Add("deserialized");
+                this.Contexts.Add(context);
+            }
+
+            void IDeserializationCallback.OnDeserialization(object sender)
+            {
+                this.History.Add("deserialization");
+            }
         }
 
         [SuppressMessage("ReSharper", "StyleCop.SA1401", Justification = "This is for testing purposes.")]

--- a/test/TestFSharp/Types.fs
+++ b/test/TestFSharp/Types.fs
@@ -25,3 +25,26 @@ type RecordOfIntOptionWithNoAttributes = { A: int option } with
 [<Serializable; Immutable>]
 type GenericRecord<'T> = { Value: 'T } with
     static member ofT x = { Value = x }
+
+[<Serializable>]
+type DiscriminatedUnion = 
+    | ArrayFieldCase of int array
+    | ListFieldCase of int list
+    | MapFieldCase of Map<int,string>
+    | SetFieldCase of Set<int>
+
+    static member array l = ArrayFieldCase l
+    static member emptyArray() = ArrayFieldCase [||]
+    static member nonEmptyArray() = ArrayFieldCase [|1; 2; 3|]
+
+    static member list l = ListFieldCase l
+    static member emptyList() = ListFieldCase []
+    static member nonEmptyList() = ListFieldCase [1; 2; 3]
+
+    static member set s = SetFieldCase s
+    static member emptySet() = SetFieldCase Set.empty
+    static member nonEmptySet() = Set.ofList [1; 2; 3] |> SetFieldCase 
+
+    static member map m = MapFieldCase m
+    static member emptyMap() = MapFieldCase Map.empty
+    static member nonEmptyMap() = Map.ofList [0, "zero"; 1, "one"] |> MapFieldCase 

--- a/test/Tester/SerializationTests/DeepCopyTests.cs
+++ b/test/Tester/SerializationTests/DeepCopyTests.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.FSharp.Collections;
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using TestExtensions;
+using UnitTests.FSharpTypes;
 using UnitTests.GrainInterfaces;
 using Xunit;
 
@@ -149,5 +152,98 @@ namespace UnitTests.Serialization
             }
         }
 
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        public void DeepCopyTests_FSharp_Collections()
+        {
+            // F# list
+            {
+                var original = FSharpList<int>.Empty;
+                var copy = (FSharpList<int>)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            {
+                var original = ListModule.OfSeq(new List<int> { 0, 1, 2 });
+                var copy = (FSharpList<int>)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+
+            // F# set
+            {
+                var original = new FSharpSet<int>(new List<int>());
+                var copy = (FSharpSet<int>)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            {
+                var elements = new List<int>() { 0, 1, 2 };
+                var original = SetModule.OfSeq(elements);
+                var copy = (FSharpSet<int>)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+
+            // F# map
+            {
+                var original = new FSharpMap<int, string>(new List<Tuple<int, string>>());
+                var copy = (FSharpMap<int, string>)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            {
+                var elements = new List<Tuple<int, string>>(){
+                    new Tuple<int, string>(0, "zero"),
+                    new Tuple<int, string>(1, "one")
+                };
+                var original = MapModule.OfSeq(elements);
+                var copy = (FSharpMap<int, string>)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        public void DeepCopyTests_FSharp_Types()
+        {
+            // discriminated union case with an array field
+            {
+                var original = DiscriminatedUnion.nonEmptyArray();
+                var copy = (DiscriminatedUnion)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            {
+                var original = DiscriminatedUnion.emptyArray();
+                var copy = (DiscriminatedUnion)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            // discriminated union case with an F# list field
+            {
+                var original = DiscriminatedUnion.emptyList();
+                var copy = (DiscriminatedUnion)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            {
+                var original = DiscriminatedUnion.nonEmptyList();
+                var copy = (DiscriminatedUnion)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            // discriminated union case with an F# set field
+            {
+                var original = DiscriminatedUnion.emptySet();
+                var copy = (DiscriminatedUnion)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            {
+                var original = DiscriminatedUnion.nonEmptySet();
+                var copy = (DiscriminatedUnion)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            // discriminated union case with an F# map field
+            {
+                var original = DiscriminatedUnion.emptyMap();
+                var copy = (DiscriminatedUnion)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+            {
+                var original = DiscriminatedUnion.nonEmptyMap();
+                var copy = (DiscriminatedUnion)this.fixture.SerializationManager.DeepCopy(original);
+                Assert.Equal(original, copy);
+            }
+        }
     }
 }

--- a/test/Tester/SerializationTests/SerializationTests.FSharpTypes.cs
+++ b/test/Tester/SerializationTests/SerializationTests.FSharpTypes.cs
@@ -1,8 +1,11 @@
 using Microsoft.FSharp.Core;
+using Microsoft.FSharp.Collections;
 using Orleans.Serialization;
 using TestExtensions;
 using UnitTests.FSharpTypes;
 using Xunit;
+using System.Collections.Generic;
+using System;
 
 namespace UnitTests.Serialization
 {
@@ -54,5 +57,57 @@ namespace UnitTests.Serialization
         {
             RoundtripSerializationTest(RecordOfIntOption.Empty);
         }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        public void SerializationTests_FSharp_Single_Case_Union()
+        {
+            RoundtripSerializationTest(SingleCaseDU.ofInt(1));
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        public void SerializationTests_FSharp_Discriminated_Union()
+        {
+
+            // discriminated union case with an array field
+            RoundtripSerializationTest(DiscriminatedUnion.emptyArray());
+            RoundtripSerializationTest(DiscriminatedUnion.nonEmptyArray());
+
+            // discriminated union case with an F# list field
+            RoundtripSerializationTest(DiscriminatedUnion.emptyList());
+            RoundtripSerializationTest(DiscriminatedUnion.nonEmptyList());
+
+            // discriminated union case with an F# set field
+            RoundtripSerializationTest(DiscriminatedUnion.emptySet());
+            RoundtripSerializationTest(DiscriminatedUnion.nonEmptySet());
+
+            // discriminated union case with an F# map  field
+            RoundtripSerializationTest(DiscriminatedUnion.emptyMap());
+            RoundtripSerializationTest(DiscriminatedUnion.nonEmptyMap());
+
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional"), TestCategory("FSharp"), TestCategory("Serialization")]
+        public void SerializationTests_FSharp_Collections()
+        {
+            var elements = new List<int>() { 0, 1, 2 };
+
+            var mapElements = new List<Tuple<int, string>>(){
+                    new Tuple<int, string>(0, "zero"),
+                    new Tuple<int, string>(1, "one")
+                };
+
+            // F# list
+            RoundtripSerializationTest(ListModule.Empty<int>());
+            RoundtripSerializationTest(ListModule.OfSeq(elements));
+
+            // F# set
+            RoundtripSerializationTest(SetModule.Empty<int>());
+            RoundtripSerializationTest(SetModule.OfSeq(elements));
+
+            // F# map
+            RoundtripSerializationTest(MapModule.OfSeq(new List<Tuple<int,string>>()));
+            RoundtripSerializationTest(MapModule.OfSeq(mapElements));
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #3650

Adds support for serialization hooks in `ILBasedSerializer` and avoids generating C#-based serializers for types which use serialization hooks such as `[OnDeserializing]`, etc.

Hopefully this doesn't break anyone, but it does have the potential to break in a persistence scenario.

Note that the ILBasedSerializer will still use the default constructor or no constructor (GetUnformattedObject) and will not use the serialization constructor. Support for serialization constructors/`ISeralizable` requires a different strategy (essentially serializing object as name-value pairs). I can add code for that in a separate PR.

Fixes F# serialization.
Includes @cata's PR commit since that PR was a failing test & it's best if we can commit it alongside a fix. Thanks, @cata!