### PR TITLE
Add more logging to AzureTableGrainStorage init, Add ConfiguratorValidator

### DIFF
--- a/src/Azure/Orleans.Persistence.AzureStorage/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Hosting/SiloBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 using Orleans.Storage;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers;
 
@@ -74,6 +75,7 @@ namespace Orleans.Hosting
         {
             configureOptions?.Invoke(services.AddOptions<AzureTableStorageOptions>(name));
             services.TryConfigureFormatterResolver<AzureTableStorageOptions, AzureTableStorageOptionsFormatterResolver>();
+            services.AddTransient<IConfigurationValidator>(sp => new AzureTableGrainStorageOptionsValidator(sp.GetService<IOptionsSnapshot<AzureTableStorageOptions>>().Get(name), name));
             services.ConfigureNamedOptionForLogging<AzureTableStorageOptions>(name);
             services.TryAddSingleton<IGrainStorage>(sp => sp.GetServiceByName<IGrainStorage>(ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME));
             return services.AddSingletonNamedService<IGrainStorage>(name, AzureTableGrainStorageFactory.Create)

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -462,9 +462,9 @@ namespace Orleans.Storage
             try
             {
                 this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, $"AzureTableGrainStorage {name} initializing: {this.options.ToString()}");
-                this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, $"AzureTableGrainStorage {name} is using DataConnectionString: {ConfigUtilities.RedactConnectionStringInfo(this.options.DataConnectionString)}");
+                this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, $"AzureTableGrainStorage {name} is using DataConnectionString: {ConfigUtilities.RedactConnectionStringInfo(this.options.ConnectionString)}");
                 this.JsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.typeResolver, this.grainFactory), this.options.UseFullAssemblyNames, this.options.IndentJson, this.options.TypeNameHandling);
-                this.tableDataManager = new GrainStateTableDataManager(this.options.TableName, this.options.DataConnectionString, this.loggerFactory);
+                this.tableDataManager = new GrainStateTableDataManager(this.options.TableName, this.options.ConnectionString, this.loggerFactory);
                 await this.tableDataManager.InitTableAsync();
                 stopWatch.Stop();
                 this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, $"Initializing provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} took {stopWatch.ElapsedMilliseconds} Milliseconds.");

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -44,16 +45,18 @@ namespace Orleans.Storage
 
         private const string BINARY_DATA_PROPERTY_NAME = "Data";
         private const string STRING_DATA_PROPERTY_NAME = "StringData";
-
+        private string name;
         /// <summary> Default constructor </summary>
-        public AzureTableGrainStorage(AzureTableStorageOptions options, SerializationManager serializationManager, IGrainFactory grainFactory, ITypeResolver typeResolver, ILoggerFactory loggerFactory)
+        public AzureTableGrainStorage(AzureTableStorageOptions options, SerializationManager serializationManager, IGrainFactory grainFactory, ITypeResolver typeResolver, ILoggerFactory loggerFactory, string name)
         {
             this.options = options;
+            this.name = name;
             this.serializationManager = serializationManager;
             this.grainFactory = grainFactory;
             this.typeResolver = typeResolver;
             this.loggerFactory = loggerFactory;
-            this.logger = this.loggerFactory.CreateLogger<AzureTableGrainStorage>();
+            var loggerName = $"{typeof(AzureTableGrainStorageFactory).FullName}.{name}";
+            this.logger = this.loggerFactory.CreateLogger(loggerName);
         }
 
         /// <summary> Read state data function for this storage provider. </summary>
