### PR TITLE
More options formatting, and related cleanup

### DIFF
--- a/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
@@ -565,8 +565,6 @@ namespace Orleans.Runtime.Configuration
         private const int DEFAULT_GLOBAL_SINGLE_INSTANCE_NUMBER_RETRIES = 10;
         private const int DEFAULT_LIVENESS_EXPECTED_CLUSTER_SIZE = 20;
         public static bool ENFORCE_MINIMUM_REQUIREMENT_FOR_AGE_LIMIT = true;
-        public const bool DEFAULT_PERFORM_DEADLOCK_DETECTION = false;
-        public const bool DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY = false;
         public static readonly string DEFAULT_MULTICLUSTER_REGISTRATION_STRATEGY = typeof(GlobalSingleInstanceRegistration).Name;
 
         private string dataConnectionStringForReminders;
@@ -615,8 +613,8 @@ namespace Orleans.Runtime.Configuration
             this.DirectoryLazyDeregistrationDelay = GrainDirectoryOptions.DEFAULT_UNREGISTER_RACE_DELAY;
             this.ClientRegistrationRefresh = SiloMessagingOptions.DEFAULT_CLIENT_REGISTRATION_REFRESH;
 
-            this.PerformDeadlockDetection = DEFAULT_PERFORM_DEADLOCK_DETECTION;
-            this.AllowCallChainReentrancy = DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY;
+            this.PerformDeadlockDetection = SchedulingOptions.DEFAULT_PERFORM_DEADLOCK_DETECTION;
+            this.AllowCallChainReentrancy = SchedulingOptions.DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY;
             this.reminderServiceType = ReminderServiceProviderType.NotSpecified;
             this.DefaultPlacementStrategy = GrainPlacementOptions.DEFAULT_PLACEMENT_STRATEGY;
             this.DeploymentLoadPublisherRefreshTime = SiloStatisticsOptions.DEFAULT_DEPLOYMENT_LOAD_PUBLISHER_REFRESH_TIME;

--- a/src/Orleans.Core.Legacy/Configuration/NodeConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/NodeConfiguration.cs
@@ -207,7 +207,7 @@ namespace Orleans.Runtime.Configuration
             this.MaxActiveThreads = SchedulingOptions.DEFAULT_MAX_ACTIVE_THREADS;
             this.DelayWarningThreshold = SchedulingOptions.DEFAULT_DELAY_WARNING_THRESHOLD;
             this.ActivationSchedulingQuantum = SchedulingOptions.DEFAULT_ACTIVATION_SCHEDULING_QUANTUM;
-            this.TurnWarningLengthThreshold = SchedulingOptions.DEFAULT_DELAY_WARNING_THRESHOLD;
+            this.TurnWarningLengthThreshold = SchedulingOptions.DEFAULT_TURN_WARNING_THRESHOLD;
             this.EnableWorkerThreadInjection = SchedulingOptions.DEFAULT_ENABLE_WORKER_THREAD_INJECTION;
 
             this.LoadSheddingEnabled = false;

--- a/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 
@@ -19,7 +18,7 @@ namespace Orleans.Hosting
         public int ClientSenderBuckets { get; set; } = 8192;
     }
 
-    public class ClientMessagingOptionFormatter : IOptionFormatter<ClientMessagingOptions>
+    public class ClientMessagingOptionFormatter : MessagingOptionsFormatter, IOptionFormatter<ClientMessagingOptions>
     {
         public string Category { get; }
 
@@ -27,24 +26,19 @@ namespace Orleans.Hosting
 
         private ClientMessagingOptions options;
         public ClientMessagingOptionFormatter(IOptions<ClientMessagingOptions> messageOptions)
+            : base(messageOptions.Value)
         {
             options = messageOptions.Value;
         }
 
         public IEnumerable<string> Format()
         {
-            return new List<string>()
+            List<string> format = base.FormatStatisticsOptions();
+            format.AddRange(new List<string>
             {
                 OptionFormattingUtilities.Format(nameof(options.ClientSenderBuckets), options.ClientSenderBuckets),
-
-                OptionFormattingUtilities.Format(nameof(options.ResponseTimeout), options.ResponseTimeout),
-                OptionFormattingUtilities.Format(nameof(options.MaxResendCount), options.MaxResendCount),
-                OptionFormattingUtilities.Format(nameof(options.ResendOnTimeout), options.ResendOnTimeout),
-                OptionFormattingUtilities.Format(nameof(options.DropExpiredMessages), options.DropExpiredMessages),
-                OptionFormattingUtilities.Format(nameof(options.BufferPoolBufferSize), options.BufferPoolBufferSize),
-                OptionFormattingUtilities.Format(nameof(options.BufferPoolMaxSize), options.BufferPoolMaxSize),
-                OptionFormattingUtilities.Format(nameof(options.BufferPoolPreallocationSize), options.BufferPoolPreallocationSize)
-            };
+            });
+            return format;
         }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
