### PR TITLE
Update Service Fabric to support .NET Standard

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,7 +69,7 @@
     <MicrosoftAzureEventHubsVersion>1.0.3</MicrosoftAzureEventHubsVersion>
     <MicrosoftDataSQLiteVersion>2.0.0</MicrosoftDataSQLiteVersion>
     <MicrosoftPowerShell5ReferenceAssembliesVersion>1.1.0</MicrosoftPowerShell5ReferenceAssembliesVersion>
-    <MicrosoftServiceFabricServicesVersion>2.7.198</MicrosoftServiceFabricServicesVersion>
+    <MicrosoftServiceFabricServicesVersion>3.0.456</MicrosoftServiceFabricServicesVersion>
     <WindowsAzureStorageVersion>8.2.1</WindowsAzureStorageVersion>
 
     <FSharpCoreVersion>4.2.3</FSharpCoreVersion>

--- a/Samples/ServiceFabric/Stateless/StatelessCalculatorApp/StatelessCalculatorApp.sfproj
+++ b/Samples/ServiceFabric/Stateless/StatelessCalculatorApp/StatelessCalculatorApp.sfproj
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets=";ValidateMSBuildFiles">
-  <Import Project="..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
+  <Import Project="..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.4\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.4\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>b4985c3e-42ad-4da4-9ee0-74f9493e27e1</ProjectGuid>
-    <ProjectVersion>1.6</ProjectVersion>
+    <ProjectVersion>2.0</ProjectVersion>
     <MinToolsVersion>1.5</MinToolsVersion>
+    <SupportedMSBuildNuGetPackageVersion>1.6.4</SupportedMSBuildNuGetPackageVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -35,9 +36,9 @@
     <ApplicationProjectTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Service Fabric Tools\Microsoft.VisualStudio.Azure.Fabric.ApplicationProject.targets</ApplicationProjectTargetsPath>
   </PropertyGroup>
   <Import Project="$(ApplicationProjectTargetsPath)" Condition="Exists('$(ApplicationProjectTargetsPath)')" />
-  <Import Project="..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
+  <Import Project="..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.4\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.4\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
   <Target Name="ValidateMSBuildFiles">
-    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.3\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.4\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.4\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.4\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.4\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
   </Target>
 </Project>

--- a/Samples/ServiceFabric/Stateless/StatelessCalculatorApp/packages.config
+++ b/Samples/ServiceFabric/Stateless/StatelessCalculatorApp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.3" />
+  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.4" />
 </packages>

--- a/Samples/ServiceFabric/Stateless/StatelessCalculatorService/BootstrapProvider.cs
+++ b/Samples/ServiceFabric/Stateless/StatelessCalculatorService/BootstrapProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using GrainInterfaces;
 using Orleans;

--- a/Samples/ServiceFabric/Stateless/StatelessCalculatorService/StatelessCalculatorService.csproj
+++ b/Samples/ServiceFabric/Stateless/StatelessCalculatorService/StatelessCalculatorService.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="$(OrleansPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Orleans.Hosting.ServiceFabric" Version="$(OrleansPackageVersion)" />
     <PackageReference Include="Microsoft.Orleans.Clustering.ServiceFabric" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="Microsoft.Orleans.Runtime.Legacy" Version="$(OrleansPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GrainInterfaces\GrainInterfaces.csproj" />

--- a/src/Orleans.Clustering.ServiceFabric/Orleans.Clustering.ServiceFabric.csproj
+++ b/src/Orleans.Clustering.ServiceFabric/Orleans.Clustering.ServiceFabric.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Orleans.Clustering.ServiceFabric</AssemblyName>
     <RootNamespace>Orleans.Clustering.ServiceFabric</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/Orleans.Hosting.ServiceFabric/Orleans.Hosting.ServiceFabric.csproj
+++ b/src/Orleans.Hosting.ServiceFabric/Orleans.Hosting.ServiceFabric.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Orleans.Hosting.ServiceFabric</AssemblyName>
     <RootNamespace>Orleans.Hosting.ServiceFabric</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
+++ b/src/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <PackageId>Microsoft.Orleans.ServiceFabric</PackageId>
     <Title>Microsoft Orleans Service Fabric Support Metapackage</Title>
     <Description>Metapackage providing support for hosing Microsoft Orleans on Service Fabric.</Description>
     <PackageTags>$(PackageTags) Azure ServiceFabric</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
I'm not sure if running the sample requires VS 15.5.6 (which includes SF SDK 6.1), but if you have trouble running the sample then that might be why.