### PR TITLE
Fix wrong config usages

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -102,14 +102,13 @@ namespace Orleans.Runtime.GrainDirectory
             RegistrarManager registrarManager,
             ExecutorService executorService,
             IOptions<DevelopmentMembershipOptions> developmentMembershipOptions,
-            IOptions<SiloOptions> siloOptions,
             IOptions<MultiClusterOptions> multiClusterOptions,
             ILoggerFactory loggerFactory)
         {
             this.log = loggerFactory.CreateLogger<LocalGrainDirectory>();
             var globalConfig = clusterConfig.Globals;
 
-            var clusterId = multiClusterOptions.Value.HasMultiClusterNetwork ? siloOptions.Value.ClusterId : null;
+            var clusterId = multiClusterOptions.Value.HasMultiClusterNetwork ? siloDetails.ClusterId : null;
             MyAddress = siloDetails.SiloAddress;
 
             Scheduler = scheduler;
@@ -135,7 +134,7 @@ namespace Orleans.Runtime.GrainDirectory
                     grainFactory, 
                     executorService,
                     loggerFactory);
-            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig, grainFactory, multiClusterOracle, executorService, siloOptions, multiClusterOptions, loggerFactory);
+            GsiActivationMaintainer = new GlobalSingleInstanceActivationMaintainer(this, this.Logger, globalConfig, grainFactory, multiClusterOracle, executorService, siloDetails, multiClusterOptions, loggerFactory);
 
             var primarySiloEndPoint = developmentMembershipOptions.Value.PrimarySiloEndpoint;
             if (primarySiloEndPoint != null)

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.GrainDirectory
             GlobalConfiguration config,
             IInternalGrainFactory grainFactory,
             IMultiClusterOracle multiClusterOracle,
-            IOptions<SiloOptions> siloOptions,
+            ILocalSiloDetails siloDetails,
             IOptions<MultiClusterOptions> multiClusterOptions)
         {
             this.directoryPartition = localDirectory.DirectoryPartition;
@@ -51,7 +51,7 @@ namespace Orleans.Runtime.GrainDirectory
             this.grainFactory = grainFactory;
             this.multiClusterOracle = multiClusterOracle;
             this.hasMultiClusterNetwork = multiClusterOptions.Value.HasMultiClusterNetwork;
-            this.clusterId = siloOptions.Value.ClusterId;
+            this.clusterId = siloDetails.ClusterId;
         }
 
         public bool IsSynchronous { get { return false; } }

--- a/src/Orleans.Runtime/LogConsistency/ProtocolServices.cs
+++ b/src/Orleans.Runtime/LogConsistency/ProtocolServices.cs
@@ -38,7 +38,6 @@ namespace Orleans.Runtime.LogConsistency
         private readonly Grain grain;   // links to the grain that owns this service object
         private readonly MultiClusterConfiguration pseudoMultiClusterConfiguration;
 
-        private readonly SiloOptions siloOptions;
         private readonly MultiClusterOptions multiClusterOptions;
 
         public ProtocolServices(
@@ -47,7 +46,7 @@ namespace Orleans.Runtime.LogConsistency
             IMultiClusterRegistrationStrategy strategy,
             SerializationManager serializationManager,
             IInternalGrainFactory grainFactory,
-            IOptions<SiloOptions> siloOptions,
+            ILocalSiloDetails siloDetails,
             IOptions<MultiClusterOptions> multiClusterOptions,
             IMultiClusterOracle multiClusterOracle)
         {
@@ -57,14 +56,14 @@ namespace Orleans.Runtime.LogConsistency
             this.RegistrationStrategy = strategy;
             this.SerializationManager = serializationManager;
             this.multiClusterOracle = multiClusterOracle;
-            this.siloOptions = siloOptions.Value;
+            this.MyClusterId = siloDetails.ClusterId;
             this.multiClusterOptions = multiClusterOptions.Value;
 
             if (!this.multiClusterOptions.HasMultiClusterNetwork)
             {
                 // we are creating a default multi-cluster configuration containing exactly one cluster, this one.
                 this.pseudoMultiClusterConfiguration = PseudoMultiClusterConfigurations.FindOrCreate(
-                    this.siloOptions.ClusterId,
+                    this.MyClusterId,
                     CreatePseudoConfig);
             }
         }
