### PR TITLE
Add ClusterClientOptions to configure ClusterId

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -24,11 +24,11 @@ namespace Orleans.Runtime.Membership
         private readonly ILoggerFactory loggerFactory;
         private readonly DynamoDBGatewayListProviderOptions options;
         private readonly TimeSpan maxStaleness;
-        public DynamoDBGatewayListProvider(ILoggerFactory loggerFactory, ClientConfiguration clientConfiguration, IOptions<DynamoDBGatewayListProviderOptions> options)
+        public DynamoDBGatewayListProvider(ILoggerFactory loggerFactory, ClientConfiguration clientConfiguration, IOptions<DynamoDBGatewayListProviderOptions> options, IOptions<ClusterClientOptions> clusterClientOptions)
         {
             this.loggerFactory = loggerFactory;
             this.options = options.Value;
-            this.clusterId = clientConfiguration.ClusterId;
+            this.clusterId = clusterClientOptions.Value.ClusterId;
             this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
         }
 

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
@@ -6,6 +6,7 @@ using Orleans.Runtime.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.AzureUtils.Options;
+using Orleans.Runtime;
 
 namespace Orleans.AzureUtils
 {
@@ -17,10 +18,10 @@ namespace Orleans.AzureUtils
         private readonly ILoggerFactory loggerFactory;
         private readonly TimeSpan maxStaleness;
 
-        public AzureGatewayListProvider(ILoggerFactory loggerFactory, IOptions<AzureTableGatewayListProviderOptions> options, ClientConfiguration clientConfiguration)
+        public AzureGatewayListProvider(ILoggerFactory loggerFactory, IOptions<AzureTableGatewayListProviderOptions> options, IOptions<ClusterClientOptions> clusterClientOptions, ClientConfiguration clientConfiguration)
         {
             this.loggerFactory = loggerFactory;
-            this.clusterId = clientConfiguration.ClusterId;
+            this.clusterId = clusterClientOptions.Value.ClusterId;
             this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
             this.options = options.Value;
         }

--- a/src/Azure/Orleans.Statistics.AzureStorage/Storage/ClientMetricsTableDataManager.cs
+++ b/src/Azure/Orleans.Statistics.AzureStorage/Storage/ClientMetricsTableDataManager.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.WindowsAzure.Storage.Table;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
@@ -56,7 +57,7 @@ namespace Orleans.AzureUtils
     {
         protected const string INSTANCE_TABLE_NAME = "OrleansClientMetrics";
 
-        private string deploymentId;
+        private readonly string deploymentId;
         private string clientId;
         private IPAddress address;
         private string myHostName;
@@ -66,15 +67,15 @@ namespace Orleans.AzureUtils
         private readonly ILoggerFactory loggerFactory;
         private static readonly TimeSpan initTimeout = AzureTableDefaultPolicies.TableCreationTimeout;
 
-        public ClientMetricsTableDataManager(ILoggerFactory loggerFactory)
+        public ClientMetricsTableDataManager(ILoggerFactory loggerFactory, IOptions<ClusterClientOptions> clusterClientOptions)
         {
             logger = loggerFactory.CreateLogger<ClientMetricsTableDataManager>();
             this.loggerFactory = loggerFactory;
+            this.deploymentId = clusterClientOptions.Value.ClusterId;
         }
 
         async Task IClientMetricsDataPublisher.Init(ClientConfiguration config, IPAddress address, string clientId)
         {
-            deploymentId = config.ClusterId;
             this.clientId = clientId;
             this.address = address;
             myHostName = config.DNSHostName;

--- a/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
@@ -18,10 +18,10 @@ namespace Orleans.Runtime.Membership
         private ILogger logger;
         private readonly ConsulGatewayListProviderOptions options;
         private readonly TimeSpan maxStaleness;
-        public ConsulGatewayListProvider(ILogger<ConsulGatewayListProvider> logger, ClientConfiguration clientConfig, IOptions<ConsulGatewayListProviderOptions> options)
+        public ConsulGatewayListProvider(ILogger<ConsulGatewayListProvider> logger, ClientConfiguration clientConfig, IOptions<ConsulGatewayListProviderOptions> options, IOptions<ClusterClientOptions> clusterClientOptions)
         {
             this.logger = logger;
-            this.clusterId = clientConfig.ClusterId;
+            this.clusterId = clusterClientOptions.Value.ClusterId;
             this.maxStaleness = clientConfig.GatewayListRefreshPeriod;
             this.options = options.Value;
         }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
@@ -26,11 +26,12 @@ namespace Orleans.Runtime.Membership
         private string deploymentConnectionString;
         private TimeSpan maxStaleness;
         public ZooKeeperGatewayListProvider(ILogger<ZooKeeperGatewayListProvider> logger, ClientConfiguration clientConfiguration,
-            IOptions<ZooKeeperGatewayListProviderOptions> options)
+            IOptions<ZooKeeperGatewayListProviderOptions> options,
+            IOptions<ClusterClientOptions> clusterClientOptions)
         {
             watcher = new ZooKeeperWatcher(logger);
 
-            deploymentPath = "/" + clientConfiguration.ClusterId;
+            deploymentPath = "/" + clusterClientOptions.Value.ClusterId;
             deploymentConnectionString = options.Value.ConnectionString + deploymentPath;
             maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
         }

--- a/src/Orleans.Core/Configuration/Legacy/LegacyConfigurationExtensions.cs
+++ b/src/Orleans.Core/Configuration/Legacy/LegacyConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.Messaging;
 using Orleans.Runtime.Configuration;
 using Orleans.Hosting;
+using Orleans.Runtime;
 
 namespace Orleans.Configuration
 {
@@ -20,6 +21,14 @@ namespace Orleans.Configuration
             // these will eventually be removed once our code doesn't depend on the old ClientConfiguration
             services.TryAddSingleton(configuration);
             services.TryAddFromExisting<IMessagingConfiguration, ClientConfiguration>();
+
+            services.Configure<ClusterClientOptions>(options =>
+            {
+                if (string.IsNullOrWhiteSpace(options.ClusterId) && !string.IsNullOrWhiteSpace(configuration.ClusterId))
+                {
+                    options.ClusterId = configuration.ClusterId;
+                }
+            });
 
             // Translate legacy configuration to new Options
             services.Configure<ClientMessagingOptions>(options =>

--- a/src/Orleans.Core/Configuration/Options/ClusterClientOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterClientOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Configures the Orleans cluster client.
+    /// </summary>
+    public class ClusterClientOptions
+    {
+        /// <summary>
+        /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
+        /// </summary>
+        public string ClusterId { get; set; }
+    }
+}

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -206,5 +206,7 @@ namespace Orleans
             configure(builder.GetApplicationPartManager());
             return builder;
         }
+
+        //public static IClientBuilder ConfigureClusterClient(Action<OptionsBuilder<ClusterClient>> configureOptions)
     }
 }

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -1,16 +1,13 @@
 using System;
 using System.IO;
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 using Orleans.Configuration.Options;
 using Orleans.Hosting;
 using Orleans.Runtime.Configuration;
