### PR TITLE
Remove FastKillOnCancel setting, add ProcessExitHandlingOptions

### DIFF
--- a/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
@@ -463,8 +463,6 @@ namespace Orleans.Runtime.Configuration
 
         public bool AssumeHomogenousSilosForTesting { get; set; }
 
-        public bool FastKillOnCancelKeyPress { get; set; }
-
         /// <summary>
         /// Determines if ADO should be used for storage of Membership and Reminders info.
         /// True if either or both of LivenessType and ReminderServiceType are set to SqlServer, false otherwise.
@@ -577,8 +575,6 @@ namespace Orleans.Runtime.Configuration
             this.GrainServiceConfigurations = new GrainServiceConfigurations();
             this.DefaultCompatibilityStrategy = BackwardCompatible.Singleton;
             this.DefaultVersionSelectorStrategy = AllCompatibleVersions.Singleton;
-
-            this.FastKillOnCancelKeyPress = true;
         }
 
         public override string ToString()

--- a/src/Orleans.Runtime.Abstractions/Silo/ProcessExitHandlingOptions.cs
+++ b/src/Orleans.Runtime.Abstractions/Silo/ProcessExitHandlingOptions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// ProcessExitHandlingOptions configure silo behavior on process exit
+    /// </summary>
+    public class ProcessExitHandlingOptions
+    {
+        /// <summary>
+        /// Whether to fast kill a silo on process exit or not. Turned on by default 
+        /// </summary>
+        public bool FastKillOnProcessExit { get; set; } = true;
+    }
+
+    public class ProcessExitHandlingOptionsFormatter : IOptionFormatter<ProcessExitHandlingOptions>
+    {
+        public string Name => nameof(ProcessExitHandlingOptions);
+
+        private ProcessExitHandlingOptions options;
+        public ProcessExitHandlingOptionsFormatter(IOptions<ProcessExitHandlingOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public IEnumerable<string> Format()
+        {
+            return new List<string>()
+            {
+                OptionFormattingUtilities.Format(nameof(this.options.FastKillOnProcessExit),this.options.FastKillOnProcessExit),
+            };
+        }
+    }
+}

--- a/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
+++ b/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
@@ -23,9 +23,6 @@ namespace Orleans.Runtime
         /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment, where as <see cref="ClusterId"/> might not.
         /// </summary>
         public Guid ServiceId { get; set; }
-
-        public bool FastKillOnCancelKeyPress { get; set; } = DEFAULT_FAST_KILL_ON_CANCEL;
-        public const bool DEFAULT_FAST_KILL_ON_CANCEL = true;
     }
 
     public class SiloOptionsFormatter : IOptionFormatter<SiloOptions>
@@ -44,8 +41,7 @@ namespace Orleans.Runtime
             {
                 OptionFormattingUtilities.Format(nameof(this.options.SiloName),this.options.SiloName),
                 OptionFormattingUtilities.Format(nameof(this.options.ClusterId), this.options.ClusterId),
-                OptionFormattingUtilities.Format(nameof(this.options.ServiceId), this.options.ServiceId),
-                OptionFormattingUtilities.Format(nameof(this.options.FastKillOnCancelKeyPress), this.options.FastKillOnCancelKeyPress)
+                OptionFormattingUtilities.Format(nameof(this.options.ServiceId), this.options.ServiceId)
             };
         }
     }

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
@@ -93,7 +93,6 @@ namespace Orleans.Hosting
                 {
                     options.ServiceId = configuration.Globals.ServiceId;
                 }
-                options.FastKillOnCancelKeyPress = configuration.Globals.FastKillOnCancelKeyPress;
             });
 
             services.Configure<MultiClusterOptions>(options =>

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -239,6 +239,7 @@ namespace Orleans.Hosting
 
             //Add default option formatter if none is configured, for options which are required to be configured 
             services.TryConfigureFormatter<SiloOptions, SiloOptionsFormatter>();
+            services.TryConfigureFormatter<ProcessExitHandlingOptions, ProcessExitHandlingOptionsFormatter>();
             services.TryConfigureFormatter<SchedulingOptions, SchedulingOptionsFormatter>();
             services.TryConfigureFormatter<ThreadPoolOptions, ThreadPoolOptionsFormatter>();
             services.TryConfigureFormatter<SerializationProviderOptions, SerializationProviderOptionsFormatter>();

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -379,7 +379,7 @@ namespace Orleans.Runtime
 
             var processExitHandlingOptions = this.Services.GetService<IOptions<ProcessExitHandlingOptions>>().Value;
             if(processExitHandlingOptions.FastKillOnProcessExit)
-             AppDomain.CurrentDomain.ProcessExit += HandleProcessExit;
+                AppDomain.CurrentDomain.ProcessExit += HandleProcessExit;
 
             //TODO: setup thead pool directly to lifecycle
             StartTaskWithPerfAnalysis("ConfigureThreadPoolAndServicePointSettings",

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -377,10 +377,10 @@ namespace Orleans.Runtime
 
             logger.Info(ErrorCode.SiloStarting, "Silo Start()");
 
-            // Hook up to receive notification of process exit / Ctrl-C events
-            AppDomain.CurrentDomain.ProcessExit += HandleProcessExit;
-            if (this.siloOptions.FastKillOnCancelKeyPress)
-                Console.CancelKeyPress += HandleConsoleCancelKeyPress;
+            var processExitHandlingOptions = this.Services.GetService<IOptions<ProcessExitHandlingOptions>>().Value;
+            if(processExitHandlingOptions.FastKillOnProcessExit)
+             AppDomain.CurrentDomain.ProcessExit += HandleProcessExit;
+
             //TODO: setup thead pool directly to lifecycle
             StartTaskWithPerfAnalysis("ConfigureThreadPoolAndServicePointSettings",
                 this.ConfigureThreadPoolAndServicePointSettings, Stopwatch.StartNew());
@@ -796,12 +796,6 @@ namespace Orleans.Runtime
             // NOTE: We need to minimize the amount of processing occurring on this code path -- we only have under approx 2-3 seconds before process exit will occur
             this.logger.Warn(ErrorCode.Runtime_Error_100220, "Process is exiting");
             this.Stop();
-        }
-
-        private void HandleConsoleCancelKeyPress(object sender, EventArgs e)
-        {
-            // Gracefully terminate the silo.
-            this.Shutdown();
         }
 
         internal void RegisterSystemTarget(SystemTarget target)


### PR DESCRIPTION
- Remove FastKillOnCancelKeyPress setting from SiloOptions and also legacy configuration, per #3957 
- Add ProcessExitHandlingOptions to configure whether to fast kill on process exit. per #4016 