### PR TITLE
Add IOptionFormatter and IOptionResolver interfaces

### DIFF
--- a/src/Orleans.Core.Abstractions/Lifecycle/LifecycleExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Lifecycle/LifecycleExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,8 +43,8 @@ namespace Orleans
                 this.onStop = onStop;
             }
 
-            public Task OnStart(CancellationToken ct) => onStart(ct);
-            public Task OnStop(CancellationToken ct) => onStop(ct);
+            public Task OnStart(CancellationToken ct) => this.onStart(ct);
+            public Task OnStop(CancellationToken ct) => this.onStop(ct);
         }
     }
 }

--- a/src/Orleans.Core/Configuration/Legacy/LegacyConfigurationExtensions.cs
+++ b/src/Orleans.Core/Configuration/Legacy/LegacyConfigurationExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -33,6 +33,7 @@ namespace Orleans.Configuration
                     options.ClusterId = configuration.ClusterId;
                 }
             });
+            services.TryConfigureFormatter<ClusterClientOptions, ClusterClientOptionsFormatter>();
 
             // Translate legacy configuration to new Options
             services.Configure<ClientMessagingOptions>(options =>
@@ -41,19 +42,24 @@ namespace Orleans.Configuration
 
                 options.ClientSenderBuckets = configuration.ClientSenderBuckets;
             });
+            services.TryConfigureFormatter<ClientMessagingOptions, ClientMessagingOptionFormatter>();
+
 
             services.Configure<NetworkingOptions>(options => CopyNetworkingOptions(configuration, options));
+            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
 
             services.Configure<SerializationProviderOptions>(options =>
             {
                 options.SerializationProviders = configuration.SerializationProviders;
                 options.FallbackSerializationProvider = configuration.FallbackSerializationProvider;
             });
+            services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();
 
             services.Configure<StatisticsOptions>((options) =>
             {
                 CopyStatisticsOptions(configuration, options);
             });
+            services.TryConfigureFormatter<StatisticsOptions,StatisticOptionsFormatter>();
 
             // GatewayProvider
             LegacyGatewayListProviderConfigurator.ConfigureServices(configuration, services);

--- a/src/Orleans.Core/Configuration/Legacy/LegacyConfigurationExtensions.cs
+++ b/src/Orleans.Core/Configuration/Legacy/LegacyConfigurationExtensions.cs
@@ -33,7 +33,6 @@ namespace Orleans.Configuration
                     options.ClusterId = configuration.ClusterId;
                 }
             });
-            services.TryConfigureFormatter<ClusterClientOptions, ClusterClientOptionsFormatter>();
 
             // Translate legacy configuration to new Options
             services.Configure<ClientMessagingOptions>(options =>
@@ -42,24 +41,20 @@ namespace Orleans.Configuration
 
                 options.ClientSenderBuckets = configuration.ClientSenderBuckets;
             });
-            services.TryConfigureFormatter<ClientMessagingOptions, ClientMessagingOptionFormatter>();
 
 
             services.Configure<NetworkingOptions>(options => CopyNetworkingOptions(configuration, options));
-            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
 
             services.Configure<SerializationProviderOptions>(options =>
             {
                 options.SerializationProviders = configuration.SerializationProviders;
                 options.FallbackSerializationProvider = configuration.FallbackSerializationProvider;
             });
-            services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();
 
             services.Configure<StatisticsOptions>((options) =>
             {
                 CopyStatisticsOptions(configuration, options);
             });
-            services.TryConfigureFormatter<StatisticsOptions,StatisticOptionsFormatter>();
 
             // GatewayProvider
             LegacyGatewayListProviderConfigurator.ConfigureServices(configuration, services);

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionFormatter.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionFormatter.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace Orleans
+{
+    /// <summary>
+    /// format the option and give it a category and a name
+    /// </summary>
+    public interface IOptionFormatter
+    {
+        string Category { get; }
+
+        string Name { get; }
+
+        //format setting values into a list of string
+        IEnumerable<string> Format();
+    }
+
+    /// <summary>
+    /// Option formatter for a certain option type <typeparamref name="T"/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IOptionFormatter<T> : IOptionFormatter
+    {
+        
+    }
+
+    /// <summary>
+    /// IOptionFormatterResolver resolve specific OptionFormatter for certain named option
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IOptionFormatterResolver<T>
+    {
+        IOptionFormatter<T> Resolve(string name);
+    }
+
+    /// <summary>
+    /// category for options
+    /// </summary>
+    public static class OptionCategory
+    {
+        //storage provider option category
+        public const string Storage = nameof(Storage);
+        //streaming provider option category 
+        public const string Streaming = nameof(Streaming);
+    }
+
+    /// <summary>
+    /// Utility class for option formatting
+    /// </summary>
+    public static class OptionFormattingUtilities
+    {
+        private const string OptionKeyValueFormat = "{0}: {1}";
+
+        /// <summary>
+        /// Format key value pair usin default format
+        /// </summary>
+        public static string Format(object key, object value)
+        {
+            return String.Format(OptionKeyValueFormat, key, value);
+        }
+    }
+}

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionFormatter.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionFormatter.cs
@@ -35,17 +35,6 @@ namespace Orleans
     }
 
     /// <summary>
