### PR TITLE
Move dispose method inside fixture class

### DIFF
--- a/test/ServiceBus.Tests/Streaming/EHProgrammaticSubscribeTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHProgrammaticSubscribeTests.cs
@@ -71,20 +71,20 @@ namespace ServiceBus.Tests.Streaming
                 config.Globals.RegisterStreamProvider<EventHubStreamProvider>(StreamProviderName2, BuildProviderSettings(ProviderSettings2));
                 config.Globals.RegisterStorageProvider<MemoryStorage>("PubSubStore");
             }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString, NullLoggerFactory.Instance);
+                dataManager.InitTableAsync().Wait();
+                dataManager.ClearTableAsync().Wait();
+                TestAzureTableStorageStreamFailureHandler.DeleteAll().Wait();
+            }
         }
 
         public EHProgrammaticSubscribeTest(ITestOutputHelper output, Fixture fixture)
             : base(fixture)
         {
-        }
-
-        public override void Dispose()
-        {
-            base.Dispose();
-            var dataManager = new AzureTableDataManager<TableEntity>(CheckpointerSettings.TableName, CheckpointerSettings.DataConnectionString, NullLoggerFactory.Instance);
-            dataManager.InitTableAsync().Wait();
-            dataManager.ClearTableAsync().Wait();
-            TestAzureTableStorageStreamFailureHandler.DeleteAll().Wait();
         }
     }
 }

--- a/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubcribeTestsRunner.cs
+++ b/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubcribeTestsRunner.cs
@@ -20,7 +20,7 @@ using UnitTests.Grains.ProgrammaticSubscribe;
 
 namespace Tester.StreamingTests
 {
-    public abstract class ProgrammaticSubcribeTestsRunner : IDisposable
+    public abstract class ProgrammaticSubcribeTestsRunner 
     {
         private BaseTestClusterFixture fixture;
         public const string StreamProviderName = "StreamProvider1";
@@ -296,11 +296,6 @@ namespace Tester.StreamingTests
             {
                 return numProduced == numConsumed;
             }
-        }
-
-        public virtual void Dispose()
-        {
-            this.fixture = null;
         }
     }
 

--- a/test/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
+++ b/test/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
@@ -31,14 +31,14 @@ namespace Tester.AzureUtils.Streaming
                 options.ClusterConfiguration.AddAzureQueueStreamProviderV2(StreamProviderName2);
                 return new TestCluster(options);
             }
-        }
 
-        public override void Dispose()
-        {
-            base.Dispose();
-            var clusterId = this.fixture.HostedCluster.ClusterId;
-            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProviderName, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
-            AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProviderName2, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
+            public override void Dispose()
+            {
+                base.Dispose();
+                var clusterId = this.HostedCluster.ClusterId;
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProviderName, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProviderName2, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
+            }
         }
 
         public AQProgrammaticSubscribeTest(ITestOutputHelper output, Fixture fixture)


### PR DESCRIPTION
`Dispose` method was in the wrong place. 
It should be called after all the tests finished, so it should be in its `Fixture`'s `Dispose()`, instead of in the testclass level Dispose(), which is called whenever per test finished. 