-using Microsoft.Extensions.Configuration;
 using Orleans.ApplicationParts;
-using Orleans.CodeGeneration;
-using Orleans.Messaging;
+using Orleans.Runtime;
 
 namespace Orleans
 {
@@ -207,6 +204,36 @@ namespace Orleans
             return builder;
         }
 
-        //public static IClientBuilder ConfigureClusterClient(Action<OptionsBuilder<ClusterClient>> configureOptions)
+        /// <summary>
+        /// Configures the cluster client general options.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="configureOptions">The delegate that configures the options.</param>
+        /// <returns>The same instance of the <see cref="IClientBuilder"/> for chaining.</returns>
+        public static IClientBuilder ConfigureClusterClient(this IClientBuilder builder, Action<ClusterClientOptions> configureOptions)
+        {
+            if (configureOptions != null)
+            {
+                builder.ConfigureServices(services => services.Configure(configureOptions));
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Configures the cluster client general options.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="configureOptions">The delegate that configures the options using the options builder.</param>
+        /// <returns>The same instance of the <see cref="IClientBuilder"/> for chaining.</returns>
+        public static IClientBuilder ConfigureClusterClient(this IClientBuilder builder, Action<OptionsBuilder<ClusterClientOptions>> configureOptions)
+        {
+            if (configureOptions != null)
+            {
+                builder.ConfigureServices(services => configureOptions.Invoke(services.AddOptions<ClusterClientOptions>()));
+            }
+
+            return builder;
+        }
     }
 }

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -17,8 +17,24 @@ namespace Orleans.Hosting
         /// Configure the container to use Orleans, including the default silo name & services.
         /// </summary>
         /// <param name="builder">The host builder.</param>
