### PR TITLE
Allow OrleansJsonSerializer to be used as an external serialization provider

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBStorageProvider.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBStorageProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -87,7 +87,8 @@ namespace Orleans.Storage
                 useJsonFormat = "true".Equals(config.Properties[USE_JSON_FORMAT_PROPERTY_NAME], StringComparison.OrdinalIgnoreCase);
 
             var grainFactory = providerRuntime.ServiceProvider.GetRequiredService<IGrainFactory>();
-            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.serializationManager, grainFactory), config);
+            var typeResolver = providerRuntime.ServiceProvider.GetRequiredService<ITypeResolver>();
+            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, grainFactory), config);
 
             initMsg = string.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetStorageProvider.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetStorageProvider.cs
@@ -1,4 +1,4 @@
-﻿using Orleans.Persistence.AdoNet.Storage;
+using Orleans.Persistence.AdoNet.Storage;
 using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Serialization;
@@ -552,7 +552,8 @@ namespace Orleans.Storage
             var deserializers = new List<IStorageDeserializer>();
             if(config.Properties.ContainsKey(UseJsonFormatPropertyName) && @true.Equals(config.Properties[UseJsonFormatPropertyName], StringComparison.OrdinalIgnoreCase))
             {
-                var jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.serializationManager, providerRuntime.GrainFactory), config);
+                var typeResolver = providerRuntime.ServiceProvider.GetRequiredService<ITypeResolver>();
+                var jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, providerRuntime.GrainFactory), config);
                 deserializers.Add(new OrleansStorageDefaultJsonDeserializer(jsonSettings, UseJsonFormatPropertyName));
             }
 
@@ -576,7 +577,8 @@ namespace Orleans.Storage
             var serializers = new List<IStorageSerializer>();
             if(config.Properties.ContainsKey(UseJsonFormatPropertyName) && @true.Equals(config.Properties[UseJsonFormatPropertyName], StringComparison.OrdinalIgnoreCase))
             {
-                var jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.serializationManager, providerRuntime.GrainFactory), config);
+                var typeResolver = providerRuntime.ServiceProvider.GetRequiredService<ITypeResolver>();
+                var jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, providerRuntime.GrainFactory), config);
                 serializers.Add(new OrleansStorageDefaultJsonSerializer(jsonSettings, UseJsonFormatPropertyName));
             }
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -69,8 +69,8 @@ namespace Orleans.Storage
             try
             {
                 this.Name = name;
-                var serializationManager = providerRuntime.ServiceProvider.GetRequiredService<SerializationManager>();
-                this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(serializationManager, providerRuntime.GrainFactory), config);
+                var typeResolver = providerRuntime.ServiceProvider.GetRequiredService<ITypeResolver>();
+                this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, providerRuntime.GrainFactory), config);
 
                 if (!config.Properties.ContainsKey(DataConnectionStringPropertyName)) throw new BadProviderConfigException($"The {DataConnectionStringPropertyName} setting has not been configured in the cloud role. Please add a {DataConnectionStringPropertyName} setting with a valid Azure Storage connection string.");
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -109,7 +109,8 @@ namespace Orleans.Storage
             if (config.Properties.ContainsKey(UseJsonFormatPropertyName))
                 useJsonFormat = "true".Equals(config.Properties[UseJsonFormatPropertyName], StringComparison.OrdinalIgnoreCase);
             var grainFactory = providerRuntime.ServiceProvider.GetRequiredService<IGrainFactory>();
-            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.serializationManager, grainFactory), config);
+            var typeResolver = providerRuntime.ServiceProvider.GetRequiredService<ITypeResolver>();
+            this.jsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, grainFactory), config);
             initMsg = String.Format("{0} UseJsonFormat={1}", initMsg, useJsonFormat);
 
             this.logger.Info((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, initMsg);

--- a/src/Orleans.Core/Runtime/IRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/IRuntimeClient.cs
@@ -63,8 +63,6 @@ namespace Orleans.Runtime
 
         IGrainTypeResolver GrainTypeResolver { get; }
 
-        SerializationManager SerializationManager { get; }
-
         IGrainReferenceRuntime GrainReferenceRuntime { get; }
 
         void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo);

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -66,7 +66,8 @@ namespace Orleans
         private IPAddress localAddress;
         private IGatewayListProvider gatewayListProvider;
         private readonly ILoggerFactory loggerFactory;
