### PR TITLE
Strongly typed endpoint options

### DIFF
--- a/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
@@ -1,7 +1,5 @@
 ﻿using Orleans.Runtime;
 using System;
-using System.Net;
-using Orleans.Runtime.Configuration;
 
 namespace Orleans.Hosting
 {
@@ -20,27 +18,5 @@ namespace Orleans.Hosting
         /// Default is TimeSpan.MaxValue (never close sockets automatically, unles they were broken).
         /// </summary>
         public TimeSpan MaxSocketAge { get; set; } = TimeSpan.MaxValue;
-
-        /// <summary>
-        /// The external IP address or host name used for clustering.
-        /// </summary>
-        public string HostNameOrIPAddress { get; set; }
-
-        /// <summary>
-        /// The IP address used for clustering. Will be inferred from <see cref="HostNameOrIPAddress"/> if this is not directly specified.
-        /// </summary>
-        public IPAddress IPAddress { get; set; }
-
-        /// <summary>
-        /// The port this silo uses for silo-to-silo communication.
-        /// </summary>
-        public int Port { get; set; }
-
-        /// <summary>
-        /// The port this silo uses for silo-to-client (gateway) communication. Specify 0 to disable gateway functionality.
-        /// </summary>
-        public int ProxyPort { get; set; }
-
-        //public bool BindToAny { get; set; }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
@@ -1,5 +1,7 @@
 ﻿using Orleans.Runtime;
 using System;
+using System.Net;
+using Orleans.Runtime.Configuration;
 
 namespace Orleans.Hosting
 {
@@ -18,5 +20,27 @@ namespace Orleans.Hosting
         /// Default is TimeSpan.MaxValue (never close sockets automatically, unles they were broken).
         /// </summary>
         public TimeSpan MaxSocketAge { get; set; } = TimeSpan.MaxValue;
+
+        /// <summary>
+        /// The external IP address or host name used for clustering.
+        /// </summary>
+        public string HostNameOrIPAddress { get; set; }
+
+        /// <summary>
+        /// The IP address used for clustering. Will be inferred from <see cref="HostNameOrIPAddress"/> if this is not directly specified.
+        /// </summary>
+        public IPAddress IPAddress { get; set; }
+
+        /// <summary>
+        /// The port this silo uses for silo-to-silo communication.
+        /// </summary>
+        public int Port { get; set; }
+
+        /// <summary>
+        /// The port this silo uses for silo-to-client (gateway) communication. Specify 0 to disable gateway functionality.
+        /// </summary>
+        public int ProxyPort { get; set; }
+
+        //public bool BindToAny { get; set; }
     }
 }

--- a/src/Orleans.Core/Runtime/ILocalSiloDetails.cs
+++ b/src/Orleans.Core/Runtime/ILocalSiloDetails.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace Orleans.Runtime
 {
     /// <summary>
@@ -14,5 +16,10 @@ namespace Orleans.Runtime
         /// Gets the address of this silo's inter-silo endpoint.
         /// </summary>
         SiloAddress SiloAddress { get; }
+
+        /// <summary>
+        /// Gets the address of this silo's gateway proxy endpoint.
+        /// </summary>
+        IPEndPoint GatewayEndpoint { get; }
     }
 }

--- a/src/Orleans.Core/Runtime/ILocalSiloDetails.cs
+++ b/src/Orleans.Core/Runtime/ILocalSiloDetails.cs
@@ -1,5 +1,3 @@
-using System.Net;
-
 namespace Orleans.Runtime
 {
     /// <summary>
@@ -13,6 +11,17 @@ namespace Orleans.Runtime
         string Name { get; }
 
         /// <summary>
+        /// Gets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
+        /// </summary>
+        string ClusterId { get; }
+
+        /// <summary>
+        /// The DNS host name of this silo.
+        /// This is a true host name, no IP address. Equals Dns.GetHostName().
+        /// </summary>
+        string DnsHostName { get; }
+
+        /// <summary>
         /// Gets the address of this silo's inter-silo endpoint.
         /// </summary>
         SiloAddress SiloAddress { get; }
@@ -20,6 +29,6 @@ namespace Orleans.Runtime
         /// <summary>
         /// Gets the address of this silo's gateway proxy endpoint.
         /// </summary>
-        IPEndPoint GatewayEndpoint { get; }
+        SiloAddress GatewayAddress { get; }
     }
 }