-    /// category for options
-    /// </summary>
-    public static class OptionCategory
-    {
-        //storage provider option category
-        public const string Storage = nameof(Storage);
-        //streaming provider option category 
-        public const string Streaming = nameof(Streaming);
-    }
-
-    /// <summary>
     /// Utility class for option formatting
     /// </summary>
     public static class OptionFormattingUtilities
@@ -55,9 +44,10 @@ namespace Orleans
         /// <summary>
         /// Format key value pair usin default format
         /// </summary>
-        public static string Format(object key, object value)
+        public static string Format(object key, object value, string format = null)
         {
-            return String.Format(OptionKeyValueFormat, key, value);
+            var formatting = format ?? OptionKeyValueFormat;
+            return String.Format(formatting, key, value);
         }
     }
 }

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionFormatter.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionFormatter.cs
@@ -8,8 +8,6 @@ namespace Orleans
     /// </summary>
     public interface IOptionFormatter
     {
-        string Category { get; }
-
         string Name { get; }
 
         //format setting values into a list of string

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
@@ -40,29 +40,17 @@ namespace Orleans
         }
         public void LogOptions()
         {
-            this.logger.LogInformation("Starting with following configuration:");
             var optionFormatters = services.GetServices<IOptionFormatter>();
-            foreach (var formatterGroup in optionFormatters
-                .GroupBy(optionFormatter => optionFormatter.Category)
-                .OrderBy(group => group.Key))
+            foreach (var optionFormatter in optionFormatters)
             {
-                foreach (var optionFormatter in formatterGroup)
-                {
-                    LogOption(optionFormatter);
-                }
-
+                LogOption(optionFormatter);
             }
         }
 
         private void LogOption(IOptionFormatter formatter)
         {
             var stringBuiler = new StringBuilder();
-            if(string.IsNullOrEmpty(formatter.Category))
-                stringBuiler.AppendLine($"{formatter.Name}:");
-            else
-            {
-                stringBuiler.AppendLine($"{formatter.Category}, {formatter.Name}:");
-            }
+            stringBuiler.AppendLine($"Configuration {formatter.Name}: ");
             foreach (var setting in formatter.Format())
             {
                 stringBuiler.AppendLine($"{setting}");

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Orleans
+{ 
+    internal class ClientOptionsLogger : OptionsLogger, ILifecycleParticipant<IClusterClientLifecycle>
+    {
+        private int ClientOptionLoggerLifeCycleRing = 1000;
+        public ClientOptionsLogger(ILogger<ClientOptionsLogger> logger, IServiceProvider services)
+            : base(logger, services)
+        {
+        }
+
+        public void Participate(IClusterClientLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(ClientOptionLoggerLifeCycleRing, this.OnRuntimeInitializeStart);
+        }
+
+        public Task OnRuntimeInitializeStart(CancellationToken token)
+        {
+            this.LogOptions();
+            return Task.CompletedTask;
+        }
+    }
+
+    public abstract class OptionsLogger 
+    {
+        private ILogger logger;
+        private IServiceProvider services;
+        protected OptionsLogger(ILogger logger, IServiceProvider services)
+        {
+            this.logger = logger;
+            this.services = services;
+        }
+        public void LogOptions()
+        {
+            this.logger.LogInformation("Starting with following configuration:");
+            var optionFormatters = services.GetServices<IOptionFormatter>();
+            foreach (var formatterGroup in optionFormatters
+                .GroupBy(optionFormatter => optionFormatter.Category)
+                .OrderBy(group => group.Key))
+            {
+                int spaceNum = 0;
+                //log out category if there's one
+                if (!string.IsNullOrEmpty(formatterGroup.Key))
+                {
+                    this.logger.LogInformation($"{CreateNSpace(spaceNum)}{formatterGroup.Key}:");
+                    spaceNum += 2;
+                }
+
+                foreach (var optionFormatter in formatterGroup)
+                {
+                    LogOption(optionFormatter, spaceNum);
+                }
+
+            }
+        }
+
+        private void LogOption(IOptionFormatter formatter, int spaces)
+        {
+            this.logger.LogInformation($"{CreateNSpace(spaces)}{formatter.Name}:");
+            foreach (var setting in formatter.Format())
+            {
+                this.logger.LogInformation($"{CreateNSpace(spaces + 2)}{setting}");
+            }
+        }
+
+        private string CreateNSpace(int n)
+        {
+            var builder = new StringBuilder();
+            while (n-- > 0)
+            {
+                builder.Append(" ");
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Orleans.Core/Configuration/OptionLogger/OptionFormatterExtensionMethods.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/OptionFormatterExtensionMethods.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans.Configuration;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Extension methods on IServiceCollection, to provider better usability to IOptionFormatter
+    /// </summary>
+    public static class OptionConfigureExtensionMethods
+    {
+        /// <summary>
+        /// configure option formatter for <typeparam name="TOptions"/>
+        /// </summary>
+        public static IServiceCollection ConfigureFormatter<TOptions, TOptionFormatter>(this IServiceCollection services)
+            where TOptions : class
+            where TOptionFormatter : class, IOptionFormatter<TOptions>
+        {
+
+            services.AddSingleton<IOptionFormatter<TOptions>, TOptionFormatter>()
+                .AddFromExisting<IOptionFormatter, IOptionFormatter<TOptions>>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configure a option formatter for option <typeparam name="TOptions"/> if none is configured
+        /// </summary>
+        /// <typeparam name="TOptions"></typeparam>
+        /// <typeparam name="TOptionFormatter"></typeparam>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection TryConfigureFormatter<TOptions, TOptionFormatter>(this IServiceCollection services)
+            where TOptions : class
+            where TOptionFormatter : class, IOptionFormatter<TOptions>
+        {
+            var registration = services.FirstOrDefault(service => service.ServiceType == typeof(IOptionFormatter<TOptions>));
+            if (registration == null)
+                services.ConfigureFormatter<TOptions, TOptionFormatter>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configure option formatter resolver for named option TOptions
+        /// </summary>
+        public static IServiceCollection ConfigureFormatter<TOptions, TOptionFormatterResolver>(this IServiceCollection services, string name)
+            where TOptions : class
+            where TOptionFormatterResolver : class, IOptionFormatterResolver<TOptions>
+        {
+            services.AddSingleton<IOptionFormatterResolver<TOptions>, TOptionFormatterResolver>()
+                .AddSingleton<IOptionFormatter>(sp => sp.GetService<IOptionFormatterResolver<TOptions>>().Resolve(name));
+            return services;
+        }
+
+        /// <summary>
+        /// Configure option formatter resolver for named option TOptions, if none is configured
+        /// </summary>
+        public static IServiceCollection TryConfigureFormatter<TOptions, TOptionFormatterResolver>(this IServiceCollection services, string name)
+            where TOptions : class
+            where TOptionFormatterResolver : class, IOptionFormatterResolver<TOptions>
+        {
+            var registration = services.FirstOrDefault(service => service.ServiceType == typeof(IOptionFormatterResolver<TOptions>));
+            if (registration == null)
+                services.ConfigureFormatter<TOptions, TOptionFormatterResolver>(name);
+            return services;
+        }
+    }
+}

--- a/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
@@ -1,4 +1,8 @@
-﻿namespace Orleans.Hosting
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace Orleans.Hosting
 {
     /// <summary>
     /// Specifies global messaging options that are client related.
@@ -13,5 +17,34 @@
         ///  If this attribute is not specified, then Math.Pow(2, 13) is used.
         /// </summary>
         public int ClientSenderBuckets { get; set; } = 8192;
+    }
+
+    public class ClientMessagingOptionFormatter : IOptionFormatter<ClientMessagingOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(ClientMessagingOptions);
+
+        private ClientMessagingOptions options;
+        public ClientMessagingOptionFormatter(IOptions<ClientMessagingOptions> messageOptions)
+        {
+            options = messageOptions.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.ClientSenderBuckets), options.ClientSenderBuckets),
+
+                OptionFormattingUtilities.Format(nameof(options.ResponseTimeout), options.ResponseTimeout),
+                OptionFormattingUtilities.Format(nameof(options.MaxResendCount), options.MaxResendCount),
+                OptionFormattingUtilities.Format(nameof(options.ResendOnTimeout), options.ResendOnTimeout),
+                OptionFormattingUtilities.Format(nameof(options.DropExpiredMessages), options.DropExpiredMessages),
+                OptionFormattingUtilities.Format(nameof(options.BufferPoolBufferSize), options.BufferPoolBufferSize),
+                OptionFormattingUtilities.Format(nameof(options.BufferPoolMaxSize), options.BufferPoolMaxSize),
+                OptionFormattingUtilities.Format(nameof(options.BufferPoolPreallocationSize), options.BufferPoolPreallocationSize)
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/ClusterClientOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterClientOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace Orleans.Runtime
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace Orleans.Runtime
 {
     /// <summary>
     /// Configures the Orleans cluster client.
@@ -9,5 +12,25 @@
         /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
         /// </summary>
         public string ClusterId { get; set; }
+    }
+
+    public class ClusterClientOptionsFormatter : IOptionFormatter<ClusterClientOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(ClusterClientOptions);
+        private ClusterClientOptions options;
+        public ClusterClientOptionsFormatter(IOptions<ClusterClientOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.ClusterId), options.ClusterId)
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -1,5 +1,7 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {

--- a/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Orleans.Hosting

--- a/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
@@ -1,5 +1,7 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
@@ -18,5 +20,27 @@ namespace Orleans.Hosting
         /// Default is TimeSpan.MaxValue (never close sockets automatically, unles they were broken).
         /// </summary>
         public TimeSpan MaxSocketAge { get; set; } = TimeSpan.MaxValue;
+    }
+
+    public class NetworkingOptionFormatter : IOptionFormatter<NetworkingOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(NetworkingOptions);
+
+        private NetworkingOptions options;
+        public NetworkingOptionFormatter(IOptions<NetworkingOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.OpenConnectionTimeout),options.OpenConnectionTimeout),
+                OptionFormattingUtilities.Format(nameof(options.MaxSocketAge), options.MaxSocketAge)
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
@@ -10,5 +11,26 @@ namespace Orleans.Hosting
     {
         public List<TypeInfo> SerializationProviders { get; set; }
         public TypeInfo FallbackSerializationProvider { get; set; }
+    }
+
+    public class SerializationProviderOptionsFormatter : IOptionFormatter<SerializationProviderOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(SerializationProviderOptions);
+        private SerializationProviderOptions options;
+        public SerializationProviderOptionsFormatter(IOptions<SerializationProviderOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.SerializationProviders), string.Join(",", options.SerializationProviders)),
+                OptionFormattingUtilities.Format(nameof(options.FallbackSerializationProvider), options.FallbackSerializationProvider)
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SiloMessagingOptions.cs
@@ -1,5 +1,7 @@
-﻿using Orleans.Runtime;
+using Orleans.Runtime;
 using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
@@ -34,4 +36,37 @@ namespace Orleans.Hosting
         /// </summary>
         public TimeSpan ClientDropTimeout { get; set; } = Constants.DEFAULT_CLIENT_DROP_TIMEOUT;
     }
+
+    public class SiloMessageingOptionFormatter : IOptionFormatter<SiloMessagingOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(SiloMessagingOptions);
+
+        private SiloMessagingOptions options;
+        public SiloMessageingOptionFormatter(IOptions<SiloMessagingOptions> messageOptions)
+        {
+            options = messageOptions.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.SiloSenderQueues), options.SiloSenderQueues),
+                OptionFormattingUtilities.Format(nameof(options.GatewaySenderQueues), options.GatewaySenderQueues),
+                OptionFormattingUtilities.Format(nameof(options.MaxForwardCount), options.MaxForwardCount),
+                OptionFormattingUtilities.Format(nameof(options.ClientDropTimeout), options.ClientDropTimeout),
+
+                OptionFormattingUtilities.Format(nameof(options.ResponseTimeout), options.ResponseTimeout),
+                OptionFormattingUtilities.Format(nameof(options.MaxResendCount), options.MaxResendCount),
+                OptionFormattingUtilities.Format(nameof(options.ResendOnTimeout), options.ResendOnTimeout),
+                OptionFormattingUtilities.Format(nameof(options.DropExpiredMessages), options.DropExpiredMessages),
+                OptionFormattingUtilities.Format(nameof(options.BufferPoolBufferSize), options.BufferPoolBufferSize),
+                OptionFormattingUtilities.Format(nameof(options.BufferPoolMaxSize), options.BufferPoolMaxSize),
+                OptionFormattingUtilities.Format(nameof(options.BufferPoolPreallocationSize), options.BufferPoolPreallocationSize)
+            };
+        }
+    }
+
 }

