### PR TITLE
CodeGen: reduce aggressiveness of serializer generation

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Properties/AssemblyInfo.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@ using Orleans.ServiceBus.Providers;
 
 [assembly: InternalsVisibleTo("ServiceBus.Tests")]
 
-[assembly: KnownAssembly(typeof(EventHubSequenceTokenV2))]
+[assembly: KnownAssembly(typeof(EventHubSequenceTokenV2), TreatTypesAsSerializable = true)]

--- a/src/Orleans.Core.Abstractions/CodeGeneration/ConsiderForCodeGenerationAttribute.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/ConsiderForCodeGenerationAttribute.cs
@@ -33,7 +33,7 @@ namespace Orleans.CodeGeneration
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public sealed class KnownTypeAttribute : ConsiderForCodeGenerationAttribute
     {
-        /// <summary>Initializes a new instance of <see cref="KnownAssemblyAttribute"/>.</summary>
+        /// <summary>Initializes a new instance of <see cref="KnownTypeAttribute"/>.</summary>
         /// <param name="type">The type that the generator should generate code for</param>
         public KnownTypeAttribute(Type type) : base(type){}
     }

--- a/src/Orleans.Core.Abstractions/CodeGeneration/KnownAssemblyAttribute.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/KnownAssemblyAttribute.cs
@@ -34,7 +34,6 @@ namespace Orleans.CodeGeneration
         /// serializable.
         /// </summary>
         /// <remarks>This is equivalent to specifying <see cref="KnownTypeAttribute"/> for all types.</remarks>
-        [Obsolete("This property is no longer supported. Serializers will be generated for all accessible types.")]
         public bool TreatTypesAsSerializable { get; set; }
     }
 }

--- a/src/OrleansProviders/Properties/AssemblyInfo.cs
+++ b/src/OrleansProviders/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using Orleans.Providers.Streams.Generator;
 [assembly: InternalsVisibleTo("UnitTestGrains")]
 [assembly: InternalsVisibleTo("UnitTests")]
 
-[assembly: KnownAssembly(typeof(EventSequenceTokenV2))]
+[assembly: KnownAssembly(typeof(EventSequenceTokenV2), TreatTypesAsSerializable = true)]
 
 [assembly: GenerateSerializer(typeof(EventSequenceTokenV2))]
 [assembly: GenerateSerializer(typeof(GeneratedBatchContainer))]


### PR DESCRIPTION
Fixes #3771 
Alleviates #3786

Places codegen's tail between its legs so it doesn't wag around destructively.

Essentially this reduces the aggressiveness of the check for what we should *try* to generate a serializer for.