### PR TITLE
Sms stream provider to lifecycle

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamOptions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubStreamOptions.cs
@@ -1,8 +1,5 @@
 ﻿
 using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
-using Orleans.Runtime.Configuration;
 
 namespace Orleans.Configuration
 {

--- a/src/Orleans.Core.Legacy/Configuration/ConfigurationExtensions.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ConfigurationExtensions.cs
@@ -11,40 +11,6 @@ namespace Orleans.Runtime.Configuration
     public static class ConfigurationExtensions
     {
         /// <summary>
-        /// Adds a stream provider of type <see cref="SimpleMessageStreamProvider"/>
-        /// </summary>
-        /// <param name="config">The cluster configuration object to add provider to.</param>
-        /// <param name="providerName">The provider name.</param>
-        /// <param name="fireAndForgetDelivery">Specifies whether the producer waits for the consumer to process the event before continuing. Setting this to false is useful for troubleshooting serialization issues.</param>
-        /// <param name="optimizeForImmutableData">If set to true items transfered via the stream are always wrapped in Immutable for delivery.</param>>
-        /// <param name="pubSubType">Specifies how can grains subscribe to this stream.</param>
-        public static void AddSimpleMessageStreamProvider(this ClientConfiguration config, string providerName,
-            bool fireAndForgetDelivery = SimpleMessageStreamProvider.DEFAULT_VALUE_FIRE_AND_FORGET_DELIVERY,
-            bool optimizeForImmutableData = SimpleMessageStreamProvider.DEFAULT_VALUE_OPTIMIZE_FOR_IMMUTABLE_DATA,
-            StreamPubSubType pubSubType = SimpleMessageStreamProvider.DEFAULT_STREAM_PUBSUB_TYPE)
-        {
-            var properties = GetSimpleMessageStreamProviderConfiguration(providerName, fireAndForgetDelivery, optimizeForImmutableData, pubSubType);
-            config.RegisterStreamProvider<SimpleMessageStreamProvider>(providerName, properties);
-        }
-
-        /// <summary>
-        /// Adds a stream provider of type <see cref="SimpleMessageStreamProvider"/>
-        /// </summary>
-        /// <param name="config">The cluster configuration object to add provider to.</param>
-        /// <param name="providerName">The provider name.</param>
-        /// <param name="fireAndForgetDelivery">Specifies whether the producer waits for the consumer to process the event before continuing. Setting this to false is useful for troubleshooting serialization issues.</param>
-        /// <param name="optimizeForImmutableData">If set to true items transfered via the stream are always wrapped in Immutable for delivery.</param>
-        /// <param name="pubSubType">Specifies how can grains subscribe to this stream.</param>
-        public static void AddSimpleMessageStreamProvider(this ClusterConfiguration config, string providerName, 
-            bool fireAndForgetDelivery = SimpleMessageStreamProvider.DEFAULT_VALUE_FIRE_AND_FORGET_DELIVERY, 
-            bool optimizeForImmutableData = SimpleMessageStreamProvider.DEFAULT_VALUE_OPTIMIZE_FOR_IMMUTABLE_DATA,
-            StreamPubSubType pubSubType = SimpleMessageStreamProvider.DEFAULT_STREAM_PUBSUB_TYPE)
-        {
-            var properties = GetSimpleMessageStreamProviderConfiguration(providerName, fireAndForgetDelivery, optimizeForImmutableData, pubSubType);
-            config.Globals.RegisterStreamProvider<SimpleMessageStreamProvider>(providerName, properties);
-        }
-
-        /// <summary>
         /// Configures all cluster nodes to use the specified startup class for dependency injection.
         /// </summary>
         /// <typeparam name="TStartup">Startup type</typeparam>
@@ -58,20 +24,6 @@ namespace Orleans.Runtime.Configuration
             }
 
             config.Defaults.StartupTypeName = startupName;
-        }
-
-        private static Dictionary<string, string> GetSimpleMessageStreamProviderConfiguration(string providerName, bool fireAndForgetDelivery, bool optimizeForImmutableData, StreamPubSubType pubSubType)
-        {
-            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
-
-            var properties = new Dictionary<string, string>
-            {
-                { SimpleMessageStreamProvider.FIRE_AND_FORGET_DELIVERY, fireAndForgetDelivery.ToString() },
-                { SimpleMessageStreamProvider.OPTIMIZE_FOR_IMMUTABLE_DATA, optimizeForImmutableData.ToString() },
-                { SimpleMessageStreamProvider.STREAM_PUBSUB_TYPE, pubSubType.ToString() },
-            };
-
-            return properties;
         }
     }
 }

--- a/src/Orleans.Core/Streams/ClientStreamExtensions.cs
+++ b/src/Orleans.Core/Streams/ClientStreamExtensions.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
 using Orleans.Providers.Streams.Common;
+using Orleans.Providers.Streams.SimpleMessageStream;
 using Orleans.Runtime;
 using Orleans.Streams;
 