@@ -33,7 +33,7 @@ namespace Orleans.Hosting
 
         public IEnumerable<string> Format()
         {
-            List<string> format = base.FormatStatisticsOptions();
+            List<string> format = base.FormatSharedOptions();
             format.AddRange(new List<string>
             {
                 OptionFormattingUtilities.Format(nameof(options.ClientSenderBuckets), options.ClientSenderBuckets),

--- a/src/Orleans.Core/Configuration/Options/ClientStatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientStatisticsOptions.cs
@@ -24,7 +24,7 @@ namespace Orleans.Hosting
 
         public IEnumerable<string> Format()
         {
-            return base.FormatStatisticsOptions();
+            return base.FormatSharedOptions();
         }
     }
 

--- a/src/Orleans.Core/Configuration/Options/GrainDirectoryOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GrainDirectoryOptions.cs
@@ -1,5 +1,7 @@
 
+using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Generic;
 
 namespace Orleans.Hosting
 {
@@ -61,5 +63,31 @@ namespace Orleans.Hosting
         /// </summary>
         public TimeSpan LazyDeregistrationDelay { get; set; } = DEFAULT_UNREGISTER_RACE_DELAY;
         public static readonly TimeSpan DEFAULT_UNREGISTER_RACE_DELAY = TimeSpan.FromMinutes(1);
+    }
+
+    public class GrainDirectoryOptionsFormatter : IOptionFormatter<GrainDirectoryOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(GrainDirectoryOptions);
+
+        private GrainDirectoryOptions options;
+        public GrainDirectoryOptionsFormatter(IOptions<GrainDirectoryOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.CachingStrategy),options.CachingStrategy),
+                OptionFormattingUtilities.Format(nameof(options.CacheSize),options.CacheSize),
+                OptionFormattingUtilities.Format(nameof(options.InitialCacheTTL),options.InitialCacheTTL),
+                OptionFormattingUtilities.Format(nameof(options.MaximumCacheTTL),options.MaximumCacheTTL),
+                OptionFormattingUtilities.Format(nameof(options.CacheTTLExtensionFactor),options.CacheTTLExtensionFactor),
+                OptionFormattingUtilities.Format(nameof(options.LazyDeregistrationDelay),options.LazyDeregistrationDelay),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/GrainPlacementOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GrainPlacementOptions.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Options;
 using Orleans.Runtime;
+using System.Collections.Generic;
 
 namespace Orleans.Hosting
 {
@@ -9,5 +11,27 @@ namespace Orleans.Hosting
 
         public int ActivationCountPlacementChooseOutOf { get; set; } = DEFAULT_ACTIVATION_COUNT_PLACEMENT_CHOOSE_OUT_OF;
         public const int DEFAULT_ACTIVATION_COUNT_PLACEMENT_CHOOSE_OUT_OF = 2;
+    }
+
+    public class GrainPlacementOptionsFormatter : IOptionFormatter<GrainPlacementOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(GrainPlacementOptions);
+
+        private GrainPlacementOptions options;
+        public GrainPlacementOptionsFormatter(IOptions<GrainPlacementOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.DefaultPlacementStrategy),options.DefaultPlacementStrategy),
+                OptionFormattingUtilities.Format(nameof(options.ActivationCountPlacementChooseOutOf), options.ActivationCountPlacementChooseOutOf),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -63,7 +63,7 @@ namespace Orleans.Hosting
             this.options = options;
         }
 
