### PR TITLE
Fixed Dead Link to XSD Source

### DIFF
--- a/src/Documentation/Deployment-and-Operations/Configuration-Guide/index.md
+++ b/src/Documentation/Deployment-and-Operations/Configuration-Guide/index.md
@@ -7,7 +7,7 @@ title: Orleans Configuration Guide
 
 This Configuration Guide explains the key configuration parameters and how they should be used for most typical usage scenarios.
 
-**Orleans Configuration xsd file** is located [here](https://github.com/dotnet/orleans/blob/master/src/Orleans/Configuration/OrleansConfiguration.xsd).
+**Orleans Configuration xsd file** is located [here](https://github.com/dotnet/orleans/blob/master/src/Orleans.Core/Configuration/OrleansConfiguration.xsd).
 
 Orleans can be used in a variety of configurations that fit different usage scenarios, such as local single node deployment for development and testing, cluster of servers, multi-instance Azure worker role, etc. All of the different target scenarios are achieved by specifying particular values in the Orleans configuration XML files. This guide provides instructions for the key configuration parameters that are necessary to make Orleans run in one of the target scenarios. There are also other configuration parameters that primarily help fine tune Orleans for better performance. They are documented in the XSD schema and in general are not required even for running the system in production.
 


### PR DESCRIPTION
Found the XSD source was dead linking to a 404 page.  Found the correct link and corrected it.

Any chance there is a [linting tool for docs](https://github.com/markdownlint/markdownlint) that could be run as part of the build process to ensure links still work?  (The linked tool does some other cool stuff with Markdown verification, but does not appear to check links for validity!)

Anyway, this link is fixed for now. ;-)