### PR TITLE
Make buffer size bounded when reading connection preamble

### DIFF
--- a/src/Orleans.Core/Logging/ErrorCodes.cs
+++ b/src/Orleans.Core/Logging/ErrorCodes.cs
@@ -690,6 +690,7 @@ namespace Orleans
         ClientRegistrarTimerFailed              = GatewayBase + 19,
         GatewayAcceptor_WrongClusterId          = GatewayBase + 20,
         GatewayManager_AllGatewaysDead          = GatewayBase + 21,
+        GatewayAcceptor_InvalidSize             = GatewayBase + 22,
 
         TimerBase                               = Runtime + 1400,
         TimerChangeError                        = PerfCounterTimerError, // Backward compatability

--- a/test/Tester/ClientConnectionTests/InvalidPreambleConnectionTests.cs
+++ b/test/Tester/ClientConnectionTests/InvalidPreambleConnectionTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Net.Sockets;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.ClientConnectionTests
+{
+    public class InvalidPreambleConnectionTests : TestClusterPerTest
+    {
+        [Fact, TestCategory("Functional")]
+        public void ShouldCloseConnectionWhenClientSendsInvalidPreambleSize()
+        {
+            var gwEndpoint = this.HostedCluster.Primary.NodeConfiguration.ProxyGatewayEndpoint;
+
+            using (Socket s = new Socket(gwEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+            {
+                s.Connect(gwEndpoint);
+
+                Int32 invalidSize = 99999;
+                s.Send(BitConverter.GetBytes(invalidSize));
+
+                bool socketClosed = s.Poll(100000, SelectMode.SelectRead) && s.Available == 0;
+                Assert.True(socketClosed);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently it's possible to DoS Orleans by sending bytes that cause the current connection preamble handling to allocate a large buffer. This PR sets an upper bound for the buffer size.