### PR TITLE
Added formatters and xml comments for remaining options.

### DIFF
--- a/src/Orleans.Core/Configuration/Options/AdoNetOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/AdoNetOptions.cs
@@ -1,6 +1,12 @@
 
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// AdoNet settings
+    /// </summary>
     public class AdoNetOptions
     {
         /// <summary>
@@ -15,5 +21,26 @@ namespace Orleans.Hosting
         /// Set this property to override <see cref="AdoInvariant"/> for reminders.
         /// </summary>
         public string InvariantForReminders { get; set; }
+    }
+
+    public class AdoNetOptionsFormatter : IOptionFormatter<AdoNetOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(AdoNetOptions);
+        private AdoNetOptions options;
+        public AdoNetOptionsFormatter(IOptions<AdoNetOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(this.options.Invariant), this.options.Invariant),
+                OptionFormattingUtilities.Format(nameof(this.options.InvariantForReminders), this.options.InvariantForReminders),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
@@ -36,7 +36,7 @@ namespace Orleans.Hosting
             List<string> format = base.FormatSharedOptions();
             format.AddRange(new List<string>
             {
-                OptionFormattingUtilities.Format(nameof(options.ClientSenderBuckets), options.ClientSenderBuckets),
+                OptionFormattingUtilities.Format(nameof(this.options.ClientSenderBuckets), this.options.ClientSenderBuckets),
             });
             return format;
         }

--- a/src/Orleans.Core/Configuration/Options/ClientStatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientStatisticsOptions.cs
@@ -4,6 +4,9 @@ using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Statistics output related options for cluster client.
+    /// </summary>
     public class ClientStatisticsOptions : StatisticsOptions
     {
     }

--- a/src/Orleans.Core/Configuration/Options/ClusterClientOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterClientOptions.cs
@@ -29,7 +29,7 @@ namespace Orleans.Runtime
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.ClusterId), options.ClusterId)
+                OptionFormattingUtilities.Format(nameof(this.options.ClusterId), this.options.ClusterId)
             };
         }
     }

--- a/src/Orleans.Core/Configuration/Options/ConsistentRingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ConsistentRingOptions.cs
@@ -1,12 +1,47 @@
 
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Configuration options for consistent hashing algorithm, used to balance resource allocations across the cluster.
+    /// </summary>
     public class ConsistentRingOptions
     {
+        /// <summary>
+        /// Determines the number of registerations a silo maintains in a consistent hash ring.  This affects the probabilistic
+        ///   balancing of resource allocations across the cluster.  More virtual buckets increase the probability of evenly balancing
+        ///   while minimally increasing management cost. 
+        /// </summary>
         public int NumVirtualBucketsConsistentRing { get; set; } = DEFAULT_NUM_VIRTUAL_RING_BUCKETS;
         public const int DEFAULT_NUM_VIRTUAL_RING_BUCKETS = 30;
 
+        /// <summary>
+        /// Enables/Disables the use of virtual buckets.
+        /// </summary>
         public bool UseVirtualBucketsConsistentRing { get; set; } = DEFAULT_USE_VIRTUAL_RING_BUCKETS;
         public const bool DEFAULT_USE_VIRTUAL_RING_BUCKETS = true;
+    }
+
+    public class ConsistentRingOptionsFormatter : IOptionFormatter<ConsistentRingOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(ConsistentRingOptions);
+        private ConsistentRingOptions options;
+        public ConsistentRingOptionsFormatter(IOptions<ConsistentRingOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(this.options.NumVirtualBucketsConsistentRing), this.options.NumVirtualBucketsConsistentRing),
+                OptionFormattingUtilities.Format(nameof(this.options.UseVirtualBucketsConsistentRing), this.options.UseVirtualBucketsConsistentRing),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/GrainCollectionOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GrainCollectionOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
@@ -8,12 +9,47 @@ namespace Orleans.Hosting
     /// </summary>
     public class GrainCollectionOptions
     {
+        /// <summary>
+        /// Regulates the periodic collection of inactive grains.
+        /// </summary>
         public TimeSpan CollectionQuantum { get; set; } = DEFAULT_COLLECTION_QUANTUM;
         public static readonly TimeSpan DEFAULT_COLLECTION_QUANTUM = TimeSpan.FromMinutes(1);
 
+        /// <summary>
+        /// Default period of inactivity necessary for a grain to be available for collection and deactivation.
+        /// </summary>
         public TimeSpan CollectionAge { get; set; } = DEFAULT_COLLECTION_AGE_LIMIT;
         public static readonly TimeSpan DEFAULT_COLLECTION_AGE_LIMIT = TimeSpan.FromHours(2);
 
+        /// <summary>
+        /// Period of inactivity necessary for a grain to be available for collection and deactivation by grain type.
+        /// </summary>
         public Dictionary<string, TimeSpan> ClassSpecificCollectionAge { get; set; } = new Dictionary<string, TimeSpan>();
+    }
+
+    public class GrainCollectionOptionsFormatter : IOptionFormatter<GrainCollectionOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(GrainCollectionOptions);
+        private GrainCollectionOptions options;
+        public GrainCollectionOptionsFormatter(IOptions<GrainCollectionOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            var formated = new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(this.options.CollectionQuantum), this.options.CollectionQuantum),
+                OptionFormattingUtilities.Format(nameof(this.options.CollectionAge), this.options.CollectionAge),
+            };
+            foreach(KeyValuePair<string, TimeSpan> classCollectionAge in this.options.ClassSpecificCollectionAge)
+            {
+                formated.Add(OptionFormattingUtilities.Format($"{nameof(this.options.CollectionAge)}.{classCollectionAge.Key}", classCollectionAge.Value));
+            }
+            return formated;
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/GrainDirectoryOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GrainDirectoryOptions.cs
@@ -1,7 +1,7 @@
 
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
@@ -81,12 +81,13 @@ namespace Orleans.Hosting
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.CachingStrategy),options.CachingStrategy),
-                OptionFormattingUtilities.Format(nameof(options.CacheSize),options.CacheSize),
-                OptionFormattingUtilities.Format(nameof(options.InitialCacheTTL),options.InitialCacheTTL),
-                OptionFormattingUtilities.Format(nameof(options.MaximumCacheTTL),options.MaximumCacheTTL),
-                OptionFormattingUtilities.Format(nameof(options.CacheTTLExtensionFactor),options.CacheTTLExtensionFactor),
-                OptionFormattingUtilities.Format(nameof(options.LazyDeregistrationDelay),options.LazyDeregistrationDelay),
+                OptionFormattingUtilities.Format(nameof(this.options.CachingStrategy),this.options.CachingStrategy),
+                OptionFormattingUtilities.Format(nameof(this.options.CacheSize),this.options.CacheSize),
+
+                OptionFormattingUtilities.Format(nameof(this.options.InitialCacheTTL),this.options.InitialCacheTTL),
+                OptionFormattingUtilities.Format(nameof(this.options.MaximumCacheTTL),this.options.MaximumCacheTTL),
+                OptionFormattingUtilities.Format(nameof(this.options.CacheTTLExtensionFactor),this.options.CacheTTLExtensionFactor),
+                OptionFormattingUtilities.Format(nameof(this.options.LazyDeregistrationDelay),this.options.LazyDeregistrationDelay),
             };
         }
     }

