### PR TITLE
Expedite gateway retries when gateway list is exhausted

### DIFF
--- a/src/Orleans.Core/Logging/ErrorCodes.cs
+++ b/src/Orleans.Core/Logging/ErrorCodes.cs
@@ -688,6 +688,7 @@ namespace Orleans
         ClientRegistrarFailedToUnregister       = GatewayBase + 18,
         ClientRegistrarTimerFailed              = GatewayBase + 19,
         GatewayAcceptor_WrongClusterId          = GatewayBase + 20,
+        GatewayManager_AllGatewaysDead          = GatewayBase + 21,
 
         TimerBase                               = Runtime + 1400,
         TimerChangeError                        = PerfCounterTimerError, // Backward compatability

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -220,27 +220,49 @@ namespace Orleans.Messaging
                 // now take whatever listProvider gave us and exclude those we think are dead.
 
                 var live = new List<Uri>();
+                var now = DateTime.UtcNow;
 
                 var knownGateways = currentKnownGateways as IList<Uri> ?? currentKnownGateways.ToList();
                 foreach (Uri trial in knownGateways)
                 {
-                    DateTime diedAt;
                     // We consider a node to be dead if we recorded it is dead due to socket error
                     // and it was recorded (diedAt) not too long ago (less than maxStaleness ago).
                     // The latter is to cover the case when the Gateway provider returns an outdated list that does not yet reflect the actually recently died Gateway.
                     // If it has passed more than maxStaleness - we assume maxStaleness is the upper bound on Gateway provider freshness.
-                    bool isDead = knownDead.TryGetValue(trial, out diedAt) && DateTime.UtcNow.Subtract(diedAt) < maxStaleness;
+                    var isDead = false;
+                    if (knownDead.TryGetValue(trial, out var diedAt))
+                    {
+                        if (now.Subtract(diedAt) < maxStaleness)
+                        {
+                            isDead = true;
+                        }
+                        else
+                        {
+                            // Remove stale entries.
+                            knownDead.Remove(trial);
+                        }
+                    }
+
                     if (!isDead)
                     {
                         live.Add(trial);
                     }
                 }
 
+                if (live.Count == 0)
+                {
+                    logger.Warn(
+                        ErrorCode.GatewayManager_AllGatewaysDead,
+                        "All gateways have previously been marked as dead. Clearing the list of dead gateways to expedite reconnection.");
+                    live.AddRange(knownGateways);
+                    knownDead.Clear();
+                }
+
                 // swap cachedLiveGateways pointer in one atomic operation
                 cachedLiveGateways = live;
 
                 DateTime prevRefresh = lastRefreshTime;
-                lastRefreshTime = DateTime.UtcNow;
+                lastRefreshTime = now;
                 if (logger.IsEnabled(LogLevel.Information))
                 {
                     logger.Info(ErrorCode.GatewayManager_FoundKnownGateways,


### PR DESCRIPTION
When a client runs out of gateways (all are marked as dead), we can force-retry all gateways which were previously marked as dead.

Hopefully this would improve reconnect times in development/on-prem scenarios in cases where a cluster reboot is not coordinated, especially in single silo scenarios.

Low pri