@@ -48,6 +49,48 @@ namespace Orleans.Hosting
             return services.AddSingletonNamedService<IStreamProvider>(name, PersistentStreamProvider.Create<TOptions>)
                            .AddSingletonNamedService<ILifecycleParticipant<IClusterClientLifecycle>>(name, (s, n) => ((PersistentStreamProvider)s.GetRequiredServiceByName<IStreamProvider>(n)).ParticipateIn<IClusterClientLifecycle>())
                            .AddSingletonNamedService<IQueueAdapterFactory>(name, adapterFactory);
+        }
+
+        /// <summary>
+        /// Configure client to use SimpleMessageProvider
+        /// </summary>
+        public static IClientBuilder AddSimpleMessageStreamProvider(this IClientBuilder builder, string name,
+            Action<SimpleMessageStreamProviderOptions> configureOptions)
+
+        {
+            return builder.ConfigureServices(services =>
+                services.AddClusterClientSimpleMessageStreamProvider(name, configureOptions));
+        }
+
+        /// <summary>
+        /// Configure client to use SimpleMessageProvider
+        /// </summary>
+        public static IClientBuilder AddSimpleMessageStreamProvider(this IClientBuilder builder, string name,
+            Action<OptionsBuilder<SimpleMessageStreamProviderOptions>> configureOptions = null)
+
+        {
+            return builder.ConfigureServices(services =>
+                services.AddClusterClientSimpleMessageStreamProvider(name, configureOptions));
+        }
+
+        /// <summary>
+        /// Configure client to use simple message stream provider
+        /// </summary>
+        public static IServiceCollection AddClusterClientSimpleMessageStreamProvider(this IServiceCollection services, string name,
+            Action<SimpleMessageStreamProviderOptions> configureOptions = null)
+        {
+            return services.AddClusterClientSimpleMessageStreamProvider(name, ob => ob.Configure(configureOptions));
+        }
+
+        /// <summary>
+        /// Configure client to use simple message provider
+        /// </summary>
+        public static IServiceCollection AddClusterClientSimpleMessageStreamProvider(this IServiceCollection services, string name,
+        Action<OptionsBuilder<SimpleMessageStreamProviderOptions>> configureOptions = null)
+        {
+            configureOptions?.Invoke(services.AddOptions<SimpleMessageStreamProviderOptions>(name));
+            return services.ConfigureNamedOptionForLogging<SimpleMessageStreamProviderOptions>(name)
+                           .AddSingletonNamedService<IStreamProvider>(name, SimpleMessageStreamProvider.Create);
         }
     }
 }

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProvider.cs
@@ -1,76 +1,49 @@
 using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.Streams.Core;