--- a/src/Orleans.Core/Configuration/Options/GrainPlacementOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GrainPlacementOptions.cs
@@ -1,14 +1,24 @@
+using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using Orleans.Runtime;
-using System.Collections.Generic;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Settings which regulate the placement of grains across a cluster.
+    /// </summary>
     public class GrainPlacementOptions
     {
+        /// <summary>
+        /// Default strategy used for placeing grains across a cluster.
+        /// </summary>
         public string DefaultPlacementStrategy { get; set; } = DEFAULT_PLACEMENT_STRATEGY;
         public static readonly string DEFAULT_PLACEMENT_STRATEGY = nameof(RandomPlacement);
 
+        /// <summary>
+        /// Number of silos randomly selected for consideration when using activation count placement policy.
+        /// Only used with Activation Count placement policy.
+        /// </summary>
         public int ActivationCountPlacementChooseOutOf { get; set; } = DEFAULT_ACTIVATION_COUNT_PLACEMENT_CHOOSE_OUT_OF;
         public const int DEFAULT_ACTIVATION_COUNT_PLACEMENT_CHOOSE_OUT_OF = 2;
     }
@@ -29,8 +39,8 @@ namespace Orleans.Hosting
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.DefaultPlacementStrategy),options.DefaultPlacementStrategy),
-                OptionFormattingUtilities.Format(nameof(options.ActivationCountPlacementChooseOutOf), options.ActivationCountPlacementChooseOutOf),
+                OptionFormattingUtilities.Format(nameof(this.options.DefaultPlacementStrategy),this.options.DefaultPlacementStrategy),
+                OptionFormattingUtilities.Format(nameof(this.options.ActivationCountPlacementChooseOutOf), this.options.ActivationCountPlacementChooseOutOf),
             };
         }
     }

