### PR TITLE
Add a configuration validator for cluster membership providers

### DIFF
--- a/src/Orleans.Core/Configuration/Validators/ApplicationPartValidator.cs
+++ b/src/Orleans.Core/Configuration/Validators/ApplicationPartValidator.cs
@@ -1,11 +1,11 @@
 using System.Linq;
 using System.Reflection;
+
 using Orleans.ApplicationParts;
-using Orleans.Hosting;
 using Orleans.Metadata;
 using Orleans.Runtime;
 
-namespace Orleans
+namespace Orleans.Configuration.Validators
 {
     internal class ApplicationPartValidator : IConfigurationValidator
     {

--- a/src/Orleans.Core/Configuration/Validators/ClientClusteringValidator.cs
+++ b/src/Orleans.Core/Configuration/Validators/ClientClusteringValidator.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Orleans.Messaging;
+using Orleans.Runtime;
+
+namespace Orleans.Configuration.Validators
+{
+    internal class ClientClusteringValidator : IConfigurationValidator
+    {
+        internal const string ClusteringNotConfigured =
+            "Clustering has not been configured. Configure clustering using one of the clustering packages, such as: "
+            + "\n  * Microsoft.Orleans.Clustering.AzureStorage for Microsoft Azure Storage"
+            + "\n  * Microsoft.Orleans.Clustering.AdoNet for ADO.NET systems such as SQL Server, MySQL, PostgreSQL, and Oracle"
+            + "\n  * Microsoft.Orleans.Clustering.DynamoDB"
+            + "\n  * Microsoft.Orleans.Clustering.ServiceFabric"
+            + "\n  * See: https://www.nuget.org/packages?q=orleans+clustering";
+
+        private readonly IServiceProvider serviceProvider;
+
+        public ClientClusteringValidator(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
+        public void ValidateConfiguration()
+        {
+            var gatewayProvider = this.serviceProvider.GetService<IGatewayListProvider>();
+            if (gatewayProvider == null)
+            {
+                throw new OrleansConfigurationException(ClusteringNotConfigured);
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Configuration/Validators/ClientClusteringValidator.cs
+++ b/src/Orleans.Core/Configuration/Validators/ClientClusteringValidator.cs
@@ -10,12 +10,14 @@ namespace Orleans.Configuration.Validators
     internal class ClientClusteringValidator : IConfigurationValidator
     {
         internal const string ClusteringNotConfigured =
-            "Clustering has not been configured. Configure clustering using one of the clustering packages, such as: "
-            + "\n  * Microsoft.Orleans.Clustering.AzureStorage for Microsoft Azure Storage"
+            "Clustering has not been configured. Configure clustering using one of the clustering packages, such as:"
+            + "\n  * Microsoft.Orleans.Clustering.AzureStorage"
             + "\n  * Microsoft.Orleans.Clustering.AdoNet for ADO.NET systems such as SQL Server, MySQL, PostgreSQL, and Oracle"
             + "\n  * Microsoft.Orleans.Clustering.DynamoDB"
             + "\n  * Microsoft.Orleans.Clustering.ServiceFabric"
-            + "\n  * See: https://www.nuget.org/packages?q=orleans+clustering";
+            + "\n  * Microsoft.Orleans.Clustering.Consul"
+            + "\n  * Microsoft.Orleans.Clustering.ZooKeeper"
+            + "\n  * Others, see: https://www.nuget.org/packages?q=Microsoft.Orleans.Clustering.";
 
         private readonly IServiceProvider serviceProvider;
 

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.ApplicationParts;
 using Orleans.Configuration;
+using Orleans.Configuration.Validators;
 using Orleans.Hosting;
 using Orleans.Metadata;
 using Orleans.Providers;
@@ -64,11 +65,13 @@ namespace Orleans
 
             services.TryAddSingleton(typeof(IKeyedServiceCollection<,>), typeof(KeyedServiceCollection<,>));
 
-            //Add default option formatter if none is configured, for options which are requied to be configured 
+            // Add default option formatter if none is configured, for options which are requied to be configured 
             services.TryConfigureFormatter<ClusterClientOptions, ClusterClientOptionsFormatter>();
             services.TryConfigureFormatter<ClientMessagingOptions, ClientMessagingOptionFormatter>();
             services.TryConfigureFormatter<NetworkingOptions, NetworkingOptionsFormatter>();
             services.TryConfigureFormatter<ClientStatisticsOptions, ClientStatisticsOptionsFormatter>();
+            
+            services.AddTransient<IConfigurationValidator, ClientClusteringValidator>();
         }
     }
 }

--- a/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
@@ -1,0 +1,34 @@
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Orleans.Configuration.Validators;
+using Orleans.Runtime.MembershipService;
+
+namespace Orleans.Runtime.Configuration
+{
+    /// <summary>
+    /// Validates basic cluster membership configuration.
+    /// </summary>
+    internal class SiloClusteringValidator : IConfigurationValidator
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        public SiloClusteringValidator(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
+        /// <inheritdoc />
+        public void ValidateConfiguration()
+        {
+            var clusteringProvider = this.serviceProvider.GetService<IMembershipOracle>();
+            var clusteringTableProvider = this.serviceProvider.GetService<IMembershipTable>();
+            var storageBackedWithNoStorage = clusteringProvider is MembershipOracle && clusteringTableProvider == null;
+            if (clusteringProvider == null || storageBackedWithNoStorage)
+            {
+                throw new OrleansConfigurationException(ClientClusteringValidator.ClusteringNotConfigured);
+            }
+        }
+    }
+}

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -36,6 +36,9 @@ using Orleans.Metadata;
 using Orleans.Statistics;
 using Microsoft.Extensions.Options;
 
+using Orleans.Configuration.Validators;
+using Orleans.Runtime.Configuration;
+
 namespace Orleans.Hosting
 {
     internal static class DefaultSiloServices
@@ -111,14 +114,18 @@ namespace Orleans.Hosting
             services.TryAddFromExisting<IRuntimeClient, InsideRuntimeClient>();
             services.TryAddFromExisting<ISiloRuntimeClient, InsideRuntimeClient>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, InsideRuntimeClient>();
+            
             services.TryAddSingleton<MultiClusterGossipChannelFactory>();
             services.TryAddSingleton<MultiClusterOracle>();
             services.TryAddSingleton<MultiClusterRegistrationStrategyManager>();
             services.TryAddFromExisting<IMultiClusterOracle, MultiClusterOracle>();
             services.TryAddSingleton<DeploymentLoadPublisher>();
+
             services.TryAddSingleton<MembershipOracle>();
             services.TryAddFromExisting<IMembershipOracle, MembershipOracle>();
             services.TryAddFromExisting<ISiloStatusOracle, MembershipOracle>();
+            services.AddTransient<IConfigurationValidator, SiloClusteringValidator>();
+
             services.TryAddSingleton<ClientObserverRegistrar>();
             services.TryAddSingleton<SiloProviderRuntime>();
             services.TryAddFromExisting<IStreamProviderRuntime, SiloProviderRuntime>();

--- a/test/NonSilo.Tests/SiloHostBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloHostBuilderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -62,13 +63,15 @@ namespace NonSilo.Tests
         [Fact]
         public void SiloHostBuilder_AssembliesTest()
         {
-            var builder = (ISiloHostBuilder) new SiloHostBuilder()
-                                                .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());
+            var builder = new SiloHostBuilder().ConfigureEndpoints(IPAddress.Any, 9999, 0)
+                .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());
             Assert.Throws<OrleansConfigurationException>(() => builder.Build());
 
-            // Adding an application assembly causes the 
-            builder = new SiloHostBuilder().UseConfiguration(new ClusterConfiguration()).ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IAccountGrain).Assembly))
-                .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>()); ;
+            // Adding an application assembly allows the silo to be correctly built.
+            builder = new SiloHostBuilder().UseConfiguration(new ClusterConfiguration())
+                .ConfigureEndpoints(IPAddress.Any, 9999, 0)
+                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IAccountGrain).Assembly))
+                .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());
             using (var silo = builder.Build())
             {
                 Assert.NotNull(silo);


### PR DESCRIPTION
Validates that a clustering provider has been configured on the client and silo.