### PR TITLE
Update SourceLink

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -99,7 +99,7 @@
     <NodaTimeVersion>2.2.2</NodaTimeVersion>
 
     <!-- Tooling related packages -->
-    <SourceLinkVersion>2.5.0</SourceLinkVersion>
+    <SourceLinkVersion>2.7.6</SourceLinkVersion>
   </PropertyGroup>
 
   <!-- Versioning properties -->


### PR DESCRIPTION
Removes those out-of-place git hashes from our build output.
![image](https://user-images.githubusercontent.com/203839/35547425-2464e03e-05cd-11e8-9994-28011b6bc231.png)
