### PR TITLE
Add startup tasks to replace deprecated bootstrap providers

### DIFF
--- a/src/Orleans.Core/Runtime/Constants.cs
+++ b/src/Orleans.Core/Runtime/Constants.cs
@@ -37,6 +37,7 @@ namespace Orleans.Runtime
         public static readonly GrainId MembershipOracleId = GrainId.GetSystemTargetGrainId(15);
         public static readonly GrainId TypeManagerId = GrainId.GetSystemTargetGrainId(17);
         public static readonly GrainId FallbackSystemTargetId = GrainId.GetSystemTargetGrainId(19);
+        public static readonly GrainId StartupTaskSystemTargetId = GrainId.GetSystemTargetGrainId(20);
         public static readonly GrainId DeploymentLoadPublisherSystemTargetId = GrainId.GetSystemTargetGrainId(22);
         public static readonly GrainId MultiClusterOracleId = GrainId.GetSystemTargetGrainId(23);
         public static readonly GrainId ClusterDirectoryServiceId = GrainId.GetSystemTargetGrainId(24);

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -260,6 +260,9 @@ namespace Orleans.Hosting
             services.TryConfigureFormatter<EndpointOptions, EndpointOptionsFormatter>();
 
             services.AddTransient<IConfigurationValidator, EndpointOptionsValidator>();
+            
+            services.AddSingleton<StartupTaskSystemTarget>();
+
         }
     }
 }

--- a/src/Orleans.Runtime/Lifecycle/IStartupTask.cs
+++ b/src/Orleans.Runtime/Lifecycle/IStartupTask.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Defines an action to be taken during silo startup.
+    /// </summary>
+    public interface IStartupTask
+    {
+        /// <summary>
+        /// Called after the silo has started.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token which is canceled when the method must abort.</param>
+        /// <returns>A <see cref="Task"/> representing the work performed.</returns>
+        Task OnStarted(CancellationToken cancellationToken);
+    }
+}

--- a/src/Orleans.Runtime/Lifecycle/IStartupTask.cs
+++ b/src/Orleans.Runtime/Lifecycle/IStartupTask.cs
@@ -13,6 +13,6 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="cancellationToken">The cancellation token which is canceled when the method must abort.</param>
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>
-        Task OnStarted(CancellationToken cancellationToken);
+        Task Execute(CancellationToken cancellationToken);
     }
 }

