### PR TITLE
CodeGen: avoid potential confusion between overridden properties in a type hierarchy

### DIFF
--- a/test/TestGrainInterfaces/SerializerTestTypes.cs
+++ b/test/TestGrainInterfaces/SerializerTestTypes.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 using Orleans.Serialization;
 
 namespace UnitTests.GrainInterfaces
@@ -18,5 +19,21 @@ namespace UnitTests.GrainInterfaces
         {
             this.Context = context;
         }
+    }
+
+    [Serializable]
+    public class BaseClassWithAutoProp
+    {
+        public int AutoProp { get; set; }
+    }
+
+    /// <summary>
+    /// Code generation test to ensure that an overridden autoprop with a type which differs from
+    /// the base autoprop is not used during serializer generation
+    /// </summary>
+    [Serializable]
+    public class SubClassOverridingAutoProp : BaseClassWithAutoProp
+    {
+        public new string AutoProp { get => base.AutoProp.ToString(); set => base.AutoProp = int.Parse(value); }
     }
 }


### PR DESCRIPTION
Fixes #3786

Without this PR, a serializer for `SubClassOverridingAutoProp` will try to use `SubClassOverridingAutoProp.AutoProp` to get/set the backing field of the base class' `AutoProp`, which will result in an `InvalidCastException`.

Rather than try to disambiguate between the properties, this PR will avoid any properties which have been overridden and instead will access the backing field using our `IFieldUtils` getter/setter delegates.

```c#
public class BaseClassWithAutoProp
{
    public int AutoProp { get; set; }
}

public class SubClassOverridingAutoProp : BaseClassWithAutoProp
{
    public new string AutoProp { get => base.AutoProp.ToString(); set => base.AutoProp = int.Parse(value); }
}
```