--- a/src/Orleans.Hosting.ServiceFabric/OrleansCommunicationListener.cs
+++ b/src/Orleans.Hosting.ServiceFabric/OrleansCommunicationListener.cs
@@ -41,7 +41,15 @@ namespace Orleans.Hosting.ServiceFabric
                 builder.ConfigureServices(
                     services =>
                     {
-                        services.AddSingleton<IConfigureOptions<FabricSiloInfo>, SiloInfoConfiguration>();
+                        services.AddOptions<FabricSiloInfo>().Configure<ILocalSiloDetails>((info, details) =>
+                        {
+                            info.Name = details.Name;
+                            info.Silo = details.SiloAddress.ToParsableString();
+                            if (details.GatewayAddress != null)
+                            {
+                                info.Gateway = details.GatewayAddress.ToParsableString();
+                            }
+                        });
                     });
                 this.configure(builder);
 
@@ -90,27 +98,6 @@ namespace Orleans.Hosting.ServiceFabric
             finally
             {
                 this.Host = null;
-            }
-        }
-
-        // ReSharper disable once ClassNeverInstantiated.Local
-        private class SiloInfoConfiguration : IConfigureOptions<FabricSiloInfo>
-        {
-            private readonly NodeConfiguration config;
-
-            public SiloInfoConfiguration(NodeConfiguration config)
-            {
-                this.config = config;
-            }
-
-            public void Configure(FabricSiloInfo info)
-            {
-                info.Name = this.config.SiloName;
-                info.Silo = SiloAddress.New(this.config.Endpoint, this.config.Generation).ToParsableString();
-                if (this.config.ProxyGatewayEndpoint != null)
-                {
-                    info.Gateway = SiloAddress.New(this.config.ProxyGatewayEndpoint, this.config.Generation).ToParsableString();
-                }
             }
         }
     }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -137,7 +137,7 @@ namespace Orleans.Runtime.GrainDirectory
                     loggerFactory);
             GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig, grainFactory, multiClusterOracle, executorService, siloOptions, multiClusterOptions, loggerFactory);
 
-            var primarySiloEndPoint = developmentMembershipOptions.Value.PrimarySiloEndPoint;
+            var primarySiloEndPoint = developmentMembershipOptions.Value.PrimarySiloEndpoint;
             if (primarySiloEndPoint != null)
             {
                 this.seed = this.MyAddress.Endpoint.Equals(primarySiloEndPoint) ? this.MyAddress : SiloAddress.New(primarySiloEndPoint, 0);

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -28,7 +28,7 @@ namespace Orleans.Hosting
                                            ?? context.HostingEnvironment.ApplicationName
                                            ?? $"Silo_{Guid.NewGuid().ToString("N").Substring(0, 5)}");
 
-                    services.TryAddSingleton<Silo>(sp => new Silo(sp.GetRequiredService<SiloInitializationParameters>(), sp));
+                    services.TryAddSingleton<Silo>();
                     DefaultSiloServices.AddDefaultServices(context, services);
 
                     context.Properties.Add("OrleansServicesAdded", true);

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -45,6 +45,7 @@ namespace Orleans.Hosting
             services.AddOptions();
 
             // Register system services.
+            services.TryAddSingleton<ILocalSiloDetails, LocalSiloDetails>();
             services.TryAddSingleton<ISiloHost, SiloWrapper>();
             services.TryAddSingleton<SiloLifecycle>();
 

