### PR TITLE
Fix bad merge

### DIFF
--- a/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
@@ -27,7 +27,7 @@ namespace Orleans.Configuration
         /// <summary>
         /// Default init stage in silo lifecycle.
         /// </summary>
-        public const int DEFAULT_INIT_STAGE = SiloLifecycleStage.ApplicationServices;
+        public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
 
         /// <summary>
         /// The default ADO.NET invariant used for storage if none is given. 


### PR DESCRIPTION
fix bad merge between #4045 and #4022 
#4045 removed SiloLifeCycle while #4022 is using it. #4022 got merged first. But #4045 didn't get merge conflicts maybe because they are not touching the same file. 

But anyway master doesn't build now. This PR shall fix it 