--- a/src/Orleans.Core/Configuration/Options/GrainServiceOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GrainServiceOptions.cs
@@ -1,10 +1,34 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Configuration of silo grain services.
+    /// </summary>
     public class GrainServiceOptions
     {
+        /// <summary>
+        /// List of grain services to initialize at startup.  List of full type name (string) and service id (short).
+        /// </summary>
         public List<KeyValuePair<string, short>> GrainServices { get; set; } = new List<KeyValuePair<string, short>>();
+    }
+
+    public class GrainServiceOptionsFormatter : IOptionFormatter<GrainServiceOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(GrainServiceOptions);
+        private GrainServiceOptions options;
+        public GrainServiceOptionsFormatter(IOptions<GrainServiceOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return this.options.GrainServices.Select(kvp => OptionFormattingUtilities.Format($"{nameof(this.options.GrainServices)}.{kvp.Key}", kvp.Value)).ToList();
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/GrainVersioningOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GrainVersioningOptions.cs
@@ -9,7 +9,7 @@ namespace Orleans.Hosting
     /// <summary>
     /// Versioning options govern grain implementation selection in heterogeneous deployments.
     /// </summary>
-    public class VersioningOptions
+    public class GrainVersioningOptions
     {
         /// <summary>
         /// Strategy used to determine grain compatibility in heterogeneous deployments.
@@ -24,14 +24,14 @@ namespace Orleans.Hosting
         public const string DEFAULT_VERSION_SELECTOR_STRATEGY = nameof(AllCompatibleVersions);
     }
 
-    public class VersioningOptionsFormatter : IOptionFormatter<VersioningOptions>
+    public class GrainVersioningOptionsFormatter : IOptionFormatter<GrainVersioningOptions>
     {
         public string Category { get; }
 
-        public string Name => nameof(VersioningOptions);
+        public string Name => nameof(GrainVersioningOptions);
 
-        private VersioningOptions options;
-        public VersioningOptionsFormatter(IOptions<VersioningOptions> options)
+        private GrainVersioningOptions options;
+        public GrainVersioningOptionsFormatter(IOptions<GrainVersioningOptions> options)
         {
             this.options = options.Value;
         }

--- a/src/Orleans.Core/Configuration/Options/MembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MembershipOptions.cs
@@ -1,8 +1,13 @@
 
 using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Settings for cluster membership.
+    /// </summary>
     public class MembershipOptions
     {
         /// <summary>
@@ -91,5 +96,38 @@ namespace Orleans.Hosting
         /// TEST ONLY - Do not modify in production environments
         /// </summary>
         public bool IsRunningAsUnitTest { get; set; } = false;
+    }
+
+    public class MembershipOptionsFormatter : IOptionFormatter<MembershipOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(MembershipOptions);
+        private MembershipOptions options;
+        public MembershipOptionsFormatter(IOptions<MembershipOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(this.options.NumMissedTableIAmAliveLimit), this.options.NumMissedTableIAmAliveLimit),
+                OptionFormattingUtilities.Format(nameof(this.options.LivenessEnabled), this.options.LivenessEnabled),
+                OptionFormattingUtilities.Format(nameof(this.options.ProbeTimeout), this.options.ProbeTimeout),
+                OptionFormattingUtilities.Format(nameof(this.options.TableRefreshTimeout), this.options.TableRefreshTimeout),
+                OptionFormattingUtilities.Format(nameof(this.options.DeathVoteExpirationTimeout), this.options.DeathVoteExpirationTimeout),
+                OptionFormattingUtilities.Format(nameof(this.options.IAmAliveTablePublishTimeout), this.options.IAmAliveTablePublishTimeout),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxJoinAttemptTime), this.options.MaxJoinAttemptTime),
+                OptionFormattingUtilities.Format(nameof(this.options.ExpectedClusterSize), this.options.ExpectedClusterSize),
+                OptionFormattingUtilities.Format(nameof(this.options.ValidateInitialConnectivity), this.options.ValidateInitialConnectivity),
+                OptionFormattingUtilities.Format(nameof(this.options.UseLivenessGossip), this.options.UseLivenessGossip),
+                OptionFormattingUtilities.Format(nameof(this.options.NumProbedSilos), this.options.NumProbedSilos),
+                OptionFormattingUtilities.Format(nameof(this.options.NumMissedProbesLimit), this.options.NumMissedProbesLimit),
+                OptionFormattingUtilities.Format(nameof(this.options.NumVotesForDeathDeclaration), this.options.NumVotesForDeathDeclaration),
+                OptionFormattingUtilities.Format(nameof(this.options.IsRunningAsUnitTest), this.options.IsRunningAsUnitTest),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -1,6 +1,6 @@
-using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
+using Orleans.Runtime;
 
 namespace Orleans.Hosting
 {

--- a/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
@@ -77,7 +77,7 @@ namespace Orleans.Hosting
             var formated = new List<string>()
             {
                 OptionFormattingUtilities.Format(nameof(this.options.HasMultiClusterNetwork), this.options.HasMultiClusterNetwork),
-                OptionFormattingUtilities.Format(nameof(this.options.DefaultMultiCluster), string.Join(";", this.options.HasMultiClusterNetwork)),
+                OptionFormattingUtilities.Format(nameof(this.options.DefaultMultiCluster), string.Join(";", this.options.DefaultMultiCluster)),
                 OptionFormattingUtilities.Format(nameof(this.options.MaxMultiClusterGateways), this.options.MaxMultiClusterGateways),
                 OptionFormattingUtilities.Format(nameof(this.options.BackgroundGossipInterval), this.options.BackgroundGossipInterval),
                 OptionFormattingUtilities.Format(nameof(this.options.UseGlobalSingleInstanceByDefault), this.options.UseGlobalSingleInstanceByDefault),

--- a/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
@@ -54,6 +55,40 @@ namespace Orleans.Hosting
         public TimeSpan GlobalSingleInstanceRetryInterval { get; set; } = DEFAULT_GLOBAL_SINGLE_INSTANCE_RETRY_INTERVAL;
         public static readonly TimeSpan DEFAULT_GLOBAL_SINGLE_INSTANCE_RETRY_INTERVAL = TimeSpan.FromSeconds(30);
 
+        /// <summary>
+        /// Inter-cluster gossip channels.
+        /// </summary>
         public Dictionary<string, string> GossipChannels { get; set; } = new Dictionary<string, string>();
+    }
+
+    public class MultiClusterOptionsFormatter : IOptionFormatter<MultiClusterOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(MultiClusterOptions);
+        private MultiClusterOptions options;
+        public MultiClusterOptionsFormatter(IOptions<MultiClusterOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            var formated = new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(this.options.HasMultiClusterNetwork), this.options.HasMultiClusterNetwork),
+                OptionFormattingUtilities.Format(nameof(this.options.DefaultMultiCluster), string.Join(";", this.options.HasMultiClusterNetwork)),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxMultiClusterGateways), this.options.MaxMultiClusterGateways),
+                OptionFormattingUtilities.Format(nameof(this.options.BackgroundGossipInterval), this.options.BackgroundGossipInterval),
+                OptionFormattingUtilities.Format(nameof(this.options.UseGlobalSingleInstanceByDefault), this.options.UseGlobalSingleInstanceByDefault),
+                OptionFormattingUtilities.Format(nameof(this.options.GlobalSingleInstanceNumberRetries), this.options.GlobalSingleInstanceNumberRetries),
+                OptionFormattingUtilities.Format(nameof(this.options.GlobalSingleInstanceRetryInterval), this.options.GlobalSingleInstanceRetryInterval),
+            };
+            foreach (KeyValuePair<string, string> channel in this.options.GossipChannels)
+            {
+                formated.Add(OptionFormattingUtilities.Format($"{nameof(this.options.GossipChannels)}.{channel.Key}", channel.Value));
+            }
+            return formated;
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
@@ -1,7 +1,7 @@
-using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Options;
+using Orleans.Runtime;
 
 namespace Orleans.Hosting
 {
@@ -22,14 +22,14 @@ namespace Orleans.Hosting
         public TimeSpan MaxSocketAge { get; set; } = TimeSpan.MaxValue;
     }
 
