### PR TITLE
Fix shutdown sequence in linuxcontainer

### DIFF
--- a/src/Orleans.Core/Messaging/SocketManager.cs
+++ b/src/Orleans.Core/Messaging/SocketManager.cs
@@ -234,7 +234,10 @@ namespace Orleans.Runtime
 
             try
             {
-                s.Disconnect(false);
+                if (s.Connected)
+                    s.Disconnect(false);
+                else
+                    s.Close();
             }
             catch (Exception)
             {


### PR DESCRIPTION
Related to #3621 

Two fixes here:

- First, do not try to restart the listening socket when the silo is stopping
- Second, for some reason, in Linux calling `Socket.Disconnect` on a Socket that is not connected completely blow up the process instead of just throwing an exception. So check if the socket is connected before calling this method.