### PR TITLE
Removed more legacy dependencies.

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -24,12 +24,12 @@ namespace Orleans.Runtime.Membership
         private readonly ILoggerFactory loggerFactory;
         private readonly DynamoDBClusteringClientOptions options;
         private readonly TimeSpan maxStaleness;
-        public DynamoDBGatewayListProvider(ILoggerFactory loggerFactory, ClientConfiguration clientConfiguration, IOptions<DynamoDBClusteringClientOptions> options, IOptions<ClusterClientOptions> clusterClientOptions)
+        public DynamoDBGatewayListProvider(ILoggerFactory loggerFactory, IOptions<DynamoDBClusteringClientOptions> options, IOptions<GatewayOptions> gatewayOptions, IOptions<ClusterClientOptions> clusterClientOptions)
         {
             this.loggerFactory = loggerFactory;
             this.options = options.Value;
             this.clusterId = clusterClientOptions.Value.ClusterId;
-            this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
+            this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
         }
 
         #region Implementation of IGatewayListProvider

--- a/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Orleans.Clustering.DynamoDB.csproj
@@ -22,7 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
   </ItemGroup>

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Clustering.AdoNet.Storage;
 using Orleans.Messaging;
-using Orleans.Runtime.Configuration;
 using Orleans.Configuration;
 
 namespace Orleans.Runtime.Membership
@@ -18,15 +17,16 @@ namespace Orleans.Runtime.Membership
         private RelationalOrleansQueries orleansQueries;
         private readonly IGrainReferenceConverter grainReferenceConverter;
         private readonly TimeSpan maxStaleness;