-    public class NetworkingOptionFormatter : IOptionFormatter<NetworkingOptions>
+    public class NetworkingOptionsFormatter : IOptionFormatter<NetworkingOptions>
     {
         public string Category { get; }
 
         public string Name => nameof(NetworkingOptions);
 
         private NetworkingOptions options;
-        public NetworkingOptionFormatter(IOptions<NetworkingOptions> options)
+        public NetworkingOptionsFormatter(IOptions<NetworkingOptions> options)
         {
             this.options = options.Value;
         }
@@ -38,8 +38,8 @@ namespace Orleans.Hosting
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.OpenConnectionTimeout),options.OpenConnectionTimeout),
-                OptionFormattingUtilities.Format(nameof(options.MaxSocketAge), options.MaxSocketAge)
+                OptionFormattingUtilities.Format(nameof(this.options.OpenConnectionTimeout),this.options.OpenConnectionTimeout),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxSocketAge), this.options.MaxSocketAge)
             };
         }
     }

--- a/src/Orleans.Core/Configuration/Options/ReminderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ReminderOptions.cs
@@ -1,8 +1,13 @@
 
 using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Settings for reminder service.
+    /// </summary>
     public class ReminderOptions
     {
         public static class BuiltIn
@@ -52,5 +57,29 @@ namespace Orleans.Hosting
         public TimeSpan MockReminderTableTimeout { get; set; } = DEFAULT_MOCK_REMINDER_TABLE_TIMEOUT;
         public static readonly TimeSpan DEFAULT_MOCK_REMINDER_TABLE_TIMEOUT = TimeSpan.FromMilliseconds(50);
         #endregion TEST
+    }
+
+    public class ReminderOptionsFormatter : IOptionFormatter<ReminderOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(ReminderOptions);
+
+        private ReminderOptions options;
+        public ReminderOptionsFormatter(IOptions<ReminderOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(this.options.ReminderService),this.options.ReminderService),
+                OptionFormattingUtilities.Format(nameof(this.options.ReminderTableAssembly), this.options.ReminderTableAssembly),
+                OptionFormattingUtilities.Format(nameof(this.options.UseMockReminderTable), this.options.UseMockReminderTable),
+                OptionFormattingUtilities.Format(nameof(this.options.MockReminderTableTimeout), this.options.MockReminderTableTimeout),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/SchedulingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SchedulingOptions.cs
@@ -1,6 +1,6 @@
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
@@ -49,9 +49,17 @@ namespace Orleans.Hosting
         public TimeSpan TurnWarningLengthThreshold { get; set; } = DEFAULT_TURN_WARNING_THRESHOLD;
         public static readonly TimeSpan DEFAULT_TURN_WARNING_THRESHOLD = TimeSpan.FromMilliseconds(200);
 
+        /// <summary>
+        /// Per work group limit of how many items can be queued up before warnings are generated.
+        /// </summary>
         public int MaxPendingWorkItemsSoftLimit { get; set; } = DEFAULT_MAX_PENDING_ITEMS_SOFT_LIMIT;
         public const int DEFAULT_MAX_PENDING_ITEMS_SOFT_LIMIT = 0;
 
+        /// <summary>
+        /// Per work group limit of how many items can be queued up before work is rejected.
+        /// NOTE: This setting is not in effect.
+        /// TODO: Remove this setting - jbragg
+        /// </summary>
         public int MaxPendingWorkItemsHardLimit { get; set; } = DEFAULT_MAX_PENDING_ITEMS_HARD_LIMIT;
         public const int DEFAULT_MAX_PENDING_ITEMS_HARD_LIMIT = 0;
 
@@ -78,14 +86,14 @@ namespace Orleans.Hosting
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.PerformDeadlockDetection),options.PerformDeadlockDetection),
-                OptionFormattingUtilities.Format(nameof(options.AllowCallChainReentrancy), options.AllowCallChainReentrancy),
-                OptionFormattingUtilities.Format(nameof(options.DelayWarningThreshold), options.DelayWarningThreshold),
-                OptionFormattingUtilities.Format(nameof(options.ActivationSchedulingQuantum), options.ActivationSchedulingQuantum),
-                OptionFormattingUtilities.Format(nameof(options.TurnWarningLengthThreshold), options.TurnWarningLengthThreshold),
-                OptionFormattingUtilities.Format(nameof(options.MaxPendingWorkItemsSoftLimit), options.MaxPendingWorkItemsSoftLimit),
-                OptionFormattingUtilities.Format(nameof(options.MaxPendingWorkItemsHardLimit), options.MaxPendingWorkItemsHardLimit),
-                OptionFormattingUtilities.Format(nameof(options.EnableWorkerThreadInjection), options.EnableWorkerThreadInjection),
+                OptionFormattingUtilities.Format(nameof(this.options.PerformDeadlockDetection), this.options.PerformDeadlockDetection),
+                OptionFormattingUtilities.Format(nameof(this.options.AllowCallChainReentrancy), this.options.AllowCallChainReentrancy),
+                OptionFormattingUtilities.Format(nameof(this.options.DelayWarningThreshold), this.options.DelayWarningThreshold),
+                OptionFormattingUtilities.Format(nameof(this.options.ActivationSchedulingQuantum), this.options.ActivationSchedulingQuantum),
+                OptionFormattingUtilities.Format(nameof(this.options.TurnWarningLengthThreshold), this.options.TurnWarningLengthThreshold),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxPendingWorkItemsSoftLimit), this.options.MaxPendingWorkItemsSoftLimit),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxPendingWorkItemsHardLimit), this.options.MaxPendingWorkItemsHardLimit),
+                OptionFormattingUtilities.Format(nameof(this.options.EnableWorkerThreadInjection), this.options.EnableWorkerThreadInjection),
             };
         }
     }

