### PR TITLE
Remove reflection usage from hot path

### DIFF
--- a/src/Orleans.Core/CodeGeneration/GrainInterfaceUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/GrainInterfaceUtils.cs
@@ -97,13 +97,6 @@ namespace Orleans.CodeGeneration
                 || IsStatelessWorker(methodInfo);
         }
 
-        public static bool IsStatelessWorker(TypeInfo grainTypeInfo)
-        {
-            return grainTypeInfo.GetCustomAttributes(typeof(StatelessWorkerAttribute), true).Any() ||
-                grainTypeInfo.GetInterfaces()
-                    .Any(i => i.GetTypeInfo().GetCustomAttributes(typeof(StatelessWorkerAttribute), true).Any());
-        }
-
         public static bool IsStatelessWorker(MethodInfo methodInfo)
         {
             var declaringTypeInfo = methodInfo.DeclaringType.GetTypeInfo();

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -619,7 +619,7 @@ namespace Orleans.Runtime
             string limitName = LimitNames.LIMIT_MAX_ENQUEUED_REQUESTS;
             int maxRequestsHardLimit = this.messagingOptions.MaxEnqueuedRequestsHardLimit;
             int maxRequestsSoftLimit = this.messagingOptions.MaxEnqueuedRequestsSoftLimit;
-            if (GrainInstanceType != null && CodeGeneration.GrainInterfaceUtils.IsStatelessWorker(GrainInstanceType.GetTypeInfo()))
+            if (IsStatelessWorker)
             {
                 limitName = LimitNames.LIMIT_MAX_ENQUEUED_REQUESTS_STATELESS_WORKER;
                 maxRequestsHardLimit = this.messagingOptions.MaxEnqueuedRequestsHardLimit_StatelessWorker;


### PR DESCRIPTION
`IsStatelessWorker` check was iterating through type attributes.