### PR TITLE
Make SiloUnObservedExceptionHandler optional

### DIFF
--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -77,7 +77,6 @@ namespace Orleans.Hosting
             services.TryAddTransient(typeof(IStreamSubscriptionObserver<>), typeof(StreamSubscriptionObserverProxy<>));
 
             services.TryAddSingleton<ProviderManagerSystemTarget>();
-            services.TryAddSingleton<SiloUnobservedExceptionsHandler>();
             services.TryAddSingleton<StatisticsProviderManager>();
             services.AddFromExisting<IProviderManager, StatisticsProviderManager>();
 

--- a/src/Orleans.Runtime/Utilities/SiloUnobservedExceptionsHandler.cs
+++ b/src/Orleans.Runtime/Utilities/SiloUnobservedExceptionsHandler.cs
@@ -3,15 +3,26 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Scheduler;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Hosting;
 
 namespace Orleans.Runtime
 {
-    internal static class SiloUnobservedExceptionsHandlerServiceProviderExtensions
+    public static class SiloUnobservedExceptionsHandlerServiceProviderExtensions
     {
-        public static void InitializeSiloUnobservedExceptionsHandler(this IServiceProvider services)
+        internal static void InitializeSiloUnobservedExceptionsHandler(this IServiceProvider services)
         {
             //resolve handler from DI to initialize it
             var ignore = services.GetService<SiloUnobservedExceptionsHandler>();
+        }
+
+        /// <summary>
+        /// Configure silo with unobserved exception handler
+        /// </summary>
+        /// <param name="services"></param>
+        public static void UseSiloUnobservedExceptionsHandler(this ISiloHostBuilder siloBuilder)
+        {
+            siloBuilder.ConfigureServices(services => services.TryAddSingleton<SiloUnobservedExceptionsHandler>());
         }
     }
 


### PR DESCRIPTION
Make SiloUnObservedExceptionHandler optional, turn it off for silo by default. User can op it in by call `UseSiloUnobservedExceptionsHandler` on `ISiloHostBuilder` 

related issue #3293 