### PR TITLE
Fixes for Multi-Cluster Support

### DIFF
--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -258,6 +258,46 @@ namespace Orleans
             throw new TimeoutException(errorMessage);
         }
 
+        /// <summary>
+        /// For making an uncancellable task cancellable, by ignoring its result.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="taskToComplete"></param>
+        /// <param name="timeSpan"></param>
+        /// <returns></returns>
+        public static Task<T> WithCancellation<T>(this Task<T> taskToComplete, CancellationToken cancellationToken)
+        {
+            if (taskToComplete.IsCompleted || !cancellationToken.CanBeCanceled)
+            {
+                return taskToComplete;
+            }
+            else if (cancellationToken.IsCancellationRequested)
+            {
+                return TaskFromCanceled<T>();
+            }
+            else 
+            {
+                return MakeCancellable(taskToComplete, cancellationToken);
+            }
+        }
+
+        private static async Task<T> MakeCancellable<T>(Task<T> task, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            using (cancellationToken.Register(() =>
+                      tcs.TrySetCanceled(cancellationToken), useSynchronizationContext: false))
+            {
+                var firstToComplete = await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
+
+                if (firstToComplete != task)
+                {
+                    task.Ignore();
+                }
+
+                return await firstToComplete.ConfigureAwait(false);
+            }
+        }
+
         internal static Task WrapInTask(Action action)
         {
             try

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -262,8 +262,8 @@ namespace Orleans
         /// For making an uncancellable task cancellable, by ignoring its result.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="taskToComplete"></param>
-        /// <param name="timeSpan"></param>
+        /// <param name="taskToComplete">The task to wait for unless cancelled</param>
+        /// <param name="cancellationToken">A cancellation token for cancelling the wait</param>
         /// <returns></returns>
         public static Task<T> WithCancellation<T>(this Task<T> taskToComplete, CancellationToken cancellationToken)
         {

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -265,7 +265,7 @@ namespace Orleans
         /// <param name="taskToComplete">The task to wait for unless cancelled</param>
         /// <param name="cancellationToken">A cancellation token for cancelling the wait</param>
         /// <returns></returns>
-        public static Task<T> WithCancellation<T>(this Task<T> taskToComplete, CancellationToken cancellationToken)
+        internal static Task<T> WithCancellation<T>(this Task<T> taskToComplete, CancellationToken cancellationToken)
         {
             if (taskToComplete.IsCompleted || !cancellationToken.CanBeCanceled)
             {

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -563,9 +563,9 @@ namespace Orleans.Runtime
             AppendIfExists(HeadersContainer.Headers.CORRELATION_ID, sb, (m) => m.Id);
             AppendIfExists(HeadersContainer.Headers.ALWAYS_INTERLEAVE, sb, (m) => m.IsAlwaysInterleave);
             AppendIfExists(HeadersContainer.Headers.IS_NEW_PLACEMENT, sb, (m) => m.IsNewPlacement);
+            AppendIfExists(HeadersContainer.Headers.IS_RETURNED_FROM_REMOTE_CLUSTER, sb, (m) => m.IsReturnedFromRemoteCluster);
             AppendIfExists(HeadersContainer.Headers.READ_ONLY, sb, (m) => m.IsReadOnly);
             AppendIfExists(HeadersContainer.Headers.IS_UNORDERED, sb, (m) => m.IsUnordered);
-            AppendIfExists(HeadersContainer.Headers.IS_RETURNED_FROM_REMOTE_CLUSTER, sb, (m) => m.IsReturnedFromRemoteCluster);
             AppendIfExists(HeadersContainer.Headers.NEW_GRAIN_TYPE, sb, (m) => m.NewGrainType);
             AppendIfExists(HeadersContainer.Headers.REJECTION_INFO, sb, (m) => m.RejectionInfo);
             AppendIfExists(HeadersContainer.Headers.REJECTION_TYPE, sb, (m) => m.RejectionType);
@@ -1101,6 +1101,7 @@ namespace Orleans.Runtime
                 headers = _sendingGrain == null ? headers & ~Headers.SENDING_GRAIN : headers | Headers.SENDING_GRAIN;
                 headers = _sendingActivation == null ? headers & ~Headers.SENDING_ACTIVATION : headers | Headers.SENDING_ACTIVATION;
                 headers = _isNewPlacement == default(bool) ? headers & ~Headers.IS_NEW_PLACEMENT : headers | Headers.IS_NEW_PLACEMENT;
+                headers = _isReturnedFromRemoteCluster == default(bool) ? headers & ~Headers.IS_RETURNED_FROM_REMOTE_CLUSTER : headers | Headers.IS_RETURNED_FROM_REMOTE_CLUSTER;
                 headers = _isUsingIfaceVersion == default(bool) ? headers & ~Headers.IS_USING_INTERFACE_VERSION : headers | Headers.IS_USING_INTERFACE_VERSION;
                 headers = _result == default(ResponseTypes)? headers & ~Headers.RESULT : headers | Headers.RESULT;
                 headers = _timeToLive == null ? headers & ~Headers.TIME_TO_LIVE : headers | Headers.TIME_TO_LIVE;
@@ -1167,6 +1168,9 @@ namespace Orleans.Runtime
 
                 if ((headers & Headers.IS_NEW_PLACEMENT) != Headers.NONE)
                     writer.Write(input.IsNewPlacement);
+
+                if ((headers & Headers.IS_RETURNED_FROM_REMOTE_CLUSTER) != Headers.NONE)
+                    writer.Write(input.IsReturnedFromRemoteCluster);
 
                 // Nothing to do with Headers.IS_USING_INTERFACE_VERSION since the value in
                 // the header is sufficient
@@ -1290,6 +1294,9 @@ namespace Orleans.Runtime
 
                 if ((headers & Headers.IS_NEW_PLACEMENT) != Headers.NONE)
                     result.IsNewPlacement = ReadBool(reader);
+
+                if ((headers & Headers.IS_RETURNED_FROM_REMOTE_CLUSTER) != Headers.NONE)
+                    result.IsReturnedFromRemoteCluster = ReadBool(reader);
 
                 if ((headers & Headers.IS_USING_INTERFACE_VERSION) != Headers.NONE)
                     result.IsUsingIfaceVersion = true;

--- a/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
@@ -80,7 +80,11 @@ namespace Orleans.EventSourcing.StateStorage
                     // for manual testing
                     //await Task.Delay(5000);
 
-                    await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainReference, GlobalStateCache);
+                    var readState = new GrainStateWithMetaDataAndETag<TLogView>();
+
+                    await globalGrainStorage.ReadStateAsync(grainTypeName, Services.GrainReference, readState);
+
+                    GlobalStateCache = readState;
 
                     Services.Log(LogLevel.Debug, "read success {0}", GlobalStateCache);
 

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -257,6 +257,10 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 maintainer.Stop();
             }
+            if (GsiActivationMaintainer != null)
+            {
+                GsiActivationMaintainer.Stop();
+            }
             DirectoryCache.Clear();
         }
 
@@ -598,6 +602,8 @@ namespace Orleans.Runtime.GrainDirectory
 
                 // we are the owner     
                 var registrar = this.registrarManager.GetRegistrarForGrain(address.Grain);
+
+                if (log.IsEnabled(LogLevel.Trace)) log.Trace($"use registrar {registrar.GetType().Name} for activation {address}");
 
                 return registrar.IsSynchronous ? registrar.Register(address, singleActivation)
                     : await registrar.RegisterAsync(address, singleActivation);

--- a/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
+++ b/src/Orleans.Runtime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
@@ -10,10 +10,12 @@ using Orleans.SystemTargetInterfaces;
 using Orleans.Runtime.Scheduler;
 using OutcomeState = Orleans.Runtime.GrainDirectory.GlobalSingleInstanceResponseOutcome.OutcomeState;
 using Orleans.Runtime.MultiClusterNetwork;
+using Orleans.MultiCluster;
+using System.Threading;
 
 namespace Orleans.Runtime.GrainDirectory
 {
-    internal class GlobalSingleInstanceActivationMaintainer : AsynchAgent
+    internal class GlobalSingleInstanceActivationMaintainer : AsynchAgent, IMultiClusterConfigurationListener
     {
         private readonly object lockable = new object();
         private readonly LocalGrainDirectory router;
@@ -28,6 +30,9 @@ namespace Orleans.Runtime.GrainDirectory
         // therefore, we maintain a list of potentially doubtful activations on the side.
         // maintainer periodically takes and processes this list.
         private List<GrainId> doubtfulGrains = new List<GrainId>();
+
+        // used to cut short the waiting time before next run
+        private ManualResetEvent runNow = new ManualResetEvent(false);
 
         public GlobalSingleInstanceActivationMaintainer(
             LocalGrainDirectory router,
@@ -47,6 +52,7 @@ namespace Orleans.Runtime.GrainDirectory
             this.siloDetails = siloDetails;
             this.multiClusterOptions = multiClusterOptions.Value;
             this.period = multiClusterOptions.Value.GlobalSingleInstanceRetryInterval;
+            multiClusterOracle.SubscribeToMultiClusterConfigurationEvents(this);
             logger.Debug("GSIP:M GlobalSingleInstanceActivationMaintainer Started, Period = {0}", period);
         }
 
@@ -83,21 +89,26 @@ namespace Orleans.Runtime.GrainDirectory
         }
 
         // the following method runs for the whole lifetime of the silo, doing the periodic maintenance
-        protected override async void Run()
+        protected override void Run()
         {
             if (!this.multiClusterOptions.HasMultiClusterNetwork)
                 return;
 
             var myClusterId = this.siloDetails.ClusterId;
 
-            while (router.Running)
+            Cts.Token.Register(this.Prod);
+
+            while (router.Running && !Cts.IsCancellationRequested)
             {
                 try
                 {
-                    await Task.Delay(period);
-                    if (!router.Running) break;
+                    // wait until it is time, or someone prodded us to continue
+                    runNow.WaitOne(period);
+                    runNow.Reset();
 
-                    logger.Debug("GSIP:M running periodic check (having waited {0})", period);
+                    if (!router.Running || Cts.IsCancellationRequested) break;
+
+                    logger.Debug("GSIP:M running check");
 
                     // examine the multicluster configuration
                     var multiClusterConfig = this.multiClusterOracle.GetMultiClusterConfiguration();
@@ -116,32 +127,39 @@ namespace Orleans.Runtime.GrainDirectory
 
                         logger.Debug("GSIP:M Not joined to multicluster. Make {0} owned entries doubtful {1}", ownedEntries.Count, logger.IsEnabled(LogLevel.Trace) ? string.Join(",", ownedEntries.Select(s => s.Item1)) : "");
 
-                        await router.Scheduler.QueueTask(
+                        router.Scheduler.QueueTask(
                             () => RunBatchedDemotion(ownedEntries),
                             router.CacheValidator.SchedulingContext
-                        );
+                        ).Wait();
                     }
                     else
                     {
                         // we are joined to the multicluster.
-                        // go through all doubtful entries and broadcast ownership requests for each
 
-                        // take them all out of the list for processing.
-                        List<GrainId> grains;
-                        lock (lockable)
+                        List<KeyValuePair<string, SiloAddress>> remoteClusters = multiClusterConfig.Clusters
+                            .Where(id => id != myClusterId)
+                            .Select(id => new KeyValuePair<string, SiloAddress>(id, this.multiClusterOracle.GetRandomClusterGateway(id)))
+                            .ToList();
+
+                        if (!remoteClusters.Any(kvp => kvp.Value == null))
                         {
-                            grains = doubtfulGrains;
-                            doubtfulGrains = new List<GrainId>();
+                            // all clusters have at least one gateway reporting.
+                            // go through all doubtful entries and broadcast ownership requests for each
+
+                            List<GrainId> grains;
+                            lock (lockable)
+                            {
+                                grains = doubtfulGrains;
+                                doubtfulGrains = new List<GrainId>();
+                            }
+
+                            logger.Debug("GSIP:M retry {0} doubtful entries {1}", grains.Count, logger.IsEnabled(LogLevel.Trace) ? string.Join(",", grains) : "");
+
+                            router.Scheduler.QueueTask(
+                                () => RunBatchedActivationRequests(remoteClusters, grains),
+                                router.CacheValidator.SchedulingContext
+                            ).Wait();
                         }
-
-                        // filter
-                        logger.Debug("GSIP:M retry {0} doubtful entries {1}", grains.Count, logger.IsEnabled(LogLevel.Trace) ? string.Join(",", grains) : "");
-
-                        var remoteClusters = multiClusterConfig.Clusters.Where(id => id != myClusterId).ToList();
-                        await router.Scheduler.QueueTask(
-                            () => RunBatchedActivationRequests(remoteClusters, grains),
-                            router.CacheValidator.SchedulingContext
-                        );
                     }
                 }
                 catch (Exception e)
@@ -162,7 +180,7 @@ namespace Orleans.Runtime.GrainDirectory
             return Task.CompletedTask;
         }
 
-        private async Task RunBatchedActivationRequests(List<string> remoteClusters, List<GrainId> grains)
+        private async Task RunBatchedActivationRequests(List<KeyValuePair<string, SiloAddress>> remoteClusters, List<GrainId> grains)
         {
             var addresses = new List<ActivationAddress>();
 
@@ -188,15 +206,14 @@ namespace Orleans.Runtime.GrainDirectory
                 return;
 
             var batchResponses = new List<RemoteClusterActivationResponse[]>();
-
-            var tasks = remoteClusters.Select(async remotecluster =>
+                   
+            var tasks = remoteClusters.Select(async remotecluster => 
             {
                 // find gateway and send batched request
                 try
                 {
-                    var clusterGatewayAddress = this.multiClusterOracle.GetRandomClusterGateway(remotecluster);
-                    var clusterGrainDir = this.grainFactory.GetSystemTarget<IClusterGrainDirectory>(Constants.ClusterDirectoryServiceId, clusterGatewayAddress);
-                    var r = await clusterGrainDir.ProcessActivationRequestBatch(addresses.Select(a => a.Grain).ToArray(), this.siloDetails.ClusterId);
+                    var clusterGrainDir = this.grainFactory.GetSystemTarget<IClusterGrainDirectory>(Constants.ClusterDirectoryServiceId, remotecluster.Value);
+                    var r = await clusterGrainDir.ProcessActivationRequestBatch(addresses.Select(a => a.Grain).ToArray(), this.siloDetails.ClusterId).WithCancellation(Cts.Token);
                     batchResponses.Add(r);
                 }
                 catch (Exception e)
@@ -335,5 +352,16 @@ namespace Orleans.Runtime.GrainDirectory
             logger.Error((int) ErrorCode.GlobalSingleInstance_ProtocolError, string.Format("GSIP:Req {0} {1}", address.Grain.ToString(), msg));
         }
 
+        public void OnMultiClusterConfigurationChange(MultiClusterConfiguration next)
+        {
+            logger.Debug($"GSIP:M MultiClusterConfiguration {next}");
+            Prod();
+        }
+
+        public void Prod()
+        {
+            // cancel the waiting, to proceed immediately
+            runNow.Set();
+        }
     }
 }

--- a/src/Orleans.Runtime/LogConsistency/ProtocolServices.cs
+++ b/src/Orleans.Runtime/LogConsistency/ProtocolServices.cs
@@ -19,7 +19,7 @@ namespace Orleans.Runtime.LogConsistency
     /// This class allows access to these services to providers that cannot see runtime-internals.
     /// It also stores grain-specific information like the grain reference, and caches 
     /// </summary>
-    internal class ProtocolServices : ILogConsistencyProtocolServices
+    internal class ProtocolServices : ILogConsistencyProtocolServices, IMultiClusterConfigurationListener
     {
         private static readonly object[] EmptyObjectArray = new object[0];
 
@@ -156,7 +156,7 @@ namespace Orleans.Runtime.LogConsistency
             if (this.MultiClusterEnabled)
             {
                 // subscribe this grain to configuration change events
-                this.multiClusterOracle.SubscribeToMultiClusterConfigurationEvents(GrainReference);
+                this.multiClusterOracle.SubscribeToMultiClusterConfigurationEvents(this);
             }
         }
 
@@ -165,8 +165,15 @@ namespace Orleans.Runtime.LogConsistency
             if (this.MultiClusterEnabled)
             {
                 // unsubscribe this grain from configuration change events
-                this.multiClusterOracle.UnSubscribeFromMultiClusterConfigurationEvents(GrainReference);
+                this.multiClusterOracle.UnSubscribeFromMultiClusterConfigurationEvents(this);
             }
+        }
+
+        public void OnMultiClusterConfigurationChange(MultiClusterConfiguration next)
+        {
+            // enqueue conf change event as grain call
+            var g = this.grainFactory.Cast<ILogConsistencyProtocolParticipant>(GrainReference);
+            g.OnMultiClusterConfigurationChange(next).Ignore();
         }
 
         public IEnumerable<string> ActiveClusters

--- a/src/Orleans.Runtime/MultiClusterNetwork/IMultiClusterOracle.cs
+++ b/src/Orleans.Runtime/MultiClusterNetwork/IMultiClusterOracle.cs
@@ -64,17 +64,31 @@ namespace Orleans.Runtime.MultiClusterNetwork
         /// </summary>
         /// <param name="observer">An observer to receive configuration change notifications.</param>
         /// <returns>bool value indicating that subscription succeeded or not.</returns>
-        bool SubscribeToMultiClusterConfigurationEvents(GrainReference observer);
+        bool SubscribeToMultiClusterConfigurationEvents(IMultiClusterConfigurationListener observer);
 
         /// <summary>
         /// UnSubscribe from multicluster configuration change events.
         /// </summary>
         /// <returns>bool value indicating that subscription succeeded or not.</returns>
-        bool UnSubscribeFromMultiClusterConfigurationEvents(GrainReference observer);
+        bool UnSubscribeFromMultiClusterConfigurationEvents(IMultiClusterConfigurationListener observer);
 
         /// <summary>
         /// A test hook for dropping protocol messages between replicated grain instances
         /// </summary>
         Func<ILogConsistencyProtocolMessage, bool> ProtocolMessageFilterForTesting { get; set; }
     }
+
+    /// <summary>
+    /// Interface for subscribers to multi-cluster configuration changes.
+    /// </summary>
+    public interface IMultiClusterConfigurationListener
+    {
+        /// <summary>
+        /// Called when a configuration change notification is received.
+        /// </summary>
+        /// <param name="next">the next multi-cluster configuration</param>
+        /// <returns></returns>
+        void OnMultiClusterConfigurationChange(MultiClusterConfiguration next);
+    }
+
 }

