### PR TITLE
Bring back PerfCounterEnvironmentStatistics 

### DIFF
--- a/src/Azure/Orleans.Statistics.AzureStorage/Storage/ClientMetricsTableDataManager.cs
+++ b/src/Azure/Orleans.Statistics.AzureStorage/Storage/ClientMetricsTableDataManager.cs
@@ -20,8 +20,8 @@ namespace Orleans.AzureUtils
         public string ClientId { get; set; }
         public string HostName { get; set; }
 
-        public double CPU { get; set; }
-        public long MemoryUsage { get; set; }
+        public double? CPU { get; set; }
+        public long? MemoryUsage { get; set; }
         public int SendQueue { get; set; }
         public int ReceiveQueue { get; set; }
         public long SentMessages { get; set; }

--- a/src/Azure/Orleans.Statistics.AzureStorage/Storage/SiloMetricsTableDataManager.cs
+++ b/src/Azure/Orleans.Statistics.AzureStorage/Storage/SiloMetricsTableDataManager.cs
@@ -18,8 +18,8 @@ namespace Orleans.AzureUtils
         public string GatewayAddress { get; set; }
         public string HostName { get; set; }
 
-        public double CPU { get; set; }
-        public long MemoryUsage { get; set; }
+        public double? CPU { get; set; }
+        public long? MemoryUsage { get; set; }
         public int Activations { get; set; }
         public int RecentlyUsedActivations { get; set; }
         public int SendQueue { get; set; }

--- a/src/Orleans.Core.Abstractions/Statistics/IAppEnvironmentStatistics.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IAppEnvironmentStatistics.cs
@@ -1,7 +1,7 @@
-﻿namespace Orleans.Statistics
+namespace Orleans.Statistics
 {
     public interface IAppEnvironmentStatistics
     {
-        long MemoryUsage { get; }
+        long? MemoryUsage { get; }
     }
 }

--- a/src/Orleans.Core.Abstractions/Statistics/IAppEnvironmentStatistics.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IAppEnvironmentStatistics.cs
@@ -1,0 +1,7 @@
+﻿namespace Orleans.Statistics
+{
+    public interface IAppEnvironmentStatistics
+    {
+        long MemoryUsage { get; }
+    }
+}

--- a/src/Orleans.Core.Abstractions/Statistics/IHostEnvironmentStatistics.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IHostEnvironmentStatistics.cs
@@ -1,11 +1,11 @@
-﻿namespace Orleans.Statistics
+namespace Orleans.Statistics
 {
     public interface IHostEnvironmentStatistics
     {
-        long TotalPhysicalMemory { get; }
+        long? TotalPhysicalMemory { get; }
 
-        float CpuUsage { get; }
+        float? CpuUsage { get; }
 
-        long AvailableMemory { get; }
+        long? AvailableMemory { get; }
     }
 }

--- a/src/Orleans.Core.Abstractions/Statistics/IHostEnvironmentStatistics.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IHostEnvironmentStatistics.cs
@@ -1,0 +1,11 @@
+﻿namespace Orleans.Statistics
+{
+    public interface IHostEnvironmentStatistics
+    {
+        long TotalPhysicalMemory { get; }
+
+        float CpuUsage { get; }
+
+        long AvailableMemory { get; }
+    }
+}

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -6,6 +6,7 @@ using Orleans.Metadata;
 using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Serialization;
+using Orleans.Statistics;
 using Orleans.Streams;
 using Orleans.Streams.Core;
 
