### PR TITLE
Refactoring SiloOptions, ClientClusterOptions to ClusterOptions

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -22,12 +22,15 @@ namespace Orleans.Clustering.DynamoDB
         private readonly DynamoDBGatewayOptions options;
         private readonly TimeSpan maxStaleness;
 
-        public DynamoDBGatewayListProvider(ILoggerFactory loggerFactory, IOptions<DynamoDBGatewayOptions> options,
-            IOptions<ClusterClientOptions> clusterClientOptions, IOptions<GatewayOptions> gatewayOptions)
+        public DynamoDBGatewayListProvider(
+            ILoggerFactory loggerFactory, 
+            IOptions<DynamoDBGatewayOptions> options,
+            IOptions<ClusterOptions> clusterOptions, 
+            IOptions<GatewayOptions> gatewayOptions)
         {
             this.loggerFactory = loggerFactory;
             this.options = options.Value;
-            this.clusterId = clusterClientOptions.Value.ClusterId;
+            this.clusterId = clusterOptions.Value.ClusterId;
             this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
         }
 

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -27,14 +27,15 @@ namespace Orleans.Clustering.DynamoDB
         private readonly DynamoDBClusteringOptions options;
         private readonly string clusterId;
 
-        public DynamoDBMembershipTable(ILoggerFactory loggerFactory, 
+        public DynamoDBMembershipTable(
+            ILoggerFactory loggerFactory, 
             IOptions<DynamoDBClusteringOptions> membershipOptions, 
-            IOptions<SiloOptions> siloOptions)
+            IOptions<ClusterOptions> clusterOptions)
         {
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<DynamoDBMembershipTable>();
             this.options = membershipOptions.Value;
-            this.clusterId = siloOptions.Value.ClusterId;
+            this.clusterId = clusterOptions.Value.ClusterId;
         }
 
         public Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDBReminderTable.cs
@@ -40,14 +40,16 @@ namespace Orleans.Reminders.DynamoDB
         /// </summary>
         /// <param name="grainReferenceConverter">The grain factory.</param>
         /// <param name="loggerFactory">logger factory to use</param>
