### PR TITLE
Mark all created threads as background & name all threads

### DIFF
--- a/src/Orleans.Runtime/Silo/SiloHost.cs
+++ b/src/Orleans.Runtime/Silo/SiloHost.cs
@@ -178,12 +178,15 @@ namespace Orleans.Runtime.Host
                     if (shutdownEvent != null)
                     {
                         var shutdownThread = new Thread(o =>
-                                       {
-                                           shutdownEvent.WaitOne();
-                                           logger.Info(ErrorCode.SiloShutdownEventReceived, "Received a shutdown event. Starting graceful shutdown.");
-                                           orleans.Shutdown();
-                                       });
-                        shutdownThread.IsBackground = true;
+                        {
+                            shutdownEvent.WaitOne();
+                            logger.Info(ErrorCode.SiloShutdownEventReceived, "Received a shutdown event. Starting graceful shutdown.");
+                            orleans.Shutdown();
+                        })
+                        {
+                            IsBackground = true,
+                            Name = "SiloShutdownMonitor"
+                        };
                         shutdownThread.Start(); 
                     }
 
@@ -266,8 +269,11 @@ namespace Orleans.Runtime.Host
             var shutdownThread = new Thread(o =>
             {
                 orleans.Shutdown();
-            });
-            shutdownThread.IsBackground = true;
+            })
+            {
+                IsBackground = true,
+                Name = nameof(ShutdownOrleansSiloAsync)
+            };
             shutdownThread.Start();
 
             return WaitForOrleansSiloShutdownAsync(millisecondsTimeout, cancellationToken);

--- a/src/Orleans.Transactions/InClusterTM/ActiveTransactionsTracker.cs
+++ b/src/Orleans.Transactions/InClusterTM/ActiveTransactionsTracker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
@@ -28,7 +28,11 @@ namespace Orleans.Transactions
             lockObj = new object();
 
             allocationEvent = new AutoResetEvent(true);
-            allocationThread = new Thread(AllocateTransactionId);
+            allocationThread = new Thread(AllocateTransactionId)
+            {
+                IsBackground = true,
+                Name = nameof(ActiveTransactionsTracker)
+            };
         }
 
         public void Start(long initialTransactionId)

--- a/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
+++ b/test/TesterInternal/GeoClusterTests/GlobalSingleInstanceClusterTests.cs
@@ -237,7 +237,11 @@ namespace Tests.GeoClusterTests
 
                 // Given a config file, create client starts a client in a new appdomain. We also create a thread on which the client will run.
                 // The thread takes a "ClientThreadArgs" as argument.
-                var thread = new Thread(ThreadFunc);
+                var thread = new Thread(ThreadFunc)
+                {
+                    IsBackground = true,
+                    Name = $"{this.GetType()}.{nameof(CreationRace)}"
+                };
                 var threadFuncArgs = new ClientThreadArgs
                 {
                     client = client,


### PR DESCRIPTION
Docs on Foreground vs Background threads: https://docs.microsoft.com/en-us/dotnet/standard/threading/foreground-and-background-threads : 

> A managed thread is either a background thread or a foreground thread. Background threads are identical to foreground threads with one exception: a background thread does not keep the managed execution environment running. Once all foreground threads have been stopped in a managed process (where the .exe file is a managed assembly), the system stops all background threads and shuts down. 

> If you use a thread to monitor an activity, such as a socket connection, set its IsBackground property to true so that the thread does not prevent your process from terminating. 

I believe that it's good hygiene for us to ensure that all of our threads are created as background threads in order to avoid potential zombie processes and given descriptive names. Names help with profiling and debugging at the least.