### PR TITLE
Fix Exception serialization on .NET Core

### DIFF
--- a/src/Orleans.Core/Serialization/BinaryFormatterISerializableSerializer.cs
+++ b/src/Orleans.Core/Serialization/BinaryFormatterISerializableSerializer.cs
@@ -20,7 +20,7 @@ namespace Orleans.Serialization
         /// <inheritdoc />
         public bool IsSupportedType(Type itemType)
         {
-            return SerializableType.IsAssignableFrom(itemType) && DotNetSerializableUtilities.HasSerializationConstructor(itemType);
+            return itemType.IsSerializable && SerializableType.IsAssignableFrom(itemType) && DotNetSerializableUtilities.HasSerializationConstructor(itemType);
         }
 
         /// <inheritdoc />

--- a/test/TestGrainInterfaces/IExceptionGrain.cs
+++ b/test/TestGrainInterfaces/IExceptionGrain.cs
@@ -12,6 +12,8 @@ namespace UnitTests.GrainInterfaces
 
         Task ThrowsInvalidOperationException();
 
+        Task ThrowsNullReferenceException();
+
         Task ThrowsAggregateExceptionWrappingInvalidOperationException();
 
         Task ThrowsNestedAggregateExceptionsWrappingInvalidOperationException();

--- a/test/TestGrains/ExceptionGrain.cs
+++ b/test/TestGrains/ExceptionGrain.cs
@@ -24,6 +24,11 @@ namespace UnitTests.Grains
             throw new InvalidOperationException("Test exception");
         }
 
+        public Task ThrowsNullReferenceException()
+        {
+            throw new NullReferenceException("null null null");
+        }
+
         public async Task ThrowsAggregateExceptionWrappingInvalidOperationException()
         {
             await Task.Delay(0);


### PR DESCRIPTION
Very small fix + some QoL test changes. I was unable to `dotnet xunit` the NetCore.Tests project without specifying `<RuntimeFrameworkVersion>`. It seems related to [these](https://github.com/dotnet/cli/issues/7901) [three](https://github.com/dotnet/core-setup/issues/3462) [issues](https://github.com/dotnet/core-setup/issues/3469).

Need to get NetCore.Tests running in CI - I'll experiment