--- a/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
+++ b/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterOracle.cs
@@ -120,14 +120,14 @@ namespace Orleans.Runtime.MultiClusterNetwork
             this.ScheduleTask(() => Utils.SafeExecute(() => this.PublishChanges())).Ignore();
         }
 
-        public bool SubscribeToMultiClusterConfigurationEvents(GrainReference observer)
+        public bool SubscribeToMultiClusterConfigurationEvents(IMultiClusterConfigurationListener listener)
         {
-            return localData.SubscribeToMultiClusterConfigurationEvents(observer);
+            return localData.SubscribeToMultiClusterConfigurationEvents(listener);
         }
 
-        public bool UnSubscribeFromMultiClusterConfigurationEvents(GrainReference observer)
+        public bool UnSubscribeFromMultiClusterConfigurationEvents(IMultiClusterConfigurationListener listener)
         {
-            return localData.UnSubscribeFromMultiClusterConfigurationEvents(observer);
+            return localData.UnSubscribeFromMultiClusterConfigurationEvents(listener);
         }
 
 
@@ -625,6 +625,12 @@ namespace Orleans.Runtime.MultiClusterNetwork
                     || !oracle.localData.Current.IsActiveGatewayForCluster(Silo, Cluster)))
                 {
                     Silo = oracle.GetRandomClusterGateway(Cluster);
+                }
+
+                // if the cluster has no gateways reporting, skip
+                if (Silo == null)
+                {
+                    return;
                 }
 
                 oracle.logger.Debug("-{0} Publish to silo {1} ({2}) {3}", id, Silo, Cluster ?? "local", data);