-using Microsoft.Extensions.Logging;
+using Orleans.Serialization;
+using Orleans.Configuration;
 
 namespace Orleans.Providers.Streams.SimpleMessageStream
 {
-    using Orleans.Serialization;
-
-    public class SimpleMessageStreamProvider : IStreamProvider, IProvider, IInternalStreamProvider, IStreamSubscriptionManagerRetriever
+    public class SimpleMessageStreamProvider : IInternalStreamProvider, IStreamProvider, IStreamSubscriptionManagerRetriever
     {
         public string                       Name { get; private set; }
 
         private ILogger                      logger;
         private IStreamProviderRuntime      providerRuntime;
-        private bool                        fireAndForgetDelivery;
-        private bool                        optimizeForImmutableData;
-        private StreamPubSubType            pubSubType;
-        private ProviderStateManager        stateManager = new ProviderStateManager();
         private IRuntimeClient              runtimeClient;
         private IStreamSubscriptionManager  streamSubscriptionManager;
         private ILoggerFactory              loggerFactory;
         private SerializationManager        serializationManager;
-
-        internal const string                STREAM_PUBSUB_TYPE = "PubSubType";
-        internal const string                FIRE_AND_FORGET_DELIVERY = "FireAndForgetDelivery";
-        internal const string                OPTIMIZE_FOR_IMMUTABLE_DATA = "OptimizeForImmutableData";
-        internal const StreamPubSubType      DEFAULT_STREAM_PUBSUB_TYPE = StreamPubSubType.ExplicitGrainBasedAndImplicit;
-        internal const bool DEFAULT_VALUE_FIRE_AND_FORGET_DELIVERY = false;
-        internal const bool DEFAULT_VALUE_OPTIMIZE_FOR_IMMUTABLE_DATA = true;
+        private SimpleMessageStreamProviderOptions options;
         public bool IsRewindable { get { return false; } }
 
-        public Task Init(string name, IProviderRuntime providerUtilitiesManager, IProviderConfiguration config)
+        public SimpleMessageStreamProvider(string name, SimpleMessageStreamProviderOptions options,
+            ILoggerFactory loggerFactory, IProviderRuntime providerRuntime, SerializationManager serializationManager)
         {
-            if (!stateManager.PresetState(ProviderState.Initialized)) return Task.CompletedTask;
+            this.loggerFactory = loggerFactory;
             this.Name = name;
-            providerRuntime = (IStreamProviderRuntime) providerUtilitiesManager;
-            this.runtimeClient = this.providerRuntime.ServiceProvider.GetRequiredService<IRuntimeClient>();
-            this.serializationManager = this.providerRuntime.ServiceProvider.GetRequiredService<SerializationManager>();
-            fireAndForgetDelivery = config.GetBoolProperty(FIRE_AND_FORGET_DELIVERY, DEFAULT_VALUE_FIRE_AND_FORGET_DELIVERY);
-            optimizeForImmutableData = config.GetBoolProperty(OPTIMIZE_FOR_IMMUTABLE_DATA, DEFAULT_VALUE_OPTIMIZE_FOR_IMMUTABLE_DATA);
-            
-            string pubSubTypeString;
-            pubSubType = !config.Properties.TryGetValue(STREAM_PUBSUB_TYPE, out pubSubTypeString)
-                ? DEFAULT_STREAM_PUBSUB_TYPE
-                : (StreamPubSubType)Enum.Parse(typeof(StreamPubSubType), pubSubTypeString);
-            if (pubSubType == StreamPubSubType.ExplicitGrainBasedAndImplicit 
-                || pubSubType == StreamPubSubType.ExplicitGrainBasedOnly)
+            this.logger = loggerFactory.CreateLogger($"{this.GetType().FullName}.{name}");
+            this.options = options;
+            this.providerRuntime = providerRuntime as IStreamProviderRuntime;
+            this.runtimeClient = providerRuntime.ServiceProvider.GetService<IRuntimeClient>();
+            this.serializationManager = serializationManager;
+            if (this.options.PubSubType == StreamPubSubType.ExplicitGrainBasedAndImplicit
+                || this.options.PubSubType == StreamPubSubType.ExplicitGrainBasedOnly)
             {
                 this.streamSubscriptionManager = this.providerRuntime.ServiceProvider
-                    .GetService<IStreamSubscriptionManagerAdmin>().GetStreamSubscriptionManager(StreamSubscriptionManagerType.ExplicitSubscribeOnly);
+                    .GetService<IStreamSubscriptionManagerAdmin>()
+                    .GetStreamSubscriptionManager(StreamSubscriptionManagerType.ExplicitSubscribeOnly);
             }
-            this.loggerFactory = providerRuntime.ServiceProvider.GetRequiredService<ILoggerFactory>();
-            logger = loggerFactory.CreateLogger(this.GetType().FullName);
-            logger.Info("Initialized SimpleMessageStreamProvider with name {0} and with property FireAndForgetDelivery: {1}, OptimizeForImmutableData: {2} " +
-                "and PubSubType: {3}", Name, fireAndForgetDelivery, optimizeForImmutableData, pubSubType);
-            stateManager.CommitState();
-            return Task.CompletedTask;
-        }
-
-        public Task Start()
-        {
-            if (stateManager.PresetState(ProviderState.Started)) stateManager.CommitState();
-            return Task.CompletedTask;
-        }
-
-        public Task Close()
-        {
-            if (stateManager.PresetState(ProviderState.Closed)) stateManager.CommitState();
-            return Task.CompletedTask;
+            logger.Info(
+                "Initialized SimpleMessageStreamProvider with name {0} and with property FireAndForgetDelivery: {1}, OptimizeForImmutableData: {2} " +
+                "and PubSubType: {3}", Name, this.options.FireAndForgetDelivery, this.options.OptimizeForImmutableData,
+                this.options.PubSubType);
         }
 
         public IStreamSubscriptionManager GetStreamSubscriptionManager()
@@ -89,7 +62,7 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         IInternalAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> stream)
         {
             return new SimpleMessageStreamProducer<T>((StreamImpl<T>)stream, Name, providerRuntime,
-                fireAndForgetDelivery, optimizeForImmutableData, providerRuntime.PubSub(pubSubType), IsRewindable,
+                this.options.FireAndForgetDelivery, this.options.OptimizeForImmutableData, providerRuntime.PubSub(this.options.PubSubType), IsRewindable,
                 this.serializationManager, this.loggerFactory);
         }
 
@@ -101,7 +74,12 @@ namespace Orleans.Providers.Streams.SimpleMessageStream
         private IInternalAsyncObservable<T> GetConsumerInterfaceImpl<T>(IAsyncStream<T> stream)
         {
             return new StreamConsumer<T>((StreamImpl<T>)stream, Name, providerRuntime,
-                providerRuntime.PubSub(pubSubType), this.logger, IsRewindable);
+                providerRuntime.PubSub(this.options.PubSubType), this.logger, IsRewindable);
+        }
+
+        public static IStreamProvider Create(IServiceProvider services, string name)
+        {
+            return ActivatorUtilities.CreateInstance<SimpleMessageStreamProvider>(services, name, services.GetService<IOptionsSnapshot<SimpleMessageStreamProviderOptions>>().Get(name));
         }
     }
 }