-        public DynamoDBReminderTable(IGrainReferenceConverter grainReferenceConverter, 
-            ILoggerFactory loggerFactory, IOptions<SiloOptions> siloOptions, 
+        public DynamoDBReminderTable(
+            IGrainReferenceConverter grainReferenceConverter, 
+            ILoggerFactory loggerFactory, 
+            IOptions<ClusterOptions> clusterOptions, 
             IOptions<DynamoDBReminderStorageOptions> storageOptions)
         {
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = loggerFactory.CreateLogger<DynamoDBReminderTable>();
             this.loggerFactory = loggerFactory;
-            this.serviceId = siloOptions.Value.ServiceId;
+            this.serviceId = clusterOptions.Value.ServiceId;
             this.options = storageOptions.Value;
         }
 

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
@@ -15,7 +15,7 @@ namespace OrleansAWSUtils.Streams
     {
         private readonly string providerName;
         private readonly SqsStreamOptions options;
-        private readonly SiloOptions siloOptions;
+        private readonly ClusterOptions clusterOptions;
         private readonly SerializationManager serializationManager;
         private readonly ILoggerFactory loggerFactory;
         private HashRingBasedStreamQueueMapper streamQueueMapper;
@@ -26,11 +26,17 @@ namespace OrleansAWSUtils.Streams
         /// </summary>
         protected Func<QueueId, Task<IStreamFailureHandler>> StreamFailureHandlerFactory { private get; set; }
 
-        public SQSAdapterFactory(string name, SqsStreamOptions options, IServiceProvider serviceProvider, IOptions<SiloOptions> siloOptions, SerializationManager serializationManager, ILoggerFactory loggerFactory)
+        public SQSAdapterFactory(
+            string name, 
+            SqsStreamOptions options, 
+            IServiceProvider serviceProvider, 
+            IOptions<ClusterOptions> clusterOptions, 
+            SerializationManager serializationManager, 
+            ILoggerFactory loggerFactory)
         {
             this.providerName = name;
             this.options = options;
-            this.siloOptions = siloOptions.Value;
+            this.clusterOptions = clusterOptions.Value;
             this.serializationManager = serializationManager;
             this.loggerFactory = loggerFactory;
         }
@@ -51,7 +57,7 @@ namespace OrleansAWSUtils.Streams
         /// <summary>Creates the Azure Queue based adapter.</summary>
         public virtual Task<IQueueAdapter> CreateAdapter()
         {
-            var adapter = new SQSAdapter(this.serializationManager, this.streamQueueMapper, this.loggerFactory, this.options.ConnectionString, this.options.ClusterId ?? this.siloOptions.ClusterId, this.providerName);
+            var adapter = new SQSAdapter(this.serializationManager, this.streamQueueMapper, this.loggerFactory, this.options.ConnectionString, this.options.ClusterId ?? this.clusterOptions.ClusterId, this.providerName);
             return Task.FromResult<IQueueAdapter>(adapter);
         }
 

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -14,12 +14,17 @@ namespace Orleans.Runtime.MembershipService
         private ILogger logger;
         private RelationalOrleansQueries orleansQueries;
         private readonly AdoNetClusteringSiloOptions clusteringTableOptions;
-        public AdoNetClusteringTable(IGrainReferenceConverter grainReferenceConverter, IOptions<SiloOptions> siloOptions, IOptions<AdoNetClusteringSiloOptions> clusterinOptions, ILogger<AdoNetClusteringTable> logger)
+
+        public AdoNetClusteringTable(
+            IGrainReferenceConverter grainReferenceConverter, 
+            IOptions<ClusterOptions> clusterOptions, 
+            IOptions<AdoNetClusteringSiloOptions> clusteringOptions, 
+            ILogger<AdoNetClusteringTable> logger)
         {
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = logger;
-            this.clusteringTableOptions = clusterinOptions.Value;
-            this.clusterId = siloOptions.Value.ClusterId;
+            this.clusteringTableOptions = clusteringOptions.Value;
+            this.clusterId = clusterOptions.Value.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
@@ -17,15 +17,17 @@ namespace Orleans.Runtime.Membership
         private RelationalOrleansQueries orleansQueries;
         private readonly IGrainReferenceConverter grainReferenceConverter;
         private readonly TimeSpan maxStaleness;
-        public AdoNetGatewayListProvider(ILogger<AdoNetGatewayListProvider> logger, IGrainReferenceConverter grainReferenceConverter,
+        public AdoNetGatewayListProvider(
+            ILogger<AdoNetGatewayListProvider> logger, 
+            IGrainReferenceConverter grainReferenceConverter,
             IOptions<AdoNetClusteringClientOptions> options,
             IOptions<GatewayOptions> gatewayOptions,
-            IOptions<ClusterClientOptions> clusterClientOptions)
+            IOptions<ClusterOptions> clusterOptions)
         {
             this.logger = logger;
             this.grainReferenceConverter = grainReferenceConverter;
             this.options = options.Value;
-            this.clusterId = clusterClientOptions.Value.ClusterId;
+            this.clusterId = clusterOptions.Value.ClusterId;
             this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
         }
 

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -131,13 +131,19 @@ namespace Orleans.Storage
         private AdoNetGrainStorageOptions options;
         private IProviderRuntime providerRuntime;
         private string name;
-        public AdoNetGrainStorage(ILogger<AdoNetGrainStorage> logger, IProviderRuntime providerRuntime, IOptions<AdoNetGrainStorageOptions> options, IOptions<SiloOptions> siloOptions, string name)
+
+        public AdoNetGrainStorage(
+            ILogger<AdoNetGrainStorage> logger, 
+            IProviderRuntime providerRuntime, 
+            IOptions<AdoNetGrainStorageOptions> options, 
+            IOptions<ClusterOptions> clusterOptions, 
+            string name)
         {
             this.options = options.Value;
             this.providerRuntime = providerRuntime;
             this.name = name;
             this.logger = logger;
-            this.serviceId = siloOptions.Value.ServiceId.ToString();
+            this.serviceId = clusterOptions.Value.ServiceId.ToString();
         }
 
         public void Participate(ISiloLifecycle lifecycle)

--- a/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTable.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTable.cs
@@ -12,10 +12,13 @@ namespace Orleans.Runtime.ReminderService
         private string serviceId;
         private RelationalOrleansQueries orleansQueries;
 
-        public AdoNetReminderTable(IGrainReferenceConverter grainReferenceConverter, IOptions<SiloOptions> siloOptions, IOptions<AdoNetReminderTableOptions> storageOptions)
+        public AdoNetReminderTable(
+            IGrainReferenceConverter grainReferenceConverter, 
+            IOptions<ClusterOptions> clusterOptions, 
+            IOptions<AdoNetReminderTableOptions> storageOptions)
         {
             this.grainReferenceConverter = grainReferenceConverter;
-            this.serviceId = siloOptions.Value.ServiceId.ToString();
+            this.serviceId = clusterOptions.Value.ServiceId.ToString();
             this.options = storageOptions.Value;
         }
 

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -23,12 +23,16 @@ namespace Orleans.Runtime.MembershipService
         private OrleansSiloInstanceManager tableManager;
         private readonly AzureStorageClusteringOptions options;
         private readonly string clusterId;
-        public AzureBasedMembershipTable(ILoggerFactory loggerFactory, IOptions<AzureStorageClusteringOptions> membershipOptions, IOptions<SiloOptions> siloOptions)
+
+        public AzureBasedMembershipTable(
+            ILoggerFactory loggerFactory, 
+            IOptions<AzureStorageClusteringOptions> membershipOptions, 
+            IOptions<ClusterOptions> clusterOptions)
         {
             this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<AzureBasedMembershipTable>();
             this.options = membershipOptions.Value;
-            this.clusterId = siloOptions.Value.ClusterId;
+            this.clusterId = clusterOptions.Value.ClusterId;
         }
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureGatewayListProvider.cs
@@ -16,10 +16,10 @@ namespace Orleans.AzureUtils
         private readonly ILoggerFactory loggerFactory;
         private readonly TimeSpan maxStaleness;
 
-        public AzureGatewayListProvider(ILoggerFactory loggerFactory, IOptions<AzureStorageGatewayOptions> options, IOptions<ClusterClientOptions> clusterClientOptions, IOptions<GatewayOptions> gatewayOptions)
+        public AzureGatewayListProvider(ILoggerFactory loggerFactory, IOptions<AzureStorageGatewayOptions> options, IOptions<ClusterOptions> clusterOptions, IOptions<GatewayOptions> gatewayOptions)
         {
             this.loggerFactory = loggerFactory;
-            this.clusterId = clusterClientOptions.Value.ClusterId;
+            this.clusterId = clusterOptions.Value.ClusterId;
             this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
             this.options = options.Value;
         }

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -13,22 +13,26 @@ namespace Orleans.Runtime.ReminderService
         private readonly IGrainReferenceConverter grainReferenceConverter;
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
-        private readonly SiloOptions siloOptions;
+        private readonly ClusterOptions clusterOptions;
         private readonly AzureTableReminderStorageOptions storageOptions;
         private RemindersTableManager remTableManager;
 
-        public AzureBasedReminderTable(IGrainReferenceConverter grainReferenceConverter, ILoggerFactory loggerFactory, IOptions<SiloOptions> siloOptions, IOptions<AzureTableReminderStorageOptions> storageOptions)
+        public AzureBasedReminderTable(
+            IGrainReferenceConverter grainReferenceConverter, 
+            ILoggerFactory loggerFactory, 
+            IOptions<ClusterOptions> clusterOptions, 
+            IOptions<AzureTableReminderStorageOptions> storageOptions)
         {
             this.grainReferenceConverter = grainReferenceConverter;
             this.logger = loggerFactory.CreateLogger<AzureBasedReminderTable>();
             this.loggerFactory = loggerFactory;
-            this.siloOptions = siloOptions.Value;
+            this.clusterOptions = clusterOptions.Value;
             this.storageOptions = storageOptions.Value;
         }
 
         public async Task Init()
         {
-            this.remTableManager = await RemindersTableManager.GetManager(this.siloOptions.ServiceId, this.siloOptions.ClusterId, this.storageOptions.ConnectionString, this.loggerFactory);
+            this.remTableManager = await RemindersTableManager.GetManager(this.clusterOptions.ServiceId, this.clusterOptions.ClusterId, this.storageOptions.ConnectionString, this.loggerFactory);
         }
 
         #region Utility methods

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -16,7 +16,7 @@ namespace Orleans.Providers.Streams.AzureQueue
     {
         private readonly string providerName;
         private readonly AzureQueueStreamOptions options;
-        private readonly SiloOptions siloOptions;
+        private readonly ClusterOptions clusterOptions;
         private readonly ILoggerFactory loggerFactory;
         private readonly Func<TDataAdapter> dataAadaptorFactory;
         private HashRingBasedStreamQueueMapper streamQueueMapper;
@@ -36,13 +36,13 @@ namespace Orleans.Providers.Streams.AzureQueue
             string name, 
             AzureQueueStreamOptions options, 
             IServiceProvider serviceProvider, 
-            IOptions<SiloOptions> siloOptions, 
+            IOptions<ClusterOptions> clusterOptions, 
             SerializationManager serializationManager, 
             ILoggerFactory loggerFactory)
         {
             this.providerName = name;
             this.options = options ?? throw new ArgumentNullException(nameof(options));
-            this.siloOptions = siloOptions.Value;
+            this.clusterOptions = clusterOptions.Value;
             this.SerializationManager = serializationManager ?? throw new ArgumentNullException(nameof(serializationManager));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.dataAadaptorFactory = () => ActivatorUtilities.GetServiceOrCreateInstance<TDataAdapter>(serviceProvider);
@@ -66,7 +66,7 @@ namespace Orleans.Providers.Streams.AzureQueue
                 this.streamQueueMapper, 
                 this.loggerFactory, 
                 this.options.ConnectionString, 
-                this.options.ClusterId ?? this.siloOptions.ClusterId, 
+                this.options.ClusterId ?? this.clusterOptions.ClusterId, 
                 this.providerName, 
                 this.options.MessageVisibilityTimeout);
             return Task.FromResult<IQueueAdapter>(adapter);

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -32,7 +32,13 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// </summary>
         protected Func<QueueId, Task<IStreamFailureHandler>> StreamFailureHandlerFactory { private get; set; }
 
-        public AzureQueueAdapterFactory(string name, AzureQueueStreamOptions options, IServiceProvider serviceProvider, IOptions<SiloOptions> siloOptions, SerializationManager serializationManager, ILoggerFactory loggerFactory)
+        public AzureQueueAdapterFactory(
+            string name, 
+            AzureQueueStreamOptions options, 
+            IServiceProvider serviceProvider, 
+            IOptions<SiloOptions> siloOptions, 
+            SerializationManager serializationManager, 
+            ILoggerFactory loggerFactory)
         {
             this.providerName = name;
             this.options = options ?? throw new ArgumentNullException(nameof(options));
@@ -54,7 +60,15 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <summary>Creates the Azure Queue based adapter.</summary>
         public virtual Task<IQueueAdapter> CreateAdapter()
         {
-            var adapter = new AzureQueueAdapter<TDataAdapter>(this.dataAadaptorFactory(), this.SerializationManager, this.streamQueueMapper, this.loggerFactory, this.options.ConnectionString, this.options.ClusterId ?? this.siloOptions.ClusterId, this.providerName, this.options.MessageVisibilityTimeout);
+            var adapter = new AzureQueueAdapter<TDataAdapter>(
+                this.dataAadaptorFactory(), 
+                this.SerializationManager, 
+                this.streamQueueMapper, 
+                this.loggerFactory, 
+                this.options.ConnectionString, 
+                this.options.ClusterId ?? this.siloOptions.ClusterId, 
+                this.providerName, 
+                this.options.MessageVisibilityTimeout);
             return Task.FromResult<IQueueAdapter>(adapter);
         }
 

--- a/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.Consul/ConsulBasedMembershipTable.cs
@@ -23,10 +23,12 @@ namespace Orleans.Runtime.Membership
         private readonly ConsulClusteringSiloOptions clusteringSiloTableOptions;
         private readonly string clusterId;
 
-        public ConsulBasedMembershipTable(ILogger<ConsulBasedMembershipTable> logger,
-            IOptions<ConsulClusteringSiloOptions> membershipTableOptions, IOptions<SiloOptions> siloOptions)
+        public ConsulBasedMembershipTable(
+            ILogger<ConsulBasedMembershipTable> logger,
+            IOptions<ConsulClusteringSiloOptions> membershipTableOptions, 
+            IOptions<ClusterOptions> clusterOptions)
         {
-            this.clusterId = siloOptions.Value.ClusterId;
+            this.clusterId = clusterOptions.Value.ClusterId;
             this._logger = logger;
             this.clusteringSiloTableOptions = membershipTableOptions.Value;
             _consulClient =

--- a/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Consul/ConsulGatewayListProvider.cs
@@ -18,10 +18,15 @@ namespace Orleans.Runtime.Membership
         private ILogger logger;
         private readonly ConsulClusteringClientOptions options;
         private readonly TimeSpan maxStaleness;
-        public ConsulGatewayListProvider(ILogger<ConsulGatewayListProvider> logger, IOptions<ConsulClusteringClientOptions> options, IOptions<GatewayOptions> gatewayOptions, IOptions<ClusterClientOptions> clusterClientOptions)
+
+        public ConsulGatewayListProvider(
+            ILogger<ConsulGatewayListProvider> logger, 
+            IOptions<ConsulClusteringClientOptions> options, 
+            IOptions<GatewayOptions> gatewayOptions, 
+            IOptions<ClusterOptions> clusterOptions)
         {
             this.logger = logger;
-            this.clusterId = clusterClientOptions.Value.ClusterId;
+            this.clusterId = clusterOptions.Value.ClusterId;
             this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
             this.options = options.Value;
         }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -56,12 +56,15 @@ namespace Orleans.Runtime.Membership
         /// </summary>
         private string rootConnectionString;
         
-        public ZooKeeperBasedMembershipTable(ILogger<ZooKeeperBasedMembershipTable> logger, IOptions<ZooKeeperClusteringSiloOptions> membershipTableOptions, IOptions<SiloOptions> siloOptions)
+        public ZooKeeperBasedMembershipTable(
+            ILogger<ZooKeeperBasedMembershipTable> logger, 
+            IOptions<ZooKeeperClusteringSiloOptions> membershipTableOptions, 
+            IOptions<ClusterOptions> clusterOptions)
         {
             this.logger = logger;
             var options = membershipTableOptions.Value;
             watcher = new ZooKeeperWatcher(logger);
-            InitConfig(options.ConnectionString, siloOptions.Value.ClusterId);
+            InitConfig(options.ConnectionString, clusterOptions.Value.ClusterId);
         }
 
         /// <summary>

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperClusteringClientOptions.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperClusteringClientOptions.cs
@@ -23,14 +23,15 @@ namespace Orleans.Runtime.Membership
         /// </summary>
         private string deploymentConnectionString;
         private TimeSpan maxStaleness;
-        public ZooKeeperClusteringClientOptions(ILogger<ZooKeeperClusteringClientOptions> logger,
+        public ZooKeeperClusteringClientOptions(
+            ILogger<ZooKeeperClusteringClientOptions> logger,
             IOptions<ZooKeeperGatewayListProviderOptions> options,
             IOptions<GatewayOptions> gatewayOptions,
-            IOptions<ClusterClientOptions> clusterClientOptions)
+            IOptions<ClusterOptions> clusterOptions)
         {
             watcher = new ZooKeeperWatcher(logger);
 
-            deploymentPath = "/" + clusterClientOptions.Value.ClusterId;
+            deploymentPath = "/" + clusterOptions.Value.ClusterId;
             deploymentConnectionString = options.Value.ConnectionString + deploymentPath;
             maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
         }

--- a/src/Orleans.Core.Legacy/Configuration/LegacyConfigurationExtensions.cs
+++ b/src/Orleans.Core.Legacy/Configuration/LegacyConfigurationExtensions.cs
@@ -34,7 +34,7 @@ namespace Orleans.Configuration
             services.TryAddSingleton(configuration);
             services.TryAddFromExisting<IMessagingConfiguration, ClientConfiguration>();
 
-            services.Configure<ClusterClientOptions>(options =>
+            services.Configure<ClusterOptions>(options =>
             {
                 if (string.IsNullOrWhiteSpace(options.ClusterId) && !string.IsNullOrWhiteSpace(configuration.ClusterId))
                 {

--- a/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
@@ -4,9 +4,9 @@ using Microsoft.Extensions.Options;
 namespace Orleans.Configuration
 {
     /// <summary>
-    /// Configures the Orleans cluster client.
+    /// Configures the Orleans cluster.
     /// </summary>
-    public class ClusterClientOptions
+    public class ClusterOptions
     {
         /// <summary>
         /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.

--- a/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
@@ -1,5 +1,4 @@
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
+using System;
 
 namespace Orleans.Configuration
 {
@@ -12,5 +11,10 @@ namespace Orleans.Configuration
         /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
         /// </summary>
         public string ClusterId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment, where as <see cref="ClusterId"/> might not.
+        /// </summary>
+        public Guid ServiceId { get; set; }
     }
 }

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -152,34 +152,34 @@ namespace Orleans
         }
 
         /// <summary>
-        /// Configures the cluster client general options.
+        /// Configures the cluster general options.
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="configureOptions">The delegate that configures the options.</param>
         /// <returns>The same instance of the <see cref="IClientBuilder"/> for chaining.</returns>
-        public static IClientBuilder ConfigureClusterClient(this IClientBuilder builder, Action<ClusterClientOptions> configureOptions)
+        public static IClientBuilder ConfigureCluster(this IClientBuilder builder, Action<ClusterOptions> configureOptions)
         {
             if (configureOptions != null)
             {
-                builder.ConfigureServices(services => services.Configure<ClusterClientOptions>(configureOptions));
+                builder.ConfigureServices(services => services.Configure<ClusterOptions>(configureOptions));
             }
 
             return builder;
         }
 
         /// <summary>
-        /// Configures the cluster client general options.
+        /// Configures the cluster general options.
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="configureOptions">The delegate that configures the options using the options builder.</param>
         /// <returns>The same instance of the <see cref="IClientBuilder"/> for chaining.</returns>
-        public static IClientBuilder ConfigureClusterClient(this IClientBuilder builder, Action<OptionsBuilder<ClusterClientOptions>> configureOptions)
+        public static IClientBuilder ConfigureCluster(this IClientBuilder builder, Action<OptionsBuilder<ClusterOptions>> configureOptions)
         {
             if (configureOptions != null)
             {
                 builder.ConfigureServices(services =>
                 {
-                    configureOptions.Invoke(services.AddOptions<ClusterClientOptions>());
+                    configureOptions.Invoke(services.AddOptions<ClusterOptions>());
                 });
             }
 

--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -70,7 +70,7 @@ namespace Orleans
             services.TryAddSingleton(typeof(IKeyedServiceCollection<,>), typeof(KeyedServiceCollection<,>));
 
             // Add default option formatter if none is configured, for options which are requied to be configured 
-            services.ConfigureFormatter<ClusterClientOptions>();
+            services.ConfigureFormatter<ClusterOptions>();
             services.ConfigureFormatter<ClientMessagingOptions>();
             services.ConfigureFormatter<NetworkingOptions>();
             services.ConfigureFormatter<ClientStatisticsOptions>();

--- a/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
+++ b/src/Orleans.Runtime.Abstractions/Silo/SiloOptions.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
-
 namespace Orleans.Configuration
 {
     /// <summary>
@@ -13,15 +9,5 @@ namespace Orleans.Configuration
         /// Gets or sets the silo name.
         /// </summary>
         public string SiloName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
-        /// </summary>
-        public string ClusterId { get; set; }
-
-        /// <summary>
-        /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment, where as <see cref="ClusterId"/> might not.
-        /// </summary>
-        public Guid ServiceId { get; set; }
     }
 }

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
@@ -77,7 +77,7 @@ namespace Orleans.Hosting
                     return () => initializationParams.NodeConfig;
                 });
 
-            services.Configure<SiloOptions>(options =>
+            services.Configure<ClusterOptions>(options =>
             {
                 if (string.IsNullOrWhiteSpace(options.ClusterId) && !string.IsNullOrWhiteSpace(configuration.Globals.ClusterId))
                 {

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -13,8 +13,9 @@ namespace Orleans.Runtime
         private readonly ISiloRuntimeClient runtimeClient;
         private readonly ILoggerFactory loggerFactory;
         private readonly ILogger logger;
+
         public GrainRuntime(
-            IOptions<SiloOptions> siloOptions,
+            IOptions<ClusterOptions> clusterOptions,
             ILocalSiloDetails localSiloDetails,
             IGrainFactory grainFactory,
             ITimerRegistry timerRegistry,
@@ -25,7 +26,7 @@ namespace Orleans.Runtime
         {
             this.logger = loggerFactory.CreateLogger<GrainRuntime>();
             this.runtimeClient = runtimeClient;
-            ServiceId = siloOptions.Value.ServiceId;
+            ServiceId = clusterOptions.Value.ServiceId;
             SiloAddress = localSiloDetails.SiloAddress;
             SiloIdentity = SiloAddress.ToLongString();
             GrainFactory = grainFactory;

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -19,22 +19,35 @@ namespace Orleans.Hosting
         /// <param name="builder">The host builder.</param>
         /// <param name="configureOptions">The delegate that configures the options.</param>
         /// <returns>The host builder.</returns>
-        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, Action<SiloOptions> configureOptions)
+        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, Action<ClusterOptions> configureOptions)
         {
-            var optionsConfigurator = configureOptions != null
-                ? ob => ob.Configure(configureOptions)
-                : default(Action<OptionsBuilder<SiloOptions>>);
-
-            return builder.ConfigureOrleans(optionsConfigurator);
+            return builder.ConfigureOrleans(null, configureOptions);
         }
 
         /// <summary>
         /// Configure the container to use Orleans, including the default silo name & services.
         /// </summary>
         /// <param name="builder">The host builder.</param>
+        /// <param name="siloName">The name to use for this silo</param>
+        /// <param name="configureOptions">The delegate that configures the options.</param>
+        /// <returns>The host builder.</returns>
+        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, string siloName, Action<ClusterOptions> configureOptions)
+        {
+            var optionsConfigurator = configureOptions != null
+                ? ob => ob.Configure(configureOptions)
+                : default(Action<OptionsBuilder<ClusterOptions>>);
+
+            return builder.ConfigureOrleans(siloName, optionsConfigurator);
+        }
+
+        /// <summary>
+        /// Configure the container to use Orleans, including the default silo name & services.
+        /// </summary>
+        /// <param name="builder">The host builder.</param>
+        /// <param name="siloName">The name to use for this silo</param>
         /// <param name="configureOptions">The delegate that configures the options using the options builder.</param>
         /// <returns>The host builder.</returns>
-        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, Action<OptionsBuilder<SiloOptions>> configureOptions = null)
+        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, string siloName, Action<OptionsBuilder<ClusterOptions>> configureOptions = null)
         {
             builder.ConfigureServices((context, services) =>
             {
@@ -50,9 +63,23 @@ namespace Orleans.Hosting
                     context.Properties.Add("OrleansServicesAdded", true);
                 }
 
-                configureOptions?.Invoke(services.AddOptions<SiloOptions>());
+                if (!string.IsNullOrEmpty(siloName))
+                    builder.ConfigureSiloName(siloName);
+
+                configureOptions?.Invoke(services.AddOptions<ClusterOptions>());
             });
             return builder;
+        }
+
+        /// <summary>
+        /// Configure the container to use Orleans, including the default silo name & services.
+        /// </summary>
+        /// <param name="builder">The host builder.</param>
+        /// <param name="configureOptions">The delegate that configures the options using the options builder.</param>
+        /// <returns>The host builder.</returns>
+        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, Action<OptionsBuilder<ClusterOptions>> configureOptions = null)
+        {
+            return builder.ConfigureOrleans(null, configureOptions);
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterGossipChannelFactory.cs
+++ b/src/Orleans.Runtime/MultiClusterNetwork/MultiClusterGossipChannelFactory.cs
@@ -9,14 +9,18 @@ namespace Orleans.Runtime.MultiClusterNetwork
 {
     internal class MultiClusterGossipChannelFactory
     {
-        private readonly SiloOptions siloOptions;
+        private readonly ClusterOptions clusterOptions;
         private readonly MultiClusterOptions multiClusterOptions;
         private readonly IServiceProvider serviceProvider;
         private readonly ILogger logger;
 
-        public MultiClusterGossipChannelFactory(IOptions<SiloOptions> siloOptions, IOptions<MultiClusterOptions> multiClusterOptions, IServiceProvider serviceProvider, ILogger<MultiClusterGossipChannelFactory> logger)
+        public MultiClusterGossipChannelFactory(
+            IOptions<ClusterOptions> clusterOptions,
+            IOptions<MultiClusterOptions> multiClusterOptions, 
+            IServiceProvider serviceProvider, 
+            ILogger<MultiClusterGossipChannelFactory> logger)
         {
-            this.siloOptions = siloOptions.Value;
+            this.clusterOptions = clusterOptions.Value;
             this.multiClusterOptions = multiClusterOptions.Value;
             this.serviceProvider = serviceProvider;
             this.logger = logger;
@@ -35,7 +39,7 @@ namespace Orleans.Runtime.MultiClusterNetwork
                     {
                         case MultiClusterOptions.BuiltIn.AzureTable:
                             var tableChannel = AssemblyLoader.LoadAndCreateInstance<IGossipChannel>(Constants.ORLEANS_CLUSTERING_AZURESTORAGE, logger, this.serviceProvider);
-                            await tableChannel.Initialize(this.siloOptions.ServiceId, channelConfig.Value);
+                            await tableChannel.Initialize(this.clusterOptions.ServiceId, channelConfig.Value);
                             gossipChannels.Add(tableChannel);
                             break;
 

--- a/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
+++ b/src/Orleans.Runtime/Silo/LocalSiloDetails.cs
@@ -12,11 +12,11 @@ namespace Orleans.Runtime
 
         public LocalSiloDetails(
             IOptions<SiloOptions> siloOptions,
+            IOptions<ClusterOptions> clusterOptions,
             IOptions<EndpointOptions> siloEndpointOptions)
         {
-            var options = siloOptions.Value;
-            this.Name = options.SiloName;
-            this.ClusterId = options.ClusterId;
+            this.Name = siloOptions.Value.SiloName;
+            this.ClusterId = clusterOptions.Value.ClusterId;
             this.DnsHostName = Dns.GetHostName();
 
             var endpointOptions = siloEndpointOptions.Value;

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -54,6 +54,7 @@ namespace Orleans.Runtime
 
         private readonly ILocalSiloDetails siloDetails;
         private readonly SiloOptions siloOptions;
+        private readonly ClusterOptions clusterOptions;
         private readonly ISiloMessageCenter messageCenter;
         private readonly OrleansTaskScheduler scheduler;
         private readonly LocalGrainDirectory localGrainDirectory;
@@ -217,6 +218,7 @@ namespace Orleans.Runtime
 
             membershipOracle = Services.GetRequiredService<IMembershipOracle>();
             this.siloOptions = Services.GetRequiredService<IOptions<SiloOptions>>().Value;
+            this.clusterOptions = Services.GetRequiredService<IOptions<ClusterOptions>>().Value;
             var multiClusterOptions = Services.GetRequiredService<IOptions<MultiClusterOptions>>().Value;
 
             if (!multiClusterOptions.HasMultiClusterNetwork)
@@ -497,7 +499,7 @@ namespace Orleans.Runtime
                 async Task StartMultiClusterOracle()
                 {
                     logger.Info("Starting multicluster oracle with my ServiceId={0} and ClusterId={1}.",
-                        this.siloOptions.ServiceId, this.siloOptions.ClusterId);
+                        this.clusterOptions.ServiceId, this.clusterOptions.ClusterId);
 
                     this.multiClusterOracleContext = (multiClusterOracle as SystemTarget)?.SchedulingContext ??
                                                      this.fallbackScheduler.SchedulingContext;

--- a/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
+++ b/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
@@ -33,7 +33,7 @@ namespace Orleans.Runtime.Providers
 
         public SiloProviderRuntime(
             ILocalSiloDetails siloDetails,
-            IOptions<SiloOptions> siloOptions,
+            IOptions<ClusterOptions> clusterOptions,
             IConsistentRingProvider consistentRingProvider,
             ISiloRuntimeClient runtimeClient,
             ImplicitStreamSubscriberTable implicitStreamSubscriberTable,
@@ -48,7 +48,7 @@ namespace Orleans.Runtime.Providers
             this.activationDirectory = activationDirectory;
             this.consistentRingProvider = consistentRingProvider;
             this.runtimeClient = runtimeClient;
-            this.ServiceId = siloOptions.Value.ServiceId;
+            this.ServiceId = clusterOptions.Value.ServiceId;
             this.SiloIdentity = siloDetails.SiloAddress.ToLongString();
 
             this.grainBasedPubSub = new GrainBasedPubSubRuntime(this.GrainFactory);

--- a/src/Orleans.Runtime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/Orleans.Runtime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -66,7 +66,7 @@ namespace Orleans.Runtime.TestHooks
             return Task.FromResult(consistentRingProvider.ToString()); 
         }
         
-        public Task<Guid> GetServiceId() => Task.FromResult(this.host.Services.GetRequiredService<IOptions<SiloOptions>>().Value.ServiceId);
+        public Task<Guid> GetServiceId() => Task.FromResult(this.host.Services.GetRequiredService<IOptions<ClusterOptions>>().Value.ServiceId);
 
         public Task<bool> HasStorageProvider(string providerName)
         {

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
@@ -15,7 +15,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
     {
         private readonly string _providerName;
         private readonly PubSubStreamOptions options;
-        private readonly SiloOptions siloOptions;
+        private readonly ClusterOptions clusterOptions;
         private readonly ILoggerFactory loggerFactory;
         private readonly Func<TDataAdapter> _adaptorFactory;
         private HashRingBasedStreamQueueMapper _streamQueueMapper;
@@ -31,11 +31,17 @@ namespace Orleans.Providers.GCP.Streams.PubSub
         /// </summary>
         protected Func<QueueId, Task<IStreamFailureHandler>> StreamFailureHandlerFactory { private get; set; }
 
-        public PubSubAdapterFactory(string name, PubSubStreamOptions options, IServiceProvider serviceProvider, IOptions<SiloOptions> siloOptions, SerializationManager serializationManager, ILoggerFactory loggerFactory)
+        public PubSubAdapterFactory(
+            string name, 
+            PubSubStreamOptions options, 
+            IServiceProvider serviceProvider, 
+            IOptions<ClusterOptions> clusterOptions, 
+            SerializationManager serializationManager, 
+            ILoggerFactory loggerFactory)
         {
             this._providerName = name;
             this.options = options;
-            this.siloOptions = siloOptions.Value;
+            this.clusterOptions = clusterOptions.Value;
             this.SerializationManager = serializationManager;
             this.loggerFactory = loggerFactory;
             this._adaptorFactory = () => ActivatorUtilities.GetServiceOrCreateInstance<TDataAdapter>(serviceProvider);
@@ -56,7 +62,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
         public virtual Task<IQueueAdapter> CreateAdapter()
         {
             var adapter = new PubSubAdapter<TDataAdapter>(_adaptorFactory(), SerializationManager, this.loggerFactory, _streamQueueMapper,
-                this.options.ProjectId, this.options.TopicId, this.options.ClusterId ?? this.siloOptions.ClusterId, this._providerName, this.options.Deadline, this.options.CustomEndpoint);
+                this.options.ProjectId, this.options.TopicId, this.options.ClusterId ?? this.clusterOptions.ClusterId, this._providerName, this.options.Deadline, this.options.CustomEndpoint);
             return Task.FromResult<IQueueAdapter>(adapter);
         }
 

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -86,7 +86,7 @@ namespace Orleans.TestingHost
 
             var builder = new ClientBuilder();
             builder.Properties["Configuration"] = configuration;
-            builder.ConfigureClusterClient(ob => ob.Bind(configuration));
+            builder.ConfigureCluster(ob => ob.Bind(configuration));
             ConfigureAppServices(configuration, builder);
 
             builder.ConfigureServices(services =>

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -35,7 +35,8 @@ namespace Orleans.TestingHost
             string siloName = configuration[nameof(TestSiloSpecificOptions.SiloName)] ?? hostName;
 
             ISiloHostBuilder hostBuilder = new SiloHostBuilder()
-                .ConfigureOrleans(ob => ob.Bind(configuration).Configure(options => options.SiloName = options.SiloName ?? siloName))
+                .ConfigureOrleans(ob => ob.Bind(configuration))
+                .ConfigureSiloName(siloName)
                 .ConfigureHostConfiguration(cb =>
                 {
                     // TODO: Instead of passing the sources individually, just chain the pre-built configuration once we upgrade to Microsoft.Extensions.Configuration 2.1

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -45,7 +45,7 @@ namespace AWSUtils.Tests.MembershipTests
         {
             var options = new DynamoDBGatewayOptions();
             LegacyDynamoDBGatewayListProviderConfigurator.ParseDataConnectionString(this.connectionString, options);
-            return new DynamoDBGatewayListProvider(this.loggerFactory, Options.Create(options), this.clientOptions, this.gatewayOptions);
+            return new DynamoDBGatewayListProvider(this.loggerFactory, Options.Create(options), this.clusterOptions, this.gatewayOptions);
         }
 
         protected override Task<string> GetConnectionString()

--- a/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
+++ b/test/AWSUtils.Tests/MembershipTests/DynamoDBMembershipTableTest.cs
@@ -38,7 +38,7 @@ namespace AWSUtils.Tests.MembershipTests
                 throw new SkipException("Unable to connect to AWS DynamoDB simulator");
             var options = new DynamoDBClusteringOptions();
             LegacyDynamoDBMembershipConfigurator.ParseDataConnectionString(this.connectionString, options);
-            return new DynamoDBMembershipTable(this.loggerFactory, Options.Create(options), this.siloOptions);
+            return new DynamoDBMembershipTable(this.loggerFactory, Options.Create(options), this.clusterOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)

--- a/test/AWSUtils.Tests/Reminder/DynamoDBRemindersTableTests.cs
+++ b/test/AWSUtils.Tests/Reminder/DynamoDBRemindersTableTests.cs
@@ -35,7 +35,7 @@ namespace AWSUtils.Tests.RemindersTest
             return new DynamoDBReminderTable(
                 this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(),
                 this.loggerFactory,
-                this.siloOptions,
+                this.clusterOptions,
                 Options.Create(options));
         }
 

--- a/test/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
@@ -58,7 +58,7 @@ namespace AWSUtils.Tests.Streaming
                 ConnectionString = AWSTestConstants.DefaultSQSConnectionString,
                 ClusterId = this.clusterId
             };
-            var adapterFactory = new SQSAdapterFactory(SQS_STREAM_PROVIDER_NAME, options, null, Options.Create(new SiloOptions()), null, null);
+            var adapterFactory = new SQSAdapterFactory(SQS_STREAM_PROVIDER_NAME, options, null, Options.Create(new ClusterOptions()), null, null);
             adapterFactory.Init();
             await SendAndReceiveFromQueueAdapter(adapterFactory);
         }

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -51,7 +51,7 @@ namespace Consul.Tests
             {
                 Address = new Uri(this.connectionString)
             };
-            return new ConsulGatewayListProvider(loggerFactory.CreateLogger<ConsulGatewayListProvider>(), Options.Create(options), this.gatewayOptions, this.clientOptions);
+            return new ConsulGatewayListProvider(loggerFactory.CreateLogger<ConsulGatewayListProvider>(), Options.Create(options), this.gatewayOptions, this.clusterOptions);
         }
 
         protected override async Task<string> GetConnectionString()

--- a/test/Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Consul.Tests/ConsulMembershipTableTest.cs
@@ -41,7 +41,7 @@ namespace Consul.Tests
             {
                 Address = new Uri(this.connectionString)
             };
-            return new ConsulBasedMembershipTable(loggerFactory.CreateLogger<ConsulBasedMembershipTable>(), Options.Create(options), this.siloOptions);
+            return new ConsulBasedMembershipTable(loggerFactory.CreateLogger<ConsulBasedMembershipTable>(), Options.Create(options), this.clusterOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)

--- a/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/NonSilo.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -684,7 +684,7 @@ namespace UnitTests.SchedulerTests
             {
                 SiloAddress = SiloAddressUtils.NewLocalSiloAddress(23)
             };
-            var grain = NonReentrentStressGrainWithoutState.Create(grainId, new GrainRuntime(Options.Create(new SiloOptions()), silo, null, null, null, null, null, NullLoggerFactory.Instance));
+            var grain = NonReentrentStressGrainWithoutState.Create(grainId, new GrainRuntime(Options.Create(new ClusterOptions()), silo, null, null, null, null, null, NullLoggerFactory.Instance));
             await grain.OnActivateAsync();
 
             Task wrapped = null;

--- a/test/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -30,7 +30,7 @@ namespace Orleans.Transactions.AzureStorage.Tests
                 var id = (uint) Guid.NewGuid().GetHashCode() % 100000;
                 hostBuilder
                     .UseInClusterTransactionManager()
-                    .AddAzureTableGrainStorage(TransactionTestConstants.TransactionStore, builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                    .AddAzureTableGrainStorage(TransactionTestConstants.TransactionStore, builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;

--- a/test/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/TestInternalGrains/PersistenceTestGrains.cs
@@ -294,16 +294,16 @@ namespace UnitTests.Grains
 
     public class ServiceIdGrain : Grain, IServiceIdGrain
     {
-        private readonly IOptions<SiloOptions> siloOptions;
+        private readonly IOptions<ClusterOptions> clusterOptions;
 
-        public ServiceIdGrain(IOptions<SiloOptions> siloOptions)
+        public ServiceIdGrain(IOptions<ClusterOptions> clusterOptions)
         {
-            this.siloOptions = siloOptions;
+            this.clusterOptions = clusterOptions;
         }
 
         public Task<Guid> GetServiceId()
         {
-            return Task.FromResult(siloOptions.Value.ServiceId);
+            return Task.FromResult(clusterOptions.Value.ServiceId);
         }
     }
 

--- a/test/TesterAdoNet/MySqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/MySqlMembershipTableTests.cs
@@ -47,7 +47,7 @@ namespace UnitTests.MembershipTests
                 ConnectionString = this.connectionString,
                 AdoInvariant = GetAdoInvariant()
             };
-            return new AdoNetGatewayListProvider(loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, Options.Create(options), this.gatewayOptions, this.clientOptions);
+            return new AdoNetGatewayListProvider(loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, Options.Create(options), this.gatewayOptions, this.clusterOptions);
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterAdoNet/MySqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/MySqlMembershipTableTests.cs
@@ -37,7 +37,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new AdoNetClusteringTable(this.GrainReferenceConverter, this.siloOptions, Options.Create(options), loggerFactory.CreateLogger<AdoNetClusteringTable>());
+            return new AdoNetClusteringTable(this.GrainReferenceConverter, this.clusterOptions, Options.Create(options), loggerFactory.CreateLogger<AdoNetClusteringTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)

--- a/test/TesterAdoNet/MySqlRemindersTableTests.cs
+++ b/test/TesterAdoNet/MySqlRemindersTableTests.cs
@@ -39,7 +39,7 @@ namespace UnitTests.RemindersTest
             };
             return new AdoNetReminderTable(
                 this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(),
-                this.siloOptions,
+                this.clusterOptions,
                 Options.Create(options));
         }
 

--- a/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
@@ -34,7 +34,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new AdoNetClusteringTable(this.GrainReferenceConverter, this.siloOptions, Options.Create(options), this.loggerFactory.CreateLogger<AdoNetClusteringTable>());
+            return new AdoNetClusteringTable(this.GrainReferenceConverter, this.clusterOptions, Options.Create(options), this.loggerFactory.CreateLogger<AdoNetClusteringTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)

--- a/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
@@ -45,7 +45,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant()
             };
             return new AdoNetGatewayListProvider(this.loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter
-                , Options.Create(options), this.gatewayOptions, this.clientOptions);
+                , Options.Create(options), this.gatewayOptions, this.clusterOptions);
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterAdoNet/PostgreSqlRemindersTableTests.cs
+++ b/test/TesterAdoNet/PostgreSqlRemindersTableTests.cs
@@ -37,7 +37,7 @@ namespace UnitTests.RemindersTest
             };
             return new AdoNetReminderTable(
                 this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(),
-                this.siloOptions,
+                this.clusterOptions,
                 Options.Create(options));
         }
 

--- a/test/TesterAdoNet/SqlServerMembershipTableTests.cs
+++ b/test/TesterAdoNet/SqlServerMembershipTableTests.cs
@@ -46,7 +46,7 @@ namespace UnitTests.MembershipTests
                 ConnectionString = this.connectionString,
                 AdoInvariant = GetAdoInvariant()
             };
-            return new AdoNetGatewayListProvider(this.loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, Options.Create(options), gatewayOptions, this.clientOptions);
+            return new AdoNetGatewayListProvider(this.loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, Options.Create(options), gatewayOptions, this.clusterOptions);
         }
 
         protected override string GetAdoInvariant()

--- a/test/TesterAdoNet/SqlServerMembershipTableTests.cs
+++ b/test/TesterAdoNet/SqlServerMembershipTableTests.cs
@@ -36,7 +36,7 @@ namespace UnitTests.MembershipTests
                 AdoInvariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
-            return new AdoNetClusteringTable(this.GrainReferenceConverter, this.siloOptions, Options.Create(options),  this.loggerFactory.CreateLogger<AdoNetClusteringTable>());
+            return new AdoNetClusteringTable(this.GrainReferenceConverter, this.clusterOptions, Options.Create(options),  this.loggerFactory.CreateLogger<AdoNetClusteringTable>());
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)

--- a/test/TesterAdoNet/SqlServerRemindersTableTests.cs
+++ b/test/TesterAdoNet/SqlServerRemindersTableTests.cs
@@ -40,7 +40,7 @@ namespace UnitTests.RemindersTest
             };
             return new AdoNetReminderTable(
                 this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(),
-                this.siloOptions,
+                this.clusterOptions,
                 Options.Create(options));
         }
 

--- a/test/TesterAdoNet/StorageTests/Relational/CommonFixture.cs
+++ b/test/TesterAdoNet/StorageTests/Relational/CommonFixture.cs
@@ -86,11 +86,11 @@ namespace UnitTests.StorageTests.Relational
                                 ConnectionString = Storage.Storage.ConnectionString,
                                 Invariant = storageInvariant
                             };
-                            var siloOptions = new SiloOptions()
+                            var clusterOptions = new ClusterOptions()
                             {
                                 ServiceId = Guid.NewGuid()
                             };
-                            var storageProvider = new AdoNetGrainStorage(DefaultProviderRuntime.ServiceProvider.GetService<ILogger<AdoNetGrainStorage>>(), DefaultProviderRuntime, Options.Create(options), Options.Create(siloOptions), storageInvariant + "_StorageProvider");
+                            var storageProvider = new AdoNetGrainStorage(DefaultProviderRuntime.ServiceProvider.GetService<ILogger<AdoNetGrainStorage>>(), DefaultProviderRuntime, Options.Create(options), Options.Create(clusterOptions), storageInvariant + "_StorageProvider");
                             var siloLifeCycle = new SiloLifecycle(NullLoggerFactory.Instance);
                             storageProvider.Participate(siloLifeCycle);
                             await siloLifeCycle.OnStart(CancellationToken.None);

--- a/test/TesterAzureUtils/AzureMembershipTableTests.cs
+++ b/test/TesterAzureUtils/AzureMembershipTableTests.cs
@@ -43,7 +43,7 @@ namespace Tester.AzureUtils
                 MaxStorageBusyRetries = 3,
                 ConnectionString = this.connectionString,
             };
-            return new AzureBasedMembershipTable(loggerFactory, Options.Create(options), this.siloOptions);
+            return new AzureBasedMembershipTable(loggerFactory, Options.Create(options), this.clusterOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)

--- a/test/TesterAzureUtils/AzureMembershipTableTests.cs
+++ b/test/TesterAzureUtils/AzureMembershipTableTests.cs
@@ -52,7 +52,7 @@ namespace Tester.AzureUtils
             {
                 ConnectionString = this.connectionString
             };
-            return new AzureGatewayListProvider(loggerFactory, Options.Create(options), this.clientOptions, this.gatewayOptions);
+            return new AzureGatewayListProvider(loggerFactory, Options.Create(options), this.clusterOptions, this.gatewayOptions);
         }
 
         protected override Task<string> GetConnectionString()