-        protected List<string> FormatStatisticsOptions()
+        protected List<string> FormatSharedOptions()
         {
             return new List<string>()
             {

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -1,7 +1,6 @@
 using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
@@ -54,4 +53,30 @@ namespace Orleans.Hosting
         public bool PropagateActivityId { get; set; } = DEFAULT_PROPAGATE_ACTIVITY_ID;
         public const bool DEFAULT_PROPAGATE_ACTIVITY_ID = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
     }
+
+    public abstract class MessagingOptionsFormatter
+    {
+        private MessagingOptions options;
+
+        protected MessagingOptionsFormatter(MessagingOptions options)
+        {
+            this.options = options;
+        }
+
+        protected List<string> FormatStatisticsOptions()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(this.options.ResponseTimeout), this.options.ResponseTimeout),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxResendCount), this.options.MaxResendCount),
+                OptionFormattingUtilities.Format(nameof(this.options.ResendOnTimeout), this.options.ResendOnTimeout),
+                OptionFormattingUtilities.Format(nameof(this.options.DropExpiredMessages), this.options.DropExpiredMessages),
+                OptionFormattingUtilities.Format(nameof(this.options.BufferPoolBufferSize), this.options.BufferPoolBufferSize),
+                OptionFormattingUtilities.Format(nameof(this.options.BufferPoolMaxSize), this.options.BufferPoolMaxSize),
+                OptionFormattingUtilities.Format(nameof(this.options.BufferPoolPreallocationSize), this.options.BufferPoolPreallocationSize),
+                OptionFormattingUtilities.Format(nameof(this.options.PropagateActivityId), this.options.PropagateActivityId),
+            };
+        }
+    }
+
 }