--- a/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProviderOptions.cs
+++ b/src/Orleans.Core/Streams/SimpleMessageStream/SimpleMessageStreamProviderOptions.cs
@@ -1,0 +1,17 @@
+﻿
+using Orleans.Streams;
+
+namespace Orleans.Configuration
+{
+    public class SimpleMessageStreamProviderOptions
+    {
+        public bool FireAndForgetDelivery { get; set; } = DEFAULT_VALUE_FIRE_AND_FORGET_DELIVERY;
+        public const bool DEFAULT_VALUE_FIRE_AND_FORGET_DELIVERY = false;
+
+        public bool OptimizeForImmutableData { get; set; } = DEFAULT_VALUE_OPTIMIZE_FOR_IMMUTABLE_DATA;
+        public const bool DEFAULT_VALUE_OPTIMIZE_FOR_IMMUTABLE_DATA = true;
+
+        public StreamPubSubType PubSubType { get; set; } = DEFAULT_PUBSUB_TYPE;
+        public static StreamPubSubType DEFAULT_PUBSUB_TYPE = StreamPubSubType.ExplicitGrainBasedAndImplicit;
+    }
+}

--- a/src/Orleans.Runtime.Abstractions/Hosting/StreamHostingExtensions.cs
+++ b/src/Orleans.Runtime.Abstractions/Hosting/StreamHostingExtensions.cs
@@ -6,6 +6,7 @@ using Orleans.Streams;
 using Orleans.Providers.Streams.Common;
 using Orleans.Providers;
 using Orleans.Configuration;
+using Orleans.Providers.Streams.SimpleMessageStream;
 
 namespace Orleans.Hosting
 {
@@ -50,6 +51,48 @@ namespace Orleans.Hosting
                            .AddSingletonNamedService<ILifecycleParticipant<ISiloLifecycle>>(name, (s, n) => ((PersistentStreamProvider)s.GetRequiredServiceByName<IStreamProvider>(n)).ParticipateIn<ISiloLifecycle>())
                            .AddSingletonNamedService<IQueueAdapterFactory>(name, adapterFactory)
                            .AddSingletonNamedService(name, (s, n) => s.GetServiceByName<IStreamProvider>(n) as IControllable);
+        }
+
+        /// <summary>
+        /// Configure silo to use SimpleMessageProvider
+        /// </summary>
+        public static ISiloHostBuilder AddSimpleMessageStreamProvider(this ISiloHostBuilder builder, string name,
+            Action<SimpleMessageStreamProviderOptions> configureOptions)
+
+        {
+            return builder.ConfigureServices(services =>
+                services.AddSiloSimpleMessageStreamProvider(name, configureOptions));
+        }
+
+        /// <summary>
+        /// Configure silo to use SimpleMessageProvider
+        /// </summary>
+        public static ISiloHostBuilder AddSimpleMessageStreamProvider(this ISiloHostBuilder builder, string name,
+            Action<OptionsBuilder<SimpleMessageStreamProviderOptions>> configureOptions = null)
+
+        {
+            return builder.ConfigureServices(services =>
+                services.AddSiloSimpleMessageStreamProvider(name, configureOptions));
+        }
+
+        /// <summary>
+        /// Configure silo to use simple message stream provider
+        /// </summary>
+        public static IServiceCollection AddSiloSimpleMessageStreamProvider(this IServiceCollection services, string name,
+            Action<SimpleMessageStreamProviderOptions> configureOptions = null)
+        {
+            return services.AddSiloSimpleMessageStreamProvider(name, ob => ob.Configure(configureOptions));
+        }
+
+        /// <summary>
+        /// Configure silo to use simple message provider
+        /// </summary>
+        public static IServiceCollection AddSiloSimpleMessageStreamProvider(this IServiceCollection services, string name,
+        Action<OptionsBuilder<SimpleMessageStreamProviderOptions>> configureOptions = null)
+        {
+            configureOptions?.Invoke(services.AddOptions<SimpleMessageStreamProviderOptions>(name));
+            return services.ConfigureNamedOptionForLogging<SimpleMessageStreamProviderOptions>(name)
+                           .AddSingletonNamedService<IStreamProvider>(name, SimpleMessageStreamProvider.Create);
         }
     }
 }

--- a/test/AWSUtils.Tests/Streaming/SQSStreamTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSStreamTests.cs
@@ -35,10 +35,6 @@ namespace AWSUtils.Tests.Streaming
                 //from the config files
                 options.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
 
-                options.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProvider", fireAndForgetDelivery: false);
-
-                options.ClientConfiguration.AddSimpleMessageStreamProvider("SMSProvider", fireAndForgetDelivery: false);
-
                 //previous silo creation
                 options.ClusterConfiguration.Globals.DataConnectionString = AWSTestConstants.DefaultSQSConnectionString;
                 options.ClientConfiguration.DataConnectionString = AWSTestConstants.DefaultSQSConnectionString;
