### PR TITLE
Proxy Gateway should honor address settings and allow localhost calls from client

### DIFF
--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
@@ -11,6 +11,7 @@ using Orleans.Runtime.Scheduler;
 using Orleans.Providers;
 using Orleans.Configuration.Options;
 using System.Collections.Generic;
+using System.Net;
 
 namespace Orleans.Hosting
 {
@@ -175,6 +176,19 @@ namespace Orleans.Hosting
                     {
                         options.ProxyPort = nodeConfig.ProxyGatewayEndpoint.Port;
                     }
+
+                    if (options.ProxyPort != 0 && options.ProxyIPAddress == null)
+                    {
+                        if (nodeConfig.ProxyGatewayEndpoint == null || nodeConfig.ProxyGatewayEndpoint.Address == IPAddress.None)
+                        {
+                            options.ProxyIPAddress = options.IPAddress;
+                        }
+                        else
+                        {
+                            options.ProxyIPAddress = nodeConfig.ProxyGatewayEndpoint.Address;
+                        }
+                    }
+
                 });
 
             services.Configure<SerializationProviderOptions>(options =>

--- a/src/Orleans.Runtime/Hosting/EndpointOptions.cs
+++ b/src/Orleans.Runtime/Hosting/EndpointOptions.cs
@@ -27,6 +27,11 @@ namespace Orleans.Hosting
         /// </summary>
         public int ProxyPort { get; set; }
 
+        /// <summary>
+        /// The IP address used for proxy.
+        /// </summary>
+        public IPAddress ProxyIPAddress { get; set; }
+
         //public bool BindToAny { get; set; }
     }
 }

--- a/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
+++ b/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
@@ -23,7 +23,7 @@ namespace Orleans.Runtime
 
             var endpointOptions = siloEndpointOptions.Value;
             this.siloAddressLazy = new Lazy<SiloAddress>(() => SiloAddress.New(ResolveEndpoint(endpointOptions), SiloAddress.AllocateNewGeneration()));
-            this.gatewayAddressLazy = new Lazy<SiloAddress>(() => endpointOptions.ProxyPort != 0 ? SiloAddress.New(new IPEndPoint(this.SiloAddress.Endpoint.Address, endpointOptions.ProxyPort), 0) : null);
+            this.gatewayAddressLazy = new Lazy<SiloAddress>(() => endpointOptions.ProxyPort != 0 ? SiloAddress.New(new IPEndPoint(endpointOptions.ProxyIPAddress, endpointOptions.ProxyPort), 0) : null);                        
         }
 
         private static IPEndPoint ResolveEndpoint(EndpointOptions options)


### PR DESCRIPTION
```
config.Defaults.ProxyGatewayEndpoint = new IPEndPoint(IPAddress.Any, 40000);
```
This setting does not work because the Gateway endpoint will always be set to the IP address of the silo.
I sidecar scenarios we want to be able to call the gateway as localhost:40000 by setting the service to IPAddress.Any or IPAddress.Loopback.
This fix allows the Gateway address setting to be honored. If the IPAddress is set to None, then we function same as today by copying Silo address to Gateway address.