--- a/src/Orleans.Core/Configuration/Options/SchedulingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SchedulingOptions.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Generic;
 
 namespace Orleans.Hosting
 {
@@ -10,12 +12,14 @@ namespace Orleans.Hosting
         /// <summary>
         /// Whether or not to perform deadlock detection.
         /// </summary>
-        public bool PerformDeadlockDetection { get; set; }
+        public bool PerformDeadlockDetection { get; set; } = DEFAULT_PERFORM_DEADLOCK_DETECTION;
+        public const bool DEFAULT_PERFORM_DEADLOCK_DETECTION = false;
 
         /// <summary>
         /// Whether or not to allow reentrancy for calls within the same call chain.
         /// </summary>
-        public bool AllowCallChainReentrancy { get; set; }
+        public bool AllowCallChainReentrancy { get; set; } = DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY;
+        public const bool DEFAULT_ALLOW_CALL_CHAIN_REENTRANCY = false;
 
         /// <summary>
         /// The MaxActiveThreads attribute specifies the maximum number of simultaneous active threads the scheduler will allow.
@@ -56,5 +60,33 @@ namespace Orleans.Hosting
         /// </summary>
         public bool EnableWorkerThreadInjection { get; set; } = DEFAULT_ENABLE_WORKER_THREAD_INJECTION;
         public const bool DEFAULT_ENABLE_WORKER_THREAD_INJECTION = false;
+    }
+
+    public class SchedulingOptionsFormatter : IOptionFormatter<SchedulingOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(SchedulingOptions);
+
+        private SchedulingOptions options;
+        public SchedulingOptionsFormatter(IOptions<SchedulingOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.PerformDeadlockDetection),options.PerformDeadlockDetection),
+                OptionFormattingUtilities.Format(nameof(options.AllowCallChainReentrancy), options.AllowCallChainReentrancy),
+                OptionFormattingUtilities.Format(nameof(options.DelayWarningThreshold), options.DelayWarningThreshold),
+                OptionFormattingUtilities.Format(nameof(options.ActivationSchedulingQuantum), options.ActivationSchedulingQuantum),
+                OptionFormattingUtilities.Format(nameof(options.TurnWarningLengthThreshold), options.TurnWarningLengthThreshold),
+                OptionFormattingUtilities.Format(nameof(options.MaxPendingWorkItemsSoftLimit), options.MaxPendingWorkItemsSoftLimit),
+                OptionFormattingUtilities.Format(nameof(options.MaxPendingWorkItemsHardLimit), options.MaxPendingWorkItemsHardLimit),
+                OptionFormattingUtilities.Format(nameof(options.EnableWorkerThreadInjection), options.EnableWorkerThreadInjection),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SiloMessagingOptions.cs
@@ -78,7 +78,7 @@ namespace Orleans.Hosting
 
         public IEnumerable<string> Format()
         {
-            List<string> format = base.FormatStatisticsOptions();
+            List<string> format = base.FormatSharedOptions();
             format.AddRange(new List<string>
             {
                 OptionFormattingUtilities.Format(nameof(options.SiloSenderQueues), options.SiloSenderQueues),

--- a/src/Orleans.Core/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SiloMessagingOptions.cs
@@ -63,36 +63,37 @@ namespace Orleans.Hosting
         public bool AssumeHomogenousSilosForTesting { get; set; } = false;
     }
 
-    public class SiloMessageingOptionFormatter : IOptionFormatter<SiloMessagingOptions>
+    public class SiloMessagingOptionFormatter : MessagingOptionsFormatter, IOptionFormatter<SiloMessagingOptions>
     {
         public string Category { get; }
 
         public string Name => nameof(SiloMessagingOptions);
 
         private SiloMessagingOptions options;
-        public SiloMessageingOptionFormatter(IOptions<SiloMessagingOptions> messageOptions)
+        public SiloMessagingOptionFormatter(IOptions<SiloMessagingOptions> messageOptions)
+            : base(messageOptions.Value)
         {
             options = messageOptions.Value;
         }
 
         public IEnumerable<string> Format()
         {
-            return new List<string>()
+            List<string> format = base.FormatStatisticsOptions();
+            format.AddRange(new List<string>
             {
                 OptionFormattingUtilities.Format(nameof(options.SiloSenderQueues), options.SiloSenderQueues),
                 OptionFormattingUtilities.Format(nameof(options.GatewaySenderQueues), options.GatewaySenderQueues),
                 OptionFormattingUtilities.Format(nameof(options.MaxForwardCount), options.MaxForwardCount),
                 OptionFormattingUtilities.Format(nameof(options.ClientDropTimeout), options.ClientDropTimeout),
-
-                OptionFormattingUtilities.Format(nameof(options.ResponseTimeout), options.ResponseTimeout),
-                OptionFormattingUtilities.Format(nameof(options.MaxResendCount), options.MaxResendCount),
-                OptionFormattingUtilities.Format(nameof(options.ResendOnTimeout), options.ResendOnTimeout),
-                OptionFormattingUtilities.Format(nameof(options.DropExpiredMessages), options.DropExpiredMessages),
-                OptionFormattingUtilities.Format(nameof(options.BufferPoolBufferSize), options.BufferPoolBufferSize),
-                OptionFormattingUtilities.Format(nameof(options.BufferPoolMaxSize), options.BufferPoolMaxSize),
-                OptionFormattingUtilities.Format(nameof(options.BufferPoolPreallocationSize), options.BufferPoolPreallocationSize)
-            };
+                OptionFormattingUtilities.Format(nameof(options.ClientRegistrationRefresh), options.ClientRegistrationRefresh),
+                OptionFormattingUtilities.Format(nameof(options.MaxEnqueuedRequestsSoftLimit), options.MaxEnqueuedRequestsSoftLimit),
+                OptionFormattingUtilities.Format(nameof(options.MaxEnqueuedRequestsHardLimit), options.MaxEnqueuedRequestsHardLimit),
+                OptionFormattingUtilities.Format(nameof(options.MaxEnqueuedRequestsSoftLimit_StatelessWorker), options.MaxEnqueuedRequestsSoftLimit_StatelessWorker),
+                OptionFormattingUtilities.Format(nameof(options.MaxEnqueuedRequestsHardLimit_StatelessWorker), options.MaxEnqueuedRequestsHardLimit_StatelessWorker),
+                OptionFormattingUtilities.Format(nameof(options.MaxRequestProcessingTime), options.MaxRequestProcessingTime),
+                OptionFormattingUtilities.Format(nameof(options.AssumeHomogenousSilosForTesting), options.AssumeHomogenousSilosForTesting)
+            });
+            return format;
         }
     }
-
 }

