### PR TITLE
Configure default application parts if no assemblies have been added

### DIFF
--- a/src/BootstrapBuild/Orleans.Core/Orleans.Core.Bootstrap.csproj
+++ b/src/BootstrapBuild/Orleans.Core/Orleans.Core.Bootstrap.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsOptionsConfigurationExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />

--- a/src/Orleans.Core.Legacy/Core/GrainClient.cs
+++ b/src/Orleans.Core.Legacy/Core/GrainClient.cs
@@ -68,7 +68,7 @@ namespace Orleans
                 throw new ArgumentException("Error loading standard client configuration file");
             }
             var orleansClient = (IInternalClusterClient)new ClientBuilder()
-                .ConfigureApplicationParts(parts => parts.AddFromAppDomain().AddFromApplicationBaseDirectory())
+                .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
                 .UseConfiguration(config)
                 .ConfigureLogging(ConfigureLoggingDelegate)
                 .Build();
@@ -111,7 +111,7 @@ namespace Orleans
                 throw new ArgumentException(string.Format("Error loading client configuration file {0}:", configFile.FullName), nameof(configFile));
             }
             var orleansClient = (IInternalClusterClient)new ClientBuilder()
-                .ConfigureApplicationParts(parts => parts.AddFromAppDomain().AddFromApplicationBaseDirectory())
+                .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
                 .UseConfiguration(config)
                 .ConfigureLogging(ConfigureLoggingDelegate)
                 .Build();
@@ -132,7 +132,7 @@ namespace Orleans
                 throw new ArgumentException("Initialize was called with null ClientConfiguration object.", nameof(config));
             }
             var orleansClient = (IInternalClusterClient)new ClientBuilder()
-                .ConfigureApplicationParts(parts => parts.AddFromAppDomain().AddFromApplicationBaseDirectory())
+                .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
                 .UseConfiguration(config)
                 .ConfigureLogging(ConfigureLoggingDelegate)
                 .Build();
@@ -168,7 +168,7 @@ namespace Orleans
             }
             config.PreferedGatewayIndex = config.Gateways.IndexOf(gatewayAddress);
             var orleansClient = (IInternalClusterClient)new ClientBuilder()
-                .ConfigureApplicationParts(parts => parts.AddFromAppDomain().AddFromApplicationBaseDirectory())
+                .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
                 .UseConfiguration(config)
                 .ConfigureLogging(ConfigureLoggingDelegate)
                 .Build();

--- a/src/Orleans.Core/Core/ClientBuilder.cs
+++ b/src/Orleans.Core/Core/ClientBuilder.cs
@@ -29,6 +29,7 @@ namespace Orleans
 
             // Configure default services and build the container.
             this.ConfigureDefaults();
+            this.ConfigureApplicationParts(parts => parts.ConfigureDefaults());
 
             var serviceProvider = this.serviceProviderBuilder.BuildServiceProvider(new HostBuilderContext(this.Properties));
             ValidateSystemConfiguration(serviceProvider);

--- a/src/Orleans.PowerShell/StartGrainClient.cs
+++ b/src/Orleans.PowerShell/StartGrainClient.cs
@@ -75,7 +75,7 @@ namespace OrleansPSUtils
                 }
 
                 this.client = builder
-                    .ConfigureApplicationParts(parts => parts.AddFromAppDomain())
+                    .ConfigureApplicationParts(parts => parts.ConfigureDefaults())
                     .Build();
                 this.client.Connect().GetAwaiter().GetResult();
                 this.SetClient(this.client);

--- a/src/Orleans.Runtime.Legacy/Hosting/SiloHost.cs
+++ b/src/Orleans.Runtime.Legacy/Hosting/SiloHost.cs
@@ -103,10 +103,7 @@ namespace Orleans.Runtime.Host
                 if (!this.ConfigLoaded) LoadOrleansConfig();
                 var builder = new SiloHostBuilder()
                     .ConfigureSiloName(this.Name)
