### PR TITLE
CreateObjectReference: disallow creating a reference to a Grain class

### DIFF
--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -770,7 +770,10 @@ namespace Orleans
         public GrainReference CreateObjectReference(IAddressable obj, IGrainMethodInvoker invoker)
         {
             if (obj is GrainReference)
-                throw new ArgumentException("Argument obj is already a grain reference.");
+                throw new ArgumentException("Argument obj is already a grain reference.", nameof(obj));
+
+            if (obj is Grain)
+                throw new ArgumentException("Argument must not be a grain class.", nameof(obj));
 
             GrainReference gr = GrainReference.NewObserverGrainReference(clientId, GuidId.GetNewGuidId(), this.GrainReferenceRuntime);
             if (!localObjects.TryAdd(gr.ObserverId, new LocalObjectData(obj, gr.ObserverId, invoker)))

--- a/test/DefaultCluster.Tests/ObserverTests.cs
+++ b/test/DefaultCluster.Tests/ObserverTests.cs
@@ -295,6 +295,30 @@ namespace DefaultCluster.Tests.General
             });
         }
 
+        [Fact, TestCategory("BVT")]
+        public async Task ObserverTest_CreateObjectReference_ThrowsForInvalidArgumentTypes()
+        {
+            TestInitialize();
+
+            // Attempt to create an object reference to a Grain class.
+            await Assert.ThrowsAsync<ArgumentException>(() => this.Client.CreateObjectReference<ISimpleGrainObserver>(new DummyObserverGrain()));
+
+            // Attempt to create an object reference to an existing GrainReference.
+            var observer = new DummyObserver();
+            var reference = await this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
+            await Assert.ThrowsAsync<ArgumentException>(() => this.Client.CreateObjectReference<ISimpleGrainObserver>(reference));
+        }
+
+        private class DummyObserverGrain : Grain, ISimpleGrainObserver
+        {
+            public void StateChanged(int a, int b) { }
+        }
+
+        private class DummyObserver : ISimpleGrainObserver
+        {
+            public void StateChanged(int a, int b) { }
+        }
+
         internal class SimpleGrainObserver : ISimpleGrainObserver
         {
             readonly Action<int, int, AsyncResultHandle> action;


### PR DESCRIPTION
Ref #3744

Cleans up a minor potential API usage error.