--- a/src/Orleans.Core/Configuration/Options/SiloStatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SiloStatisticsOptions.cs
@@ -50,7 +50,7 @@ namespace Orleans.Hosting
 
         public IEnumerable<string> Format()
         {
-            List<string> format = base.FormatStatisticsOptions();
+            List<string> format = base.FormatSharedOptions();
             format.AddRange(new List<string>
             {
                 OptionFormattingUtilities.Format(nameof(this.options.DeploymentLoadPublisherRefreshTime), this.options.DeploymentLoadPublisherRefreshTime),

--- a/src/Orleans.Core/Configuration/Options/StatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/StatisticsOptions.cs
@@ -55,7 +55,7 @@ namespace Orleans.Hosting
             this.options = options;
         }
 
-        protected List<string> FormatStatisticsOptions()
+        protected List<string> FormatSharedOptions()
         {
             return new List<string>()
             {

--- a/src/Orleans.Core/Configuration/Options/ThreadPoolOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ThreadPoolOptions.cs
@@ -1,9 +1,33 @@
 
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+
 namespace Orleans.Hosting
 {
     public class ThreadPoolOptions
     {
         public int MinDotNetThreadPoolSize { get; set; } = DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE;
         public const int DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE = 200;
+    }
+
+    public class ThreadPoolOptionsFormatter : IOptionFormatter<ThreadPoolOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(ThreadPoolOptions);
+
+        private ThreadPoolOptions options;
+        public ThreadPoolOptionsFormatter(IOptions<ThreadPoolOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.MinDotNetThreadPoolSize),options.MinDotNetThreadPoolSize),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/TypeManagementOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/TypeManagementOptions.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Generic;
 
 namespace Orleans.Hosting
 {
@@ -9,6 +11,26 @@ namespace Orleans.Hosting
         /// </summary>
         public TimeSpan TypeMapRefreshInterval { get; set; } = DEFAULT_REFRESH_CLUSTER_INTERFACEMAP_TIME;
         public static readonly TimeSpan DEFAULT_REFRESH_CLUSTER_INTERFACEMAP_TIME = TimeSpan.FromMinutes(1);
+    }
 
+    public class TypeManagementOptionsFormatter : IOptionFormatter<TypeManagementOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(TypeManagementOptions);
+
+        private TypeManagementOptions options;
+        public TypeManagementOptionsFormatter(IOptions<TypeManagementOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.TypeMapRefreshInterval),options.TypeMapRefreshInterval),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/VersioningOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/VersioningOptions.cs
@@ -1,6 +1,8 @@
 
+using Microsoft.Extensions.Options;
 using Orleans.Versions.Compatibility;
 using Orleans.Versions.Selector;
+using System.Collections.Generic;
 
 namespace Orleans.Hosting
 {
@@ -11,5 +13,27 @@ namespace Orleans.Hosting
 
         public string DefaultVersionSelectorStrategy { get; set; } = DEFAULT_VERSION_SELECTOR_STRATEGY;
         public const string DEFAULT_VERSION_SELECTOR_STRATEGY = nameof(AllCompatibleVersions);
+    }
+
+    public class VersioningOptionsFormatter : IOptionFormatter<VersioningOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(VersioningOptions);
+
+        private VersioningOptions options;
+        public VersioningOptionsFormatter(IOptions<VersioningOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.DefaultCompatibilityStrategy),options.DefaultCompatibilityStrategy),
+                OptionFormattingUtilities.Format(nameof(options.DefaultVersionSelectorStrategy),options.DefaultVersionSelectorStrategy),
+            };
+        }
     }
 }

