### PR TITLE
Fix StartupTask tests

### DIFF
--- a/test/Tester/StartupTaskTests.cs
+++ b/test/Tester/StartupTaskTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -36,10 +37,8 @@ namespace DefaultCluster.Tests
                         async (services, cancellation) =>
                         {
                             var grainFactory = services.GetRequiredService<IGrainFactory>();
-                            var grain = grainFactory.GetGrain<ISimpleGrain>(98052);
-
-                            // Modify "A" to validate ordering of events.
-                            await grain.SetA(await grain.GetA() * 2);
+                            var grain = grainFactory.GetGrain<ISimpleGrain>(1);
+                            await grain.SetA(888);
                         });
                 }
             }
@@ -56,8 +55,8 @@ namespace DefaultCluster.Tests
 
             public async Task Execute(CancellationToken cancellationToken)
             {
-                var grain = this.grainFactory.GetGrain<ISimpleGrain>(98052);
-                await grain.SetA(1331);
+                var grain = this.grainFactory.GetGrain<ISimpleGrain>(2);
+                await grain.SetA(777);
             }
         }
 
@@ -69,14 +68,18 @@ namespace DefaultCluster.Tests
         }
 
         /// <summary>
-        /// Ensures that startup tasks can call grains and are executed in the registered order.
+        /// Ensures that startup tasks can call grains.
         /// </summary>
         [Fact]
         public async Task StartupTaskCanCallGrains()
         {
-            var grain = this.fixture.GrainFactory.GetGrain<ISimpleGrain>(98052);
+            var grain = this.fixture.GrainFactory.GetGrain<ISimpleGrain>(1);
             var value = await grain.GetA();
-            Assert.Equal(2662, value);
+            Assert.Equal(888, value);
+
+            grain = this.fixture.GrainFactory.GetGrain<ISimpleGrain>(2);
+            value = await grain.GetA();
+            Assert.Equal(777, value);
         }
     }
 }


### PR DESCRIPTION
Execution order is not guaranteed - my bad.