### PR TITLE
Options formating improvements.

### DIFF
--- a/src/Azure/Orleans.Persistence.AzureStorage/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Hosting/SiloBuilderExtensions.cs
@@ -73,7 +73,8 @@ namespace Orleans.Hosting
             Action<OptionsBuilder<AzureTableStorageOptions>> configureOptions = null)
         {
             configureOptions?.Invoke(services.AddOptions<AzureTableStorageOptions>(name));
-            services.TryConfigureFormatter<AzureTableStorageOptions, AzureTableStorageOptionsFormatterResolver>(name);
+            services.TryConfigureFormatterResolver<AzureTableStorageOptions, AzureTableStorageOptionsFormatterResolver>();
+            services.ConfigureNamedOptionForLogging<AzureTableStorageOptions>(name);
             services.TryAddSingleton<IGrainStorage>(sp => sp.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
             return services.AddSingletonNamedService<IGrainStorage>(name, AzureTableGrainStorageFactory.Create)
                            .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => (ILifecycleParticipant<ISiloLifecycle>)s.GetRequiredServiceByName<IGrainStorage>(n));

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
@@ -40,14 +40,18 @@ namespace Orleans
         }
         public void LogOptions()
         {
-            var optionFormatters = services.GetServices<IOptionFormatter>();
-            foreach (var optionFormatter in optionFormatters)
+            this.LogOptions(services.GetServices<IOptionFormatter>());
+        }
+
+        public void LogOptions(IEnumerable<IOptionFormatter> formatters)
+        {
+            foreach (var optionFormatter in formatters.OrderBy(f => f.Name))
             {
-                LogOption(optionFormatter);
+                this.LogOption(optionFormatter);
             }
         }
 
-        private void LogOption(IOptionFormatter formatter)
+        public void LogOption(IOptionFormatter formatter)
         {
             var stringBuiler = new StringBuilder();
             stringBuiler.AppendLine($"Configuration {formatter.Name}: ");

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
@@ -29,6 +29,9 @@ namespace Orleans
         }
     }
 
+    /// <summary>
+    /// Base class for client and silo default options loggers.
+    /// </summary>
     public abstract class OptionsLogger 
     {
         private ILogger logger;
@@ -38,11 +41,19 @@ namespace Orleans
             this.logger = logger;
             this.services = services;
         }
+
+        /// <summary>
+        /// Log all options with registered formatters
+        /// </summary>
         public void LogOptions()
         {
             this.LogOptions(services.GetServices<IOptionFormatter>());
         }
 
+        /// <summary>
+        /// Log options using a set of formatters
+        /// </summary>
+        /// <param name="formatters"></param>
         public void LogOptions(IEnumerable<IOptionFormatter> formatters)
         {
             foreach (var optionFormatter in formatters.OrderBy(f => f.Name))
@@ -51,6 +62,10 @@ namespace Orleans
             }
         }
 
+        /// <summary>
+        /// Log an options using a formatter
+        /// </summary>
+        /// <param name="formatter"></param>
         public void LogOption(IOptionFormatter formatter)
         {
             var stringBuiler = new StringBuilder();

--- a/src/Orleans.Core/Configuration/OptionLogger/OptionFormatterExtensionMethods.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/OptionFormatterExtensionMethods.cs
@@ -42,35 +42,41 @@ namespace Orleans
         {
             var registration = services.FirstOrDefault(service => service.ServiceType == typeof(IOptionFormatter<TOptions>));
             if (registration == null)
-                services.AddSingleton<IOptionFormatter<TOptions>, TOptionFormatter>()
-                        .AddFromExisting<IOptionFormatter, IOptionFormatter<TOptions>>();
+                services.ConfigureFormatter<TOptions, TOptionFormatter>();
             return services;
         }
 
         /// <summary>
         /// Configure option formatter resolver for named option TOptions
         /// </summary>
-        public static IServiceCollection ConfigureFormatter<TOptions, TOptionFormatterResolver>(this IServiceCollection services, string name)
+        public static IServiceCollection ConfigureFormatterResolver<TOptions, TOptionFormatterResolver>(this IServiceCollection services)
             where TOptions : class
             where TOptionFormatterResolver : class, IOptionFormatterResolver<TOptions>
         {
-            services.AddSingleton<IOptionFormatterResolver<TOptions>, TOptionFormatterResolver>()
-                    .AddSingleton<IOptionFormatter>(sp => sp.GetService<IOptionFormatterResolver<TOptions>>().Resolve(name));
-            return services;
+            return services.AddSingleton<IOptionFormatterResolver<TOptions>, TOptionFormatterResolver>();
         }
 
         /// <summary>
         /// Configure option formatter resolver for named option TOptions, if none is configured
         /// </summary>
-        public static IServiceCollection TryConfigureFormatter<TOptions, TOptionFormatterResolver>(this IServiceCollection services, string name)
+        public static IServiceCollection TryConfigureFormatterResolver<TOptions, TOptionFormatterResolver>(this IServiceCollection services)
             where TOptions : class
             where TOptionFormatterResolver : class, IOptionFormatterResolver<TOptions>
         {
             var registration = services.FirstOrDefault(service => service.ServiceType == typeof(IOptionFormatterResolver<TOptions>));
             if (registration == null)
-                services.AddSingleton<IOptionFormatterResolver<TOptions>, TOptionFormatterResolver>();
-            services.AddSingleton<IOptionFormatter>(sp => sp.GetService<IOptionFormatterResolver<TOptions>>().Resolve(name));
+                return services.ConfigureFormatterResolver<TOptions, TOptionFormatterResolver>();
             return services;
         }
+
+        /// <summary>
+        /// Configure a named option to be logged
+        /// </summary>
+        public static IServiceCollection ConfigureNamedOptionForLogging<TOptions>(this IServiceCollection services, string name)
+            where TOptions : class
+        {
+            return services.AddSingleton<IOptionFormatter>(sp => sp.GetService<IOptionFormatterResolver<TOptions>>().Resolve(name));
+        }
+
     }
 }

