### PR TITLE
Rename Use*Membership extensions to Use*Clustering

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/AWSUtilsHostingExtensions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/AWSUtilsHostingExtensions.cs
@@ -10,79 +10,107 @@ namespace Orleans.Hosting
     public static class AwsUtilsHostingExtensions
     {
         /// <summary>
-        /// Configure SiloHostBuilder with DynamoDBMembership
+        /// Configures the silo to use DynamoDB for clustering.
         /// </summary>
-        public static ISiloHostBuilder UseDynamoDBMembership(this ISiloHostBuilder builder,
-            Action<DynamoDBMembershipOptions> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseDynamoDBClustering(
+            this ISiloHostBuilder builder,
+            Action<DynamoDBClusteringSiloOptions> configureOptions)
         {
-            builder.ConfigureServices(services => services.UseDynamoDBMembership(configureOptions));
-            return builder;
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IMembershipTable, DynamoDBMembershipTable>();
+                });
         }
 
         /// <summary>
-        /// Configure SiloHostBuilder with DynamoDBMembership
+        /// Configures the silo to use DynamoDB for clustering.
         /// </summary>
-        public static ISiloHostBuilder UseDynamoDBMembership(this ISiloHostBuilder builder,
-            Action<OptionsBuilder<DynamoDBMembershipOptions>> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseDynamoDBClustering(
+            this ISiloHostBuilder builder,
+            Action<OptionsBuilder<DynamoDBClusteringSiloOptions>> configureOptions)
         {
-            builder.ConfigureServices(services => services.UseDynamoDBMembership(configureOptions));
-            return builder;
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<DynamoDBClusteringSiloOptions>());
+                    services.AddSingleton<IMembershipTable, DynamoDBMembershipTable>();
+                });
         }
 
         /// <summary>
-        /// Configure ClientBuilder with DynamoDBGatewayListProvider
+        /// Configures the client to use DynamoDB for clustering.
         /// </summary>
