### PR TITLE
CodeGen: support builds which use reference assemblies

### DIFF
--- a/src/ClientGenerator/AssemblyResolver.cs
+++ b/src/ClientGenerator/AssemblyResolver.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyModel;
+using Microsoft.Extensions.DependencyModel.Resolution;
+using Orleans.Runtime;
+
+namespace Orleans.CodeGeneration
+{
+    internal class AssemblyResolver
+    {
+        /// <summary>
+        /// Needs to be public so can be serialized accross the the app domain.
+        /// </summary>
+        public Dictionary<string, string> ReferenceAssemblyPaths { get; } = new Dictionary<string, string>();
+
+        private readonly ICompilationAssemblyResolver assemblyResolver;
+
+        private readonly DependencyContext dependencyContext;
+        private readonly DependencyContext resolverRependencyContext;
+        
+        public AssemblyResolver(string path, List<string> referencedAssemblies)
+        {
+            if (Path.GetFileName(path) == "Orleans.dll")
+                this.Assembly = typeof(RuntimeVersion).Assembly;
+            else
+                this.Assembly = Assembly.LoadFrom(path);
+            this.dependencyContext = DependencyContext.Load(this.Assembly);
+            this.resolverRependencyContext = DependencyContext.Load(typeof(AssemblyResolver).Assembly);
+            var codegenPath = Path.GetDirectoryName(new Uri(typeof(AssemblyResolver).Assembly.CodeBase).LocalPath);
+            this.assemblyResolver = new CompositeCompilationAssemblyResolver(
+                new ICompilationAssemblyResolver[]
+                {
+                    new AppBaseCompilationAssemblyResolver(codegenPath),
+                    new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(path)),
+                    new ReferenceAssemblyPathResolver(),
+                    new PackageCompilationAssemblyResolver()
+                });
+            
+            foreach (var assemblyPath in referencedAssemblies)
+            {
+                var libName = Path.GetFileNameWithoutExtension(assemblyPath);
+                if (!string.IsNullOrWhiteSpace(libName)) this.ReferenceAssemblyPaths[libName] = assemblyPath;
+                var asmName = AssemblyName.GetAssemblyName(assemblyPath);
+                this.ReferenceAssemblyPaths[asmName.FullName] = assemblyPath;
+            }
+        }
+
+        public Assembly Assembly { get; }
+        
+        /// <summary>
+        /// Handles System.AppDomain.AssemblyResolve event of an System.AppDomain
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="args">The event data.</param>
+        /// <returns>The assembly that resolves the type, assembly, or resource; 
+        /// or null if theassembly cannot be resolved.
+        /// </returns>
+        public Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+        {
+            var name = new AssemblyName(args.Name);
+
+            // Attempt to resolve the library from one of the dependency contexts.
+            var library = this.resolverRependencyContext?.RuntimeLibraries?.FirstOrDefault(NamesMatch)
+                ?? this.dependencyContext?.RuntimeLibraries?.FirstOrDefault(NamesMatch);
+            if (library != null)
+            {
+                var wrapper = new CompilationLibrary(
+                    library.Type,
+                    library.Name,
+                    library.Version,
+                    library.Hash,
+                    library.RuntimeAssemblyGroups.SelectMany(g => g.AssetPaths),
+                    library.Dependencies,
+                    library.Serviceable);
+
+                var assemblies = new List<string>();
+                if (this.assemblyResolver.TryResolveAssemblyPaths(wrapper, assemblies))
+                {
+                    foreach (var asm in assemblies)
+                    {
+                        var assembly = TryLoadAssemblyFromPath(asm);
+                        if (assembly != null) return assembly;
+                    }
+                }
+            }
+
+            if (this.ReferenceAssemblyPaths.TryGetValue(name.FullName, out var pathByFullName))
+            {
+                var assembly = TryLoadAssemblyFromPath(pathByFullName);
+                if (assembly != null) return assembly;
+            }
+
+            if (this.ReferenceAssemblyPaths.TryGetValue(name.Name, out var pathByName))
+            {
+                //
+                // Only try to load it if the resolved path is different than from before
+                //
+
+                if (String.Compare(pathByFullName, pathByName, StringComparison.OrdinalIgnoreCase) != 0)
+                {
+                    var assembly = TryLoadAssemblyFromPath(pathByName);
+                    if (assembly != null) return assembly;
+                }
+            }
+
+            return null;
+
+            bool NamesMatch(RuntimeLibrary runtime)
+            {
+                return string.Equals(runtime.Name, name.Name, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private Assembly TryLoadAssemblyFromPath(string path)
+        {
+            try
+            {
+                return Assembly.LoadFrom(path);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/ClientGenerator/ClientGenerator.csproj
+++ b/src/ClientGenerator/ClientGenerator.csproj
@@ -63,6 +63,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyResolver.cs" />
     <Compile Include="ClientGenerator.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/ClientGenerator/project.json
+++ b/src/ClientGenerator/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.Extensions.DependencyModel": "2.0.3"
   },
   "frameworks": {
     "net461": {}

--- a/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.Build.nuspec
+++ b/src/NuGet/Microsoft.Orleans.OrleansCodeGenerator.Build.nuspec
@@ -36,6 +36,8 @@
     <file src="OrleansCodeGenerator.pdb" target="tools" />
     <file src="Microsoft.CodeAnalysis.CSharp.dll" target="tools" />
     <file src="Microsoft.CodeAnalysis.dll" target="tools" />
+    <file src="Microsoft.DotNet.PlatformAbstractions.dll" target="tools" />
+    <file src="Microsoft.Extensions.DependencyModel.dll" target="tools" />
     <file src="Microsoft.Extensions.DependencyInjection.Abstractions.dll" target="tools" />
     <file src="Microsoft.Extensions.DependencyInjection.dll" target="tools" />
     <file src="Microsoft.Win32.Primitives.dll" target="tools" />

--- a/src/Orleans.SDK.targets
+++ b/src/Orleans.SDK.targets
@@ -37,8 +37,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!-- This target is run just before Compile for an Orleans Grain Interface Project -->
   <Target Name="OrleansCodeGeneration"
-          AfterTargets="BeforeCompile"
-          BeforeTargets="CoreCompile"
+          AfterTargets="GenerateBuildDependencyFile"
+          BeforeTargets="AssignTargetPaths"
           Condition="'$(OrleansCodeGenPrecompile)'!='true'"
           Inputs="@(Compile);@(ReferencePath)"
           Outputs="$(IntermediateOutputPath)$(TargetName).orleans.g.cs">
@@ -62,7 +62,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CodeGenArgs Include="/out:$(CodeGenFilename)"/>
       <CodeGenArgs Include="@(ReferencePath->'/r:%(Identity)')"/>
     </ItemGroup>
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" Properties="OrleansCodeGenPrecompile=true;DefineConstants=$(ExcludeCodeGen);DesignTimeBuild=true" UnloadProjectsOnCompletion="true" UseResultsCache="false" />
+    <Copy SourceFiles="$(ProjectDepsFilePath)" DestinationFolder="$(CodeGenDirectory)" ContinueOnError="WarnAndContinue" Condition="Exists('$(ProjectDepsFilePath)')" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" Properties="OrleansCodeGenPrecompile=true;DefineConstants=$(ExcludeCodeGen);DesignTimeBuild=true;PreserveCompilationContext=true" UnloadProjectsOnCompletion="true" UseResultsCache="false" />
     <Message Text="[OrleansCodeGeneration] - Code-gen args file=$(ArgsFile)"/>
     <WriteLinesToFile Overwrite="true" File="$(ArgsFile)" Lines="@(CodeGenArgs)"/>
     <Message Text="[OrleansCodeGeneration] - Precompiled assembly"/>


### PR DESCRIPTION
Backported codegen fixes to 1.5.x branch.
Supports resolving assemblies using `*.deps.json` file.
This includes some divergences from the current master, notably:
* We ensure the deps is generated via `AfterTargets="GenerateBuildDependencyFile"`
* We copy the generated deps file to sit next to the intermediate assembly, since I couldn't see any other way to make MSBuild emit the deps file to that location (not without triggering the target manually).