### PR TITLE
Add an additional [OneWay] test for grains

### DIFF
--- a/test/TestGrainInterfaces/ITestGrain.cs
+++ b/test/TestGrainInterfaces/ITestGrain.cs
@@ -56,6 +56,8 @@ namespace UnitTests.GrainInterfaces
         [OneWay]
         Task ThrowsOneWay();
 
+        Task<bool> NotifyOtherGrain(IOneWayGrain otherGrain, ISimpleGrainObserver observer);
+
         Task<int> GetCount();
     }
 

--- a/test/TestInternalGrains/TestGrain.cs
+++ b/test/TestInternalGrains/TestGrain.cs
@@ -196,6 +196,14 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
+        public async Task<bool> NotifyOtherGrain(IOneWayGrain otherGrain, ISimpleGrainObserver observer)
+        {
+            var task = otherGrain.Notify(observer);
+            var completedSynchronously = task.Status == TaskStatus.RanToCompletion;
+            await task;
+            return completedSynchronously;
+        }
+
         public Task<int> GetCount() => Task.FromResult(this.count);
 
         public Task ThrowsOneWay()


### PR DESCRIPTION
Checks that the behavior is as-expected when calling from within a grain, too (currently we only check from the client).