--- a/src/Orleans.Runtime/Hosting/EndpointOptions.cs
+++ b/src/Orleans.Runtime/Hosting/EndpointOptions.cs
@@ -1,0 +1,32 @@
+﻿using System.Net;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Configures the Silo endpoint options
+    /// </summary>
+    public class EndpointOptions
+    { 
+        /// <summary>
+        /// The external IP address or host name used for clustering.
+        /// </summary>
+        public string HostNameOrIPAddress { get; set; }
+
+        /// <summary>
+        /// The IP address used for clustering. Will be inferred from <see cref="HostNameOrIPAddress"/> if this is not directly specified.
+        /// </summary>
+        public IPAddress IPAddress { get; set; }
+
+        /// <summary>
+        /// The port this silo uses for silo-to-silo communication.
+        /// </summary>
+        public int Port { get; set; }
+
+        /// <summary>
+        /// The port this silo uses for silo-to-client (gateway) communication. Specify 0 to disable gateway functionality.
+        /// </summary>
+        public int ProxyPort { get; set; }
+
+        //public bool BindToAny { get; set; }
+    }
+}

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -24,15 +23,13 @@ namespace Orleans.Hosting
 
             // these will eventually be removed once our code doesn't depend on the old ClientConfiguration
             services.AddSingleton(configuration);
-            services.TryAddSingleton<SiloInitializationParameters>();
-            services.TryAddFromExisting<ILocalSiloDetails, SiloInitializationParameters>();
-            services.TryAddSingleton(sp => sp.GetRequiredService<SiloInitializationParameters>().ClusterConfig);
-            services.TryAddSingleton(sp => sp.GetRequiredService<SiloInitializationParameters>().ClusterConfig.Globals);
-            services.TryAddTransient(sp => sp.GetRequiredService<SiloInitializationParameters>().NodeConfig);
+            services.TryAddSingleton<LegacyConfigurationWrapper>();
+            services.TryAddSingleton(sp => sp.GetRequiredService<LegacyConfigurationWrapper>().ClusterConfig.Globals);
+            services.TryAddTransient(sp => sp.GetRequiredService<LegacyConfigurationWrapper>().NodeConfig);
             services.TryAddSingleton<Factory<NodeConfiguration>>(
                 sp =>
                 {
-                    var initializationParams = sp.GetRequiredService<SiloInitializationParameters>();
+                    var initializationParams = sp.GetRequiredService<LegacyConfigurationWrapper>();
                     return () => initializationParams.NodeConfig;
                 });
 

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -79,8 +79,9 @@ namespace Orleans.Hosting
                 options.ClientDropTimeout = configuration.Globals.ClientDropTimeout;
             });
 
-            services.AddOptions<NetworkingOptions>()
-                .Configure(options => LegacyConfigurationExtensions.CopyNetworkingOptions(configuration.Globals, options))
+            services.Configure<NetworkingOptions>(options => LegacyConfigurationExtensions.CopyNetworkingOptions(configuration.Globals, options));
+
+            services.AddOptions<EndpointOptions>()
                 .Configure<IOptions<SiloOptions>>((options, siloOptions) =>
                 {
                     var nodeConfig = configuration.GetOrCreateNodeConfigurationForSilo(siloOptions.Value.SiloName);

--- a/src/Orleans.Runtime/MembershipService/DevelopmentMembershipOptions.cs
+++ b/src/Orleans.Runtime/MembershipService/DevelopmentMembershipOptions.cs
@@ -8,6 +8,6 @@ namespace Orleans.Hosting
         /// <summary>
         /// Gets or sets the seed node to find the membership system grain.
         /// </summary>
-        public IPEndPoint PrimarySiloEndPoint { get; set; }
+        public IPEndPoint PrimarySiloEndpoint { get; set; }
     }
 }

