### PR TITLE
Migrate to use string template, instead of String.Format

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -76,7 +76,7 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task<bool> InsertRow(MembershipEntry entry, TableVersion tableVersion)
         {
-            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace(string.Format("AdoNetClusteringTable.InsertRow called with entry {0} and tableVersion {1}.", entry, tableVersion));
+            if (logger.IsEnabled(LogLevel.Trace)) logger.Trace($"AdoNetClusteringTable.InsertRow called with entry {entry} and tableVersion {tableVersion}.");
 
             //The "tableVersion" parameter should always exist when inserting a row as Init should
             //have been called and membership version created and read. This is an optimization to

--- a/src/Orleans.Core/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Orleans.Core/AssemblyLoader/AssemblyLoader.cs
@@ -448,7 +448,7 @@ namespace Orleans.Runtime
             // generate feedback so that the operator can determine why her DLL didn't load.
             var msg = new StringBuilder();
             string bullet = Environment.NewLine + "\t* ";
-            msg.Append(String.Format("User assembly ignored: {0}", pathName));
+            msg.Append($"User assembly ignored: {pathName}");
             int count = 0;
             foreach (var i in distinctComplaints)
             {

--- a/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
+++ b/src/Orleans.Core/Async/AsyncExecutorWithRetries.cs
@@ -252,7 +252,7 @@ namespace Orleans
             }
             currMax = StandardExtensions.Min(currMax, maxDelay);
 
-            if (minDelay >= currMax) throw new ArgumentOutOfRangeException(String.Format("minDelay {0}, currMax = {1}", minDelay, currMax));
+            if (minDelay >= currMax) throw new ArgumentOutOfRangeException($"minDelay {minDelay}, currMax = {currMax}");
             return random.NextTimeSpan(minDelay, currMax);
         }
     }

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -178,7 +178,7 @@ namespace Orleans
         {
             if (!task.Wait(timeout))
             {
-                throw new TimeoutException(String.Format("Task.WaitWithThrow has timed out after {0}.", timeout));
+                throw new TimeoutException($"Task.WaitWithThrow has timed out after {timeout}.");
             }
         }
 
@@ -186,7 +186,7 @@ namespace Orleans
         {
             if (!task.Wait(timeout))
             {
-                throw new TimeoutException(String.Format("Task<T>.WaitForResultWithThrow has timed out after {0}.", timeout));
+                throw new TimeoutException($"Task<T>.WaitForResultWithThrow has timed out after {timeout}.");
             }
             return task.Result;
         }

--- a/src/Orleans.Core/Messaging/GatewayClientReceiver.cs
+++ b/src/Orleans.Core/Messaging/GatewayClientReceiver.cs
@@ -50,8 +50,7 @@ namespace Orleans.Messaging
             catch (Exception ex)
             {
                 buffer.Reset();
-                Log.Warn(ErrorCode.ProxyClientUnhandledExceptionWhileReceiving, String.Format("Unexpected/unhandled exception while receiving: {0}. Restarting gateway receiver for {1}.",
-                    ex, gatewayConnection.Address), ex);
+                Log.Warn(ErrorCode.ProxyClientUnhandledExceptionWhileReceiving, $"Unexpected/unhandled exception while receiving: {ex}. Restarting gateway receiver for {gatewayConnection.Address}.", ex);
                 throw;
             }
         }
@@ -85,7 +84,7 @@ namespace Orleans.Messaging
                 // Only try to reconnect if we're not shutting down
                 if (Cts.IsCancellationRequested) return 0;
 
-                Log.Warn(ErrorCode.Runtime_Error_100158, String.Format("Exception receiving from gateway {0}: {1}", gatewayConnection.Address, ex.Message));
+                Log.Warn(ErrorCode.Runtime_Error_100158, $"Exception receiving from gateway {gatewayConnection.Address}: {ex.Message}", ex);
                 gatewayConnection.MarkAsDisconnected(socket);
                 socket = null;
                 return 0;