+        /// <param name="configureOptions">The delegate that configures the options.</param>
         /// <returns>The host builder.</returns>
-        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder)
+        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, Action<SiloOptions> configureOptions)
+        {
+            var optionsConfigurator = configureOptions != null
+                ? ob => ob.Configure(configureOptions)
+                : default(Action<OptionsBuilder<SiloOptions>>);
+
+            return builder.ConfigureOrleans(optionsConfigurator);
+        }
+
+        /// <summary>
+        /// Configure the container to use Orleans, including the default silo name & services.
+        /// </summary>
+        /// <param name="builder">The host builder.</param>
+        /// <param name="configureOptions">The delegate that configures the options using the options builder.</param>
+        /// <returns>The host builder.</returns>
+        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, Action<OptionsBuilder<SiloOptions>> configureOptions = null)
         {
             builder.ConfigureServices((context, services) =>
             {
@@ -33,6 +49,8 @@ namespace Orleans.Hosting
 
                     context.Properties.Add("OrleansServicesAdded", true);
                 }
+
+                configureOptions?.Invoke(services.AddOptions<SiloOptions>());
             });
             return builder;
         }

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -35,12 +35,10 @@ namespace Orleans.Hosting
 
             services.Configure<SiloOptions>(options =>
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                if (string.IsNullOrWhiteSpace(options.ClusterId) && !string.IsNullOrWhiteSpace(configuration.Globals.DeploymentId))
+                if (string.IsNullOrWhiteSpace(options.ClusterId) && !string.IsNullOrWhiteSpace(configuration.Globals.ClusterId))
                 {
-                    options.ClusterId = configuration.Globals.DeploymentId;
+                    options.ClusterId = configuration.Globals.ClusterId;
                 }
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 if (options.ServiceId == Guid.Empty)
                 {

--- a/src/Orleans.Runtime/Silo/SiloOptions.cs
+++ b/src/Orleans.Runtime/Silo/SiloOptions.cs
@@ -3,7 +3,7 @@ using System;
 namespace Orleans.Runtime
 {
     /// <summary>
-    /// Silo identity configuration options.
+    /// Silo configuration options.
     /// </summary>
     public class SiloOptions
     {

--- a/src/OrleansSQLUtils/Messaging/SqlGatewayListProvider.cs
+++ b/src/OrleansSQLUtils/Messaging/SqlGatewayListProvider.cs
@@ -20,12 +20,13 @@ namespace Orleans.Runtime.Membership
         private readonly IGrainReferenceConverter grainReferenceConverter;
         private readonly TimeSpan maxStaleness;
         public SqlGatewayListProvider(ILogger<SqlGatewayListProvider> logger, IGrainReferenceConverter grainReferenceConverter, ClientConfiguration clientConfiguration,
-            IOptions<SqlGatewayListProviderOptions> options)
+            IOptions<SqlGatewayListProviderOptions> options,
+            IOptions<ClusterClientOptions> clusterClientOptions)
         {
             this.logger = logger;
             this.grainReferenceConverter = grainReferenceConverter;
             this.options = options.Value;
-            this.clusterId = clientConfiguration.ClusterId;
+            this.clusterId = clusterClientOptions.Value.ClusterId;
             this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
         }
 

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -54,7 +54,7 @@ namespace AWSUtils.Tests.MembershipTests
         {
             var options = new DynamoDBGatewayListProviderOptions();
             LegacyDynamoDBGatewayListProviderConfigurator.ParseDataConnectionString(this.connectionString, options);
-            return new DynamoDBGatewayListProvider(this.loggerFactory, this.clientConfiguration, Options.Create<DynamoDBGatewayListProviderOptions>(options));
+            return new DynamoDBGatewayListProvider(this.loggerFactory, this.clientConfiguration, Options.Create(options), this.clientOptions);
         }
 
         protected override Task<string> GetConnectionString()

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -52,7 +52,7 @@ namespace Consul.Tests
             {
                 Address = new Uri(this.connectionString)
             };
-            return new ConsulGatewayListProvider(loggerFactory.CreateLogger<ConsulGatewayListProvider>(), this.clientConfiguration, Options.Create(options));
+            return new ConsulGatewayListProvider(loggerFactory.CreateLogger<ConsulGatewayListProvider>(), this.clientConfiguration, Options.Create(options), this.clientOptions);
         }
 
         protected override async Task<string> GetConnectionString()

--- a/test/TesterAzureUtils/AzureMembershipTableTests.cs
+++ b/test/TesterAzureUtils/AzureMembershipTableTests.cs
@@ -53,7 +53,7 @@ namespace Tester.AzureUtils
             {
                 ConnectionString = this.connectionString
             };
-            return new AzureGatewayListProvider(loggerFactory, Options.Create(options), this.clientConfiguration);
+            return new AzureGatewayListProvider(loggerFactory, Options.Create(options), this.clientOptions, this.clientConfiguration);
         }
 
         protected override Task<string> GetConnectionString()

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -11,7 +11,6 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
-using UnitTests.StorageTests;
 using Xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -41,6 +40,7 @@ namespace UnitTests.MembershipTests
         protected readonly string connectionString;
         protected ILoggerFactory loggerFactory;
         protected IOptions<SiloOptions> siloOptions;
+        protected IOptions<ClusterClientOptions> clientOptions;
         protected const string testDatabaseName = "OrleansMembershipTest";//for relational storage
         protected readonly ClientConfiguration clientConfiguration;
         protected MembershipTableTestsBase(ConnectionStringFixture fixture, TestEnvironmentFixture environment, LoggerFilterOptions filters)
@@ -55,7 +55,8 @@ namespace UnitTests.MembershipTests
 
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
             this.connectionString = fixture.ConnectionString;
-            this.siloOptions = Options.Create(new SiloOptions() { ClusterId = this.clusterId });
+            this.siloOptions = Options.Create(new SiloOptions { ClusterId = this.clusterId });
+            this.clientOptions = Options.Create(new ClusterClientOptions { ClusterId = this.clusterId });
             var adoVariant = GetAdoInvariant();
 
             membershipTable = CreateMembershipTable(logger);
@@ -409,6 +410,8 @@ namespace UnitTests.MembershipTests
         }
 
         private static int generation;