--- a/src/Orleans.Runtime/MembershipService/GrainBasedMembershipTable.cs
+++ b/src/Orleans.Runtime/MembershipService/GrainBasedMembershipTable.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime.MembershipService
         {
             var options = this.serviceProvider.GetRequiredService<IOptions<DevelopmentMembershipOptions>>().Value;
             var siloDetails = this.serviceProvider.GetService<ILocalSiloDetails>();
-            bool isPrimarySilo = siloDetails.SiloAddress.Endpoint.Equals(options.PrimarySiloEndPoint);
+            bool isPrimarySilo = siloDetails.SiloAddress.Endpoint.Equals(options.PrimarySiloEndpoint);
             if (isPrimarySilo)
             {
                 this.logger.Info(ErrorCode.MembershipFactory1, "Creating membership table grain");

--- a/src/Orleans.Runtime/MembershipService/ILegacyMembershipConfigurator.cs
+++ b/src/Orleans.Runtime/MembershipService/ILegacyMembershipConfigurator.cs
@@ -63,7 +63,7 @@ namespace Orleans.Runtime.MembershipService
             {
                 if (configuration.SeedNodes?.Count > 0)
                 {
-                    options.PrimarySiloEndPoint = configuration.SeedNodes?.FirstOrDefault();
+                    options.PrimarySiloEndpoint = configuration.SeedNodes?.FirstOrDefault();
                 }
             }
         }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -40,7 +40,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ILoggerFactory loggerFactory;
         private readonly SiloMessagingOptions messagingOptions;
         
-        public Gateway(MessageCenter msgCtr, NodeConfiguration nodeConfig, MessageFactory messageFactory, SerializationManager serializationManager, ExecutorService executorService, ILoggerFactory loggerFactory, IOptions<SiloMessagingOptions> options, IOptions<SiloOptions> siloOptions, IOptions<MultiClusterOptions> multiClusterOptions)
+        public Gateway(MessageCenter msgCtr, ILocalSiloDetails siloDetails, MessageFactory messageFactory, SerializationManager serializationManager, ExecutorService executorService, ILoggerFactory loggerFactory, IOptions<SiloMessagingOptions> options, IOptions<MultiClusterOptions> multiClusterOptions)
         {
             this.messagingOptions = options.Value;
             this.loggerFactory = loggerFactory;
@@ -49,14 +49,14 @@ namespace Orleans.Runtime.Messaging
             this.logger = this.loggerFactory.CreateLogger<Gateway>();
             this.serializationManager = serializationManager;
             this.executorService = executorService;
-            acceptor = new GatewayAcceptor(msgCtr,this, nodeConfig.ProxyGatewayEndpoint, this.messageFactory, this.serializationManager, executorService, siloOptions, multiClusterOptions, loggerFactory);
+            acceptor = new GatewayAcceptor(msgCtr,this, siloDetails.GatewayAddress?.Endpoint, this.messageFactory, this.serializationManager, executorService, siloDetails, multiClusterOptions, loggerFactory);
             senders = new Lazy<GatewaySender>[messagingOptions.GatewaySenderQueues];
             nextGatewaySenderToUseForRoundRobin = 0;
             dropper = new GatewayClientCleanupAgent(this, executorService, loggerFactory, messagingOptions.ClientDropTimeout);
             clients = new ConcurrentDictionary<GrainId, ClientState>();
             clientSockets = new ConcurrentDictionary<Socket, ClientState>();
             clientsReplyRoutingCache = new ClientsReplyRoutingCache(messagingOptions.ResponseTimeout);
-            this.gatewayAddress = SiloAddress.New(nodeConfig.ProxyGatewayEndpoint, 0);
+            this.gatewayAddress = siloDetails.GatewayAddress;
             lockable = new object();
         }
 

--- a/src/Orleans.Runtime/Silo/LegacyConfigurationWrapper.cs
+++ b/src/Orleans.Runtime/Silo/LegacyConfigurationWrapper.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Options;
+using Orleans.Runtime.Configuration;
+
+namespace Orleans.Runtime
+{
+    internal class LegacyConfigurationWrapper
+    {
+        public LegacyConfigurationWrapper(IOptions<SiloOptions> siloOptions,
+            ClusterConfiguration config)
+        {
+            var siloName = siloOptions.Value.SiloName;
+            this.ClusterConfig = config;
+            this.ClusterConfig.OnConfigChange(
+                "Defaults",
+                () => this.NodeConfig = this.ClusterConfig.GetOrCreateNodeConfigurationForSilo(siloName));
+
+            if (this.NodeConfig.Generation == 0)
+            {
+                this.NodeConfig.Generation = SiloAddress.AllocateNewGeneration();
+            }
+
+            this.NodeConfig.InitNodeSettingsFromGlobals(config);
+            this.Type = this.NodeConfig.IsPrimaryNode ? Silo.SiloType.Primary : Silo.SiloType.Secondary;
+        }
+        /// <summary>
+        /// Gets the cluster configuration.
+        /// </summary>
+        public ClusterConfiguration ClusterConfig { get; }
+
+        /// <summary>
+        /// Gets the node configuration.
+        /// </summary>
+        public NodeConfiguration NodeConfig { get; private set; }
+
+        /// <summary>
+        /// Gets the type of this silo.
+        /// </summary>
+        public Silo.SiloType Type { get; }
+    }
+}

--- a/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
+++ b/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
@@ -57,39 +57,4 @@ namespace Orleans.Runtime
         /// <inheritdoc />
         public SiloAddress GatewayAddress => this.gatewayAddressLazy.Value;
     }
