### PR TITLE
Rename ConfigureOrleans methods to Configure

### DIFF
--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -19,9 +19,9 @@ namespace Orleans.Hosting
         /// <param name="builder">The host builder.</param>
         /// <param name="configureOptions">The delegate that configures the options.</param>
         /// <returns>The host builder.</returns>
-        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, Action<ClusterOptions> configureOptions)
+        public static ISiloHostBuilder Configure(this ISiloHostBuilder builder, Action<ClusterOptions> configureOptions)
         {
-            return builder.ConfigureOrleans(null, configureOptions);
+            return builder.Configure(null, configureOptions);
         }
 
         /// <summary>
@@ -31,13 +31,13 @@ namespace Orleans.Hosting
         /// <param name="siloName">The name to use for this silo</param>
         /// <param name="configureOptions">The delegate that configures the options.</param>
         /// <returns>The host builder.</returns>
-        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, string siloName, Action<ClusterOptions> configureOptions)
+        public static ISiloHostBuilder Configure(this ISiloHostBuilder builder, string siloName, Action<ClusterOptions> configureOptions)
         {
             var optionsConfigurator = configureOptions != null
                 ? ob => ob.Configure(configureOptions)
                 : default(Action<OptionsBuilder<ClusterOptions>>);
 
-            return builder.ConfigureOrleans(siloName, optionsConfigurator);
+            return builder.Configure(siloName, optionsConfigurator);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Orleans.Hosting
         /// <param name="siloName">The name to use for this silo</param>
         /// <param name="configureOptions">The delegate that configures the options using the options builder.</param>
         /// <returns>The host builder.</returns>
-        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, string siloName, Action<OptionsBuilder<ClusterOptions>> configureOptions = null)
+        public static ISiloHostBuilder Configure(this ISiloHostBuilder builder, string siloName, Action<OptionsBuilder<ClusterOptions>> configureOptions = null)
         {
             builder.ConfigureServices((context, services) =>
             {
@@ -77,9 +77,9 @@ namespace Orleans.Hosting
         /// <param name="builder">The host builder.</param>
         /// <param name="configureOptions">The delegate that configures the options using the options builder.</param>
         /// <returns>The host builder.</returns>
-        public static ISiloHostBuilder ConfigureOrleans(this ISiloHostBuilder builder, Action<OptionsBuilder<ClusterOptions>> configureOptions = null)
+        public static ISiloHostBuilder Configure(this ISiloHostBuilder builder, Action<OptionsBuilder<ClusterOptions>> configureOptions = null)
         {
-            return builder.ConfigureOrleans(null, configureOptions);
+            return builder.Configure(null, configureOptions);
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilder.cs
+++ b/src/Orleans.Runtime/Hosting/Generic/SiloHostBuilder.cs
@@ -34,7 +34,7 @@ namespace Orleans.Hosting
 
             // Automatically configure Orleans if it wasn't configured before. 
             // This will not happen once we use the generic host builder from Microsoft.Extensions.Hosting
-            this.ConfigureOrleans();
+            this.Configure();
 
             BuildHostConfiguration();
             CreateHostingEnvironment();

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -35,7 +35,7 @@ namespace Orleans.TestingHost
             string siloName = configuration[nameof(TestSiloSpecificOptions.SiloName)] ?? hostName;
 
             ISiloHostBuilder hostBuilder = new SiloHostBuilder()
-                .ConfigureOrleans(ob => ob.Bind(configuration))
+                .Configure(ob => ob.Bind(configuration))
                 .ConfigureSiloName(siloName)
                 .ConfigureHostConfiguration(cb =>
                 {

--- a/test/NonSilo.Tests/SiloHostBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloHostBuilderTests.cs
@@ -65,7 +65,7 @@ namespace NonSilo.Tests
         [Fact]
         public void SiloHostBuilder_NoSpecifiedConfigurationTest()
         {
-            var builder = new SiloHostBuilder().ConfigureOrleans()
+            var builder = new SiloHostBuilder().Configure()
                 .UseConfiguration(new ClusterConfiguration())
                 .ConfigureServices(RemoveConfigValidators)
                 .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());
@@ -81,7 +81,7 @@ namespace NonSilo.Tests
         [Fact]
         public void SiloHostBuilder_DoubleBuildTest()
         {
-            var builder = new SiloHostBuilder().ConfigureOrleans()
+            var builder = new SiloHostBuilder().Configure()
                 .UseConfiguration(new ClusterConfiguration())
                 .ConfigureServices(RemoveConfigValidators)
                 .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());
@@ -97,7 +97,7 @@ namespace NonSilo.Tests
         [Fact]
         public void SiloHostBuilder_DoubleSpecifyConfigurationTest()
         {
-            var builder = new SiloHostBuilder().ConfigureOrleans()
+            var builder = new SiloHostBuilder().Configure()
                 .ConfigureServices(RemoveConfigValidators)
                 .UseConfiguration(new ClusterConfiguration())
                 .UseConfiguration(new ClusterConfiguration());
@@ -110,7 +110,7 @@ namespace NonSilo.Tests
         [Fact]
         public void SiloHostBuilder_NullConfigurationTest()
         {
-            var builder = new SiloHostBuilder().ConfigureOrleans()
+            var builder = new SiloHostBuilder().Configure()
                 .ConfigureServices(RemoveConfigValidators);
             Assert.Throws<ArgumentNullException>(() => builder.UseConfiguration(null));
         }
@@ -121,7 +121,7 @@ namespace NonSilo.Tests
         [Fact]
         public void SiloHostBuilder_ServiceProviderTest()
         {
-            var builder = new SiloHostBuilder().ConfigureOrleans()
+            var builder = new SiloHostBuilder().Configure()
                 .UseConfiguration(new ClusterConfiguration())
                 .ConfigureServices(RemoveConfigValidators)
                 .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());


### PR DESCRIPTION
Rename `ConfigureOrleans` methods to `Configure` to avoid having the project name in method names.