### PR TITLE
BUG: Some MembershipOptions default values were not being set causing errors.

### DIFF
--- a/src/Orleans.Core/Configuration/Options/MembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MembershipOptions.cs
@@ -30,38 +30,39 @@ namespace Orleans.Configuration
         /// <summary>
         /// The number of seconds to periodically probe other silos for their liveness or for the silo to send "I am alive" heartbeat  messages about itself.
         /// </summary>
-        public TimeSpan ProbeTimeout { get; set; }
+        public TimeSpan ProbeTimeout { get; set; } = DEFAULT_LIVENESS_PROBE_TIMEOUT;
         public static readonly TimeSpan DEFAULT_LIVENESS_PROBE_TIMEOUT = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// The number of seconds to periodically fetch updates from the membership table.
         /// </summary>
-        public TimeSpan TableRefreshTimeout { get; set; }
+        public TimeSpan TableRefreshTimeout { get; set; } = DEFAULT_LIVENESS_TABLE_REFRESH_TIMEOUT;
         public static readonly TimeSpan DEFAULT_LIVENESS_TABLE_REFRESH_TIMEOUT = TimeSpan.FromSeconds(60);
 
         /// <summary>
         /// Expiration time in seconds for death vote in the membership table.
         /// </summary>
-        public TimeSpan DeathVoteExpirationTimeout { get; set; }
+        public TimeSpan DeathVoteExpirationTimeout { get; set; } = DEFAULT_LIVENESS_DEATH_VOTE_EXPIRATION_TIMEOUT;
         public static readonly TimeSpan DEFAULT_LIVENESS_DEATH_VOTE_EXPIRATION_TIMEOUT = TimeSpan.FromSeconds(120);
 
         /// <summary>
         /// The number of seconds to periodically write in the membership table that this silo is alive. Used ony for diagnostics.
         /// </summary>
-        public TimeSpan IAmAliveTablePublishTimeout { get; set; }
+        public TimeSpan IAmAliveTablePublishTimeout { get; set; } = DEFAULT_LIVENESS_I_AM_ALIVE_TABLE_PUBLISH_TIMEOUT;
         public static readonly TimeSpan DEFAULT_LIVENESS_I_AM_ALIVE_TABLE_PUBLISH_TIMEOUT = TimeSpan.FromMinutes(5);
 
         /// <summary>
         /// The number of seconds to attempt to join a cluster of silos before giving up.
         /// </summary>
-        public TimeSpan MaxJoinAttemptTime { get; set; }
+        public TimeSpan MaxJoinAttemptTime { get; set; } = DEFAULT_LIVENESS_MAX_JOIN_ATTEMPT_TIME;
         public static readonly TimeSpan DEFAULT_LIVENESS_MAX_JOIN_ATTEMPT_TIME = TimeSpan.FromMinutes(5); // 5 min
 
         /// <summary>
         /// The expected size of a cluster. Need not be very accurate, can be an overestimate.
         /// </summary>
-        public int ExpectedClusterSize { get; set; }
-
+        public int ExpectedClusterSize { get; set; } = DEFAULT_LIVENESS_EXPECTED_CLUSTER_SIZE;
+        public static readonly int DEFAULT_LIVENESS_EXPECTED_CLUSTER_SIZE = 20;
+        
         /// <summary>
         /// Whether new silo that joins the cluster has to validate the initial connectivity with all other Active silos.
         /// </summary>


### PR DESCRIPTION
How Found:
Set silo to startup via code without using legacy mode.  Exception thrown due to TimeSpan being set to 0.

SafeRandom.NextTimeSpan timeSpan must be a positive number.
Parameter name: timeSpan
Actual value was 00:00:00.

Code that fails on MembershipOracle.Start()
```
                // randomly delay the startup, so not all silos write to the table at once.
                // Use random time not larger than MaxJoinAttemptTime, one minute and 0.5sec*ExpectedClusterSize;
                var random = new SafeRandom();
                var maxDelay = TimeSpan.FromMilliseconds(500).Multiply(this.membershipOptions.ExpectedClusterSize);
                maxDelay = StandardExtensions.Min(maxDelay, StandardExtensions.Min(this.membershipOptions.MaxJoinAttemptTime, TimeSpan.FromMinutes(1)));
                var randomDelay = random.NextTimeSpan(maxDelay);
                await Task.Delay(randomDelay);
```

ExpectedClusterSize and MaxJoinAttempTime all had the value of zero before the fix.