-        public SerializationManager SerializationManager { get; set; }
+
+        private SerializationManager serializationManager;
 
         public ActivationAddress CurrentActivationAddress
         {
@@ -122,7 +123,7 @@ namespace Orleans
 
             this.InternalGrainFactory = this.ServiceProvider.GetRequiredService<IInternalGrainFactory>();
             this.ClientStatistics = this.ServiceProvider.GetRequiredService<ClientStatisticsManager>();
-            this.SerializationManager = this.ServiceProvider.GetRequiredService<SerializationManager>();
+            this.serializationManager = this.ServiceProvider.GetRequiredService<SerializationManager>();
             this.messageFactory = this.ServiceProvider.GetService<MessageFactory>();
 
             this.config = this.ServiceProvider.GetRequiredService<ClientConfiguration>();
@@ -401,7 +402,7 @@ namespace Orleans
                         continue;
 
                     RequestContextExtensions.Import(message.RequestContextData);
-                    var request = (InvokeMethodRequest)message.GetDeserializedBody(this.SerializationManager);
+                    var request = (InvokeMethodRequest)message.GetDeserializedBody(this.serializationManager);
                     var targetOb = (IAddressable)objectData.LocalObject.Target;
                     object resultObject = null;
                     Exception caught = null;
@@ -455,7 +456,7 @@ namespace Orleans
             try
             {
                 // we're expected to notify the caller if the deep copy failed.
-                deepCopy = this.SerializationManager.DeepCopy(resultObject);
+                deepCopy = this.serializationManager.DeepCopy(resultObject);
             }
             catch (Exception exc2)
             {
@@ -474,7 +475,7 @@ namespace Orleans
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private void ReportException(Message message, Exception exception)
         {
-            var request = (InvokeMethodRequest)message.GetDeserializedBody(this.SerializationManager);
+            var request = (InvokeMethodRequest)message.GetDeserializedBody(this.serializationManager);
             switch (message.Direction)
             {
                 default:
@@ -496,7 +497,7 @@ namespace Orleans
                         try
                         {
                             // we're expected to notify the caller if the deep copy failed.
-                            deepCopy = (Exception)this.SerializationManager.DeepCopy(exception);
+                            deepCopy = (Exception)this.serializationManager.DeepCopy(exception);
                         }
                         catch (Exception ex2)
                         {

--- a/src/Orleans.Core/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans.Core/Serialization/OrleansJsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -18,18 +18,17 @@ namespace Orleans.Serialization
         public const string TypeNameHandlingProperty = "TypeNameHandling";
         private readonly JsonSerializerSettings settings;
 
-        public OrleansJsonSerializer(SerializationManager serializationManager, IGrainFactory grainFactory)
+        public OrleansJsonSerializer(ITypeResolver typeResolver, IGrainFactory grainFactory)
         {
-            this.settings = GetDefaultSerializerSettings(serializationManager, grainFactory);
+            this.settings = GetDefaultSerializerSettings(typeResolver, grainFactory);
         }
 
         /// <summary>
         /// Returns the default serializer settings.
         /// </summary>
         /// <returns>The default serializer settings.</returns>
-        public static JsonSerializerSettings GetDefaultSerializerSettings(SerializationManager serializationManager, IGrainFactory grainFactory)
+        public static JsonSerializerSettings GetDefaultSerializerSettings(ITypeResolver typeResolver, IGrainFactory grainFactory)
         {
-            var typeResolver = serializationManager.ServiceProvider.GetRequiredService<ITypeResolver>();
             var serializationBinder = new OrleansJsonSerializationBinder(typeResolver);
             var settings = new JsonSerializerSettings
             {
@@ -41,9 +40,6 @@ namespace Orleans.Serialization
                 NullValueHandling = NullValueHandling.Ignore,
                 ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
                 TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
-
-                // Types such as GrainReference need context during deserialization, so provide that context now.
-                Context = new StreamingContext(StreamingContextStates.All, new SerializationContext(serializationManager)),
                 Formatting = Formatting.None,
                 SerializationBinder = serializationBinder
             };

--- a/src/Orleans.Core/Serialization/SerializationManager.cs
+++ b/src/Orleans.Core/Serialization/SerializationManager.cs
@@ -107,7 +107,7 @@ namespace Orleans.Serialization
 
         public SerializationManager(
             IServiceProvider serviceProvider,
-            IOptions<SerializationProviderOptions> serializatonProviderOptions,
+            IOptions<SerializationProviderOptions> serializationProviderOptions,
             ILoggerFactory loggerFactory,
             ITypeResolver typeResolver)
         {
@@ -128,9 +128,9 @@ namespace Orleans.Serialization
             deserializers = new Dictionary<RuntimeTypeHandle, Deserializer>();
             grainRefConstructorDictionary = new ConcurrentDictionary<Type, Func<GrainReference, GrainReference>>();
 
-            var serializatonProviderOptionsValue = serializatonProviderOptions.Value;
+            var options = serializationProviderOptions.Value;
 
-            fallbackSerializer = GetFallbackSerializer(serviceProvider, serializatonProviderOptionsValue.FallbackSerializationProvider);
+            fallbackSerializer = GetFallbackSerializer(serviceProvider, options.FallbackSerializationProvider);
 
             if (StatisticsCollector.CollectSerializationStats)
             {
@@ -167,7 +167,7 @@ namespace Orleans.Serialization
                 FallbackCopiesTimeStatistic = CounterStatistic.FindOrCreate(StatisticNames.SERIALIZATION_BODY_FALLBACK_DEEPCOPY_MILLIS, storeFallback).AddValueConverter(Utils.TicksToMilliSeconds);
             }
 
-            RegisterSerializationProviders(serializatonProviderOptionsValue.SerializationProviders);
+            RegisterSerializationProviders(options.SerializationProviders);
         }
 
         public void RegisterSerializers(IApplicationPartManager applicationPartManager)

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Orleans.Providers.Streams.SimpleMessageStream
 {
+    using Orleans.Serialization;
+
     public class SimpleMessageStreamProvider : IInternalStreamProvider, IStreamSubscriptionManagerRetriever
     {
         public string                       Name { get; private set; }
@@ -21,6 +23,8 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         private IRuntimeClient              runtimeClient;
         private IStreamSubscriptionManager  streamSubscriptionManager;
         private ILoggerFactory              loggerFactory;
+        private SerializationManager        serializationManager;
+
         internal const string                STREAM_PUBSUB_TYPE = "PubSubType";
         internal const string                FIRE_AND_FORGET_DELIVERY = "FireAndForgetDelivery";
         internal const string                OPTIMIZE_FOR_IMMUTABLE_DATA = "OptimizeForImmutableData";
@@ -35,6 +39,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
             this.Name = name;
             providerRuntime = (IStreamProviderRuntime) providerUtilitiesManager;
             this.runtimeClient = this.providerRuntime.ServiceProvider.GetRequiredService<IRuntimeClient>();
+            this.serializationManager = this.providerRuntime.ServiceProvider.GetRequiredService<SerializationManager>();
             fireAndForgetDelivery = config.GetBoolProperty(FIRE_AND_FORGET_DELIVERY, DEFAULT_VALUE_FIRE_AND_FORGET_DELIVERY);
             optimizeForImmutableData = config.GetBoolProperty(OPTIMIZE_FOR_IMMUTABLE_DATA, DEFAULT_VALUE_OPTIMIZE_FOR_IMMUTABLE_DATA);
             
@@ -85,7 +90,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         {
             return new SimpleMessageStreamProducer<T>((StreamImpl<T>)stream, Name, providerRuntime,
                 fireAndForgetDelivery, optimizeForImmutableData, providerRuntime.PubSub(pubSubType), IsRewindable,
-                this.runtimeClient.SerializationManager, this.loggerFactory);
+                this.serializationManager, this.loggerFactory);
         }
 
         IInternalAsyncObservable<T> IInternalStreamProvider.GetConsumerInterface<T>(IAsyncStream<T> streamId)

--- a/test/DefaultCluster.Tests/GrainReferenceTest.cs
+++ b/test/DefaultCluster.Tests/GrainReferenceTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -14,6 +14,8 @@ using Xunit;
 
 namespace DefaultCluster.Tests.General
 {
+    using Microsoft.Extensions.DependencyInjection;
+
     /// <summary>
     /// Summary description for GrainReferenceTest
     /// </summary>
@@ -105,7 +107,8 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("Serialization"), TestCategory("JSON")]
         public async Task GrainReference_Json_Serialization_Nested()
         {
-            var settings = OrleansJsonSerializer.GetDefaultSerializerSettings(HostedCluster.SerializationManager, HostedCluster.GrainFactory);
+            var typeResolver = this.HostedCluster.Client.ServiceProvider.GetRequiredService<ITypeResolver>();
+            var settings = OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, HostedCluster.GrainFactory);
             
             var grain = HostedCluster.GrainFactory.GetGrain<ISimpleGrain>(GetRandomGrainId());
             await grain.SetA(56820);
@@ -238,7 +241,8 @@ namespace DefaultCluster.Tests.General
 
         private T NewtonsoftJsonSerializeRoundtrip<T>(T obj)
         {
-            var settings = OrleansJsonSerializer.GetDefaultSerializerSettings(this.HostedCluster.SerializationManager, this.GrainFactory);
+            var typeResolver = this.HostedCluster.Client.ServiceProvider.GetRequiredService<ITypeResolver>();
+            var settings = OrleansJsonSerializer.GetDefaultSerializerSettings(typeResolver, this.GrainFactory);
             // http://james.newtonking.com/json/help/index.html?topic=html/T_Newtonsoft_Json_JsonConvert.htm
             string json = JsonConvert.SerializeObject(obj, settings);
             object other = JsonConvert.DeserializeObject(json, typeof(T), settings);

--- a/test/NonSilo.Tests/Serialization/ExternalSerializerTest.cs
+++ b/test/NonSilo.Tests/Serialization/ExternalSerializerTest.cs
@@ -62,7 +62,7 @@ namespace UnitTests.Serialization
             this.environment.SerializationManager.RoundTripSerializationForTesting(data);
             Assert.True(FakeSerializer.SerializeCalled);
             Assert.True(FakeSerializer.DeserializeCalled);
-    }
+        }
 
         private class FakeSerializedWithNoCodegenSerializers : FakeSerialized
         {

--- a/test/NonSilo.Tests/Serialization/OrleansJsonSerializerTests.cs
+++ b/test/NonSilo.Tests/Serialization/OrleansJsonSerializerTests.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using Orleans.Runtime.Configuration;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.Serialization
+{
+    using System.Text;
+
+    using Newtonsoft.Json;
+
+    using Orleans.Serialization;
+
+    [TestCategory("Serialization"), TestCategory("BVT")]
+    public class OrleansJsonSerializerTests
+    {
+        private readonly SerializationTestEnvironment environment;
+
+        public OrleansJsonSerializerTests()
+        {
+            var config = new ClientConfiguration { SerializationProviders = { typeof(OrleansJsonSerializer).GetTypeInfo() } };
+            this.environment = SerializationTestEnvironment.InitializeWithDefaults(config);
+        }
+
+        [Fact]
+        public void OrleansJsonSerializer_ExternalSerializer()
+        {
+            var data = new JsonPoco { Prop = "some data" };
+            var serialized = this.environment.SerializationManager.SerializeToByteArray(data);
+            var subSequence = Encoding.UTF8.GetBytes("crazy_name");
+
+            // The serialized data should have our custom [JsonProperty] name, 'crazy_name', in it.
+            Assert.Contains(ToString(subSequence), ToString(serialized));
+
+            var deserialized = this.environment.SerializationManager.DeserializeFromByteArray<JsonPoco>(serialized);
+
+            Assert.Equal(data.Prop, deserialized.Prop);
+
+            string ToString(byte[] bytes)
+            {
+                var result = new StringBuilder(bytes.Length * 2);
+                foreach (var b in bytes)
+                {
+                    result.Append($"{b:x2}");
+                }
+
+                return result.ToString();
+            }
+        }
+        
+        public class JsonPoco
+        {
+            [JsonProperty("crazy_name")]
+            public string Prop { get; set; }
+        }
+    }
+}

--- a/test/TestExtensions/SerializationTestEnvironment.cs
+++ b/test/TestExtensions/SerializationTestEnvironment.cs
@@ -67,7 +67,7 @@ namespace TestExtensions
 
         internal IServiceProvider Services => this.RuntimeClient.ServiceProvider;
 
-        public SerializationManager SerializationManager => this.RuntimeClient.SerializationManager;
+        public SerializationManager SerializationManager => this.RuntimeClient.ServiceProvider.GetRequiredService<SerializationManager>();
         
         public void Dispose()
         {


### PR DESCRIPTION
Fixes #3853

Problem: `SerializationManager` attempts to create all configured serialization providers in its constructor, but `OrleansJsonSerializer` has a constructor dependency on `SerializationManager`. This causes a DI cycle and subsequently a `StackOverflowException`.

This PR fixes that issue.

* Removes `SerializationManager` property from `IRuntimeClient` (I'm really happy about this)
* Modifies the constructors of `InsideRuntimeClient`, `OutsideRuntimeClient`, and `OrleansJsonSerializer` to no longer take `SerializationManager`