@@ -66,6 +62,7 @@ namespace AWSUtils.Tests.Streaming
             public void Configure(ISiloHostBuilder hostBuilder)
             {
                 hostBuilder
+                    .AddSimpleMessageStreamProvider("SMSProvider")
                     .AddSqsStreams("SQSProvider", options =>
                     {
                         options.ConnectionString = AWSTestConstants.DefaultSQSConnectionString;
@@ -82,6 +79,7 @@ namespace AWSUtils.Tests.Streaming
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
+                    .AddSimpleMessageStreamProvider("SMSProvider")
                     .AddSqsStreams("SQSProvider", options =>
                     {
                         options.ConnectionString = AWSTestConstants.DefaultSQSConnectionString;

--- a/test/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
+++ b/test/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
@@ -31,8 +31,6 @@ namespace GoogleUtils.Tests.Streaming
             {
                 //from the config files
                 legacy.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
-                legacy.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProvider", fireAndForgetDelivery: false);
-                legacy.ClientConfiguration.AddSimpleMessageStreamProvider("SMSProvider", fireAndForgetDelivery: false);
 
                 legacy.ClusterConfiguration.Globals.RegisterStorageProvider<MemoryStorage>("PubSubStore");
             });
@@ -45,6 +43,7 @@ namespace GoogleUtils.Tests.Streaming
             public void Configure(ISiloHostBuilder hostBuilder)
             {
                 hostBuilder
+                    .AddSimpleMessageStreamProvider("SMSProvider")
                     .AddPubSubStreams<PubSubDataAdapter>(PUBSUB_STREAM_PROVIDER_NAME, options =>
                     {
                         options.ProjectId = GoogleTestUtils.ProjectId;
@@ -60,6 +59,7 @@ namespace GoogleUtils.Tests.Streaming
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
+                    .AddSimpleMessageStreamProvider("SMSProvider")
                     .AddPubSubStreams<PubSubDataAdapter>(PUBSUB_STREAM_PROVIDER_NAME, options =>
                     {
                         options.ProjectId = GoogleTestUtils.ProjectId;

--- a/test/Tester/GrainCallFilterTests.cs
+++ b/test/Tester/GrainCallFilterTests.cs
@@ -32,9 +32,24 @@ namespace UnitTests.General
                 {
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("Default");
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProvider");
-                    legacy.ClientConfiguration.AddSimpleMessageStreamProvider("SMSProvider");
                 });
+                builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+            }
+
+            public class SiloConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.AddSimpleMessageStreamProvider("SMSProvider");
+                }
+            }
+            public class ClientConfiguretor : IClientBuilderConfigurator
+            {
+                public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+                {
+                    clientBuilder.AddSimpleMessageStreamProvider("SMSProvider");
+                }
             }
 
             private class SiloInvokerTestSiloBuilderConfigurator : ISiloBuilderConfigurator

--- a/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestSMSStreamProvider.cs
+++ b/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestSMSStreamProvider.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Hosting;
 using Orleans.Runtime.Configuration;
 using Orleans.Streams;
 using Orleans.TestingHost;
@@ -23,15 +26,17 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
                 {
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("Default");
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamProviderName,
-                        false,
-                        true,
-                        StreamPubSubType.ExplicitGrainBasedAndImplicit);
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamProviderName2,
-                        false,
-                        true,
-                        StreamPubSubType.ExplicitGrainBasedOnly);
                 });
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+            }
+        }
+
+        public class SiloConfigurator : ISiloBuilderConfigurator
+        {
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder.AddSimpleMessageStreamProvider(StreamProviderName);
+                hostBuilder.AddSimpleMessageStreamProvider(StreamProviderName2, options => options.PubSubType = StreamPubSubType.ExplicitGrainBasedOnly);
             }
         }
 

--- a/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestsWithImplicitSubscrbingGrains.cs
+++ b/test/Tester/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestsWithImplicitSubscrbingGrains.cs
@@ -3,6 +3,9 @@ using Orleans.Streams;
 using Orleans.TestingHost;
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Hosting;
 using TestExtensions;
 using Xunit;
 using UnitTests.Grains.ProgrammaticSubscribe;
@@ -22,17 +25,28 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
                 {
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("Default");
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamProviderName,
-                        false,
-                        true,
-                        StreamPubSubType.ImplicitOnly);
-                    legacy.ClientConfiguration.AddSimpleMessageStreamProvider(StreamProviderName,
-                        false,
-                        true,
-                        StreamPubSubType.ImplicitOnly);
                 });
+                builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
             }
         }