@@ -455,11 +458,23 @@ namespace Orleans.Storage
 
         private async Task Init(CancellationToken ct)
         {
-            this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, $"AzureTableGrainStorage initializing: {this.options.ToString()}");
-            this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, "AzureTableGrainStorage is using DataConnectionString: {0}", ConfigUtilities.RedactConnectionStringInfo(this.options.DataConnectionString));
-            this.JsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.typeResolver, this.grainFactory), this.options.UseFullAssemblyNames, this.options.IndentJson, this.options.TypeNameHandling);
-            this.tableDataManager = new GrainStateTableDataManager(this.options.TableName, this.options.DataConnectionString, this.loggerFactory);
-            await this.tableDataManager.InitTableAsync();
+            var stopWatch = Stopwatch.StartNew();
+            try
+            {
+                this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, $"AzureTableGrainStorage {name} initializing: {this.options.ToString()}");
+                this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_ParamConnectionString, $"AzureTableGrainStorage {name} is using DataConnectionString: {ConfigUtilities.RedactConnectionStringInfo(this.options.DataConnectionString)}");
+                this.JsonSettings = OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(this.typeResolver, this.grainFactory), this.options.UseFullAssemblyNames, this.options.IndentJson, this.options.TypeNameHandling);
+                this.tableDataManager = new GrainStateTableDataManager(this.options.TableName, this.options.DataConnectionString, this.loggerFactory);
+                await this.tableDataManager.InitTableAsync();
+                stopWatch.Stop();
+                this.logger.LogInformation((int)AzureProviderErrorCode.AzureTableProvider_InitProvider, $"Initializing provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} took {stopWatch.ElapsedMilliseconds} Milliseconds.");
+            }
+            catch (Exception ex)
+            {
+                stopWatch.Stop();
+                this.logger.LogError((int)ErrorCode.Provider_ErrorFromInit, $"Initialization failed for provider {this.name} of type {this.GetType().Name} in stage {this.options.InitStage} in {stopWatch.ElapsedMilliseconds} Milliseconds.", ex);
+                throw;
+            }
         }
 
         private Task Close(CancellationToken ct)
@@ -479,7 +494,7 @@ namespace Orleans.Storage
         public static IGrainStorage Create(IServiceProvider services, string name)
         {
             IOptionsSnapshot<AzureTableStorageOptions> optionsSnapshot = services.GetRequiredService<IOptionsSnapshot<AzureTableStorageOptions>>();
-            return ActivatorUtilities.CreateInstance<AzureTableGrainStorage>(services, optionsSnapshot.Get(name));
+            return ActivatorUtilities.CreateInstance<AzureTableGrainStorage>(services, optionsSnapshot.Get(name), name);
         }
     }
 }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -46,8 +46,10 @@ namespace Orleans.Storage
         private const string BINARY_DATA_PROPERTY_NAME = "Data";
         private const string STRING_DATA_PROPERTY_NAME = "StringData";
         private string name;
+
         /// <summary> Default constructor </summary>
-        public AzureTableGrainStorage(AzureTableStorageOptions options, SerializationManager serializationManager, IGrainFactory grainFactory, ITypeResolver typeResolver, ILoggerFactory loggerFactory, string name)
+        public AzureTableGrainStorage(string name, AzureTableStorageOptions options, SerializationManager serializationManager, 
+            IGrainFactory grainFactory, ITypeResolver typeResolver, ILoggerFactory loggerFactory)
         {
             this.options = options;
             this.name = name;

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
@@ -17,9 +17,9 @@ namespace Orleans.Hosting
         public string ServiceId { get; set; } = string.Empty;
 
         /// <summary>
-        /// Azure data connection string
+        /// Azure table connection string
         /// </summary>
-        public string DataConnectionString { get; set; }
+        public string ConnectionString { get; set; }
 
         /// <summary>
         /// Table name where grain stage is stored
@@ -45,6 +45,27 @@ namespace Orleans.Hosting
         public TypeNameHandling? TypeNameHandling { get; set; }
         #endregion json serialization
     }
