### PR TITLE
Streamline IGrainTypeResolver

### DIFF
--- a/src/Orleans.Core/Messaging/ProxiedMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ProxiedMessageCenter.cs
@@ -305,10 +305,10 @@ namespace Orleans.Messaging
             }
         }
 
-        public Task<IGrainTypeResolver> GetTypeCodeMap(IInternalGrainFactory grainFactory)
+        public Task<IGrainTypeResolver> GetGrainTypeResolver(IInternalGrainFactory grainFactory)
         {
             var silo = GetLiveGatewaySiloAddress();
-            return GetTypeManager(silo, grainFactory).GetClusterTypeCodeMap();
+            return GetTypeManager(silo, grainFactory).GetClusterGrainTypeResolver();
         }
 
         public Task<Streams.ImplicitStreamSubscriberTable> GetImplicitStreamSubscriberTable(IInternalGrainFactory grainFactory)

--- a/src/Orleans.Core/Runtime/GrainClassData.cs
+++ b/src/Orleans.Core/Runtime/GrainClassData.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Metadata for a grain class
+    /// </summary>
+    [Serializable]
+    internal sealed class GrainClassData
+    {
+        [NonSerialized]
+        private readonly Dictionary<string, string> genericClassNames;
+
+        private readonly bool isGeneric;
+
+        internal int GrainTypeCode { get; private set; }
+        internal string GrainClass { get; private set; }
+        internal bool IsGeneric { get { return isGeneric; } }
+
+        internal GrainClassData(int grainTypeCode, string grainClass, bool isGeneric)
+        {
+            GrainTypeCode = grainTypeCode;
+            GrainClass = grainClass;
+            this.isGeneric = isGeneric;
+            genericClassNames = new Dictionary<string, string>(); // TODO: initialize only for generic classes
+        }
+
+        internal string GetClassName(string typeArguments)
+        {
+            // Knowing whether the grain implementation is generic allows for non-generic grain classes 
+            // to implement one or more generic grain interfaces.
+            // For generic grain classes, the assumption that they take the same generic arguments 
+            // as the implemented generic interface(s) still holds.
+            if (!isGeneric || String.IsNullOrWhiteSpace(typeArguments))
+            {
+                return GrainClass;
+            }
+            else
+            {
+                lock (this)
+                {
+                    if (genericClassNames.ContainsKey(typeArguments))
+                        return genericClassNames[typeArguments];
+
+                    var className = String.Format("{0}[{1}]", GrainClass, typeArguments);
+                    genericClassNames.Add(typeArguments, className);
+                    return className;
+                }
+
+            }
+        }
+
+        internal long GetTypeCode(Type interfaceType)
+        {
+            var typeInfo = interfaceType.GetTypeInfo();
+            if (typeInfo.IsGenericType && this.IsGeneric)
+            {
+                string args = TypeUtils.GetGenericTypeArgs(typeInfo.GetGenericArguments(), t => true);
+                int hash = Utils.CalculateIdHash(args);
+                return (((long)(hash & 0x00FFFFFF)) << 32) + GrainTypeCode;
+            }
+            else
+            {
+                return GrainTypeCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0}:{1}", GrainClass, GrainTypeCode);
+        }
+
+        public override int GetHashCode()
+        {
+            return GrainTypeCode;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if(!(obj is GrainClassData))
+                return false;
+
+            return GrainTypeCode == ((GrainClassData) obj).GrainTypeCode;
+        }
+    }
+}

--- a/src/Orleans.Core/Runtime/GrainInterfaceData.cs
+++ b/src/Orleans.Core/Runtime/GrainInterfaceData.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Metadata for a grain interface
+    /// </summary>
+    [Serializable]
+    internal class GrainInterfaceData
+    {
+        [NonSerialized]
+        private readonly Type iface;
+        private readonly HashSet<GrainClassData> implementations;
+
+        internal Type Interface { get { return iface; } }
+        internal int InterfaceId { get; private set; }
+        internal ushort InterfaceVersion { get; private set; }
+        internal string GrainInterface { get; private set; }
+        internal GrainClassData[] Implementations { get { return implementations.ToArray(); } }
+        internal GrainClassData PrimaryImplementation { get; private set; }
+
+        internal GrainInterfaceData(int interfaceId, ushort interfaceVersion, Type iface, string grainInterface)
+        {
+            InterfaceId = interfaceId;
+            InterfaceVersion = interfaceVersion;
+            this.iface = iface;
+            GrainInterface = grainInterface;
+            implementations = new HashSet<GrainClassData>();
+        }
+
+        internal void AddImplementation(GrainClassData implementation, bool primaryImplemenation = false)
+        {
+            lock (this)
+            {
+                if (!implementations.Contains(implementation))
+                    implementations.Add(implementation);
+
+                if (primaryImplemenation)
+                    PrimaryImplementation = implementation;
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0}:{1}", GrainInterface, InterfaceId);
+        }
+    }
+}