+
+        public class SiloConfigurator : ISiloBuilderConfigurator
+        {
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder.AddSimpleMessageStreamProvider(StreamProviderName,options => options.PubSubType = StreamPubSubType.ImplicitOnly);
+            }
+        }
+
+        public class ClientConfiguretor : IClientBuilderConfigurator
+        {
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+            {
+                clientBuilder.AddSimpleMessageStreamProvider(StreamProviderName, options => options.PubSubType = StreamPubSubType.ImplicitOnly);
+            }
+        }
+
 
         public ProgrammaticSubscribeTestsWithImplicitSubscrbingGrains(Fixture fixture)
         {

--- a/test/Tester/StreamingTests/SMSClientStreamTests.cs
+++ b/test/Tester/StreamingTests/SMSClientStreamTests.cs
@@ -1,6 +1,9 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
@@ -30,11 +33,25 @@ namespace Tester.StreamingTests
             builder.ConfigureLegacyConfiguration(legacy =>
             {
                 legacy.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
-                legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(SMSStreamProviderName);
                 legacy.ClusterConfiguration.Globals.ClientDropTimeout = TimeSpan.FromSeconds(5);
-
-                legacy.ClientConfiguration.AddSimpleMessageStreamProvider(SMSStreamProviderName);
             });
+            builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+            builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        }
+
+        public class SiloConfigurator : ISiloBuilderConfigurator
+        {
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder.AddSimpleMessageStreamProvider(SMSStreamProviderName);
+            }
+        }
+        public class ClientConfiguretor : IClientBuilderConfigurator
+        {
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+            {
+                clientBuilder.AddSimpleMessageStreamProvider(SMSStreamProviderName);
+            }
         }
 
         [Fact, TestCategory("SlowBVT"), TestCategory("Functional"), TestCategory("Streaming")]

--- a/test/Tester/StreamingTests/SMSDeactivationTests.cs
+++ b/test/Tester/StreamingTests/SMSDeactivationTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Orleans;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
@@ -30,9 +32,24 @@ namespace UnitTests.StreamingTests
                 legacy.ClusterConfiguration.Globals.ResponseTimeout = TimeSpan.FromMinutes(30);
 
                 legacy.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
-                legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
-                legacy.ClientConfiguration.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
             });
+            builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+            builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        }
+
+        public class SiloConfigurator : ISiloBuilderConfigurator
+        {
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
+            }
+        }
+        public class ClientConfiguretor : IClientBuilderConfigurator
+        {
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+            {
+                clientBuilder.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
+            }
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]

--- a/test/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
+++ b/test/Tester/StreamingTests/SMSSubscriptionMultiplicityTests.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
@@ -10,18 +13,33 @@ namespace UnitTests.StreamingTests
 {
     public class SMSSubscriptionMultiplicityTests : OrleansTestingBase, IClassFixture<SMSSubscriptionMultiplicityTests.Fixture>
     {
+       
         public class Fixture : BaseTestClusterFixture
         {
-            public const string StreamProvider = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
 
+            public const string StreamProvider = StreamTestsConstants.SMS_STREAM_PROVIDER_NAME;
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamProvider);
-                    legacy.ClientConfiguration.AddSimpleMessageStreamProvider(StreamProvider);
                 });
+                builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+            }
+            public class SiloConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.AddSimpleMessageStreamProvider(StreamProvider);
+                }
+            }
+            public class ClientConfiguretor : IClientBuilderConfigurator
+            {
+                public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+                {
+                    clientBuilder.AddSimpleMessageStreamProvider(StreamProvider);
+                }
             }
         }
 

--- a/test/Tester/StreamingTests/SampleStreamingTests.cs
+++ b/test/Tester/StreamingTests/SampleStreamingTests.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Streams;
@@ -27,10 +30,24 @@ namespace UnitTests.StreamingTests
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
-
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamProvider, false);
-                    legacy.ClientConfiguration.AddSimpleMessageStreamProvider(StreamProvider, false);
                 });
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+                builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+            }
+
+            public class SiloConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.AddSimpleMessageStreamProvider(StreamProvider);
+                }
+            }
+            public class ClientConfiguretor : IClientBuilderConfigurator
+            {
+                public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+                {
+                    clientBuilder.AddSimpleMessageStreamProvider(StreamProvider);
+                }
             }
         }
 

--- a/test/Tester/StreamingTests/StreamFilteringTests_SMS.cs
+++ b/test/Tester/StreamingTests/StreamFilteringTests_SMS.cs
@@ -2,6 +2,9 @@ using System;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Hosting;
 using Xunit;
 using TestExtensions;
 using UnitTests.StreamingTests;
@@ -19,10 +22,24 @@ namespace Tester.StreamingTests
                 {
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore");
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
-
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamProvider, false);
-                    legacy.ClientConfiguration.AddSimpleMessageStreamProvider(StreamProvider, false);
                 });
+                builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+            }
+
+            public class SiloConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.AddSimpleMessageStreamProvider(StreamProvider);
+                }
+            }
+            public class ClientConfiguretor : IClientBuilderConfigurator
+            {
+                public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+                {
+                    clientBuilder.AddSimpleMessageStreamProvider(StreamProvider);
+                }
             }
         }
 

--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -30,9 +30,6 @@ namespace Tester.AzureUtils.Streaming
             builder.ConfigureLegacyConfiguration(legacy =>
             {
                 legacy.ClusterConfiguration.AddMemoryStorageProvider();
-
-                legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
-                legacy.ClientConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
             });
             builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
             builder.AddClientBuilderConfigurator<MyClientBuilderConfigurator>();