--- a/src/Orleans.TestingHost.Legacy/LogConsistencyProviderConfiguration.cs
+++ b/src/Orleans.TestingHost.Legacy/LogConsistencyProviderConfiguration.cs
@@ -26,11 +26,6 @@ namespace Orleans.TestingHost
         {
             {
                 var props = new Dictionary<string, string>();
-                props.Add("DataConnectionString", dataConnectionString);
-                config.Globals.RegisterStorageProvider("Orleans.Storage.AzureTableStorage", "AzureStore", props);
-            }
-            {
-                var props = new Dictionary<string, string>();
                 config.Globals.RegisterLogConsistencyProvider("Orleans.EventSourcing.StateStorage.LogConsistencyProvider", "StateStorage", props);
             }
             {

--- a/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
@@ -13,7 +13,7 @@ using Orleans.Configuration;
 
 namespace Tests.GeoClusterTests
 {
-    [TestCategory("GeoCluster")]
+    [TestCategory("GeoCluster"), TestCategory("Functional")]
     public class BasicLogTestGrainTests : IClassFixture<BasicLogTestGrainTests.Fixture>
     {
         private readonly Fixture fixture;

--- a/test/TesterInternal/GeoClusterTests/LogConsistencyTestFixture.cs
+++ b/test/TesterInternal/GeoClusterTests/LogConsistencyTestFixture.cs
@@ -1,4 +1,4 @@
-﻿using Orleans;
+using Orleans;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.LogConsistency;
@@ -143,6 +143,8 @@ namespace Tests.GeoClusterTests
 
         public void StartClustersIfNeeded(int numclusters, ITestOutputHelper output)
         {
+            this.output = output;
+
             if (MultiCluster.Clusters.Count != numclusters)
             {
                 if (MultiCluster.Clusters.Count > 0)
@@ -191,6 +193,8 @@ namespace Tests.GeoClusterTests
             }
         }
 
+        private ITestOutputHelper output;
+
         public virtual void Dispose()
         {
             _hostedMultiCluster?.Dispose();
@@ -203,6 +207,16 @@ namespace Tests.GeoClusterTests
 
         private const int Xyz = 333;
 
+        private void AssertEqual<T>(T expected, T actual, string grainIdentity)
+        {
+            if (! expected.Equals(actual))
+            {
+                // need to write grain identity to output so we can search for it in the trace
+                output.WriteLine($"identity of offending grain: {grainIdentity}");
+                Assert.Equal(expected, actual);
+            }
+        }
+
         public async Task RunChecksOnGrainClass(string grainClass, bool may_update_in_all_clusters, int phases, ITestOutputHelper output)
         {
             var random = new SafeRandom();
@@ -211,66 +225,66 @@ namespace Tests.GeoClusterTests
             Func<Task> checker1 = () => Task.Run(() =>
             {
                 int x = GetRandom();
-                var grainidentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
+                var grainIdentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
                 // force creation of replicas
                 for (int i = 0; i < numclusters; i++) 
-                   Assert.Equal(0, Client[i].GetALocal(grainClass, x)); 
+                   AssertEqual(0, Client[i].GetALocal(grainClass, x), grainIdentity); 
                 // write global on client 0
                 Client[0].SetAGlobal(grainClass, x, Xyz);
                 // read global on other clients
                 for (int i = 1; i < numclusters; i++)
                 {
                     int r = Client[i].GetAGlobal(grainClass, x);
-                    Assert.Equal(Xyz, r);
+                    AssertEqual(Xyz, r, grainIdentity);
                 }
                 // check local stability
                 for (int i = 0; i < numclusters; i++)
-                    Assert.Equal(Xyz, Client[i].GetALocal(grainClass, x));
+                    AssertEqual(Xyz, Client[i].GetALocal(grainClass, x), grainIdentity);
                 // check versions
                 for (int i = 0; i < numclusters; i++)
-                    Assert.Equal(1, Client[i].GetConfirmedVersion(grainClass, x));
+                    AssertEqual(1, Client[i].GetConfirmedVersion(grainClass, x), grainIdentity);
             });
 
             Func<Task> checker2 = () => Task.Run(() =>
             {
                 int x = GetRandom();
-                var grainidentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
+                var grainIdentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
                 // increment on replica 0
                 Client[0].IncrementAGlobal(grainClass, x);
                 // expect on other replicas
                 for (int i = 1; i < numclusters; i++)
                 {
                     int r = Client[i].GetAGlobal(grainClass, x);
-                    Assert.Equal(1, r);
+                    AssertEqual(1, r, grainIdentity);
                 }
                 // check versions
                 for (int i = 0; i < numclusters; i++)
-                    Assert.Equal(1, Client[i].GetConfirmedVersion(grainClass, x));
+                    AssertEqual(1, Client[i].GetConfirmedVersion(grainClass, x), grainIdentity);
             });
 
             Func<Task> checker2b = () => Task.Run(() =>
             {
                 int x = GetRandom();
-                var grainidentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
+                var grainIdentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
                 // force first creation on replica 1
-                Assert.Equal(0, Client[1].GetAGlobal(grainClass, x));
+                AssertEqual(0, Client[1].GetAGlobal(grainClass, x), grainIdentity);
                 // increment on replica 0
                 Client[0].IncrementAGlobal(grainClass, x);
                 // expect on other replicas
                 for (int i = 1; i < numclusters; i++)
                 {
                     int r = Client[i].GetAGlobal(grainClass, x);
-                    Assert.Equal(1, r);
+                    AssertEqual(1, r, grainIdentity);
                 }
                 // check versions
                 for (int i = 0; i < numclusters; i++)
-                    Assert.Equal(1, Client[i].GetConfirmedVersion(grainClass, x));
+                    AssertEqual(1, Client[i].GetConfirmedVersion(grainClass, x), grainIdentity);
             });
 
             Func<int, Task> checker3 = (int numupdates) => Task.Run(() =>
             {
                 int x = GetRandom();
-                var grainidentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
+                var grainIdentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
 
                 // concurrently chaotically increment (numupdates) times
                 Parallel.For(0, numupdates, i =>
@@ -286,29 +300,30 @@ namespace Tests.GeoClusterTests
                 }
 
                 // push & get all
-                Assert.Equal(numupdates, Client[0].GetAGlobal(grainClass, x)); 
+                AssertEqual(numupdates, Client[0].GetAGlobal(grainClass, x), grainIdentity); 
 
                 for (int i = 1; i < numclusters; i++)
-                    Assert.Equal(numupdates, Client[i].GetAGlobal(grainClass, x)); // get all
+                    AssertEqual(numupdates, Client[i].GetAGlobal(grainClass, x), grainIdentity); // get all
 
                 // check versions
                 for (int i = 0; i < numclusters; i++)
-                    Assert.Equal(numupdates, Client[i].GetConfirmedVersion(grainClass, x));
+                    AssertEqual(numupdates, Client[i].GetConfirmedVersion(grainClass, x), grainIdentity);
             });
 
             Func<Task> checker4 = () => Task.Run(() =>
             {
                 int x = GetRandom();
+                var grainIdentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
                 var t = new List<Task>();
                 for (int i = 0; i < numclusters; i++)
                 {
                     int c = i;
-                    t.Add(Task.Run(() => Assert.True(Client[c].GetALocal(grainClass, x) == 0)));
+                    t.Add(Task.Run(() => AssertEqual(true, Client[c].GetALocal(grainClass, x) == 0, grainIdentity)));
                 }
                 for (int i = 0; i < numclusters; i++)
                 {
                     int c = i;
-                    t.Add(Task.Run(() => Assert.True(Client[c].GetAGlobal(grainClass, x) == 0)));
+                    t.Add(Task.Run(() => AssertEqual(true, Client[c].GetAGlobal(grainClass, x) == 0, grainIdentity)));
                 }
                 return Task.WhenAll(t);
             });
@@ -316,6 +331,7 @@ namespace Tests.GeoClusterTests
             Func<Task> checker5 = () => Task.Run(() =>
             {
                 var x = GetRandom();
+                var grainIdentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
                 Task.WaitAll(
                    Task.Run(() =>
                    {
@@ -332,8 +348,8 @@ namespace Tests.GeoClusterTests
                  })
                );
                 var result = Client[0].GetReservationsGlobal(grainClass, x);
-                Assert.Single(result);
-                Assert.Equal(2, result[0]);
+                AssertEqual(1, result.Length, grainIdentity);
+                AssertEqual(2, result[0], grainIdentity);
             });
 
             Func<int, Task> checker6 = async (int preload) =>
@@ -381,14 +397,14 @@ namespace Tests.GeoClusterTests
                 if ((variation / 2) % 2 == 0)
                     Client[0].GetAGlobal(grainClass, x);
 
-                var grainidentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
+                var grainIdentity = string.Format("grainref={0}", Client[0].GetGrainRef(grainClass, x));
 
                 // write conditional on client 0, should always succeed
                 {
                     var result = Client[0].SetAConditional(grainClass, x, Xyz);
-                    Assert.Equal(0, result.Item1);
-                    Assert.True(result.Item2);
-                    Assert.Equal(1, Client[0].GetConfirmedVersion(grainClass, x));
+                    AssertEqual(0, result.Item1, grainIdentity);
+                    AssertEqual(true, result.Item2, grainIdentity);
+                    AssertEqual(1, Client[0].GetConfirmedVersion(grainClass, x), grainIdentity);
                 }
 
                 if ((variation / 4) % 2 == 1)
@@ -399,25 +415,25 @@ namespace Tests.GeoClusterTests
                     var result = Client[1].SetAConditional(grainClass, x, 444);
                     if (result.Item1 == 0) // was stale, thus failed
                     {
-                        Assert.False(result.Item2);
+                        AssertEqual(false, result.Item2, grainIdentity);
                         // must have updated as a result
-                        Assert.Equal(1, Client[1].GetConfirmedVersion(grainClass, x));
+                        AssertEqual(1, Client[1].GetConfirmedVersion(grainClass, x), grainIdentity);
                         // check stability
-                        Assert.Equal(Xyz, Client[0].GetALocal(grainClass, x));
-                        Assert.Equal(Xyz, Client[1].GetALocal(grainClass, x));
-                        Assert.Equal(Xyz, Client[0].GetAGlobal(grainClass, x));
-                        Assert.Equal(Xyz, Client[1].GetAGlobal(grainClass, x));
+                        AssertEqual(Xyz, Client[0].GetALocal(grainClass, x), grainIdentity);
+                        AssertEqual(Xyz, Client[1].GetALocal(grainClass, x), grainIdentity);
+                        AssertEqual(Xyz, Client[0].GetAGlobal(grainClass, x), grainIdentity);
+                        AssertEqual(Xyz, Client[1].GetAGlobal(grainClass, x), grainIdentity);
                     }
                     else // was up-to-date, thus succeeded
                     {
-                        Assert.True(result.Item2);
-                        Assert.Equal(1, result.Item1);
+                        AssertEqual(true, result.Item2, grainIdentity);
+                        AssertEqual(1, result.Item1, grainIdentity);
                         // version is now 2
-                        Assert.Equal(2, Client[1].GetConfirmedVersion(grainClass, x));
+                        AssertEqual(2, Client[1].GetConfirmedVersion(grainClass, x), grainIdentity);
                         // check stability
-                        Assert.Equal(444, Client[1].GetALocal(grainClass, x));
-                        Assert.Equal(444, Client[0].GetAGlobal(grainClass, x));
-                        Assert.Equal(444, Client[1].GetAGlobal(grainClass, x));
+                        AssertEqual(444, Client[1].GetALocal(grainClass, x), grainIdentity);
+                        AssertEqual(444, Client[0].GetAGlobal(grainClass, x), grainIdentity);
+                        AssertEqual(444, Client[1].GetAGlobal(grainClass, x), grainIdentity);
                     }
                 }
             });

--- a/test/TesterInternal/GeoClusterTests/LogConsistencyTestsTwoClusters.cs
+++ b/test/TesterInternal/GeoClusterTests/LogConsistencyTestsTwoClusters.cs
@@ -41,7 +41,7 @@ namespace Tests.GeoClusterTests
             await fixture.RunChecksOnGrainClass("TestGrains.GsiLogTestGrain", true, phases, output);
         }
 
-        [SkippableFact]
+        [SkippableFact, TestCategory("Functional")]
         public async Task TestBattery_MemoryStorageProvider()
         {
             await fixture.RunChecksOnGrainClass("TestGrains.LogTestGrainMemoryStorage", true, phases, output);

--- a/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
+++ b/test/TesterInternal/GeoClusterTests/MultiClusterRegistrationTests.cs
@@ -33,7 +33,7 @@ namespace UnitTests.GeoClusterTests
         {
         }
 
-        [SkippableFact, TestCategory("Functional")]
+        [SkippableFact]
         public async Task TwoClusterBattery()
         {
 
@@ -52,7 +52,7 @@ namespace UnitTests.GeoClusterTests
                 await t;
         }
 
-        [SkippableFact]
+        [SkippableFact, TestCategory("Functional")]
         public async Task ThreeClusterBattery()
         {
 
@@ -446,7 +446,7 @@ namespace UnitTests.GeoClusterTests
                 AssertEqual(1, p.Result, gref);
         }
 
-        [SkippableFact]
+        [SkippableFact, TestCategory("Functional")]
         public async Task BlockedDeact()
         {
             await RunWithTimeout("Start Clusters and Clients", 180 * 1000, () =>

--- a/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -176,9 +176,12 @@ namespace Tests.GeoClusterTests
             {
                 hostBuilder.ConfigureLogging(builder =>
                 {
-                    builder.AddFilter("Runtime.Catalog", LogLevel.Debug);
-                    builder.AddFilter("Runtime.Dispatcher", LogLevel.Trace);
-                    builder.AddFilter("Orleans.GrainDirectory.LocalGrainDirectory", LogLevel.Trace);
+                    builder.AddFilter("Orleans.Runtime.Catalog", LogLevel.Debug);
+                    builder.AddFilter("Orleans.Runtime.Dispatcher", LogLevel.Trace);
+                    builder.AddFilter("Orleans.Runtime.GrainDirectory.LocalGrainDirectory", LogLevel.Trace);
+                    builder.AddFilter("Orleans.Runtime.GrainDirectory.GlobalSingleInstanceRegistrar", LogLevel.Trace);
+                    builder.AddFilter("Orleans.Runtime.LogConsistency.ProtocolServices", LogLevel.Trace);
+                    builder.AddFilter("Orleans.Storage.MemoryStorageGrain", LogLevel.Debug);
                 });
                 hostBuilder.AddAzureBlobGrainStorage("PubSubStore", (AzureBlobStorageOptions options) =>
                 {

--- a/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -14,6 +14,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Orleans.MultiCluster;
 using Orleans.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Tests.GeoClusterTests
 {
@@ -183,6 +184,11 @@ namespace Tests.GeoClusterTests
                     builder.AddFilter("Orleans.Runtime.LogConsistency.ProtocolServices", LogLevel.Trace);
                     builder.AddFilter("Orleans.Storage.MemoryStorageGrain", LogLevel.Debug);
                 });
+                hostBuilder.AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
+                {
+                    options.ServiceId = silo.Value.ServiceId.ToString();
+                    options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                }));
                 hostBuilder.AddAzureBlobGrainStorage("PubSubStore", (AzureBlobStorageOptions options) =>
                 {
                     options.ConnectionString = TestDefaultConfiguration.DataConnectionString;


### PR DESCRIPTION
It's been a while since we added multi-cluster support. Running all the tests, I found some bugs:

- when running with at least three clusters, and activating a grain concurrently, messages could get forwarded excessively, causing activation to fail (due to the forward count limit). I fixed this by forwarding only to destinations that are known to be the owner.
- Message.cs contained a bug that made the IsReturnedFromRemoteCluster flag not work correctly. This could also cause excessive forwarding, and failure to remove stale directory cache entries.
- in two places, NullReferenceExceptions were thrown when multi-clusters had no gateways reporting. I put in the proper handling of these situations.
- some tests were failing because the gsi-directory-maintenance was happening too late. To fix this I changed the periodic maintenance loop so it  runs the maintenance immediately after each multi-cluster-configuration change.

I also fixed some tracing issues and added more tests to the Functional category, so we can cover these types of errors in regression.