--- a/src/Orleans.Core/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans.Core/Runtime/GrainInterfaceMap.cs
@@ -7,65 +7,12 @@ using Orleans.GrainDirectory;
 
 namespace Orleans.Runtime
 {
-    internal interface IGrainTypeResolver
-    {
-        bool TryGetGrainClassData(Type grainInterfaceType, out GrainClassData implementation, string grainClassNamePrefix);
-        bool TryGetGrainClassData(int grainInterfaceId, out GrainClassData implementation, string grainClassNamePrefix);
-        bool TryGetGrainClassData(string grainImplementationClassName, out GrainClassData implementation);
-        bool IsUnordered(int grainTypeCode);
-        string GetLoadedGrainAssemblies();
-    }
-
     /// <summary>
     /// Internal data structure that holds a grain interfaces to grain classes map.
     /// </summary>
     [Serializable]
     internal class GrainInterfaceMap : IGrainTypeResolver
     {
-        /// <summary>
-        /// Metadata for a grain interface
-        /// </summary>
-        [Serializable]
-        internal class GrainInterfaceData
-        {
-            [NonSerialized]
-            private readonly Type iface;
-            private readonly HashSet<GrainClassData> implementations;
-
-            internal Type Interface { get { return iface; } }
-            internal int InterfaceId { get; private set; }
-            internal ushort InterfaceVersion { get; private set; }
-            internal string GrainInterface { get; private set; }
-            internal GrainClassData[] Implementations { get { return implementations.ToArray(); } }
-            internal GrainClassData PrimaryImplementation { get; private set; }
-
-            internal GrainInterfaceData(int interfaceId, ushort interfaceVersion, Type iface, string grainInterface)
-            {
-                InterfaceId = interfaceId;
-                InterfaceVersion = interfaceVersion;
-                this.iface = iface;
-                GrainInterface = grainInterface;
-                implementations = new HashSet<GrainClassData>();
-            }
-
-            internal void AddImplementation(GrainClassData implementation, bool primaryImplemenation = false)
-            {
-                lock (this)
-                {
-                    if (!implementations.Contains(implementation))
-                        implementations.Add(implementation);
-
-                    if (primaryImplemenation)
-                        PrimaryImplementation = implementation;
-                }
-            }
-
-            public override string ToString()
-            {
-                return String.Format("{0}:{1}", GrainInterface, InterfaceId);
-            }
-        }
-
         private readonly Dictionary<string, GrainInterfaceData> typeToInterfaceData;
         private readonly Dictionary<int, GrainInterfaceData> table;
         private readonly HashSet<int> unordered;
@@ -418,88 +365,6 @@ namespace Orleans.Runtime
         public bool IsUnordered(int grainTypeCode)
         {
             return unordered.Contains(grainTypeCode);
-        }
-    }
-
-    /// <summary>
-    /// Metadata for a grain class
-    /// </summary>
-    [Serializable]
-    internal sealed class GrainClassData
-    {
-        [NonSerialized]
-        private readonly Dictionary<string, string> genericClassNames;
-
-        private readonly bool isGeneric;
-
-        internal int GrainTypeCode { get; private set; }
-        internal string GrainClass { get; private set; }
-        internal bool IsGeneric { get { return isGeneric; } }
-
-        internal GrainClassData(int grainTypeCode, string grainClass, bool isGeneric)
-        {
-            GrainTypeCode = grainTypeCode;
-            GrainClass = grainClass;
-            this.isGeneric = isGeneric;
-            genericClassNames = new Dictionary<string, string>(); // TODO: initialize only for generic classes
-        }
-
-        internal string GetClassName(string typeArguments)
-        {
-            // Knowing whether the grain implementation is generic allows for non-generic grain classes 
-            // to implement one or more generic grain interfaces.
-            // For generic grain classes, the assumption that they take the same generic arguments 
-            // as the implemented generic interface(s) still holds.
-            if (!isGeneric || String.IsNullOrWhiteSpace(typeArguments))
-            {
-                return GrainClass;
-            }
-            else
-            {
-                lock (this)
-                {
-                    if (genericClassNames.ContainsKey(typeArguments))
-                        return genericClassNames[typeArguments];
-
-                    var className = String.Format("{0}[{1}]", GrainClass, typeArguments);
-                    genericClassNames.Add(typeArguments, className);
-                    return className;
-                }
-
-            }
-        }
-
-        internal long GetTypeCode(Type interfaceType)
-        {
-            var typeInfo = interfaceType.GetTypeInfo();
-            if (typeInfo.IsGenericType && this.IsGeneric)
-            {
-                string args = TypeUtils.GetGenericTypeArgs(typeInfo.GetGenericArguments(), t => true);
-                int hash = Utils.CalculateIdHash(args);
-                return (((long)(hash & 0x00FFFFFF)) << 32) + GrainTypeCode;
-            }
-            else
-            {
-                return GrainTypeCode;
-            }
-        }
-
-        public override string ToString()
-        {
-            return String.Format("{0}:{1}", GrainClass, GrainTypeCode);
-        }
-
-        public override int GetHashCode()
-        {
-            return GrainTypeCode;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if(!(obj is GrainClassData))
-                return false;
-
-            return GrainTypeCode == ((GrainClassData) obj).GrainTypeCode;
         }
     }
 }