--- a/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
@@ -9,7 +9,14 @@ namespace Orleans.Hosting
     /// </summary>
     public class SerializationProviderOptions
     {
+        /// <summary>
+        /// Externally registered serializers
+        /// </summary>
         public List<TypeInfo> SerializationProviders { get; set; } = new List<TypeInfo>();
+
+        /// <summary>
+        /// Serializer used if no serializer is found for a type.
+        /// </summary>
         public TypeInfo FallbackSerializationProvider { get; set; }
     }
 
@@ -28,8 +35,8 @@ namespace Orleans.Hosting
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.SerializationProviders), string.Join(",", options.SerializationProviders)),
-                OptionFormattingUtilities.Format(nameof(options.FallbackSerializationProvider), options.FallbackSerializationProvider)
+                OptionFormattingUtilities.Format(nameof(this.options.SerializationProviders), string.Join(",", this.options.SerializationProviders)),
+                OptionFormattingUtilities.Format(nameof(this.options.FallbackSerializationProvider), this.options.FallbackSerializationProvider)
             };
         }
     }

--- a/src/Orleans.Core/Configuration/Options/ServicePointOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ServicePointOptions.cs
@@ -1,6 +1,14 @@
 
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Settings for tuning service point for faster access to azure storage.
+    /// NOTE: Should not be part of orleans core.
+    /// TODO: Remove - jbragg
+    /// </summary>
     public class ServicePointOptions
     {
         public int DefaultConnectionLimit { get; set; } = DEFAULT_MIN_DOT_NET_CONNECTION_LIMIT;
@@ -9,5 +17,28 @@ namespace Orleans.Hosting
         public bool Expect100Continue { get; set; }
 
         public bool UseNagleAlgorithm { get; set; }
+    }
+
+    public class ServicePointOptionsFormatter : IOptionFormatter<ServicePointOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(ServicePointOptions);
+
+        private ServicePointOptions options;
+        public ServicePointOptionsFormatter(IOptions<ServicePointOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(this.options.DefaultConnectionLimit), this.options.DefaultConnectionLimit),
+                OptionFormattingUtilities.Format(nameof(this.options.Expect100Continue), this.options.Expect100Continue),
+                OptionFormattingUtilities.Format(nameof(this.options.UseNagleAlgorithm), this.options.UseNagleAlgorithm),
+            };
+        }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SiloMessagingOptions.cs
@@ -1,7 +1,7 @@
-using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Options;
+using Orleans.Runtime;
 
 namespace Orleans.Hosting
 {
@@ -36,18 +36,33 @@ namespace Orleans.Hosting
         /// </summary>
         public TimeSpan ClientDropTimeout { get; set; } = Constants.DEFAULT_CLIENT_DROP_TIMEOUT;
 
+        /// <summary>
+        /// Interval in which the list of connected clients is refreshed.
+        /// </summary>
         public TimeSpan ClientRegistrationRefresh { get; set; } = DEFAULT_CLIENT_REGISTRATION_REFRESH;
         public static readonly TimeSpan DEFAULT_CLIENT_REGISTRATION_REFRESH = TimeSpan.FromMinutes(5);
 
+        /// <summary>
+        /// Per grain threshold for pending requests.  Generated warning when exceeded.
+        /// </summary>
         public int MaxEnqueuedRequestsSoftLimit { get; set; } = DEFAULT_MAX_ENQUEUED_REQUESTS_SOFT_LIMIT;
         public const int DEFAULT_MAX_ENQUEUED_REQUESTS_SOFT_LIMIT = 0;
 
+        /// <summary>
+        /// Per grain threshold for pending requests.  Requests are rejected when exceeded.
+        /// </summary>
         public int MaxEnqueuedRequestsHardLimit { get; set; } = DEFAULT_MAX_ENQUEUED_REQUESTS_HARD_LIMIT;
         public const int DEFAULT_MAX_ENQUEUED_REQUESTS_HARD_LIMIT = 0;
 
+        /// <summary>
+        /// Per grain threshold for pending requests for stateless workers.  Generated warning when exceeded.
+        /// </summary>
         public int MaxEnqueuedRequestsSoftLimit_StatelessWorker { get; set; } = DEFAULT_MAX_ENQUEUED_REQUESTS_STATELESS_WORKER_SOFT_LIMIT;
         public const int DEFAULT_MAX_ENQUEUED_REQUESTS_STATELESS_WORKER_SOFT_LIMIT = 0;
 
+        /// <summary>
+        /// Per grain threshold for pending requests for stateless workers.  Requests are rejected when exceeded.
+        /// </summary>
         public int MaxEnqueuedRequestsHardLimit_StatelessWorker { get; set; } = DEFAULT_MAX_ENQUEUED_REQUESTS_STATELESS_WORKER_HARD_LIMIT;
         public const int DEFAULT_MAX_ENQUEUED_REQUESTS_STATELESS_WORKER_HARD_LIMIT = 0;
 
@@ -81,17 +96,17 @@ namespace Orleans.Hosting
             List<string> format = base.FormatSharedOptions();
             format.AddRange(new List<string>
             {
-                OptionFormattingUtilities.Format(nameof(options.SiloSenderQueues), options.SiloSenderQueues),
-                OptionFormattingUtilities.Format(nameof(options.GatewaySenderQueues), options.GatewaySenderQueues),
-                OptionFormattingUtilities.Format(nameof(options.MaxForwardCount), options.MaxForwardCount),
-                OptionFormattingUtilities.Format(nameof(options.ClientDropTimeout), options.ClientDropTimeout),
-                OptionFormattingUtilities.Format(nameof(options.ClientRegistrationRefresh), options.ClientRegistrationRefresh),
-                OptionFormattingUtilities.Format(nameof(options.MaxEnqueuedRequestsSoftLimit), options.MaxEnqueuedRequestsSoftLimit),
-                OptionFormattingUtilities.Format(nameof(options.MaxEnqueuedRequestsHardLimit), options.MaxEnqueuedRequestsHardLimit),
-                OptionFormattingUtilities.Format(nameof(options.MaxEnqueuedRequestsSoftLimit_StatelessWorker), options.MaxEnqueuedRequestsSoftLimit_StatelessWorker),
-                OptionFormattingUtilities.Format(nameof(options.MaxEnqueuedRequestsHardLimit_StatelessWorker), options.MaxEnqueuedRequestsHardLimit_StatelessWorker),
-                OptionFormattingUtilities.Format(nameof(options.MaxRequestProcessingTime), options.MaxRequestProcessingTime),
-                OptionFormattingUtilities.Format(nameof(options.AssumeHomogenousSilosForTesting), options.AssumeHomogenousSilosForTesting)
+                OptionFormattingUtilities.Format(nameof(this.options.SiloSenderQueues), this.options.SiloSenderQueues),
+                OptionFormattingUtilities.Format(nameof(this.options.GatewaySenderQueues), this.options.GatewaySenderQueues),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxForwardCount), this.options.MaxForwardCount),
+                OptionFormattingUtilities.Format(nameof(this.options.ClientDropTimeout), this.options.ClientDropTimeout),
+                OptionFormattingUtilities.Format(nameof(this.options.ClientRegistrationRefresh), this.options.ClientRegistrationRefresh),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxEnqueuedRequestsSoftLimit), this.options.MaxEnqueuedRequestsSoftLimit),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxEnqueuedRequestsHardLimit), this.options.MaxEnqueuedRequestsHardLimit),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxEnqueuedRequestsSoftLimit_StatelessWorker), this.options.MaxEnqueuedRequestsSoftLimit_StatelessWorker),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxEnqueuedRequestsHardLimit_StatelessWorker), this.options.MaxEnqueuedRequestsHardLimit_StatelessWorker),
+                OptionFormattingUtilities.Format(nameof(this.options.MaxRequestProcessingTime), this.options.MaxRequestProcessingTime),
+                OptionFormattingUtilities.Format(nameof(this.options.AssumeHomogenousSilosForTesting), this.options.AssumeHomogenousSilosForTesting)
             });
             return format;
         }