-        public AdoNetGatewayListProvider(ILogger<AdoNetGatewayListProvider> logger, IGrainReferenceConverter grainReferenceConverter, ClientConfiguration clientConfiguration,
+        public AdoNetGatewayListProvider(ILogger<AdoNetGatewayListProvider> logger, IGrainReferenceConverter grainReferenceConverter,
             IOptions<AdoNetClusteringClientOptions> options,
+            IOptions<GatewayOptions> gatewayOptions,
             IOptions<ClusterClientOptions> clusterClientOptions)
         {
             this.logger = logger;
             this.grainReferenceConverter = grainReferenceConverter;
             this.options = options.Value;
             this.clusterId = clusterClientOptions.Value.ClusterId;
-            this.maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
+            this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
         }
 
         public TimeSpan MaxStaleness

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
@@ -34,7 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
   </ItemGroup>

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
@@ -35,7 +35,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />
   </ItemGroup>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrleansProviders\OrleansProviders.csproj" />

--- a/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
@@ -18,11 +18,11 @@ namespace Orleans.Runtime.Membership
         private ILogger logger;
         private readonly ConsulClusteringClientOptions options;
         private readonly TimeSpan maxStaleness;
-        public ConsulGatewayListProvider(ILogger<ConsulGatewayListProvider> logger, ClientConfiguration clientConfig, IOptions<ConsulClusteringClientOptions> options, IOptions<ClusterClientOptions> clusterClientOptions)
+        public ConsulGatewayListProvider(ILogger<ConsulGatewayListProvider> logger, IOptions<ConsulClusteringClientOptions> options, IOptions<GatewayOptions> gatewayOptions, IOptions<ClusterClientOptions> clusterClientOptions)
         {
             this.logger = logger;
             this.clusterId = clusterClientOptions.Value.ClusterId;
-            this.maxStaleness = clientConfig.GatewayListRefreshPeriod;
+            this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
             this.options = options.Value;
         }
 

--- a/src/Orleans.Clustering.Consul/Orleans.Clustering.Consul.csproj
+++ b/src/Orleans.Clustering.Consul/Orleans.Clustering.Consul.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
+++ b/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\Orleans.Runtime.Abstractions\Orleans.Runtime.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperClusteringClientOptions.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperClusteringClientOptions.cs
@@ -23,15 +23,16 @@ namespace Orleans.Runtime.Membership
         /// </summary>
         private string deploymentConnectionString;
         private TimeSpan maxStaleness;
-        public ZooKeeperClusteringClientOptions(ILogger<ZooKeeperClusteringClientOptions> logger, ClientConfiguration clientConfiguration,
+        public ZooKeeperClusteringClientOptions(ILogger<ZooKeeperClusteringClientOptions> logger,
             IOptions<ZooKeeperGatewayListProviderOptions> options,
+            IOptions<GatewayOptions> gatewayOptions,
             IOptions<ClusterClientOptions> clusterClientOptions)
         {
             watcher = new ZooKeeperWatcher(logger);
 
             deploymentPath = "/" + clusterClientOptions.Value.ClusterId;
             deploymentConnectionString = options.Value.ConnectionString + deploymentPath;
-            maxStaleness = clientConfiguration.GatewayListRefreshPeriod;
+            maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
         }
 
         /// <summary>

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -53,7 +53,7 @@ namespace AWSUtils.Tests.MembershipTests
         {
             var options = new DynamoDBClusteringClientOptions();
             LegacyDynamoDBGatewayListProviderConfigurator.ParseDataConnectionString(this.connectionString, options);
-            return new DynamoDBGatewayListProvider(this.loggerFactory, this.clientConfiguration, Options.Create(options), this.clientOptions);
+            return new DynamoDBGatewayListProvider(this.loggerFactory, Options.Create(options), this.gatewayOptions, this.clientOptions);
         }
 
         protected override Task<string> GetConnectionString()

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -51,7 +51,7 @@ namespace Consul.Tests
             {
                 Address = new Uri(this.connectionString)
             };
-            return new ConsulGatewayListProvider(loggerFactory.CreateLogger<ConsulGatewayListProvider>(), this.clientConfiguration, Options.Create(options), this.clientOptions);
+            return new ConsulGatewayListProvider(loggerFactory.CreateLogger<ConsulGatewayListProvider>(), Options.Create(options), this.gatewayOptions, this.clientOptions);
         }
 
         protected override async Task<string> GetConnectionString()

--- a/test/TesterAdoNet/MySqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/MySqlMembershipTableTests.cs
@@ -1,19 +1,15 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans;
+using Orleans.Configuration;
 using Orleans.Messaging;
-using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.Runtime.Membership;
 using Orleans.Runtime.MembershipService;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
 using UnitTests.General;
 using Xunit;
-using Orleans.AdoNet;
-using Orleans.Configuration;
 
 namespace UnitTests.MembershipTests
 {
@@ -51,7 +47,7 @@ namespace UnitTests.MembershipTests
                 ConnectionString = this.connectionString,
                 AdoInvariant = GetAdoInvariant()
             };
-            return new AdoNetGatewayListProvider(loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, this.clientConfiguration, Options.Create(options), this.clientOptions);
+            return new AdoNetGatewayListProvider(loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, Options.Create(options), this.gatewayOptions, this.clientOptions);
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
@@ -1,19 +1,15 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans;
 using Orleans.Messaging;
-using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.Runtime.Membership;
 using Orleans.Runtime.MembershipService;
 using Orleans.Tests.SqlUtils;
+using Orleans.Configuration;
 using TestExtensions;
 using UnitTests.General;
 using Xunit;
-using Orleans.AdoNet;
-using Orleans.Configuration;
 
 namespace UnitTests.MembershipTests
 {
@@ -49,7 +45,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant()
             };
             return new AdoNetGatewayListProvider(this.loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter
-                ,this.clientConfiguration, Options.Create(options), this.clientOptions);
+                , Options.Create(options), this.gatewayOptions, this.clientOptions);
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterAdoNet/SqlServerMembershipTableTests.cs
+++ b/test/TesterAdoNet/SqlServerMembershipTableTests.cs
@@ -1,18 +1,15 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans;
+using Orleans.Configuration;
 using Orleans.Messaging;
-using Orleans.Runtime;
 using Orleans.Runtime.Membership;
 using Orleans.Runtime.MembershipService;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
 using UnitTests.General;
 using Xunit;
-using Orleans.AdoNet;
-using Orleans.Configuration;
 
 namespace UnitTests.MembershipTests
 {
@@ -49,7 +46,7 @@ namespace UnitTests.MembershipTests
                 ConnectionString = this.connectionString,
                 AdoInvariant = GetAdoInvariant()
             };
-            return new AdoNetGatewayListProvider(this.loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, this.clientConfiguration, Options.Create(options), this.clientOptions);
+            return new AdoNetGatewayListProvider(this.loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, Options.Create(options), gatewayOptions, this.clientOptions);
         }
 
         protected override string GetAdoInvariant()


### PR DESCRIPTION
Removed from:
- Orleans.Cluster.AdoNet
- Orleans.Persistence.AdoNet
- Orleans.Clustering.DynomoDb
- Orleans.Persistence.AzureStorage
- Orleans.Clustering.Consul
- Orleans.Clustering.ZooKeeper