@@ -17,6 +18,7 @@ namespace Orleans
         {
             services.TryAddSingleton<TelemetryManager>();
             services.TryAddFromExisting<ITelemetryProducer, TelemetryManager>();
+            services.TryAddSingleton<IAppEnvironmentStatistics, AppEnvironmentStatistics>();
             services.AddLogging();
             services.TryAddSingleton<ExecutorService>();
             services.TryAddSingleton<TypeMetadataCache>();

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -18,6 +18,8 @@ namespace Orleans
         {
             services.TryAddSingleton<TelemetryManager>();
             services.TryAddFromExisting<ITelemetryProducer, TelemetryManager>();
+            // if no IHostEnvironmentStatistics registered, use the dummy one
+            services.TryAddSingleton<IHostEnvironmentStatistics, DummyHostEnvironmentStatistics>();
             services.TryAddSingleton<IAppEnvironmentStatistics, AppEnvironmentStatistics>();
             services.AddLogging();
             services.TryAddSingleton<ExecutorService>();

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -18,8 +18,7 @@ namespace Orleans
         {
             services.TryAddSingleton<TelemetryManager>();
             services.TryAddFromExisting<ITelemetryProducer, TelemetryManager>();
-            // if no IHostEnvironmentStatistics registered, use the dummy one
-            services.TryAddSingleton<IHostEnvironmentStatistics, DummyHostEnvironmentStatistics>();
+            services.TryAddSingleton<IHostEnvironmentStatistics, NoOpHostEnvironmentStatistics>();
             services.TryAddSingleton<IAppEnvironmentStatistics, AppEnvironmentStatistics>();
             services.AddLogging();
             services.TryAddSingleton<ExecutorService>();

--- a/src/Orleans.Core/Shims/RuntimeStatisticsGroup.cs
+++ b/src/Orleans.Core/Shims/RuntimeStatisticsGroup.cs
@@ -4,7 +4,7 @@ using Orleans.Statistics;
 
 namespace Orleans.Runtime
 {
-    internal class DummyHostEnvironmentStatistics : IHostEnvironmentStatistics
+    internal class NoOpHostEnvironmentStatistics : IHostEnvironmentStatistics
     {
         public long? TotalPhysicalMemory => null;
 
@@ -12,9 +12,9 @@ namespace Orleans.Runtime
 
         public long? AvailableMemory => null;
 
-        public DummyHostEnvironmentStatistics(ILoggerFactory loggerFactory)
+        public NoOpHostEnvironmentStatistics(ILoggerFactory loggerFactory)
         {
-            var logger = loggerFactory.CreateLogger<DummyHostEnvironmentStatistics>();
+            var logger = loggerFactory.CreateLogger<NoOpHostEnvironmentStatistics>();
             logger.Warn(ErrorCode.PerfCounterNotRegistered,
                 "No implementation of IHostEnvironmentStatistics was found. Load shedding will not work yet");
         }

--- a/src/Orleans.Core/Shims/RuntimeStatisticsGroup.cs
+++ b/src/Orleans.Core/Shims/RuntimeStatisticsGroup.cs
@@ -1,33 +1,22 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
+using Orleans.Statistics;
 
 namespace Orleans.Runtime
 {
-    internal class RuntimeStatisticsGroup : IDisposable
+    internal class DummyHostEnvironmentStatistics : IHostEnvironmentStatistics
     {
-        private readonly ILogger logger;
         public long TotalPhysicalMemory => int.MaxValue;
-        public long AvailableMemory => TotalPhysicalMemory;
+
         public float CpuUsage => 0;
 
-        public RuntimeStatisticsGroup(ILoggerFactory loggerFactory)
-        {
-            this.logger = loggerFactory.CreateLogger<RuntimeStatisticsGroup>();
-        }
+        public long AvailableMemory => TotalPhysicalMemory;
 
-        internal void Start()
+        public DummyHostEnvironmentStatistics(ILoggerFactory loggerFactory)
         {
-
+            var logger = loggerFactory.CreateLogger<DummyHostEnvironmentStatistics>();
             logger.Warn(ErrorCode.PerfCounterNotRegistered,
-                "CPU & Memory perf counters are not available in .NET Standard. Load shedding will not work yet");
-        }
-
-        public void Stop()
-        {
-        }
-
-        public void Dispose()
-        {
+                "No implementation of IHostEnvironmentStatistics was found. Load shedding will not work yet");
         }
     }
 }

--- a/src/Orleans.Core/Shims/RuntimeStatisticsGroup.cs
+++ b/src/Orleans.Core/Shims/RuntimeStatisticsGroup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Logging;
 using Orleans.Statistics;
 
@@ -6,11 +6,11 @@ namespace Orleans.Runtime
 {
     internal class DummyHostEnvironmentStatistics : IHostEnvironmentStatistics
     {
-        public long TotalPhysicalMemory => int.MaxValue;
+        public long? TotalPhysicalMemory => null;
 
-        public float CpuUsage => 0;
+        public float? CpuUsage => null;
 
-        public long AvailableMemory => TotalPhysicalMemory;
+        public long? AvailableMemory => null;
 
         public DummyHostEnvironmentStatistics(ILoggerFactory loggerFactory)
         {

--- a/src/Orleans.Core/Shims/RuntimeStatisticsGroup.cs
+++ b/src/Orleans.Core/Shims/RuntimeStatisticsGroup.cs
@@ -6,7 +6,6 @@ namespace Orleans.Runtime
     internal class RuntimeStatisticsGroup : IDisposable
     {
         private readonly ILogger logger;
-        public long MemoryUsage => 0;
         public long TotalPhysicalMemory => int.MaxValue;
         public long AvailableMemory => TotalPhysicalMemory;
         public float CpuUsage => 0;

--- a/src/Orleans.Core/Statistics/AppEnvironmentStatistics.cs
+++ b/src/Orleans.Core/Statistics/AppEnvironmentStatistics.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 
 namespace Orleans.Statistics
 {
     internal class AppEnvironmentStatistics : IAppEnvironmentStatistics
     {
-        public long MemoryUsage => GC.GetTotalMemory(false);
+        public long? MemoryUsage => GC.GetTotalMemory(false);
     }
 }

--- a/src/Orleans.Core/Statistics/AppEnvironmentStatistics.cs
+++ b/src/Orleans.Core/Statistics/AppEnvironmentStatistics.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Orleans.Statistics
+{
+    internal class AppEnvironmentStatistics : IAppEnvironmentStatistics
+    {
+        public long MemoryUsage => GC.GetTotalMemory(false);
+    }
+}

--- a/src/Orleans.Core/Statistics/ClientStatisticsManager.cs
+++ b/src/Orleans.Core/Statistics/ClientStatisticsManager.cs
@@ -15,11 +15,11 @@ namespace Orleans.Runtime
         private readonly ClientConfiguration config;
         private readonly StatisticsOptions statisticsOptions;
         private readonly IServiceProvider serviceProvider;
+        private readonly IHostEnvironmentStatistics hostEnvironmentStatistics;
         private readonly IAppEnvironmentStatistics appEnvironmentStatistics;
         private readonly ClusterClientOptions clusterClientOptions;
         private ClientTableStatistics tableStatistics;
         private LogStatistics logStatistics;
-        private RuntimeStatisticsGroup runtimeStats;
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
 
@@ -27,6 +27,7 @@ namespace Orleans.Runtime
             ClientConfiguration config, 
             SerializationManager serializationManager, 
             IServiceProvider serviceProvider,
+            IHostEnvironmentStatistics hostEnvironmentStatistics,
             IAppEnvironmentStatistics appEnvironmentStatistics,
             ILoggerFactory loggerFactory, 
             IOptions<StatisticsOptions> statisticsOptions, 
@@ -35,9 +36,9 @@ namespace Orleans.Runtime
             this.config = config;
             this.statisticsOptions = statisticsOptions.Value;
             this.serviceProvider = serviceProvider;
+            this.hostEnvironmentStatistics = hostEnvironmentStatistics;
             this.appEnvironmentStatistics = appEnvironmentStatistics;
             this.clusterClientOptions = clusterClientOptions.Value;
-            runtimeStats = new RuntimeStatisticsGroup(loggerFactory);
             logStatistics = new LogStatistics(this.statisticsOptions.LogWriteInterval, false, serializationManager, loggerFactory);
             logger = loggerFactory.CreateLogger<ClientStatisticsManager>();
             this.loggerFactory = loggerFactory;
@@ -48,8 +49,6 @@ namespace Orleans.Runtime
 
         internal async Task Start(IMessageCenter transport, GrainId clientId)
         {
-            runtimeStats.Start();
-
             IClientMetricsDataPublisher metricsDataPublisher = this.serviceProvider.GetService<IClientMetricsDataPublisher>();
             if (metricsDataPublisher != null)
             {
@@ -59,7 +58,7 @@ namespace Orleans.Runtime
                     configurableMetricsDataPublisher.AddConfiguration(
                         this.clusterClientOptions.ClusterId, config.DNSHostName, clientId.ToString(), transport.MyAddress.Endpoint.Address);
                 }
-                tableStatistics = new ClientTableStatistics(transport, metricsDataPublisher, runtimeStats, this.appEnvironmentStatistics, this.loggerFactory)
+                tableStatistics = new ClientTableStatistics(transport, metricsDataPublisher, this.hostEnvironmentStatistics, this.appEnvironmentStatistics, this.loggerFactory)
                 {
                     MetricsTableWriteInterval = statisticsOptions.MetricsTableWriteInterval
                 };
@@ -69,7 +68,7 @@ namespace Orleans.Runtime
                 // Hook up to publish client metrics to Azure storage table
                 var publisher = AssemblyLoader.LoadAndCreateInstance<IClientMetricsDataPublisher>(Constants.ORLEANS_STATISTICS_AZURESTORAGE, logger, this.serviceProvider);
                 await publisher.Init(config, transport.MyAddress.Endpoint.Address, clientId.ToParsableString());
-                tableStatistics = new ClientTableStatistics(transport, publisher, runtimeStats, this.appEnvironmentStatistics, this.loggerFactory)
+                tableStatistics = new ClientTableStatistics(transport, publisher, this.hostEnvironmentStatistics, this.appEnvironmentStatistics, this.loggerFactory)
                 {
                     MetricsTableWriteInterval = statisticsOptions.MetricsTableWriteInterval
                 };
@@ -97,9 +96,6 @@ namespace Orleans.Runtime
 
         internal void Stop()
         {
-            runtimeStats?.Stop();
-            runtimeStats = null;
-
             if (logStatistics != null)
             {
                 logStatistics.Stop();
@@ -114,9 +110,6 @@ namespace Orleans.Runtime
 
         public void Dispose()
         {
-            if (runtimeStats != null)
-                runtimeStats.Dispose();
-            runtimeStats = null;
             if (logStatistics != null)
                 logStatistics.Dispose();
             logStatistics = null;

--- a/src/Orleans.Core/Statistics/ClientTableStatistics.cs
+++ b/src/Orleans.Core/Statistics/ClientTableStatistics.cs
@@ -1,4 +1,4 @@
-﻿#define LOG_MEMORY_PERF_COUNTERS 
+#define LOG_MEMORY_PERF_COUNTERS 
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -38,21 +38,21 @@ namespace Orleans.Runtime
 
         #region IClientPerformanceMetrics Members
 
-        public float CpuUsage
+        public float? CpuUsage
         {
             get { return hostEnvironmentStatistics.CpuUsage; }
         }
 
-        public long AvailablePhysicalMemory
+        public long? AvailablePhysicalMemory
         {
             get { return hostEnvironmentStatistics.AvailableMemory; }
         }
 
-        public long MemoryUsage
+        public long? MemoryUsage
         {
             get { return appEnvironmentStatistics.MemoryUsage; }
         }
-        public long TotalPhysicalMemory
+        public long? TotalPhysicalMemory
         {
             get { return hostEnvironmentStatistics.TotalPhysicalMemory; }
         }

--- a/src/Orleans.Core/Statistics/ClientTableStatistics.cs
+++ b/src/Orleans.Core/Statistics/ClientTableStatistics.cs
@@ -13,15 +13,15 @@ namespace Orleans.Runtime
         private TimeSpan reportFrequency;
 
         private readonly IntValueStatistic connectedGatewayCount;
-        private readonly RuntimeStatisticsGroup runtimeStats;
+        private readonly IHostEnvironmentStatistics hostEnvironmentStatistics;
         private readonly IAppEnvironmentStatistics appEnvironmentStatistics;
         private AsyncTaskSafeTimer reportTimer;
         private readonly ILogger logger;
         private readonly ILogger timerLogger;
         internal ClientTableStatistics(
             IMessageCenter mc, 
-            IClientMetricsDataPublisher metricsDataPublisher, 
-            RuntimeStatisticsGroup runtime, 
+            IClientMetricsDataPublisher metricsDataPublisher,
+            IHostEnvironmentStatistics hostEnvironmentStatistics, 
             IAppEnvironmentStatistics appEnvironmentStatistics,
             ILoggerFactory loggerFactory)
         {
@@ -30,7 +30,7 @@ namespace Orleans.Runtime
             this.logger = loggerFactory.CreateLogger<ClientTableStatistics>();
             //async timer created through current class all share this logger for perf reasons
             this.timerLogger = loggerFactory.CreateLogger<AsyncTaskSafeTimer>();
-            runtimeStats = runtime;
+            this.hostEnvironmentStatistics = hostEnvironmentStatistics;
             this.appEnvironmentStatistics = appEnvironmentStatistics;
             reportFrequency = TimeSpan.Zero;
             connectedGatewayCount = IntValueStatistic.Find(StatisticNames.CLIENT_CONNECTED_GATEWAY_COUNT);
@@ -40,12 +40,12 @@ namespace Orleans.Runtime
 
         public float CpuUsage
         {
-            get { return runtimeStats.CpuUsage; }
+            get { return hostEnvironmentStatistics.CpuUsage; }
         }
 
         public long AvailablePhysicalMemory
         {
-            get { return runtimeStats.AvailableMemory; }
+            get { return hostEnvironmentStatistics.AvailableMemory; }
         }
 
         public long MemoryUsage
@@ -54,7 +54,7 @@ namespace Orleans.Runtime
         }
         public long TotalPhysicalMemory
         {
-            get { return runtimeStats.TotalPhysicalMemory; }
+            get { return hostEnvironmentStatistics.TotalPhysicalMemory; }
         }
 
         public int SendQueueLength

--- a/src/Orleans.Core/Statistics/ClientTableStatistics.cs
+++ b/src/Orleans.Core/Statistics/ClientTableStatistics.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-
+using Orleans.Statistics;
 
 namespace Orleans.Runtime
 {
@@ -14,11 +14,16 @@ namespace Orleans.Runtime
 
         private readonly IntValueStatistic connectedGatewayCount;
         private readonly RuntimeStatisticsGroup runtimeStats;
-
+        private readonly IAppEnvironmentStatistics appEnvironmentStatistics;
         private AsyncTaskSafeTimer reportTimer;
         private readonly ILogger logger;
         private readonly ILogger timerLogger;
-        internal ClientTableStatistics(IMessageCenter mc, IClientMetricsDataPublisher metricsDataPublisher, RuntimeStatisticsGroup runtime, ILoggerFactory loggerFactory)
+        internal ClientTableStatistics(
+            IMessageCenter mc, 
+            IClientMetricsDataPublisher metricsDataPublisher, 
+            RuntimeStatisticsGroup runtime, 
+            IAppEnvironmentStatistics appEnvironmentStatistics,
+            ILoggerFactory loggerFactory)
         {
             this.mc = mc;
             this.metricsDataPublisher = metricsDataPublisher;
@@ -26,6 +31,7 @@ namespace Orleans.Runtime
             //async timer created through current class all share this logger for perf reasons
             this.timerLogger = loggerFactory.CreateLogger<AsyncTaskSafeTimer>();
             runtimeStats = runtime;
+            this.appEnvironmentStatistics = appEnvironmentStatistics;
             reportFrequency = TimeSpan.Zero;
             connectedGatewayCount = IntValueStatistic.Find(StatisticNames.CLIENT_CONNECTED_GATEWAY_COUNT);
         }
@@ -44,7 +50,7 @@ namespace Orleans.Runtime
 
         public long MemoryUsage
         {
-            get { return runtimeStats.MemoryUsage; }
+            get { return appEnvironmentStatistics.MemoryUsage; }
         }
         public long TotalPhysicalMemory
         {

--- a/src/Orleans.Core/Statistics/IPerformanceMetrics.cs
+++ b/src/Orleans.Core/Statistics/IPerformanceMetrics.cs
@@ -13,22 +13,22 @@ namespace Orleans.Runtime
         /// <summary>
         /// CPU utilization
         /// </summary>
-        float CpuUsage { get; }
+        float? CpuUsage { get; }
 
         /// <summary>
         /// Amount of memory available to processes running on the machine
         /// </summary>
-        long AvailablePhysicalMemory { get; }
+        long? AvailablePhysicalMemory { get; }
 
         /// <summary>
         /// Current memory usage
         /// </summary>
-        long MemoryUsage { get; }
+        long? MemoryUsage { get; }
 
         /// <summary>
         /// Amount of physical memory on the machine
         /// </summary>
-        long TotalPhysicalMemory { get; }
+        long? TotalPhysicalMemory { get; }
 
         /// <summary>
         /// the current size of the send queue (number of messages waiting to be sent). 
@@ -172,22 +172,22 @@ namespace Orleans.Runtime
         /// <summary>
         /// The CPU utilization.
         /// </summary>
-        public float CpuUsage { get; internal set; }
+        public float? CpuUsage { get; internal set; }
 
         /// <summary>
         /// The amount of memory available in the silo [bytes].
         /// </summary>
-        public float AvailableMemory { get; internal set; }
+        public float? AvailableMemory { get; internal set; }
 
         /// <summary>
         /// The used memory size.
         /// </summary>
-        public long MemoryUsage { get; internal set; }
+        public long? MemoryUsage { get; internal set; }
 
         /// <summary>
         /// The total physical memory available [bytes].
         /// </summary>
-        public long TotalPhysicalMemory { get; internal set; }
+        public long? TotalPhysicalMemory { get; internal set; }
 
         /// <summary>
         /// Is this silo overloaded.

--- a/src/Orleans.Runtime/Counters/SiloPerformanceMetrics.cs
+++ b/src/Orleans.Runtime/Counters/SiloPerformanceMetrics.cs
@@ -68,22 +68,22 @@ namespace Orleans.Runtime.Counters
 
         #region ISiloPerformanceMetrics Members
 
-        public float CpuUsage 
+        public float? CpuUsage 
         { 
             get { return cpuUsageLatch.HasValue ? cpuUsageLatch.Value : hostEnvironmentStatistics.CpuUsage; } 
         }
 
-        public long AvailablePhysicalMemory
+        public long? AvailablePhysicalMemory
         {
             get { return hostEnvironmentStatistics.AvailableMemory; }
         }
 
-        public long TotalPhysicalMemory
+        public long? TotalPhysicalMemory
         {
             get { return hostEnvironmentStatistics.TotalPhysicalMemory; }
         }
 
-        public long MemoryUsage 
+        public long? MemoryUsage 
         {
             get { return appEnvironmentStatistics.MemoryUsage; } 
         }

--- a/src/Orleans.Runtime/Counters/SiloPerformanceMetrics.cs
+++ b/src/Orleans.Runtime/Counters/SiloPerformanceMetrics.cs
@@ -20,20 +20,20 @@ namespace Orleans.Runtime.Counters
         private TimeSpan reportFrequency;
         private bool overloadLatched;
         private bool overloadValue;
-        private readonly RuntimeStatisticsGroup runtimeStats;
+        private readonly IHostEnvironmentStatistics hostEnvironmentStatistics;
         private readonly IAppEnvironmentStatistics appEnvironmentStatistics;
         private AsyncTaskSafeTimer tableReportTimer;
         private readonly ILogger logger;
         private float? cpuUsageLatch;
 
         internal SiloPerformanceMetrics(
-            RuntimeStatisticsGroup runtime,
+            IHostEnvironmentStatistics hostEnvironmentStatistics,
             IAppEnvironmentStatistics appEnvironmentStatistics,
             ILoggerFactory loggerFactory, 
             NodeConfiguration cfg = null)
         {
             this.loggerFactory = loggerFactory;
-            runtimeStats = runtime;
+            this.hostEnvironmentStatistics = hostEnvironmentStatistics;
             this.appEnvironmentStatistics = appEnvironmentStatistics;
             reportFrequency = TimeSpan.Zero;
             overloadLatched = false;
@@ -70,17 +70,17 @@ namespace Orleans.Runtime.Counters
 
         public float CpuUsage 
         { 
-            get { return cpuUsageLatch.HasValue ? cpuUsageLatch.Value : runtimeStats.CpuUsage; } 
+            get { return cpuUsageLatch.HasValue ? cpuUsageLatch.Value : hostEnvironmentStatistics.CpuUsage; } 
         }
 
         public long AvailablePhysicalMemory
         {
-            get { return runtimeStats.AvailableMemory; }
+            get { return hostEnvironmentStatistics.AvailableMemory; }
         }
 
         public long TotalPhysicalMemory
         {
-            get { return runtimeStats.TotalPhysicalMemory; }
+            get { return hostEnvironmentStatistics.TotalPhysicalMemory; }
         }
 
         public long MemoryUsage 

--- a/src/Orleans.Runtime/Counters/SiloPerformanceMetrics.cs
+++ b/src/Orleans.Runtime/Counters/SiloPerformanceMetrics.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.Scheduler;
+using Orleans.Statistics;
 
 namespace Orleans.Runtime.Counters
 {
@@ -20,14 +21,20 @@ namespace Orleans.Runtime.Counters
         private bool overloadLatched;
         private bool overloadValue;
         private readonly RuntimeStatisticsGroup runtimeStats;
+        private readonly IAppEnvironmentStatistics appEnvironmentStatistics;
         private AsyncTaskSafeTimer tableReportTimer;
         private readonly ILogger logger;
         private float? cpuUsageLatch;
 
-        internal SiloPerformanceMetrics(RuntimeStatisticsGroup runtime, ILoggerFactory loggerFactory, NodeConfiguration cfg = null)
+        internal SiloPerformanceMetrics(
+            RuntimeStatisticsGroup runtime,
+            IAppEnvironmentStatistics appEnvironmentStatistics,
+            ILoggerFactory loggerFactory, 
+            NodeConfiguration cfg = null)
         {
             this.loggerFactory = loggerFactory;
             runtimeStats = runtime;
+            this.appEnvironmentStatistics = appEnvironmentStatistics;
             reportFrequency = TimeSpan.Zero;
             overloadLatched = false;
             overloadValue = false;
@@ -78,7 +85,7 @@ namespace Orleans.Runtime.Counters
 
         public long MemoryUsage 
         {
-            get { return runtimeStats.MemoryUsage; } 
+            get { return appEnvironmentStatistics.MemoryUsage; } 
         }
 
         public bool IsOverloaded

--- a/src/Orleans.Runtime/Counters/SiloStatisticsManager.cs
+++ b/src/Orleans.Runtime/Counters/SiloStatisticsManager.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Orleans.Hosting;
 using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
+using Orleans.Statistics;
 
 namespace Orleans.Runtime.Counters
 {
@@ -18,7 +19,14 @@ namespace Orleans.Runtime.Counters
         private readonly ILogger logger;
         private readonly ILocalSiloDetails siloDetails;
 
-        public SiloStatisticsManager(NodeConfiguration nodeConfiguration, ILocalSiloDetails siloDetails, SerializationManager serializationManager, ITelemetryProducer telemetryProducer, ILoggerFactory loggerFactory, IOptions<MessagingOptions> messagingOptions)
+        public SiloStatisticsManager(
+            NodeConfiguration nodeConfiguration, 
+            ILocalSiloDetails siloDetails, 
+            SerializationManager serializationManager, 
+            ITelemetryProducer telemetryProducer, 
+            IAppEnvironmentStatistics appEnvironmentStatistics,
+            ILoggerFactory loggerFactory, 
+            IOptions<MessagingOptions> messagingOptions)
         {
             this.siloDetails = siloDetails;
             MessagingStatisticsGroup.Init(true);
@@ -31,7 +39,7 @@ namespace Orleans.Runtime.Counters
             this.logger = loggerFactory.CreateLogger<SiloStatisticsManager>();
             runtimeStats = new RuntimeStatisticsGroup(loggerFactory);
             this.logStatistics = new LogStatistics(nodeConfiguration.StatisticsLogWriteInterval, true, serializationManager, loggerFactory);
-            this.MetricsTable = new SiloPerformanceMetrics(this.runtimeStats, loggerFactory, nodeConfiguration);
+            this.MetricsTable = new SiloPerformanceMetrics(this.runtimeStats, appEnvironmentStatistics, loggerFactory, nodeConfiguration);
             this.countersPublisher = new CountersStatistics(nodeConfiguration.StatisticsPerfCountersWriteInterval, telemetryProducer, loggerFactory);
         }
 

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -68,8 +68,7 @@ namespace Orleans.Hosting
             services.TryAddFromExisting<ITelemetryProducer, TelemetryManager>();
 
             services.TryAddSingleton<IAppEnvironmentStatistics, AppEnvironmentStatistics>();
-            // if no IHostEnvironmentStatistics registered, use the dummy one
-            services.TryAddSingleton<IHostEnvironmentStatistics, DummyHostEnvironmentStatistics>();
+            services.TryAddSingleton<IHostEnvironmentStatistics, NoOpHostEnvironmentStatistics>();
 
             services.TryAddSingleton<ExecutorService>();
             // queue balancer contructing related

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -68,6 +68,8 @@ namespace Orleans.Hosting
             services.TryAddFromExisting<ITelemetryProducer, TelemetryManager>();
 
             services.TryAddSingleton<IAppEnvironmentStatistics, AppEnvironmentStatistics>();
+            // if no IHostEnvironmentStatistics registered, use the dummy one
+            services.TryAddSingleton<IHostEnvironmentStatistics, DummyHostEnvironmentStatistics>();
 
             services.TryAddSingleton<ExecutorService>();
             // queue balancer contructing related

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -33,6 +33,7 @@ using Orleans.ApplicationParts;
 using Orleans.Runtime.Utilities;
 using System;
 using Orleans.Metadata;
+using Orleans.Statistics;
 
 namespace Orleans.Hosting
 {
@@ -65,6 +66,8 @@ namespace Orleans.Hosting
             });
             services.TryAddSingleton<TelemetryManager>();
             services.TryAddFromExisting<ITelemetryProducer, TelemetryManager>();
+
+            services.TryAddSingleton<IAppEnvironmentStatistics, AppEnvironmentStatistics>();
 
             services.TryAddSingleton<ExecutorService>();
             // queue balancer contructing related

--- a/src/Orleans.TelemetryConsumers.Counters/Orleans.TelemetryConsumers.Counters.csproj
+++ b/src/Orleans.TelemetryConsumers.Counters/Orleans.TelemetryConsumers.Counters.csproj
@@ -24,6 +24,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Orleans.Core\Orleans.Core.csproj" />
+    <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
+    <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.TelemetryConsumers.Counters/Orleans.TelemetryConsumers.Counters.csproj
+++ b/src/Orleans.TelemetryConsumers.Counters/Orleans.TelemetryConsumers.Counters.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <Reference Include="System.Configuration.Install" />
+    <Reference Include="System.Management" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.TelemetryConsumers.Counters/Statistics/HostBuilderExtensions.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/Statistics/HostBuilderExtensions.cs
@@ -1,0 +1,23 @@
+﻿#define LOG_MEMORY_PERF_COUNTERS
+
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Hosting;
+
+namespace Orleans.Statistics
+{
+    public static class SiloHostBuilderExtensions
+    {
+        public static ISiloHostBuilder UsePerfCounterEnvironmentStatistics(this ISiloHostBuilder builder)
+        {
+            return builder.ConfigureServices(services => services.AddSingleton<IHostEnvironmentStatistics, PerfCounterEnvironmentStatistics>());
+        }
+    }
+
+    public static class ClientBuilderExtensions
+    {
+        public static IClientBuilder UsePerfCounterEnvironmentStatistics(this IClientBuilder builder)
+        {
+            return builder.ConfigureServices(services => services.AddSingleton<IHostEnvironmentStatistics, PerfCounterEnvironmentStatistics>());
+        }
+    }
+}

--- a/src/Orleans.TelemetryConsumers.Counters/Statistics/HostBuilderExtensions.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/Statistics/HostBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿#define LOG_MEMORY_PERF_COUNTERS
+#define LOG_MEMORY_PERF_COUNTERS
 
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Hosting;
@@ -7,6 +7,9 @@ namespace Orleans.Statistics
 {
     public static class SiloHostBuilderExtensions
     {
+        /// <summary>
+        /// Use Windows performance counters as source for host environment statistics
+        /// </summary>
         public static ISiloHostBuilder UsePerfCounterEnvironmentStatistics(this ISiloHostBuilder builder)
         {
             return builder.ConfigureServices(services => services.AddSingleton<IHostEnvironmentStatistics, PerfCounterEnvironmentStatistics>());
@@ -15,6 +18,9 @@ namespace Orleans.Statistics
 
     public static class ClientBuilderExtensions
     {
+        /// <summary>
+        /// Use Windows performance counters as source for host environment statistics
+        /// </summary>
         public static IClientBuilder UsePerfCounterEnvironmentStatistics(this IClientBuilder builder)
         {
             return builder.ConfigureServices(services => services.AddSingleton<IHostEnvironmentStatistics, PerfCounterEnvironmentStatistics>());

--- a/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
@@ -106,7 +106,6 @@ namespace Orleans.Statistics
                 promotedFinalizationMemoryFromGen0PF = new PerformanceCounter(".NET CLR Memory", "Promoted Finalization-Memory from Gen 0", thisProcess, true);
 #endif
 
-#if !(NETSTANDARD || __MonoCS__)
                 //.NET on Windows without mono
                 const string Query = "SELECT Capacity FROM Win32_PhysicalMemory";
                 var searcher = new ManagementObjectSearcher(Query);
@@ -118,13 +117,6 @@ namespace Orleans.Statistics
                     throw new Exception("No physical ram installed on machine?");
 
                 TotalPhysicalMemory = Capacity;
-#elif __MonoCS__
-                //Cross platform mono
-                var totalPhysicalMemory = new PerformanceCounter("Mono Memory", "Total Physical Memory");
-                TotalPhysicalMemory = Convert.ToInt64(totalPhysicalMemory.NextValue());
-#elif NETSTANDARD
-                //Cross platform CoreCLR
-#endif
                 countersAvailable = true;
             }
             catch (Exception)

--- a/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
@@ -1,4 +1,4 @@
-﻿#define LOG_MEMORY_PERF_COUNTERS
+#define LOG_MEMORY_PERF_COUNTERS
 
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
@@ -37,14 +37,14 @@ namespace Orleans.Statistics
         ///
         /// <summary>Amount of physical memory on the machine</summary>
         ///
-        public long TotalPhysicalMemory { get; private set; }
+        public long? TotalPhysicalMemory { get; private set; }
 
         ///
         /// <summary>Amount of memory available to processes running on the machine</summary>
         ///
-        public long AvailableMemory { get { return availableMemoryCounterPF != null ? Convert.ToInt64(availableMemoryCounterPF.NextValue()) : 0; } }
+        public long? AvailableMemory { get { return availableMemoryCounterPF != null ? Convert.ToInt64(availableMemoryCounterPF.NextValue()) : (long?)null; } }
 
-        public float CpuUsage { get; private set; }
+        public float? CpuUsage { get; private set; }
 
         private static string GCGenCollectionCount
         {
@@ -196,7 +196,7 @@ namespace Orleans.Statistics
                 CpuUsage = 0;
             }
 
-            FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_CPUUSAGE, () => CpuUsage);
+            FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_CPUUSAGE, () => CpuUsage.Value);
             IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_TOTALMEMORYKB, () => (long)((MemoryUsage + KB - 1.0) / KB)); // Round up
 #if LOG_MEMORY_PERF_COUNTERS    // print GC stats in the silo log file.
             StringValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_GENCOLLECTIONCOUNT, () => GCGenCollectionCount);

--- a/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
@@ -1,0 +1,274 @@
+﻿#define LOG_MEMORY_PERF_COUNTERS
+
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+using System;
+using System.Diagnostics;
+using System.Management;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Statistics
+{
+    internal class PerfCounterEnvironmentStatistics : IHostEnvironmentStatistics, ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver, IDisposable
+    {
+        private readonly ILogger logger;
+        private const float KB = 1024f;
+
+        private PerformanceCounter cpuCounterPF;
+        private PerformanceCounter availableMemoryCounterPF;
+#if LOG_MEMORY_PERF_COUNTERS
+        private PerformanceCounter timeInGCPF;
+        private PerformanceCounter[] genSizesPF;
+        private PerformanceCounter allocatedBytesPerSecPF;
+        private PerformanceCounter promotedMemoryFromGen1PF;
+        private PerformanceCounter numberOfInducedGCsPF;
+        private PerformanceCounter largeObjectHeapSizePF;
+        private PerformanceCounter promotedFinalizationMemoryFromGen0PF;
+#endif
+        private SafeTimer cpuUsageTimer;
+        private readonly TimeSpan CPU_CHECK_PERIOD = TimeSpan.FromSeconds(5);
+        private readonly TimeSpan INITIALIZATION_TIMEOUT = TimeSpan.FromMinutes(1);
+        private bool countersAvailable;
+
+        public long MemoryUsage { get { return GC.GetTotalMemory(false); } }
+
+        ///
+        /// <summary>Amount of physical memory on the machine</summary>
+        ///
+        public long TotalPhysicalMemory { get; private set; }
+
+        ///
+        /// <summary>Amount of memory available to processes running on the machine</summary>
+        ///
+        public long AvailableMemory { get { return availableMemoryCounterPF != null ? Convert.ToInt64(availableMemoryCounterPF.NextValue()) : 0; } }
+
+        public float CpuUsage { get; private set; }
+
+        private static string GCGenCollectionCount
+        {
+            get
+            {
+                return String.Format("gen0={0}, gen1={1}, gen2={2}", GC.CollectionCount(0), GC.CollectionCount(1), GC.CollectionCount(2));
+            }
+        }
+
+#if LOG_MEMORY_PERF_COUNTERS
+
+        private string GCGenSizes
+        {
+            get
+            {
+                if (genSizesPF == null) return String.Empty;
+                return String.Format("gen0={0:0.00}, gen1={1:0.00}, gen2={2:0.00}", genSizesPF[0].NextValue() / KB, genSizesPF[1].NextValue() / KB, genSizesPF[2].NextValue() / KB);
+            }
+        }
+
+#endif
+
+        public PerfCounterEnvironmentStatistics(ILoggerFactory loggerFactory)
+        {
+            this.logger = loggerFactory.CreateLogger<PerfCounterEnvironmentStatistics>();
+            try
+            {
+                Task.Run(() =>
+                {
+                    InitCpuMemoryCounters();
+                }).WaitWithThrow(INITIALIZATION_TIMEOUT);
+            }
+            catch (TimeoutException)
+            {
+                logger.Warn(ErrorCode.PerfCounterConnectError,
+                   "Timeout occurred during initialization of CPU & Memory perf counters");
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        private void InitCpuMemoryCounters()
+        {
+            try
+            {
+                cpuCounterPF = new PerformanceCounter("Processor", "% Processor Time", "_Total", true);
+                availableMemoryCounterPF = new PerformanceCounter("Memory", "Available Bytes", true);
+#if LOG_MEMORY_PERF_COUNTERS
+                string thisProcess = Process.GetCurrentProcess().ProcessName;
+                timeInGCPF = new PerformanceCounter(".NET CLR Memory", "% Time in GC", thisProcess, true);
+                genSizesPF = new PerformanceCounter[] {
+                    new PerformanceCounter(".NET CLR Memory", "Gen 0 heap size", thisProcess, true),
+                    new PerformanceCounter(".NET CLR Memory", "Gen 1 heap size", thisProcess, true),
+                    new PerformanceCounter(".NET CLR Memory", "Gen 2 heap size", thisProcess, true)
+                };
+                allocatedBytesPerSecPF = new PerformanceCounter(".NET CLR Memory", "Allocated Bytes/sec", thisProcess, true);
+                promotedMemoryFromGen1PF = new PerformanceCounter(".NET CLR Memory", "Promoted Memory from Gen 1", thisProcess, true);
+                numberOfInducedGCsPF = new PerformanceCounter(".NET CLR Memory", "# Induced GC", thisProcess, true);
+                largeObjectHeapSizePF = new PerformanceCounter(".NET CLR Memory", "Large Object Heap size", thisProcess, true);
+                promotedFinalizationMemoryFromGen0PF = new PerformanceCounter(".NET CLR Memory", "Promoted Finalization-Memory from Gen 0", thisProcess, true);
+#endif
+
+#if !(NETSTANDARD || __MonoCS__)
+                //.NET on Windows without mono
+                const string Query = "SELECT Capacity FROM Win32_PhysicalMemory";
+                var searcher = new ManagementObjectSearcher(Query);
+                long Capacity = 0;
+                foreach (ManagementObject WniPART in searcher.Get())
+                    Capacity += Convert.ToInt64(WniPART.Properties["Capacity"].Value);
+
+                if (Capacity == 0)
+                    throw new Exception("No physical ram installed on machine?");
+
+                TotalPhysicalMemory = Capacity;
+#elif __MonoCS__
+                //Cross platform mono
+                var totalPhysicalMemory = new PerformanceCounter("Mono Memory", "Total Physical Memory");
+                TotalPhysicalMemory = Convert.ToInt64(totalPhysicalMemory.NextValue());
+#elif NETSTANDARD
+                //Cross platform CoreCLR
+#endif
+                countersAvailable = true;
+            }
+            catch (Exception)
+            {
+                logger.Warn(ErrorCode.PerfCounterConnectError,
+                    "Error initializing CPU & Memory perf counters - you need to repair Windows perf counter config on this machine with 'lodctr /r' command");
+            }
+        }
+
+        private void CheckCpuUsage(object m)
+        {
+            if (cpuCounterPF != null)
+            {
+                var currentUsage = cpuCounterPF.NextValue();
+                // We calculate a decaying average for CPU utilization
+                CpuUsage = (CpuUsage + 2 * currentUsage) / 3;
+            }
+            else
+            {
+                CpuUsage = 0;
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed")]
+        public void Dispose()
+        {
+            cpuCounterPF?.Dispose();
+            availableMemoryCounterPF?.Dispose();
+
+            timeInGCPF?.Dispose();
+            if (genSizesPF != null)
+                foreach (var item in genSizesPF)
+                {
+                    item?.Dispose();
+                }
+            allocatedBytesPerSecPF?.Dispose();
+            promotedMemoryFromGen1PF?.Dispose();
+            numberOfInducedGCsPF?.Dispose();
+            largeObjectHeapSizePF?.Dispose();
+            promotedFinalizationMemoryFromGen0PF?.Dispose();
+            cpuUsageTimer?.Dispose();
+        }
+
+        #region Lifecycle
+
+        public Task OnStart(CancellationToken ct)
+        {
+            if (!countersAvailable)
+            {
+                logger.Warn(ErrorCode.PerfCounterNotRegistered,
+                    "CPU & Memory perf counters did not initialize correctly - try repairing Windows perf counter config on this machine with 'lodctr /r' command");
+            }
+
+            if (cpuCounterPF != null)
+            {
+                cpuUsageTimer = new SafeTimer(this.logger, CheckCpuUsage, null, CPU_CHECK_PERIOD, CPU_CHECK_PERIOD);
+            }
+            try
+            {
+                if (cpuCounterPF != null)
+                {
+                    // Read initial value of CPU Usage counter
+                    CpuUsage = cpuCounterPF.NextValue();
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Can sometimes get exception accessing CPU Usage counter for first time in some runtime environments
+                CpuUsage = 0;
+            }
+
+            FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_CPUUSAGE, () => CpuUsage);
+            IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_TOTALMEMORYKB, () => (long)((MemoryUsage + KB - 1.0) / KB)); // Round up
+#if LOG_MEMORY_PERF_COUNTERS    // print GC stats in the silo log file.
+            StringValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_GENCOLLECTIONCOUNT, () => GCGenCollectionCount);
+            StringValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_GENSIZESKB, () => GCGenSizes);
+            if (timeInGCPF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PERCENTOFTIMEINGC, () => timeInGCPF.NextValue());
+            }
+            if (allocatedBytesPerSecPF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_ALLOCATEDBYTESINKBPERSEC, () => allocatedBytesPerSecPF.NextValue() / KB);
+            }
+            if (promotedMemoryFromGen1PF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PROMOTEDMEMORYFROMGEN1KB, () => promotedMemoryFromGen1PF.NextValue() / KB);
+            }
+            if (largeObjectHeapSizePF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_LARGEOBJECTHEAPSIZEKB, () => largeObjectHeapSizePF.NextValue() / KB);
+            }
+            if (promotedFinalizationMemoryFromGen0PF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_PROMOTEDMEMORYFROMGEN0KB, () => promotedFinalizationMemoryFromGen0PF.NextValue() / KB);
+            }
+            if (numberOfInducedGCsPF != null)
+            {
+                FloatValueStatistic.FindOrCreate(StatisticNames.RUNTIME_GC_NUMBEROFINDUCEDGCS, () => numberOfInducedGCsPF.NextValue());
+            }
+            IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_MEMORY_TOTALPHYSICALMEMORYMB, () => (long)((TotalPhysicalMemory / KB) / KB));
+            if (availableMemoryCounterPF != null)
+            {
+                IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_MEMORY_AVAILABLEMEMORYMB, () => (long)((AvailableMemory / KB) / KB)); // Round up
+            }
+#endif
+            IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_DOT_NET_THREADPOOL_INUSE_WORKERTHREADS, () =>
+            {
+                int maXworkerThreads;
+                int maXcompletionPortThreads;
+                ThreadPool.GetMaxThreads(out maXworkerThreads, out maXcompletionPortThreads);
+                int workerThreads;
+                int completionPortThreads;
+                // GetAvailableThreads Retrieves the difference between the maximum number of thread pool threads
+                // and the number currently active.
+                // So max-Available is the actual number in use. If it goes beyond min, it means we are stressing the thread pool.
+                ThreadPool.GetAvailableThreads(out workerThreads, out completionPortThreads);
+                return maXworkerThreads - workerThreads;
+            });
+            IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_DOT_NET_THREADPOOL_INUSE_COMPLETIONPORTTHREADS, () =>
+            {
+                int maXworkerThreads;
+                int maXcompletionPortThreads;
+                ThreadPool.GetMaxThreads(out maXworkerThreads, out maXcompletionPortThreads);
+                int workerThreads;
+                int completionPortThreads;
+                ThreadPool.GetAvailableThreads(out workerThreads, out completionPortThreads);
+                return maXcompletionPortThreads - completionPortThreads;
+            });
+            return Task.CompletedTask;
+        }
+
+        public Task OnStop(CancellationToken ct)
+        {
+            cpuUsageTimer?.Dispose();
+            cpuUsageTimer = null;
+            return Task.CompletedTask;
+        }
+
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(SiloLifecycleStage.RuntimeInitialize, this);
+        }
+
+        #endregion Lifecycle
+    }
+}

--- a/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
@@ -246,13 +246,13 @@ namespace Orleans.Statistics
             });
             IntValueStatistic.FindOrCreate(StatisticNames.RUNTIME_DOT_NET_THREADPOOL_INUSE_COMPLETIONPORTTHREADS, () =>
             {
-                int maXworkerThreads;
-                int maXcompletionPortThreads;
-                ThreadPool.GetMaxThreads(out maXworkerThreads, out maXcompletionPortThreads);
+                int maxWorkerThreads;
+                int maxCompletionPortThreads;
+                ThreadPool.GetMaxThreads(out maxWorkerThreads, out maxCompletionPortThreads);
                 int workerThreads;
                 int completionPortThreads;
                 ThreadPool.GetAvailableThreads(out workerThreads, out completionPortThreads);
-                return maXcompletionPortThreads - completionPortThreads;
+                return maxCompletionPortThreads - completionPortThreads;
             });
             return Task.CompletedTask;
         }

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
@@ -19,7 +19,6 @@ namespace UnitTests.SchedulerTests
     public class OrleansTaskSchedulerAdvancedTests : MarshalByRefObject, IDisposable
     {
         private readonly ITestOutputHelper output;
-        private readonly RuntimeStatisticsGroup runtimeStatisticsGroup;
         private readonly SiloPerformanceMetrics performanceMetrics;
         private OrleansTaskScheduler orleansTaskScheduler;
 
@@ -36,8 +35,7 @@ namespace UnitTests.SchedulerTests
         {
             this.output = output;
             loggerFactory = OrleansTaskSchedulerBasicTests.InitSchedulerLogging();
-            this.runtimeStatisticsGroup = new RuntimeStatisticsGroup(loggerFactory);
-            this.performanceMetrics = new SiloPerformanceMetrics(this.runtimeStatisticsGroup, new AppEnvironmentStatistics(), this.loggerFactory);
+            this.performanceMetrics = new SiloPerformanceMetrics(new DummyHostEnvironmentStatistics(loggerFactory), new AppEnvironmentStatistics(), this.loggerFactory);
             
         }
 
@@ -48,7 +46,6 @@ namespace UnitTests.SchedulerTests
                 orleansTaskScheduler.Stop();
             }
             this.loggerFactory.Dispose();
-            this.runtimeStatisticsGroup.Dispose();
             this.performanceMetrics.Dispose();
         }
 

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -35,7 +35,7 @@ namespace UnitTests.SchedulerTests
         {
             this.output = output;
             loggerFactory = OrleansTaskSchedulerBasicTests.InitSchedulerLogging();
-            this.performanceMetrics = new SiloPerformanceMetrics(new DummyHostEnvironmentStatistics(loggerFactory), new AppEnvironmentStatistics(), this.loggerFactory);
+            this.performanceMetrics = new SiloPerformanceMetrics(new NoOpHostEnvironmentStatistics(loggerFactory), new AppEnvironmentStatistics(), this.loggerFactory);
             
         }
 

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
@@ -9,6 +9,7 @@ using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Counters;
 using Orleans.Runtime.Scheduler;
+using Orleans.Statistics;
 using UnitTests.TesterInternal;
 using Xunit;
 using Xunit.Abstractions;
@@ -36,7 +37,7 @@ namespace UnitTests.SchedulerTests
             this.output = output;
             loggerFactory = OrleansTaskSchedulerBasicTests.InitSchedulerLogging();
             this.runtimeStatisticsGroup = new RuntimeStatisticsGroup(loggerFactory);
-            this.performanceMetrics = new SiloPerformanceMetrics(this.runtimeStatisticsGroup, this.loggerFactory);
+            this.performanceMetrics = new SiloPerformanceMetrics(this.runtimeStatisticsGroup, new AppEnvironmentStatistics(), this.loggerFactory);
             
         }
 

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -11,6 +11,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.Counters;
 using Orleans.Runtime.Scheduler;
+using Orleans.Statistics;
 using TestExtensions;
 using UnitTests.Grains;
 using UnitTests.TesterInternal;
@@ -36,7 +37,7 @@ namespace UnitTests.SchedulerTests
             loggerFactory = OrleansTaskSchedulerBasicTests.InitSchedulerLogging();
             context = new UnitTestSchedulingContext();
             this.runtimeStatisticsGroup = new RuntimeStatisticsGroup(loggerFactory);
-            this.performanceMetrics = new SiloPerformanceMetrics(this.runtimeStatisticsGroup, this.loggerFactory);
+            this.performanceMetrics = new SiloPerformanceMetrics(this.runtimeStatisticsGroup, new AppEnvironmentStatistics(), this.loggerFactory);
             masterScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, loggerFactory);
         }
         

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -29,15 +29,13 @@ namespace UnitTests.SchedulerTests
         private readonly OrleansTaskScheduler masterScheduler;
         private readonly UnitTestSchedulingContext context;
         private readonly SiloPerformanceMetrics performanceMetrics;
-        private readonly RuntimeStatisticsGroup runtimeStatisticsGroup;
         private readonly ILoggerFactory loggerFactory;
         public OrleansTaskSchedulerAdvancedTests_Set2(ITestOutputHelper output)
         {
             this.output = output;
             loggerFactory = OrleansTaskSchedulerBasicTests.InitSchedulerLogging();
             context = new UnitTestSchedulingContext();
-            this.runtimeStatisticsGroup = new RuntimeStatisticsGroup(loggerFactory);
-            this.performanceMetrics = new SiloPerformanceMetrics(this.runtimeStatisticsGroup, new AppEnvironmentStatistics(), this.loggerFactory);
+            this.performanceMetrics = new SiloPerformanceMetrics(new DummyHostEnvironmentStatistics(loggerFactory), new AppEnvironmentStatistics(), this.loggerFactory);
             masterScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, loggerFactory);
         }
         
