### PR TITLE
Add networking mask options in EndpointOptions

### DIFF
--- a/src/Orleans.Runtime/Hosting/EndpointOptions.cs
+++ b/src/Orleans.Runtime/Hosting/EndpointOptions.cs
@@ -1,4 +1,7 @@
-﻿using System.Net;
+using Orleans.Runtime;
+using System;
+using System.Net;
+using System.Net.Sockets;
 
 namespace Orleans.Hosting
 {
@@ -6,16 +9,23 @@ namespace Orleans.Hosting
     /// Configures the Silo endpoint options
     /// </summary>
     public class EndpointOptions
-    { 
+    {
         /// <summary>
-        /// The external IP address or host name used for clustering.
+        /// The external IP address or host name used for clustering. IP address will be inferred from <see cref="NetworkAddress"/> if this is not
+        /// directly specified.
         /// </summary>
         public string HostNameOrIPAddress { get; set; }
 
         /// <summary>
-        /// The IP address used for clustering. Will be inferred from <see cref="HostNameOrIPAddress"/> if this is not directly specified.
+        /// The IP address used for clustering. Will be inferred from <see cref="HostNameOrIPAddress"/> or <see cref="NetworkAddress"/> if this is not directly specified.
         /// </summary>
         public IPAddress IPAddress { get; set; }
+
+        /// <summary>
+        /// Specify the subnet to determine to IP address used for clustering.
+        /// If <see cref="IPAddress"/> is specified, this property will be ignored.
+        /// </summary>
+        public NetworkAddress NetworkAddress { get; set; } = new NetworkAddress();
 
         /// <summary>
         /// The port this silo uses for silo-to-silo communication.
@@ -28,5 +38,66 @@ namespace Orleans.Hosting
         public int ProxyPort { get; set; }
 
         //public bool BindToAny { get; set; }
+    }
+
+    /// <summary>
+    /// Represent a network address with its mask
+    /// </summary>
+    public class NetworkAddress
+    {
+        /// <summary>
+        /// Address of the network
+        /// </summary>
+        public IPAddress Address { get; set; }
+
+        /// <summary>
+        /// Mask of the network
+        /// </summary>
+        public IPAddress Mask { get; set; }
+
+        public AddressFamily AddressFamily => Address.AddressFamily;
+
+        /// <summary>
+        /// Create a new NetworkAddress
+        /// </summary>
+        public NetworkAddress()
+            : this(IPAddress.Any, IPAddress.Any)
+        { }
+
+        /// <summary>
+        /// Create a new NetworkAddress
+        /// </summary>
+        public NetworkAddress(IPAddress address, IPAddress mask)
+        {
+            if (address.AddressFamily != mask.AddressFamily)
+                throw new ArgumentException("address and mask should have the same AddressFamily");
+            this.Address = address;
+            this.Mask = mask;
+        }
+
+        /// <summary>
+        /// Return true if <paramref name="otherAddress"/> belongs to this network
+        /// </summary>
+        internal bool Contains(IPAddress otherAddress)
+        {
+            if (this.Address.AddressFamily != otherAddress.AddressFamily)
+                return false;
+
+            var otherAddressBytes = otherAddress.GetAddressBytes();
+            var maskBytes = this.Mask.GetAddressBytes();
+
+            for (var i = 0; i < otherAddressBytes.Length; i++)
+            {
+                otherAddressBytes[i] = (byte)(otherAddressBytes[i] & maskBytes[i]);
+            }
+
+            return new IPAddress(otherAddressBytes).Equals(this.Address);
+        }
+
+        public override string ToString()
+        {
+            return $"{this.Address} netmask {this.Mask}";
+        }
+
     }
 }

--- a/src/Orleans.Runtime/Hosting/EndpointOptionsExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/EndpointOptionsExtensions.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Orleans.Hosting
+{
+    internal static class EndpointOptionsExtensions
+    {
+        private static IPAddress ResolveIPAddress(this EndpointOptions options)
+        {
+            if (options.IPAddress != null)
+                return options.IPAddress;
+
+            var family = options.NetworkAddress.AddressFamily;
+            var loopback = family == AddressFamily.InterNetwork ? IPAddress.Loopback : IPAddress.IPv6Loopback;
+            var any = family == AddressFamily.InterNetwork ? IPAddress.Any : IPAddress.IPv6Any;
+
+            // IF the address is an empty string, default to the local machine
+            if (string.IsNullOrEmpty(options.HostNameOrIPAddress))
+            {
+                options.HostNameOrIPAddress = Dns.GetHostName();
+            }
+
+            // Fix StreamFilteringTests_SMS tests
+            if (options.HostNameOrIPAddress.Equals("loopback", StringComparison.OrdinalIgnoreCase))
+            {
+                return loopback;
+            }
+
+            // check if addrOrHost is a valid IP address including loopback (127.0.0.0/8, ::1) and any (0.0.0.0/0, ::) addresses
+            IPAddress address;
+            if (IPAddress.TryParse(options.HostNameOrIPAddress, out address))
+            {
+                return address;
+            }
+
+            var candidates = new List<IPAddress>();
+
+            // Get IP address from DNS. If addrOrHost is localhost will 
+            // return loopback IPv4 address (or IPv4 and IPv6 addresses if OS is supported IPv6)
+            var nodeIps = Dns.GetHostAddresses(options.HostNameOrIPAddress);
+            foreach (var nodeIp in nodeIps.Where(x => x.AddressFamily == family))
+            {
+                // If the subnet does not match - we can't resolve this address.
+                // If subnet is not specified - pick smallest address deterministically.
+                if (options.NetworkAddress.Address == any)
+                {
+                    candidates.Add(nodeIp);
+                }
+                else
+                {
+                    var ip = nodeIp;
+                    if (options.NetworkAddress.Contains(ip))
+                    {
+                        candidates.Add(nodeIp);
+                    }
+                }
+            }
+            if (candidates.Count > 0)
+            {
+                return candidates.First();
+            }
+            throw new ArgumentException("Hostname '" + options.HostNameOrIPAddress + "' with subnet " + options.NetworkAddress + " and family " + family + " is not a valid IP address or DNS name");
+        }
+
+        public static IPEndPoint ResolveEndpoint(this EndpointOptions options)
+        {
+            return new IPEndPoint(options.ResolveIPAddress(), options.Port);
+        }
+
+    }
+}

--- a/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
+++ b/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.Extensions.Options;
@@ -22,24 +24,8 @@ namespace Orleans.Runtime
             this.DnsHostName = Dns.GetHostName();
 
             var endpointOptions = siloEndpointOptions.Value;
-            this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(ResolveEndpoint(endpointOptions), SiloAddress.AllocateNewGeneration()));
+            this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(endpointOptions.ResolveEndpoint(), SiloAddress.AllocateNewGeneration()));
             this.gatewayAddressLazy = new Lazy<SiloAddress>(() => endpointOptions.ProxyPort != 0 ? SiloAddress.New(new IPEndPoint(this.SiloAddress.Endpoint.Address, endpointOptions.ProxyPort), 0) : null);
