### PR TITLE
Use UriBuilder instead of String.Format in ToGatewayUri()

### DIFF
--- a/src/Orleans.Core/Utils/Utils.cs
+++ b/src/Orleans.Core/Utils/Utils.cs
@@ -160,7 +160,8 @@ namespace Orleans.Runtime
         /// <returns></returns>
         public static Uri ToGatewayUri(this System.Net.IPEndPoint ep)
         {
-            return new Uri(string.Format("gwy.tcp://{0}:{1}/0", ep.Address, ep.Port));
+            var builder = new UriBuilder("gwy.tcp", ep.Address.ToString(), ep.Port, "0");
+            return builder.Uri;
         }
 
         /// <summary>
@@ -170,7 +171,8 @@ namespace Orleans.Runtime
         /// <returns></returns>
         public static Uri ToGatewayUri(this SiloAddress address)
         {
-            return new Uri(string.Format("gwy.tcp://{0}:{1}/{2}", address.Endpoint.Address, address.Endpoint.Port, address.Generation));
+            var builder = new UriBuilder("gwy.tcp", address.Endpoint.Address.ToString(), address.Endpoint.Port, address.Generation.ToString());
+            return builder.Uri;
         }
 
         

--- a/test/NonSilo.Tests/General/UtilsTests.cs
+++ b/test/NonSilo.Tests/General/UtilsTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using UnitTests.TestHelper;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace UnitTests.UtilsTests
+{
+    [TestCategory("Utils")]
+    public class UtilsTests
+    {
+        private readonly ITestOutputHelper output;
+
+
+        public UtilsTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact, TestCategory("BVT")]
+        public void ToGatewayUriTest()
+        {
+            var ipv4 = new IPEndPoint(IPAddress.Any, 11111);
+            var uri = ipv4.ToGatewayUri();
+            Assert.Equal("gwy.tcp://0.0.0.0:11111/0", uri.ToString());
+
+            var ipv4silo = SiloAddress.New(ipv4, 100);
+            uri = ipv4silo.ToGatewayUri();
+            Assert.Equal("gwy.tcp://0.0.0.0:11111/100", uri.ToString());
+
+            var ipv6 = new IPEndPoint(IPAddress.IPv6Any, 11111);
+            uri = ipv6.ToGatewayUri();
+            Assert.Equal("gwy.tcp://[::]:11111/0", uri.ToString());
+
+            var ipv6silo = SiloAddress.New(ipv6, 100);
+            uri = ipv6silo.ToGatewayUri();
+            Assert.Equal("gwy.tcp://[::]:11111/100", uri.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3832.