--- a/src/Orleans.Core/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans.Core/Runtime/GrainInterfaceMap.cs
@@ -11,7 +11,7 @@ namespace Orleans.Runtime
     /// Internal data structure that holds a grain interfaces to grain classes map.
     /// </summary>
     [Serializable]
-    internal class GrainInterfaceMap : IGrainTypeResolver
+    internal class GrainInterfaceMap
     {
         private readonly Dictionary<string, GrainInterfaceData> typeToInterfaceData;
         private readonly Dictionary<int, GrainInterfaceData> table;
@@ -223,43 +223,7 @@ namespace Orleans.Runtime
             }
         }
 
-        public bool TryGetGrainClassData(Type interfaceType, out GrainClassData implementation, string grainClassNamePrefix)
-        {
-            implementation = null;
-            GrainInterfaceData interfaceData;
-            var typeInfo = interfaceType.GetTypeInfo();
-
-            // First, try to find a non-generic grain implementation:
-            if (this.typeToInterfaceData.TryGetValue(GetTypeKey(interfaceType, false), out interfaceData) &&
-                TryGetGrainClassData(interfaceData, out implementation, grainClassNamePrefix))
-            {
-                return true;
-            }
-
-            // If a concrete implementation was not found and the interface is generic, 
-            // try to find a generic grain implementation:
-            if (typeInfo.IsGenericType && 
-                this.typeToInterfaceData.TryGetValue(GetTypeKey(interfaceType, true), out interfaceData) &&
-                TryGetGrainClassData(interfaceData, out implementation, grainClassNamePrefix))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public bool TryGetGrainClassData(int grainInterfaceId, out GrainClassData implementation, string grainClassNamePrefix = null)
-        {
-            implementation = null;
-            GrainInterfaceData interfaceData;
-            if (!table.TryGetValue(grainInterfaceId, out interfaceData))
-            {
-                return false;
-            }
-            return TryGetGrainClassData(interfaceData, out implementation, grainClassNamePrefix);
-        }
-
-        private string GetTypeKey(Type interfaceType, bool isGenericGrainClass)
+        internal static string GetTypeKey(Type interfaceType, bool isGenericGrainClass)
         {
             var typeInfo = interfaceType.GetTypeInfo();
             if (isGenericGrainClass && typeInfo.IsGenericType)
@@ -276,85 +240,6 @@ namespace Orleans.Runtime
             }
         }
 
