### PR TITLE
Clean up abstraction of ApplicationPartsManager

### DIFF
--- a/src/Orleans.Core/AssemblyLoader/TypeMetadataCache.cs
+++ b/src/Orleans.Core/AssemblyLoader/TypeMetadataCache.cs
@@ -23,7 +23,7 @@ namespace Orleans.Runtime
         /// </summary>
         private readonly Dictionary<Type, Type> grainToReferenceMapping = new Dictionary<Type, Type>();
 
-        public TypeMetadataCache(ApplicationPartManager applicationPartManager)
+        public TypeMetadataCache(IApplicationPartManager applicationPartManager)
         {
             var grainInterfaceFeature = applicationPartManager.CreateAndPopulateFeature<GrainInterfaceFeature>();
             foreach (var grain in grainInterfaceFeature.Interfaces)

--- a/src/Orleans.Core/Core/ApplicationPartValidator.cs
+++ b/src/Orleans.Core/Core/ApplicationPartValidator.cs
@@ -9,9 +9,9 @@ namespace Orleans
 {
     internal class ApplicationPartValidator : IConfigurationValidator
     {
-        private readonly ApplicationPartManager applicationPartManager;
+        private readonly IApplicationPartManager applicationPartManager;
 
-        public ApplicationPartValidator(ApplicationPartManager applicationPartManager)
+        public ApplicationPartValidator(IApplicationPartManager applicationPartManager)
         {
             this.applicationPartManager = applicationPartManager;
         }

--- a/src/Orleans.Core/Core/ClientBuilder.cs
+++ b/src/Orleans.Core/Core/ClientBuilder.cs
@@ -51,7 +51,7 @@ namespace Orleans
             ValidateSystemConfiguration(serviceProvider);
 
             // Construct and return the cluster client.
-            serviceProvider.GetService<SerializationManager>().RegisterSerializers(serviceProvider.GetService<ApplicationPartManager>());
+            serviceProvider.GetService<SerializationManager>().RegisterSerializers(serviceProvider.GetService<IApplicationPartManager>());
             serviceProvider.GetRequiredService<OutsideRuntimeClient>().ConsumeServices(serviceProvider);
             return serviceProvider.GetRequiredService<IClusterClient>();
         }

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -180,7 +180,7 @@ namespace Orleans
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The <see cref="ApplicationPartManager"/> for this builder.</returns>
-        public static ApplicationPartManager GetApplicationPartManager(this IClientBuilder builder) => ApplicationPartManagerExtensions.GetApplicationPartManager(builder.Properties);
+        public static IApplicationPartManager GetApplicationPartManager(this IClientBuilder builder) => ApplicationPartManagerExtensions.GetApplicationPartManager(builder.Properties);
         
         /// <summary>
         /// Configures the <see cref="ApplicationPartManager"/> for this builder.

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -55,7 +55,7 @@ namespace Orleans
 
             // Application parts
             var parts = builder.GetApplicationPartManager();
-            services.TryAddSingleton<ApplicationPartManager>(parts);
+            services.TryAddSingleton<IApplicationPartManager>(parts);
             parts.AddApplicationPart(new AssemblyPart(typeof(RuntimeVersion).Assembly) { IsFrameworkAssembly = true });
             parts.AddFeatureProvider(new BuiltInTypesSerializationFeaturePopulator());
             parts.AddFeatureProvider(new AssemblyAttributeFeatureProvider<GrainInterfaceFeature>());

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -170,7 +170,7 @@ namespace Orleans.Serialization
             RegisterSerializationProviders(serializatonProviderOptionsValue.SerializationProviders);
         }
 
-        public void RegisterSerializers(ApplicationPartManager applicationPartManager)
+        public void RegisterSerializers(IApplicationPartManager applicationPartManager)
         {
             var serializerFeature = applicationPartManager.CreateAndPopulateFeature<SerializerFeature>();
             this.RegisterSerializers(serializerFeature);

--- a/src/Orleans.Runtime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/GrainTypeManager.cs
@@ -37,7 +37,7 @@ namespace Orleans.Runtime
 
         public GrainTypeManager(
             ILocalSiloDetails siloDetails,
-            ApplicationPartManager applicationPartManager,
+            IApplicationPartManager applicationPartManager,
             DefaultPlacementStrategy defaultPlacementStrategy,
             SerializationManager serializationManager,
             MultiClusterRegistrationStrategyManager multiClusterRegistrationStrategyManager,

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -222,7 +222,7 @@ namespace Orleans.Hosting
 
             // Application Parts
             var applicationPartManager = context.GetApplicationPartManager();
-            services.TryAddSingleton<ApplicationPartManager>(applicationPartManager);
+            services.TryAddSingleton<IApplicationPartManager>(applicationPartManager);
             applicationPartManager.AddApplicationPart(new AssemblyPart(typeof(RuntimeVersion).Assembly) {IsFrameworkAssembly = true});
             applicationPartManager.AddApplicationPart(new AssemblyPart(typeof(Silo).Assembly) {IsFrameworkAssembly = true});
             applicationPartManager.AddFeatureProvider(new BuiltInTypesSerializationFeaturePopulator());

--- a/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilderExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilderExtensions.cs
@@ -116,7 +116,7 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <returns>The <see cref="ApplicationPartManager"/> for this instance.</returns>
-        public static ApplicationPartManager GetApplicationPartManager(this ISiloHostBuilder builder) => ApplicationPartManagerExtensions.GetApplicationPartManager(builder.Properties);
+        public static IApplicationPartManager GetApplicationPartManager(this ISiloHostBuilder builder) => ApplicationPartManagerExtensions.GetApplicationPartManager(builder.Properties);
         
         /// <summary>
         /// Configures the <see cref="ApplicationPartManager"/> using the given <see cref="Action{IApplicationPartBuilder}"/>.

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -159,7 +159,7 @@ namespace Orleans.Runtime
 
             var localEndpoint = this.siloDetails.SiloAddress.Endpoint;
 
-            services.GetService<SerializationManager>().RegisterSerializers(services.GetService<ApplicationPartManager>());
+            services.GetService<SerializationManager>().RegisterSerializers(services.GetService<IApplicationPartManager>());
 
             this.Services = services;
             this.Services.InitializeSiloUnobservedExceptionsHandler();


### PR DESCRIPTION
We were referencing application part manager directly in many places, forfeiting the advantages of the abstraction.  Only code creating the manager now references the concrete class.