@@ -75,10 +74,10 @@ namespace Orleans.Runtime.LogConsistency
 
         public async Task<ILogConsistencyProtocolMessage> SendMessage(ILogConsistencyProtocolMessage payload, string clusterId)
         {
-            log?.Trace("SendMessage {0}->{1}: {2}", this.siloOptions.ClusterId, clusterId, payload);
+            log?.Trace("SendMessage {0}->{1}: {2}", this.MyClusterId, clusterId, payload);
 
             // send the message to ourself if we are the destination cluster
-            if (this.siloOptions.ClusterId == clusterId)
+            if (this.MyClusterId == clusterId)
             {
                 var g = (ILogConsistencyProtocolParticipant)grain;
                 // we are on the same scheduler, so we can call the method directly
@@ -128,13 +127,7 @@ namespace Orleans.Runtime.LogConsistency
 
         public bool MultiClusterEnabled => this.multiClusterOptions.HasMultiClusterNetwork;
     
-        public string MyClusterId
-        {
-            get
-            {
-                return this.siloOptions.ClusterId;
-            }
-        }
+        public string MyClusterId { get; }
 
         private string ClusterDisplayName => this.MultiClusterEnabled ? " " + this.MyClusterId : string.Empty;
 
@@ -153,7 +146,7 @@ namespace Orleans.Runtime.LogConsistency
             {
                 foreach (var cluster in this.multiClusterOracle.GetMultiClusterConfiguration().Clusters)
                 {
-                    if (cluster != this.siloOptions.ClusterId)
+                    if (cluster != this.MyClusterId)
                         yield return cluster;
                 }
             }
@@ -203,7 +196,7 @@ namespace Orleans.Runtime.LogConsistency
             if (!this.MultiClusterEnabled)
                 throw new OrleansException(string.Format("{0} (grain={1})", msg, grain.GrainReference));
             else
-                throw new OrleansException(string.Format("{0} (grain={1}, cluster={2})", msg, grain.GrainReference, this.siloOptions.ClusterId));
+                throw new OrleansException(string.Format("{0} (grain={1}, cluster={2})", msg, grain.GrainReference, this.MyClusterId));
         }
 
         public void CaughtException(string where, Exception e)

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -46,7 +46,6 @@ namespace Orleans.Runtime.Messaging
 
         public MessageCenter(
             ILocalSiloDetails siloDetails,
-            NodeConfiguration nodeConfig,
             IOptions<SiloMessagingOptions> messagingOptions,
             IOptions<NetworkingOptions> networkingOptions,
             SerializationManager serializationManager,
@@ -61,8 +60,8 @@ namespace Orleans.Runtime.Messaging
             this.serializationManager = serializationManager;
             this.messageFactory = messageFactory;
             this.executorService = executorService;
-            this.Initialize(siloDetails.SiloAddress.Endpoint, nodeConfig.Generation, messagingOptions, networkingOptions, metrics);
-            if (nodeConfig.IsGatewayNode)
+            this.Initialize(siloDetails.SiloAddress.Endpoint, siloDetails.SiloAddress.Generation, messagingOptions, networkingOptions, metrics);
+            if (siloDetails.GatewayAddress != null)
             {
                 Gateway = gatewayFactory(this);
             }

--- a/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -33,7 +33,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
         private readonly IInternalGrainFactory grainFactory;
         private MultiClusterConfiguration injectedConfig;
         private readonly ILoggerFactory loggerFactory;
-        public MultiClusterOracle(ILocalSiloDetails siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory, IOptions<SiloOptions> siloOptions, IOptions<MultiClusterOptions> multiClusterOptions)
+        public MultiClusterOracle(ILocalSiloDetails siloDetails, MultiClusterGossipChannelFactory channelFactory, ISiloStatusOracle siloStatusOracle, IInternalGrainFactory grainFactory, ILoggerFactory loggerFactory, IOptions<MultiClusterOptions> multiClusterOptions)
             : base(Constants.MultiClusterOracleId, siloDetails.SiloAddress, loggerFactory)
         {
             this.loggerFactory = loggerFactory;
@@ -43,7 +43,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
 
             logger = loggerFactory.CreateLogger<MultiClusterOracle>();
             localData = new MultiClusterOracleData(logger, grainFactory);
-            clusterId = siloOptions.Value.ClusterId;
+            clusterId = siloDetails.ClusterId;
             var multiClusterOptionsSnapshot = multiClusterOptions.Value;
             defaultMultiCluster = multiClusterOptionsSnapshot.DefaultMultiCluster?.ToList();
             random = new SafeRandom();

--- a/src/Orleans.Runtime/Silo/LegacyConfigurationWrapper.cs
+++ b/src/Orleans.Runtime/Silo/LegacyConfigurationWrapper.cs
@@ -14,11 +14,6 @@ namespace Orleans.Runtime
                 "Defaults",
                 () => this.NodeConfig = this.ClusterConfig.GetOrCreateNodeConfigurationForSilo(siloName));
 
-            if (this.NodeConfig.Generation == 0)
-            {
-                this.NodeConfig.Generation = SiloAddress.AllocateNewGeneration();
-            }
-
             this.NodeConfig.InitNodeSettingsFromGlobals(config);
             this.Type = this.NodeConfig.IsPrimaryNode ? Silo.SiloType.Primary : Silo.SiloType.Secondary;
         }

--- a/src/Orleans.Runtime/Versions/GrainVersionStore.cs
+++ b/src/Orleans.Runtime/Versions/GrainVersionStore.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Options;
-using Orleans.Runtime.Configuration;
 using Orleans.Storage;
 using Orleans.Versions;
 using Orleans.Versions.Compatibility;
@@ -21,10 +16,10 @@ namespace Orleans.Runtime.Versions
 
         public bool IsEnabled { get; private set; }
 
-        public GrainVersionStore(IInternalGrainFactory grainFactory, IOptions<SiloOptions> siloOptions)
+        public GrainVersionStore(IInternalGrainFactory grainFactory, ILocalSiloDetails siloDetails)
         {
             this.grainFactory = grainFactory;
-            this.clusterId = siloOptions.Value.ClusterId;
+            this.clusterId = siloDetails.ClusterId;
             this.IsEnabled = false;
         }
 

--- a/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -185,7 +185,6 @@ namespace UnitTests.ActivationsLifeCycleTests
         {
             var options = new TestClusterOptions(2);
             options.ClusterConfiguration.Globals.MaxForwardCount = forwardCount;
-            options.ClusterConfiguration.Defaults.Generation = 13;
             // For this test we only want to talk to the primary
             options.ClientConfiguration.Gateways.RemoveAt(1);
             Initialize(options);


### PR DESCRIPTION
- Remove incorrect usages of `NodeConfiguration`
- Replace usages of `SiloOptions` with `ILocalSiloDetails`

First commit is the important one, which removes some incorrect usages of `NodeConfiguration.Generation`.
The other commit are some opportunistic cleanup code.