-        private static bool TryGetGrainClassData(GrainInterfaceData interfaceData, out GrainClassData implementation, string grainClassNamePrefix)
-        {
-            implementation = null;
-            var implementations = interfaceData.Implementations;
-
-            if (implementations.Length == 0)
-                return false;
-
-            if (String.IsNullOrEmpty(grainClassNamePrefix))
-            {
-                if (implementations.Length == 1)
-                {
-                    implementation = implementations[0];
-                    return true;
-                }
-
-                if (interfaceData.PrimaryImplementation != null)
-                {
-                    implementation = interfaceData.PrimaryImplementation;
-                    return true;
-                }
-
-                throw new OrleansException(String.Format("Cannot resolve grain interface ID={0} to a grain class because of multiple implementations of it: {1}",
-                    interfaceData.InterfaceId, Utils.EnumerableToString(implementations, d => d.GrainClass, ",", false)));
-            }
-
-            if (implementations.Length == 1)
-            {
-                if (implementations[0].GrainClass.StartsWith(grainClassNamePrefix, StringComparison.Ordinal))
-                {
-                    implementation = implementations[0];
-                    return true;
-                }
-
-                return false;
-            }
-
-            var matches = implementations.Where(impl => impl.GrainClass.Equals(grainClassNamePrefix)).ToArray(); //exact match?
-            if (matches.Length == 0)
-                matches = implementations.Where(
-                    impl => impl.GrainClass.StartsWith(grainClassNamePrefix, StringComparison.Ordinal)).ToArray(); //prefix matches
-
-            if (matches.Length == 0)
-                return false;
-
-            if (matches.Length == 1)
-            {
-                implementation = matches[0];
-                return true;
-            }
-
-            throw new OrleansException(String.Format("Cannot resolve grain interface ID={0}, grainClassNamePrefix={1} to a grain class because of multiple implementations of it: {2}",
-                interfaceData.InterfaceId,
-                grainClassNamePrefix,
-                Utils.EnumerableToString(matches, d => d.GrainClass, ",", false)));
-        }
-
-        public bool TryGetGrainClassData(string grainImplementationClassName, out GrainClassData implementation)
-        {
-            implementation = null;
-            // have to iterate since _primaryImplementations is not serialized.
-            foreach (var interfaceData in table.Values)
-            {
-                foreach(var implClass in interfaceData.Implementations)
-                    if (implClass.GrainClass.Equals(grainImplementationClassName))
-                    {
-                        implementation = implClass;
-                        return true;
-                    }
-            }
-            return false;
-        }
-
-
-        public string GetLoadedGrainAssemblies()
-        {
-            return loadedGrainAsemblies != null ? loadedGrainAsemblies.ToStrings() : String.Empty;
-        }
-
         public void AddToUnorderedList(Type grainClass)
         {
             var grainClassTypeCode = GrainInterfaceUtils.GetGrainClassTypeCode(grainClass);
@@ -365,6 +250,16 @@ namespace Orleans.Runtime
         public bool IsUnordered(int grainTypeCode)
         {
             return unordered.Contains(grainTypeCode);
+        }
+
+        public IGrainTypeResolver GetGrainTypeResolver()
+        {
+            return new GrainTypeResolver(
+                this.typeToInterfaceData,
+                this.table,
+                this.loadedGrainAsemblies,
+                this.unordered
+                );
         }
     }
 }

--- a/src/Orleans.Core/Runtime/GrainInterfaceMap.cs
+++ b/src/Orleans.Core/Runtime/GrainInterfaceMap.cs
@@ -146,7 +146,7 @@ namespace Orleans.Runtime
 
                 var grainInterfaceData = GetOrAddGrainInterfaceData(iface, isGenericGrainClass);
 
-                var implementation = new GrainClassData(grainTypeCode, grainName, isGenericGrainClass, grainInterfaceData, placement, registrationStrategy);
+                var implementation = new GrainClassData(grainTypeCode, grainName, isGenericGrainClass, placement, registrationStrategy);
                 if (!implementationIndex.ContainsKey(grainTypeCode))
                     implementationIndex.Add(grainTypeCode, implementation);
 