--- a/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
+++ b/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Generic;
 
 namespace Orleans.Runtime
 {
@@ -24,5 +26,29 @@ namespace Orleans.Runtime
 
         public bool FastKillOnCancelKeyPress { get; set; } = DEFAULT_FAST_KILL_ON_CANCEL;
         public const bool DEFAULT_FAST_KILL_ON_CANCEL = true;
+    }
+
+    public class SiloOptionsFormatter : IOptionFormatter<SiloOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(SiloOptions);
+
+        private SiloOptions options;
+        public SiloOptionsFormatter(IOptions<SiloOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(options.SiloName),options.SiloName),
+                OptionFormattingUtilities.Format(nameof(options.ClusterId), options.ClusterId),
+                OptionFormattingUtilities.Format(nameof(options.ServiceId), options.ServiceId),
+                OptionFormattingUtilities.Format(nameof(options.FastKillOnCancelKeyPress), options.FastKillOnCancelKeyPress)
+            };
+        }
     }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -235,17 +235,17 @@ namespace Orleans.Hosting
             services.AddTransient<IConfigurationValidator, ApplicationPartValidator>();
 
             //Add default option formatter if none is configured, for options which are requied to be configured 
-            services.TryConfigureFormatter<SiloMessagingOptions, SiloMessagingOptionFormatter>();
-            services.TryConfigureFormatter<SiloStatisticsOptions, SiloStatisticsOptionsFormatter>();
-            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
-            services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();
             services.TryConfigureFormatter<SiloOptions, SiloOptionsFormatter>();
             services.TryConfigureFormatter<SchedulingOptions, SchedulingOptionsFormatter>();
             services.TryConfigureFormatter<ThreadPoolOptions, ThreadPoolOptionsFormatter>();
-            services.TryConfigureFormatter<GrainPlacementOptions, GrainPlacementOptionsFormatter>();
+            services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();
+            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
+            services.TryConfigureFormatter<SiloMessagingOptions, SiloMessagingOptionFormatter>();
             services.TryConfigureFormatter<TypeManagementOptions, TypeManagementOptionsFormatter>();
             services.TryConfigureFormatter<GrainDirectoryOptions, GrainDirectoryOptionsFormatter>();
+            services.TryConfigureFormatter<GrainPlacementOptions, GrainPlacementOptionsFormatter>();
             services.TryConfigureFormatter<VersioningOptions, VersioningOptionsFormatter>();
+            services.TryConfigureFormatter<SiloStatisticsOptions, SiloStatisticsOptionsFormatter>();
         }
     }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -235,10 +235,17 @@ namespace Orleans.Hosting
             services.AddTransient<IConfigurationValidator, ApplicationPartValidator>();
 
             //Add default option formatter if none is configured, for options which are requied to be configured 
-            services.TryConfigureFormatter<SiloMessagingOptions, SiloMessageingOptionFormatter>();
+            services.TryConfigureFormatter<SiloMessagingOptions, SiloMessagingOptionFormatter>();
             services.TryConfigureFormatter<SiloStatisticsOptions, SiloStatisticsOptionsFormatter>();
             services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
             services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();
+            services.TryConfigureFormatter<SiloOptions, SiloOptionsFormatter>();
+            services.TryConfigureFormatter<SchedulingOptions, SchedulingOptionsFormatter>();
+            services.TryConfigureFormatter<ThreadPoolOptions, ThreadPoolOptionsFormatter>();
+            services.TryConfigureFormatter<GrainPlacementOptions, GrainPlacementOptionsFormatter>();
+            services.TryConfigureFormatter<TypeManagementOptions, TypeManagementOptionsFormatter>();
+            services.TryConfigureFormatter<GrainDirectoryOptions, GrainDirectoryOptionsFormatter>();
+            services.TryConfigureFormatter<VersioningOptions, VersioningOptionsFormatter>();
         }
     }
 }


### PR DESCRIPTION
Added formatters for grain directory options, grain placement options, schedualling options, thread pool options, type managment options, versioning options and silo options.
Fixed formatting of messaging options.
Fixed some options defaults.