--- a/src/Orleans.Runtime/Lifecycle/SiloBuilderStartupExtensions.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloBuilderStartupExtensions.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.Runtime.Providers;
+using Orleans.Runtime.Scheduler;
+using Orleans.Runtime.Startup;
+
+namespace Orleans.Hosting
+{
+    /// <summary>
+    /// The silo builder startup extensions.
+    /// </summary>
+    public static class SiloBuilderStartupExtensions
+    {
+        /// <summary>
+        /// Adds a startup task to be executed when the silo has started.
+        /// </summary>
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <typeparam name="TStartup">
+        /// The startup task type.
+        /// </typeparam>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder AddStartupTask<TStartup>(this ISiloHostBuilder builder)
+            where TStartup : class, IStartupTask
+        {
+            EnsureStartupAdded(builder);
+            builder.ConfigureServices(services => services.AddSingleton<IStartupTask, TStartup>());
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a startup task to be executed when the silo has started.
+        /// </summary>
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="startupTask">
+        /// The startup task.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder AddStartupTask(this ISiloHostBuilder builder, IStartupTask startupTask)
+        {
+            EnsureStartupAdded(builder);
+            builder.ConfigureServices(services => services.AddSingleton(startupTask));
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a startup task to be executed when the silo has started.
+        /// </summary>
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="startupTask">
+        /// The startup task.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder AddStartupTask(this ISiloHostBuilder builder, Func<IServiceProvider, CancellationToken, Task> startupTask)
+        {
+            EnsureStartupAdded(builder);
+            builder.ConfigureServices(services => services.AddSingleton<IStartupTask>(sp => new DelegateStartupTask(sp, startupTask)));
+            return builder;
+        }
+
+        private static void EnsureStartupAdded(ISiloHostBuilder builder)
+        {
+            if (!builder.Properties.TryGetValue(typeof(StartupTask), out var _))
+            {
+                builder.ConfigureServices(
+                    services =>
+                    {
+                        services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, StartupTask>();
+                        services.TryAddSingleton<StartupTaskSystemTarget>();
+                    });
+                builder.Properties[typeof(StartupTask)] = true;
+            }
+        }
+
+        private class StartupTask : ILifecycleParticipant<ISiloLifecycle>
+        {
+            private readonly IEnumerable<IStartupTask> startupTasks;
+
+            private readonly OrleansTaskScheduler scheduler;
+
+            private readonly SiloProviderRuntime siloProviderRuntime;
+
+            private readonly StartupTaskSystemTarget schedulingTarget;
+
+            public StartupTask(
+                IEnumerable<IStartupTask> startupTasks,
+                OrleansTaskScheduler scheduler,
+                StartupTaskSystemTarget schedulingTarget,
+                SiloProviderRuntime siloProviderRuntime)
+            {
+                this.startupTasks = startupTasks;
+                this.scheduler = scheduler;
+                this.siloProviderRuntime = siloProviderRuntime;
+                this.schedulingTarget = schedulingTarget;
+            }
+
+            public void Participate(ISiloLifecycle lifecycle)
+            {
+                lifecycle.Subscribe(SiloLifecycleStage.RuntimeServices, this.RegisterSystemTarget);
+                lifecycle.Subscribe(SiloLifecycleStage.SiloActive, this.OnStarted);
+            }
+
+            private Task RegisterSystemTarget(CancellationToken cancellationToken)
+            {
+                // Register the target used for scheduling startup tasks.
+                this.siloProviderRuntime.RegisterSystemTarget(this.schedulingTarget);
+                return Task.CompletedTask;
+            }
+
+            private Task OnStarted(CancellationToken cancellationToken)
+            {
+                return this.scheduler.QueueTask(
+                    async () =>
+                    {
+                        foreach (var task in this.startupTasks)
+                        {
+                            await task.OnStarted(cancellationToken);
+                        }
+                    },
+                    this.schedulingTarget.SchedulingContext);
+            }
+        }
+
+        // A dummy system target for scheduling startup tasks.
+        internal class StartupTaskSystemTarget : SystemTarget
+        {
+            public StartupTaskSystemTarget(ILocalSiloDetails localSiloDetails, ILoggerFactory loggerFactory)
+                : base(Constants.StartupTaskSystemTargetId, localSiloDetails.SiloAddress, loggerFactory)
+            {
+            }
+        }
+
+        private class DelegateStartupTask : IStartupTask
+        {
+            private readonly IServiceProvider serviceProvider;
+
+            private readonly Func<IServiceProvider, CancellationToken, Task> startupTask;
+
+            public DelegateStartupTask(IServiceProvider serviceProvider, Func<IServiceProvider, CancellationToken, Task> startupTask)
+            {
+                this.serviceProvider = serviceProvider;
+                this.startupTask = startupTask;
+            }
+
+            public Task OnStarted(CancellationToken cancellationToken) => this.startupTask(this.serviceProvider, cancellationToken);
+        }
+    }
+}

--- a/src/Orleans.Runtime/Lifecycle/SiloBuilderStartupExtensions.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloBuilderStartupExtensions.cs
@@ -1,17 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 
-using Orleans.Hosting;
 using Orleans.Runtime;
-using Orleans.Runtime.Providers;
 using Orleans.Runtime.Scheduler;
-using Orleans.Runtime.Startup;
 
 namespace Orleans.Hosting
 {
@@ -26,18 +20,21 @@ namespace Orleans.Hosting
         /// <param name="builder">
         /// The builder.
         /// </param>
+        /// <param name="stage">
+        /// The stage to execute the startup task, see values in <see cref="SiloLifecycleStage"/>.
+        /// </param>
         /// <typeparam name="TStartup">
         /// The startup task type.
         /// </typeparam>
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>.
         /// </returns>
-        public static ISiloHostBuilder AddStartupTask<TStartup>(this ISiloHostBuilder builder)
+        public static ISiloHostBuilder AddStartupTask<TStartup>(
+            this ISiloHostBuilder builder,
+            int stage = SiloLifecycleStage.SiloActive)
             where TStartup : class, IStartupTask
         {
-            EnsureStartupAdded(builder);
-            builder.ConfigureServices(services => services.AddSingleton<IStartupTask, TStartup>());
-            return builder;
+            return builder.AddStartupTask((sp, ct) => ActivatorUtilities.GetServiceOrCreateInstance<TStartup>(sp).Execute(ct), stage);
         }
 
         /// <summary>
@@ -49,14 +46,18 @@ namespace Orleans.Hosting
         /// <param name="startupTask">
         /// The startup task.
         /// </param>
+        /// <param name="stage">
+        /// The stage to execute the startup task, see values in <see cref="SiloLifecycleStage"/>.
+        /// </param>
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>.
         /// </returns>
-        public static ISiloHostBuilder AddStartupTask(this ISiloHostBuilder builder, IStartupTask startupTask)
+        public static ISiloHostBuilder AddStartupTask(
+            this ISiloHostBuilder builder,
+            IStartupTask startupTask,
+            int stage = SiloLifecycleStage.SiloActive)
         {
-            EnsureStartupAdded(builder);
-            builder.ConfigureServices(services => services.AddSingleton(startupTask));
-            return builder;
+            return builder.AddStartupTask((sp, ct) => startupTask.Execute(ct), stage);
         }
 
         /// <summary>
@@ -68,101 +69,61 @@ namespace Orleans.Hosting
         /// <param name="startupTask">
         /// The startup task.
         /// </param>
+        /// <param name="stage">
+        /// The stage to execute the startup task, see values in <see cref="SiloLifecycleStage"/>.
+        /// </param>
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>.
         /// </returns>
-        public static ISiloHostBuilder AddStartupTask(this ISiloHostBuilder builder, Func<IServiceProvider, CancellationToken, Task> startupTask)
+        public static ISiloHostBuilder AddStartupTask(
+            this ISiloHostBuilder builder,
+            Func<IServiceProvider, CancellationToken, Task> startupTask,
+            int stage = SiloLifecycleStage.SiloActive)
         {
-            EnsureStartupAdded(builder);
-            builder.ConfigureServices(services => services.AddSingleton<IStartupTask>(sp => new DelegateStartupTask(sp, startupTask)));
+            builder.ConfigureServices(services =>
+                services.AddTransient<ILifecycleParticipant<ISiloLifecycle>>(sp =>
+                    new StartupTask(
+                        sp,
+                        sp.GetRequiredService<OrleansTaskScheduler>(),
+                        sp.GetRequiredService<StartupTaskSystemTarget>(),
+                        startupTask,
+                        stage)));
             return builder;
         }
 
-        private static void EnsureStartupAdded(ISiloHostBuilder builder)
-        {
-            if (!builder.Properties.TryGetValue(typeof(StartupTask), out var _))
-            {
-                builder.ConfigureServices(
-                    services =>
-                    {
-                        services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>, StartupTask>();
-                        services.TryAddSingleton<StartupTaskSystemTarget>();
-                    });
-                builder.Properties[typeof(StartupTask)] = true;
-            }
-        }
-
+        /// <inheritdoc />
         private class StartupTask : ILifecycleParticipant<ISiloLifecycle>
         {
-            private readonly IEnumerable<IStartupTask> startupTasks;
-
-            private readonly OrleansTaskScheduler scheduler;
-
-            private readonly SiloProviderRuntime siloProviderRuntime;
-
-            private readonly StartupTaskSystemTarget schedulingTarget;
-
-            public StartupTask(
-                IEnumerable<IStartupTask> startupTasks,
-                OrleansTaskScheduler scheduler,
-                StartupTaskSystemTarget schedulingTarget,
-                SiloProviderRuntime siloProviderRuntime)
-            {
-                this.startupTasks = startupTasks;
-                this.scheduler = scheduler;
-                this.siloProviderRuntime = siloProviderRuntime;
-                this.schedulingTarget = schedulingTarget;
-            }
-
-            public void Participate(ISiloLifecycle lifecycle)
-            {
-                lifecycle.Subscribe(SiloLifecycleStage.RuntimeServices, this.RegisterSystemTarget);
-                lifecycle.Subscribe(SiloLifecycleStage.SiloActive, this.OnStarted);
-            }
-
-            private Task RegisterSystemTarget(CancellationToken cancellationToken)
-            {
-                // Register the target used for scheduling startup tasks.
-                this.siloProviderRuntime.RegisterSystemTarget(this.schedulingTarget);
-                return Task.CompletedTask;
-            }
-
-            private Task OnStarted(CancellationToken cancellationToken)
-            {
-                return this.scheduler.QueueTask(
-                    async () =>
-                    {
-                        foreach (var task in this.startupTasks)
-                        {
-                            await task.Execute(cancellationToken);
-                        }
-                    },
-                    this.schedulingTarget.SchedulingContext);
-            }
-        }
-
-        // A dummy system target for scheduling startup tasks.
-        internal class StartupTaskSystemTarget : SystemTarget
-        {
-            public StartupTaskSystemTarget(ILocalSiloDetails localSiloDetails, ILoggerFactory loggerFactory)
-                : base(Constants.StartupTaskSystemTargetId, localSiloDetails.SiloAddress, loggerFactory)
-            {
-            }
-        }
-
-        private class DelegateStartupTask : IStartupTask
-        {
             private readonly IServiceProvider serviceProvider;
-
+            private readonly OrleansTaskScheduler scheduler;
+            private readonly StartupTaskSystemTarget schedulingTarget;
             private readonly Func<IServiceProvider, CancellationToken, Task> startupTask;
 
-            public DelegateStartupTask(IServiceProvider serviceProvider, Func<IServiceProvider, CancellationToken, Task> startupTask)
+            private readonly int stage;
+
+            public StartupTask(
+                IServiceProvider serviceProvider,
+                OrleansTaskScheduler scheduler,
+                StartupTaskSystemTarget schedulingTarget,
+                Func<IServiceProvider, CancellationToken, Task> startupTask,
+                int stage)
             {
                 this.serviceProvider = serviceProvider;
+                this.scheduler = scheduler;
+                this.schedulingTarget = schedulingTarget;
                 this.startupTask = startupTask;
+                this.stage = stage;
             }
 
-            public Task Execute(CancellationToken cancellationToken) => this.startupTask(this.serviceProvider, cancellationToken);
+            /// <inheritdoc />
+            public void Participate(ISiloLifecycle lifecycle)
+            {
+                lifecycle.Subscribe(
+                    this.stage,
+                    cancellation => this.scheduler.QueueTask(
+                        () => this.startupTask(this.serviceProvider, cancellation),
+                        this.schedulingTarget.SchedulingContext));
+            }
         }
     }
 }

--- a/src/Orleans.Runtime/Lifecycle/SiloBuilderStartupExtensions.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloBuilderStartupExtensions.cs
@@ -134,7 +134,7 @@ namespace Orleans.Hosting
                     {
                         foreach (var task in this.startupTasks)
                         {
-                            await task.OnStarted(cancellationToken);
+                            await task.Execute(cancellationToken);
                         }
                     },
                     this.schedulingTarget.SchedulingContext);