@@ -403,7 +403,6 @@ namespace Orleans.Runtime
     [Serializable]
     internal sealed class GrainClassData
     {
-        private readonly GrainInterfaceMap.GrainInterfaceData interfaceData;
         [NonSerialized]
         private readonly Dictionary<string, string> genericClassNames;
 
@@ -414,16 +413,14 @@ namespace Orleans.Runtime
         internal int GrainTypeCode { get; private set; }
         internal string GrainClass { get; private set; }
         internal PlacementStrategy PlacementStrategy { get { return placementStrategy; } }
-        internal GrainInterfaceMap.GrainInterfaceData InterfaceData { get { return interfaceData; } }
         internal bool IsGeneric { get { return isGeneric; } }
         public MultiClusterRegistrationStrategy RegistrationStrategy { get { return registrationStrategy; } }
 
-        internal GrainClassData(int grainTypeCode, string grainClass, bool isGeneric, GrainInterfaceMap.GrainInterfaceData interfaceData, PlacementStrategy placement, MultiClusterRegistrationStrategy registrationStrategy)
+        internal GrainClassData(int grainTypeCode, string grainClass, bool isGeneric, PlacementStrategy placement, MultiClusterRegistrationStrategy registrationStrategy)
         {
             GrainTypeCode = grainTypeCode;
             GrainClass = grainClass;
             this.isGeneric = isGeneric;
-            this.interfaceData = interfaceData;
             genericClassNames = new Dictionary<string, string>(); // TODO: initialize only for generic classes
             placementStrategy = placement;
             this.registrationStrategy = registrationStrategy;

--- a/src/Orleans.Core/Runtime/GrainTypeResolver.cs
+++ b/src/Orleans.Core/Runtime/GrainTypeResolver.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace Orleans.Runtime
 {
@@ -9,5 +12,144 @@ namespace Orleans.Runtime
         bool TryGetGrainClassData(string grainImplementationClassName, out GrainClassData implementation);
         bool IsUnordered(int grainTypeCode);
         string GetLoadedGrainAssemblies();
+    }
+
+    internal class GrainTypeResolver : IGrainTypeResolver
+    {
+        private readonly Dictionary<string, GrainInterfaceData> typeToInterfaceData;
+        private readonly Dictionary<int, GrainInterfaceData> table;
+        private readonly HashSet<string> loadedGrainAsemblies;
+        private readonly HashSet<int> unordered;
+
+        public GrainTypeResolver(
+            Dictionary<string, GrainInterfaceData> typeToInterfaceData,
+            Dictionary<int, GrainInterfaceData> table,
+            HashSet<string> loadedGrainAsemblies,
+            HashSet<int> unordered)
+        {
+            this.typeToInterfaceData = typeToInterfaceData;
+            this.table = table;
+            this.loadedGrainAsemblies = loadedGrainAsemblies;
+            this.unordered = unordered;
+        }
+
+        public bool TryGetGrainClassData(Type interfaceType, out GrainClassData implementation, string grainClassNamePrefix)
+        {
+            implementation = null;
+            GrainInterfaceData interfaceData;
+            var typeInfo = interfaceType.GetTypeInfo();
+
+            // First, try to find a non-generic grain implementation:
+            if (this.typeToInterfaceData.TryGetValue(GrainInterfaceMap.GetTypeKey(interfaceType, false), out interfaceData) &&
+                TryGetGrainClassData(interfaceData, out implementation, grainClassNamePrefix))
+            {
+                return true;
+            }
+
+            // If a concrete implementation was not found and the interface is generic, 
+            // try to find a generic grain implementation:
+            if (typeInfo.IsGenericType &&
+                this.typeToInterfaceData.TryGetValue(GrainInterfaceMap.GetTypeKey(interfaceType, true), out interfaceData) &&
+                TryGetGrainClassData(interfaceData, out implementation, grainClassNamePrefix))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryGetGrainClassData(int grainInterfaceId, out GrainClassData implementation, string grainClassNamePrefix = null)
+        {
+            implementation = null;
+            GrainInterfaceData interfaceData;
+            if (!table.TryGetValue(grainInterfaceId, out interfaceData))
+            {
+                return false;
+            }
+            return TryGetGrainClassData(interfaceData, out implementation, grainClassNamePrefix);
+        }
+
+        public bool TryGetGrainClassData(string grainImplementationClassName, out GrainClassData implementation)
+        {
+            implementation = null;
+            // have to iterate since _primaryImplementations is not serialized.
+            foreach (var interfaceData in table.Values)
+            {
+                foreach (var implClass in interfaceData.Implementations)
+                    if (implClass.GrainClass.Equals(grainImplementationClassName))
+                    {
+                        implementation = implClass;
+                        return true;
+                    }
+            }
+            return false;
+        }
+
+        public string GetLoadedGrainAssemblies()
+        {
+            return loadedGrainAsemblies != null ? loadedGrainAsemblies.ToStrings() : String.Empty;
+        }
+
+        public bool IsUnordered(int grainTypeCode)
+        {
+            return unordered.Contains(grainTypeCode);
+        }
+
+        private static bool TryGetGrainClassData(GrainInterfaceData interfaceData, out GrainClassData implementation, string grainClassNamePrefix)
+        {
+            implementation = null;
+            var implementations = interfaceData.Implementations;
+
+            if (implementations.Length == 0)
+                return false;
+
+            if (String.IsNullOrEmpty(grainClassNamePrefix))
+            {
+                if (implementations.Length == 1)
+                {
+                    implementation = implementations[0];
+                    return true;
+                }
+
+                if (interfaceData.PrimaryImplementation != null)
+                {
+                    implementation = interfaceData.PrimaryImplementation;
+                    return true;
+                }
+
+                throw new OrleansException(String.Format("Cannot resolve grain interface ID={0} to a grain class because of multiple implementations of it: {1}",
+                    interfaceData.InterfaceId, Utils.EnumerableToString(implementations, d => d.GrainClass, ",", false)));
+            }
+
+            if (implementations.Length == 1)
+            {
+                if (implementations[0].GrainClass.StartsWith(grainClassNamePrefix, StringComparison.Ordinal))
+                {
+                    implementation = implementations[0];
+                    return true;
+                }
+
+                return false;
+            }
+
+            var matches = implementations.Where(impl => impl.GrainClass.Equals(grainClassNamePrefix)).ToArray(); //exact match?
+            if (matches.Length == 0)
+                matches = implementations.Where(
+                    impl => impl.GrainClass.StartsWith(grainClassNamePrefix, StringComparison.Ordinal)).ToArray(); //prefix matches
+
+            if (matches.Length == 0)
+                return false;
+
+            if (matches.Length == 1)
+            {
+                implementation = matches[0];
+                return true;
+            }
+
+            throw new OrleansException(String.Format("Cannot resolve grain interface ID={0}, grainClassNamePrefix={1} to a grain class because of multiple implementations of it: {2}",
+                interfaceData.InterfaceId,
+                grainClassNamePrefix,
+                Utils.EnumerableToString(matches, d => d.GrainClass, ",", false)));
+        }
     }
 }

--- a/src/Orleans.Core/Runtime/GrainTypeResolver.cs
+++ b/src/Orleans.Core/Runtime/GrainTypeResolver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -14,6 +14,7 @@ namespace Orleans.Runtime
         string GetLoadedGrainAssemblies();
     }
 
+    [Serializable]
     internal class GrainTypeResolver : IGrainTypeResolver
     {
         private readonly Dictionary<string, GrainInterfaceData> typeToInterfaceData;

--- a/src/Orleans.Core/Runtime/GrainTypeResolver.cs
+++ b/src/Orleans.Core/Runtime/GrainTypeResolver.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Orleans.Runtime
+{
+    internal interface IGrainTypeResolver
+    {
+        bool TryGetGrainClassData(Type grainInterfaceType, out GrainClassData implementation, string grainClassNamePrefix);
+        bool TryGetGrainClassData(int grainInterfaceId, out GrainClassData implementation, string grainClassNamePrefix);
+        bool TryGetGrainClassData(string grainImplementationClassName, out GrainClassData implementation);
+        bool IsUnordered(int grainTypeCode);
+        string GetLoadedGrainAssemblies();
+    }
+}

--- a/src/Orleans.Core/Runtime/ITypeManager.cs
+++ b/src/Orleans.Core/Runtime/ITypeManager.cs
@@ -12,7 +12,7 @@ namespace Orleans.Runtime
         /// Acquires grain interface map for all grain types supported across the entire cluster
         /// </summary>
         /// <returns></returns>
-        Task<IGrainTypeResolver> GetClusterTypeCodeMap();
+        Task<IGrainTypeResolver> GetClusterGrainTypeResolver();
 
         Task<Streams.ImplicitStreamSubscriberTable> GetImplicitStreamSubscriberTable(SiloAddress silo);
     }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -43,7 +43,7 @@ namespace Orleans
         internal ClientStatisticsManager ClientStatistics;
         private GrainId clientId;
         private readonly GrainId handshakeClientId;
-        private IGrainTypeResolver grainInterfaceMap;
+        private IGrainTypeResolver grainTypeResolver;
         private ThreadTrackingStatistic incomingMessagesThreadTimeTracking;
         private readonly Func<Message, bool> tryResendMessage;
         private readonly Action<Message> unregisterCallback;
@@ -232,7 +232,7 @@ namespace Orleans
                     }
                 },
                 ct).Ignore();
