### PR TITLE
Fix tests. Remove ServiceId and ClusterId getter, turn on file logging

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/SqlUtilsHostingExtensions.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/SqlUtilsHostingExtensions.cs
@@ -45,7 +45,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure DI container with SqlMemebership
+        /// Configure DI container with SqlMembership
         /// </summary>
         public static IServiceCollection UseSqlMembership(this IServiceCollection services,
             Action<SqlMembershipOptions> configureOptions)
@@ -54,7 +54,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure DI container with SqlMemebership
+        /// Configure DI container with SqlMembership
         /// </summary>
         public static IServiceCollection UseSqlMembership(this IServiceCollection services,
             Action<OptionsBuilder<SqlMembershipOptions>> configureOptions)

--- a/src/Orleans.Clustering.Consul/ConsulUtilsHostingExtensions.cs
+++ b/src/Orleans.Clustering.Consul/ConsulUtilsHostingExtensions.cs
@@ -46,7 +46,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure DI container with Consul based Memebership
+        /// Configure DI container with Consul based Membership
         /// </summary>
         public static IServiceCollection UseConsulMembership(this IServiceCollection services,
             Action<ConsulMembershipOptions> configureOptions)
@@ -55,7 +55,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure DI container with Consul based Memebership
+        /// Configure DI container with Consul based Membership
         /// </summary>
         public static IServiceCollection UseConsulMembership(this IServiceCollection services,
             Action<OptionsBuilder<ConsulMembershipOptions>> configureOptions)

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperHostingExtensions.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperHostingExtensions.cs
@@ -46,7 +46,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure DI container with ZooKeeper based Memebership
+        /// Configure DI container with ZooKeeper based Membership
         /// </summary>
         public static IServiceCollection UseZooKeeperMembership(this IServiceCollection services,
             Action<ZooKeeperMembershipOptions> configureOptions)
@@ -55,7 +55,7 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
-        /// Configure DI container with ZooKeeper based Memebership
+        /// Configure DI container with ZooKeeper based Membership
         /// </summary>
         public static IServiceCollection UseZooKeeperMembership(this IServiceCollection services,
             Action<OptionsBuilder<ZooKeeperMembershipOptions>> configureOptions)

--- a/src/Orleans.TestingHost/LegacyTestClusterConfiguration.cs
+++ b/src/Orleans.TestingHost/LegacyTestClusterConfiguration.cs
@@ -55,7 +55,6 @@ namespace Orleans.TestingHost
             {
                 config.Globals.ClusterId = this.builder.Options.ClusterId;
             }
-
             config.Globals.ExpectedClusterSize = this.builder.Options.InitialSilosCount;
             config.Globals.AssumeHomogenousSilosForTesting = this.builder.Options.AssumeHomogenousSilosForTesting;
 

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -28,21 +28,26 @@ namespace Orleans.TestingHost
     /// </remarks>
     public class TestCluster
     {
+        private readonly List<SiloHandle> additionalSilos = new List<SiloHandle>();
+        private readonly TestClusterOptions options;
+        private readonly StringBuilder log = new StringBuilder();
+
         private int startedInstances;
 
         /// <summary>
-        /// Primary silo handle
+        /// Primary silo handle, if applicable.
         /// </summary>
-        /// <remarks>This only provide valid data if your cluster are using GrainBasedMemebership</remarks>
+        /// <remarks>This handle is valid only when using Grain-based membership.</remarks>
         public SiloHandle Primary { get; private set; }
 
         /// <summary>
-        /// List of handles to the secondary silos
+        /// List of handles to the secondary silos.
         /// </summary>
         public IReadOnlyList<SiloHandle> SecondarySilos => this.additionalSilos;
 
-        private readonly List<SiloHandle> additionalSilos = new List<SiloHandle>();
-
+        /// <summary>
+        /// Collection of all known silos.
+        /// </summary>
         public ReadOnlyCollection<SiloHandle> Silos
         {
             get
@@ -59,13 +64,12 @@ namespace Orleans.TestingHost
             }
         }
 
-        private readonly StringBuilder log = new StringBuilder();
-
         /// <summary>
-        /// Options you used to configure your test cluster
+        /// Options used to configure the test cluster.
         /// </summary>
         /// <remarks>This is the options you configured your test cluster with, or the default one. 