--- a/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Configuration.Options
 {
@@ -13,5 +14,24 @@ namespace Orleans.Configuration.Options
         /// Static gateways to use
         /// </summary>
         public IList<Uri> Gateways { get; set; } = new List<Uri>();
+    }
+
+    public class StaticGatewayListProviderOptionsFormatter : IOptionFormatter<StaticGatewayListProviderOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(StaticGatewayListProviderOptions);
+
+        private StaticGatewayListProviderOptions options;
+        public StaticGatewayListProviderOptionsFormatter(IOptions<StaticGatewayListProviderOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+                {OptionFormattingUtilities.Format(nameof(options.Gateways), string.Join(",", options.Gateways))};
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/StatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/StatisticsOptions.cs
@@ -1,6 +1,8 @@
-﻿using Orleans.Runtime;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using System;
+using System.Collections.Generic;
 
 namespace Orleans.Hosting
 {
@@ -37,5 +39,28 @@ namespace Orleans.Hosting
         /// The CollectionLevel property specifies the verbosity level of statistics to collect. The default is Info.
         /// </summary>
         public StatisticsLevel CollectionLevel { get; set; } = StatisticsLevel.Info;
+    }
+
+    public class StatisticOptionsFormatter : IOptionFormatter<StatisticsOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(StatisticsOptions);
+        private StatisticsOptions options;
+        public StatisticOptionsFormatter(IOptions<StatisticsOptions> options)
+        {
+            this.options = options.Value;
+        }
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.MetricsTableWriteInterval), options.MetricsTableWriteInterval),
+                OptionFormattingUtilities.Format(nameof(options.PerfCountersWriteInterval), options.PerfCountersWriteInterval),
+                OptionFormattingUtilities.Format(nameof(options.LogWriteInterval), options.LogWriteInterval),
+                OptionFormattingUtilities.Format(nameof(options.WriteLogStatisticsToTable), options.WriteLogStatisticsToTable),
+                OptionFormattingUtilities.Format(nameof(options.CollectionLevel), options.CollectionLevel),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -98,7 +98,8 @@ namespace Orleans.Configuration
             Action<OptionsBuilder<StaticGatewayListProviderOptions>> configureOptions)
         {
             configureOptions?.Invoke(services.AddOptions<StaticGatewayListProviderOptions>());
-            return services.AddSingleton<IGatewayListProvider, StaticGatewayListProvider>();
+            return services.AddSingleton<IGatewayListProvider, StaticGatewayListProvider>()
+                .ConfigureFormatter<StaticGatewayListProviderOptions,StaticGatewayListProviderOptionsFormatter>();
         }
 
         public static bool IsInCollection<T>(this IServiceCollection services)