@@ -46,7 +44,6 @@ namespace UnitTests.SchedulerTests
             masterScheduler.Stop();
             this.loggerFactory.Dispose();
             this.performanceMetrics.Dispose();
-            this.runtimeStatisticsGroup.Dispose();
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Net;
 using System.Threading;
@@ -35,7 +35,7 @@ namespace UnitTests.SchedulerTests
             this.output = output;
             loggerFactory = OrleansTaskSchedulerBasicTests.InitSchedulerLogging();
             context = new UnitTestSchedulingContext();
-            this.performanceMetrics = new SiloPerformanceMetrics(new DummyHostEnvironmentStatistics(loggerFactory), new AppEnvironmentStatistics(), this.loggerFactory);
+            this.performanceMetrics = new SiloPerformanceMetrics(new NoOpHostEnvironmentStatistics(loggerFactory), new AppEnvironmentStatistics(), this.loggerFactory);
             masterScheduler = TestInternalHelper.InitializeSchedulerForTesting(context, this.performanceMetrics, loggerFactory);
         }
         

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -55,7 +55,7 @@ namespace UnitTests.SchedulerTests
             this.output = output;
             SynchronizationContext.SetSynchronizationContext(null);
             loggerFactory = InitSchedulerLogging();
-            this.performanceMetrics = new SiloPerformanceMetrics(new DummyHostEnvironmentStatistics(loggerFactory), new AppEnvironmentStatistics(), this.loggerFactory);
+            this.performanceMetrics = new SiloPerformanceMetrics(new NoOpHostEnvironmentStatistics(loggerFactory), new AppEnvironmentStatistics(), this.loggerFactory);
             this.rootContext = new UnitTestSchedulingContext();
             this.scheduler = TestInternalHelper.InitializeSchedulerForTesting(rootContext, this.performanceMetrics, loggerFactory);
         }

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -46,7 +46,6 @@ namespace UnitTests.SchedulerTests
     {
         private readonly ITestOutputHelper output;
         private static readonly object lockable = new object();
-        private readonly RuntimeStatisticsGroup runtimeStatisticsGroup;
         private readonly SiloPerformanceMetrics performanceMetrics;
         private readonly UnitTestSchedulingContext rootContext;
         private readonly OrleansTaskScheduler scheduler;
@@ -56,8 +55,7 @@ namespace UnitTests.SchedulerTests
             this.output = output;
             SynchronizationContext.SetSynchronizationContext(null);
             loggerFactory = InitSchedulerLogging();
-            this.runtimeStatisticsGroup = new RuntimeStatisticsGroup(loggerFactory);
-            this.performanceMetrics = new SiloPerformanceMetrics(this.runtimeStatisticsGroup, new AppEnvironmentStatistics(), this.loggerFactory);
+            this.performanceMetrics = new SiloPerformanceMetrics(new DummyHostEnvironmentStatistics(loggerFactory), new AppEnvironmentStatistics(), this.loggerFactory);
             this.rootContext = new UnitTestSchedulingContext();
             this.scheduler = TestInternalHelper.InitializeSchedulerForTesting(rootContext, this.performanceMetrics, loggerFactory);
         }