--- a/test/TesterAzureUtils/AzureRemindersTableTests.cs
+++ b/test/TesterAzureUtils/AzureRemindersTableTests.cs
@@ -48,7 +48,7 @@ namespace UnitTests.RemindersTest
                     {
                         ConnectionString = this.connectionStringFixture.ConnectionString
                     });
-            return new AzureBasedReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(), loggerFactory, this.siloOptions, options);
+            return new AzureBasedReminderTable(this.ClusterFixture.Services.GetRequiredService<IGrainReferenceConverter>(), loggerFactory, this.clusterOptions, options);
         }
 
         protected override Task<string> GetConnectionString()

--- a/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
+++ b/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
@@ -35,7 +35,7 @@ namespace Tester.AzureUtils.General
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                        .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                        .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
@@ -51,23 +51,23 @@ namespace Tester.AzureUtils.Persistence
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                        .AddAzureTableGrainStorage("GrainStorageForTest", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                        .AddAzureTableGrainStorage("GrainStorageForTest", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.DeleteStateOnClear = true;
                         }))
-                        .AddAzureTableGrainStorage("AzureStore1", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                        .AddAzureTableGrainStorage("AzureStore1", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
-                        .AddAzureTableGrainStorage("AzureStore2", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                        .AddAzureTableGrainStorage("AzureStore2", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
-                        .AddAzureTableGrainStorage("AzureStore3", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                        .AddAzureTableGrainStorage("AzureStore3", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;

--- a/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/TesterAzureUtils/Reminder/ReminderTests_Azure_Standalone.cs
@@ -47,10 +47,10 @@ namespace Tester.AzureUtils.TimerTests
         [SkippableFact, TestCategory("ReminderService"), TestCategory("Performance")]
         public async Task Reminders_AzureTable_InsertRate()
         {
-            var siloOptions = Options.Create(new SiloOptions { ClusterId = "TMSLocalTesting", ServiceId = this.serviceId });
+            var clusterOptions = Options.Create(new ClusterOptions { ClusterId = "TMSLocalTesting", ServiceId = this.serviceId });
             var storageOptions = Options.Create(new AzureTableReminderStorageOptions { ConnectionString = TestDefaultConfiguration.DataConnectionString });
 
-            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, siloOptions, storageOptions);
+            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, clusterOptions, storageOptions);
             await table.Init();
 
             await TestTableInsertRate(table, 10);
@@ -61,9 +61,9 @@ namespace Tester.AzureUtils.TimerTests
         public async Task Reminders_AzureTable_InsertNewRowAndReadBack()
         {
             string clusterId = NewClusterId();
-            var siloOptions = Options.Create(new SiloOptions { ClusterId = clusterId, ServiceId = this.serviceId });
+            var clusterOptions = Options.Create(new ClusterOptions { ClusterId = clusterId, ServiceId = this.serviceId });
             var storageOptions = Options.Create(new AzureTableReminderStorageOptions { ConnectionString = TestDefaultConfiguration.DataConnectionString });
-            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, siloOptions, storageOptions);
+            IReminderTable table = new AzureBasedReminderTable(this.fixture.Services.GetRequiredService<IGrainReferenceConverter>(), this.loggerFactory, clusterOptions, storageOptions);
             await table.Init();
 
             ReminderEntry[] rows = (await GetAllRows(table)).ToArray();

--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -55,13 +55,13 @@ namespace Tester.AzureUtils.Streaming
             {
                 hostBuilder
                     .AddSimpleMessageStreamProvider(SmsStreamProviderName)
-                    .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                    .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
-                    .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                    .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;

--- a/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -57,7 +57,7 @@ namespace Tester.AzureUtils.Streaming
                 ClusterId = this.clusterId,
                 MessageVisibilityTimeout = TimeSpan.FromSeconds(30)
             };
-            var adapterFactory = new AzureQueueAdapterFactory<AzureQueueDataAdapterV2>(AZURE_QUEUE_STREAM_PROVIDER_NAME, options, this.fixture.Services, this.fixture.Services.GetService<IOptions<SiloOptions>>(), this.fixture.Services.GetRequiredService<SerializationManager>(), loggerFactory);
+            var adapterFactory = new AzureQueueAdapterFactory<AzureQueueDataAdapterV2>(AZURE_QUEUE_STREAM_PROVIDER_NAME, options, this.fixture.Services, this.fixture.Services.GetService<IOptions<ClusterOptions>>(), this.fixture.Services.GetRequiredService<SerializationManager>(), loggerFactory);
             adapterFactory.Init();
             await SendAndReceiveFromQueueAdapter(adapterFactory);
         }

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -43,7 +43,7 @@ namespace UnitTests.HaloTests.Streaming
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                        .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                        .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
@@ -51,7 +51,7 @@ namespace UnitTests.HaloTests.Streaming
                         }))
                         .AddSimpleMessageStreamProvider(SmsStreamProviderName)
                         .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false)
