### PR TITLE
Fix programatic subscribe bugs

### DIFF
--- a/src/Orleans.Core/Streams/Core/StreamSubscriptionManager.cs
+++ b/src/Orleans.Core/Streams/Core/StreamSubscriptionManager.cs
@@ -30,7 +30,7 @@ namespace Orleans.Streams.Core
 
         public async Task RemoveSubscription(string streamProviderName, IStreamIdentity streamId, Guid subscriptionId)
         {
-            await streamPubSub.UnregisterConsumer(GuidId.GetGuidId(subscriptionId), (StreamId)streamId, streamProviderName);
+            await streamPubSub.UnregisterConsumer(GuidId.GetGuidId(subscriptionId), StreamId.GetStreamId(streamId.Guid, streamProviderName, streamId.Namespace), streamProviderName);
         }
 
         public Task<IEnumerable<StreamSubscription>> GetSubscriptions(string streamProviderName, IStreamIdentity streamIdentity)

--- a/src/Orleans.Core/Streams/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans.Core/Streams/PubSub/ImplicitStreamPubSub.cs
@@ -97,6 +97,11 @@ namespace Orleans.Streams
             return implicitTable.IsImplicitSubscriber(GrainExtensions.GetGrainId(addressable), streamId);
         }
 
+        internal bool IsImplicitSubscribeEligibleStreamNameSpace(StreamId streamId)
+        {
+            return !string.IsNullOrEmpty(streamId.Namespace);
+        }
+
         internal bool IsImplicitSubscriber(GuidId subscriptionId, StreamId streamId)
         {
             return SubscriptionMarker.IsImplicitSubscription(subscriptionId.Guid);

--- a/src/Orleans.Core/Streams/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans.Core/Streams/PubSub/ImplicitStreamSubscriberTable.cs
@@ -66,7 +66,7 @@ namespace Orleans.Streams
         /// <exception cref="System.InvalidOperationException">Internal invariant violation.</exception>
         internal IDictionary<Guid, IStreamConsumerExtension> GetImplicitSubscribers(StreamId streamId, IInternalGrainFactory grainFactory)
         {
-            if (string.IsNullOrWhiteSpace(streamId.Namespace))
+            if (!IsImplicitSubscribeEligibleNameSpace(streamId.Namespace))
             {
                 throw new ArgumentException("The stream ID doesn't have an associated namespace.", nameof(streamId));
             }
@@ -173,9 +173,14 @@ namespace Orleans.Streams
             return SubscriptionMarker.MarkAsImplictSubscriptionId(new Guid(grainIdTypeCode, s1, s2, tail.ToArray()));
         }
 
+        internal static bool IsImplicitSubscribeEligibleNameSpace(string streamNameSpace)
+        {
+            return !string.IsNullOrWhiteSpace(streamNameSpace);
+        }
+
         private bool HasImplicitSubscription(string streamNamespace, int grainIdTypeCode)
         {
-            if (String.IsNullOrWhiteSpace(streamNamespace))
+            if (!IsImplicitSubscribeEligibleNameSpace(streamNamespace))
             {
                 return false;
             }

--- a/src/Orleans.Core/Streams/PubSub/StreamPubSubImpl.cs
+++ b/src/Orleans.Core/Streams/PubSub/StreamPubSubImpl.cs
@@ -75,14 +75,7 @@ namespace Orleans.Streams
             }
             else
             {
-                List<StreamSubscription> implicitSubs = new List<StreamSubscription>();
-                //implicit pubsub requires a non-empty nor null namespace, so if the namespace is null or empty, there won't be any 
-                // subscription for that stream in implicitPubSub. Skip it to avoid unnecessary exception thrown
-                if (implicitPubSub.IsImplicitSubscribeEligibleStreamNameSpace(streamId))
-                {
-                    implicitSubs = await implicitPubSub.GetAllSubscriptions(streamId);
-                }
-                
+                var implicitSubs = await implicitPubSub.GetAllSubscriptions(streamId);
                 var explicitSubs = await explicitPubSub.GetAllSubscriptions(streamId);
                 return implicitSubs.Concat(explicitSubs).ToList();
             }

--- a/src/Orleans.Core/Streams/PubSub/StreamPubSubImpl.cs
+++ b/src/Orleans.Core/Streams/PubSub/StreamPubSubImpl.cs
@@ -75,7 +75,14 @@ namespace Orleans.Streams
             }
             else
             {
-                var implicitSubs = await implicitPubSub.GetAllSubscriptions(streamId);
+                List<StreamSubscription> implicitSubs = new List<StreamSubscription>();
+                //implicit pubsub requires a non-empty nor null namespace, so if the namespace is null or empty, there won't be any 
+                // subscription for that stream in implicitPubSub. Skip it to avoid unnecessary exception thrown
+                if (implicitPubSub.IsImplicitSubscribeEligibleStreamNameSpace(streamId))
+                {
+                    implicitSubs = await implicitPubSub.GetAllSubscriptions(streamId);
+                }
+                
                 var explicitSubs = await explicitPubSub.GetAllSubscriptions(streamId);
                 return implicitSubs.Concat(explicitSubs).ToList();
             }

--- a/test/TestGrains/ProgrammaticSubscribe/SubscribeGrain.cs
+++ b/test/TestGrains/ProgrammaticSubscribe/SubscribeGrain.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
     {
         Task<List<StreamSubscription>> SetupStreamingSubscriptionForStream<TGrainInterface>(FullStreamIdentity streamIdentity, int grainCount)
             where TGrainInterface : IGrainWithGuidKey;
-        Task RemoveSubscription(StreamSubscription subscription);
+        Task RemoveSubscription(FullStreamIdentity streamId, Guid subscriptionId);
         Task<StreamSubscription> AddSubscription<TGrainInterface>(FullStreamIdentity streamId, Guid grainId)
             where TGrainInterface : IGrainWithGuidKey;
         Task<IEnumerable<StreamSubscription>> GetSubscriptions(FullStreamIdentity streamIdentity);
@@ -64,10 +64,10 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
             return subManager.GetSubscriptions(streamIdentity.ProviderName, streamIdentity);
         }
 
-        public async Task RemoveSubscription(StreamSubscription subscription)
+        public async Task RemoveSubscription(FullStreamIdentity streamId, Guid subscriptionId)
         {
             var subManager = this.ServiceProvider.GetService<IStreamSubscriptionManagerAdmin>().GetStreamSubscriptionManager(StreamSubscriptionManagerType.ExplicitSubscribeOnly);
-            await subManager.RemoveSubscription(subscription.StreamProviderName, subscription.StreamId, subscription.SubscriptionId);
+            await subManager.RemoveSubscription(streamId.ProviderName, streamId, subscriptionId);
         }
     }
 


### PR DESCRIPTION
Fix bugs 
- #3843 
- use `StreamSubscriptionManager.RemoveSubscription` with custom `IStreamIdentity` implementation throws casting exception
  
  