-            grainInterfaceMap = await transport.GetTypeCodeMap(this.InternalGrainFactory);
+            grainTypeResolver = await transport.GetGrainTypeResolver(this.InternalGrainFactory);
 
             await ClientStatistics.Start(transport, clientId)
                 .WithTimeout(initTimeout);
@@ -840,7 +840,7 @@ namespace Orleans
 
         public IGrainTypeResolver GrainTypeResolver
         {
-            get { return grainInterfaceMap; }
+            get { return grainTypeResolver; }
         }
 
         public void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo)

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -728,8 +728,7 @@ namespace Orleans.Runtime
             return Task.CompletedTask;
         }
 
-        public IGrainTypeResolver GrainTypeResolver => typeManager.ClusterGrainInterfaceMap;
-
+        public IGrainTypeResolver GrainTypeResolver => typeManager.GrainTypeResolver;
 
         public void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo)
         {

--- a/src/Orleans.Runtime/GrainTypeManager/GrainTypeManager.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/GrainTypeManager.cs
@@ -35,6 +35,8 @@ namespace Orleans.Runtime
 
         public GrainInterfaceMap ClusterGrainInterfaceMap { get; private set; }
 
+        public IGrainTypeResolver GrainTypeResolver { get; private set; }
+
         public GrainTypeManager(
             ILocalSiloDetails siloDetails,
             IApplicationPartManager applicationPartManager,
@@ -51,6 +53,7 @@ namespace Orleans.Runtime
             this.multiClusterRegistrationStrategyManager = multiClusterRegistrationStrategyManager;
             grainInterfaceMap = new GrainInterfaceMap(localTestMode, this.defaultPlacementStrategy);
             ClusterGrainInterfaceMap = grainInterfaceMap;
+            GrainTypeResolver = grainInterfaceMap.GetGrainTypeResolver();
             grainInterfaceMapsBySilo = new Dictionary<SiloAddress, GrainInterfaceMap>();
 
             var grainClassFeature = applicationPartManager.CreateAndPopulateFeature<GrainClassFeature>();
@@ -306,6 +309,7 @@ namespace Orleans.Runtime
                 silos.Sort(); 
             }
             ClusterGrainInterfaceMap = newClusterGrainInterfaceMap;
+            GrainTypeResolver = ClusterGrainInterfaceMap.GetGrainTypeResolver();
             supportedSilosByTypeCode = newSupportedSilosByTypeCode;
             supportedSilosByInterface = newSupportedSilosByInterface;
         }