+    /// <summary>
+    /// Configuration validator for AzureTableStorageOptions
+    /// </summary>
+    public class AzureTableGrainStorageOptionsValidator : IConfigurationValidator
+    {
+        private readonly AzureTableStorageOptions options;
+        private readonly string name;
+        public AzureTableGrainStorageOptionsValidator(AzureTableStorageOptions options, string name)
+        {
+            this.options = options;
+            this.name = name;
+        }
+
+        public void ValidateConfiguration()
+        {
+            if (string.IsNullOrEmpty(this.options.ConnectionString))
+                throw new OrleansConfigurationException(
+                    $"Configuration for AzureTableStorageProvider {name} is invalid. Connection is required.");
+        }
+    }
+
 
     public class AzureTableStorageOptionsFormatterResolver : IOptionFormatterResolver<AzureTableStorageOptions>
     {
@@ -75,7 +96,7 @@ namespace Orleans.Hosting
                 return new List<string>()
                 {
                     OptionFormattingUtilities.Format(nameof(this.options.ServiceId),this.options.ServiceId),
-                    OptionFormattingUtilities.Format(nameof(this.options.DataConnectionString), ConfigUtilities.RedactConnectionStringInfo(this.options.DataConnectionString)),
+                    OptionFormattingUtilities.Format(nameof(this.options.ConnectionString), ConfigUtilities.RedactConnectionStringInfo(this.options.ConnectionString)),
                     OptionFormattingUtilities.Format(nameof(this.options.TableName),this.options.TableName),
                     OptionFormattingUtilities.Format(nameof(this.options.DeleteStateOnClear),this.options.DeleteStateOnClear),
                     OptionFormattingUtilities.Format(nameof(this.options.InitStage),this.options.InitStage),

--- a/test/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -33,7 +33,7 @@ namespace Orleans.Transactions.AzureStorage.Tests
                     .AddAzureTableGrainStorage(TransactionTestConstants.TransactionStore, builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
-                        options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                        options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     }))
                     .UseAzureTransactionLog(options => {
                         // TODO: Find better way for test isolation.  Possibly different partition keys.

--- a/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
+++ b/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
@@ -37,7 +37,7 @@ namespace Tester.AzureUtils.General
                         .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
-                            options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }));
                 }
             }

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
@@ -54,23 +54,23 @@ namespace Tester.AzureUtils.Persistence
                         .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
-                            options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.DeleteStateOnClear = true;
                         }))
                         .AddAzureTableGrainStorage("AzureStore1", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
-                            options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
                         .AddAzureTableGrainStorage("AzureStore2", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
-                            options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
                         .AddAzureTableGrainStorage("AzureStore3", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
-                            options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }));
                 }
             }

--- a/test/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceProviderTests.cs
@@ -282,7 +282,7 @@ namespace Tester.AzureUtils.Persistence
         {
             var options = new AzureTableStorageOptions
             {
-                DataConnectionString = TestDefaultConfiguration.DataConnectionString,
+                ConnectionString = TestDefaultConfiguration.DataConnectionString,
                 UseJson = useJson
             };
             return InitAzureTableGrainStorage(options);

--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -47,13 +47,13 @@ namespace Tester.AzureUtils.Streaming
                     .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
-                        options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                        options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
                     .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                      {
                          options.ServiceId = silo.Value.ServiceId.ToString();
-                         options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                          options.DeleteStateOnClear = true;
                      }));
             }

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -55,14 +55,14 @@ namespace UnitTests.HaloTests.Streaming
                         .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
-                            options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.DeleteStateOnClear = true;
                         }))
                         .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.DeleteStateOnClear = true;
-                            options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }));
                 }
             }

--- a/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
@@ -59,14 +59,14 @@ namespace UnitTests.StreamingTests
                     .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
-                        options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                        options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
                     .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
                         options.DeleteStateOnClear = true;
-                        options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                        options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     }));
             }
         }

--- a/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
@@ -65,14 +65,14 @@ namespace UnitTests.StreamingTests
                     .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
-                        options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                        options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
                     .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
                         options.DeleteStateOnClear = true;
-                        options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                        options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     }));
             }
         }

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -90,14 +90,14 @@ namespace UnitTests.Streaming.Reliability
                 .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
-                        options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                        options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
                 .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                 {
                     options.ServiceId = silo.Value.ServiceId.ToString();
                     options.DeleteStateOnClear = true;
-                    options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                    options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                 }));
             }
         }

--- a/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
@@ -48,12 +48,12 @@ namespace Tests.GeoClusterTests
                         .AddAzureTableGrainStorageAsDefault(builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
-                            options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
                         .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
-                            options.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }));
                 }
             }


### PR DESCRIPTION
- Add more logging to AzureTableGrainStorage init to improve debugging experience
- Add Configuration validator to  `AzureTableGrainStorageOptions`
- rename `DataConnectionString` to be `ConnectionString`. To be consistent with the `ConnectionString` in AzureGatewaylistprovider and AzureMembershipProvier