-
-    internal class LegacyConfigurationWrapper
-    {
-        public LegacyConfigurationWrapper(IOptions<SiloOptions> siloOptions,
-            ClusterConfiguration config)
-        {
-            var siloName = siloOptions.Value.SiloName;
-            this.ClusterConfig = config;
-            this.ClusterConfig.OnConfigChange(
-                "Defaults",
-                () => this.NodeConfig = this.ClusterConfig.GetOrCreateNodeConfigurationForSilo(siloName));
-
-            if (this.NodeConfig.Generation == 0)
-            {
-                this.NodeConfig.Generation = SiloAddress.AllocateNewGeneration();
-            }
-
-            this.NodeConfig.InitNodeSettingsFromGlobals(config);
-            this.Type = this.NodeConfig.IsPrimaryNode ? Silo.SiloType.Primary : Silo.SiloType.Secondary;
-        }
-        /// <summary>
-        /// Gets the cluster configuration.
-        /// </summary>
-        public ClusterConfiguration ClusterConfig { get; }
-
-        /// <summary>
-        /// Gets the node configuration.
-        /// </summary>
-        public NodeConfiguration NodeConfig { get; private set; }
-
-        /// <summary>
-        /// Gets the type of this silo.
-        /// </summary>
-        public Silo.SiloType Type { get; }
-    }
 }

--- a/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
+++ b/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
@@ -14,19 +14,19 @@ namespace Orleans.Runtime
 
         public LocalSiloDetails(
             IOptions<SiloOptions> siloOptions,
-            IOptions<NetworkingOptions> networkingOptions)
+            IOptions<EndpointOptions> siloEndpointOptions)
         {
             var options = siloOptions.Value;
             this.Name = options.SiloName;
             this.ClusterId = options.ClusterId;
             this.DnsHostName = Dns.GetHostName();
 
-            var network = networkingOptions.Value;
-            this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(ResolveEndpoint(network), SiloAddress.AllocateNewGeneration()));
-            this.gatewayAddressLazy = new Lazy<SiloAddress>(() => network.ProxyPort != 0 ? SiloAddress.New(new IPEndPoint(this.SiloAddress.Endpoint.Address, network.ProxyPort), 0) : null);
+            var endpointOptions = siloEndpointOptions.Value;
+            this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(ResolveEndpoint(endpointOptions), SiloAddress.AllocateNewGeneration()));
+            this.gatewayAddressLazy = new Lazy<SiloAddress>(() => endpointOptions.ProxyPort != 0 ? SiloAddress.New(new IPEndPoint(this.SiloAddress.Endpoint.Address, endpointOptions.ProxyPort), 0) : null);
         }
 
