### PR TITLE
Remove legacy initialization from Silo class

### DIFF
--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -58,7 +58,7 @@ namespace Orleans.Hosting
                 {
                     options.HasMultiClusterNetwork = true;
                     options.BackgroundGossipInterval = globals.BackgroundGossipInterval;
-                    options.DefaultMultiCluster = globals.DefaultMultiCluster?.ToList() ?? new List<string>();
+                    options.DefaultMultiCluster = globals.DefaultMultiCluster?.ToList();
                     options.GlobalSingleInstanceNumberRetries = globals.GlobalSingleInstanceNumberRetries;
                     options.GlobalSingleInstanceRetryInterval = globals.GlobalSingleInstanceRetryInterval;
                     options.MaxMultiClusterGateways = globals.MaxMultiClusterGateways;

--- a/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Orleans.Hosting;
 using Orleans.MultiCluster;
 
 namespace Orleans.Runtime.MultiClusterNetwork
@@ -32,24 +33,23 @@ namespace Orleans.Runtime.MultiClusterNetwork
         private readonly IInternalGrainFactory grainFactory;
         private MultiClusterConfiguration injectedConfig;
         private readonly ILoggerFactory loggerFactory;
-        public MultiClusterOracle(SiloInitializationParameters siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory, IOptions<SiloOptions> siloOptions)
+        public MultiClusterOracle(ILocalSiloDetails siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory, IOptions<SiloOptions> siloOptions, IOptions<MultiClusterOptions> multiClusterOptions)
             : base(Constants.MultiClusterOracleId, siloDetails.SiloAddress, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
             this.channelFactory = channelFactory;
             this.siloStatusOracle = siloStatusOracle;
             this.grainFactory = grainFactory;
-            if (siloDetails == null) throw new ArgumentNullException(nameof(siloDetails));
 
-            var config = siloDetails.ClusterConfig.Globals;
             logger = loggerFactory.CreateLogger<MultiClusterOracle>();
             localData = new MultiClusterOracleData(logger, grainFactory);
             clusterId = siloOptions.Value.ClusterId;
-            defaultMultiCluster = config.DefaultMultiCluster;
+            var multiClusterOptionsSnapshot = multiClusterOptions.Value;
+            defaultMultiCluster = multiClusterOptionsSnapshot.DefaultMultiCluster?.ToList();
             random = new SafeRandom();
 
             // to avoid convoying, each silo varies these period intervals a little
-            backgroundGossipInterval = RandomizeTimespanSlightly(config.BackgroundGossipInterval);
+            backgroundGossipInterval = RandomizeTimespanSlightly(multiClusterOptionsSnapshot.BackgroundGossipInterval);
             resendActiveStatusAfter = RandomizeTimespanSlightly(ResendActiveStatusAfter);
         }
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -34,7 +34,6 @@ using Orleans.Transactions;
 using Orleans.Runtime.Versions;
 using Orleans.Versions;
 using Orleans.ApplicationParts;
-using Orleans.Configuration;
 using Orleans.Serialization;
 
 namespace Orleans.Runtime
@@ -136,17 +135,6 @@ namespace Orleans.Runtime
         /// <summary>
         /// Initializes a new instance of the <see cref="Silo"/> class.
         /// </summary>
-        /// <param name="name">Name of this silo.</param>
-        /// <param name="siloType">Type of this silo.</param>
-        /// <param name="config">Silo config data to be used for this silo.</param>
-        public Silo(string name, SiloType siloType, ClusterConfiguration config)
-            : this(new SiloInitializationParameters(name, siloType, config), null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Silo"/> class.
-        /// </summary>
         /// <param name="initializationParams">The silo initialization parameters.</param>
         /// <param name="services">Dependency Injection container</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope",
@@ -173,24 +161,6 @@ namespace Orleans.Runtime
             }
 
             var localEndpoint = this.initializationParams.SiloAddress.Endpoint;
-            // Configure DI using Startup type
-            if (services == null)
-            {
-                var serviceCollection = new ServiceCollection();
-                serviceCollection.AddSingleton<Silo>(this);
-                serviceCollection.AddSingleton(initializationParams);
-                serviceCollection.AddLegacyClusterConfigurationSupport(config);
-                serviceCollection.Configure<SiloOptions>(options => options.SiloName = name);
-                var hostContext = new HostBuilderContext(new Dictionary<object, object>());
-                DefaultSiloServices.AddDefaultServices(hostContext, serviceCollection);
-
-                hostContext.GetApplicationPartManager()
-                    .AddFromAppDomain()
-                    .AddFromApplicationBaseDirectory();
-
-                services = StartupBuilder.ConfigureStartup(this.LocalConfig.StartupTypeName, serviceCollection);
-                services.GetService<TelemetryManager>()?.AddFromConfiguration(services, LocalConfig.TelemetryConfiguration);
-            }
 
             services.GetService<SerializationManager>().RegisterSerializers(services.GetService<ApplicationPartManager>());
 

--- a/src/Orleans.Runtime/Silo/SiloHost.cs
+++ b/src/Orleans.Runtime/Silo/SiloHost.cs
@@ -8,6 +8,8 @@ using Orleans.Logging;
 using System.Threading.Tasks;
 using Orleans.Runtime.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Hosting;
+using Orleans.Runtime.Startup;
 
 namespace Orleans.Runtime.Host
 {
@@ -99,7 +101,25 @@ namespace Orleans.Runtime.Host
             try
             {
                 if (!ConfigLoaded) LoadOrleansConfig();
-                orleans = new Silo(Name, Type, Config);
+                var builder = new SiloHostBuilder()
+                    .ConfigureSiloName(Name)
+                    .UseConfiguration(Config)
+                    .ConfigureApplicationParts(parts => parts
+                        .AddFromAppDomain()
+                        .AddFromApplicationBaseDirectory());
+
+                if (!string.IsNullOrWhiteSpace(Config.Defaults.StartupTypeName))
+                {
+                    builder.UseServiceProviderFactory(services =>
+                        StartupBuilder.ConfigureStartup(Config.Defaults.StartupTypeName, services));
+                }
+
+                var host = builder.Build();
+
+                orleans = host.Services.GetRequiredService<Silo>();
+                var localConfig = host.Services.GetRequiredService<NodeConfiguration>();
+                host.Services.GetService<TelemetryManager>()?.AddFromConfiguration(host.Services, localConfig.TelemetryConfiguration);
+
                 logger.Info(ErrorCode.Runtime_Error_100288, "Successfully initialized Orleans silo '{0}' as a {1} node.", orleans.Name, orleans.Type);
             }
             catch (Exception exc)

--- a/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
+++ b/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
@@ -15,7 +15,6 @@ namespace Orleans.Runtime.Providers
 {
     internal class SiloProviderRuntime : ISiloSideStreamProviderRuntime
     {
-        private readonly SiloInitializationParameters siloDetails;
         private readonly ISiloStatusOracle siloStatusOracle;
         private readonly OrleansTaskScheduler scheduler;
         private readonly ActivationDirectory activationDirectory;
@@ -33,7 +32,7 @@ namespace Orleans.Runtime.Providers
         public string SiloIdentity { get; }
 
         public SiloProviderRuntime(
-            SiloInitializationParameters siloDetails,
+            ILocalSiloDetails siloDetails,
             IOptions<SiloOptions> siloOptions,
             IConsistentRingProvider consistentRingProvider,
             ISiloRuntimeClient runtimeClient,
@@ -44,7 +43,6 @@ namespace Orleans.Runtime.Providers
             ILoggerFactory loggerFactory)
         {
             this.loggerFactory = loggerFactory;
-            this.siloDetails = siloDetails;
             this.siloStatusOracle = siloStatusOracle;
             this.scheduler = scheduler;
             this.activationDirectory = activationDirectory;


### PR DESCRIPTION
- Remove legacy initialization from Silo class.
- Remove most usages of `SiloInitializationParameters` concrete type.

This is in preparation for getting rid of the legacy configuration objects as a Core dependency