--- a/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
@@ -99,7 +99,7 @@ namespace Orleans.Configuration
         {
             configureOptions?.Invoke(services.AddOptions<StaticGatewayListProviderOptions>());
             return services.AddSingleton<IGatewayListProvider, StaticGatewayListProvider>()
-                .ConfigureFormatter<StaticGatewayListProviderOptions,StaticGatewayListProviderOptionsFormatter>();
+                .TryConfigureFormatter<StaticGatewayListProviderOptions,StaticGatewayListProviderOptionsFormatter>();
         }
 
         public static bool IsInCollection<T>(this IServiceCollection services)

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -214,8 +214,7 @@ namespace Orleans
         {
             if (configureOptions != null)
             {
-                builder.ConfigureServices(services => services.Configure<ClusterClientOptions>(configureOptions)
-                .TryConfigureFormatter<ClusterClientOptions, ClusterClientOptionsFormatter>());
+                builder.ConfigureServices(services => services.Configure<ClusterClientOptions>(configureOptions));
             }
 
             return builder;
@@ -234,7 +233,6 @@ namespace Orleans
                 builder.ConfigureServices(services =>
                 {
                     configureOptions.Invoke(services.AddOptions<ClusterClientOptions>());
-                    services.TryConfigureFormatter<ClusterClientOptions, ClusterClientOptionsFormatter>();
                 });
             }
 

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -214,7 +214,8 @@ namespace Orleans
         {
             if (configureOptions != null)
             {
-                builder.ConfigureServices(services => services.Configure(configureOptions));
+                builder.ConfigureServices(services => services.Configure<ClusterClientOptions>(configureOptions)
+                .TryConfigureFormatter<ClusterClientOptions, ClusterClientOptionsFormatter>());
             }
 
             return builder;
@@ -230,7 +231,11 @@ namespace Orleans
         {
             if (configureOptions != null)
             {
-                builder.ConfigureServices(services => configureOptions.Invoke(services.AddOptions<ClusterClientOptions>()));
+                builder.ConfigureServices(services =>
+                {
+                    configureOptions.Invoke(services.AddOptions<ClusterClientOptions>());
+                    services.TryConfigureFormatter<ClusterClientOptions, ClusterClientOptionsFormatter>();
+                });
             }
 
             return builder;

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.ApplicationParts;
 using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Metadata;
 using Orleans.Providers;
 using Orleans.Runtime;
@@ -15,6 +16,7 @@ namespace Orleans
     {
         public static void AddDefaultServices(IClientBuilder builder, IServiceCollection services)
         {
+            services.TryAddSingleton<ILifecycleParticipant<IClusterClientLifecycle>, ClientOptionsLogger>();
             services.TryAddSingleton<TelemetryManager>();
             services.TryAddFromExisting<ITelemetryProducer, TelemetryManager>();
             services.AddLogging();
@@ -58,6 +60,12 @@ namespace Orleans
             services.AddTransient<IConfigurationValidator, ApplicationPartValidator>();
 
             services.TryAddSingleton(typeof(IKeyedServiceCollection<,>), typeof(KeyedServiceCollection<,>));
+
+            //Add default option formatter if none is configured, for options which are requied to be configured 
+            services.TryConfigureFormatter<ClusterClientOptions, ClusterClientOptionsFormatter>();
+            services.TryConfigureFormatter<ClientMessagingOptions, ClientMessagingOptionFormatter>();
+            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
+            services.TryConfigureFormatter<StatisticsOptions, StatisticOptionsFormatter>();
         }
     }
 }

--- a/src/Orleans.Core/Hosting/Options/OptionsServiceCollectionExtensions.cs
+++ b/src/Orleans.Core/Hosting/Options/OptionsServiceCollectionExtensions.cs
@@ -18,7 +18,8 @@ namespace Orleans.Hosting
         /// <typeparam name="TOptions">The options type to be configured.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
         /// <returns>The <see cref="OptionsBuilder{TOptions}"/> so that configure calls can be chained in it.</returns>
-        public static OptionsBuilder<TOptions> AddOptions<TOptions>(this IServiceCollection services) where TOptions : class
+        public static OptionsBuilder<TOptions> AddOptions<TOptions>(this IServiceCollection services)
+            where TOptions : class
             => services.AddOptions<TOptions>(Options.DefaultName);
 
         /// <summary>

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -32,6 +32,7 @@ using Microsoft.Extensions.Logging;
 using Orleans.ApplicationParts;
 using Orleans.Runtime.Utilities;
 using System;
+using System.Collections.Generic;
 using Orleans.Metadata;
 
 namespace Orleans.Hosting
@@ -46,7 +47,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ILocalSiloDetails, LocalSiloDetails>();
             services.TryAddSingleton<ISiloHost, SiloWrapper>();
             services.TryAddSingleton<SiloLifecycle>();
-
+            services.TryAddSingleton<ILifecycleParticipant<ISiloLifecycle>, SiloOptionsLogger>();
             services.PostConfigure<SiloMessagingOptions>(options =>
             {
                 //
@@ -206,6 +207,12 @@ namespace Orleans.Hosting
             applicationPartManager.AddFeatureProvider(new AssemblyAttributeFeatureProvider<GrainClassFeature>());
             applicationPartManager.AddFeatureProvider(new AssemblyAttributeFeatureProvider<SerializerFeature>());
             services.AddTransient<IConfigurationValidator, ApplicationPartValidator>();
+
+            //Add default option formatter if none is configured, for options which are requied to be configured 
+            services.TryConfigureFormatter<SiloMessagingOptions, SiloMessageingOptionFormatter>();
+            services.TryConfigureFormatter<StatisticsOptions, StatisticOptionsFormatter>();
+            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
+            services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();
         }
     }
 }

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -71,7 +71,6 @@ namespace Orleans.Hosting
 
             services.AddOptions<StatisticsOptions>()
                 .Configure<NodeConfiguration>((options, nodeConfig) => LegacyConfigurationExtensions.CopyStatisticsOptions(nodeConfig, options));
