### PR TITLE
Add processing time measure on silo start up sequence and code gen

### DIFF
--- a/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
+++ b/src/Orleans.CodeGeneration.Build/CodeGenerator.cs
@@ -3,13 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Orleans.ApplicationParts;
-using Orleans.Runtime.Configuration;
 using Orleans.CodeGenerator;
 using Orleans.Serialization;
 using Orleans.Runtime;
-using Orleans.Hosting;
 using Orleans.Metadata;
 #if NETCOREAPP2_0
 using System.Runtime.Loader;

--- a/src/Orleans.CodeGeneration.Build/Program.cs
+++ b/src/Orleans.CodeGeneration.Build/Program.cs
@@ -120,6 +120,7 @@ namespace Orleans.CodeGeneration
                 }
 
                 // STEP 5 : Finally call code generation
+                var stopWatch = Stopwatch.StartNew();
                 if (referencesOrleans)
                 {
                     if (!CodeGenerator.GenerateCode(options))
@@ -132,7 +133,8 @@ namespace Orleans.CodeGeneration
                     Console.WriteLine("ERROR: Orleans-CodeGen - the input assembly does not reference Orleans and therefore code can not be generated.");
                     return -2;
                 }
-
+                stopWatch.Stop();
+                Console.WriteLine($"Built time code generation for assembly {options.InputAssembly} took {stopWatch.ElapsedMilliseconds} miliseconds");
                 // DONE!
                 return 0;
             }

--- a/src/Orleans.CodeGeneration.Build/Program.cs
+++ b/src/Orleans.CodeGeneration.Build/Program.cs
@@ -134,7 +134,7 @@ namespace Orleans.CodeGeneration
                     return -2;
                 }
                 stopWatch.Stop();
-                Console.WriteLine($"Built time code generation for assembly {options.InputAssembly} took {stopWatch.ElapsedMilliseconds} miliseconds");
+                Console.WriteLine($"Build time code generation for assembly {options.InputAssembly} took {stopWatch.ElapsedMilliseconds} milliseconds");
                 // DONE!
                 return 0;
             }

--- a/src/Orleans.Core/Logging/ErrorCodes.cs
+++ b/src/Orleans.Core/Logging/ErrorCodes.cs
@@ -338,7 +338,7 @@ namespace Orleans
         Runtime_Error_100329 = Runtime + 329,
         Runtime_Error_100330 = Runtime + 330,
         Runtime_Error_100331 = Runtime + 331,
-
+        
         SiloBase                        = Runtime + 400,
         SiloStarting                    = SiloBase + 1,
         SiloStarted                     = SiloBase + 2,
@@ -390,6 +390,7 @@ namespace Orleans
         SiloShutdownEventFailure        = SiloBase + 49,
         LifecycleStartFailure           = SiloBase + 50,
         LifecycleStopFailure            = SiloBase + 51,
+        SiloStartPerfMeasure            = SiloBase + 52,
 
         CatalogBase                     = Runtime + 500,
         CatalogNonExistingActivation1   = CatalogBase + 1,

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -722,8 +722,11 @@ namespace Orleans.Runtime
 
         private Task OnRuntimeInitializeStart(CancellationToken tc)
         {
+            var stopWatch = Stopwatch.StartNew();
             typeManager.Start();
             GrainTypeResolver = typeManager.GetTypeCodeMap();
+            stopWatch.Stop();
+            this.logger.Info(ErrorCode.SiloStartPerfMeasure, $"Start InsideRuntimeClient took {stopWatch.ElapsedMilliseconds} Milliseconds");
             return Task.CompletedTask;
         }
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -68,7 +68,6 @@ namespace Orleans.Runtime
         private readonly IncomingMessageAgent incomingPingAgent;
         private readonly ILogger logger;
         private TypeManager typeManager;
-
         private readonly TaskCompletionSource<int> siloTerminatedTask =
             new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly SiloStatisticsManager siloStatistics;
@@ -143,7 +142,6 @@ namespace Orleans.Runtime
             // Temporarily still require this. Hopefuly gone when 2.0 is released.
             this.legacyConfiguration = services.GetRequiredService<LegacyConfigurationWrapper>();
             this.siloDetails = siloDetails;
