### PR TITLE
increase timeout on ClientStreamTestRunner

### DIFF
--- a/test/Tester/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Tester/StreamingTests/ClientStreamTestRunner.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Threading.Tasks;
 using Orleans;
@@ -14,7 +14,7 @@ namespace Tester.StreamingTests
     public class ClientStreamTestRunner
     {
         private static readonly Func<Task<int>> DefaultDeliveryFailureCount = () => Task.FromResult(0); 
-        private static readonly TimeSpan _timeout = TimeSpan.FromMinutes(3);
+        private static readonly TimeSpan _timeout = TimeSpan.FromMinutes(6);
 
         private readonly TestCluster testHost;
         public ClientStreamTestRunner(TestCluster testHost)


### PR DESCRIPTION
Test fail intermittently in vso. Increase the timeout to make it pass more consistently