### PR TITLE
Add transaction exceptions for distributed TM

### DIFF
--- a/src/Orleans.Core/Transactions/OrleansTransactionException.cs
+++ b/src/Orleans.Core/Transactions/OrleansTransactionException.cs
@@ -70,6 +70,16 @@ namespace Orleans.Transactions
             this.TransactionId = transactionId;
         }
 
+        public OrleansTransactionInDoubtException(string transactionId, Exception exc) : base(string.Format("Transaction {0} is InDoubt", transactionId), exc)
+        {
+            this.TransactionId = transactionId;
+        }
+
+        public OrleansTransactionInDoubtException(string transactionId, string msg) : base(string.Format("Transaction {0} is InDoubt: {1}", transactionId, msg))
+        {
+            this.TransactionId = transactionId;
+        }
+
         public OrleansTransactionInDoubtException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -103,6 +113,12 @@ namespace Orleans.Transactions
         }
 
         public OrleansTransactionAbortedException(string transactionId, string msg) : base(msg) 
+        {
+            this.TransactionId = transactionId;
+        }
+
+        public OrleansTransactionAbortedException(string transactionId, string msg, Exception innerException) :
+            base(string.Format("Transaction {0} Aborted: {1}", transactionId, msg), innerException)
         {
             this.TransactionId = transactionId;
         }
@@ -150,6 +166,11 @@ namespace Orleans.Transactions
             this.DependentTransactionId = dependentId;
         }
 
+        public OrleansCascadingAbortException(string transactionId)
+            : base(transactionId, string.Format("Transaction {0} aborted because a dependent transaction aborted", transactionId))
+        {
+        }
+
         public OrleansCascadingAbortException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -190,6 +211,16 @@ namespace Orleans.Transactions
     {
         public OrleansPrepareFailedException(string transactionId)
             : base(transactionId, string.Format("Transaction {0} aborted because Prepare phase did not succeed", transactionId))
+        {
+        }
+
+        public OrleansPrepareFailedException(string transactionId, string message)
+        : base(transactionId, string.Format("Transaction {0} aborted because Prepare failed: {1}", transactionId, message))
+        {
+        }
+
+        public OrleansPrepareFailedException(string transactionId, string message, Exception innerException) 
+            : base(transactionId, message, innerException)
         {
         }
 

--- a/src/Orleans.Core/Transactions/OrleansTransactionException.cs
+++ b/src/Orleans.Core/Transactions/OrleansTransactionException.cs
@@ -384,7 +384,7 @@ namespace Orleans.Transactions
     }
 
     /// <summary>
-    /// Signifies that the executing transaction has aborted because its execution lock was broken
+    /// Signifies that the executing transaction has aborted because the TM did not receive all prepared messages in time
     /// </summary>
     [Serializable]
     public class OrleansTransactionPrepareTimeoutException : OrleansTransactionAbortedException