-        private static IPEndPoint ResolveEndpoint(NetworkingOptions options)
+        private static IPEndPoint ResolveEndpoint(EndpointOptions options)
         {
             IPAddress ipAddress;
             if (options.IPAddress != null)

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -179,7 +179,7 @@ namespace Orleans.Runtime
             }
 
             logger.Info(ErrorCode.SiloInitializing, "-------------- Initializing {0} silo on host {1} MachineName {2} at {3}, gen {4} --------------",
-                this.initializationParams.Type, LocalConfig.DNSHostName, Environment.MachineName, localEndpoint, this.initializationParams.SiloAddress.Generation);
+                this.initializationParams.Type, initializationParams.DnsHostName, Environment.MachineName, localEndpoint, this.initializationParams.SiloAddress.Generation);
             logger.Info(ErrorCode.SiloInitConfig, "Starting silo {0} with the following configuration= " + Environment.NewLine + "{1}",
                 name, config.ToString(name));
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -25,7 +25,6 @@ using Orleans.Runtime.Messaging;
 using Orleans.Runtime.MultiClusterNetwork;
 using Orleans.Runtime.Providers;
 using Orleans.Runtime.Scheduler;
-using Orleans.Runtime.Startup;
 using Orleans.Runtime.Storage;
 using Orleans.Services;
 using Orleans.Storage;
@@ -57,7 +56,8 @@ namespace Orleans.Runtime
             Secondary,
         }
 
-        private readonly SiloInitializationParameters initializationParams;
+        private readonly ILocalSiloDetails siloDetails;
+        private readonly LegacyConfigurationWrapper legacyConfiguration;
         private readonly SiloOptions siloOptions;
         private readonly ISiloMessageCenter messageCenter;
         private readonly OrleansTaskScheduler scheduler;
@@ -96,11 +96,9 @@ namespace Orleans.Runtime
         /// <summary>
         /// Gets the type of this 
         /// </summary>
-        public SiloType Type => this.initializationParams.Type;
-        internal string Name => this.initializationParams.Name;
-        internal ClusterConfiguration OrleansConfig => this.initializationParams.ClusterConfig;
-        internal GlobalConfiguration GlobalConfig => this.initializationParams.ClusterConfig.Globals;
-        internal NodeConfiguration LocalConfig => this.initializationParams.NodeConfig;
+        internal string Name => this.siloDetails.Name;
+        internal GlobalConfiguration GlobalConfig => this.legacyConfiguration.ClusterConfig.Globals;
+        internal NodeConfiguration LocalConfig => this.legacyConfiguration.NodeConfig;
         internal OrleansTaskScheduler LocalScheduler { get { return scheduler; } }
         internal ILocalGrainDirectory LocalGrainDirectory { get { return localGrainDirectory; } }
         internal IMultiClusterOracle LocalMultiClusterOracle { get { return multiClusterOracle; } }
@@ -118,7 +116,7 @@ namespace Orleans.Runtime
         internal IServiceProvider Services { get; }
 
         /// <summary> SiloAddress for this silo. </summary>
-        public SiloAddress SiloAddress => this.initializationParams.SiloAddress;
+        public SiloAddress SiloAddress => this.siloDetails.SiloAddress;
 
         /// <summary>
         ///  Silo termination event used to signal shutdown of this silo.
@@ -139,11 +137,12 @@ namespace Orleans.Runtime
         /// <param name="services">Dependency Injection container</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "Should not Dispose of messageCenter in this method because it continues to run / exist after this point.")]