-        ///If you configured your TestCluster with ClusterConfiguration, then this option may not reflect settings in that.</remarks>
+        /// If the cluster is being configured via ClusterConfiguration, then this object may not reflect the true settings.
+        /// </remarks>
         public TestClusterOptions Options => this.options;
 
         /// <summary>
@@ -97,8 +101,6 @@ namespace Orleans.TestingHost
         /// SerializationManager to use in the tests
         /// </summary>
         public SerializationManager SerializationManager { get; private set; }
-
-        private readonly TestClusterOptions options;
         
         /// <summary>
         /// Configures the test cluster plus client in-process.

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -33,6 +33,7 @@ namespace Orleans.TestingHost
         /// <summary>
         /// Primary silo handle
         /// </summary>
+        /// <remarks>This only provide valid data if your cluster are using GrainBasedMemebership</remarks>
         public SiloHandle Primary { get; private set; }
 
         /// <summary>
@@ -60,17 +61,12 @@ namespace Orleans.TestingHost
 
         private readonly StringBuilder log = new StringBuilder();
 
+        /// <summary>
+        /// Options you used to configure your test cluster
+        /// </summary>
+        /// <remarks>This is the options you configured your test cluster with, or the default one. 
+        ///If you configured your TestCluster with ClusterConfiguration, then this option may not reflect settings in that.</remarks>
         public TestClusterOptions Options => this.options;
-
-        /// <summary>
-        /// ClusterId of the cluster
-        /// </summary>
-        public string ClusterId => this.options.ClusterId;
-
-        /// <summary>
-        /// ServiceId of the cluster
-        /// </summary>
-        public Guid ServiceId => this.options.ServiceId;
 
         /// <summary>
         /// The internal client interface.

--- a/src/Orleans.TestingHost/TestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/TestClusterBuilder.cs
@@ -101,7 +101,7 @@ namespace Orleans.TestingHost
             return testCluster;
         }
 
-        private static string CreateClusterId()
+        public static string CreateClusterId()
         {
             string prefix = "testcluster-";
             int randomSuffix = ThreadSafeRandom.Next(1000);

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -30,7 +30,7 @@ namespace Orleans.TestingHost
             }
             var configuration = configBuilder.Build();
 
-            string siloName = configuration["SiloName"] ?? hostName;
+            string siloName = configuration[nameof(TestSiloSpecificOptions.SiloName)] ?? hostName;
 
             ISiloHostBuilder hostBuilder = new SiloHostBuilder()
                 .ConfigureOrleans(ob => ob.Bind(configuration).Configure(options => options.SiloName = options.SiloName ?? siloName))