--- a/src/Orleans.Core/Transactions/OrleansTransactionException.cs
+++ b/src/Orleans.Core/Transactions/OrleansTransactionException.cs
@@ -63,9 +63,9 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansTransactionInDoubtException : OrleansTransactionException
     {
-        public long TransactionId { get; private set; }
+        public string TransactionId { get; private set; }
 
-        public OrleansTransactionInDoubtException(long transactionId) : base(string.Format("Transaction {0} is InDoubt", transactionId))
+        public OrleansTransactionInDoubtException(string transactionId) : base(string.Format("Transaction {0} is InDoubt", transactionId))
         {
             this.TransactionId = transactionId;
         }
@@ -73,7 +73,7 @@ namespace Orleans.Transactions
         public OrleansTransactionInDoubtException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            this.TransactionId = info.GetInt64(nameof(this.TransactionId));
+            this.TransactionId = info.GetString(nameof(this.TransactionId));
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -89,20 +89,20 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansTransactionAbortedException : OrleansTransactionException
     {
-        public long TransactionId { get; private set; }
+        public string TransactionId { get; private set; }
 
-        public OrleansTransactionAbortedException(long transactionId) : base(string.Format("Transaction {0} Aborted", transactionId)) 
+        public OrleansTransactionAbortedException(string transactionId) : base(string.Format("Transaction {0} Aborted", transactionId)) 
         {
             this.TransactionId = transactionId;
         }
 
-        public OrleansTransactionAbortedException(long transactionId, Exception innerException) : 
+        public OrleansTransactionAbortedException(string transactionId, Exception innerException) : 
             base(string.Format("Transaction {0} Aborted because of an unhandled exception. See InnerException for details", transactionId), innerException)
         {
             this.TransactionId = transactionId;
         }
 
-        public OrleansTransactionAbortedException(long transactionId, string msg) : base(msg) 
+        public OrleansTransactionAbortedException(string transactionId, string msg) : base(msg) 
         {
             this.TransactionId = transactionId;
         }
@@ -110,7 +110,7 @@ namespace Orleans.Transactions
         public OrleansTransactionAbortedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            this.TransactionId = info.GetInt64(nameof(this.TransactionId));
+            this.TransactionId = info.GetString(nameof(this.TransactionId));
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -126,7 +126,7 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansValidationFailedException : OrleansTransactionAbortedException
     {
-        public OrleansValidationFailedException(long transactionId) : base(transactionId) 
+        public OrleansValidationFailedException(string transactionId) : base(transactionId) 
         { 
         }
 
@@ -142,9 +142,9 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansCascadingAbortException : OrleansTransactionAbortedException
     {
-        public long DependentTransactionId { get; private set; }
+        public string DependentTransactionId { get; private set; }
 
-        public OrleansCascadingAbortException(long transactionId, long dependentId)
+        public OrleansCascadingAbortException(string transactionId, string dependentId)
             : base(transactionId, string.Format("Transaction {0} aborted because its dependent transaction {1} aborted", transactionId, dependentId))
         {
             this.DependentTransactionId = dependentId;
@@ -153,7 +153,7 @@ namespace Orleans.Transactions
         public OrleansCascadingAbortException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            this.DependentTransactionId = info.GetInt64(nameof(this.DependentTransactionId));
+            this.DependentTransactionId = info.GetString(nameof(this.DependentTransactionId));
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -169,7 +169,7 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansOrphanCallException : OrleansTransactionAbortedException
     {
-        public OrleansOrphanCallException(long transactionId, int pendingCalls)
+        public OrleansOrphanCallException(string transactionId, int pendingCalls)
             : base(
                 transactionId,
                 $"Transaction {transactionId} aborted because method did not await all its outstanding calls ({pendingCalls})")
@@ -188,7 +188,7 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansPrepareFailedException : OrleansTransactionAbortedException
     {
-        public OrleansPrepareFailedException(long transactionId)
+        public OrleansPrepareFailedException(string transactionId)
             : base(transactionId, string.Format("Transaction {0} aborted because Prepare phase did not succeed", transactionId))
         {
         }
@@ -205,7 +205,7 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansTransactionTimeoutException : OrleansTransactionAbortedException
     {
-        public OrleansTransactionTimeoutException(long transactionId)
+        public OrleansTransactionTimeoutException(string transactionId)
             : base(transactionId, string.Format("Transaction {0} aborted because it exceeded timeout period", transactionId))
         {
         }
@@ -222,7 +222,7 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansTransactionWaitDieException : OrleansTransactionAbortedException
     {
-        public OrleansTransactionWaitDieException(long transactionId)
+        public OrleansTransactionWaitDieException(string transactionId)
             : base(transactionId, string.Format("Transaction {0} aborted because of Wait-Die cycle prevention", transactionId))
         {
         }
@@ -239,7 +239,7 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansReadOnlyViolatedException : OrleansTransactionAbortedException
     {
-        public OrleansReadOnlyViolatedException(long transactionId)
+        public OrleansReadOnlyViolatedException(string transactionId)
             : base(transactionId, string.Format("Transaction {0} aborted because it attempted to write a grain", transactionId))
         {
         }
@@ -256,7 +256,7 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansTransactionVersionDeletedException : OrleansTransactionAbortedException
     {
-        public OrleansTransactionVersionDeletedException(long transactionId)
+        public OrleansTransactionVersionDeletedException(string transactionId)
             : base(
                 transactionId,
                 string.Format(
@@ -277,7 +277,7 @@ namespace Orleans.Transactions
     [Serializable]
     public class OrleansTransactionUnstableVersionException : OrleansTransactionAbortedException
     {
-        public OrleansTransactionUnstableVersionException(long transactionId)
+        public OrleansTransactionUnstableVersionException(string transactionId)
             : base(transactionId, $"Transaction {transactionId} references not yet stable data.")
         {
         }

--- a/src/Orleans.Core/Transactions/OrleansTransactionException.cs
+++ b/src/Orleans.Core/Transactions/OrleansTransactionException.cs
@@ -331,4 +331,73 @@ namespace Orleans.Transactions
         {
         }
     }
+
+    /// <summary>
+    /// Signifies that the executing transaction has aborted because its execution lock was broken
+    /// </summary>
+    [Serializable]
+    public class OrleansBrokenTransactionLockException : OrleansTransactionAbortedException
+    {
+        public OrleansBrokenTransactionLockException(string transactionId, string situation)
+            : base(transactionId, $"Transaction {transactionId} aborted because a broken lock was detected, {situation}")
+        {
+        }
+
+        public OrleansBrokenTransactionLockException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Signifies that the executing transaction has aborted because it could not acquire some lock in time
+    /// </summary>
+    [Serializable]
+    public class OrleansTransactionLockAcquireTimeoutException : OrleansTransactionAbortedException
+    {
+        public OrleansTransactionLockAcquireTimeoutException(string transactionId)
+            : base(transactionId, $"Transaction {transactionId} Aborted because some lock could not be acquired within the transaction timeout limit")
+        {
+        }
+
+        public OrleansTransactionLockAcquireTimeoutException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Signifies that the executing transaction has aborted because it could not upgrade some lock
+    /// </summary>
+    [Serializable]
+    public class OrleansTransactionLockUpgradeException : OrleansTransactionAbortedException
+    {
+        public OrleansTransactionLockUpgradeException(string transactionId) :
+            base(transactionId, $"Transaction {transactionId} Aborted because it could not upgrade a lock, because of a higher-priority conflicting transaction")
+        {
+        }
+
+        public OrleansTransactionLockUpgradeException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Signifies that the executing transaction has aborted because its execution lock was broken
+    /// </summary>
+    [Serializable]
+    public class OrleansTransactionPrepareTimeoutException : OrleansTransactionAbortedException
+    {
+        public OrleansTransactionPrepareTimeoutException(string transactionId)
+            : base(transactionId, $"Transaction {transactionId} Aborted because the prepare phase did not complete within the timeout limit")
+        {
+        }
+
+        public OrleansTransactionPrepareTimeoutException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
 }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -388,7 +388,7 @@ namespace Orleans.Runtime
                         if (startNewTransaction)
                         {
                             var abortException = (exc1 as OrleansTransactionAbortedException) ?? 
-                                new OrleansTransactionAbortedException(transactionInfo.TransactionId, exc1);
+                                new OrleansTransactionAbortedException(transactionInfo.TransactionId.ToString(), exc1);
                             this.transactionAgent.Value.Abort(transactionInfo, abortException);
                             exc1 = abortException;
                         }
@@ -421,7 +421,7 @@ namespace Orleans.Runtime
                 transactionInfo = TransactionContext.GetTransactionInfo();
                 if (transactionInfo != null && ! transactionInfo.ReconcilePending(out var numberOrphans))
                 {
-                    var abortException = new OrleansOrphanCallException(transactionInfo.TransactionId, numberOrphans);
+                    var abortException = new OrleansOrphanCallException(transactionInfo.TransactionId.ToString(), numberOrphans);
                     // Can't exit before the transaction completes.
                     TransactionContext.GetTransactionInfo().IsAborted = true;
                     if (startNewTransaction)
@@ -465,7 +465,7 @@ namespace Orleans.Runtime
                         // Must abort the transaction on exceptions
                         TransactionContext.GetTransactionInfo().IsAborted = true;
                         var abortException = (exc2 as OrleansTransactionAbortedException) ??
-                            new OrleansTransactionAbortedException(TransactionContext.GetTransactionInfo().TransactionId, exc2);
+                            new OrleansTransactionAbortedException(TransactionContext.GetTransactionInfo().TransactionId.ToString(), exc2);
                         this.transactionAgent.Value.Abort(TransactionContext.GetTransactionInfo(), abortException);
                     }
                 }

--- a/src/Orleans.Runtime/Transactions/TransactionAgent.cs
+++ b/src/Orleans.Runtime/Transactions/TransactionAgent.cs
@@ -198,7 +198,7 @@ namespace Orleans.Transactions
             {
                 TransactionsStatisticsGroup.OnTransactionAborted();
                 abortedTransactions.TryAdd(transactionInfo.TransactionId, 0);
-                throw new OrleansPrepareFailedException(transactionInfo.TransactionId);
+                throw new OrleansPrepareFailedException(transactionInfo.TransactionId.ToString());
             }
             commitCompletions.TryAdd(transactionInfo.TransactionId, completion);
             transactionCommitQueue.Enqueue(transactionInfo);
@@ -351,7 +351,7 @@ namespace Orleans.Transactions
                             else
                             {
                                 TransactionsStatisticsGroup.OnTransactionInDoubt();
-                                completion.SetException(new OrleansTransactionInDoubtException(completedId));
+                                completion.SetException(new OrleansTransactionInDoubtException(completedId.ToString()));
                             }
                         }
                     }
@@ -377,7 +377,7 @@ namespace Orleans.Transactions
                     if (commitCompletions.TryRemove(tx.TransactionId, out completion))
                     {
                         outstandingCommits.Remove(tx.TransactionId);
-                        completion.SetException(new OrleansTransactionInDoubtException(tx.TransactionId));
+                        completion.SetException(new OrleansTransactionInDoubtException(tx.TransactionId.ToString()));
                     }
                 }
             }

--- a/src/Orleans.Runtime/Transactions/TransactionInfo.cs
+++ b/src/Orleans.Runtime/Transactions/TransactionInfo.cs
@@ -143,7 +143,7 @@ namespace Orleans.Transactions
                     && resourceWriteNumber > readVersion.WriteNumber)
                 {
                     // Context has record of more writes than we have, some writes must be lost.
-                    throw new OrleansTransactionAbortedException(TransactionId, "Lost Write");
+                    throw new OrleansTransactionAbortedException(TransactionId.ToString(), "Lost Write");
                 }
             }
             else
@@ -153,7 +153,7 @@ namespace Orleans.Transactions
                     && resourceReadVersion != readVersion)
                 {
                     // Uh-oh. Read two different versions of the grain.
-                    throw new OrleansValidationFailedException(TransactionId);
+                    throw new OrleansValidationFailedException(TransactionId.ToString());
                 }
 
                 ReadSet[transactionalResource] = readVersion;

--- a/src/Orleans.Transactions/InClusterTM/TransactionManager.cs
+++ b/src/Orleans.Transactions/InClusterTM/TransactionManager.cs
@@ -169,7 +169,7 @@ namespace Orleans.Transactions
                 {
                     foreach (var waiting in tx.WaitingTransactions)
                     {
-                        var cascading = new OrleansCascadingAbortException(waiting.Info.TransactionId, tx.TransactionId);
+                        var cascading = new OrleansCascadingAbortException(waiting.Info.TransactionId.ToString(), tx.TransactionId.ToString());
                         AbortTransaction(waiting.Info.TransactionId, cascading);
                     }
 
@@ -241,7 +241,7 @@ namespace Orleans.Transactions
 
                         if (abort)
                         {
-                            AbortTransaction(transactionInfo.TransactionId, new OrleansCascadingAbortException(transactionInfo.TransactionId, cascadingDependentId));
+                            AbortTransaction(transactionInfo.TransactionId, new OrleansCascadingAbortException(transactionInfo.TransactionId.ToString(), cascadingDependentId.ToString()));
                         }
                         else if (pending)
                         {
@@ -264,7 +264,7 @@ namespace Orleans.Transactions
             else
             {
                 // Don't have a record of the transaction any more so presumably it's aborted.
-                throw new OrleansTransactionAbortedException(transactionInfo.TransactionId, "Transaction presumed to be aborted");
+                throw new OrleansTransactionAbortedException(transactionInfo.TransactionId.ToString(), "Transaction presumed to be aborted");
             }
         }
 
@@ -644,7 +644,7 @@ namespace Orleans.Transactions
                 if (txRecord.Value.State == TransactionState.Started &&
                     txRecord.Value.ExpirationTime < now)
                 {
-                    AbortTransaction(txRecord.Key, new OrleansTransactionTimeoutException(txRecord.Key));
+                    AbortTransaction(txRecord.Key, new OrleansTransactionTimeoutException(txRecord.Key.ToString()));
                 }
             }
 

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -79,7 +79,7 @@ namespace Orleans.Transactions
             if (info.IsReadOnly)
             {
                 // For obvious reasons...
-                throw new OrleansReadOnlyViolatedException(info.TransactionId);
+                throw new OrleansReadOnlyViolatedException(info.TransactionId.ToString());
             }
 
             Rollback();
@@ -93,7 +93,7 @@ namespace Orleans.Transactions
             if (this.version.TransactionId > info.TransactionId || this.highestReadTransactionId >= info.TransactionId)
             {
                 // Prevent cycles. Wait-die
-                throw new OrleansTransactionWaitDieException(info.TransactionId);
+                throw new OrleansTransactionWaitDieException(info.TransactionId.ToString());
             }
 
             TransactionalResourceVersion nextVersion = TransactionalResourceVersion.Create(info.TransactionId,
@@ -359,12 +359,12 @@ namespace Orleans.Transactions
             if (!TryGetVersion(info.TransactionId, out TState readState, out TransactionalResourceVersion readVersion))
             {
                 // This can only happen if old versions are gone due to checkpointing.
-                throw new OrleansTransactionVersionDeletedException(info.TransactionId);
+                throw new OrleansTransactionVersionDeletedException(info.TransactionId.ToString());
             }
 
             if (info.IsReadOnly && readVersion.TransactionId > this.metadata.StableVersion.TransactionId)
             {
-                throw new OrleansTransactionUnstableVersionException(info.TransactionId);
+                throw new OrleansTransactionUnstableVersionException(info.TransactionId.ToString());
             }
 
             info.RecordRead(transactionalResource, readVersion, this.metadata.StableVersion.TransactionId);

--- a/test/Orleans.Transactions.Tests/Grains/TransactionOrchestrationGrain.cs
+++ b/test/Orleans.Transactions.Tests/Grains/TransactionOrchestrationGrain.cs
@@ -98,12 +98,12 @@ namespace Orleans.Transactions.Tests
                 TransactionalResourceVersion readVersion;
                 if (!TryGetVersion(info.TransactionId, out readVersion))
                 {
-                    throw new OrleansTransactionVersionDeletedException(info.TransactionId);
+                    throw new OrleansTransactionVersionDeletedException(info.TransactionId.ToString());
                 }
 
                 if (info.IsReadOnly && readVersion.TransactionId > this.stableVersion)
                 {
-                    throw new OrleansTransactionUnstableVersionException(info.TransactionId);
+                    throw new OrleansTransactionUnstableVersionException(info.TransactionId.ToString());
                 }
 
                 info.RecordRead(transactionalResource, readVersion, this.stableVersion);
@@ -112,7 +112,7 @@ namespace Orleans.Transactions.Tests
 
                 if (this.version.TransactionId > info.TransactionId || this.writeLowerBound >= info.TransactionId)
                 {
-                    throw new OrleansTransactionWaitDieException(info.TransactionId);
+                    throw new OrleansTransactionWaitDieException(info.TransactionId.ToString());
                 }
 
                 TransactionalResourceVersion nextVersion = TransactionalResourceVersion.Create(info.TransactionId,

--- a/test/Orleans.Transactions.Tests/Runners/GoldenPathTransactionManagerTestRunner.cs
+++ b/test/Orleans.Transactions.Tests/Runners/GoldenPathTransactionManagerTestRunner.cs
@@ -105,11 +105,11 @@ namespace Orleans.Transactions.Tests
             OrleansTransactionAbortedException abort;
             Assert.True(this.transactionManager.GetTransactionStatus(id2, out abort) == TransactionStatus.InProgress);
 
-            this.transactionManager.AbortTransaction(id1, new OrleansTransactionAbortedException(id1));
+            this.transactionManager.AbortTransaction(id1, new OrleansTransactionAbortedException(id1.ToString()));
 
             var e = await Assert.ThrowsAsync<OrleansCascadingAbortException>(() => WaitForTransactionCommit(id2, this.logMaintenanceInterval + this.storageDelay));
-            Assert.True(e.TransactionId == id2);
-            Assert.True(e.DependentTransactionId == id1);
+            Assert.True(e.TransactionId == id2.ToString());
+            Assert.True(e.DependentTransactionId == id1.ToString());
         }
 
         private async Task WaitForTransactionCommit(long transactionId, TimeSpan timeout)
@@ -126,7 +126,7 @@ namespace Orleans.Transactions.Tests
                     case TransactionStatus.Aborted:
                         throw e;
                     case TransactionStatus.Unknown:
-                        throw new OrleansTransactionInDoubtException(transactionId);
+                        throw new OrleansTransactionInDoubtException(transactionId.ToString());
                     default:
                         Assert.True(result == TransactionStatus.InProgress);
                         await Task.Delay(logMaintenanceInterval);


### PR DESCRIPTION
in preparation for the distributed TM implementation, some straightforward modifications of the application-visible exceptions:

 - use string instead of long for transaction ids (since distributed TM algorithm uses Guid, not long)
 - add some constructor overloads to some exceptions, so we can specify message and inner exception
 - add several new exception that describe failures specific to the distributed TM algorithm