--- a/src/Orleans.Core/Configuration/OptionLogger/OptionFormatterExtensionMethods.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/OptionFormatterExtensionMethods.cs
@@ -1,9 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.Configuration;
 
 namespace Orleans
@@ -20,9 +16,16 @@ namespace Orleans
             where TOptions : class
             where TOptionFormatter : class, IOptionFormatter<TOptions>
         {
-
-            services.AddSingleton<IOptionFormatter<TOptions>, TOptionFormatter>()
-                .AddFromExisting<IOptionFormatter, IOptionFormatter<TOptions>>();
+            var registration = services.FirstOrDefault(service => service.ServiceType == typeof(IOptionFormatter<TOptions>));
+            if (registration == null)
+            {
+                services.AddSingleton<IOptionFormatter<TOptions>, TOptionFormatter>()
+                        .AddFromExisting<IOptionFormatter, IOptionFormatter<TOptions>>();
+            } else
+            {
+                // override IOptionFormatter<TOptions>
+                services.AddSingleton<IOptionFormatter<TOptions>, TOptionFormatter>();
+            }
             return services;
         }
 
@@ -39,7 +42,8 @@ namespace Orleans
         {
             var registration = services.FirstOrDefault(service => service.ServiceType == typeof(IOptionFormatter<TOptions>));
             if (registration == null)
-                services.ConfigureFormatter<TOptions, TOptionFormatter>();
+                services.AddSingleton<IOptionFormatter<TOptions>, TOptionFormatter>()
+                        .AddFromExisting<IOptionFormatter, IOptionFormatter<TOptions>>();
             return services;
         }
 
@@ -51,7 +55,7 @@ namespace Orleans
             where TOptionFormatterResolver : class, IOptionFormatterResolver<TOptions>
         {
             services.AddSingleton<IOptionFormatterResolver<TOptions>, TOptionFormatterResolver>()
-                .AddSingleton<IOptionFormatter>(sp => sp.GetService<IOptionFormatterResolver<TOptions>>().Resolve(name));
+                    .AddSingleton<IOptionFormatter>(sp => sp.GetService<IOptionFormatterResolver<TOptions>>().Resolve(name));
             return services;
         }
 
@@ -64,7 +68,8 @@ namespace Orleans
         {
             var registration = services.FirstOrDefault(service => service.ServiceType == typeof(IOptionFormatterResolver<TOptions>));
             if (registration == null)
-                services.ConfigureFormatter<TOptions, TOptionFormatterResolver>(name);
+                services.AddSingleton<IOptionFormatterResolver<TOptions>, TOptionFormatterResolver>();
+            services.AddSingleton<IOptionFormatter>(sp => sp.GetService<IOptionFormatterResolver<TOptions>>().Resolve(name));
             return services;
         }
     }

--- a/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
@@ -29,8 +29,6 @@ namespace Orleans.Hosting
 
     public class ClientMessagingOptionFormatter : MessagingOptionsFormatter, IOptionFormatter<ClientMessagingOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(ClientMessagingOptions);
 
         private ClientMessagingOptions options;

--- a/src/Orleans.Core/Configuration/Options/ClientStatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientStatisticsOptions.cs
@@ -13,8 +13,6 @@ namespace Orleans.Hosting
 
     public class ClientStatisticsOptionsFormatter : StatisticsOptionsFormatter, IOptionFormatter<ClientStatisticsOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(ClientStatisticsOptions);
 
         private ClientStatisticsOptions options;

--- a/src/Orleans.Core/Configuration/Options/ClusterClientOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterClientOptions.cs
@@ -16,8 +16,6 @@ namespace Orleans.Runtime
 
     public class ClusterClientOptionsFormatter : IOptionFormatter<ClusterClientOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(ClusterClientOptions);
         private ClusterClientOptions options;
         public ClusterClientOptionsFormatter(IOptions<ClusterClientOptions> options)

