### PR TITLE
Sort list of silos in HashBasedPlacementDirector

### DIFF
--- a/src/Orleans.Runtime/Placement/HashBasedPlacementDirector.cs
+++ b/src/Orleans.Runtime/Placement/HashBasedPlacementDirector.cs
@@ -8,7 +8,7 @@ namespace Orleans.Runtime.Placement
         public virtual Task<SiloAddress> OnAddActivation(
             PlacementStrategy strategy, PlacementTarget target, IPlacementContext context)
         {
-            var allSilos = context.GetCompatibleSilos(target).OrderBy(s => s).ToArray();
+            var allSilos = context.GetCompatibleSilos(target).OrderBy(s => s).ToArray(); // need to sort the list, so that the outcome is deterministic
             int hash = (int) (target.GrainIdentity.GetUniformHashCode() & 0x7fffffff); // reset highest order bit to avoid negative ints
 
             return Task.FromResult(allSilos[hash % allSilos.Length]);

--- a/src/Orleans.Runtime/Placement/HashBasedPlacementDirector.cs
+++ b/src/Orleans.Runtime/Placement/HashBasedPlacementDirector.cs
@@ -8,11 +8,10 @@ namespace Orleans.Runtime.Placement
         public virtual Task<SiloAddress> OnAddActivation(
             PlacementStrategy strategy, PlacementTarget target, IPlacementContext context)
         {
-            var allSilos = context.GetCompatibleSilos(target);
-
+            var allSilos = context.GetCompatibleSilos(target).OrderBy(s => s).ToArray();
             int hash = (int) (target.GrainIdentity.GetUniformHashCode() & 0x7fffffff); // reset highest order bit to avoid negative ints
 
-            return Task.FromResult(allSilos[hash % allSilos.Count]);
+            return Task.FromResult(allSilos[hash % allSilos.Length]);
         }
     }
 }

--- a/test/Tester/Placement/CustomPlacementTests.cs
+++ b/test/Tester/Placement/CustomPlacementTests.cs
@@ -57,7 +57,7 @@ namespace Tester.CustomPlacementTests
 
             // sort silo IDs into an array
             this.silos = fixture.HostedCluster.GetActiveSilos().Select(h => h.SiloAddress.ToString()).OrderBy(s => s).ToArray();
-            this.siloAddresses = fixture.HostedCluster.GetActiveSilos().Select(h => h.SiloAddress).OrderBy(s => s.ToString()).ToArray();
+            this.siloAddresses = fixture.HostedCluster.GetActiveSilos().Select(h => h.SiloAddress).OrderBy(s => s).ToArray();
         }
 
         [Fact]

--- a/test/Tester/Placement/CustomPlacementTests.cs
+++ b/test/Tester/Placement/CustomPlacementTests.cs
@@ -31,7 +31,7 @@ namespace Tester.CustomPlacementTests
                 builder.AddSiloBuilderConfigurator<TestSiloBuilderConfigurator>();
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
-                    legacy.ClusterConfiguration.Globals.AssumeHomogenousSilosForTesting = false;
+                    legacy.ClusterConfiguration.Globals.AssumeHomogenousSilosForTesting = true;
                     legacy.ClusterConfiguration.Globals.TypeMapRefreshInterval = TimeSpan.FromMilliseconds(100);
                 });
             }


### PR DESCRIPTION
Sort list of available compatible silos before picking a target one based on the grain ID hash.
Fixes non-deterministic behavior of HashBasedPlacementDirector and related tests.