### PR TITLE
Fix intermittent failures in custom placement tests

### DIFF
--- a/test/Tester/Placement/CustomPlacementTests.cs
+++ b/test/Tester/Placement/CustomPlacementTests.cs
@@ -56,7 +56,7 @@ namespace Tester.CustomPlacementTests
             this.fixture = fixture;
 
             // sort silo IDs into an array
-            this.silos = fixture.HostedCluster.GetActiveSilos().Select(h => h.SiloAddress.ToString()).OrderBy(s => s).ToArray();
+            this.silos = fixture.HostedCluster.GetActiveSilos().OrderBy(s => s.SiloAddress).Select(h => h.SiloAddress.ToString()).ToArray();
             this.siloAddresses = fixture.HostedCluster.GetActiveSilos().Select(h => h.SiloAddress).OrderBy(s => s).ToArray();
         }
 


### PR DESCRIPTION
Make sorting of silos in the custom placement tests match the order used in the placement director.