--- a/src/Orleans.Core/Configuration/Options/GrainVersioningOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GrainVersioningOptions.cs
@@ -26,8 +26,6 @@ namespace Orleans.Hosting
 
     public class GrainVersioningOptionsFormatter : IOptionFormatter<GrainVersioningOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(GrainVersioningOptions);
 
         private GrainVersioningOptions options;

--- a/src/Orleans.Core/Configuration/Options/LoadSheddingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/LoadSheddingOptions.cs
@@ -25,8 +25,6 @@ namespace Orleans.Hosting
 
     public class LoadSheddingOptionsFormatter : IOptionFormatter<LoadSheddingOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(LoadSheddingOptions);
 
         private readonly LoadSheddingOptions options;

--- a/src/Orleans.Core/Configuration/Options/MembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MembershipOptions.cs
@@ -100,8 +100,6 @@ namespace Orleans.Hosting
 
     public class MembershipOptionsFormatter : IOptionFormatter<MembershipOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(MembershipOptions);
         private MembershipOptions options;
         public MembershipOptionsFormatter(IOptions<MembershipOptions> options)

--- a/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
@@ -63,8 +63,6 @@ namespace Orleans.Hosting
 
     public class MultiClusterOptionsFormatter : IOptionFormatter<MultiClusterOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(MultiClusterOptions);
         private MultiClusterOptions options;
         public MultiClusterOptionsFormatter(IOptions<MultiClusterOptions> options)

--- a/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
@@ -24,8 +24,6 @@ namespace Orleans.Hosting
 
     public class NetworkingOptionsFormatter : IOptionFormatter<NetworkingOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(NetworkingOptions);
 
         private NetworkingOptions options;

--- a/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
@@ -22,8 +22,6 @@ namespace Orleans.Hosting
 
     public class SerializationProviderOptionsFormatter : IOptionFormatter<SerializationProviderOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(SerializationProviderOptions);
         private SerializationProviderOptions options;
         public SerializationProviderOptionsFormatter(IOptions<SerializationProviderOptions> options)

--- a/src/Orleans.Core/Configuration/Options/ServicePointOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ServicePointOptions.cs
@@ -21,8 +21,6 @@ namespace Orleans.Hosting
 
     public class ServicePointOptionsFormatter : IOptionFormatter<ServicePointOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(ServicePointOptions);
 
         private ServicePointOptions options;

--- a/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
@@ -17,8 +17,6 @@ namespace Orleans.Configuration.Options
 
     public class StaticGatewayListProviderOptionsFormatter : IOptionFormatter<StaticGatewayListProviderOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(StaticGatewayListProviderOptions);
 
         private StaticGatewayListProviderOptions options;

--- a/src/Orleans.Core/Configuration/Options/TelemetryOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/TelemetryOptions.cs
@@ -27,8 +27,6 @@ namespace Orleans.Hosting
 
     public class TelemetryOptionsFormatter : IOptionFormatter<TelemetryOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(TelemetryOptions);
 
         private TelemetryOptions options;

--- a/src/Orleans.Core/Configuration/Options/ThreadPoolOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ThreadPoolOptions.cs
@@ -19,8 +19,6 @@ namespace Orleans.Hosting
 
     public class ThreadPoolOptionsFormatter : IOptionFormatter<ThreadPoolOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(ThreadPoolOptions);
 
         private ThreadPoolOptions options;

--- a/src/Orleans.Core/Configuration/Options/TypeManagementOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/TypeManagementOptions.cs
@@ -18,8 +18,6 @@ namespace Orleans.Hosting
 
     public class TypeManagementOptionsFormatter : IOptionFormatter<TypeManagementOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(TypeManagementOptions);
 
         private TypeManagementOptions options;

--- a/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
+++ b/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
@@ -30,8 +30,6 @@ namespace Orleans.Runtime
 
     public class SiloOptionsFormatter : IOptionFormatter<SiloOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(SiloOptions);
 
         private SiloOptions options;

--- a/src/Orleans.Runtime/Configuration/Options/ConsistentRingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/ConsistentRingOptions.cs
@@ -26,8 +26,6 @@ namespace Orleans.Hosting
 
     public class ConsistentRingOptionsFormatter : IOptionFormatter<ConsistentRingOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(ConsistentRingOptions);
         private ConsistentRingOptions options;
         public ConsistentRingOptionsFormatter(IOptions<ConsistentRingOptions> options)

--- a/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainCollectionOptions.cs
@@ -29,8 +29,6 @@ namespace Orleans.Hosting
 
     public class GrainCollectionOptionsFormatter : IOptionFormatter<GrainCollectionOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(GrainCollectionOptions);
         private GrainCollectionOptions options;
         public GrainCollectionOptionsFormatter(IOptions<GrainCollectionOptions> options)