--- a/src/Orleans.Core/Messaging/GatewayConnection.cs
+++ b/src/Orleans.Core/Messaging/GatewayConnection.cs
@@ -97,7 +97,7 @@ namespace Orleans.Messaging
                 {
                     s = Socket;
                     Socket = null;
-                    Log.Warn(ErrorCode.ProxyClient_MarkGatewayDisconnected, String.Format("Marking gateway at address {0} as Disconnected", Address));
+                    Log.Warn(ErrorCode.ProxyClient_MarkGatewayDisconnected, $"Marking gateway at address {Address} as Disconnected");
                     if ( MsgCenter != null && MsgCenter.GatewayManager != null)
                         // We need a refresh...
                         MsgCenter.GatewayManager.ExpediteUpdateLiveGatewaysSnapshot();
@@ -114,7 +114,7 @@ namespace Orleans.Messaging
 
         public void MarkAsDead()
         {
-            Log.Warn(ErrorCode.ProxyClient_MarkGatewayDead, String.Format("Marking gateway at address {0} as Dead in my client local gateway list.", Address));
+            Log.Warn(ErrorCode.ProxyClient_MarkGatewayDead, $"Marking gateway at address {Address} as Dead in my client local gateway list.");
             MsgCenter.GatewayManager.MarkAsDead(Address);
             Stop();
         }
@@ -253,8 +253,8 @@ namespace Orleans.Messaging
         {
             // we only get here if we failed to serialise the msg (or any other catastrophic failure).
             // Request msg fails to serialise on the sending silo, so we just enqueue a rejection msg.
-            Log.Warn(ErrorCode.ProxyClient_SerializationError, String.Format("Unexpected error serializing message to gateway {0}.", Address), exc);
-            FailMessage(msg, String.Format("Unexpected error serializing message to gateway {0}. {1}", Address, exc));
+            Log.Warn(ErrorCode.ProxyClient_SerializationError, $"Unexpected error serializing message to gateway {Address}.", exc);
+            FailMessage(msg, $"Unexpected error serializing message to gateway {Address}. {exc}");
             if (msg.Direction == Message.Directions.Request || msg.Direction == Message.Directions.OneWay)
             {
                 return;

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -48,7 +48,7 @@ namespace Orleans.Messaging
             if (knownGateways.Count == 0)
             {
                 string gatewayProviderType = gatewayListProvider.GetType().FullName;
-                string err = String.Format("Could not find any gateway in {0}. Orleans client cannot initialize.", gatewayProviderType);
+                string err = $"Could not find any gateway in {gatewayProviderType}. Orleans client cannot initialize.";
                 logger.Error(ErrorCode.GatewayManager_NoGateways, err);
                 throw new OrleansException(err);
             }

--- a/src/Orleans.Core/Messaging/OutgoingMessageSender.cs
+++ b/src/Orleans.Core/Messaging/OutgoingMessageSender.cs
@@ -75,7 +75,7 @@ namespace Orleans.Messaging
                 {
                     // The complete message wasn't sent, even though no error was reported; treat this as an error
                     countMismatchSending = true;
-                    sendErrorStr = String.Format("Byte count mismatch on sending to {0}: sent {1}, expected {2}", targetSilo, bytesSent, length);
+                    sendErrorStr = $"Byte count mismatch on sending to {targetSilo}: sent {bytesSent}, expected {length}";
                     Log.Warn(ErrorCode.Messaging_CountMismatchSending, sendErrorStr);
                 }
             }
@@ -84,7 +84,7 @@ namespace Orleans.Messaging
                 exceptionSending = true;
                 if (!(exc is ObjectDisposedException))
                 {
-                    sendErrorStr = String.Format("Exception sending message to {0}. Message: {1}. {2}", targetSilo, msg, exc);
+                    sendErrorStr = $"Exception sending message to {targetSilo}. Message: {msg}. {exc}";
                     Log.Warn(ErrorCode.Messaging_ExceptionSending, sendErrorStr, exc);
                 }
             }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -180,7 +180,7 @@ namespace Orleans
 
         private void UnhandledException(ISchedulingContext context, Exception exception)
         {
-            logger.Error(ErrorCode.Runtime_Error_100007, String.Format("OutsideRuntimeClient caught an UnobservedException."), exception);
+            logger.Error(ErrorCode.Runtime_Error_100007, "OutsideRuntimeClient caught an UnobservedException.", exception);
             logger.Assert(ErrorCode.Runtime_Error_100008, context == null, "context should be not null only inside OrleansRuntime and not on the client.");
         }
 
@@ -283,7 +283,7 @@ namespace Orleans
                             break;
                         }
                     default:
-                        logger.Error(ErrorCode.Runtime_Error_100327, String.Format("Message not supported: {0}.", message));
+                        logger.Error(ErrorCode.Runtime_Error_100327, $"Message not supported: {message}.");
                         break;
                 }
 #if TRACK_DETAILED_STATS
@@ -308,7 +308,7 @@ namespace Orleans
             {
                 logger.Error(
                     ErrorCode.ProxyClient_OGC_TargetNotFound_2,
-                    String.Format("Did not find TargetObserverId header in the message = {0}. A request message to a client is expected to have an observerId.", message));
+                    $"Did not find TargetObserverId header in the message = {message}. A request message to a client is expected to have an observerId.");
                 return;
             }
 