-                        .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                        .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.DeleteStateOnClear = true;

--- a/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
@@ -65,13 +65,13 @@ namespace UnitTests.StreamingTests
                 hostBuilder
                     .AddSimpleMessageStreamProvider(SmsStreamProviderName)
                     .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false)
-                    .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                    .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
-                    .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                    .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
                         options.DeleteStateOnClear = true;

--- a/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
@@ -56,13 +56,13 @@ namespace UnitTests.StreamingTests
                 hostBuilder
                     .AddSimpleMessageStreamProvider(SmsStreamProviderName)
                     .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false)
-                    .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                    .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
-                    .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                    .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
                         options.DeleteStateOnClear = true;

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -85,14 +85,14 @@ namespace UnitTests.Streaming.Reliability
                     options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     options.MaxStorageBusyRetries = 3;
                 })
-                .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
                         options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
                 .AddSimpleMessageStreamProvider(SMS_STREAM_PROVIDER_NAME)
-                .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                 {
                     options.ServiceId = silo.Value.ServiceId.ToString();
                     options.DeleteStateOnClear = true;

--- a/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
@@ -43,12 +43,12 @@ namespace Tests.GeoClusterTests
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                        .AddAzureTableGrainStorageAsDefault(builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                        .AddAzureTableGrainStorageAsDefault(builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
-                        .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<SiloOptions>>((options, silo) =>
+                        .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
                             options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -58,7 +58,6 @@ namespace UnitTests.MembershipTests
 
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
             this.connectionString = fixture.ConnectionString;
-            this.siloOptions = Options.Create(new SiloOptions { ClusterId = this.clusterId });
             this.clusterOptions = Options.Create(new ClusterOptions { ClusterId = this.clusterId });
             var adoVariant = GetAdoInvariant();
 

--- a/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
+++ b/test/TesterInternal/MembershipTests/MembershipTableTestsBase.cs
@@ -41,10 +41,11 @@ namespace UnitTests.MembershipTests
         protected readonly string connectionString;
         protected ILoggerFactory loggerFactory;
         protected IOptions<SiloOptions> siloOptions;
-        protected IOptions<ClusterClientOptions> clientOptions;
+        protected IOptions<ClusterOptions> clusterOptions;
         protected const string testDatabaseName = "OrleansMembershipTest";//for relational storage
         protected readonly IOptions<GatewayOptions> gatewayOptions;
         protected readonly ClientConfiguration clientConfiguration;
+
         protected MembershipTableTestsBase(ConnectionStringFixture fixture, TestEnvironmentFixture environment, LoggerFilterOptions filters)
         {
             this.environment = environment;
@@ -58,7 +59,7 @@ namespace UnitTests.MembershipTests
             fixture.InitializeConnectionStringAccessor(GetConnectionString);
             this.connectionString = fixture.ConnectionString;
             this.siloOptions = Options.Create(new SiloOptions { ClusterId = this.clusterId });
-            this.clientOptions = Options.Create(new ClusterClientOptions { ClusterId = this.clusterId });
+            this.clusterOptions = Options.Create(new ClusterOptions { ClusterId = this.clusterId });
             var adoVariant = GetAdoInvariant();
 
             membershipTable = CreateMembershipTable(logger);

--- a/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/TesterInternal/RemindersTest/ReminderTableTestsBase.cs
@@ -23,7 +23,7 @@ namespace UnitTests.RemindersTest
 
         private readonly IReminderTable remindersTable;
         protected ILoggerFactory loggerFactory;
-        protected IOptions<SiloOptions> siloOptions;
+        protected IOptions<ClusterOptions> clusterOptions;
 
         protected ConnectionStringFixture connectionStringFixture;
 
@@ -40,7 +40,7 @@ namespace UnitTests.RemindersTest
             var clusterId = "test-" + serviceId;
 
             logger.Info("ClusterId={0}", clusterId);
-            this.siloOptions = Options.Create(new SiloOptions { ClusterId = clusterId, ServiceId = serviceId });
+            this.clusterOptions = Options.Create(new ClusterOptions { ClusterId = clusterId, ServiceId = serviceId });
             
             var rmndr = CreateRemindersTable();
             rmndr.Init().WithTimeout(TimeSpan.FromMinutes(1)).Wait();

--- a/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
+++ b/test/TesterZooKeeperUtils/ZookeeperMembershipTableTests.cs
@@ -37,7 +37,7 @@ namespace UnitTests.MembershipTests
             var options = new ZooKeeperClusteringSiloOptions();
             options.ConnectionString = this.connectionString;
            
-            return new ZooKeeperBasedMembershipTable(this.Services.GetService<ILogger<ZooKeeperBasedMembershipTable>>(), Options.Create(options), this.siloOptions);
+            return new ZooKeeperBasedMembershipTable(this.Services.GetService<ILogger<ZooKeeperBasedMembershipTable>>(), Options.Create(options), this.clusterOptions);
         }
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)


### PR DESCRIPTION
Right now provider that run on the client and the silo (like streaming) are broken on the client, because they expect `SiloOptions` which is obviously not set, because the client expect to use `ClusterClientOptions`.

The proposal is to configure ClusterId/ServiceId in a common option for clients and silos.

In this PR, I:

- Renamed `ClusterClientOptions` to a more generic term `ClusterOptions`
- Rremoved `ClusterId` and `ServiceId` from `SiloOption`, and added `ServiceId` to `ClusterOptions`
- Used `ClusterOptions` instead of `SiloOption` when `ClusterId` was needed `ServiceId` 