@@ -43,6 +40,7 @@ namespace Tester.AzureUtils.Streaming
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
+                    .AddSimpleMessageStreamProvider(SmsStreamProviderName)
                     .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName,
                         options =>
                         {
@@ -56,6 +54,7 @@ namespace Tester.AzureUtils.Streaming
             public void Configure(ISiloHostBuilder hostBuilder)
             {
                 hostBuilder
+                    .AddSimpleMessageStreamProvider(SmsStreamProviderName)
                     .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -34,11 +34,6 @@ namespace UnitTests.HaloTests.Streaming
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
-
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData",
-                        fireAndForgetDelivery: false,
-                        optimizeForImmutableData: false);
                 });
                 builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
             }
@@ -54,6 +49,8 @@ namespace UnitTests.HaloTests.Streaming
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.DeleteStateOnClear = true;
                         }))
+                        .AddSimpleMessageStreamProvider(SmsStreamProviderName)
+                        .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false)
                         .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();

--- a/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
@@ -39,13 +39,6 @@ namespace UnitTests.StreamingTests
             builder.ConfigureLegacyConfiguration(legacy =>
             {
                 legacy.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
-
-                legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
-                legacy.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData",
-                    fireAndForgetDelivery: false,
-                    optimizeForImmutableData: false);
-
-                legacy.ClientConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
             });
             builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
             builder.AddClientBuilderConfigurator<MyClientBuilderConfigurator>();
@@ -56,6 +49,7 @@ namespace UnitTests.StreamingTests
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
+                    .AddSimpleMessageStreamProvider(SmsStreamProviderName)
                     .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName,
                         options =>
                         {
@@ -69,6 +63,8 @@ namespace UnitTests.StreamingTests
             public void Configure(ISiloHostBuilder hostBuilder)
             {
                 hostBuilder
+                    .AddSimpleMessageStreamProvider(SmsStreamProviderName)
+                    .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false)
                     .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();

--- a/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
@@ -44,13 +44,7 @@ namespace UnitTests.StreamingTests
 
             builder.ConfigureLegacyConfiguration(legacy =>
             {
-
                 legacy.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
-
-                legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
-                legacy.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData",
-                    fireAndForgetDelivery: false,
-                    optimizeForImmutableData: false);
             });
             builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
         }
@@ -60,6 +54,8 @@ namespace UnitTests.StreamingTests
             public void Configure(ISiloHostBuilder hostBuilder)
             {
                 hostBuilder
+                    .AddSimpleMessageStreamProvider(SmsStreamProviderName)
+                    .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false)
                     .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -53,10 +53,6 @@ namespace UnitTests.Streaming.Reliability
             builder.ConfigureLegacyConfiguration(legacy =>
             {
                 legacy.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
-
-                legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(SMS_STREAM_PROVIDER_NAME, fireAndForgetDelivery: false);
-
-                legacy.ClientConfiguration.AddSimpleMessageStreamProvider(SMS_STREAM_PROVIDER_NAME, fireAndForgetDelivery: false);
             });
 
             builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
@@ -75,7 +71,8 @@ namespace UnitTests.Streaming.Reliability
                     options =>
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                    });
+                    })
+                .AddSimpleMessageStreamProvider(SMS_STREAM_PROVIDER_NAME);
             }
         }
 
@@ -94,6 +91,7 @@ namespace UnitTests.Streaming.Reliability
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
+                .AddSimpleMessageStreamProvider(SMS_STREAM_PROVIDER_NAME)
                 .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
                 {
                     options.ServiceId = silo.Value.ServiceId.ToString();

--- a/test/TesterInternal/StreamProvidersTests.cs
+++ b/test/TesterInternal/StreamProvidersTests.cs
@@ -11,6 +11,8 @@ using UnitTests.StreamingTests;
 using Xunit;
 using Xunit.Abstractions;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans.Hosting;
 using Orleans.Runtime.TestHooks;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
@@ -112,12 +114,17 @@ namespace UnitTests.Streaming
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
-
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME, fireAndForgetDelivery: false);
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData",
-                        fireAndForgetDelivery: false,
-                        optimizeForImmutableData: false);
                 });
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+            }
+
+            public class SiloConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME)
+                        .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false);
+                }
             }
         }
 

--- a/test/TesterInternal/StreamingTests/SMSStreamingTests.cs
+++ b/test/TesterInternal/StreamingTests/SMSStreamingTests.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans;
+using Orleans.Hosting;
 using Orleans.Providers;
 using Orleans.Providers.Streams.SimpleMessageStream;
 using Orleans.Runtime.Configuration;
@@ -16,7 +19,7 @@ namespace UnitTests.StreamingTests
             private static readonly Guid ServiceId = Guid.NewGuid();
             public const string AzureQueueStreamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
             public const string SmsStreamProviderName = "SMSProvider";
