### PR TITLE
Added optional listenerAddress parameter to ConfigureEndpoints()

### DIFF
--- a/src/Orleans.Runtime/Hosting/EndpointOptions.cs
+++ b/src/Orleans.Runtime/Hosting/EndpointOptions.cs
@@ -67,39 +67,76 @@ namespace Orleans.Configuration
 
     public static class EndpointOptionsExtensions
     {
+        /// <summary>
+        /// Configure endpoints for the silo.
+        /// </summary>        
+        /// <param name="builder">The host builder to configure.</param>
+        /// <param name="advertisedIP">The IP address to be advertised in membership tables</param>
+        /// <param name="siloPort">The port this silo uses for silo-to-silo communication.</param>
+        /// <param name="gatewayPort">The port this silo uses for client-to-silo (gateway) communication. Specify 0 to disable gateway functionality.</param>
+        /// <param name="listenOnAllHostAddresses">Set to true to listen on all IP addresses of the host instead of just the advertiseIP.</param>
+        /// <returns></returns>
         public static ISiloHostBuilder ConfigureEndpoints(
             this ISiloHostBuilder builder,
-            IPAddress ip,
+            IPAddress advertisedIP,
             int siloPort,
-            int gatewayPort)
+            int gatewayPort,
+            bool listenOnAllHostAddresses = false)
         {
             builder.Configure<EndpointOptions>(options =>
             {
-                options.AdvertisedIPAddress = ip;
+                options.AdvertisedIPAddress = advertisedIP;
                 options.GatewayPort = gatewayPort;
                 options.SiloPort = siloPort;
+
+                if (listenOnAllHostAddresses)
+                {
+                    options.SiloListeningEndpoint = new IPEndPoint(IPAddress.Any, siloPort);
+                    options.GatewayListeningEndpoint = new IPEndPoint(IPAddress.Any, gatewayPort);
+                }
             });
             return builder;
         }
 
+        /// <summary>
+        /// Configure endpoints for the silo.
+        /// </summary>        
+        /// <param name="builder">The host builder to configure.</param>
+        /// <param name="hostname">The host name the silo is running on.</param>
+        /// <param name="siloPort">The port this silo uses for silo-to-silo communication.</param>
+        /// <param name="gatewayPort">The port this silo uses for client-to-silo (gateway) communication. Specify 0 to disable gateway functionality.</param>
+        /// <param name="addressFamily">Address family to listen on.  Default IPv4 address family.</param>
+        /// <param name="listenOnAllHostAddresses">Set to true to listen on all IP addresses of the host instead of just the advertiseIP.</param>
+        /// <returns></returns>
         public static ISiloHostBuilder ConfigureEndpoints(
             this ISiloHostBuilder builder, 
             string hostname, 
             int siloPort, 
             int gatewayPort,
-            AddressFamily addressFamily = AddressFamily.InterNetwork)
+            AddressFamily addressFamily = AddressFamily.InterNetwork,
+            bool listenOnAllHostAddresses = false)
         {
             var ip = ConfigUtilities.ResolveIPAddress(hostname, null, addressFamily).Result;
-            return builder.ConfigureEndpoints(ip, siloPort, gatewayPort);
+            return builder.ConfigureEndpoints(ip, siloPort, gatewayPort, listenOnAllHostAddresses);
         }
 
+        /// <summary>
+        /// Configure endpoints for the silo.
+        /// </summary>        
+        /// <param name="builder">The host builder to configure.</param>
+        /// <param name="siloPort">The port this silo uses for silo-to-silo communication.</param>
+        /// <param name="gatewayPort">The port this silo uses for client-to-silo (gateway) communication. Specify 0 to disable gateway functionality.</param>
+        /// <param name="addressFamily">Address family to listen on.  Default IPv4 address family.</param>
+        /// <param name="listenOnAllHostAddresses">Set to true to listen on all IP addresses of the host instead of just the advertiseIP.</param>
+        /// <returns></returns>
         public static ISiloHostBuilder ConfigureEndpoints(
             this ISiloHostBuilder builder,
             int siloPort,
             int gatewayPort,
-            AddressFamily addressFamily = AddressFamily.InterNetwork)
+            AddressFamily addressFamily = AddressFamily.InterNetwork,
+            bool listenOnAllHostAddresses = false)
         {
-            return builder.ConfigureEndpoints(null, siloPort, gatewayPort, addressFamily);
+            return builder.ConfigureEndpoints(null, siloPort, gatewayPort, addressFamily, listenOnAllHostAddresses);
         }
 
         internal static IPEndPoint GetPublicSiloEndpoint(this EndpointOptions options)


### PR DESCRIPTION
@benjaminpetit please review.

Instead of using this code:

```
 .Configure<EndpointOptions>(o =>
{
       o.AdvertisedIPAddress = Dns.GetHostAddresses(Dns.GetHostName()).First(s => s.AddressFamily == AddressFamily.InterNetwork);
       o.SiloPort = 22222;
       o.GatewayPort = 40000;
       o.SiloListeningEndpoint = new IPEndPoint(IPAddress.Any, 22222);
       o.GatewayListeningEndpoint = new IPEndPoint(IPAddress.Any, 40000);
})
```

I'd like it simplified with this:

```
.ConfigureEndpoints(22222, 40000, AddressFamily.InterNetwork, IPAddress.Any)
```