@@ -66,7 +64,6 @@ namespace UnitTests.SchedulerTests
         {
             SynchronizationContext.SetSynchronizationContext(null);
             this.performanceMetrics.Dispose();
-            this.runtimeStatisticsGroup.Dispose();
             this.scheduler.Stop();
         }
 

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Orleans;
 using Orleans.TestingHost.Utils;
+using Orleans.Statistics;
 
 // ReSharper disable ConvertToConstant.Local
 
@@ -56,7 +57,7 @@ namespace UnitTests.SchedulerTests
             SynchronizationContext.SetSynchronizationContext(null);
             loggerFactory = InitSchedulerLogging();
             this.runtimeStatisticsGroup = new RuntimeStatisticsGroup(loggerFactory);
-            this.performanceMetrics = new SiloPerformanceMetrics(this.runtimeStatisticsGroup, this.loggerFactory);
+            this.performanceMetrics = new SiloPerformanceMetrics(this.runtimeStatisticsGroup, new AppEnvironmentStatistics(), this.loggerFactory);
             this.rootContext = new UnitTestSchedulingContext();
             this.scheduler = TestInternalHelper.InitializeSchedulerForTesting(rootContext, this.performanceMetrics, loggerFactory);
         }

--- a/test/TesterSQLUtils/SqlStatisticsPublisherTests/DummyPerformanceMetrics.cs
+++ b/test/TesterSQLUtils/SqlStatisticsPublisherTests/DummyPerformanceMetrics.cs
@@ -1,13 +1,13 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 
 namespace UnitTests.SqlStatisticsPublisherTests
 {
     internal class DummyPerformanceMetrics : IClientPerformanceMetrics, ISiloPerformanceMetrics
     {
-        public float CpuUsage {get { return 1; } }
-        public long AvailablePhysicalMemory { get { return 2; } }
-        public long MemoryUsage { get { return 3; } }
-        public long TotalPhysicalMemory { get { return 4; } }
+        public float? CpuUsage {get { return 1; } }
+        public long? AvailablePhysicalMemory { get { return 2; } }
+        public long? MemoryUsage { get { return 3; } }
+        public long? TotalPhysicalMemory { get { return 4; } }
         public int SendQueueLength { get { return 5; } }
         public int ReceiveQueueLength { get { return 6; } }
         public long SentMessages { get { return 7; } }


### PR DESCRIPTION
Related issues: #3567 #3586

I added abstractions to get the total physical memory and the cpu/memory usage (`IAppEnvironmentStatistics` and `IHostEnvironmentStatistics`), and refactored the old `PerfCounterEnvironmentStatistics` to implement `IAppEnvironmentStatistics`, as a Windows-only solution. This class also now follow the lifecycle pattern.

The built-in implementation of  `IAppEnvironmentStatistics` should be cross-platform, but the developer can make a custom implementation if needed.

A Linux-specific implementation of `IHostEnvironmentStatistics` could be done in the future,