@@ -162,7 +162,7 @@ namespace Orleans.Hosting
                 this.startupTask = startupTask;
             }
 
-            public Task OnStarted(CancellationToken cancellationToken) => this.startupTask(this.serviceProvider, cancellationToken);
+            public Task Execute(CancellationToken cancellationToken) => this.startupTask(this.serviceProvider, cancellationToken);
         }
     }
 }

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -361,7 +361,6 @@ namespace Orleans.Runtime
 
             // SystemTarget for provider init calls
             this.fallbackScheduler = Services.GetRequiredService<FallbackSystemTarget>();
-
             RegisterSystemTarget(fallbackScheduler);
         }
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -362,6 +362,10 @@ namespace Orleans.Runtime
             // SystemTarget for provider init calls
             this.fallbackScheduler = Services.GetRequiredService<FallbackSystemTarget>();
             RegisterSystemTarget(fallbackScheduler);
+
+            // SystemTarget for startup tasks
+            var startupTaskTarget = Services.GetRequiredService<StartupTaskSystemTarget>();
+            RegisterSystemTarget(startupTaskTarget);
         }
 
         private Task OnRuntimeInitializeStart(CancellationToken ct)
@@ -865,6 +869,15 @@ namespace Orleans.Runtime
     {
         public FallbackSystemTarget(ILocalSiloDetails localSiloDetails, ILoggerFactory loggerFactory)
             : base(Constants.FallbackSystemTargetId, localSiloDetails.SiloAddress, loggerFactory)
+        {
+        }
+    }
+
+    // A dummy system target for scheduling startup tasks.
+    internal class StartupTaskSystemTarget : SystemTarget
+    {
+        public StartupTaskSystemTarget(ILocalSiloDetails localSiloDetails, ILoggerFactory loggerFactory)
+            : base(Constants.StartupTaskSystemTargetId, localSiloDetails.SiloAddress, loggerFactory)
         {
         }
     }