-        }
-
-        private static IPEndPoint ResolveEndpoint(EndpointOptions options)
-        {
-            IPAddress ipAddress;
-            if (options.IPAddress != null)
-            {
-                ipAddress = options.IPAddress;
-            }
-            else
-            {
-                // TODO: refactor this out of ClusterConfiguration
-                ipAddress = ConfigUtilities.ResolveIPAddress(options.HostNameOrIPAddress, null, AddressFamily.InterNetwork).GetAwaiter().GetResult();
-            }
-
-            return new IPEndPoint(ipAddress, options.Port);
         }
 
         /// <inheritdoc />

--- a/test/NonSilo.Tests/NetworkAddressTests.cs
+++ b/test/NonSilo.Tests/NetworkAddressTests.cs
@@ -1,0 +1,90 @@
+using Orleans.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NonSilo.Tests
+{
+    [TestCategory("BVT")]
+    public class NetworkAddressTests
+    {
+        [Fact]
+        public void SubnetInclusion()
+        {
+            var netAddress = new NetworkAddress
+            {
+                Address = IPAddress.Parse("10.0.0.0"),
+                Mask = IPAddress.Parse("255.0.0.0")
+            };
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.0.1")));
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.1.1")));
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.1.1.1")));
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.254.1.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("172.16.1.1")));
+
+            netAddress.Mask = IPAddress.Parse("255.128.0.0");
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.0.1")));
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.1.1")));
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.1.1.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("10.254.1.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("172.16.1.1")));
+
+            netAddress.Mask = IPAddress.Parse("255.255.0.0");
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.0.1")));
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.1.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("10.1.1.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("10.254.1.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("172.16.1.1")));
+
+            netAddress.Mask = IPAddress.Parse("255.255.255.0");
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.0.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("10.0.1.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("10.1.1.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("10.254.1.1")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("172.16.1.1")));
+
+            netAddress.Mask = IPAddress.Parse("255.255.255.252");
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.0.1")));
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.0.2")));
+            Assert.True(netAddress.Contains(IPAddress.Parse("10.0.0.3")));
+            Assert.False(netAddress.Contains(IPAddress.Parse("10.0.0.4")));
+        }
+
+        [Fact]
+        public void SelectIpv4ByDefault()
+        {
+            var option = new EndpointOptions
+            {
+                Port = 3000,
+            };
+            var resolvedEndpoint = option.ResolveEndpoint();
+
+            Assert.Equal(AddressFamily.InterNetwork, resolvedEndpoint.AddressFamily);
+            Assert.True(option.NetworkAddress.Contains(resolvedEndpoint.Address));
+        }
+
+        [SkippableFact]
+        public void SelectIpv6()
+        {
+            var ipAddresses = Dns.GetHostAddresses(Dns.GetHostName());
+            Skip.IfNot(
+                ipAddresses.Any(ip => ip.AddressFamily == AddressFamily.InterNetworkV6),
+                "IPv6 is not available on this machine");
+
+            var option = new EndpointOptions
+            {
+                NetworkAddress = new NetworkAddress(IPAddress.IPv6Any, IPAddress.IPv6Any),
+                Port = 3000,
+            };
+            var resolvedEndpoint = option.ResolveEndpoint();
+
+            Assert.Equal(AddressFamily.InterNetworkV6, resolvedEndpoint.AddressFamily);
+            Assert.True(option.NetworkAddress.Contains(resolvedEndpoint.Address));
+        }
+    }
+}


### PR DESCRIPTION
Related issue: #3203 

Right now, using the legacy configuration, in the case of a "multi-homed" server, to force the selection of a specific IP address for the membership/gateway table, users have to use `GlobalConfiguration.SubNet`.  This solution is not suitable if the networks available on the server are not using network sliced in 8/16/24.

With this implementation in `EndpointOptions`, the user can use a real network address, with a real network mask.