--- a/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
@@ -67,8 +67,6 @@ namespace Orleans.Hosting
 
     public class GrainDirectoryOptionsFormatter : IOptionFormatter<GrainDirectoryOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(GrainDirectoryOptions);
 
         private GrainDirectoryOptions options;

--- a/src/Orleans.Runtime/Configuration/Options/GrainPlacementOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainPlacementOptions.cs
@@ -25,8 +25,6 @@ namespace Orleans.Hosting
 
     public class GrainPlacementOptionsFormatter : IOptionFormatter<GrainPlacementOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(GrainPlacementOptions);
 
         private GrainPlacementOptions options;

--- a/src/Orleans.Runtime/Configuration/Options/GrainServiceOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainServiceOptions.cs
@@ -17,8 +17,6 @@ namespace Orleans.Hosting
 
     public class GrainServiceOptionsFormatter : IOptionFormatter<GrainServiceOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(GrainServiceOptions);
         private GrainServiceOptions options;
         public GrainServiceOptionsFormatter(IOptions<GrainServiceOptions> options)

--- a/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SchedulingOptions.cs
@@ -72,8 +72,6 @@ namespace Orleans.Hosting
 
     public class SchedulingOptionsFormatter : IOptionFormatter<SchedulingOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(SchedulingOptions);
 
         private SchedulingOptions options;

--- a/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SiloMessagingOptions.cs
@@ -80,8 +80,6 @@ namespace Orleans.Hosting
 
     public class SiloMessagingOptionFormatter : MessagingOptionsFormatter, IOptionFormatter<SiloMessagingOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(SiloMessagingOptions);
 
         private SiloMessagingOptions options;