-        internal Silo(SiloInitializationParameters initializationParams, IServiceProvider services)
+        public Silo(ILocalSiloDetails siloDetails, IServiceProvider services)
         {
-            string name = initializationParams.Name;
-            ClusterConfiguration config = initializationParams.ClusterConfig;
-            this.initializationParams = initializationParams;
+            string name = siloDetails.Name;
+            // Temporarily still require this. Hopefuly gone when 2.0 is released.
+            this.legacyConfiguration = services.GetRequiredService<LegacyConfigurationWrapper>();
+            this.siloDetails = siloDetails;
 
             this.SystemStatus = SystemStatus.Creating;
             AsynchAgent.IsStarting = true;
@@ -160,14 +159,14 @@ namespace Orleans.Runtime
                 stopTimeout = initTimeout;
             }
 
-            var localEndpoint = this.initializationParams.SiloAddress.Endpoint;
+            var localEndpoint = this.siloDetails.SiloAddress.Endpoint;
 
             services.GetService<SerializationManager>().RegisterSerializers(services.GetService<ApplicationPartManager>());
 
             this.Services = services;
             this.Services.InitializeSiloUnobservedExceptionsHandler();
             //set PropagateActivityId flag from node cofnig
-            RequestContext.PropagateActivityId = this.initializationParams.NodeConfig.PropagateActivityId;
+            RequestContext.PropagateActivityId = this.legacyConfiguration.NodeConfig.PropagateActivityId;
             this.loggerFactory = this.Services.GetRequiredService<ILoggerFactory>();
             logger = this.loggerFactory.CreateLogger<Silo>();
 
@@ -179,9 +178,9 @@ namespace Orleans.Runtime
             }
 
             logger.Info(ErrorCode.SiloInitializing, "-------------- Initializing {0} silo on host {1} MachineName {2} at {3}, gen {4} --------------",
-                this.initializationParams.Type, initializationParams.DnsHostName, Environment.MachineName, localEndpoint, this.initializationParams.SiloAddress.Generation);
+                this.legacyConfiguration.Type, this.siloDetails.DnsHostName, Environment.MachineName, localEndpoint, this.siloDetails.SiloAddress.Generation);
             logger.Info(ErrorCode.SiloInitConfig, "Starting silo {0} with the following configuration= " + Environment.NewLine + "{1}",
-                name, config.ToString(name));
+                name, this.legacyConfiguration.ClusterConfig.ToString(name));
 
             var siloMessagingOptions = this.Services.GetRequiredService<IOptions<SiloMessagingOptions>>();
             BufferPool.InitGlobalBufferPool(siloMessagingOptions);

--- a/src/Orleans.Runtime/Silo/SiloHost.cs
+++ b/src/Orleans.Runtime/Silo/SiloHost.cs
@@ -120,7 +120,7 @@ namespace Orleans.Runtime.Host
                 var localConfig = host.Services.GetRequiredService<NodeConfiguration>();
                 host.Services.GetService<TelemetryManager>()?.AddFromConfiguration(host.Services, localConfig.TelemetryConfiguration);
 