--- a/src/Orleans.Core/Configuration/Options/SiloStatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SiloStatisticsOptions.cs
@@ -4,6 +4,9 @@ using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Statistics output related options for silo.
+    /// </summary>
     public class SiloStatisticsOptions : StatisticsOptions
     {
         public static readonly TimeSpan SILO_DEFAULT_PERF_COUNTERS_WRITE_PERIOD = TimeSpan.FromSeconds(30);
@@ -13,6 +16,9 @@ namespace Orleans.Hosting
             this.PerfCountersWriteInterval = SILO_DEFAULT_PERF_COUNTERS_WRITE_PERIOD;
         }
 
+        /// <summary>
+        /// Interval in which deployment statistics are published.
+        /// </summary>
         public TimeSpan DeploymentLoadPublisherRefreshTime { get; set; } = DEFAULT_DEPLOYMENT_LOAD_PUBLISHER_REFRESH_TIME;
         public static readonly TimeSpan DEFAULT_DEPLOYMENT_LOAD_PUBLISHER_REFRESH_TIME = TimeSpan.FromSeconds(1);
 

--- a/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Extensions.Options;
 
 namespace Orleans.Configuration.Options
@@ -31,7 +30,7 @@ namespace Orleans.Configuration.Options
         public IEnumerable<string> Format()
         {
             return new List<string>()
-                {OptionFormattingUtilities.Format(nameof(options.Gateways), string.Join(",", options.Gateways))};
+                {OptionFormattingUtilities.Format(nameof(this.options.Gateways), string.Join(",", this.options.Gateways))};
         }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/StatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/StatisticsOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 

--- a/src/Orleans.Core/Configuration/Options/TelemetryOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/TelemetryOptions.cs
@@ -1,12 +1,19 @@
-using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
 
-namespace Orleans.Configuration.Options
+namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Telemetry consumer settings
+    /// </summary>
     public class TelemetryOptions
     {
-        internal IList<Type> Consumers { get; set; } = new List<Type>();
+        /// <summary>
+        /// Configured telemetry consumers
+        /// </summary>
+        public IList<Type> Consumers { get; set; } = new List<Type>();
     }
 
     public static class TelemetryOptionsExtensions
@@ -15,6 +22,25 @@ namespace Orleans.Configuration.Options
         {
             options.Consumers.Add(typeof(T));
             return options;
+        }
+    }
+
+    public class TelemetryOptionsFormatter : IOptionFormatter<TelemetryOptions>
+    {
+        public string Category { get; }
+
+        public string Name => nameof(TelemetryOptions);
+
+        private TelemetryOptions options;
+        public TelemetryOptionsFormatter(IOptions<TelemetryOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+                {OptionFormattingUtilities.Format(nameof(this.options.Consumers), string.Join(";", this.options.Consumers))};
         }
     }
 }