--- a/src/Orleans.Runtime/Configuration/Options/SiloStatisticsOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/SiloStatisticsOptions.cs
@@ -25,8 +25,6 @@ namespace Orleans.Hosting
 
     public class SiloStatisticsOptionsFormatter : StatisticsOptionsFormatter, IOptionFormatter<SiloStatisticsOptions>
     {
-        public string Category { get; }
-
         public string Name => nameof(SiloStatisticsOptions);
 
         private SiloStatisticsOptions options;

--- a/test/Tester/LogFomatterTests.cs
+++ b/test/Tester/LogFomatterTests.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans;
 using Xunit;
@@ -14,100 +16,342 @@ namespace Tester
         [Fact]
         public void CanResolveFormatter()
         {
+            // expected output
+            TestLoggerFactory expected = BuildOptionsExpectedResult();
+
+            // actual output
             var services = new ServiceCollection();
             services.AddOptions();
+            services.AddSingleton<TestLoggerFactory>();
+            services.AddSingleton<ILoggerFactory>(sp => sp.GetRequiredService<TestLoggerFactory>());
+            services.AddSingleton(typeof(ILogger<>), typeof(TestLogger<>));
+            services.AddSingleton<OptionsLogger, TestOptionsLogger>();
             services.Configure<TestOptions>(options => options.IntField = 1);
             services.ConfigureFormatter<TestOptions, TestOptionsFormatter>();
             var servicesProvider = services.BuildServiceProvider();
+            servicesProvider.GetRequiredService<OptionsLogger>().LogOptions();
+
             var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
             Assert.Single(logFormatters);
             Assert.True(logFormatters.First() is TestOptionsFormatter);
             Assert.True(logFormatters.First() is IOptionFormatter<TestOptions>);
+            // ensure logging output is as expected
+            var actual = servicesProvider.GetRequiredService<TestLoggerFactory>();
+            Assert.Equal(expected.ToString(), actual.ToString());
         }
 
         [Fact]
-        public void FormatterConfiguredTwiceLeadsToDuplicatedFormatter()
+        public void FormatterConfiguredTwiceDoesNotLeadToDuplicatedFormatter()
         {
+            // expected output
+            TestLoggerFactory expected = BuildOptionsExpectedResult();
+
+            // actual output
             var services = new ServiceCollection();
             services.AddOptions();
+            services.AddSingleton<TestLoggerFactory>();
+            services.AddSingleton<ILoggerFactory>(sp => sp.GetRequiredService<TestLoggerFactory>());
+            services.AddSingleton(typeof(ILogger<>), typeof(TestLogger<>));
+            services.AddSingleton<OptionsLogger, TestOptionsLogger>();
             services.Configure<TestOptions>(options => options.IntField = 1);
-            services.ConfigureFormatter<TestOptions, TestOptionsFormatter>();
+            services.ConfigureFormatter<TestOptions, TestOptionsFormatter2>();
             //the formatter configured second time will override the first one in DI and
             //DI will end up with two formatter for the same option
-            services.ConfigureFormatter<TestOptions, TestOptionsFormatter2>();
+            services.ConfigureFormatter<TestOptions, TestOptionsFormatter>();
             var servicesProvider = services.BuildServiceProvider();
+            servicesProvider.GetRequiredService<OptionsLogger>().LogOptions();
+
+            // only one options formater and it points to the right one
             var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
+            Assert.Single(logFormatters);
+            Assert.True(logFormatters.First() is TestOptionsFormatter);
+            Assert.True(logFormatters.First() is IOptionFormatter<TestOptions>);
+            // two type specific formaters, one of each.
+            logFormatters = servicesProvider.GetServices<IOptionFormatter<TestOptions>>();
             Assert.True(logFormatters.Count() == 2);
             Assert.True(logFormatters.First() is TestOptionsFormatter2);
-            Assert.True(logFormatters.ElementAt(1) is TestOptionsFormatter2);
+            Assert.True(logFormatters.ElementAt(1) is TestOptionsFormatter);
+            // when resolving singe type specific formatter, we get the right one
+            var logFormatter = servicesProvider.GetService<IOptionFormatter<TestOptions>>();
+            Assert.True(logFormatter is TestOptionsFormatter);
+            // ensure logging output is as expected
+            var actual = servicesProvider.GetRequiredService<TestLoggerFactory>();
+            Assert.Equal(expected.ToString(), actual.ToString());
         }
 
         [Fact]
-        public void DefaultFormatterWontOverrideCustomFormatter()
+        public void CustomFormatterOverridesDefaultFormatter_PreRegistration()
         {
+            // expected output
+            TestLoggerFactory expected = BuildOptionsExpectedResult();
+
+            // actual output
             var services = new ServiceCollection();
             services.AddOptions();
+            services.AddSingleton<TestLoggerFactory>();
+            services.AddSingleton<ILoggerFactory>(sp => sp.GetRequiredService<TestLoggerFactory>());
+            services.AddSingleton(typeof(ILogger<>), typeof(TestLogger<>));
+            services.AddSingleton<OptionsLogger, TestOptionsLogger>();
             services.Configure<TestOptions>(options => options.IntField = 1);
             services.ConfigureFormatter<TestOptions, TestOptionsFormatter>();
             //TestOptionsFormatter2 is configured as the default 
             services.TryConfigureFormatter<TestOptions, TestOptionsFormatter2>();
             var servicesProvider = services.BuildServiceProvider();
+            servicesProvider.GetRequiredService<OptionsLogger>().LogOptions();
+
             var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
             Assert.Single(logFormatters);
             Assert.True(logFormatters.First() is TestOptionsFormatter);
             Assert.True(logFormatters.First() is IOptionFormatter<TestOptions>);
+            // ensure logging output is as expected
+            var actual = servicesProvider.GetRequiredService<TestLoggerFactory>();
+            Assert.Equal(expected.ToString(), actual.ToString());
         }
 
         [Fact]
-        public void NamedFormatterConfiguredTwiceLeadsToDuplicatedFormatter()
+        public void CustomFormatterOverridesDefaultFormatter_PostRegistration()
         {
-            string name = "test";
+            // expected output
+            TestLoggerFactory expected = BuildOptionsExpectedResult();
+
+            // actual output
             var services = new ServiceCollection();
             services.AddOptions();
+            services.AddSingleton<TestLoggerFactory>();
+            services.AddSingleton<ILoggerFactory>(sp => sp.GetRequiredService<TestLoggerFactory>());
+            services.AddSingleton(typeof(ILogger<>), typeof(TestLogger<>));
+            services.AddSingleton<OptionsLogger, TestOptionsLogger>();
             services.Configure<TestOptions>(options => options.IntField = 1);
-            services.ConfigureFormatter<TestOptions, TestOptionFormatterResolver>(name);
-            //the formatter configured second time will override the first one in DI and
-            //DI will end up with two formatter for the same option
-            services.ConfigureFormatter<TestOptions, TestOptionFormatterResolver2>(name);
+            services.TryConfigureFormatter<TestOptions, TestOptionsFormatter2>();
+            services.ConfigureFormatter<TestOptions, TestOptionsFormatter>();
+            //TestOptionsFormatter2 is configured as the default 
             var servicesProvider = services.BuildServiceProvider();
+            servicesProvider.GetRequiredService<OptionsLogger>().LogOptions();
+
             var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
+            Assert.Single(logFormatters);
+            Assert.True(logFormatters.First() is TestOptionsFormatter);
+            Assert.True(logFormatters.First() is IOptionFormatter<TestOptions>);
+            // two type specific formaters, one of each.
+            logFormatters = servicesProvider.GetServices<IOptionFormatter<TestOptions>>();
             Assert.True(logFormatters.Count() == 2);
             Assert.True(logFormatters.First() is TestOptionsFormatter2);
-            Assert.True(logFormatters.ElementAt(1) is TestOptionsFormatter2);
+            Assert.True(logFormatters.ElementAt(1) is TestOptionsFormatter);
+            // when resolving singe type specific formatter, we get the right one
+            var logFormatter = servicesProvider.GetService<IOptionFormatter<TestOptions>>();
+            Assert.True(logFormatter is TestOptionsFormatter);
+            // ensure logging output is as expected
+            var actual = servicesProvider.GetRequiredService<TestLoggerFactory>();
+            Assert.Equal(expected.ToString(), actual.ToString());
         }
 
         [Fact]
-        public void NamedDefaultFormatterWontOverrideCustomFormatter()
+        public void NamedFormatterGoldenPath()
         {
-            string name = "test";
+            // expected output
+            TestLoggerFactory expected = BuildNamedOptionsExpectedResult();
+
+            // actual output
             var services = new ServiceCollection();
             services.AddOptions();
-            services.Configure<TestOptions>(options => options.IntField = 1);
-            services.ConfigureFormatter<TestOptions, TestOptionFormatterResolver>(name);
-            //TestOptionsFormatter2 is configured as the default 
-            services.TryConfigureFormatter<TestOptions, TestOptionFormatterResolver2>(name);
+            services.AddSingleton<TestLoggerFactory>();
+            services.AddSingleton<ILoggerFactory>(sp => sp.GetRequiredService<TestLoggerFactory>());
+            services.AddSingleton(typeof(ILogger<>), typeof(TestLogger<>));
+            services.AddSingleton<OptionsLogger, TestOptionsLogger>();
+            Enumerable
+                .Range(1, 3)
+                .ToList()
+                .ForEach(i =>
+                {
+                    string name = i.ToString();
+                    services.Configure<TestOptions>(name, (options => options.IntField = i));
+                    services.ConfigureFormatter<TestOptions, TestOptionsFormatter.Resolver>(name);
+                });
             var servicesProvider = services.BuildServiceProvider();
+            servicesProvider.GetRequiredService<OptionsLogger>().LogOptions();
+
             var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
-            Assert.Single(logFormatters);
+            Assert.Equal(3, logFormatters.Count());
             Assert.True(logFormatters.First() is TestOptionsFormatter);
-            Assert.True(logFormatters.First() is IOptionFormatter<TestOptions>);
+            Assert.True(logFormatters.ElementAt(1) is TestOptionsFormatter);
+            Assert.True(logFormatters.ElementAt(2) is TestOptionsFormatter);
+            var logFormatter = servicesProvider.GetService<IOptionFormatterResolver<TestOptions>>();
+            Assert.True(logFormatter is TestOptionsFormatter.Resolver);
+            var actual = servicesProvider.GetRequiredService<TestLoggerFactory>();
+            Assert.Equal(expected.ToString(), actual.ToString());
         }
 
-        public class TestOptions
+        [Fact]
+        public void CustomFormatterResolverOverridesDefaultFormatter_PreRegistration()
         {
-            public int IntField { get; set; } = 1;
+            // expected output
+            TestLoggerFactory expected = BuildNamedOptionsExpectedResult();
+
+            // actual output
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.AddSingleton<TestLoggerFactory>();
+            services.AddSingleton<ILoggerFactory>(sp => sp.GetRequiredService<TestLoggerFactory>());
+            services.AddSingleton(typeof(ILogger<>), typeof(TestLogger<>));
+            services.AddSingleton<OptionsLogger, TestOptionsLogger>();
+            // pre register overrides
+            services.Configure<TestOptions>("1", (options => options.IntField = 1));
+            services.ConfigureFormatter<TestOptions, TestOptionsFormatter.Resolver>("1");
+            // defaults
+            Enumerable
+                .Range(2, 2)
+                .ToList()
+                .ForEach(i =>
+                {
+                    string name = i.ToString();
+                    services.Configure<TestOptions>(name, (options => options.IntField = i));
+                    services.TryConfigureFormatter<TestOptions, TestOptionsFormatter2.Resolver>(name);
+                });
+            var servicesProvider = services.BuildServiceProvider();
+            servicesProvider.GetRequiredService<OptionsLogger>().LogOptions();
+
+            var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
+            Assert.Equal(3, logFormatters.Count());
+            Assert.True(logFormatters.First() is TestOptionsFormatter);
+            Assert.True(logFormatters.ElementAt(1) is TestOptionsFormatter);
+            Assert.True(logFormatters.ElementAt(2) is TestOptionsFormatter);
+            var logFormatter = servicesProvider.GetService<IOptionFormatterResolver<TestOptions>>();
+            Assert.True(logFormatter is TestOptionsFormatter.Resolver);
+            var actual = servicesProvider.GetRequiredService<TestLoggerFactory>();
+            Assert.Equal(expected.ToString(), actual.ToString());
         }
 
-        public class TestOptionsFormatter2 : IOptionFormatter<TestOptions>
+        [Fact]
+        public void CustomFormatterResolverOverridesDefaultFormatter_PostRegistration()
         {
-            public string Category { get; }
+            // expected output
+            TestLoggerFactory expected = BuildNamedOptionsExpectedResult();
 
-            public string Name => nameof(TestOptions);
+            // actual output
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.AddSingleton<TestLoggerFactory>();
+            services.AddSingleton<ILoggerFactory>(sp => sp.GetRequiredService<TestLoggerFactory>());
+            services.AddSingleton(typeof(ILogger<>), typeof(TestLogger<>));
+            services.AddSingleton<OptionsLogger, TestOptionsLogger>();
+            // defaults
+            Enumerable
+                .Range(1, 2)
+                .ToList()
+                .ForEach(i =>
+                {
+                    string name = i.ToString();
+                    services.Configure<TestOptions>(name, (options => options.IntField = i));
+                    services.TryConfigureFormatter<TestOptions, TestOptionsFormatter2.Resolver>(name);
+                });
+            // post register overrides
+            services.Configure<TestOptions>("3", (options => options.IntField = 3));
+            services.ConfigureFormatter<TestOptions, TestOptionsFormatter.Resolver>("3");
+            var servicesProvider = services.BuildServiceProvider();
+            servicesProvider.GetRequiredService<OptionsLogger>().LogOptions();
+
+            var logFormatters = servicesProvider.GetServices<IOptionFormatter>();
+            Assert.Equal(3, logFormatters.Count());
+            Assert.True(logFormatters.First() is TestOptionsFormatter);
+            Assert.True(logFormatters.ElementAt(1) is TestOptionsFormatter);
+            Assert.True(logFormatters.ElementAt(2) is TestOptionsFormatter);
+            var logFormatter = servicesProvider.GetService<IOptionFormatterResolver<TestOptions>>();
+            Assert.True(logFormatter is TestOptionsFormatter.Resolver);
+            var actual = servicesProvider.GetRequiredService<TestLoggerFactory>();
+            Assert.Equal(expected.ToString(), actual.ToString());
+        }
+
+        private TestLoggerFactory BuildOptionsExpectedResult()
+        {
+            var services = new ServiceCollection();
+            var testOptions = new TestOptions
+            {
+                IntField = 1
+            };
+            var expected = new TestLoggerFactory();
+            var formatter = new TestOptionsFormatter(Options.Create(testOptions));
+            var optionsLogger = new TestOptionsLogger(expected.CreateLogger<TestOptionsLogger>(), services.BuildServiceProvider());
+            optionsLogger.LogOption(formatter);
+            return expected;
+        }
+
+        private TestLoggerFactory BuildNamedOptionsExpectedResult()
+        {
+            var services = new ServiceCollection();
+            IOptionFormatter[] formatters = Enumerable
+                .Range(1, 3)
+                .Select(i =>  TestOptionsFormatter.CreateNamed(i.ToString(), Options.Create(new TestOptions { IntField = i })))
+                .ToArray<IOptionFormatter>();
+            var expected = new TestLoggerFactory();
+            var optionsLogger = new TestOptionsLogger(expected.CreateLogger<TestOptionsLogger>(), services.BuildServiceProvider());
+            optionsLogger.LogOptions(formatters);
+            return expected;
+        }
+
+        private class TestOptions
+        {
+            public int IntField { get; set; } = 0;
+        }
+
+        private class TestOptionsFormatter2 : IOptionFormatter<TestOptions>
+        {
+            public string Name { get; private set; }
 
             private TestOptions options;
             public TestOptionsFormatter2(IOptions<TestOptions> options)
             {
                 this.options = options.Value;
+                this.Name = nameof(TestOptions);
+            }
+
+            public static TestOptionsFormatter2 CreateNamed(string name, IOptions<TestOptions> options)
+            {
+                var result = new TestOptionsFormatter2(options);
+                // different format
+                result.Name = $"{nameof(TestOptions)}+{name}";
+                return result;
+            }
+
+            public IEnumerable<string> Format()
+            {
+                return new List<string>()
+                {
+                    // different format
+                    OptionFormattingUtilities.Format(nameof(options.IntField), options.IntField, "{0}=>{1}")
+                };
+            }
+
+            public class Resolver : IOptionFormatterResolver<TestOptions>
+            {
+                private readonly IOptionsSnapshot<TestOptions> optionsSnapshot;
+                public Resolver(IOptionsSnapshot<TestOptions> optionsSnapshot)
+                {
+                    this.optionsSnapshot = optionsSnapshot;
+                }
+
+                public IOptionFormatter<TestOptions> Resolve(string name)
+                {
+                    return TestOptionsFormatter2.CreateNamed(name, Options.Create(this.optionsSnapshot.Get(name)));
+                }
+            }
+        }
+
+        private class TestOptionsFormatter : IOptionFormatter<TestOptions>
+        {
+            public string Name { get; private set; }
+
+            private TestOptions options;
+            public TestOptionsFormatter(IOptions<TestOptions> options)
+            {
+                this.options = options.Value;
+                this.Name = nameof(TestOptions);
+            }
+
+            public static TestOptionsFormatter CreateNamed(string name, IOptions<TestOptions> options)
+            {
+                var result = new TestOptionsFormatter(options);
+                result.Name = $"{nameof(TestOptions)}-{name}";
+                return result;
             }
 
             public IEnumerable<string> Format()
@@ -117,54 +361,102 @@ namespace Tester
                     OptionFormattingUtilities.Format(nameof(options.IntField), options.IntField)
                 };
             }