-                    .UseConfiguration(this.Config)
-                    .ConfigureApplicationParts(parts => parts
-                        .AddFromAppDomain()
-                        .AddFromApplicationBaseDirectory());
+                    .UseConfiguration(this.Config);
 
                 if (!string.IsNullOrWhiteSpace(this.Config.Defaults.StartupTypeName))
                 {

--- a/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilder.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilder.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.ApplicationParts;
 
 namespace Orleans.Hosting
 {
@@ -38,6 +40,11 @@ namespace Orleans.Hosting
             CreateHostingEnvironment();
             CreateHostBuilderContext();
             BuildAppConfiguration();
+            this.ConfigureApplicationParts(parts =>
+            {
+                // If the user has not added any application parts, add some defaults.
+                parts.ConfigureDefaults();
+            });
 
             var serviceProvider = CreateServiceProvider();
 

--- a/src/Orleans.TelemetryConsumers.Counters/OrleansPerformanceCounterInstaller.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/OrleansPerformanceCounterInstaller.cs
@@ -34,7 +34,7 @@ namespace OrleansTelemetryConsumers.Counters
             var loggerFactory = CreateDefaultLoggerFactory($"{this.GetType()}.log");
 
             var parts = new ApplicationPartManager();
-            parts.AddFromAppDomain().AddFromApplicationBaseDirectory().AddFeatureProvider(new AssemblyAttributeFeatureProvider<GrainClassFeature>());
+            parts.ConfigureDefaults().AddFeatureProvider(new AssemblyAttributeFeatureProvider<GrainClassFeature>());
             var grainClassFeature = parts.CreateAndPopulateFeature<GrainClassFeature>();
 
             CrashUtils.GrainTypes = grainClassFeature.Classes.Select(metadata => TypeUtils.GetFullName(metadata.ClassType)).ToList();

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -68,7 +68,7 @@ namespace Orleans.TestingHost
                 }
             });
 
-            AddDefaultApplicationParts(hostBuilder.GetApplicationPartManager());
+            hostBuilder.GetApplicationPartManager().ConfigureDefaults();
 
             var host = hostBuilder.Build();
             InitializeTestHooksSystemTarget(host);
@@ -95,7 +95,7 @@ namespace Orleans.TestingHost
                 TryConfigureFileLogging(configuration, services, hostName);
             });
 
-            AddDefaultApplicationParts(builder.GetApplicationPartManager());
+            builder.GetApplicationPartManager().ConfigureDefaults();
             return builder.Build();
         }
 
@@ -246,17 +246,6 @@ namespace Orleans.TestingHost
             {
                 var fileName = TestingUtils.CreateTraceFileName(name, configuration[nameof(TestClusterOptions.ClusterId)]);
                 services.AddLogging(loggingBuilder => loggingBuilder.AddFile(fileName));
-            }
-        }
-
-        private static void AddDefaultApplicationParts(IApplicationPartManager applicationPartsManager)
-        {
-            var hasApplicationParts = applicationPartsManager.ApplicationParts.OfType<AssemblyPart>()
-                .Any(part => !part.IsFrameworkAssembly);
-            if (!hasApplicationParts)
-            {
-                applicationPartsManager.AddFromAppDomain();
-                applicationPartsManager.AddFromApplicationBaseDirectory();
             }
         }
 

--- a/src/OrleansCounterControl/CounterControl.cs
+++ b/src/OrleansCounterControl/CounterControl.cs
@@ -37,8 +37,7 @@ namespace Orleans.Counter.Control
             IsRunningAsAdministrator = userPrincipal.IsInRole(WindowsBuiltInRole.Administrator);
 
             var parts = new ApplicationPartManager();
-            parts.AddFromAppDomain()
-                .AddFromApplicationBaseDirectory()
+            parts.ConfigureDefaults()
                 .AddFeatureProvider(new AssemblyAttributeFeatureProvider<GrainClassFeature>());
             var grainClassFeature = parts.CreateAndPopulateFeature<GrainClassFeature>();
 

--- a/src/OrleansManager/Program.cs
+++ b/src/OrleansManager/Program.cs
@@ -45,7 +45,6 @@ namespace OrleansManager
         private static void RunCommand(string command, string[] args)
         {
             var clientBuilder = new ClientBuilder()
-                .ConfigureApplicationParts(parts => parts.AddFromAppDomain().AddFromApplicationBaseDirectory())
                 .LoadConfiguration();
             using (client = (IInternalClusterClient)clientBuilder.Build())
             {

--- a/test/NetCore.Tests/ExceptionTests.cs
+++ b/test/NetCore.Tests/ExceptionTests.cs
@@ -27,10 +27,6 @@ namespace NetCore.Tests
             this.silo.StartAsync().GetAwaiter().GetResult();
 
             this.client = new ClientBuilder()
-                .ConfigureApplicationParts(
-                    parts => parts
-                        .AddFromApplicationBaseDirectory()
-                        .AddFromAppDomain())
                 .ConfigureApplicationParts(parts =>
                     parts.AddApplicationPart(typeof(IExceptionGrain).Assembly).WithReferences())
                 .UseConfiguration(ClientConfiguration.LocalhostSilo())

--- a/test/NonSilo.Tests/ClientBuilderTests.cs
+++ b/test/NonSilo.Tests/ClientBuilderTests.cs
@@ -38,25 +38,6 @@ namespace NonSilo.Tests
     public class ClientBuilderTests
     {
         /// <summary>
-        /// Tests that the client builder will fail if no assemblies are configured.
-        /// </summary>
-        [Fact]
-        public void ClientBuilder_AssembliesTest()
-        {
-            var builder = new ClientBuilder()
-                .ConfigureServices(services => services.AddSingleton<IGatewayListProvider, NoOpGatewaylistProvider>());
-            Assert.Throws<OrleansConfigurationException>(() => builder.Build());
-
-            // Adding an application assembly allows the builder to build successfully.
-            builder = new ClientBuilder().ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IAccountGrain).Assembly))
-                .ConfigureServices(services => services.AddSingleton<IGatewayListProvider, NoOpGatewaylistProvider>());
-            using (var client = builder.Build())
-            {
-                Assert.NotNull(client);
-            }
-        }
-
-        /// <summary>
         /// Tests that a client can be created without specifying configuration.
         /// </summary>
         [Fact]
