### PR TITLE
Fix multicluster test (#3929)

### DIFF
--- a/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
@@ -215,6 +215,9 @@ namespace Orleans.Runtime.MembershipService
         internal void UpdateMyFaultAndUpdateZone(MembershipEntry entry)
         {
             this.myFaultAndUpdateZones = new UpdateFaultCombo(entry.UpdateZone, entry.FaultZone);
+
+            if (this.multiClusterActive)
+                localMultiClusterGatewaysCopy = DetermineMultiClusterGateways();
         }
 
         internal bool TryUpdateStatusAndNotify(MembershipEntry entry)

--- a/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipOracleData.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Orleans.Hosting;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Configuration;
+using System.Text;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -216,6 +217,8 @@ namespace Orleans.Runtime.MembershipService
         {
             this.myFaultAndUpdateZones = new UpdateFaultCombo(entry.UpdateZone, entry.FaultZone);
 
+            if (logger.IsEnabled(LogLevel.Debug)) logger.Debug($"-Updated my FaultZone={entry.FaultZone} UpdateZone={entry.UpdateZone}");
+
             if (this.multiClusterActive)
                 localMultiClusterGatewaysCopy = DetermineMultiClusterGateways();
         }
@@ -288,20 +291,35 @@ namespace Orleans.Runtime.MembershipService
             if (! this.multiClusterActive)
                 throw new OrleansException("internal error: should not call this function without multicluster network");
 
+            List<SiloAddress> result;
+
             // take all the active silos if their count does not exceed the desired number of gateways
             if (localTableCopyOnlyActive.Count <= this.maxMultiClusterGateways)
-                return localTableCopyOnlyActive.Keys.ToList();
+            {
+                result = localTableCopyOnlyActive.Keys.ToList();
+            }
+            else
+            {
+                result = DeterministicBalancedChoice<SiloAddress, UpdateFaultCombo>(
+                    localTableCopyOnlyActive.Keys,
+                    this.maxMultiClusterGateways,
+                   (SiloAddress a) => a.Equals(MyAddress) ? this.myFaultAndUpdateZones : new UpdateFaultCombo(localTable[a]),
+                   logger);
+            }
 
-            return DeterministicBalancedChoice<SiloAddress, UpdateFaultCombo>(
-                localTableCopyOnlyActive.Keys,
-                this.maxMultiClusterGateways,
-               (SiloAddress a) => a.Equals(MyAddress) ? this.myFaultAndUpdateZones : new UpdateFaultCombo(localTable[a]));
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                var gateways = string.Join(", ", result.Select(silo => silo.ToString()));
+                logger.Debug($"-DetermineMultiClusterGateways {gateways}");
+            }
+
+            return result;
         }
 
         // pick a specified number of elements from a set of candidates
         // - in a balanced way (try to pick evenly from groups)
         // - in a deterministic way (using sorting order on candidates and keys)
-        internal static List<T> DeterministicBalancedChoice<T, K>(IEnumerable<T> candidates, int count, Func<T, K> group)
+        internal static List<T> DeterministicBalancedChoice<T, K>(IEnumerable<T> candidates, int count, Func<T, K> group, ILogger logger = null)
             where T:IComparable where K:IComparable
         {
             // organize candidates by groups
@@ -328,6 +346,23 @@ namespace Orleans.Runtime.MembershipService
             keys.Sort();
             foreach(var kvp in groups)
                 kvp.Value.Sort();
+
+            // for debugging, trace all the gateway candidates
+            if (logger != null && logger.IsEnabled(LogLevel.Trace))
+            {
+                var b = new StringBuilder();
+                foreach (var k in keys)
+                {
+                    b.Append(k);
+                    b.Append(':');
+                    foreach (var s in groups[k])
+                    {
+                        b.Append(' ');
+                        b.Append(s);
+                    }
+                }
+                logger.Trace($"-DeterministicBalancedChoice candidates {b}");
+            }
               
             // pick round-robin from groups
             var  result = new List<T>();
@@ -364,6 +399,11 @@ namespace Orleans.Runtime.MembershipService
                 int comp = UpdateZone.CompareTo(other.UpdateZone);
                 if (comp != 0) return comp;
                 return FaultZone.CompareTo(other.FaultZone);
+            }
+
+            public override string ToString()
+            {
+                return $"({UpdateZone},{FaultZone})";
             }
         }
 

--- a/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -781,7 +781,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
                 || (myStatus.Status == GatewayStatus.Active
                       && myStatus.HeartbeatTimestamp - existingEntry.HeartbeatTimestamp > this.resendActiveStatusAfter))
             {
-                logger.Trace("-InjectLocalStatus {0}", myStatus);
+                logger.Info($"Report as {myStatus}");
 
                 // update current data with status
                 var delta = this.localData.ApplyDataAndNotify(new MultiClusterData(myStatus));

--- a/test/TesterInternal/GeoClusterTests/MultiClusterNetworkTests.cs
+++ b/test/TesterInternal/GeoClusterTests/MultiClusterNetworkTests.cs
@@ -146,7 +146,7 @@ namespace Tests.GeoClusterTests
             }
         }
 
-        [SkippableFact(Skip = "Flaky test. SebastianBurckhardt to investigate."), TestCategory("Functional")]
+        [SkippableFact(), TestCategory("Functional")]
         public async Task TestMultiClusterConf_3_3()
         {
             // use a random global service id for testing purposes
@@ -164,12 +164,12 @@ namespace Tests.GeoClusterTests
             // create cluster A and clientA
             NewGeoCluster(globalserviceid, clusterA, 3, configcustomizer);
             var clientA = this.NewClient<ClientWrapper>(clusterA, 0, ClientWrapper.Factory);
-            var portsA = Clusters[clusterA].Cluster.GetActiveSilos().Select(x => x.SiloAddress.Endpoint.Port).ToArray();
+            var portsA = Clusters[clusterA].Cluster.GetActiveSilos().OrderBy(x => x.SiloAddress).Select(x => x.SiloAddress.Endpoint.Port).ToArray();
 
             // create cluster B and clientB
             NewGeoCluster(globalserviceid, clusterB, 3, configcustomizer);
             var clientB = this.NewClient<ClientWrapper>(clusterB, 0, ClientWrapper.Factory);
-            var portsB = Clusters[clusterB].Cluster.GetActiveSilos().Select(x => x.SiloAddress.Endpoint.Port).ToArray();
+            var portsB = Clusters[clusterB].Cluster.GetActiveSilos().OrderBy(x => x.SiloAddress).Select(x => x.SiloAddress.Endpoint.Port).ToArray();
 
             // wait for membership to stabilize
             await WaitForLivenessToStabilizeAsync();


### PR DESCRIPTION
It turned out to be a simple oversight in the test construction - need to sort the silo addresses in the test so they match the order used by the multi-cluster gateway selection.

There are three commits here:
- an easy fix for the test
- while trying to find the root cause, I came across a small bug
- added tracing  that I needed to track this down