--- a/test/Tester/StartupTaskTests.cs
+++ b/test/Tester/StartupTaskTests.cs
@@ -54,7 +54,7 @@ namespace DefaultCluster.Tests
                 this.grainFactory = grainFactory;
             }
 
-            public async Task OnStarted(CancellationToken cancellationToken)
+            public async Task Execute(CancellationToken cancellationToken)
             {
                 var grain = this.grainFactory.GetGrain<ISimpleGrain>(98052);
                 await grain.SetA(1331);

--- a/test/Tester/StartupTaskTests.cs
+++ b/test/Tester/StartupTaskTests.cs
@@ -1,0 +1,82 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Orleans;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+
+using TestExtensions;
+
+using UnitTests.GrainInterfaces;
+
+using Xunit;
+
+namespace DefaultCluster.Tests
+{
+    [TestCategory("BVT")]
+    public class StartupTaskTests : IClassFixture<StartupTaskTests.Fixture>
+    {
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
+                builder.AddSiloBuilderConfigurator<StartupTaskSiloConfigurator>();
+            }
+
+            private class StartupTaskSiloConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.AddStartupTask<CallGrainStartupTask>();
+                    hostBuilder.AddStartupTask(
+                        async (services, cancellation) =>
+                        {
+                            var grainFactory = services.GetRequiredService<IGrainFactory>();
+                            var grain = grainFactory.GetGrain<ISimpleGrain>(98052);
+
+                            // Modify "A" to validate ordering of events.
+                            await grain.SetA(await grain.GetA() * 2);
+                        });
+                }
+            }
+        }
+
+        public class CallGrainStartupTask : IStartupTask
+        {
+            private readonly IGrainFactory grainFactory;
+
+            public CallGrainStartupTask(IGrainFactory grainFactory)
+            {
+                this.grainFactory = grainFactory;
+            }
+
+            public async Task OnStarted(CancellationToken cancellationToken)
+            {
+                var grain = this.grainFactory.GetGrain<ISimpleGrain>(98052);
+                await grain.SetA(1331);
+            }
+        }
+
+        private readonly Fixture fixture;
+
+        public StartupTaskTests(Fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        /// <summary>
+        /// Ensures that startup tasks can call grains and are executed in the registered order.
+        /// </summary>
+        [Fact]
+        public async Task StartupTaskCanCallGrains()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ISimpleGrain>(98052);
+            var value = await grain.GetA();
+            Assert.Equal(2662, value);
+        }
+    }
+}

--- a/test/Tester/StartupTaskTests.cs
+++ b/test/Tester/StartupTaskTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace DefaultCluster.Tests
 {
-    [TestCategory("BVT")]
+    [TestCategory("BVT"), TestCategory("Lifecycle")]
     public class StartupTaskTests : IClassFixture<StartupTaskTests.Fixture>
     {
         public class Fixture : BaseTestClusterFixture


### PR DESCRIPTION
Resolves #4014

Developers can register an implementation of `IStartupTask` and perform operations such as calling grains from within the `OnStarted()` method.

Added a new `SystemTarget` for the purpose of scheduling startup tasks. I didn't extend scheduling to all lifecycle participants because the scheduler itself is only started at a certain silo lifecycle stage and therefore wont pump tasks before then. If this is an issue, maybe someone has an idea for how to solve it?

See the tests at the bottom for usage.