-
+            public const bool SMSFireAndForgetOnSilo = false;
             public ClusterConfiguration ClusterConfiguration { get; set; }
 
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
@@ -28,16 +31,32 @@ namespace UnitTests.StreamingTests
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("PubSubStore");
 
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData",
-                        fireAndForgetDelivery: false,
-                        optimizeForImmutableData: false);
-
-                    legacy.ClientConfiguration.AddSimpleMessageStreamProvider(SmsStreamProviderName, fireAndForgetDelivery: false);
-
                     legacy.ClusterConfiguration.Globals.ServiceId = ServiceId;
                     this.ClusterConfiguration = legacy.ClusterConfiguration;
                 });
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+                builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+            }
+
+            public class SiloConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    hostBuilder.AddSimpleMessageStreamProvider(SmsStreamProviderName)
+                        .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData",
+                            options =>
+                            {
+                                options.OptimizeForImmutableData = false;
+                                options.FireAndForgetDelivery = SMSFireAndForgetOnSilo;
+                            });
+                }
+            }
+            public class ClientConfiguretor : IClientBuilderConfigurator
+            {
+                public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+                {
+                    clientBuilder.AddSimpleMessageStreamProvider(SmsStreamProviderName);
+                }
             }
         }
 
@@ -48,7 +67,7 @@ namespace UnitTests.StreamingTests
         {
             runner = new SingleStreamTestRunner(fixture.HostedCluster.InternalClient, SingleStreamTestRunner.SMS_STREAM_PROVIDER_NAME);
             // runner = new SingleStreamTestRunner(SingleStreamTestRunner.SMS_STREAM_PROVIDER_NAME, 0, false);
-            fireAndForgetDeliveryProperty = ExtractFireAndForgetDeliveryProperty(fixture);
+            fireAndForgetDeliveryProperty = Fixture.SMSFireAndForgetOnSilo;
         }
 
         #region Simple Message Stream Tests
@@ -142,27 +161,6 @@ namespace UnitTests.StreamingTests
         public async Task SMS_14_SameGrain_ProducerFirstConsumerLater()
         {
             await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(!fireAndForgetDeliveryProperty);
-        }
-
-        private bool ExtractFireAndForgetDeliveryProperty(Fixture fixture)
-        {
-            ProviderCategoryConfiguration providerConfigs;
-            if (fixture.ClusterConfiguration.Globals.ProviderConfigurations.TryGetValue(ProviderCategoryConfiguration.STREAM_PROVIDER_CATEGORY_NAME, 
-                out providerConfigs))
-            {
-                IProviderConfiguration provider;
-                if (providerConfigs.Providers.TryGetValue(SingleStreamTestRunner.SMS_STREAM_PROVIDER_NAME, out provider))
-                {
-                    string fireAndForgetProperty = null;
-                    bool fireAndForget = false;
-                    if (provider.Properties.TryGetValue(SimpleMessageStreamProvider.FIRE_AND_FORGET_DELIVERY, out fireAndForgetProperty))
-                    {
-                        fireAndForget = Boolean.Parse(fireAndForgetProperty);
-                    }
-                    return fireAndForget;
-                }
-            }
-            throw new Exception("failed to get fire and forget");
         }
 
         //----------------------------------------------//

--- a/test/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
+++ b/test/TesterInternal/StreamingTests/StreamPubSubReliabilityTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Orleans;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.TestingHost;
@@ -24,17 +26,30 @@ namespace UnitTests.StreamingTests
                     legacy.ClusterConfiguration.AddMemoryStorageProvider("MemoryStore", numStorageGrains: 1);
                     legacy.ClusterConfiguration.Globals.RegisterStorageProvider<UnitTests.StorageTests.ErrorInjectionStorageProvider>(PubSubStoreProviderName);
 
-                    legacy.ClusterConfiguration.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME, fireAndForgetDelivery: false);
-
                     legacy.ClusterConfiguration.Globals.MaxResendCount = 0;
                     legacy.ClusterConfiguration.Globals.ResponseTimeout = TimeSpan.FromSeconds(30);
-
-                    legacy.ClientConfiguration.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME, fireAndForgetDelivery: false);
 
                     legacy.ClientConfiguration.ClientSenderBuckets = 8192;
                     legacy.ClientConfiguration.ResponseTimeout = TimeSpan.FromSeconds(30);
                     legacy.ClientConfiguration.MaxResendCount = 0;
                 });
+                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+                builder.AddClientBuilderConfigurator<ClientConfiguretor>();
+            }
+        }
+
+        public class SiloConfigurator : ISiloBuilderConfigurator
+        {
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
+            }
+        }
+        public class ClientConfiguretor : IClientBuilderConfigurator
+        {
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+            {
+                clientBuilder.AddSimpleMessageStreamProvider(StreamTestsConstants.SMS_STREAM_PROVIDER_NAME);
             }
         }
 


### PR DESCRIPTION

The SMS stream provider was refactored to use options and lifecycle, and is no longer an IProvider.
This work was done by @xiazen.  Published by me because it depends on my branch, and she's working on other tasks atm.

