### PR TITLE
Fix Azure Storage tests

### DIFF
--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
@@ -57,6 +57,7 @@ namespace Tester.AzureUtils.Persistence
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.MaxStorageBusyRetries = 3;
                     })
+                    .ConfigureApplicationParts(parts => parts.AddFromApplicationBaseDirectory().AddFromAppDomain().WithReferences())
                     .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(siloName, clusterConfiguration.Globals.ClusterId)));
             }
         }
@@ -66,7 +67,7 @@ namespace Tester.AzureUtils.Persistence
             {
                 gatewayOptions.ConnectionString = TestDefaultConfiguration.DataConnectionString;
             })
-            .ConfigureApplicationParts(parts => parts.AddFromAppDomain())
+            .ConfigureApplicationParts(parts => parts.AddFromApplicationBaseDirectory().AddFromAppDomain().WithReferences())
             .ConfigureLogging(builder => TestingUtils.ConfigureDefaultLoggingBuilder(builder, TestingUtils.CreateTraceFileName(config.ClientName, config.ClusterId)));
 
         public static IProviderConfiguration GetNamedProviderConfigForShardedProvider(IEnumerable<KeyValuePair<string, IProviderConfiguration>> providers, string providerName)


### PR DESCRIPTION
* Tests were failing with a serialization error.
* The error indicated that a placement strategy could not be deserialized.
* The root cause is that the strategy is not included in the ApplicationParts

Fix: include everything deployed alongside the test as an ApplicationPart