--- a/src/Orleans.Core/Configuration/Options/ThreadPoolOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ThreadPoolOptions.cs
@@ -1,11 +1,18 @@
 
-using Microsoft.Extensions.Options;
 using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Thread pool settings
+    /// NOTE: Should this be in orleans core? - jbragg
+    /// </summary>
     public class ThreadPoolOptions
     {
+        /// <summary>
+        /// Minimum number of DotNet threads.
+        /// </summary>
         public int MinDotNetThreadPoolSize { get; set; } = DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE;
         public const int DEFAULT_MIN_DOT_NET_THREAD_POOL_SIZE = 200;
     }
@@ -26,7 +33,7 @@ namespace Orleans.Hosting
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.MinDotNetThreadPoolSize),options.MinDotNetThreadPoolSize),
+                OptionFormattingUtilities.Format(nameof(this.options.MinDotNetThreadPoolSize),this.options.MinDotNetThreadPoolSize),
             };
         }
     }

--- a/src/Orleans.Core/Configuration/Options/TypeManagementOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/TypeManagementOptions.cs
@@ -1,9 +1,12 @@
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Type management settings for in place upgrade.
+    /// </summary>
     public class TypeManagementOptions
     {
         /// <summary>
@@ -29,7 +32,7 @@ namespace Orleans.Hosting
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.TypeMapRefreshInterval),options.TypeMapRefreshInterval),
+                OptionFormattingUtilities.Format(nameof(this.options.TypeMapRefreshInterval),this.options.TypeMapRefreshInterval),
             };
         }
     }

--- a/src/Orleans.Core/Configuration/Options/VersioningOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/VersioningOptions.cs
@@ -1,16 +1,25 @@
 
+using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using Orleans.Versions.Compatibility;
 using Orleans.Versions.Selector;
-using System.Collections.Generic;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Versioning options govern grain implementation selection in heterogeneous deployments.
+    /// </summary>
     public class VersioningOptions
     {
+        /// <summary>
+        /// Strategy used to determine grain compatibility in heterogeneous deployments.
+        /// </summary>
         public string DefaultCompatibilityStrategy { get; set; } = DEFAULT_COMPATABILITY_STRATEGY;
         public const string DEFAULT_COMPATABILITY_STRATEGY = nameof(BackwardCompatible);
 
+        /// <summary>
+        /// Strategy for selecting grain versions in heterogeneous deployments.
+        /// </summary>
         public string DefaultVersionSelectorStrategy { get; set; } = DEFAULT_VERSION_SELECTOR_STRATEGY;
         public const string DEFAULT_VERSION_SELECTOR_STRATEGY = nameof(AllCompatibleVersions);
     }
@@ -31,8 +40,8 @@ namespace Orleans.Hosting
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.DefaultCompatibilityStrategy),options.DefaultCompatibilityStrategy),
-                OptionFormattingUtilities.Format(nameof(options.DefaultVersionSelectorStrategy),options.DefaultVersionSelectorStrategy),
+                OptionFormattingUtilities.Format(nameof(this.options.DefaultCompatibilityStrategy),this.options.DefaultCompatibilityStrategy),
+                OptionFormattingUtilities.Format(nameof(this.options.DefaultVersionSelectorStrategy),this.options.DefaultVersionSelectorStrategy),
             };
         }
     }

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -67,7 +67,7 @@ namespace Orleans
             //Add default option formatter if none is configured, for options which are requied to be configured 
             services.TryConfigureFormatter<ClusterClientOptions, ClusterClientOptionsFormatter>();
             services.TryConfigureFormatter<ClientMessagingOptions, ClientMessagingOptionFormatter>();
-            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
+            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionsFormatter>();
             services.TryConfigureFormatter<ClientStatisticsOptions, ClientStatisticsOptionsFormatter>();
         }
     }

--- a/src/Orleans.Core/Telemetry/TelemetryManager.cs
+++ b/src/Orleans.Core/Telemetry/TelemetryManager.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Orleans.Configuration.Options;
-using Orleans.Runtime.Configuration;
+using Orleans.Hosting;
 
 namespace Orleans.Runtime
 {

--- a/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
+++ b/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
@@ -1,6 +1,6 @@
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Runtime
 {
@@ -44,10 +44,10 @@ namespace Orleans.Runtime
         {
             return new List<string>()
             {
-                OptionFormattingUtilities.Format(nameof(options.SiloName),options.SiloName),
-                OptionFormattingUtilities.Format(nameof(options.ClusterId), options.ClusterId),
-                OptionFormattingUtilities.Format(nameof(options.ServiceId), options.ServiceId),
-                OptionFormattingUtilities.Format(nameof(options.FastKillOnCancelKeyPress), options.FastKillOnCancelKeyPress)
+                OptionFormattingUtilities.Format(nameof(this.options.SiloName),this.options.SiloName),
+                OptionFormattingUtilities.Format(nameof(this.options.ClusterId), this.options.ClusterId),
+                OptionFormattingUtilities.Format(nameof(this.options.ServiceId), this.options.ServiceId),
+                OptionFormattingUtilities.Format(nameof(this.options.FastKillOnCancelKeyPress), this.options.FastKillOnCancelKeyPress)
             };
         }
     }

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
@@ -291,11 +291,11 @@ namespace Orleans.Hosting
                     options.MockReminderTableTimeout = config.MockReminderTableTimeout;
                 });
 