@@ -318,10 +318,7 @@ namespace Orleans
             {
                 logger.Error(
                     ErrorCode.ProxyClient_OGC_TargetNotFound,
-                    String.Format(
-                        "Unexpected target grain in request: {0}. Message={1}",
-                        message.TargetGrain,
-                        message));
+                    $"Unexpected target grain in request: {message.TargetGrain}. Message={message}");
             }
         }
 
@@ -332,7 +329,7 @@ namespace Orleans
             {
                 //// Remove from the dictionary record for the garbage collected object? But now we won't be able to detect invalid dispatch IDs anymore.
                 logger.Warn(ErrorCode.Runtime_Error_100162,
-                    String.Format("Object associated with Observer ID {0} has been garbage collected. Deleting object reference and unregistering it. Message = {1}", objectData.ObserverId, message));
+                    $"Object associated with Observer ID {objectData.ObserverId} has been garbage collected. Deleting object reference and unregistering it. Message = {message}");
 
                 LocalObjectData ignore;
                 // Try to remove. If it's not there, we don't care.
@@ -477,10 +474,7 @@ namespace Orleans
                     {
                         logger.Error(
                             ErrorCode.ProxyClient_OGC_UnhandledExceptionInOneWayInvoke,
-                            String.Format(
-                                "Exception during invocation of notification method {0}, interface {1}. Ignoring exception because this is a one way request.",
-                                request.MethodId,
-                                request.InterfaceId),
+                            $"Exception during invocation of notification method {request.MethodId}, interface {request.InterfaceId}. Ignoring exception because this is a one way request.",
                             exception);
                         break;
                     }
@@ -776,7 +770,7 @@ namespace Orleans
             try
             {
                 logger.Warn(ErrorCode.ProxyClient_AppDomain_Unload,
-                    String.Format("Current AppDomain={0} is unloading.", PrintAppDomainDetails()));
+                    $"Current AppDomain={PrintAppDomainDetails()} is unloading.");
             }
             catch (Exception)
             {

--- a/src/Orleans.Core/Statistics/ThreadCycleStopWatch.cs
+++ b/src/Orleans.Core/Statistics/ThreadCycleStopWatch.cs
@@ -88,8 +88,7 @@ namespace Orleans.Runtime
             {
                 if (logger.IsEnabled(LogLevel.Trace))
                     logger.Trace(0,
-                        String.Format("Invalid cycle counts startCycles = {0}, stopCycles = {1}", startCycles,
-                            stopCycles));
+                        $"Invalid cycle counts startCycles = {startCycles}, stopCycles = {stopCycles}");
 
                 // Some threadpool threads seem to be reset, this is normal with .NET threadpool threads as its assumed they are restart out of our control
                 elapsedCycles += stopCycles;

--- a/src/Orleans.Core/Streams/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans.Core/Streams/PersistentStreams/PersistentStreamProvider.cs
@@ -181,8 +181,7 @@ namespace Orleans.Providers.Streams.Common
                 return pullingAgentManager.ExecuteCommand((PersistentStreamProviderCommand)command, arg);
             }
 
-            logger.Warn(0, String.Format("Got command {0} with arg {1}, but PullingAgentManager is not initialized yet. Ignoring the command.", 
-                (PersistentStreamProviderCommand)command, arg != null ? arg.ToString() : "null"));
+            logger.Warn(0, $"Got command {(PersistentStreamProviderCommand)command} with arg {arg}, but PullingAgentManager is not initialized yet. Ignoring the command.");
             throw new ArgumentException("PullingAgentManager is not initialized yet.");
         }
     }

--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -174,8 +174,7 @@ namespace Orleans.Runtime
                 string stats = Utils.EnumerableToString(activations.Values.OrderBy(act => act.Name), act => string.Format("++{0}", act.DumpStatus()), Environment.NewLine);
                 if (stats.Length > 0)
                 {
-                    logger.Info(ErrorCode.Catalog_ActivationDirectory_Statistics, String.Format("ActivationDirectory.PrintActivationDirectory(): Size = {0}, Directory:" + Environment.NewLine + "{1}",
-                        activations.Count, stats));
+                    logger.Info(ErrorCode.Catalog_ActivationDirectory_Statistics, $"ActivationDirectory.PrintActivationDirectory(): Size = { activations.Count}, Directory:{Environment.NewLine}{stats}");
                 }
             }
         }

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -131,7 +131,7 @@ namespace Orleans.Runtime
                     var nea = ex as Catalog.NonExistentActivationException;
                     if (nea == null)
                     {
-                        var str = String.Format("Error creating activation for {0}. Message {1}", message.NewGrainType, message);
+                        var str = $"Error creating activation for {message.NewGrainType}. Message {message}";
                         logger.Error(ErrorCode.Dispatcher_ErrorCreatingActivation, str, ex);
                         throw new OrleansException(str, ex);
                     }
