### PR TITLE
Make FileLogger, LegacyFileLogConsumer and FileTelemetryConusmer all use UTF8 encoding.

### DIFF
--- a/src/Orleans.Core/Logging/FileLogger.cs
+++ b/src/Orleans.Core/Logging/FileLogger.cs
@@ -27,7 +27,7 @@ namespace Orleans.Logging
         /// <param name="fileName"></param>
         public FileLoggingOutput(string fileName)
         {
-            logOutput = new StreamWriter(File.Open(fileName, FileMode.Append, FileAccess.Write, FileShare.Write));
+            logOutput = new StreamWriter(File.Open(fileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite), Encoding.UTF8);
             this.logFileName = fileName;
         }
 

--- a/src/Orleans.Core/Telemetry/Consumers/FileTelemetryConsumer.cs
+++ b/src/Orleans.Core/Telemetry/Consumers/FileTelemetryConsumer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace Orleans.Runtime
 {
@@ -17,9 +18,7 @@ namespace Orleans.Runtime
         public FileTelemetryConsumer(FileInfo file)
         {
             _logFileName = file.FullName;
-            var fileExists = File.Exists(_logFileName);
-            _logOutput = fileExists ? file.AppendText() : file.CreateText();
-            file.Refresh();
+            _logOutput = new StreamWriter(File.Open(_logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite), Encoding.UTF8);
         }
 
         public void TrackTrace(string message)

--- a/src/Orleans.Logging.Legacy/LegacyFileLogConsumer.cs
+++ b/src/Orleans.Logging.Legacy/LegacyFileLogConsumer.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Text;
 
 namespace Orleans.Logging.Legacy
 {
@@ -17,7 +18,8 @@ namespace Orleans.Logging.Legacy
 
         public LegacyFileLogConsumer(string fileName)
         {
-            logOutput = new StreamWriter(File.Open(fileName, FileMode.Append, FileAccess.Write, FileShare.Write));
+            this.logFileName = fileName;
+            logOutput = new StreamWriter(File.Open(fileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite), Encoding.UTF8);
         }
 
         public void Log(


### PR DESCRIPTION
- Make FileLogger, FileLogConsumer and FileTelemetryConusmer all use UTF8 encoding
- Remove read lock on log file so that file can be read when messages is writing to the file.