-                logger.Info(ErrorCode.Runtime_Error_100288, "Successfully initialized Orleans silo '{0}' as a {1} node.", orleans.Name, orleans.Type);
+                logger.Info(ErrorCode.Runtime_Error_100288, "Successfully initialized Orleans silo '{0}'.", orleans.Name);
             }
             catch (Exception exc)
             {

--- a/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
+++ b/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
@@ -1,30 +1,8 @@
-using System;
 using Microsoft.Extensions.Options;
 using Orleans.Runtime.Configuration;
 
 namespace Orleans.Runtime
 {
-    /// <summary>
-    /// Silo identity configuration options.
-    /// </summary>
-    public class SiloOptions
-    {
-        /// <summary>
-        /// Gets or sets the silo name.
-        /// </summary>
-        public string SiloName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
-        /// </summary>
-        public string ClusterId { get; set; }
-
-        /// <summary>
-        /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment, where as <see cref="ClusterId"/> might not.
-        /// </summary>
-        public Guid ServiceId { get; set; }
-    }
-
     /// <summary>
     /// Parameters used to initialize a silo and values derived from those parameters.
     /// </summary>

--- a/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
+++ b/src/Orleans.Runtime/Silo/SiloInitializationParameters.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.Extensions.Options;
 using Orleans.Runtime.Configuration;
 
@@ -75,9 +76,10 @@ namespace Orleans.Runtime
         /// </summary>
         public NodeConfiguration NodeConfig { get; private set; }
 
-        /// <summary>
-        /// Gets the address of this silo's inter-silo endpoint.
-        /// </summary>
+        /// <inheritdoc />
         public SiloAddress SiloAddress { get; }
+
+        /// <inheritdoc />
+        public IPEndPoint GatewayEndpoint { get; }
     }
 }

--- a/src/Orleans.Runtime/Silo/SiloOptions.cs
+++ b/src/Orleans.Runtime/Silo/SiloOptions.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Silo identity configuration options.
+    /// </summary>
+    public class SiloOptions
+    {
+        /// <summary>
+        /// Gets or sets the silo name.
+        /// </summary>
+        public string SiloName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
+        /// </summary>
+        public string ClusterId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment, where as <see cref="ClusterId"/> might not.
+        /// </summary>
+        public Guid ServiceId { get; set; }
+    }
+}

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -771,9 +771,11 @@ namespace UnitTests.SchedulerTests
 
         private class MockSiloDetails : ILocalSiloDetails
         {
+            public string DnsHostName { get; }
             public SiloAddress SiloAddress { get; set; }
-            public IPEndPoint GatewayEndpoint { get; set; }
+            public SiloAddress GatewayAddress { get; }
             public string Name { get; set; } = Guid.NewGuid().ToString();
+            public string ClusterId { get; }
         }
     }
 }

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -771,6 +772,7 @@ namespace UnitTests.SchedulerTests
         private class MockSiloDetails : ILocalSiloDetails
         {
             public SiloAddress SiloAddress { get; set; }
+            public IPEndPoint GatewayEndpoint { get; set; }
             public string Name { get; set; } = Guid.NewGuid().ToString();
         }
     }

--- a/test/TestServiceFabric/FabricMembershipOracleTests.cs
+++ b/test/TestServiceFabric/FabricMembershipOracleTests.cs
@@ -264,8 +264,10 @@ namespace TestServiceFabric
         private class MockSiloDetails : ILocalSiloDetails
         {
             public string Name { get; set; }
+            public string ClusterId { get; }
+            public string DnsHostName { get; }
             public SiloAddress SiloAddress { get; set; }
-            public IPEndPoint GatewayEndpoint { get; set; }
+            public SiloAddress GatewayAddress { get; }
         }
 
         private void AssertStatus(SiloStatus expected)

--- a/test/TestServiceFabric/FabricMembershipOracleTests.cs
+++ b/test/TestServiceFabric/FabricMembershipOracleTests.cs
@@ -265,6 +265,7 @@ namespace TestServiceFabric
         {
             public string Name { get; set; }
             public SiloAddress SiloAddress { get; set; }
+            public IPEndPoint GatewayEndpoint { get; set; }
         }
 
         private void AssertStatus(SiloStatus expected)


### PR DESCRIPTION
- Add GatewayAddress to ILocalSiloDetails
- Read endpoints information from EndpointOptions
- Break dependency between LocalSiloDetails and legacy configuration (and get rid of SiloInitializationParameters)

Note to reviewers:
- I did find a few more usages of the legacy configuration to configure endpoints that can be eventually migrated to not rely on the legacy config (mainly in the ServiceFabric code), but it's not required for this PR.
- Kept separate commits to make diff simpler. Please squash anyway and keep the PR description as the commit message description (without the note to reviewers of course).