-            services.TryConfigureFormatter<StatisticsOptions, StatisticOptionsFormatter>();
 
             // Translate legacy configuration to new Options
             services.Configure<SiloMessagingOptions>(options =>
@@ -85,7 +84,6 @@ namespace Orleans.Hosting
             });
 
             services.Configure<NetworkingOptions>(options => LegacyConfigurationExtensions.CopyNetworkingOptions(configuration.Globals, options));
-            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
 
             services.AddOptions<EndpointOptions>()
                 .Configure<IOptions<SiloOptions>>((options, siloOptions) =>
@@ -107,7 +105,6 @@ namespace Orleans.Hosting
                 options.SerializationProviders = configuration.Globals.SerializationProviders;
                 options.FallbackSerializationProvider = configuration.Globals.FallbackSerializationProvider;
             });
-            services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();
 
             services.AddOptions<GrainClassOptions>().Configure<IOptions<SiloOptions>>((options, siloOptions) =>
             {

--- a/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/LegacyClusterConfigurationExtensions.cs
@@ -71,6 +71,7 @@ namespace Orleans.Hosting
 
             services.AddOptions<StatisticsOptions>()
                 .Configure<NodeConfiguration>((options, nodeConfig) => LegacyConfigurationExtensions.CopyStatisticsOptions(nodeConfig, options));
+            services.TryConfigureFormatter<StatisticsOptions, StatisticOptionsFormatter>();
 
             // Translate legacy configuration to new Options
             services.Configure<SiloMessagingOptions>(options =>
@@ -84,6 +85,7 @@ namespace Orleans.Hosting
             });
 
             services.Configure<NetworkingOptions>(options => LegacyConfigurationExtensions.CopyNetworkingOptions(configuration.Globals, options));
+            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
 
             services.AddOptions<EndpointOptions>()
                 .Configure<IOptions<SiloOptions>>((options, siloOptions) =>
@@ -105,6 +107,7 @@ namespace Orleans.Hosting
                 options.SerializationProviders = configuration.Globals.SerializationProviders;
                 options.FallbackSerializationProvider = configuration.Globals.FallbackSerializationProvider;
             });