@@ -64,10 +45,7 @@ namespace NonSilo.Tests
         {
             var builder = new ClientBuilder()
                 .ConfigureDefaults()
-                .ConfigureApplicationParts(
-                    parts => parts
-                        .AddFromApplicationBaseDirectory()
-                        .AddFromAppDomain()).ConfigureServices(RemoveConfigValidators)
+                .ConfigureServices(RemoveConfigValidators)
                 .ConfigureServices(services => services.AddSingleton<IGatewayListProvider, NoOpGatewaylistProvider>());
             using (var client = builder.Build())
             {
@@ -83,10 +61,7 @@ namespace NonSilo.Tests
         {
             var builder = new ClientBuilder()
                 .ConfigureDefaults()
-                .ConfigureApplicationParts(
-                    parts => parts
-                        .AddFromApplicationBaseDirectory()
-                        .AddFromAppDomain()).ConfigureServices(RemoveConfigValidators)
+                .ConfigureServices(RemoveConfigValidators)
                 .ConfigureServices(services => services.AddSingleton<IGatewayListProvider, NoOpGatewaylistProvider>());
             using (builder.Build())
             {
@@ -102,10 +77,7 @@ namespace NonSilo.Tests
         {
             var builder = new ClientBuilder()
                 .ConfigureDefaults()
-                .ConfigureApplicationParts(
-                    parts => parts
-                        .AddFromApplicationBaseDirectory()
-                        .AddFromAppDomain()).ConfigureServices(RemoveConfigValidators)
+                .ConfigureServices(RemoveConfigValidators)
                 .UseConfiguration(new ClientConfiguration())
                 .UseConfiguration(new ClientConfiguration());
             Assert.Throws<InvalidOperationException>(() => builder.Build());
@@ -119,10 +91,7 @@ namespace NonSilo.Tests
         {
             var builder = new ClientBuilder()
                 .ConfigureDefaults()
-                .ConfigureApplicationParts(
-                    parts => parts
-                        .AddFromApplicationBaseDirectory()
-                        .AddFromAppDomain()).ConfigureServices(RemoveConfigValidators);
+                .ConfigureServices(RemoveConfigValidators);
             Assert.Throws<ArgumentNullException>(() => builder.UseConfiguration(null));
         }
         
@@ -135,10 +104,7 @@ namespace NonSilo.Tests
         {
             var builder = new ClientBuilder()
                 .ConfigureDefaults()
-                .ConfigureApplicationParts(
-                    parts => parts
-                        .AddFromApplicationBaseDirectory()
-                        .AddFromAppDomain()).ConfigureServices(RemoveConfigValidators)
+                .ConfigureServices(RemoveConfigValidators)
                 .ConfigureServices(services => services.AddSingleton<IGatewayListProvider, NoOpGatewaylistProvider>());
 
             Assert.Throws<ArgumentNullException>(() => builder.ConfigureServices(null));

--- a/test/NonSilo.Tests/SiloHostBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloHostBuilderTests.cs
@@ -60,37 +60,12 @@ namespace NonSilo.Tests
     public class SiloHostBuilderTests
     {
         /// <summary>
-        /// Tests that the silo builder will fail if no assemblies are configured.
-        /// </summary>
-        [Fact]
-        public void SiloHostBuilder_AssembliesTest()
-        {
-            var builder = new SiloHostBuilder()
-                .ConfigureEndpoints(IPAddress.Loopback, 9999, 0)
-                .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());
-            Assert.Throws<OrleansConfigurationException>(() => builder.Build());
-
-            // Adding an application assembly allows the silo to be correctly built.
-            builder = new SiloHostBuilder()
-                .ConfigureOrleans()
-                .ConfigureEndpoints(IPAddress.Loopback, 9999, 0)
-                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IAccountGrain).Assembly))
-                .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>())
-                .ConfigureServices(RemoveConfigValidators);
-            using (var silo = builder.Build())
-            {
-                Assert.NotNull(silo);
-            }
-        }
-
-        /// <summary>
         /// Tests that a silo can be created without specifying configuration.
         /// </summary>
         [Fact]
         public void SiloHostBuilder_NoSpecifiedConfigurationTest()
         {
             var builder = new SiloHostBuilder().ConfigureOrleans()
-                .ConfigureApplicationParts(parts => parts.AddFromApplicationBaseDirectory().AddFromAppDomain())
                 .UseConfiguration(new ClusterConfiguration())
                 .ConfigureServices(RemoveConfigValidators)
                 .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());
@@ -107,7 +82,6 @@ namespace NonSilo.Tests
         public void SiloHostBuilder_DoubleBuildTest()
         {
             var builder = new SiloHostBuilder().ConfigureOrleans()
-                .ConfigureApplicationParts(parts => parts.AddFromApplicationBaseDirectory().AddFromAppDomain())
                 .UseConfiguration(new ClusterConfiguration())
                 .ConfigureServices(RemoveConfigValidators)
                 .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());
@@ -124,7 +98,6 @@ namespace NonSilo.Tests
         public void SiloHostBuilder_DoubleSpecifyConfigurationTest()
         {
             var builder = new SiloHostBuilder().ConfigureOrleans()
-                .ConfigureApplicationParts(parts => parts.AddFromApplicationBaseDirectory().AddFromAppDomain())
                 .ConfigureServices(RemoveConfigValidators)
                 .UseConfiguration(new ClusterConfiguration())
                 .UseConfiguration(new ClusterConfiguration());
@@ -138,7 +111,6 @@ namespace NonSilo.Tests
         public void SiloHostBuilder_NullConfigurationTest()
         {
             var builder = new SiloHostBuilder().ConfigureOrleans()
-                .ConfigureApplicationParts(parts => parts.AddFromApplicationBaseDirectory().AddFromAppDomain())
                 .ConfigureServices(RemoveConfigValidators);
             Assert.Throws<ArgumentNullException>(() => builder.UseConfiguration(null));
         }
@@ -150,7 +122,6 @@ namespace NonSilo.Tests
         public void SiloHostBuilder_ServiceProviderTest()
         {
             var builder = new SiloHostBuilder().ConfigureOrleans()
-                .ConfigureApplicationParts(parts => parts.AddFromApplicationBaseDirectory().AddFromAppDomain())
                 .UseConfiguration(new ClusterConfiguration())
                 .ConfigureServices(RemoveConfigValidators)
                 .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());

--- a/test/TestExtensions/SerializationTestEnvironment.cs
+++ b/test/TestExtensions/SerializationTestEnvironment.cs
@@ -17,14 +17,8 @@ namespace TestExtensions
         {
             if (config == null) config = this.DefaultConfig();
 
-            var builder = new ClientBuilder()
-                .ConfigureDefaults()
-                .ConfigureApplicationParts(
-                    parts => parts
-                        .AddFromApplicationBaseDirectory()
-                        .AddFromAppDomain());
+            var builder = new ClientBuilder().ConfigureDefaults();
             builder.UseConfiguration(config);
-            builder.ConfigureApplicationParts(parts => parts.AddFromAppDomain().AddFromApplicationBaseDirectory());
             configureClientBuilder?.Invoke(builder);
             this.Client = builder.Build();
             this.RuntimeClient = this.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();

--- a/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -312,7 +312,6 @@ namespace Tests.GeoClusterTests
                 configCustomizer?.Invoke(config);
 
                 this.InternalClient = (IInternalClusterClient) new ClientBuilder()
-                    .ConfigureApplicationParts(parts => parts.AddFromAppDomain().AddFromApplicationBaseDirectory())
                     .UseConfiguration(config)
                     .Build();
                 this.InternalClient.Connect().Wait();

--- a/test/Versions/TestVersionGrains/VersionGrainsSiloBuilderfactory.cs
+++ b/test/Versions/TestVersionGrains/VersionGrainsSiloBuilderfactory.cs
@@ -14,9 +14,7 @@ namespace TestVersionGrains
     {
         public void Configure(ISiloHostBuilder hostBuilder)
         {
-            hostBuilder
-                .ConfigureServices(this.ConfigureServices)
-                .ConfigureApplicationParts(parts => parts.AddFromAppDomain().AddFromApplicationBaseDirectory());
+            hostBuilder.ConfigureServices(this.ConfigureServices);
         }
 
         private void ConfigureServices(IServiceCollection services)


### PR DESCRIPTION
* Adds `IApplicationPartManager.AddFromDependencyContext()` to add app parts from the application's deps.json file.
* Adds `IApplicationPartManager.ConfigureDefaults()` to add parts from dependency context, app domain, and application base directory if no non-framework assemblies have been added yet. Called by SiloHostBuilder and ClientBuilder just before building the container.