-        }
 
-        public class TestOptionsFormatter : IOptionFormatter<TestOptions>
-        {
-            public string Category { get; }
-
-            public string Name => nameof(TestOptions);
-
-            private TestOptions options;
-            public TestOptionsFormatter(IOptions<TestOptions> options)
+            public class Resolver : IOptionFormatterResolver<TestOptions>
             {
-                this.options = options.Value;
-            }
+                private readonly IOptionsSnapshot<TestOptions> optionsSnapshot;
+                public Resolver(IOptionsSnapshot<TestOptions> optionsSnapshot)
+                {
+                    this.optionsSnapshot = optionsSnapshot;
+                }
 
-            public IEnumerable<string> Format()
-            {
-               return new List<string>()
-               {
-                   OptionFormattingUtilities.Format(nameof(options.IntField), options.IntField)
-               };
+                public IOptionFormatter<TestOptions> Resolve(string name)
+                {
+                    return TestOptionsFormatter.CreateNamed(name, Options.Create(this.optionsSnapshot.Get(name)));
+                }
             }
         }
 
-        public class TestOptionFormatterResolver : IOptionFormatterResolver<TestOptions>
+        private class TestLoggerFactory : ILoggerFactory
         {
-            private IOptionsSnapshot<TestOptions> optionsAccessor;
-            public TestOptionFormatterResolver(IOptionsSnapshot<TestOptions> optionsAccessor)
+            private readonly ConcurrentDictionary<string, Logger> loggers = new ConcurrentDictionary<string, Logger>();
+
+            public void AddProvider(ILoggerProvider provider)
             {
-                this.optionsAccessor = optionsAccessor;
+                throw new NotImplementedException();
             }
 
-            public IOptionFormatter<TestOptions> Resolve(string name)
+            public ILogger CreateLogger(string categoryName)
             {
-                return new TestOptionsFormatter(Options.Create(optionsAccessor.Get(name)));
+                return this.loggers.GetOrAdd(categoryName, new Logger());
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public override string ToString()
+            {
+                return string.Join(":", this.loggers.Select(kvp => $"{kvp.Key} =\n{kvp.Value.ToString()}\n"));
+            }
+
+            private class Logger : ILogger
+            {
+                private readonly List<string> entries = new List<string>();
+
+                public IDisposable BeginScope<TState>(TState state)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override string ToString()
+                {
+                    return string.Join(";", this.entries);
+                }
+
+                public bool IsEnabled(LogLevel logLevel)
+                {
+                    return true;
+                }
+
+                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                {
+                    entries.Add(formatter(state, exception));
+                }
             }
         }
 
-        public class TestOptionFormatterResolver2 : IOptionFormatterResolver<TestOptions>
+        private class TestLogger<T> : ILogger<T>
         {
-            private IOptionsSnapshot<TestOptions> optionsAccessor;
-            public TestOptionFormatterResolver2(IOptionsSnapshot<TestOptions> optionsAccessor)
+            private readonly ILogger<T> logger;
+
+            public TestLogger(ILoggerFactory loggerFactory)
             {
-                this.optionsAccessor = optionsAccessor;
+                this.logger = loggerFactory.CreateLogger<T>();
             }
 
-            public IOptionFormatter<TestOptions> Resolve(string name)
+            public IDisposable BeginScope<TState>(TState state)
             {
-                return new TestOptionsFormatter2(Options.Create(optionsAccessor.Get(name)));
+                return logger.BeginScope<TState>(state);
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return logger.IsEnabled(logLevel);
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                logger.Log<TState>(logLevel, eventId, state, exception, formatter);
+            }
+        }
+
+
+        private class TestOptionsLogger : OptionsLogger
+        {
+            public TestOptionsLogger(ILogger<TestOptionsLogger> logger, IServiceProvider services)
+                : base(logger, services)
+            {
             }
         }
     }


### PR DESCRIPTION
Removed catalog, as it was deemed unnecessary.
Order logging by formatter name.  Helps with grouping of related options when using default formatters.
Allow user override of formatters before or after defaults.
Fixed issues with named options not reporting correctly.
Updated tests to verify by confirming expected log output.