-            services.AddOptions<VersioningOptions>()
+            services.AddOptions<GrainVersioningOptions>()
                 .Configure<GlobalConfiguration>((options, config) =>
                 {
-                    options.DefaultCompatibilityStrategy = config.DefaultCompatibilityStrategy?.GetType().Name ?? VersioningOptions.DEFAULT_COMPATABILITY_STRATEGY;
-                    options.DefaultVersionSelectorStrategy = config.DefaultVersionSelectorStrategy?.GetType().Name ?? VersioningOptions.DEFAULT_VERSION_SELECTOR_STRATEGY;
+                    options.DefaultCompatibilityStrategy = config.DefaultCompatibilityStrategy?.GetType().Name ?? GrainVersioningOptions.DEFAULT_COMPATABILITY_STRATEGY;
+                    options.DefaultVersionSelectorStrategy = config.DefaultVersionSelectorStrategy?.GetType().Name ?? GrainVersioningOptions.DEFAULT_VERSION_SELECTOR_STRATEGY;
                 });
 
             services.AddOptions<ThreadPoolOptions>()

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -246,7 +246,7 @@ namespace Orleans.Hosting
             services.TryConfigureFormatter<GrainDirectoryOptions, GrainDirectoryOptionsFormatter>();
             services.TryConfigureFormatter<GrainPlacementOptions, GrainPlacementOptionsFormatter>();
             services.TryConfigureFormatter<GrainCollectionOptions, GrainCollectionOptionsFormatter>();
-            services.TryConfigureFormatter<VersioningOptions, VersioningOptionsFormatter>();
+            services.TryConfigureFormatter<GrainVersioningOptions, GrainVersioningOptionsFormatter>();
             services.TryConfigureFormatter<ConsistentRingOptions, ConsistentRingOptionsFormatter>();
             services.TryConfigureFormatter<MultiClusterOptions, MultiClusterOptionsFormatter>();
             services.TryConfigureFormatter<SiloStatisticsOptions, SiloStatisticsOptionsFormatter>();

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -239,13 +239,22 @@ namespace Orleans.Hosting
             services.TryConfigureFormatter<SchedulingOptions, SchedulingOptionsFormatter>();
             services.TryConfigureFormatter<ThreadPoolOptions, ThreadPoolOptionsFormatter>();
             services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();
-            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionFormatter>();
+            services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionsFormatter>();
             services.TryConfigureFormatter<SiloMessagingOptions, SiloMessagingOptionFormatter>();
             services.TryConfigureFormatter<TypeManagementOptions, TypeManagementOptionsFormatter>();
+            services.TryConfigureFormatter<MembershipOptions, MembershipOptionsFormatter>();
             services.TryConfigureFormatter<GrainDirectoryOptions, GrainDirectoryOptionsFormatter>();
             services.TryConfigureFormatter<GrainPlacementOptions, GrainPlacementOptionsFormatter>();
+            services.TryConfigureFormatter<GrainCollectionOptions, GrainCollectionOptionsFormatter>();
             services.TryConfigureFormatter<VersioningOptions, VersioningOptionsFormatter>();
+            services.TryConfigureFormatter<ConsistentRingOptions, ConsistentRingOptionsFormatter>();
+            services.TryConfigureFormatter<MultiClusterOptions, MultiClusterOptionsFormatter>();
             services.TryConfigureFormatter<SiloStatisticsOptions, SiloStatisticsOptionsFormatter>();
+            services.TryConfigureFormatter<AdoNetOptions, AdoNetOptionsFormatter>();
+            services.TryConfigureFormatter<GrainServiceOptions, GrainServiceOptionsFormatter>();
+            services.TryConfigureFormatter<ReminderOptions, ReminderOptionsFormatter>();
+            services.TryConfigureFormatter<ServicePointOptions, ServicePointOptionsFormatter>();
+            services.TryConfigureFormatter<TelemetryOptions, TelemetryOptionsFormatter>();
         }
     }
 }

--- a/src/Orleans.Runtime/Versions/Compatibility/CompatibilityDirectorManager.cs
+++ b/src/Orleans.Runtime/Versions/Compatibility/CompatibilityDirectorManager.cs
@@ -15,7 +15,7 @@ namespace Orleans.Runtime.Versions.Compatibility
         public ICompatibilityDirector Default { get; private set; }
 
 
-        public CompatibilityDirectorManager(IServiceProvider serviceProvider, IOptions<VersioningOptions> options)
+        public CompatibilityDirectorManager(IServiceProvider serviceProvider, IOptions<GrainVersioningOptions> options)
         {
             this.serviceProvider = serviceProvider;
             this.strategyFromConfig = serviceProvider.GetRequiredServiceByName<CompatibilityStrategy>(options.Value.DefaultCompatibilityStrategy);

--- a/src/Orleans.Runtime/Versions/Selector/VersionDirectorManager.cs
+++ b/src/Orleans.Runtime/Versions/Selector/VersionDirectorManager.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime.Versions.Selector
 
         public IVersionSelector Default { get; set; }
 
-        public VersionSelectorManager(IServiceProvider serviceProvider, IOptions<VersioningOptions> options)
+        public VersionSelectorManager(IServiceProvider serviceProvider, IOptions<GrainVersioningOptions> options)
         {
             this.serviceProvider = serviceProvider;
             this.strategyFromConfig = serviceProvider.GetRequiredServiceByName<VersionSelectorStrategy>(options.Value.DefaultVersionSelectorStrategy);


### PR DESCRIPTION
Added formatters for all remaining options except StorageOptions, which will be refactored anyway.
Added xml comments for all remaining options and properties except StorageOptions and ServicePointOptions.

Formatters have only been registered on silo, will need to register them on the client once we've an idea of what options are needed client side (Out of scope).

Related to:
"Configuration Work - Formatters" #3955 
"Configuration Work - XML docs" #3950 