--- a/src/Orleans.Runtime/GrainTypeManager/TypeManager.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/TypeManager.cs
@@ -75,7 +75,7 @@ namespace Orleans.Runtime
                 this.refreshClusterMapInterval);
         }
 
-        public Task<IGrainTypeResolver> GetClusterTypeCodeMap()
+        public Task<IGrainTypeResolver> GetClusterGrainTypeResolver()
         {
             return Task.FromResult<IGrainTypeResolver>(grainTypeManager.GrainTypeResolver);
         }

--- a/src/Orleans.Runtime/GrainTypeManager/TypeManager.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/TypeManager.cs
@@ -77,7 +77,7 @@ namespace Orleans.Runtime
 
         public Task<IGrainTypeResolver> GetClusterTypeCodeMap()
         {
-            return Task.FromResult<IGrainTypeResolver>(grainTypeManager.ClusterGrainInterfaceMap);
+            return Task.FromResult<IGrainTypeResolver>(grainTypeManager.GrainTypeResolver);
         }
 
         public Task<GrainInterfaceMap> GetSiloTypeCodeMap()


### PR DESCRIPTION
Related issue: #3138 

I extracted the `IGrainTypeResolver` logic to another class, that will be used by the client and for grain to grain calls.

`GrainInterfaceMap` stil has the "merge" logic along with some silos only infos (placement, registration). At some point in the future I think we could merge `GrainTypeManager` and `GrainInterfaceMap`.