-
             this.SystemStatus = SystemStatus.Creating;
             AsynchAgent.IsStarting = true;
 
@@ -395,126 +393,189 @@ namespace Orleans.Runtime
             AppDomain.CurrentDomain.ProcessExit += HandleProcessExit;
             if (GlobalConfig.FastKillOnCancelKeyPress)
                 Console.CancelKeyPress += HandleProcessExit;
-
             //TODO: setup thead pool directly to lifecycle
-            ConfigureThreadPoolAndServicePointSettings();
-
+            StartTaskWithPerfAnalysis("ConfigureThreadPoolAndServicePointSettings",
+                this.ConfigureThreadPoolAndServicePointSettings, Stopwatch.StartNew());
             return Task.CompletedTask;
+        }
+
+        private void StartTaskWithPerfAnalysis(string taskName, Action task, Stopwatch stopWatch)
+        {
+            stopWatch.Restart();
+            task.Invoke();
+            stopWatch.Stop();
+            this.logger.Info(ErrorCode.SiloStartPerfMeasure, $"{taskName} took {stopWatch.ElapsedMilliseconds} Milliseconds to finish");
+        }
+
+        private async Task StartAsyncTaskWithPerfAnalysis(string taskName, Func<Task> task, Stopwatch stopWatch)
+        {
+            stopWatch.Restart();
+            await task.Invoke();
+            stopWatch.Stop();
+            this.logger.Info(ErrorCode.SiloStartPerfMeasure, $"{taskName} took {stopWatch.ElapsedMilliseconds} Milliseconds to finish");
         }
 
         private async Task OnRuntimeServicesStart(CancellationToken ct)
         {
             //TODO: Setup all (or as many as possible) of the class started in this call to work directly with lifecyce
-
+            var stopWatch = Stopwatch.StartNew();
             // The order of these 4 is pretty much arbitrary.
-            scheduler.Start();
-            messageCenter.Start();
-            incomingPingAgent.Start();
-            incomingSystemAgent.Start();
-            incomingAgent.Start();
+            StartTaskWithPerfAnalysis("Start Scheduler", scheduler.Start, stopWatch);
+            StartTaskWithPerfAnalysis("Start Message center",messageCenter.Start,stopWatch);
+            StartTaskWithPerfAnalysis("Start Incoming message agents", IncomingMessageAgentsStart, stopWatch);
+            void IncomingMessageAgentsStart()
+            {
+                incomingPingAgent.Start();
+                incomingSystemAgent.Start();
+                incomingAgent.Start();
+            } 
 
-            LocalGrainDirectory.Start();
+            StartTaskWithPerfAnalysis("Start local grain directory", LocalGrainDirectory.Start,stopWatch);
 
             // Set up an execution context for this thread so that the target creation steps can use asynch values.
             RuntimeContext.InitializeMainThread();
 
-            // Initialize the implicit stream subscribers table.
-            var implicitStreamSubscriberTable = Services.GetRequiredService<ImplicitStreamSubscriberTable>();
-            var grainTypeManager = Services.GetRequiredService<GrainTypeManager>();
-            implicitStreamSubscriberTable.InitImplicitStreamSubscribers(grainTypeManager.GrainClassTypeData.Select(t => t.Value.Type).ToArray());
+            StartTaskWithPerfAnalysis("Init implicit stream subscribe table", InitImplicitStreamSubscribeTable, stopWatch);
+            void InitImplicitStreamSubscribeTable()
+            {             
+                // Initialize the implicit stream subscribers table.
+                var implicitStreamSubscriberTable = Services.GetRequiredService<ImplicitStreamSubscriberTable>();
+                var grainTypeManager = Services.GetRequiredService<GrainTypeManager>();
+                implicitStreamSubscriberTable.InitImplicitStreamSubscribers(grainTypeManager.GrainClassTypeData.Select(t => t.Value.Type).ToArray());
+            }
+
 
             var siloProviderRuntime = Services.GetRequiredService<SiloProviderRuntime>();
             runtimeClient.CurrentStreamProviderRuntime = siloProviderRuntime;
-            statisticsProviderManager = this.Services.GetRequiredService<StatisticsProviderManager>();
-            string statsProviderName =  await statisticsProviderManager.LoadProvider(GlobalConfig.ProviderConfigurations)
-                .WithTimeout(initTimeout);
-            if (statsProviderName != null)
-                LocalConfig.StatisticsProviderName = statsProviderName;
+            await StartAsyncTaskWithPerfAnalysis("Load StatisticProviders", LoadStatsProvider, stopWatch);
+            async Task LoadStatsProvider()
+            {
+                statisticsProviderManager = this.Services.GetRequiredService<StatisticsProviderManager>();
+                string statsProviderName = await statisticsProviderManager.LoadProvider(GlobalConfig.ProviderConfigurations)
+                    .WithTimeout(initTimeout);
+                if (statsProviderName != null)
+                    LocalConfig.StatisticsProviderName = statsProviderName;
 
-            // can call SetSiloMetricsTableDataManager only after MessageCenter is created (dependency on this.SiloAddress).
-            await siloStatistics.SetSiloStatsTableDataManager(this, LocalConfig).WithTimeout(initTimeout);
-            await siloStatistics.SetSiloMetricsTableDataManager(this, LocalConfig).WithTimeout(initTimeout);
-
-
+                // can call SetSiloMetricsTableDataManager only after MessageCenter is created (dependency on this.SiloAddress).
+                await siloStatistics.SetSiloStatsTableDataManager(this, LocalConfig).WithTimeout(initTimeout);
+                await siloStatistics.SetSiloMetricsTableDataManager(this, LocalConfig).WithTimeout(initTimeout);
+            }
+            
             // This has to follow the above steps that start the runtime components
-            CreateSystemTargets();
-
-            await InjectDependencies();
+            await StartAsyncTaskWithPerfAnalysis("Create system targets and inject dependencies", () =>
+            {
+                CreateSystemTargets();
+                return InjectDependencies();
+            }, stopWatch);
 
             // Validate the configuration.
             GlobalConfig.Application.ValidateConfiguration(logger);
 
-            // Initialize storage providers once we have a basic silo runtime environment operating
-            storageProviderManager = this.Services.GetRequiredService<StorageProviderManager>();
-            await scheduler.QueueTask(
-                () => storageProviderManager.LoadStorageProviders(GlobalConfig.ProviderConfigurations),
-                providerManagerSystemTarget.SchedulingContext)
+            await StartAsyncTaskWithPerfAnalysis("Init StorageProviders", InitStorageProviders, stopWatch);
+            async Task InitStorageProviders()
+            {
+                // Initialize storage providers once we have a basic silo runtime environment operating
+                storageProviderManager = this.Services.GetRequiredService<StorageProviderManager>();
+                await scheduler.QueueTask(
+                        () => storageProviderManager.LoadStorageProviders(GlobalConfig.ProviderConfigurations),
+                        providerManagerSystemTarget.SchedulingContext)
                     .WithTimeout(initTimeout);
+            }
 
-            ITransactionAgent transactionAgent = this.Services.GetRequiredService<ITransactionAgent>();
-            ISchedulingContext transactionAgentContext = (transactionAgent as SystemTarget)?.SchedulingContext;
-            await scheduler.QueueTask(transactionAgent.Start, transactionAgentContext)
-                        .WithTimeout(initTimeout);
+            await StartAsyncTaskWithPerfAnalysis("Init transaction agent", InitTransactionAgent, stopWatch);
+            async Task InitTransactionAgent()
+            {
+                ITransactionAgent transactionAgent = this.Services.GetRequiredService<ITransactionAgent>();
+                ISchedulingContext transactionAgentContext = (transactionAgent as SystemTarget)?.SchedulingContext;
+                await scheduler.QueueTask(transactionAgent.Start, transactionAgentContext)
+                    .WithTimeout(initTimeout);
+            }
 
             var versionStore = Services.GetService<IVersionStore>() as GrainVersionStore;
             versionStore?.SetStorageManager(storageProviderManager);
-            logger.Debug("Storage provider manager created successfully."); 
+            logger.Debug("Storage provider manager created successfully.");
 
-            // Initialize log consistency providers once we have a basic silo runtime environment operating
-            logConsistencyProviderManager = this.Services.GetRequiredService<LogConsistencyProviderManager>();
-            await scheduler.QueueTask(
-                () => logConsistencyProviderManager.LoadLogConsistencyProviders(GlobalConfig.ProviderConfigurations),
-                providerManagerSystemTarget.SchedulingContext)
+            await StartAsyncTaskWithPerfAnalysis("Init LogConsistencyProviders", InitLogConsistencyProviders,
+                stopWatch);
+            async Task InitLogConsistencyProviders()
+            {
+                // Initialize log consistency providers once we have a basic silo runtime environment operating
+                logConsistencyProviderManager = this.Services.GetRequiredService<LogConsistencyProviderManager>();
+                await scheduler.QueueTask(
+                        () => logConsistencyProviderManager.LoadLogConsistencyProviders(GlobalConfig.ProviderConfigurations),
+                        providerManagerSystemTarget.SchedulingContext)
                     .WithTimeout(initTimeout);
-            logger.Debug("Log consistency provider manager created successfully."); 
+                logger.Debug("Log consistency provider manager created successfully.");
+            }
 
-            // Load and init stream providers before silo becomes active
-            var siloStreamProviderManager = (StreamProviderManager) this.Services.GetRequiredService<IStreamProviderManager>();
-            await scheduler.QueueTask(
-                () => siloStreamProviderManager.LoadStreamProviders(GlobalConfig.ProviderConfigurations, siloProviderRuntime),
-                    providerManagerSystemTarget.SchedulingContext)
-                        .WithTimeout(initTimeout);
-            runtimeClient.CurrentStreamProviderManager = siloStreamProviderManager;
-            logger.Debug("Stream provider manager created successfully."); 
+            await StartAsyncTaskWithPerfAnalysis("Init StreamProviders", InitStreamProviders, stopWatch);
+            async Task InitStreamProviders()
+            {
+                // Load and init stream providers before silo becomes active
+                var siloStreamProviderManager = (StreamProviderManager)this.Services.GetRequiredService<IStreamProviderManager>();
+                await scheduler.QueueTask(
+                        () => siloStreamProviderManager.LoadStreamProviders(GlobalConfig.ProviderConfigurations, siloProviderRuntime),
+                        providerManagerSystemTarget.SchedulingContext)
+                    .WithTimeout(initTimeout);
+                runtimeClient.CurrentStreamProviderManager = siloStreamProviderManager;
+                logger.Debug("Stream provider manager created successfully.");
+            }
 
             // Load and init grain services before silo becomes active.
-            await CreateGrainServices(GlobalConfig.GrainServiceConfigurations);
+            await StartAsyncTaskWithPerfAnalysis("Init grain services",
+                () => CreateGrainServices(GlobalConfig.GrainServiceConfigurations), stopWatch);
 
             this.membershipOracleContext = (this.membershipOracle as SystemTarget)?.SchedulingContext ??
                                        this.providerManagerSystemTarget.SchedulingContext;
-            await scheduler.QueueTask(() => this.membershipOracle.Start(), this.membershipOracleContext)
-                .WithTimeout(initTimeout);
-            logger.Debug("Local silo status oracle created successfully."); 
-            await scheduler.QueueTask(this.membershipOracle.BecomeActive, this.membershipOracleContext)
-                .WithTimeout(initTimeout);
-            logger.Debug("Local silo status oracle became active successfully."); 
-            await scheduler.QueueTask(() => this.typeManager.Initialize(versionStore), this.typeManager.SchedulingContext)
-                .WithTimeout(this.initTimeout);
+            await StartAsyncTaskWithPerfAnalysis("Start local silo status oracle", StartMembershipOracle, stopWatch);
+
+            async Task StartMembershipOracle()
+            {
+                await scheduler.QueueTask(() => this.membershipOracle.Start(), this.membershipOracleContext)
+                    .WithTimeout(initTimeout);
+                logger.Debug("Local silo status oracle created successfully.");
+                await scheduler.QueueTask(this.membershipOracle.BecomeActive, this.membershipOracleContext)
+                    .WithTimeout(initTimeout);
+                logger.Debug("Local silo status oracle became active successfully.");
+            }
+
+            await StartAsyncTaskWithPerfAnalysis("Init type manager", () => scheduler
+                .QueueTask(() => this.typeManager.Initialize(versionStore), this.typeManager.SchedulingContext)
+                .WithTimeout(this.initTimeout), stopWatch);
 
             //if running in multi cluster scenario, start the MultiClusterNetwork Oracle
-            if (this.multiClusterOracle != null) 
+            if (this.multiClusterOracle != null)
             {
-                logger.Info("Starting multicluster oracle with my ServiceId={0} and ClusterId={1}.",
-                    this.siloOptions.ServiceId, this.siloOptions.ClusterId);
+                await StartAsyncTaskWithPerfAnalysis("Start multicluster oracle", StartMultiClusterOracle, stopWatch);
+                async Task StartMultiClusterOracle()
+                {
+                    logger.Info("Starting multicluster oracle with my ServiceId={0} and ClusterId={1}.",
+                        this.siloOptions.ServiceId, this.siloOptions.ClusterId);
 
-                this.multiClusterOracleContext = (multiClusterOracle as SystemTarget)?.SchedulingContext ??
-                                                          this.providerManagerSystemTarget.SchedulingContext;
-                await scheduler.QueueTask(() => multiClusterOracle.Start(), multiClusterOracleContext)
-                                    .WithTimeout(initTimeout);
-                logger.Debug("multicluster oracle created successfully."); 
+                    this.multiClusterOracleContext = (multiClusterOracle as SystemTarget)?.SchedulingContext ??
+                                                     this.providerManagerSystemTarget.SchedulingContext;
+                    await scheduler.QueueTask(() => multiClusterOracle.Start(), multiClusterOracleContext)
+                        .WithTimeout(initTimeout);
+                    logger.Debug("multicluster oracle created successfully.");
+                }
             }
 
             try
             {
-                this.siloStatistics.Start(this.LocalConfig);
+                StartTaskWithPerfAnalysis("Start silo statistics", ()=>this.siloStatistics.Start(this.LocalConfig), stopWatch);
                 logger.Debug("Silo statistics manager started successfully."); 
 
                 // Finally, initialize the deployment load collector, for grains with load-based placement
-                var deploymentLoadPublisher = Services.GetRequiredService<DeploymentLoadPublisher>();
-                await this.scheduler.QueueTask(deploymentLoadPublisher.Start, deploymentLoadPublisher.SchedulingContext)
-                    .WithTimeout(this.initTimeout);
-                logger.Debug("Silo deployment load publisher started successfully."); 
+                await StartAsyncTaskWithPerfAnalysis("Start deployment load collector", StartDeploymentLoadCollector, stopWatch);
+                async Task StartDeploymentLoadCollector()
+                {
+                    var deploymentLoadPublisher = Services.GetRequiredService<DeploymentLoadPublisher>();
+                    await this.scheduler.QueueTask(deploymentLoadPublisher.Start, deploymentLoadPublisher.SchedulingContext)
+                        .WithTimeout(this.initTimeout);
+                    logger.Debug("Silo deployment load publisher started successfully.");
+                }
 
+            
                 // Start background timer tick to watch for platform execution stalls, such as when GC kicks in
                 this.platformWatchdog = new Watchdog(this.LocalConfig.StatisticsLogWriteInterval, this.healthCheckParticipants, this.executorService, this.loggerFactory);
                 this.platformWatchdog.Start();
@@ -522,34 +583,49 @@ namespace Orleans.Runtime
 
                 if (this.reminderService != null)
                 {
-                    // so, we have the view of the membership in the consistentRingProvider. We can start the reminder service
-                    this.reminderServiceContext = (this.reminderService as SystemTarget)?.SchedulingContext ??
-                                                           this.providerManagerSystemTarget.SchedulingContext;
-                    await this.scheduler.QueueTask(this.reminderService.Start, this.reminderServiceContext)
+                    await StartAsyncTaskWithPerfAnalysis("Start reminder service", StartReminderService, stopWatch);
+                    async Task StartReminderService()
+                    {
+                        // so, we have the view of the membership in the consistentRingProvider. We can start the reminder service
+                        this.reminderServiceContext = (this.reminderService as SystemTarget)?.SchedulingContext ??
+                                                      this.providerManagerSystemTarget.SchedulingContext;
+                        await this.scheduler.QueueTask(this.reminderService.Start, this.reminderServiceContext)
+                            .WithTimeout(this.initTimeout);
+                        this.logger.Debug("Reminder service started successfully.");
+                    }
+                }
+                await StartAsyncTaskWithPerfAnalysis("App boostrap", AppBootstrap, stopWatch);
+                async Task AppBootstrap()
+                {
+                    this.bootstrapProviderManager = this.Services.GetRequiredService<BootstrapProviderManager>();
+                    await this.scheduler.QueueTask(
+                            () => this.bootstrapProviderManager.LoadAppBootstrapProviders(siloProviderRuntime, this.GlobalConfig.ProviderConfigurations),
+                            this.providerManagerSystemTarget.SchedulingContext)
                         .WithTimeout(this.initTimeout);
-                    this.logger.Debug("Reminder service started successfully.");
+                    this.BootstrapProviders = this.bootstrapProviderManager.GetProviders(); // Data hook for testing & diagnotics
+
+                    logger.Debug("App bootstrap calls done successfully.");
                 }
 
-                this.bootstrapProviderManager = this.Services.GetRequiredService<BootstrapProviderManager>();
-                await this.scheduler.QueueTask(
-                    () => this.bootstrapProviderManager.LoadAppBootstrapProviders(siloProviderRuntime, this.GlobalConfig.ProviderConfigurations),
-                    this.providerManagerSystemTarget.SchedulingContext)
+                await StartAsyncTaskWithPerfAnalysis("Start StreamProviders", StartStreamProviders, stopWatch);
+                async Task StartStreamProviders()
+                {
+                    // Start stream providers after silo is active (so the pulling agents don't start sending messages before silo is active).
+                    // also after bootstrap provider started so bootstrap provider can initialize everything stream before events from this silo arrive.
+                    var siloStreamProviderManager = (StreamProviderManager)this.Services.GetRequiredService<IStreamProviderManager>();
+                    await this.scheduler.QueueTask(siloStreamProviderManager.StartStreamProviders, this.providerManagerSystemTarget.SchedulingContext)
                         .WithTimeout(this.initTimeout);
-                this.BootstrapProviders = this.bootstrapProviderManager.GetProviders(); // Data hook for testing & diagnotics
+                    logger.Debug("Stream providers started successfully.");
+                }
 
-                logger.Debug("App bootstrap calls done successfully."); 
-
-                // Start stream providers after silo is active (so the pulling agents don't start sending messages before silo is active).
-                // also after bootstrap provider started so bootstrap provider can initialize everything stream before events from this silo arrive.
-                await this.scheduler.QueueTask(siloStreamProviderManager.StartStreamProviders, this.providerManagerSystemTarget.SchedulingContext)
-                    .WithTimeout(this.initTimeout);
-                logger.Debug("Stream providers started successfully."); 
-
-                // Now that we're active, we can start the gateway
-                var mc = this.messageCenter as MessageCenter;
-                mc?.StartGateway(this.Services.GetRequiredService<ClientObserverRegistrar>());
-               logger.Debug("Message gateway service started successfully."); 
-
+                StartTaskWithPerfAnalysis("Start gateway", StartGateway, stopWatch);
+                void StartGateway()
+                {
+                    // Now that we're active, we can start the gateway
+                    var mc = this.messageCenter as MessageCenter;
+                    mc?.StartGateway(this.Services.GetRequiredService<ClientObserverRegistrar>());
+                    logger.Debug("Message gateway service started successfully.");
+                }
                 this.SystemStatus = SystemStatus.Running;
             }
             catch (Exception exc)

--- a/test/Tester/OrleansLoggingTests.cs
+++ b/test/Tester/OrleansLoggingTests.cs
@@ -282,8 +282,7 @@ namespace Tester
 
             var serviceProvider = new ServiceCollection().AddLogging(builder =>
                     builder.AddLegacyOrleansLogging(new List<ILogConsumer>() { logConsumer }, null,
-                        eventBulkingOptions)
-                        .AddFile("Test.log"))
+                        eventBulkingOptions))
                 .BuildServiceProvider();
             var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger(testName);
 


### PR DESCRIPTION
Add processing time measure 
- silo start up
- built time code gen
- runtime code gen

AFAIK, there's only two participants on silo lifecycle now, which is silo itself, and InsideRuntimeClient. So I added processing time measure to their OnRuntimeInitializeStart and OnRuntimeServicesStart methods. 
Let me know if I missed anything on silo start up sequence 