@@ -119,8 +119,8 @@ namespace Orleans.TestingHost
 
         private static void ConfigureListeningPorts(HostBuilderContext context, IServiceCollection services)
         {
-            int siloPort = int.Parse(context.Configuration["SiloPort"]);
-            int gatewayPort = int.Parse(context.Configuration["GatewayPort"]);
+            int siloPort = int.Parse(context.Configuration[nameof(TestSiloSpecificOptions.SiloPort)]);
+            int gatewayPort = int.Parse(context.Configuration[nameof(TestSiloSpecificOptions.GatewayPort)]);
 
             services.Configure<EndpointOptions>(options =>
             {
@@ -201,7 +201,7 @@ namespace Orleans.TestingHost
             // If the test involves a custom membership oracle and no membership table, special care will be required
             if (useTestClusterMembership && services.All(svc => svc.ServiceType != typeof(IMembershipTable)))
             {
-                var primarySiloEndPoint = new IPEndPoint(IPAddress.Loopback, int.Parse(context.Configuration["PrimarySiloPort"]));
+                var primarySiloEndPoint = new IPEndPoint(IPAddress.Loopback, int.Parse(context.Configuration[nameof(TestSiloSpecificOptions.PrimarySiloPort)]));
 
                 services.UseDevelopmentMembership(options => options.PrimarySiloEndpoint = primarySiloEndPoint);
             }
@@ -214,8 +214,8 @@ namespace Orleans.TestingHost
             {
                 services.UseStaticGatewayListProvider(options =>
                 {
-                    int baseGatewayPort = int.Parse(configuration["BaseGatewayPort"]);
-                    int initialSilosCount = int.Parse(configuration["InitialSilosCount"]);
+                    int baseGatewayPort = int.Parse(configuration[nameof(TestClusterOptions.BaseGatewayPort)]);
+                    int initialSilosCount = int.Parse(configuration[nameof(TestClusterOptions.InitialSilosCount)]);
 
                     options.Gateways = Enumerable.Range(baseGatewayPort, initialSilosCount)
                         .Select(port => new IPEndPoint(IPAddress.Loopback, port).ToGatewayUri())
@@ -227,7 +227,7 @@ namespace Orleans.TestingHost
 
         private static void TryConfigureFileLogging(IConfiguration configuration, IServiceCollection services, string name)
         {
-            var fileName = TestingUtils.CreateTraceFileName(name, configuration["ClusterId"]);
+            var fileName = TestingUtils.CreateTraceFileName(name, configuration[nameof(TestClusterOptions.ClusterId)]);
             services.AddLogging(loggingBuilder => loggingBuilder.AddFile(fileName));
         }
 

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -227,8 +227,12 @@ namespace Orleans.TestingHost
 
         private static void TryConfigureFileLogging(IConfiguration configuration, IServiceCollection services, string name)
         {
-            var fileName = TestingUtils.CreateTraceFileName(name, configuration[nameof(TestClusterOptions.ClusterId)]);
-            services.AddLogging(loggingBuilder => loggingBuilder.AddFile(fileName));
+            bool.TryParse(configuration[nameof(TestClusterOptions.ConfigureFileLogging)], out bool configureFileLogging);
+            if (configureFileLogging)
+            {
+                var fileName = TestingUtils.CreateTraceFileName(name, configuration[nameof(TestClusterOptions.ClusterId)]);
+                services.AddLogging(loggingBuilder => loggingBuilder.AddFile(fileName));
+            }
         }
 
         private static void AddDefaultApplicationParts(IApplicationPartManager applicationPartsManager)

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -227,12 +227,8 @@ namespace Orleans.TestingHost
 
         private static void TryConfigureFileLogging(IConfiguration configuration, IServiceCollection services, string name)
         {
-            bool.TryParse(configuration["UseTestClusterMemebership"], out bool configureFileLogging);
-            if (configureFileLogging)
-            {
-                var fileName = TestingUtils.CreateTraceFileName(name, configuration["ClusterId"]);
-                services.AddLogging(loggingBuilder => loggingBuilder.AddFile(fileName));
-            }
+            var fileName = TestingUtils.CreateTraceFileName(name, configuration["ClusterId"]);
+            services.AddLogging(loggingBuilder => loggingBuilder.AddFile(fileName));
         }
 
         private static void AddDefaultApplicationParts(IApplicationPartManager applicationPartsManager)

--- a/src/Orleans.TestingHost/TestClusterOptions.cs
+++ b/src/Orleans.TestingHost/TestClusterOptions.cs
@@ -14,7 +14,7 @@ namespace Orleans.TestingHost
         public bool InitializeClientOnDeploy { get; set; }
         public short InitialSilosCount { get; set; }
         public string ApplicationBaseDirectory { get; set; }
-        public bool ConfigureFileLogging { get; set; }
+        public bool ConfigureFileLogging { get; set; } = true;
         public bool AssumeHomogenousSilosForTesting { get; set; }
         public List<string> SiloBuilderConfiguratorTypes { get; } = new List<string>();
         public List<string> ClientBuilderConfiguratorTypes { get; } = new List<string>();

--- a/test/AWSUtils.Tests/StorageTests/Base_PersistenceGrainTests_AWSStore.cs
+++ b/test/AWSUtils.Tests/StorageTests/Base_PersistenceGrainTests_AWSStore.cs
@@ -263,10 +263,10 @@ namespace AWSUtils.Tests.StorageTests
 
         protected async Task Grain_AWSStore_SiloRestart()
         {
-            var initialServiceId = this.HostedCluster.ServiceId;
-            var initialDeploymentId = this.HostedCluster.ClusterId;
+            var initialServiceId = this.HostedCluster.Options.ServiceId;
+            var initialDeploymentId = this.HostedCluster.Options.ClusterId;
             var serviceId = await this.HostedCluster.Client.GetGrain<IServiceIdGrain>(Guid.Empty).GetServiceId();
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, serviceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.Options.ClusterId, serviceId);
 
             Guid id = Guid.NewGuid();
             IAWSStorageTestGrain grain = this.fixture.GrainFactory.GetGrain<IAWSStorageTestGrain>(id);
@@ -287,9 +287,9 @@ namespace AWSUtils.Tests.StorageTests
             output.WriteLine("Silos restarted");
 
             serviceId = await this.HostedCluster.Client.GetGrain<IServiceIdGrain>(Guid.Empty).GetServiceId();
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, serviceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.Options.ClusterId, serviceId);
             Assert.Equal(initialServiceId, serviceId);  // "ServiceId same after restart."
-            Assert.Equal(initialDeploymentId, this.HostedCluster.ClusterId);  // "ClusterId same after restart."
+            Assert.Equal(initialDeploymentId, this.HostedCluster.Options.ClusterId);  // "ClusterId same after restart."
 
             val = await grain.GetValue();
             Assert.Equal(1, val);  // "Value after Write-1"

--- a/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSClientStreamTests.cs
@@ -59,7 +59,7 @@ namespace AWSUtils.Tests.Streaming
 
         public override void Dispose()
         {
-            var clusterId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.Options.ClusterId;
             base.Dispose();
             SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, clusterId, StorageConnectionString, NullLoggerFactory.Instance).Wait();
         }

--- a/test/AWSUtils.Tests/Streaming/SQSStreamTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSStreamTests.cs
@@ -74,7 +74,7 @@ namespace AWSUtils.Tests.Streaming
 
         public override void Dispose()
         {
-            var clusterId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.Options.ClusterId;
             base.Dispose();
             SQSStreamProviderUtils.DeleteAllUsedQueues(SQS_STREAM_PROVIDER_NAME, clusterId, AWSTestConstants.DefaultSQSConnectionString, NullLoggerFactory.Instance).Wait();
         }

--- a/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -56,7 +56,7 @@ namespace AWSUtils.Tests.Streaming
 
         public override void Dispose()
         {
-            var clusterId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.Options.ClusterId;
             base.Dispose();
             SQSStreamProviderUtils.DeleteAllUsedQueues(SQSStreamProviderName, clusterId, StreamConnectionString, NullLoggerFactory.Instance).Wait();
         }

--- a/test/Tester/MembershipTests/LivenessTests.cs
+++ b/test/Tester/MembershipTests/LivenessTests.cs
@@ -27,7 +27,7 @@ namespace UnitTests.MembershipTests
 
         protected async Task Do_Liveness_OracleTest_1()
         {
-            output.WriteLine("ClusterId= {0}", this.HostedCluster.ClusterId);
+            output.WriteLine("ClusterId= {0}", this.HostedCluster.Options.ClusterId);
 
             SiloHandle silo3 = this.HostedCluster.StartAdditionalSilo();
 

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
@@ -25,19 +25,19 @@ namespace Tester.AzureUtils.Persistence
     [TestCategory("Persistence"), TestCategory("Azure")]
     public class PersistenceGrainTests_AzureBlobStore : Base_PersistenceGrainTests_AzureStore, IClassFixture<PersistenceGrainTests_AzureBlobStore.Fixture>
     {
+        public static Guid ServiceId = Guid.NewGuid();
         public class Fixture : BaseAzureTestClusterFixture
         {
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                Guid serviceId = Guid.NewGuid();
+                
                 builder.Options.InitialSilosCount = 4;
                 builder.Options.UseTestClusterMembership = false;
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
                     legacy.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
 
-                    legacy.ClusterConfiguration.Globals.ServiceId = serviceId;
-
+                    legacy.ClusterConfiguration.Globals.ServiceId = ServiceId;
                     legacy.ClusterConfiguration.Globals.MaxResendCount = 0;
 
                     legacy.ClusterConfiguration.Globals.RegisterStorageProvider<UnitTests.StorageTests.MockStorageProvider>("test1");
@@ -117,7 +117,7 @@ namespace Tester.AzureUtils.Persistence
         [SkippableFact, TestCategory("Functional")]
         public async Task Grain_AzureBlobStore_SiloRestart()
         {
-            await base.Grain_AzureStore_SiloRestart();
+            await base.Grain_AzureStore_SiloRestart(ServiceId);
         }
 
         [SkippableFact, TestCategory("CorePerf"), TestCategory("Performance"), TestCategory("Stress")]

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
@@ -45,7 +45,6 @@ namespace Tester.AzureUtils.Persistence
 
         private const int MaxReadTime = 200;
         private const int MaxWriteTime = 2000;
-
         public class SiloBuilderConfigurator : ISiloBuilderConfigurator
         {
             public void Configure(ISiloHostBuilder hostBuilder)
@@ -303,11 +302,11 @@ namespace Tester.AzureUtils.Persistence
             Assert.Equal(expected3,  val3);  // "Value after Re-Read - 3"
         }
 
-        protected async Task Grain_AzureStore_SiloRestart()
+        protected async Task Grain_AzureStore_SiloRestart(Guid serviceID)
         {
-            var initialServiceId = this.HostedCluster.ServiceId;
+            var initialServiceId = serviceID;
 
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, this.HostedCluster.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.Options.ClusterId, serviceID);
 
             Guid id = Guid.NewGuid();
             IAzureStorageTestGrain grain = this.GrainFactory.GetGrain<IAzureStorageTestGrain>(id);
@@ -328,7 +327,7 @@ namespace Tester.AzureUtils.Persistence
             output.WriteLine("Silos restarted");
 
             var serviceId = await this.GrainFactory.GetGrain<IServiceIdGrain>(Guid.Empty).GetServiceId();
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, serviceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.Options.ClusterId, serviceId);
             Assert.Equal(initialServiceId, serviceId);  // "ServiceId same after restart."
             
             val = await grain.GetValue();

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableStore.cs
@@ -35,18 +35,18 @@ namespace Tester.AzureUtils.Persistence
             {"DataConnectionString", TestDefaultConfiguration.DataConnectionString}
         };
 
+        public static Guid ServiceId = Guid.NewGuid();
         public class Fixture : BaseAzureTestClusterFixture
         {
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                Guid serviceId = Guid.NewGuid();
                 builder.Options.InitialSilosCount = 4;
                 builder.Options.UseTestClusterMembership = false;
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
                     legacy.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
 
-                    legacy.ClusterConfiguration.Globals.ServiceId = serviceId;
+                    legacy.ClusterConfiguration.Globals.ServiceId = ServiceId;
 
                     legacy.ClusterConfiguration.Globals.MaxResendCount = 0;
 
@@ -131,7 +131,7 @@ namespace Tester.AzureUtils.Persistence
         [SkippableFact, TestCategory("Functional")]
         public async Task Grain_AzureTableStore_SiloRestart()
         {
-            await base.Grain_AzureStore_SiloRestart();
+            await base.Grain_AzureStore_SiloRestart(ServiceId);
         }
 
         [SkippableFact, TestCategory("CorePerf"), TestCategory("Performance"), TestCategory("Stress")]

--- a/test/TesterAzureUtils/Streaming/AQClientStreamTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQClientStreamTests.cs
@@ -43,7 +43,7 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var clusterId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.Options.ClusterId;
             base.Dispose();
             AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AQStreamProviderName, clusterId,
                 TestDefaultConfiguration.DataConnectionString).Wait();

--- a/test/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
+++ b/test/TesterAzureUtils/Streaming/AQProgrammaticSubscribeTest.cs
@@ -28,7 +28,7 @@ namespace Tester.AzureUtils.Streaming
             public override void Dispose()
             {
                 base.Dispose();
-                var clusterId = this.HostedCluster?.ClusterId;
+                var clusterId = this.HostedCluster?.Options.ClusterId;
                 AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProviderName, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
                 AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProviderName2, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
             }

--- a/test/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
@@ -33,7 +33,7 @@ namespace Tester.AzureUtils.Streaming
 
             public override void Dispose()
             {
-                var clusterId = this.HostedCluster?.ClusterId;
+                var clusterId = this.HostedCluster?.Options.ClusterId;
                 base.Dispose();
                 AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProvider, clusterId, TestDefaultConfiguration.DataConnectionString)
                     .Wait();
@@ -43,7 +43,7 @@ namespace Tester.AzureUtils.Streaming
         public StreamFilteringTests_AQ(Fixture fixture) : base(fixture)
         {
             fixture.EnsurePreconditionsMet();
-            this.clusterId = fixture.HostedCluster.ClusterId;
+            this.clusterId = fixture.HostedCluster.Options.ClusterId;
             streamProviderName = Fixture.StreamProvider;
         }
 

--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -45,7 +45,7 @@ namespace Tester.AzureUtils.Streaming
         
         public override void Dispose()
         {
-            var clusterId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.Options.ClusterId;
             base.Dispose();
             AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
         }

--- a/test/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQSubscriptionMultiplicityTests.cs
@@ -37,7 +37,7 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var clusterId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.Options.ClusterId;
             base.Dispose();
             AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AQStreamProviderName, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
         }

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -49,7 +49,7 @@ namespace UnitTests.HaloTests.Streaming
 
             public override void Dispose()
             {
-                var clusterId = this.HostedCluster?.ClusterId;
+                var clusterId = this.HostedCluster?.Options.ClusterId;
                 base.Dispose();
                 if (clusterId != null)
                 {
@@ -77,7 +77,7 @@ namespace UnitTests.HaloTests.Streaming
 
         public void Dispose()
         {
-            var clusterId = this.HostedCluster?.ClusterId;
+            var clusterId = this.HostedCluster?.Options.ClusterId;
             if (clusterId != null && _streamProvider != null && _streamProvider.Equals(AzureQueueStreamProviderName))
             {
                 AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(this.loggerFactory, _streamProvider, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();

--- a/test/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/SampleAzureQueueStreamingTests.cs
@@ -33,7 +33,7 @@ namespace Tester.AzureUtils.Streaming
 
         public override void Dispose()
         {
-            var clusterId = HostedCluster?.ClusterId;
+            var clusterId = HostedCluster?.Options.ClusterId;
             if (clusterId != null)
             {
                 AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, StreamProvider, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -111,7 +111,7 @@ namespace UnitTests.Streaming.Reliability
             }
             Task.WhenAll(promises).Wait();
 #endif
-            var clusterId = HostedCluster.ClusterId;
+            var clusterId = HostedCluster.Options.ClusterId;
             base.Dispose();
             if (_streamProviderName != null && _streamProviderName.Equals(AZURE_QUEUE_STREAM_PROVIDER_NAME))
             {
@@ -136,15 +136,12 @@ namespace UnitTests.Streaming.Reliability
             StreamTestUtils.LogStartTest(testName, _streamId, _streamProviderName, logger, HostedCluster);
 
             CheckSilosRunning("Before Restart", numExpectedSilos);
-            SiloHandle prim1 = this.HostedCluster.Primary;
-            SiloHandle sec1 = this.HostedCluster.SecondarySilos.First();
-
+            var silos = this.HostedCluster.Silos;
             RestartAllSilos();
 
             CheckSilosRunning("After Restart", numExpectedSilos);
-
-            Assert.NotEqual(prim1, this.HostedCluster.Primary); // Should be different Primary silos after restart
-            Assert.NotEqual(sec1, this.HostedCluster.SecondarySilos.First()); // Should be different Secondary silos after restart
+            
+            Assert.NotEqual(silos, this.HostedCluster.Silos); // Should be different silos after restart
 
             StreamTestUtils.LogEndTest(testName, logger);
         }

--- a/test/TesterInternal/StreamProvidersTests.cs
+++ b/test/TesterInternal/StreamProvidersTests.cs
@@ -92,7 +92,7 @@ namespace UnitTests.Streaming
 
             output.WriteLine("..... Silos restarted");
 
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.ClusterId, this.fixture.ClusterConfiguration.Globals.ServiceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.Options.ClusterId, this.fixture.ClusterConfiguration.Globals.ServiceId);
 
             Assert.Equal(ServiceId, this.fixture.ClusterConfiguration.Globals.ServiceId);  // "ServiceId same after restart."
 


### PR DESCRIPTION
- fix some tests
- remove `ServiceId` and `ClusterId` getter from `TestCluster`, since they are misleading. They only reflect values you set using `TestClusterOptions`, may not reflect values if you configure cluster using legacy `ClusterConfiguration`. 
- turn on file logger for TestCluster by default
