### PR TITLE
Outgoing grain call filters

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainCallFilter.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainCallFilter.cs
@@ -1,11 +1,29 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Orleans
 {
     /// <summary>
-    /// Interface for grain call filters.
+    /// Interface for incoming grain call filters.
     /// </summary>
-    public interface IGrainCallFilter
+    public interface IIncomingGrainCallFilter
+    {
+        /// <summary>
+        /// Invokes this filter.
+        /// </summary>
+        /// <param name="context">The grain call context.</param>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        Task Invoke(IGrainCallContext context);
+    }
+
+    /// <inheritdoc />
+    [Obsolete("Use " + nameof(IIncomingGrainCallFilter))]
+    public interface IGrainCallFilter : IIncomingGrainCallFilter { }
+
+    /// <summary>
+    /// Interface for outgoing grain call filters.
+    /// </summary>
+    public interface IOutgoingGrainCallFilter
     {
         /// <summary>
         /// Invokes this filter.

--- a/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
@@ -47,41 +47,112 @@ namespace Orleans.Configuration
         }
 
         /// <summary>
-        /// Adds an <see cref="IGrainCallFilter"/> to the filter pipeline.
+        /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline.
         /// </summary>
         /// <param name="services">The service collection.</param>
         /// <param name="filter">The filter.</param>
         /// <returns>The service collection.</returns>
-        public static IServiceCollection AddGrainCallFilter(this IServiceCollection services, IGrainCallFilter filter)
+        [Obsolete("Use " + nameof(AddIncomingGrainCallFilter))]
+        public static IServiceCollection AddGrainCallFilter(this IServiceCollection services, IIncomingGrainCallFilter filter)
         {
             return services.AddSingleton(filter);
         }
 
         /// <summary>
-        /// Adds an <see cref="IGrainCallFilter"/> to the filter pipeline.
+        /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline.
         /// </summary>
         /// <typeparam name="TImplementation">The filter implementation type.</typeparam>
         /// <param name="services">The service collection.</param>
         /// <returns>The service collection.</returns>
+        [Obsolete("Use " + nameof(AddIncomingGrainCallFilter))]
+
         public static IServiceCollection AddGrainCallFilter<TImplementation>(this IServiceCollection services)
-            where TImplementation : class, IGrainCallFilter
+            where TImplementation : class, IIncomingGrainCallFilter
         {
-            return services.AddSingleton<IGrainCallFilter, TImplementation>();
+            return services.AddSingleton<IIncomingGrainCallFilter, TImplementation>();
         }
 
         /// <summary>
-        /// Adds an <see cref="IGrainCallFilter"/> to the filter pipeline via a delegate.
+        /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline via a delegate.
         /// </summary>
         /// <param name="services">The service collection.</param>
         /// <param name="filter">The filter.</param>
         /// <returns>The service collection.</returns>
+        [Obsolete("Use " + nameof(AddIncomingGrainCallFilter))]
         public static IServiceCollection AddGrainCallFilter(this IServiceCollection services, GrainCallFilterDelegate filter)
         {
-            return services.AddSingleton<IGrainCallFilter>(
-                new GrainCallFilterWrapper(filter));
+            return AddIncomingGrainCallFilter(services, filter);
         }
 
-        private class GrainCallFilterWrapper : IGrainCallFilter
+        /// <summary>
+        /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddIncomingGrainCallFilter(this IServiceCollection services, IIncomingGrainCallFilter filter)
+        {
+            return services.AddSingleton(filter);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <typeparam name="TImplementation">The filter implementation type.</typeparam>
+        /// <param name="services">The service collection.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddIncomingGrainCallFilter<TImplementation>(this IServiceCollection services)
+            where TImplementation : class, IIncomingGrainCallFilter
+        {
+            return services.AddSingleton<IIncomingGrainCallFilter, TImplementation>();
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline via a delegate.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddIncomingGrainCallFilter(this IServiceCollection services, GrainCallFilterDelegate filter)
+        {
+            return services.AddSingleton<IIncomingGrainCallFilter>(new GrainCallFilterWrapper(filter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddOutgoingGrainCallFilter(this IServiceCollection services, IOutgoingGrainCallFilter filter)
+        {
+            return services.AddSingleton(filter);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <typeparam name="TImplementation">The filter implementation type.</typeparam>
+        /// <param name="services">The service collection.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddOutgoingGrainCallFilter<TImplementation>(this IServiceCollection services)
+            where TImplementation : class, IOutgoingGrainCallFilter
+        {
+            return services.AddSingleton<IOutgoingGrainCallFilter, TImplementation>();
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline via a delegate.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddOutgoingGrainCallFilter(this IServiceCollection services, GrainCallFilterDelegate filter)
+        {
+            return services.AddSingleton<IOutgoingGrainCallFilter>(new GrainCallFilterWrapper(filter));
+        }
+
+        private class GrainCallFilterWrapper : IIncomingGrainCallFilter, IOutgoingGrainCallFilter
         {
             private readonly GrainCallFilterDelegate interceptor;
 

--- a/src/Orleans.Core/Core/ClientBuilderGrainCallFilterExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderGrainCallFilterExtensions.cs
@@ -1,0 +1,44 @@
+using Orleans.Configuration;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Extensions for configuring grain call filters.
+    /// </summary>
+    public static class ClientBuilderGrainCallFilterExtensions
+    {
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The builder.</returns>
+        public static IClientBuilder AddOutgoingGrainCallFilter(this IClientBuilder builder, IOutgoingGrainCallFilter filter)
+        {
+            return builder.ConfigureServices(services => services.AddOutgoingGrainCallFilter(filter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <typeparam name="TImplementation">The filter implementation type.</typeparam>
+        /// <param name="builder">The builder.</param>
+        /// <returns>The builder.</returns>
+        public static IClientBuilder AddOutgoingGrainCallFilter<TImplementation>(this IClientBuilder builder)
+            where TImplementation : class, IOutgoingGrainCallFilter
+        {
+            return builder.ConfigureServices(services => services.AddOutgoingGrainCallFilter<TImplementation>());
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline via a delegate.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The builder.</returns>
+        public static IClientBuilder AddOutgoingGrainCallFilter(this IClientBuilder builder, GrainCallFilterDelegate filter)
+        {
+            return builder.ConfigureServices(services => services.AddOutgoingGrainCallFilter(filter));
+        }
+    }
+}

--- a/src/Orleans.Runtime.Abstractions/Hosting/Generic/SiloHostBuilderExtensions.cs
+++ b/src/Orleans.Runtime.Abstractions/Hosting/Generic/SiloHostBuilderExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime
         private ILocalGrainDirectory directory;
         private Catalog catalog;
         private Dispatcher dispatcher;
-        private List<IGrainCallFilter> grainCallFilters;
+        private List<IIncomingGrainCallFilter> grainCallFilters;
         private SerializationManager serializationManager;
 
         private readonly InterfaceToImplementationMappingCache interfaceToImplementationMapping = new InterfaceToImplementationMappingCache();
@@ -108,8 +108,8 @@ namespace Orleans.Runtime
         private ILocalGrainDirectory Directory
             => this.directory ?? (this.directory = this.ServiceProvider.GetRequiredService<ILocalGrainDirectory>());
 
-        private List<IGrainCallFilter> GrainCallFilters
-            => this.grainCallFilters ?? (this.grainCallFilters = new List<IGrainCallFilter>(this.ServiceProvider.GetServices<IGrainCallFilter>()));
+        private List<IIncomingGrainCallFilter> GrainCallFilters
+            => this.grainCallFilters ?? (this.grainCallFilters = new List<IIncomingGrainCallFilter>(this.ServiceProvider.GetServices<IIncomingGrainCallFilter>()));
 
         private Dispatcher Dispatcher => this.dispatcher ?? (this.dispatcher = this.ServiceProvider.GetRequiredService<Dispatcher>());
 

--- a/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilderGrainCallFilterExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilderGrainCallFilterExtensions.cs
@@ -1,0 +1,78 @@
+using Orleans.Configuration;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// Extensions for configuring grain call filters.
+    /// </summary>
+    public static class SiloHostBuilderGrainCallFilterExtensions
+    {
+        /// <summary>
+        /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder AddIncomingGrainCallFilter(this ISiloHostBuilder builder, IIncomingGrainCallFilter filter)
+        {
+            return builder.ConfigureServices(services => services.AddIncomingGrainCallFilter(filter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IIncomingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <typeparam name="TImplementation">The filter implementation type.</typeparam>
+        /// <param name="builder">The builder.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder AddIncomingGrainCallFilter<TImplementation>(this ISiloHostBuilder builder)
+            where TImplementation : class, IIncomingGrainCallFilter
+        {
+            return builder.ConfigureServices(services => services.AddIncomingGrainCallFilter<TImplementation>());
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline via a delegate.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder AddIncomingGrainCallFilter(this ISiloHostBuilder builder, GrainCallFilterDelegate filter)
+        {
+            return builder.ConfigureServices(services => services.AddIncomingGrainCallFilter(filter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder AddOutgoingGrainCallFilter(this ISiloHostBuilder builder, IOutgoingGrainCallFilter filter)
+        {
+            return builder.ConfigureServices(services => services.AddOutgoingGrainCallFilter(filter));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline.
+        /// </summary>
+        /// <typeparam name="TImplementation">The filter implementation type.</typeparam>
+        /// <param name="builder">The builder.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder AddOutgoingGrainCallFilter<TImplementation>(this ISiloHostBuilder builder)
+            where TImplementation : class, IOutgoingGrainCallFilter
+        {
+            return builder.ConfigureServices(services => services.AddOutgoingGrainCallFilter<TImplementation>());
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IOutgoingGrainCallFilter"/> to the filter pipeline via a delegate.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The builder.</returns>
+        public static ISiloHostBuilder AddOutgoingGrainCallFilter(this ISiloHostBuilder builder, GrainCallFilterDelegate filter)
+        {
+            return builder.ConfigureServices(services => services.AddOutgoingGrainCallFilter(filter));
+        }
+    }
+}

--- a/src/Orleans.Runtime/Orleans.Runtime.csproj
+++ b/src/Orleans.Runtime/Orleans.Runtime.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
     <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Orleans.TestingHost/Orleans.TestingHost.csproj
+++ b/src/Orleans.TestingHost/Orleans.TestingHost.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
+    <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
     <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
     <ProjectReference Include="..\OrleansProviders\OrleansProviders.csproj" />

--- a/test/TestGrainInterfaces/IMethodInterceptionGrain.cs
+++ b/test/TestGrainInterfaces/IMethodInterceptionGrain.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Orleans.CodeGeneration;
 
 namespace UnitTests.GrainInterfaces
@@ -15,6 +16,11 @@ namespace UnitTests.GrainInterfaces
         Task<string> Throw();
         Task<string> IncorrectResultType();
         Task FilterThrows();
+    }
+    
+    public interface IOutgoingMethodInterceptionGrain : IGrainWithIntegerKey
+    {
+        Task<Dictionary<string, object>> EchoViaOtherGrain(IMethodInterceptionGrain otherGrain, string message);
     }
 
     public interface IGenericMethodInterceptionGrain<in T> : IGrainWithIntegerKey, IMethodFromAnotherInterface

--- a/test/Tester/GrainCallFilterTests.cs
+++ b/test/Tester/GrainCallFilterTests.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Runtime;
@@ -26,6 +27,7 @@ namespace UnitTests.General
             {
                 builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
                 builder.AddSiloBuilderConfigurator<SiloInvokerTestSiloBuilderConfigurator>();
+                builder.AddClientBuilderConfigurator<ClientConfigurator>();
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("Default");
@@ -39,9 +41,8 @@ namespace UnitTests.General
             {
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
-                    hostBuilder.ConfigureServices((hostBuilderContext, services) =>
-                    {
-                        services.AddGrainCallFilter(context =>
+                    hostBuilder
+                        .AddIncomingGrainCallFilter(context =>
                         {
                             if (string.Equals(context.Method.Name, nameof(IGrainCallFilterTestGrain.GetRequestContext)))
                             {
@@ -50,17 +51,48 @@ namespace UnitTests.General
                             }
 
                             return context.Invoke();
-                        });
+                        })
+                        .AddIncomingGrainCallFilter<GrainCallFilterWithDependencies>()
+                        .AddOutgoingGrainCallFilter(async ctx =>
+                        {
+                            if (ctx.Method?.Name == "Echo")
+                            {
+                                // Concatenate the input to itself.
+                                var orig = (string) ctx.Arguments[0];
+                                ctx.Arguments[0] = orig + orig;
+                            }
 
-                        services.AddGrainCallFilter<GrainCallFilterWithDependencies>();
+                            await ctx.Invoke();
+                        });
+                }
+            }
+
+            private class ClientConfigurator : IClientBuilderConfigurator
+            {
+                public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+                {
+                    clientBuilder.AddOutgoingGrainCallFilter(async ctx =>
+                    {
+                        if (ctx.Method?.DeclaringType == typeof(IOutgoingMethodInterceptionGrain))
+                        {
+                            ctx.Arguments[1] = ((string) ctx.Arguments[1]).ToUpperInvariant();
+                        }
+
+                        await ctx.Invoke();
+
+                        if (ctx.Method?.DeclaringType == typeof(IOutgoingMethodInterceptionGrain))
+                        {
+                            var result = (Dictionary<string, object>) ctx.Result;
+                            result["orig"] = result["result"];
+                            result["result"] = "intercepted!";
+                        }
                     });
                 }
-
             }
         }
 
         [SuppressMessage("ReSharper", "NotAccessedField.Local")]
-        public class GrainCallFilterWithDependencies : IGrainCallFilter
+        public class GrainCallFilterWithDependencies : IIncomingGrainCallFilter
         {
             private readonly SerializationManager serializationManager;
             private readonly Silo silo;
@@ -93,12 +125,34 @@ namespace UnitTests.General
         {
             this.fixture = fixture;
         }
+        
+        /// <summary>
+        /// Ensures that grain call filters are invoked around method calls in the correct order.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        [Fact]
+        public async Task GrainCallFilter_Outgoing_Test()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<IOutgoingMethodInterceptionGrain>(random.Next());
+            var grain2 = this.fixture.GrainFactory.GetGrain<IMethodInterceptionGrain>(random.Next());
+
+            // This grain method reads the context and returns it
+            var result = await grain.EchoViaOtherGrain(grain2, "ab");
+
+            // Original arg should have been:
+            // 1. Converted to upper case on the way out of the client: ab -> AB.
+            // 2. Doubled on the way out of grain1: AB -> ABAB.
+            // 3. Reversed on the wya in to grain2: ABAB -> BABA.
+            Assert.Equal("BABA", result["orig"] as string);
+            Assert.NotNull(result["result"]);
+            Assert.Equal("intercepted!", result["result"]);
+        }
 
         /// <summary>
         /// Ensures that grain call filters are invoked around method calls in the correct order.
         /// </summary>
         [Fact]
-        public async Task GrainCallFilter_Order_Test()
+        public async Task GrainCallFilter_Incoming_Order_Test()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IGrainCallFilterTestGrain>(random.Next());
 
@@ -112,7 +166,7 @@ namespace UnitTests.General
         /// Ensures that the invocation interceptor is invoked for stream subscribers.
         /// </summary>
         [Fact]
-        public async Task GrainCallFilter_Stream_Test()
+        public async Task GrainCallFilter_Incoming_Stream_Test()
         {
             var streamProvider = this.fixture.Client.GetStreamProvider("SMSProvider");
             var id = Guid.NewGuid();
@@ -130,7 +184,7 @@ namespace UnitTests.General
         /// Tests that some invalid usages of invoker interceptors are denied.
         /// </summary>
         [Fact]
-        public async Task GrainCallFilter_InvalidOrder_Test()
+        public async Task GrainCallFilter_Incoming_InvalidOrder_Test()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IGrainCallFilterTestGrain>(0);
 
@@ -146,7 +200,7 @@ namespace UnitTests.General
         /// Tests filters on just the grain level.
         /// </summary>
         [Fact]
-        public async Task GrainCallFilter_GrainLevel_Test()
+        public async Task GrainCallFilter_Incoming_GrainLevel_Test()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IMethodInterceptionGrain>(0);
             var result = await grain.One();
@@ -166,7 +220,7 @@ namespace UnitTests.General
         /// Tests filters on generic grains.
         /// </summary>
         [Fact]
-        public async Task GrainCallFilter_GenericGrain_Test()
+        public async Task GrainCallFilter_Incoming_GenericGrain_Test()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IGenericMethodInterceptionGrain<int>>(0);
             var result = await grain.GetInputAsString(679);
@@ -181,7 +235,7 @@ namespace UnitTests.General
         /// Tests filters on grains which implement multiple of the same generic interface.
         /// </summary>
         [Fact]
-        public async Task GrainCallFilter_ConstructedGenericInheritance_Test()
+        public async Task GrainCallFilter_Incoming_ConstructedGenericInheritance_Test()
         {
             var grain = this.fixture.GrainFactory.GetGrain<ITrickyMethodInterceptionGrain>(0);
 
@@ -203,7 +257,7 @@ namespace UnitTests.General
         /// Tests that grain call filters can handle exceptions.
         /// </summary>
         [Fact]
-        public async Task GrainCallFilter_ExceptionHandling_Test()
+        public async Task GrainCallFilter_Incoming_ExceptionHandling_Test()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IMethodInterceptionGrain>(random.Next());
 
@@ -218,7 +272,7 @@ namespace UnitTests.General
         /// Tests that grain call filters can throw exceptions.
         /// </summary>
         [Fact]
-        public async Task GrainCallFilter_FilterThrows_Test()
+        public async Task GrainCallFilter_Incoming_FilterThrows_Test()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IMethodInterceptionGrain>(random.Next());
             
@@ -232,7 +286,7 @@ namespace UnitTests.General
         /// an exception is thrown on the caller.
         /// </summary>
         [Fact]
-        public async Task GrainCallFilter_SetIncorrectResultType_Test()
+        public async Task GrainCallFilter_Incoming_SetIncorrectResultType_Test()
         {
             var grain = this.fixture.GrainFactory.GetGrain<IMethodInterceptionGrain>(random.Next());
 

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\src\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\..\src\Orleans.EventSourcing\Orleans.EventSourcing.csproj" />
     <ProjectReference Include="..\..\src\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />
+    <ProjectReference Include="..\..\src\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
     <ProjectReference Include="..\TestGrains\TestGrains.csproj" />
     <ProjectReference Include="..\TestInternalGrains\TestInternalGrains.csproj" />


### PR DESCRIPTION
Fixes #3214 
Fixes #2125 

* Adds `IOutgoingGrainCallFilter` as a replacement for the current client-side interceptors (which are too low-level and less powerful than their counterpart, `IGrainCallFilter`).
* Rename `IGrainCallFilter` to `IIncomingGrainCallFilter` and add `IGrainCallFilter : IIncomingGrainCallFilter` as `[Obsolete]`
* Add methods to configure incoming/outgoing call filters to `IServiceCollection`, `IClientBuilder`, `ISiloHostBuilder`
* Mark existing `AddGrainCallFilter` methods as `[Obsolete]`, pointing to the new methods.
 
Need to perform perf test