@@ -139,12 +139,12 @@ namespace Orleans.Runtime
                     if (nea.IsStatelessWorker)
                     {
                         if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.Dispatcher_Intermediate_GetOrCreateActivation,
-                           String.Format("Intermediate StatelessWorker NonExistentActivation for message {0}", message), ex);
+                           $"Intermediate StatelessWorker NonExistentActivation for message {message}, Exception {ex}");
                     }
                     else
                     {
                         logger.Info(ErrorCode.Dispatcher_Intermediate_GetOrCreateActivation,
-                            String.Format("Intermediate NonExistentActivation for message {0}", message), ex);
+                            $"Intermediate NonExistentActivation for message {message}, with Exception {ex}");
                     }
 
                     ActivationAddress nonExistentActivation = nea.NonExistentActivation;
@@ -171,8 +171,7 @@ namespace Orleans.Runtime
                                 catch (Exception exc)
                                 {
                                     logger.Warn(ErrorCode.Dispatcher_FailedToUnregisterNonExistingAct,
-                                        String.Format("Failed to un-register NonExistentActivation {0}",
-                                            nonExistentActivation), exc);
+                                        $"Failed to un-register NonExistentActivation {nonExistentActivation}", exc);
                                 }
                             },
                             "LocalGrainDirectory.UnregisterAfterNonexistingActivation"),
@@ -501,9 +500,7 @@ namespace Orleans.Runtime
             if (logger.IsEnabled(LogLevel.Information))
             {
                 logger.Info(ErrorCode.Messaging_Dispatcher_ForwardingRequests,
-                    string.Format("Forwarding {0} requests destined for address {1} to address {2} after {3}.",
-                        messages.Count, oldAddress, forwardingAddress,
-                        failedOperation));
+                    $"Forwarding {messages.Count} requests destined for address {oldAddress} to address {forwardingAddress} after {failedOperation}.");
             }
 
             // IMPORTANT: do not do anything on activation context anymore, since this activation is invalid already.
@@ -532,8 +529,7 @@ namespace Orleans.Runtime
             try
             {
 
-                logger.Info(ErrorCode.Messaging_Dispatcher_TryForward, 
-                    String.Format("Trying to forward after {0}, ForwardCount = {1}. Message {2}.", failedOperation, message.ForwardCount, message));
+                logger.Info(ErrorCode.Messaging_Dispatcher_TryForward, $"Trying to forward after {failedOperation}, ForwardCount = {message.ForwardCount}. Message {message}.");
 
                 // if this message is from a different cluster and hit a non-existing activation
                 // in this cluster (which can happen due to stale cache or directory states)
@@ -546,8 +542,7 @@ namespace Orleans.Runtime
                 {
                     message.IsReturnedFromRemoteCluster = true; // marks message to force invalidation of stale directory entry
                     forwardingAddress = ActivationAddress.NewActivationAddress(message.SendingSilo, message.TargetGrain);
-                    logger.Info(ErrorCode.Messaging_Dispatcher_ReturnToOriginCluster,
-                        String.Format("Forwarding back to origin cluster, to fictional activation {0}", message));
+                    logger.Info(ErrorCode.Messaging_Dispatcher_ReturnToOriginCluster, $"Forwarding back to origin cluster, to fictional activation {message}");
                 }
 
                 MessagingProcessingStatisticsGroup.OnDispatcherMessageReRouted(message);
@@ -567,8 +562,7 @@ namespace Orleans.Runtime
             {
                 if (!forwardingSucceded)
                 {
-                    var str = String.Format("Forwarding failed: tried to forward message {0} for {1} times after {2} to invalid activation. Rejecting now.", 
-                        message, message.ForwardCount, failedOperation);
+                    var str = $"Forwarding failed: tried to forward message {message} for {message.ForwardCount} times after {failedOperation} to invalid activation. Rejecting now.";
                     logger.Warn(ErrorCode.Messaging_Dispatcher_TryForwardFailed, str, exc);
                     RejectMessage(message, Message.RejectionTypes.Transient, exc, str);
                 }


### PR DESCRIPTION
Migrate part of our logging message to use string template, instead of String.Format 
Reasons:
- String.Format is error prone. You may miss one arg or give extra arg. While string template doesn't have that problem
- Easy to use the logger extension method in a wrong way. See #4015 for more info. 