-        public static IClientBuilder UseDynamoDBGatewayListProvider(this IClientBuilder builder,
-            Action<DynamoDBGatewayListProviderOptions> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseDynamoDBClustering(
+            this IClientBuilder builder,
+            Action<DynamoDBClusteringClientOptions> configureOptions)
         {
-            return  builder.ConfigureServices(services => services.UseDynamoDBGatewayListProvider(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IGatewayListProvider, DynamoDBGatewayListProvider>();
+                });
         }
 
         /// <summary>
-        /// Configure ClientBuilder with DynamoDBGatewayListProvider
+        /// Configures the client to use DynamoDB for clustering.
         /// </summary>
-        public static IClientBuilder UseDynamoDBGatewayListProvider(this IClientBuilder builder,
-            Action<OptionsBuilder<DynamoDBGatewayListProviderOptions>> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseDynamoDBClustering(
+            this IClientBuilder builder,
+            Action<OptionsBuilder<DynamoDBClusteringClientOptions>> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseDynamoDBGatewayListProvider(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with DynamoDBMembership
-        /// </summary>
-        public static IServiceCollection UseDynamoDBMembership(this IServiceCollection services,
-            Action<DynamoDBMembershipOptions> configureOptions)
-        {
-            return services.UseDynamoDBMembership(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with DynamoDBMembership
-        /// </summary>
-        public static IServiceCollection UseDynamoDBMembership(this IServiceCollection services,
-            Action<OptionsBuilder<DynamoDBMembershipOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<DynamoDBMembershipOptions>());
-            return services.AddSingleton<IMembershipTable, DynamoDBMembershipTable>();
-        }
-
-        /// <summary>
-        /// Condifure client with DynamoDBGatewayListProvider
-        /// </summary>
-        public static IServiceCollection UseDynamoDBGatewayListProvider(this IServiceCollection services,
-            Action<DynamoDBGatewayListProviderOptions> configureOptions)
-        {
-            return services.UseDynamoDBGatewayListProvider(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Condifure client with DynamoDBGatewayListProvider
-        /// </summary>
-        public static IServiceCollection UseDynamoDBGatewayListProvider(this IServiceCollection services,
-            Action<OptionsBuilder<DynamoDBGatewayListProviderOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<DynamoDBGatewayListProviderOptions>());
-            return services.AddSingleton<IGatewayListProvider, DynamoDBGatewayListProvider>();
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<DynamoDBClusteringClientOptions>());
+                    services.AddSingleton<IGatewayListProvider, DynamoDBGatewayListProvider>();
+                });
         }
     }
 }

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -22,9 +22,9 @@ namespace Orleans.Runtime.Membership
         private string clusterId;
         private readonly string INSTANCE_STATUS_ACTIVE = ((int)SiloStatus.Active).ToString();
         private readonly ILoggerFactory loggerFactory;
-        private readonly DynamoDBGatewayListProviderOptions options;
+        private readonly DynamoDBClusteringClientOptions options;
         private readonly TimeSpan maxStaleness;
-        public DynamoDBGatewayListProvider(ILoggerFactory loggerFactory, ClientConfiguration clientConfiguration, IOptions<DynamoDBGatewayListProviderOptions> options, IOptions<ClusterClientOptions> clusterClientOptions)
+        public DynamoDBGatewayListProvider(ILoggerFactory loggerFactory, ClientConfiguration clientConfiguration, IOptions<DynamoDBClusteringClientOptions> options, IOptions<ClusterClientOptions> clusterClientOptions)
         {
             this.loggerFactory = loggerFactory;
             this.options = options.Value;

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -25,9 +25,9 @@ namespace Orleans.Runtime.MembershipService
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
         private DynamoDBStorage storage;
-        private readonly DynamoDBMembershipOptions options;
+        private readonly DynamoDBClusteringSiloOptions options;
         private readonly string clusterId;
-        public DynamoDBMembershipTable(ILoggerFactory loggerFactory, IOptions<DynamoDBMembershipOptions> options, IOptions<SiloOptions> siloOptions)
+        public DynamoDBMembershipTable(ILoggerFactory loggerFactory, IOptions<DynamoDBClusteringSiloOptions> options, IOptions<SiloOptions> siloOptions)
         {
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<DynamoDBMembershipTable>();

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/LegacyDynamoDBGatewayListProviderConfigurator.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/LegacyDynamoDBGatewayListProviderConfigurator.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
 using Orleans.Clustering.DynamoDB;
-using Orleans.Hosting;
-using Orleans.Messaging;
-using Orleans.Runtime.Configuration;
 using Orleans.Configuration;
+using Orleans.Messaging;
+using Orleans.Runtime.Membership;
 
 namespace OrleansAWSUtils.Membership
 {
@@ -13,11 +15,14 @@ namespace OrleansAWSUtils.Membership
         /// <inheritdoc/>
         public void ConfigureServices(object configuration, IServiceCollection services)
         {
-            services.UseDynamoDBGatewayListProvider(options =>
-            {
-                var reader = new ClientConfigurationReader(configuration);
-                ParseDataConnectionString(reader.GetPropertyValue<string>("DataConnectionString"), options);
-            });
+            services.Configure<DynamoDBClusteringClientOptions>(
+                options =>
+                {
+                    var reader = new ClientConfigurationReader(configuration);
+                    ParseDataConnectionString(reader.GetPropertyValue<string>("DataConnectionString"), options);
+                });
+
+            services.AddSingleton<IGatewayListProvider, DynamoDBGatewayListProvider>();
         }
 
         /// <summary>
@@ -25,7 +30,7 @@ namespace OrleansAWSUtils.Membership
         /// </summary>
         /// <param name="dataConnectionString"></param>
         /// <param name="options"></param>
-        public static void ParseDataConnectionString(string dataConnectionString, DynamoDBGatewayListProviderOptions options)
+        public static void ParseDataConnectionString(string dataConnectionString, DynamoDBClusteringClientOptions options)
         {
             DynamoDBStorage.ParseDataConnectionString(dataConnectionString, out var accessKey, out var secretKey, out var service, out var readCapacityUnits, out var writeCapacityUnits);
             options.AccessKey = accessKey;

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/LegacyDynamoDBMembershipConfigurator.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/LegacyDynamoDBMembershipConfigurator.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Hosting;
-using Orleans.Runtime.Configuration;
+
+using Orleans.Configuration;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -10,7 +10,9 @@ namespace Orleans.Runtime.MembershipService
         public void Configure(object configuration, IServiceCollection services)
         {
             var reader = new GlobalConfigurationReader(configuration);
-            services.UseDynamoDBMembership(options => options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString"));
+
+            services.Configure<DynamoDBClusteringSiloOptions>(options => options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString"));
+            services.AddSingleton<IMembershipTable, DynamoDBMembershipTable>();
         }
     }
 }

--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringClientOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringClientOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Orleans.Configuration
 {
-    public class DynamoDBGatewayListProviderOptions
+    public class DynamoDBClusteringClientOptions
     {
         /// <summary>
         /// AccessKey string for DynamoDB Storage

--- a/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringSiloOptions.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Options/DynamoDBClusteringSiloOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Orleans.Configuration
 {
-    public class DynamoDBMembershipOptions
+    public class DynamoDBClusteringSiloOptions
     {
         /// <summary>
         /// Connection string for DynamoDB Storage

--- a/src/AdoNet/Orleans.Clustering.AdoNet/AdoNetHostingExtensions.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/AdoNetHostingExtensions.cs
@@ -10,75 +10,107 @@ namespace Orleans.Hosting
     public static class AdoNetHostingExtensions
     {
         /// <summary>
-        /// Configure SiloHostBuilder with ADO.NET clustering
+        /// Configures this silo to use ADO.NET for clustering.
         /// </summary>
-        public static ISiloHostBuilder UseAdoNetClustering(this ISiloHostBuilder builder,
-            Action<AdoNetClusteringOptions> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseAdoNetClustering(
+            this ISiloHostBuilder builder,
+            Action<AdoNetClusteringSiloOptions> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseAdoNetClustering(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IMembershipTable, AdoNetClusteringTable>();
+                });
         }
 
         /// <summary>
-        /// Configure SiloHostBuilder with ADO.NET clustering
+        /// Configures this silo to use ADO.NET for clustering.
         /// </summary>
-        public static ISiloHostBuilder UseAdoNetClustering(this ISiloHostBuilder builder,
-            Action<OptionsBuilder<AdoNetClusteringOptions>> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseAdoNetClustering(
+            this ISiloHostBuilder builder,
+            Action<OptionsBuilder<AdoNetClusteringSiloOptions>> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseAdoNetClustering(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<AdoNetClusteringSiloOptions>());
+                    services.AddSingleton<IMembershipTable, AdoNetClusteringTable>();
+                });
         }
 
         /// <summary>
-        /// Configure client to use ADO.NET gateway list provider
+        /// Configures this client to use ADO.NET for clustering.
         /// </summary>
-        public static IClientBuilder UseAdoNetlGatewayListProvider(this IClientBuilder builder, Action<AdoNetGatewayListProviderOptions> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseAdoNetClustering(
+            this IClientBuilder builder,
+            Action<AdoNetClusteringClientOptions> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseAdoNetlGatewayListProvider(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IGatewayListProvider, AdoNetGatewayListProvider>();
+                });
         }
 
         /// <summary>
-        /// Configure client to use ADO.NET gateway list provider
+        /// Configures this client to use ADO.NET for clustering.
         /// </summary>
-        public static IClientBuilder UseAdoNetlGatewayListProvider(this IClientBuilder builder, Action<OptionsBuilder<AdoNetGatewayListProviderOptions>> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseAdoNetClustering(
+            this IClientBuilder builder,
+            Action<OptionsBuilder<AdoNetClusteringClientOptions>> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseAdoNetlGatewayListProvider(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with ADO.NET clustering
-        /// </summary>
-        public static IServiceCollection UseAdoNetClustering(this IServiceCollection services,
-            Action<AdoNetClusteringOptions> configureOptions)
-        {
-            return services.UseAdoNetClustering(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with ADO.NET clustering
-        /// </summary>
-        public static IServiceCollection UseAdoNetClustering(this IServiceCollection services,
-            Action<OptionsBuilder<AdoNetClusteringOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<AdoNetClusteringOptions>());
-            return services.AddSingleton<IMembershipTable, AdoNetClusteringTable>();
-        }
-
-        /// <summary>
-        /// Configure DI container with ADO.NET gateway list provider
-        /// </summary>
-        public static IServiceCollection UseAdoNetlGatewayListProvider(this IServiceCollection services,
-            Action<AdoNetGatewayListProviderOptions> configureOptions)
-        {
-            return services.UseAdoNetlGatewayListProvider(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with ADO.NET gateway list provider
-        /// </summary>
-        public static IServiceCollection UseAdoNetlGatewayListProvider(this IServiceCollection services,
-            Action<OptionsBuilder<AdoNetGatewayListProviderOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<AdoNetGatewayListProviderOptions>());
-            return services.AddSingleton<IGatewayListProvider, AdoNetGatewayListProvider>();
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<AdoNetClusteringClientOptions>());
+                    services.AddSingleton<IGatewayListProvider, AdoNetGatewayListProvider>();
+                });
         }
     }
 }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -13,8 +13,8 @@ namespace Orleans.Runtime.MembershipService
         private string clusterId;        
         private ILogger logger;
         private RelationalOrleansQueries orleansQueries;
-        private readonly AdoNetClusteringOptions clusteringTableOptions;
-        public AdoNetClusteringTable(IGrainReferenceConverter grainReferenceConverter, IOptions<SiloOptions> siloOptions, IOptions<AdoNetClusteringOptions> clusterinOptions, ILogger<AdoNetClusteringTable> logger)
+        private readonly AdoNetClusteringSiloOptions clusteringTableOptions;
+        public AdoNetClusteringTable(IGrainReferenceConverter grainReferenceConverter, IOptions<SiloOptions> siloOptions, IOptions<AdoNetClusteringSiloOptions> clusterinOptions, ILogger<AdoNetClusteringTable> logger)
         {
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = logger;

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
@@ -14,12 +14,12 @@ namespace Orleans.Runtime.Membership
     {
         private readonly ILogger logger;
         private string clusterId;
-        private readonly AdoNetGatewayListProviderOptions options;
+        private readonly AdoNetClusteringClientOptions options;
         private RelationalOrleansQueries orleansQueries;
         private readonly IGrainReferenceConverter grainReferenceConverter;
         private readonly TimeSpan maxStaleness;
         public AdoNetGatewayListProvider(ILogger<AdoNetGatewayListProvider> logger, IGrainReferenceConverter grainReferenceConverter, ClientConfiguration clientConfiguration,
-            IOptions<AdoNetGatewayListProviderOptions> options,
+            IOptions<AdoNetClusteringClientOptions> options,
             IOptions<ClusterClientOptions> clusterClientOptions)
         {
             this.logger = logger;

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetClusteringConfigurator.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetClusteringConfigurator.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Runtime.Configuration;
+
+using Orleans.Configuration;
 using Orleans.Runtime.MembershipService;
-using Orleans.Hosting;
 
 namespace Orleans.AdoNet
 {
@@ -10,13 +10,14 @@ namespace Orleans.AdoNet
     {
         public void Configure(object configuration, IServiceCollection services)
         {
-            services.UseAdoNetClustering(
+            services.Configure<AdoNetClusteringSiloOptions>(
                 options =>
                 {
                     var reader = new GlobalConfigurationReader(configuration);
                     options.AdoInvariant = reader.GetPropertyValue<string>("AdoInvariant");
                     options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
                 });
+            services.AddSingleton<IMembershipTable, AdoNetClusteringTable>();
         }
     }
 }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetGatewayListProviderConfigurator.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetGatewayListProviderConfigurator.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Orleans.Hosting;
+
+using Orleans.Configuration;
 using Orleans.Messaging;
+using Orleans.Runtime.Membership;
 
 namespace Orleans.AdoNet.Messaging
 {
@@ -9,12 +11,14 @@ namespace Orleans.AdoNet.Messaging
     {
         public void ConfigureServices(object configuration, IServiceCollection services)
         {
-            services.UseAdoNetlGatewayListProvider(options =>
-            {
-                var reader = new ClientConfigurationReader(configuration);
-                options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
-                options.AdoInvariant = reader.GetPropertyValue<string>("AdoInvariant");
-            });
+            services.Configure<AdoNetClusteringClientOptions>(
+                options =>
+                {
+                    var reader = new ClientConfigurationReader(configuration);
+                    options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
+                    options.AdoInvariant = reader.GetPropertyValue<string>("AdoInvariant");
+                });
+            services.AddSingleton<IGatewayListProvider, AdoNetGatewayListProvider>();
         }
     }
 }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptions.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Orleans.Configuration
 {
-    public class AdoNetGatewayListProviderOptions
+    public class AdoNetClusteringClientOptions
     {
         /// <summary>
         /// Connection string for Sql

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringSiloOptions.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringSiloOptions.cs
@@ -3,12 +3,13 @@
     /// <summary>
     /// Options for ADO.NET clustering
     /// </summary>
-    public class AdoNetClusteringOptions
+    public class AdoNetClusteringSiloOptions
     {
         /// <summary>
         /// Connection string for Sql Storage
         /// </summary>
         public string ConnectionString { get; set; }
+
         /// <summary>
         /// The invariant name of the connector for membership's database.
         /// </summary>

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -21,9 +21,9 @@ namespace Orleans.Runtime.MembershipService
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
         private OrleansSiloInstanceManager tableManager;
-        private readonly AzureTableMembershipOptions options;
+        private readonly AzureStorageClusteringOptions options;
         private readonly string clusterId;
-        public AzureBasedMembershipTable(ILoggerFactory loggerFactory, IOptions<AzureTableMembershipOptions> membershipOptions, IOptions<SiloOptions> siloOptions)
+        public AzureBasedMembershipTable(ILoggerFactory loggerFactory, IOptions<AzureStorageClusteringOptions> membershipOptions, IOptions<SiloOptions> siloOptions)
         {
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<AzureBasedMembershipTable>();

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
@@ -12,11 +12,11 @@ namespace Orleans.AzureUtils
     {
         private OrleansSiloInstanceManager siloInstanceManager;
         private readonly string clusterId;
-        private readonly AzureTableGatewayListProviderOptions options;
+        private readonly AzureStorageGatewayOptions options;
         private readonly ILoggerFactory loggerFactory;
         private readonly TimeSpan maxStaleness;
 
-        public AzureGatewayListProvider(ILoggerFactory loggerFactory, IOptions<AzureTableGatewayListProviderOptions> options, IOptions<ClusterClientOptions> clusterClientOptions, IOptions<GatewayOptions> gatewayOptions)
+        public AzureGatewayListProvider(ILoggerFactory loggerFactory, IOptions<AzureStorageGatewayOptions> options, IOptions<ClusterClientOptions> clusterClientOptions, IOptions<GatewayOptions> gatewayOptions)
         {
             this.loggerFactory = loggerFactory;
             this.clusterId = clusterClientOptions.Value.ClusterId;

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureTableClusteringExtensions.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureTableClusteringExtensions.cs
@@ -10,77 +10,107 @@ namespace Orleans.Hosting
     public static class AzureTableClusteringExtensions
     {
         /// <summary>
-        /// Configure ISiloHostBuilder to use AzureTableBasedMembership
+        /// Configures the silo to use Azure Storage for clustering.
         /// </summary>
-        public static ISiloHostBuilder UseAzureTableMembership(this ISiloHostBuilder builder,
-            Action<AzureTableMembershipOptions> configureOptions)
+        /// <param name="builder">
+        /// The silo builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseAzureStorageClustering(
+            this ISiloHostBuilder builder,
+            Action<AzureStorageClusteringOptions> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseAzureTableMembership(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IMembershipTable, AzureBasedMembershipTable>();
+                });
         }
 
         /// <summary>
-        /// Configure ISiloHostBuilder to use AzureTableBasedMembership
+        /// Configures the silo to use Azure Storage for clustering.
         /// </summary>
-        public static ISiloHostBuilder UseAzureTableMembership(this ISiloHostBuilder builder,
-            Action<OptionsBuilder<AzureTableMembershipOptions>> configureOptions)
+        /// <param name="builder">
+        /// The silo builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseAzureStorageClustering(
+            this ISiloHostBuilder builder,
+            Action<OptionsBuilder<AzureStorageClusteringOptions>> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseAzureTableMembership(configureOptions));
-        }
-
-        /// Configure client to use AzureTableGatewayListProvider
-        /// </summary>
-        public static IClientBuilder UseAzureTableGatewayListProvider(this IClientBuilder builder,
-            Action<AzureTableGatewayListProviderOptions> configureOptions)
-        {
-            return builder.ConfigureServices(services => services.UseAzureTableGatewayListProvider(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure client to use AzureTableGatewayListProvider
-        /// </summary>
-        public static IClientBuilder UseAzureTableGatewayListProvider(this IClientBuilder builder,
-            Action<OptionsBuilder<AzureTableGatewayListProviderOptions>> configureOptions)
-        {
-            return builder.ConfigureServices(services => services.UseAzureTableGatewayListProvider(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container to use AzureTableBasedMembership
-        /// </summary>
-        public static IServiceCollection UseAzureTableMembership(this IServiceCollection services,
-            Action<AzureTableMembershipOptions> configureOptions)
-        {
-            return services.UseAzureTableMembership(ob => ob.Configure(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<AzureStorageClusteringOptions>());
+                    services.AddSingleton<IMembershipTable, AzureBasedMembershipTable>();
+                });
         }
 
         /// <summary>
-        /// Configure DI container to use AzureTableBasedMembership
+        /// Configures the client to use Azure Storage for clustering.
         /// </summary>
-        public static IServiceCollection UseAzureTableMembership(this IServiceCollection services,
-            Action<OptionsBuilder<AzureTableMembershipOptions>> configureOptions)
+        /// <param name="builder">
+        /// The client builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseAzureStorageClustering(
+            this IClientBuilder builder,
+            Action<AzureStorageGatewayOptions> configureOptions)
         {
-            configureOptions?.Invoke(services.AddOptions<AzureTableMembershipOptions>());
-            services.AddSingleton<IMembershipTable, AzureBasedMembershipTable>();
-            return services;
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IGatewayListProvider, AzureGatewayListProvider>();
+                });
         }
 
         /// <summary>
-        /// Configure DI container to use AzureTableGatewayListProvider
+        /// Configures the client to use Azure Storage for clustering.
         /// </summary>
-        public static IServiceCollection UseAzureTableGatewayListProvider(this IServiceCollection services,
-            Action<AzureTableGatewayListProviderOptions> configureOptions)
+        /// <param name="builder">
+        /// The client builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseAzureStorageClustering(
+            this IClientBuilder builder,
+            Action<OptionsBuilder<AzureStorageGatewayOptions>> configureOptions)
         {
-            return services.UseAzureTableGatewayListProvider(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container to use AzureTableGatewayListProvider
-        /// </summary>
-        public static IServiceCollection UseAzureTableGatewayListProvider(this IServiceCollection services,
-            Action<OptionsBuilder<AzureTableGatewayListProviderOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<AzureTableGatewayListProviderOptions>());
-            return services.AddSingleton<IGatewayListProvider, AzureGatewayListProvider>();
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<AzureStorageGatewayOptions>());
+                    services.AddSingleton<IGatewayListProvider, AzureGatewayListProvider>();
+                });
         }
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/LegacyAzureMembershipConfigurator.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/LegacyAzureMembershipConfigurator.cs
@@ -1,4 +1,8 @@
+using System;
+
 using Microsoft.Extensions.DependencyInjection;
+
+using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Runtime.Configuration;
 
@@ -9,13 +13,14 @@ namespace Orleans.Runtime.MembershipService
     {
         public void Configure(object configuration, IServiceCollection services)
         {
-            services.UseAzureTableMembership(
-                options =>
+            services.Configure((Action<AzureStorageClusteringOptions>)(options =>
                 {
                     var reader = new GlobalConfigurationReader(configuration);
                     options.MaxStorageBusyRetries = reader.GetPropertyValue<int>("MaxStorageBusyRetries");
                     options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
-                });
+                }));
+            services.AddSingleton<IMembershipTable, AzureBasedMembershipTable>();
+            IServiceCollection temp = services;
         }
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/LegacyAzureTableGatewayListProviderConfigurator.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/LegacyAzureTableGatewayListProviderConfigurator.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Orleans.Hosting;
+
+using Orleans.Configuration;
 using Orleans.Messaging;
 
 namespace Orleans.AzureUtils.Storage
@@ -10,11 +11,13 @@ namespace Orleans.AzureUtils.Storage
         /// <inheritdoc/>
         public void ConfigureServices(object configuration, IServiceCollection services)
         {
-            services.UseAzureTableGatewayListProvider(options =>
-            {
-                var reader = new ClientConfigurationReader(configuration);
-                options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
-            });
+            services.Configure<AzureStorageGatewayOptions>(
+                options =>
+                {
+                    var reader = new ClientConfigurationReader(configuration);
+                    options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
+                });
+            services.AddSingleton<IGatewayListProvider, AzureGatewayListProvider>();
         }
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageClusteringOptions.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageClusteringOptions.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Specify options used for AzureTableBasedMembership
     /// </summary>
-    public class AzureTableMembershipOptions
+    public class AzureStorageClusteringOptions
     {
         /// <summary>
         /// Retry count for Azure Table operations. 

--- a/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageGatewayOptions.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Options/AzureStorageGatewayOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Orleans.Configuration
 {
-    public class AzureTableGatewayListProviderOptions
+    public class AzureStorageGatewayOptions
     {
         /// <summary>
         /// Connection string for Azure Storage

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -20,17 +20,17 @@ namespace Orleans.Runtime.Membership
 
         private ILogger _logger;
         private readonly ConsulClient _consulClient;
-        private readonly ConsulMembershipOptions membershipTableOptions;
+        private readonly ConsulClusteringSiloOptions clusteringSiloTableOptions;
         private readonly string clusterId;
 
         public ConsulBasedMembershipTable(ILogger<ConsulBasedMembershipTable> logger,
-            IOptions<ConsulMembershipOptions> membershipTableOptions, IOptions<SiloOptions> siloOptions)
+            IOptions<ConsulClusteringSiloOptions> membershipTableOptions, IOptions<SiloOptions> siloOptions)
         {
             this.clusterId = siloOptions.Value.ClusterId;
             this._logger = logger;
-            this.membershipTableOptions = membershipTableOptions.Value;
+            this.clusteringSiloTableOptions = membershipTableOptions.Value;
             _consulClient =
-                new ConsulClient(config => config.Address = this.membershipTableOptions.Address);
+                new ConsulClient(config => config.Address = this.clusteringSiloTableOptions.Address);
         }
 
         /// <summary>

--- a/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
@@ -16,9 +16,9 @@ namespace Orleans.Runtime.Membership
         private ConsulClient consulClient;
         private string clusterId;
         private ILogger logger;
-        private readonly ConsulGatewayListProviderOptions options;
+        private readonly ConsulClusteringClientOptions options;
         private readonly TimeSpan maxStaleness;
-        public ConsulGatewayListProvider(ILogger<ConsulGatewayListProvider> logger, ClientConfiguration clientConfig, IOptions<ConsulGatewayListProviderOptions> options, IOptions<ClusterClientOptions> clusterClientOptions)
+        public ConsulGatewayListProvider(ILogger<ConsulGatewayListProvider> logger, ClientConfiguration clientConfig, IOptions<ConsulClusteringClientOptions> options, IOptions<ClusterClientOptions> clusterClientOptions)
         {
             this.logger = logger;
             this.clusterId = clusterClientOptions.Value.ClusterId;

--- a/src/Orleans.Clustering.Consul/ConsulUtilsHostingExtensions.cs
+++ b/src/Orleans.Clustering.Consul/ConsulUtilsHostingExtensions.cs
@@ -9,78 +9,106 @@ namespace Orleans.Hosting
     public static class ConsulUtilsHostingExtensions 
     {
         /// <summary>
-        /// Configure siloHostBuilder to use ConsulMembership
+        /// Configures the silo to use Consul for clustering.
         /// </summary>
-        public static ISiloHostBuilder UseConsulMembership(this ISiloHostBuilder builder,
-            Action<ConsulMembershipOptions> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseConsulClustering(
+            this ISiloHostBuilder builder,
+            Action<ConsulClusteringSiloOptions> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseConsulMembership(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IMembershipTable, ConsulBasedMembershipTable>();
+                });
         }
 
         /// <summary>
-        /// Configure siloHostBuilder to use ConsulMembership
+        /// Configures the silo to use Consul for clustering.
         /// </summary>
-        public static ISiloHostBuilder UseConsulMembership(this ISiloHostBuilder builder,
-            Action<OptionsBuilder<ConsulMembershipOptions>> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseConsulClustering(
+            this ISiloHostBuilder builder,
+            Action<OptionsBuilder<ConsulClusteringSiloOptions>> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseConsulMembership(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<ConsulClusteringSiloOptions>());
+                    services.AddSingleton<IMembershipTable, ConsulBasedMembershipTable>();
+                });
         }
 
         /// <summary>
-        /// Configure client to use ConsulGatewayListProvider
+        /// Configures the client to use Consul for clustering.
         /// </summary>
-        public static IClientBuilder UseConsulGatewayListProvider(this IClientBuilder builder,
-            Action<ConsulGatewayListProviderOptions> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseConsulClustering(
+            this IClientBuilder builder,
+            Action<ConsulClusteringClientOptions> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseConsulGatewayListProvider(configureOptions));
+            return builder.ConfigureServices(services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IGatewayListProvider, ConsulGatewayListProvider>();
+                });
         }
 
         /// <summary>
-        /// Configure client to use ConsulGatewayListProvider
+        /// Configures the client to use Consul for clustering.
         /// </summary>
-        public static IClientBuilder UseConsulGatewayListProvider(this IClientBuilder builder,
-            Action<OptionsBuilder<ConsulGatewayListProviderOptions>> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseConsulClustering(
+            this IClientBuilder builder,
+            Action<OptionsBuilder<ConsulClusteringClientOptions>> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseConsulGatewayListProvider(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with Consul based Membership
-        /// </summary>
-        public static IServiceCollection UseConsulMembership(this IServiceCollection services,
-            Action<ConsulMembershipOptions> configureOptions)
-        {
-            return services.UseConsulMembership(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with Consul based Membership
-        /// </summary>
-        public static IServiceCollection UseConsulMembership(this IServiceCollection services,
-            Action<OptionsBuilder<ConsulMembershipOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<ConsulMembershipOptions>());
-            services.AddSingleton<IMembershipTable, ConsulBasedMembershipTable>();
-            return services;
-        }
-
-        /// <summary>
-        /// Configure DI container with ConsulGatewayListProvider
-        /// </summary>
-        public static IServiceCollection UseConsulGatewayListProvider(this IServiceCollection services,
-            Action<ConsulGatewayListProviderOptions> configureOptions)
-        {
-            return services.UseConsulGatewayListProvider(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with ConsulGatewayProvider
-        /// </summary>
-        public static IServiceCollection UseConsulGatewayListProvider(this IServiceCollection services,
-            Action<OptionsBuilder<ConsulGatewayListProviderOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<ConsulGatewayListProviderOptions>());
-            return services.AddSingleton<IGatewayListProvider, ConsulGatewayListProvider>();
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<ConsulClusteringClientOptions>());
+                    services.AddSingleton<IGatewayListProvider, ConsulGatewayListProvider>();
+                });
         }
     }
 }

--- a/src/Orleans.Clustering.Consul/LegacyConsulGatewayListProviderConfigurator.cs
+++ b/src/Orleans.Clustering.Consul/LegacyConsulGatewayListProviderConfigurator.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Hosting;
+
+using Orleans.Configuration;
 using Orleans.Messaging;
+using Orleans.Runtime.Membership;
 
 namespace Orleans.ConsulUtils
 {
@@ -11,11 +13,13 @@ namespace Orleans.ConsulUtils
         /// <inheritdoc/>
         public void ConfigureServices(object configuration, IServiceCollection services)
         {
-            services.UseConsulGatewayListProvider(options =>
-            {
-                var reader = new ClientConfigurationReader(configuration);
-                options.Address = new Uri(reader.GetPropertyValue<string>("DataConnectionString"));
-            });
+            services.Configure<ConsulClusteringClientOptions>(
+                options =>
+                {
+                    var reader = new ClientConfigurationReader(configuration);
+                    options.Address = new Uri(reader.GetPropertyValue<string>("DataConnectionString"));
+                });
+            services.AddSingleton<IGatewayListProvider, ConsulGatewayListProvider>();
         }
     }
 }

--- a/src/Orleans.Clustering.Consul/LegacyConsulMembershipConfigurator.cs
+++ b/src/Orleans.Clustering.Consul/LegacyConsulMembershipConfigurator.cs
@@ -1,6 +1,8 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Hosting;
+
+using Orleans.Configuration;
+using Orleans.Runtime.Membership;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -10,7 +12,9 @@ namespace Orleans.Runtime.MembershipService
         public void Configure(object configuration, IServiceCollection services)
         {
             var reader = new GlobalConfigurationReader(configuration);
-            services.UseConsulMembership(options => options.Address = new Uri(reader.GetPropertyValue<string>("DataConnectionString")));
+
+            services.Configure<ConsulClusteringSiloOptions>(options => options.Address = new Uri(reader.GetPropertyValue<string>("DataConnectionString")));
+            services.AddSingleton<IMembershipTable, ConsulBasedMembershipTable>();
         }
     }
 }

--- a/src/Orleans.Clustering.Consul/Options/ConsulClusteringClientOptions.cs
+++ b/src/Orleans.Clustering.Consul/Options/ConsulClusteringClientOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Orleans.Configuration
 {
-    public class ConsulGatewayListProviderOptions
+    public class ConsulClusteringClientOptions
     {
         /// <summary>
         /// Address for ConsulClient

--- a/src/Orleans.Clustering.Consul/Options/ConsulClusteringSiloOptions.cs
+++ b/src/Orleans.Clustering.Consul/Options/ConsulClusteringSiloOptions.cs
@@ -7,7 +7,7 @@ namespace Orleans.Configuration
     /// <summary>
     /// Options for configuring ConsulBasedMembership
     /// </summary>
-    public class ConsulMembershipOptions
+    public class ConsulClusteringSiloOptions
     {
         /// <summary>
         /// Address for consul client

--- a/src/Orleans.Clustering.ZooKeeper/LegacyZooKeeperGatewayListProviderConfigurator.cs
+++ b/src/Orleans.Clustering.ZooKeeper/LegacyZooKeeperGatewayListProviderConfigurator.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Orleans.Hosting;
+
+using Orleans.Configuration;
 using Orleans.Messaging;
+using Orleans.Runtime.Membership;
 
 namespace OrleansZooKeeperUtils
 {
@@ -9,11 +11,13 @@ namespace OrleansZooKeeperUtils
     {
         public void ConfigureServices(object configuration, IServiceCollection services)
         {
-            services.UseZooKeeperGatewayListProvider(options =>
-            {
-                var reader = new ClientConfigurationReader(configuration);
-                options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
-            });
+            services.Configure<ZooKeeperGatewayListProviderOptions>(
+                options =>
+                {
+                    var reader = new ClientConfigurationReader(configuration);
+                    options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
+                });
+            services.AddSingleton<IGatewayListProvider, ZooKeeperClusteringClientOptions>();
         }
     }
 }

--- a/src/Orleans.Clustering.ZooKeeper/LegacyZooKeeperMembershipConfigurator.cs
+++ b/src/Orleans.Clustering.ZooKeeper/LegacyZooKeeperMembershipConfigurator.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Runtime.Configuration;
+
+using Orleans;
+using Orleans.Configuration;
 using Orleans.Runtime.MembershipService;
-using Orleans.Hosting;
+using Orleans.Runtime.Membership;
 
 namespace OrleansZooKeeperUtils
 {
@@ -11,7 +13,8 @@ namespace OrleansZooKeeperUtils
         public void Configure(object configuration, IServiceCollection services)
         {
             var reader = new GlobalConfigurationReader(configuration);
-            services.UseZooKeeperMembership(options => options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString"));
+            services.Configure<ZooKeeperClusteringSiloOptions>(options => options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString"));
+            services.AddSingleton<IMembershipTable, ZooKeeperBasedMembershipTable>();
         }
     }
 }

--- a/src/Orleans.Clustering.ZooKeeper/Options/ZooKeeperClusteringSiloOptions.cs
+++ b/src/Orleans.Clustering.ZooKeeper/Options/ZooKeeperClusteringSiloOptions.cs
@@ -7,7 +7,7 @@ namespace Orleans.Configuration
     /// <summary>
     /// Option to configure ZooKeeperMembership
     /// </summary>
-    public class ZooKeeperMembershipOptions
+    public class ZooKeeperClusteringSiloOptions
     {
         /// <summary>
         /// Connection string for ZooKeeper Storage

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -56,7 +56,7 @@ namespace Orleans.Runtime.Membership
         /// </summary>
         private string rootConnectionString;
         
-        public ZooKeeperBasedMembershipTable(ILogger<ZooKeeperBasedMembershipTable> logger, IOptions<ZooKeeperMembershipOptions> membershipTableOptions, IOptions<SiloOptions> siloOptions)
+        public ZooKeeperBasedMembershipTable(ILogger<ZooKeeperBasedMembershipTable> logger, IOptions<ZooKeeperClusteringSiloOptions> membershipTableOptions, IOptions<SiloOptions> siloOptions)
         {
             this.logger = logger;
             var options = membershipTableOptions.Value;

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperClusteringClientOptions.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperClusteringClientOptions.cs
@@ -10,7 +10,7 @@ using Orleans.Configuration;
 
 namespace Orleans.Runtime.Membership
 {
-    public class ZooKeeperGatewayListProvider : IGatewayListProvider
+    public class ZooKeeperClusteringClientOptions : IGatewayListProvider
     {
         private ZooKeeperWatcher watcher;
         /// <summary>
@@ -23,7 +23,7 @@ namespace Orleans.Runtime.Membership
         /// </summary>
         private string deploymentConnectionString;
         private TimeSpan maxStaleness;
-        public ZooKeeperGatewayListProvider(ILogger<ZooKeeperGatewayListProvider> logger, ClientConfiguration clientConfiguration,
+        public ZooKeeperClusteringClientOptions(ILogger<ZooKeeperClusteringClientOptions> logger, ClientConfiguration clientConfiguration,
             IOptions<ZooKeeperGatewayListProviderOptions> options,
             IOptions<ClusterClientOptions> clusterClientOptions)
         {

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperHostingExtensions.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperHostingExtensions.cs
@@ -9,77 +9,107 @@ namespace Orleans.Hosting
     public static class ZooKeeperHostingExtensions
     {
         /// <summary>
-        /// Configures the silo to use ZooKeeper for cluster membership
+        /// Configures the silo to use ZooKeeper for cluster membership.
         /// </summary>
-        public static ISiloHostBuilder UseZooKeeperMembership(this ISiloHostBuilder builder,
-            Action<ZooKeeperMembershipOptions> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseZooKeeperClustering(
+            this ISiloHostBuilder builder,
+            Action<ZooKeeperClusteringSiloOptions> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseZooKeeperMembership(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IMembershipTable, ZooKeeperBasedMembershipTable>();
+                });
         }
 
         /// <summary>
-        /// Configures the silo to use ZooKeeper for cluster membership
+        /// Configures the silo to use ZooKeeper for cluster membership.
         /// </summary>
-        public static ISiloHostBuilder UseZooKeeperMembership(this ISiloHostBuilder builder,
-            Action<OptionsBuilder<ZooKeeperMembershipOptions>> configureOptions)
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="ISiloHostBuilder"/>.
+        /// </returns>
+        public static ISiloHostBuilder UseZooKeeperClustering(
+            this ISiloHostBuilder builder,
+            Action<OptionsBuilder<ZooKeeperClusteringSiloOptions>> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseZooKeeperMembership(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<ZooKeeperClusteringSiloOptions>());
+                    services.AddSingleton<IMembershipTable, ZooKeeperBasedMembershipTable>();
+                });
         }
 
         /// <summary>
-        /// Configure the client to use ZooKeeper as the Gateway List provider
+        /// Configure the client to use ZooKeeper for clustering.
         /// </summary>
-        public static IClientBuilder UseZooKeeperGatewayListProvider(this IClientBuilder builder,
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseZooKeeperClustering(
+            this IClientBuilder builder,
             Action<ZooKeeperGatewayListProviderOptions> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseZooKeeperGatewayListProvider(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services.AddSingleton<IGatewayListProvider, ZooKeeperClusteringClientOptions>();
+                });
         }
 
         /// <summary>
-        /// Configure the client to use ZooKeeper as the Gateway List provider
+        /// Configure the client to use ZooKeeper for clustering.
         /// </summary>
-        public static IClientBuilder UseZooKeeperGatewayListProvider(this IClientBuilder builder,
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="configureOptions">
+        /// The configuration delegate.
+        /// </param>
+        /// <returns>
+        /// The provided <see cref="IClientBuilder"/>.
+        /// </returns>
+        public static IClientBuilder UseZooKeeperClustering(
+            this IClientBuilder builder,
             Action<OptionsBuilder<ZooKeeperGatewayListProviderOptions>> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseZooKeeperGatewayListProvider(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with ZooKeeper based Membership
-        /// </summary>
-        public static IServiceCollection UseZooKeeperMembership(this IServiceCollection services,
-            Action<ZooKeeperMembershipOptions> configureOptions)
-        {
-            return services.UseZooKeeperMembership(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with ZooKeeper based Membership
-        /// </summary>
-        public static IServiceCollection UseZooKeeperMembership(this IServiceCollection services,
-            Action<OptionsBuilder<ZooKeeperMembershipOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<ZooKeeperMembershipOptions>());
-            return services.AddSingleton<IMembershipTable, ZooKeeperBasedMembershipTable>();
-        }
-
-        /// <summary>
-        /// Configure DI container with ZooKeeperGatewayListProvider
-        /// </summary>
-        public static IServiceCollection UseZooKeeperGatewayListProvider(this IServiceCollection services,
-            Action<ZooKeeperGatewayListProviderOptions> configureOptions)
-        {
-            return services.UseZooKeeperGatewayListProvider(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure DI container with ZooKeeperGatewayListProvider
-        /// </summary>
-        public static IServiceCollection UseZooKeeperGatewayListProvider(this IServiceCollection services,
-            Action<OptionsBuilder<ZooKeeperGatewayListProviderOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<ZooKeeperGatewayListProviderOptions>());
-            return services.AddSingleton<IGatewayListProvider, ZooKeeperGatewayListProvider>();
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<ZooKeeperGatewayListProviderOptions>());
+                    services.AddSingleton<IGatewayListProvider, ZooKeeperClusteringClientOptions>();
+                });
         }
     }
 }

--- a/src/Orleans.Core.Legacy/Messaging/LegacyGatewayListProviderConfigurator.cs
+++ b/src/Orleans.Core.Legacy/Messaging/LegacyGatewayListProviderConfigurator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -63,10 +64,14 @@ namespace Orleans.Messaging
     {
         public void ConfigureServices(object clientConfiguration, IServiceCollection services)
         {
-            services.UseStaticGatewayListProvider(options =>
-            {
-                options.Gateways = ((ClientConfiguration)clientConfiguration).Gateways.Select(ep => ep.ToGatewayUri()).ToList();
-            });
+            services.Configure<StaticGatewayListProviderOptions>(
+                options =>
+                {
+                    options.Gateways = ((ClientConfiguration)clientConfiguration).Gateways.Select(ep => ep.ToGatewayUri()).ToList();
+                });
+
+            services.AddSingleton<IGatewayListProvider, StaticGatewayListProvider>()
+                .TryConfigureFormatter<StaticGatewayListProviderOptions, StaticGatewayListProviderOptionsFormatter>();
         }
     }
 }

--- a/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
@@ -81,32 +81,6 @@ namespace Orleans.Configuration
                 new GrainCallFilterWrapper(filter));
         }
 
-        /// <summary>
-        /// Add an <see cref="StaticGatewayListProvider"/> and configure it using <paramref name="configureOptions"/>
-        /// </summary>
-        public static IServiceCollection UseStaticGatewayListProvider(this IServiceCollection services,
-            Action<StaticGatewayListProviderOptions> configureOptions)
-        {
-            return services.UseStaticGatewayListProvider(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Add an <see cref="StaticGatewayListProvider"/> and configure it using <paramref name="configureOptions"/>
-        /// </summary>
-        public static IServiceCollection UseStaticGatewayListProvider(this IServiceCollection services,
-            Action<OptionsBuilder<StaticGatewayListProviderOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<StaticGatewayListProviderOptions>());
-            return services.AddSingleton<IGatewayListProvider, StaticGatewayListProvider>()
-                .TryConfigureFormatter<StaticGatewayListProviderOptions,StaticGatewayListProviderOptionsFormatter>();
-        }
-
-        public static bool IsInCollection<T>(this IServiceCollection services)
-        {
-            return services.Any(s => s.ServiceType == typeof(T));
-        }
-
-
         private class GrainCallFilterWrapper : IGrainCallFilter
         {
             private readonly GrainCallFilterDelegate interceptor;

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.ApplicationParts;
+using Orleans.Messaging;
 
 namespace Orleans
 {
@@ -90,24 +91,35 @@ namespace Orleans
         }
 
         /// <summary>
-        /// Configure the client to use <see cref="StaticGatewayListProvider"/>
+        /// Configures the client to use static clustering.
         /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="configureOptions"></param>
-        /// <returns></returns>
-        public static IClientBuilder UseStaticGatewayListProvider(this IClientBuilder builder, Action<StaticGatewayListProviderOptions> configureOptions)
+        public static IClientBuilder UseStaticClustering(this IClientBuilder builder, Action<StaticGatewayListProviderOptions> configureOptions)
         {
-            return builder.ConfigureServices(collection =>
-                collection.UseStaticGatewayListProvider(configureOptions));
+            return builder.ConfigureServices(
+                collection =>
+                {
+                    if (configureOptions != null)
+                    {
+                        collection.Configure(configureOptions);
+                    }
+
+                    collection.AddSingleton<IGatewayListProvider, StaticGatewayListProvider>()
+                        .TryConfigureFormatter<StaticGatewayListProviderOptions, StaticGatewayListProviderOptionsFormatter>();
+                });
         }
 
         /// <summary>
-        /// Configure the client to use <see cref="StaticGatewayListProvider"/>
+        /// Configures the client to use static clustering.
         /// </summary>
-        public static IClientBuilder UseStaticGatewayListProvider(this IClientBuilder builder, Action<OptionsBuilder<StaticGatewayListProviderOptions>> configureOptions)
+        public static IClientBuilder UseStaticClustering(this IClientBuilder builder, Action<OptionsBuilder<StaticGatewayListProviderOptions>> configureOptions)
         {
-            return builder.ConfigureServices(collection =>
-                collection.UseStaticGatewayListProvider(configureOptions));
+            return builder.ConfigureServices(
+                collection =>
+                {
+                    configureOptions?.Invoke(collection.AddOptions<StaticGatewayListProviderOptions>());
+                    collection.AddSingleton<IGatewayListProvider, StaticGatewayListProvider>()
+                        .TryConfigureFormatter<StaticGatewayListProviderOptions, StaticGatewayListProviderOptionsFormatter>();
+                });
         }
 
         /// <summary>

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyMembershipConfigurator.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyMembershipConfigurator.cs
@@ -3,7 +3,6 @@ using System.Linq;
 
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
-using Orleans.Configuration;
 using Orleans.Core.Legacy;
 using Orleans.Hosting;
 using Orleans.Runtime.Configuration;

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyMembershipConfigurator.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyMembershipConfigurator.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
+using Orleans.Configuration;
 using Orleans.Core.Legacy;
 using Orleans.Hosting;
 using Orleans.Runtime.Configuration;
@@ -66,7 +67,10 @@ namespace Orleans.Runtime.MembershipService
 
             private void ConfigureServices(GlobalConfiguration configuration, IServiceCollection services)
             {
-                services.UseDevelopmentMembership(options => CopyGlobalGrainBasedMembershipOptions(configuration, options));
+                services.Configure<DevelopmentMembershipOptions>(options => CopyGlobalGrainBasedMembershipOptions(configuration, options));
+                services
+                    .AddSingleton<GrainBasedMembershipTable>()
+                    .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();
             }
 
             private static void CopyGlobalGrainBasedMembershipOptions(GlobalConfiguration configuration, DevelopmentMembershipOptions options)

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -70,38 +70,35 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use Development membership
         /// </summary>
-        public static ISiloHostBuilder UseDevelopmentMembership(this ISiloHostBuilder builder, Action<DevelopmentMembershipOptions> configureOptions)
+        public static ISiloHostBuilder UseDevelopmentClustering(this ISiloHostBuilder builder, Action<DevelopmentMembershipOptions> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseDevelopmentMembership(configureOptions));
+            return builder.ConfigureServices(
+                services =>
+                {
+                    if (configureOptions != null)
+                    {
+                        services.Configure(configureOptions);
+                    }
+
+                    services
+                        .AddSingleton<GrainBasedMembershipTable>()
+                        .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();
+                });
         }
 
         /// <summary>
         /// Configure silo to use Development membership
         /// </summary>
-        public static ISiloHostBuilder UseDevelopmentMembership(this ISiloHostBuilder builder, Action<OptionsBuilder<DevelopmentMembershipOptions>> configureOptions)
+        public static ISiloHostBuilder UseDevelopmentClustering(this ISiloHostBuilder builder, Action<OptionsBuilder<DevelopmentMembershipOptions>> configureOptions)
         {
-            return builder.ConfigureServices(services => services.UseDevelopmentMembership(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure silo to use Development membership
-        /// </summary>
-        public static IServiceCollection UseDevelopmentMembership(this IServiceCollection services, Action<DevelopmentMembershipOptions> configureOptions)
-        {
-            return services.UseDevelopmentMembership(ob => ob.Configure(configureOptions));
-        }
-
-        /// <summary>
-        /// Configure silo to use Development membership
-        /// </summary>
-        public static IServiceCollection UseDevelopmentMembership(this IServiceCollection services, Action<OptionsBuilder<DevelopmentMembershipOptions>> configureOptions)
-        {
-            configureOptions?.Invoke(services.AddOptions<DevelopmentMembershipOptions>());
-            services
-                .AddSingleton<GrainBasedMembershipTable>()
-                .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();
-
-            return services;
+            return builder.ConfigureServices(
+                services =>
+                {
+                    configureOptions?.Invoke(services.AddOptions<DevelopmentMembershipOptions>());
+                    services
+                        .AddSingleton<GrainBasedMembershipTable>()
+                        .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();
+                });
         }
     }
 }

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -15,6 +15,7 @@ using Orleans.Configuration;
 using Orleans.Logging;
 using Orleans.Messaging;
 using Orleans.Runtime;
+using Orleans.Runtime.MembershipService;
 using Orleans.Statistics;
 using Orleans.TestingHost.Utils;
 
@@ -206,7 +207,10 @@ namespace Orleans.TestingHost
             {
                 var primarySiloEndPoint = new IPEndPoint(IPAddress.Loopback, int.Parse(context.Configuration[nameof(TestSiloSpecificOptions.PrimarySiloPort)]));
 
-                services.UseDevelopmentMembership(options => options.PrimarySiloEndpoint = primarySiloEndPoint);
+                services.Configure<DevelopmentMembershipOptions>(options => options.PrimarySiloEndpoint = primarySiloEndPoint);
+                services
+                    .AddSingleton<GrainBasedMembershipTable>()
+                    .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();
             }
         }
 
@@ -215,15 +219,22 @@ namespace Orleans.TestingHost
             bool.TryParse(configuration[nameof(TestClusterOptions.UseTestClusterMembership)], out bool useTestClusterMembership);
             if (useTestClusterMembership && services.All(svc => svc.ServiceType != typeof(IGatewayListProvider)))
             {
-                services.UseStaticGatewayListProvider(options =>
-                {
-                    int baseGatewayPort = int.Parse(configuration[nameof(TestClusterOptions.BaseGatewayPort)]);
-                    int initialSilosCount = int.Parse(configuration[nameof(TestClusterOptions.InitialSilosCount)]);
+                Action<StaticGatewayListProviderOptions> configureOptions = options =>
+                    {
+                        int baseGatewayPort = int.Parse(configuration[nameof(TestClusterOptions.BaseGatewayPort)]);
+                        int initialSilosCount = int.Parse(configuration[nameof(TestClusterOptions.InitialSilosCount)]);
 
-                    options.Gateways = Enumerable.Range(baseGatewayPort, initialSilosCount)
-                        .Select(port => new IPEndPoint(IPAddress.Loopback, port).ToGatewayUri())
-                        .ToList();
-                });
+                        options.Gateways = Enumerable.Range(baseGatewayPort, initialSilosCount)
+                            .Select(port => new IPEndPoint(IPAddress.Loopback, port).ToGatewayUri())
+                            .ToList();
+                    };
+                if (configureOptions != null)
+                {
+                    services.Configure(configureOptions);
+                }
+
+                services.AddSingleton<IGatewayListProvider, StaticGatewayListProvider>()
+                    .TryConfigureFormatter<StaticGatewayListProviderOptions, StaticGatewayListProviderOptionsFormatter>();
             }
         }
 

--- a/test/AWSUtils.Tests/LivenessTests.cs
+++ b/test/AWSUtils.Tests/LivenessTests.cs
@@ -76,7 +76,7 @@ namespace AWSUtils.Tests.Liveness
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {
-                hostBuilder.UseDynamoDBMembership(options => { options.ConnectionString = ConnectionString; });
+                hostBuilder.UseDynamoDBClustering(options => { options.ConnectionString = ConnectionString; });
             }
         }
 
@@ -84,7 +84,7 @@ namespace AWSUtils.Tests.Liveness
         {
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
-                clientBuilder.UseDynamoDBGatewayListProvider(gatewayOptions =>
+                clientBuilder.UseDynamoDBClustering(gatewayOptions =>
                 {
                     LegacyDynamoDBGatewayListProviderConfigurator.ParseDataConnectionString(ConnectionString, gatewayOptions);
                 });

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -42,7 +42,7 @@ namespace AWSUtils.Tests.MembershipTests
         {
             if (!AWSTestConstants.IsDynamoDbAvailable)
                 throw new SkipException("Unable to connect to AWS DynamoDB simulator");
-            var options = new DynamoDBMembershipOptions()
+            var options = new DynamoDBClusteringSiloOptions()
             {
                 ConnectionString = this.connectionString,
             };
@@ -51,7 +51,7 @@ namespace AWSUtils.Tests.MembershipTests
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
         {
-            var options = new DynamoDBGatewayListProviderOptions();
+            var options = new DynamoDBClusteringClientOptions();
             LegacyDynamoDBGatewayListProviderConfigurator.ParseDataConnectionString(this.connectionString, options);
             return new DynamoDBGatewayListProvider(this.loggerFactory, this.clientConfiguration, Options.Create(options), this.clientOptions);
         }

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -37,7 +37,7 @@ namespace Consul.Tests
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
         {
             ConsulTestUtils.EnsureConsul();
-            var options = new ConsulMembershipOptions()
+            var options = new ConsulClusteringSiloOptions()
             {
                 Address = new Uri(this.connectionString)
             };
@@ -47,7 +47,7 @@ namespace Consul.Tests
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
         {
             ConsulTestUtils.EnsureConsul();
-            var options = new ConsulGatewayListProviderOptions()
+            var options = new ConsulClusteringClientOptions()
             {
                 Address = new Uri(this.connectionString)
             };

--- a/test/Consul.Tests/LivenessTests.cs
+++ b/test/Consul.Tests/LivenessTests.cs
@@ -37,7 +37,7 @@ namespace Consul.Tests
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {
-                hostBuilder.UseConsulMembership(options => { options.Address = new Uri(ConsulTestUtils.CONSUL_ENDPOINT); });
+                hostBuilder.UseConsulClustering(options => { options.Address = new Uri(ConsulTestUtils.CONSUL_ENDPOINT); });
             }
         }
 
@@ -46,7 +46,7 @@ namespace Consul.Tests
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
-                    .UseConsulGatewayListProvider(gatewayOptions =>
+                    .UseConsulClustering(gatewayOptions =>
                     {
                         gatewayOptions.Address = new Uri(ConsulTestUtils.CONSUL_ENDPOINT);
                         ;

--- a/test/TesterAdoNet/MySqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/MySqlMembershipTableTests.cs
@@ -36,7 +36,7 @@ namespace UnitTests.MembershipTests
 
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
         {
-            var options = new AdoNetClusteringOptions()
+            var options = new AdoNetClusteringSiloOptions()
             {
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
@@ -46,7 +46,7 @@ namespace UnitTests.MembershipTests
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
         {
-            var options = new AdoNetGatewayListProviderOptions()
+            var options = new AdoNetClusteringClientOptions()
             {
                 ConnectionString = this.connectionString,
                 AdoInvariant = GetAdoInvariant()

--- a/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
@@ -33,7 +33,7 @@ namespace UnitTests.MembershipTests
 
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
         {
-            var options = new AdoNetClusteringOptions()
+            var options = new AdoNetClusteringSiloOptions()
             {
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
@@ -43,7 +43,7 @@ namespace UnitTests.MembershipTests
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
         {
-            var options = new AdoNetGatewayListProviderOptions()
+            var options = new AdoNetClusteringClientOptions()
             {
                 ConnectionString = this.connectionString,
                 AdoInvariant = GetAdoInvariant()

--- a/test/TesterAdoNet/SqlServerMembershipTableTests.cs
+++ b/test/TesterAdoNet/SqlServerMembershipTableTests.cs
@@ -34,7 +34,7 @@ namespace UnitTests.MembershipTests
         }
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
         {
-            var options = new AdoNetClusteringOptions()
+            var options = new AdoNetClusteringSiloOptions()
             {
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
@@ -44,7 +44,7 @@ namespace UnitTests.MembershipTests
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
         {
-            var options = new AdoNetGatewayListProviderOptions()
+            var options = new AdoNetClusteringClientOptions()
             {
                 ConnectionString = this.connectionString,
                 AdoInvariant = GetAdoInvariant()

--- a/test/TesterAzureUtils/AzureMembershipTableTests.cs
+++ b/test/TesterAzureUtils/AzureMembershipTableTests.cs
@@ -38,7 +38,7 @@ namespace Tester.AzureUtils
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
         {
             TestUtils.CheckForAzureStorage();
-            var options = new AzureTableMembershipOptions()
+            var options = new AzureStorageClusteringOptions()
             {
                 MaxStorageBusyRetries = 3,
                 ConnectionString = this.connectionString,
@@ -48,7 +48,7 @@ namespace Tester.AzureUtils
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
         {
-            var options = new AzureTableGatewayListProviderOptions()
+            var options = new AzureStorageGatewayOptions()
             {
                 ConnectionString = this.connectionString
             };

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
@@ -44,7 +44,7 @@ namespace Tester.AzureUtils.Persistence
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {
-                hostBuilder.UseAzureTableMembership(options =>
+                hostBuilder.UseAzureStorageClustering(options =>
                 {
                     options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     options.MaxStorageBusyRetries = 3;
@@ -56,7 +56,7 @@ namespace Tester.AzureUtils.Persistence
         {
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
-                clientBuilder.UseAzureTableGatewayListProvider(gatewayOptions => { gatewayOptions.ConnectionString = TestDefaultConfiguration.DataConnectionString; });
+                clientBuilder.UseAzureStorageClustering(gatewayOptions => { gatewayOptions.ConnectionString = TestDefaultConfiguration.DataConnectionString; });
             }
         }
 

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -71,7 +71,7 @@ namespace UnitTests.Streaming.Reliability
         {
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
-                clientBuilder.UseAzureTableGatewayListProvider(gatewayOptions =>
+                clientBuilder.UseAzureStorageClustering(gatewayOptions =>
                 {
                     gatewayOptions.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                 });
@@ -82,7 +82,7 @@ namespace UnitTests.Streaming.Reliability
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {
-                hostBuilder.UseAzureTableMembership(options =>
+                hostBuilder.UseAzureStorageClustering(options =>
                 {
                     options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     options.MaxStorageBusyRetries = 3;

--- a/test/TesterZooKeeperUtils/LivenessTests.cs
+++ b/test/TesterZooKeeperUtils/LivenessTests.cs
@@ -34,7 +34,7 @@ namespace Tester.ZooKeeperUtils
         {
             public void Configure(ISiloHostBuilder hostBuilder)
             {
-                hostBuilder.UseZooKeeperMembership(options => { options.ConnectionString = TestDefaultConfiguration.DataConnectionString; });
+                hostBuilder.UseZooKeeperClustering(options => { options.ConnectionString = TestDefaultConfiguration.DataConnectionString; });
             }
         }
 

--- a/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -34,7 +34,7 @@ namespace UnitTests.MembershipTests
 
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
         {
-            var options = new ZooKeeperMembershipOptions();
+            var options = new ZooKeeperClusteringSiloOptions();
             options.ConnectionString = this.connectionString;
            
             return new ZooKeeperBasedMembershipTable(this.Services.GetService<ILogger<ZooKeeperBasedMembershipTable>>(), Options.Create(options), this.siloOptions);


### PR DESCRIPTION
Removes extensions from `IServiceCollection`
Renames client and silo methods so that they are symmetric (`UseAzureStorageClustering()`);