### PR TITLE
Return Cluster GrainInterfaceMap in InsideRuntimeClient

### DIFF
--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -727,13 +727,12 @@ namespace Orleans.Runtime
         {
             var stopWatch = Stopwatch.StartNew();
             typeManager.Start();
-            GrainTypeResolver = typeManager.GetTypeCodeMap();
             stopWatch.Stop();
             this.logger.Info(ErrorCode.SiloStartPerfMeasure, $"Start InsideRuntimeClient took {stopWatch.ElapsedMilliseconds} Milliseconds");
             return Task.CompletedTask;
         }
 
-        public IGrainTypeResolver GrainTypeResolver { get; private set; }
+        public IGrainTypeResolver GrainTypeResolver => typeManager.ClusterGrainInterfaceMap;
 
 
         public void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo)


### PR DESCRIPTION
Currently the `GrainTypeResolver` returned by `InsideRuntimeClient` is the local version of the `GrainInterfaceMap`. It should be the cluster version.

It seems that it is only used by `GrainReferenceRuntime` to check if the Grain call should be marked as `InvokeMethodOptions.Unordered` is  so the impact of this bug is pretty limited.