+            services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();
 
             services.AddOptions<GrainClassOptions>().Configure<IOptions<SiloOptions>>((options, siloOptions) =>
             {

--- a/src/Orleans.Runtime/Lifecycle/SiloLifecycleStage.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloLifecycleStage.cs
@@ -1,4 +1,6 @@
 
+using System.Xml;
+
 namespace Orleans.Runtime
 {
     /// <summary>
@@ -6,6 +8,11 @@ namespace Orleans.Runtime
     /// </summary>
     public static class SiloLifecycleStage
     {
+        /// <summary>
+        /// First ring in silo's lifecycle
+        /// </summary>
+        public const int First = int.MinValue;
+
         /// <summary>
         /// Initialize silo runtime
         /// </summary>

--- a/src/Orleans.Runtime/OptionsLogger/OptionsLogger.cs
+++ b/src/Orleans.Runtime/OptionsLogger/OptionsLogger.cs
@@ -7,7 +7,6 @@ namespace Orleans.Runtime
 {
     internal class SiloOptionsLogger : OptionsLogger, ILifecycleParticipant<ISiloLifecycle>
     {
-        private int SiloOptionLoggerLifeCycleRing = int.MinValue;
         public SiloOptionsLogger(ILogger<SiloOptionsLogger> logger, IServiceProvider services)
             : base(logger, services)
         {
@@ -15,7 +14,7 @@ namespace Orleans.Runtime
 
         public void Participate(ISiloLifecycle lifecycle)
         {
-            lifecycle.Subscribe(SiloOptionLoggerLifeCycleRing, this.OnStart);
+            lifecycle.Subscribe(SiloLifecycleStage.First, this.OnStart);
         }
 
         public Task OnStart(CancellationToken token)

--- a/src/Orleans.Runtime/OptionsLogger/OptionsLogger.cs
+++ b/src/Orleans.Runtime/OptionsLogger/OptionsLogger.cs
@@ -7,6 +7,7 @@ namespace Orleans.Runtime
 {
     internal class SiloOptionsLogger : OptionsLogger, ILifecycleParticipant<ISiloLifecycle>
     {
+        private int SiloOptionLoggerLifeCycleRing = int.MinValue;
         public SiloOptionsLogger(ILogger<SiloOptionsLogger> logger, IServiceProvider services)
             : base(logger, services)
         {
@@ -14,10 +15,10 @@ namespace Orleans.Runtime
 
         public void Participate(ISiloLifecycle lifecycle)
         {
-            lifecycle.Subscribe(SiloLifecycleStage.RuntimeInitialize, this.OnRuntimeInitializeStart);
+            lifecycle.Subscribe(SiloOptionLoggerLifeCycleRing, this.OnStart);
         }
 
-        public Task OnRuntimeInitializeStart(CancellationToken token)
+        public Task OnStart(CancellationToken token)
         {
             this.LogOptions();
             return Task.CompletedTask;

--- a/src/Orleans.Runtime/OptionsLogger/OptionsLogger.cs
+++ b/src/Orleans.Runtime/OptionsLogger/OptionsLogger.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.Runtime
+{
+    internal class SiloOptionsLogger : OptionsLogger, ILifecycleParticipant<ISiloLifecycle>
+    {
+        public SiloOptionsLogger(ILogger<SiloOptionsLogger> logger, IServiceProvider services)
+            : base(logger, services)
+        {
+        }
+
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(SiloLifecycleStage.RuntimeInitialize, this.OnRuntimeInitializeStart);
+        }
+
+        public Task OnRuntimeInitializeStart(CancellationToken token)
+        {
+            this.LogOptions();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Tester/LogFomatterTests.cs
+++ b/test/Tester/LogFomatterTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Xunit;
+
+namespace Tester
+{
+    [TestCategory("BVT")]
+    public class LogFomatterTests
+    {
+        [Fact]
+        public void CanResolveFormatter()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.Configure<TestOptions>(options => options.IntField = 1);
+            services.ConfigureFormatter<TestOptions, TestOptionsFormatter>();
+            var servicesProvider = services.BuildServiceProvider();
+            var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
+            Assert.Single(logFormatters);
+            Assert.True(logFormatters.First() is TestOptionsFormatter);
+            Assert.True(logFormatters.First() is IOptionFormatter<TestOptions>);
+        }
+
+        [Fact]
+        public void FormatterConfiguredTwiceLeadsToDuplicatedFormatter()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.Configure<TestOptions>(options => options.IntField = 1);
+            services.ConfigureFormatter<TestOptions, TestOptionsFormatter>();
+            //the formatter configured second time will override the first one in DI and
+            //DI will end up with two formatter for the same option
+            services.ConfigureFormatter<TestOptions, TestOptionsFormatter2>();
+            var servicesProvider = services.BuildServiceProvider();
+            var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
+            Assert.True(logFormatters.Count() == 2);
+            Assert.True(logFormatters.First() is TestOptionsFormatter2);
+            Assert.True(logFormatters.ElementAt(1) is TestOptionsFormatter2);
+        }
+
+        [Fact]
+        public void DefaultFormatterWontOverrideCustomFormatter()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.Configure<TestOptions>(options => options.IntField = 1);
+            services.ConfigureFormatter<TestOptions, TestOptionsFormatter>();
+            //TestOptionsFormatter2 is configured as the default 
+            services.TryConfigureFormatter<TestOptions, TestOptionsFormatter2>();
+            var servicesProvider = services.BuildServiceProvider();
+            var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
+            Assert.Single(logFormatters);
+            Assert.True(logFormatters.First() is TestOptionsFormatter);
+            Assert.True(logFormatters.First() is IOptionFormatter<TestOptions>);
+        }
+
+        [Fact]
+        public void NamedFormatterConfiguredTwiceLeadsToDuplicatedFormatter()
+        {
+            string name = "test";
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.Configure<TestOptions>(options => options.IntField = 1);
+            services.ConfigureFormatter<TestOptions, TestOptionFormatterResolver>(name);
+            //the formatter configured second time will override the first one in DI and
+            //DI will end up with two formatter for the same option
+            services.ConfigureFormatter<TestOptions, TestOptionFormatterResolver2>(name);
+            var servicesProvider = services.BuildServiceProvider();
+            var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
+            Assert.True(logFormatters.Count() == 2);
+            Assert.True(logFormatters.First() is TestOptionsFormatter2);
+            Assert.True(logFormatters.ElementAt(1) is TestOptionsFormatter2);
+        }
+
+        [Fact]
+        public void NamedDefaultFormatterWontOverrideCustomFormatter()
+        {
+            string name = "test";
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.Configure<TestOptions>(options => options.IntField = 1);
+            services.ConfigureFormatter<TestOptions, TestOptionFormatterResolver>(name);
+            //TestOptionsFormatter2 is configured as the default 
+            services.TryConfigureFormatter<TestOptions, TestOptionFormatterResolver2>(name);
+            var servicesProvider = services.BuildServiceProvider();
+            var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
+            Assert.Single(logFormatters);
+            Assert.True(logFormatters.First() is TestOptionsFormatter);
+            Assert.True(logFormatters.First() is IOptionFormatter<TestOptions>);
+        }
+
+        public class TestOptions
+        {
+            public int IntField { get; set; } = 1;
+        }
+
+        public class TestOptionsFormatter2 : IOptionFormatter<TestOptions>
+        {
+            public string Category { get; }
+
+            public string Name => nameof(TestOptions);
+
+            private TestOptions options;
+            public TestOptionsFormatter2(IOptions<TestOptions> options)
+            {
+                this.options = options.Value;
+            }
+
+            public IEnumerable<string> Format()
+            {
+                return new List<string>()
+                {
+                    OptionFormattingUtilities.Format(nameof(options.IntField), options.IntField)
+                };
+            }
+        }
+
+        public class TestOptionsFormatter : IOptionFormatter<TestOptions>
+        {
+            public string Category { get; }
+
+            public string Name => nameof(TestOptions);
+
+            private TestOptions options;
+            public TestOptionsFormatter(IOptions<TestOptions> options)
+            {
+                this.options = options.Value;
+            }
+
+            public IEnumerable<string> Format()
+            {
+               return new List<string>()
+               {
+                   OptionFormattingUtilities.Format(nameof(options.IntField), options.IntField)
+               };
+            }
+        }
+
+        public class TestOptionFormatterResolver : IOptionFormatterResolver<TestOptions>
+        {
+            private IOptionsSnapshot<TestOptions> optionsAccessor;
+            public TestOptionFormatterResolver(IOptionsSnapshot<TestOptions> optionsAccessor)
+            {
+                this.optionsAccessor = optionsAccessor;
+            }
+
+            public IOptionFormatter<TestOptions> Resolve(string name)
+            {
+                return new TestOptionsFormatter(Options.Create(optionsAccessor.Get(name)));
+            }
+        }
+
+        public class TestOptionFormatterResolver2 : IOptionFormatterResolver<TestOptions>
+        {
+            private IOptionsSnapshot<TestOptions> optionsAccessor;
+            public TestOptionFormatterResolver2(IOptionsSnapshot<TestOptions> optionsAccessor)
+            {
+                this.optionsAccessor = optionsAccessor;
+            }
+
+            public IOptionFormatter<TestOptions> Resolve(string name)
+            {
+                return new TestOptionsFormatter2(Options.Create(optionsAccessor.Get(name)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add IOptionFormatter and IOptionResolver interfaces
- Add extension methods to provide better usability to configure option and option formatter together 
- Added option formatter for some options as a starting point

Didn't end up adding interface `IOptionsLogger` for two reasons
- not many people will be interested in writing their own IOptionsLogger, we should be wary to add an public interface which no user expressed need for
-  the interface is mostly just a marker interface, as a marker interface it doesn't really bring any constraints or guidance on how user should be using it. 

So I end up just created two internal class `SiloOptionsLogger` and `ClientOptionsLogger` which share the same base class `OptionsLogger`. SiloOptionsLogger subscribed to silo lifecycle, and ClientOptionsLogger subscribed to client lifecycle 