+
+
         // Utility methods
         private static MembershipEntry CreateMembershipEntryForTest()
         {

--- a/test/TesterSQLUtils/MySqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/MySqlMembershipTableTests.cs
@@ -52,7 +52,7 @@ namespace UnitTests.MembershipTests
                 ConnectionString = this.connectionString,
                 AdoInvariant = GetAdoInvariant()
             };
-            return new SqlGatewayListProvider(loggerFactory.CreateLogger<SqlGatewayListProvider>(), this.GrainReferenceConverter, this.clientConfiguration, Options.Create(options));
+            return new SqlGatewayListProvider(loggerFactory.CreateLogger<SqlGatewayListProvider>(), this.GrainReferenceConverter, this.clientConfiguration, Options.Create(options), this.clientOptions);
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterSQLUtils/PostgreSqlMembershipTableTests.cs
@@ -50,7 +50,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant()
             };
             return new SqlGatewayListProvider(this.loggerFactory.CreateLogger<SqlGatewayListProvider>(), this.GrainReferenceConverter
-                ,this.clientConfiguration, Options.Create(options));
+                ,this.clientConfiguration, Options.Create(options), this.clientOptions);
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
+++ b/test/TesterSQLUtils/SqlServerMembershipTableTests.cs
@@ -50,7 +50,7 @@ namespace UnitTests.MembershipTests
                 ConnectionString = this.connectionString,
                 AdoInvariant = GetAdoInvariant()
             };
-            return new SqlGatewayListProvider(this.loggerFactory.CreateLogger<SqlGatewayListProvider>(), this.GrainReferenceConverter, this.clientConfiguration, Options.Create(options));
+            return new SqlGatewayListProvider(this.loggerFactory.CreateLogger<SqlGatewayListProvider>(), this.GrainReferenceConverter, this.clientConfiguration, Options.Create(options), this.clientOptions);
         }
 
         protected override string GetAdoInvariant()


### PR DESCRIPTION
* Add ClusterClientOptions to configure ClusterId
* Add extension methods to configure general options
   Enables clientBuilder.ConfigureClusterClient(...) and hostBuilder.ConfigureOrleans(...)
