### PR TITLE
Fix test configuration bug in AzureQueue tests introduced in #4067

### DIFF
--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -67,7 +67,7 @@ namespace Tester.AzureUtils.Streaming
                         {
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         })
-                    .AddMemoryGrainStorageAsDefault();
+                    .AddMemoryGrainStorage("MemoryStore");
             }
         }
 


### PR DESCRIPTION
Need a memory store provider named "MemoryStore" instead of the default one.