### PR TITLE
Add basic sample using docker and asp.net core

### DIFF
--- a/Samples/docker-aspnet-core/.dockerignore
+++ b/Samples/docker-aspnet-core/.dockerignore
@@ -1,0 +1,12 @@
+.dockerignore
+.env
+.git
+.gitignore
+.vs
+.vscode
+docker-compose.yml
+docker-compose.*.yml
+*/bin
+*/obj
+!obj/Docker/publish/*
+!obj/Docker/empty/

--- a/Samples/docker-aspnet-core/API/API.csproj
+++ b/Samples/docker-aspnet-core/API/API.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GrainInterfaces\GrainInterfaces.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/docker-aspnet-core/API/API.csproj
+++ b/Samples/docker-aspnet-core/API/API.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="2.0.0-rc0" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="2.0.0-rc0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/docker-aspnet-core/API/Controllers/ValuesController.cs
+++ b/Samples/docker-aspnet-core/API/Controllers/ValuesController.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GrainInterfaces;
+using Microsoft.AspNetCore.Mvc;
+using Orleans;
+
+namespace API.Controllers
+{
+    [Route("api/[controller]")]
+    public class ValuesController : Controller
+    {
+        private IClusterClient client;
+        
+        public ValuesController(IClusterClient client)
+        {
+            this.client = client;
+        }
+
+        // GET api/values
+        [HttpGet]
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "value1", "value2" };
+        }
+
+        // GET api/values/5
+        [HttpGet("{id}")]
+        public async Task<string> Get(int id)
+        {
+            var grain = this.client.GetGrain<IValueGrain>(id);
+            return await grain.GetValue();
+        }
+
+        // PUT api/values/5
+        [HttpPost("{id}")]
+        public async Task Post(int id, [FromBody]string value)
+        {
+            var grain = this.client.GetGrain<IValueGrain>(id);
+            await grain.SetValue(value);
+        }
+    }
+}

--- a/Samples/docker-aspnet-core/API/Dockerfile
+++ b/Samples/docker-aspnet-core/API/Dockerfile
@@ -5,7 +5,6 @@ EXPOSE 80
 FROM microsoft/aspnetcore-build:2.0 AS build
 WORKDIR /src
 COPY *.sln ./
-COPY NuGet.Config ./
 COPY API/API.csproj API/
 RUN dotnet restore
 COPY . .

--- a/Samples/docker-aspnet-core/API/Dockerfile
+++ b/Samples/docker-aspnet-core/API/Dockerfile
@@ -1,0 +1,22 @@
+FROM microsoft/aspnetcore:2.0 AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM microsoft/aspnetcore-build:2.0 AS build
+WORKDIR /src
+COPY *.sln ./
+COPY NuGet.Config ./
+COPY API/API.csproj API/
+RUN dotnet restore
+COPY . .
+WORKDIR /src/API
+RUN dotnet build -c Release -o /app
+
+FROM build AS publish
+RUN dotnet publish -c Release -o /app
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app .
+COPY connection_string.txt .
+ENTRYPOINT ["dotnet", "API.dll"]

--- a/Samples/docker-aspnet-core/API/Dockerfile
+++ b/Samples/docker-aspnet-core/API/Dockerfile
@@ -18,5 +18,4 @@ RUN dotnet publish -c Release -o /app
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app .
-COPY connection_string.txt .
 ENTRYPOINT ["dotnet", "API.dll"]

--- a/Samples/docker-aspnet-core/API/Program.cs
+++ b/Samples/docker-aspnet-core/API/Program.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace API
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/Samples/docker-aspnet-core/API/Properties/launchSettings.json
+++ b/Samples/docker-aspnet-core/API/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8236/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "api/values",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "API": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "api/values",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:8237/"
+    }
+  }
+}

--- a/Samples/docker-aspnet-core/API/Startup.cs
+++ b/Samples/docker-aspnet-core/API/Startup.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading.Tasks;
+using GrainInterfaces;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Hosting;
+
+namespace API
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            services.AddSingleton<IClusterClient>(CreateClusterClient);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, Microsoft.AspNetCore.Hosting.IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseMvc();
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+        }
+
+        private IClusterClient CreateClusterClient(IServiceProvider serviceProvider)
+        {
+            // TODO replace with your connection string
+            const string connectionString = "YOUR_CONNECTION_STRING_HERE";
+            var client = new ClientBuilder()
+                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IValueGrain).Assembly))
+                .ConfigureCluster(options => options.ClusterId = "orleans-docker")
+                .UseAzureStorageClustering(options => options.ConnectionString = connectionString)
+                .Build();
+            StartClientWithRetries(client).Wait();
+            return client;
+        }
+
+        private static async Task StartClientWithRetries(IClusterClient client)
+        {
+            for (var i=0; i<5; i++)
+            {
+                try
+                {
+                    await client.Connect();
+                    return;
+                }
+                catch(Exception)
+                { }
+                await Task.Delay(TimeSpan.FromSeconds(5));
+            }
+        }
+    }
+}

--- a/Samples/docker-aspnet-core/API/appsettings.Development.json
+++ b/Samples/docker-aspnet-core/API/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/Samples/docker-aspnet-core/API/appsettings.json
+++ b/Samples/docker-aspnet-core/API/appsettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  }
+}

--- a/Samples/docker-aspnet-core/API/wwwroot/StyleSheet.css
+++ b/Samples/docker-aspnet-core/API/wwwroot/StyleSheet.css
@@ -1,0 +1,31 @@
+﻿html,
+body {
+    height: 100%;
+}
+
+body {
+    display: -ms-flexbox;
+    display: -webkit-box;
+    display: flex;
+    -ms-flex-align: center;
+    -ms-flex-pack: center;
+    -webkit-box-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    justify-content: center;
+    padding-top: 40px;
+    padding-bottom: 40px;
+    background-color: #f5f5f5;
+}
+
+.form-values {
+    width: 100%;
+    max-width: 420px;
+    padding: 15px;
+    margin: 1rem auto;
+}
+
+.form-label-group {
+    position: relative;
+    margin-bottom: 1rem;
+}

--- a/Samples/docker-aspnet-core/API/wwwroot/index.html
+++ b/Samples/docker-aspnet-core/API/wwwroot/index.html
@@ -1,0 +1,60 @@
+﻿<!doctype html>
+<html lang="en">
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="StyleSheet.css" />
+
+    <!-- JavaScript -->
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $.ajaxSetup({
+                contentType: "application/json; charset=utf-8"
+            });
+            $('#buttonGet').click(function () {
+                var id = $('#inputGrainId').val();
+                $.get("api/values/" + id, function (value) {
+                    console.log('GET Grain{' + id + "}=" + value);
+                    $('#inputValue').val(value);
+                });
+                return false;
+            });
+            $('#buttonSet').click(function () {
+                var id = $('#inputGrainId').val();
+                var val = '"' + $('#inputValue').val() + '"';
+                $.post("api/values/" + id, val, function () {
+                    console.log('SET Grain{' + id + "}=" + val);
+                });
+                return false;
+            });
+        });
+    </script>
+
+    <title>Orleans + ASP.NET Core</title>
+</head>
+<body>
+    <form class="form-values" action="">
+        <div class="text-center mb-4">
+            <h1 class="h3 mb-3 font-weight-normal">Value in Grains</h1>
+        </div>
+        <div class="form-label-group">
+            <label for="inputGrainId">Grain ID</label>
+            <input class="form-control" id="inputGrainId" autofocus="" required="" type="number" value="0">
+        </div>
+        <div class="form-label-group">
+            <label for="inputValue">Value</label>
+            <input class="form-control" id="inputValue" type="text">
+        </div>
+        <button id="buttonGet" class="btn btn-lg btn-primary btn-block" type="submit">Get Value</button>
+        <button id="buttonSet" class="btn btn-lg btn-primary btn-block" type="submit">Set Value</button>
+    </form>
+</body>
+</html>

--- a/Samples/docker-aspnet-core/GrainInterfaces/GrainInterfaces.csproj
+++ b/Samples/docker-aspnet-core/GrainInterfaces/GrainInterfaces.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.0.0-rc0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc1" />
   </ItemGroup>
 
 </Project>

--- a/Samples/docker-aspnet-core/GrainInterfaces/GrainInterfaces.csproj
+++ b/Samples/docker-aspnet-core/GrainInterfaces/GrainInterfaces.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc0" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/docker-aspnet-core/GrainInterfaces/IValueGrain.cs
+++ b/Samples/docker-aspnet-core/GrainInterfaces/IValueGrain.cs
@@ -1,0 +1,15 @@
+﻿using Orleans;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GrainInterfaces
+{
+    public interface IValueGrain : IGrainWithIntegerKey
+    {
+        Task<string> GetValue();
+
+        Task SetValue(string value);
+    }
+}

--- a/Samples/docker-aspnet-core/Grains/Grains.csproj
+++ b/Samples/docker-aspnet-core/Grains/Grains.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GrainInterfaces\GrainInterfaces.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/docker-aspnet-core/Grains/Grains.csproj
+++ b/Samples/docker-aspnet-core/Grains/Grains.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.0.0-rc0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/docker-aspnet-core/Grains/ValueGrain.cs
+++ b/Samples/docker-aspnet-core/Grains/ValueGrain.cs
@@ -1,0 +1,23 @@
+﻿using GrainInterfaces;
+using Orleans;
+using System;
+using System.Threading.Tasks;
+
+namespace Grains
+{
+    public class ValueGrain : Grain, IValueGrain
+    {
+        private string value = "none";
+
+        public Task<string> GetValue()
+        {
+            return Task.FromResult(this.value);
+        }
+
+        public Task SetValue(string value)
+        {
+            this.value = value;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Samples/docker-aspnet-core/NuGet.Config
+++ b/Samples/docker-aspnet-core/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="myget.org" value="https://dotnet.myget.org/F/orleans-ci/api/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/Samples/docker-aspnet-core/NuGet.Config
+++ b/Samples/docker-aspnet-core/NuGet.Config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="myget.org" value="https://dotnet.myget.org/F/orleans-ci/api/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/Samples/docker-aspnet-core/Silo/Dockerfile
+++ b/Samples/docker-aspnet-core/Silo/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 FROM microsoft/aspnetcore-build:2.0 AS build
 WORKDIR /src
 COPY *.sln ./
-COPY NuGet.Config ./
 COPY Silo/Silo.csproj Silo/
 RUN dotnet restore
 COPY . .

--- a/Samples/docker-aspnet-core/Silo/Dockerfile
+++ b/Samples/docker-aspnet-core/Silo/Dockerfile
@@ -1,0 +1,21 @@
+FROM microsoft/aspnetcore:2.0 AS base
+WORKDIR /app
+
+FROM microsoft/aspnetcore-build:2.0 AS build
+WORKDIR /src
+COPY *.sln ./
+COPY NuGet.Config ./
+COPY Silo/Silo.csproj Silo/
+RUN dotnet restore
+COPY . .
+WORKDIR /src/Silo
+RUN dotnet build -c Release -o /app
+
+FROM build AS publish
+RUN dotnet publish -c Release -o /app
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app .
+COPY connection_string.txt .
+ENTRYPOINT ["dotnet", "Silo.dll"]

--- a/Samples/docker-aspnet-core/Silo/Dockerfile
+++ b/Samples/docker-aspnet-core/Silo/Dockerfile
@@ -17,5 +17,4 @@ RUN dotnet publish -c Release -o /app
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app .
-COPY connection_string.txt .
 ENTRYPOINT ["dotnet", "Silo.dll"]

--- a/Samples/docker-aspnet-core/Silo/Program.cs
+++ b/Samples/docker-aspnet-core/Silo/Program.cs
@@ -1,0 +1,54 @@
+﻿using Grains;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using System;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Silo
+{
+    public class Program
+    {
+        private static ISiloHost silo;
+        private static readonly ManualResetEvent siloStopped = new ManualResetEvent(false);
+
+        static void Main(string[] args)
+        {
+            // TODO replace with your connection string
+            const string connectionString = "YOUR_CONNECTION_STRING_HERE";
+            silo = new SiloHostBuilder()
+                .Configure(options => options.ClusterId = "orleans-docker")
+                .UseAzureStorageClustering(options => options.ConnectionString = connectionString)
+                .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
+                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ValueGrain).Assembly).WithReferences())
+                .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole())
+                .Build();
+
+            Task.Run(StartSilo);
+
+            AssemblyLoadContext.Default.Unloading += context =>
+            {
+                Task.Run(StopSilo);
+                siloStopped.WaitOne();
+            };
+
+            siloStopped.WaitOne();
+        }
+
+        private static async Task StartSilo()
+        {
+            await silo.StartAsync();
+            Console.WriteLine("Silo started");
+        }
+
+        private static async Task StopSilo()
+        {
+            await silo.StopAsync();
+            Console.WriteLine("Silo stopped");
+            siloStopped.Set();
+        }
+    }
+}

--- a/Samples/docker-aspnet-core/Silo/Silo.csproj
+++ b/Samples/docker-aspnet-core/Silo/Silo.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <ApplicationIcon />
+    <OutputType>Exe</OutputType>
+    <StartupObject />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime.Legacy" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="2.0.0-rc0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GrainInterfaces\GrainInterfaces.csproj" />
+    <ProjectReference Include="..\Grains\Grains.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/docker-aspnet-core/Silo/Silo.csproj
+++ b/Samples/docker-aspnet-core/Silo/Silo.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="2.0.0-rc0" />
-    <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="2.0.0-rc0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="2.0.0-rc0" />
-    <PackageReference Include="Microsoft.Orleans.Runtime.Legacy" Version="2.0.0-rc0" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="2.0.0-rc0" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.Runtime.Legacy" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="2.0.0-rc1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/docker-aspnet-core/docker-aspnet-core.sln
+++ b/Samples/docker-aspnet-core/docker-aspnet-core.sln
@@ -1,0 +1,51 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "API", "API\API.csproj", "{F28B975D-A1D1-4115-9BCF-C69FD97774AD}"
+EndProject
+Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{66D6545D-BC17-48CE-AB70-8E494ED42606}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrainInterfaces", "GrainInterfaces\GrainInterfaces.csproj", "{21023A72-1417-4B24-AECF-53FC43C8551F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grains", "Grains\Grains.csproj", "{C9C75B82-4399-425A-9800-4AE0EF5E6D56}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Silo", "Silo\Silo.csproj", "{3C38E1F6-2628-47D5-A90B-E2636F4CF456}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{22D52A07-938F-4FE7-8B70-5AEEC1734E30}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F28B975D-A1D1-4115-9BCF-C69FD97774AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F28B975D-A1D1-4115-9BCF-C69FD97774AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F28B975D-A1D1-4115-9BCF-C69FD97774AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F28B975D-A1D1-4115-9BCF-C69FD97774AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{66D6545D-BC17-48CE-AB70-8E494ED42606}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{66D6545D-BC17-48CE-AB70-8E494ED42606}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66D6545D-BC17-48CE-AB70-8E494ED42606}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66D6545D-BC17-48CE-AB70-8E494ED42606}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21023A72-1417-4B24-AECF-53FC43C8551F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21023A72-1417-4B24-AECF-53FC43C8551F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21023A72-1417-4B24-AECF-53FC43C8551F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21023A72-1417-4B24-AECF-53FC43C8551F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9C75B82-4399-425A-9800-4AE0EF5E6D56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9C75B82-4399-425A-9800-4AE0EF5E6D56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9C75B82-4399-425A-9800-4AE0EF5E6D56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9C75B82-4399-425A-9800-4AE0EF5E6D56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C38E1F6-2628-47D5-A90B-E2636F4CF456}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C38E1F6-2628-47D5-A90B-E2636F4CF456}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C38E1F6-2628-47D5-A90B-E2636F4CF456}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C38E1F6-2628-47D5-A90B-E2636F4CF456}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {144D219D-93C7-4F7E-9640-81BA2078D57D}
+	EndGlobalSection
+EndGlobal

--- a/Samples/docker-aspnet-core/docker-compose.ci.build.yml
+++ b/Samples/docker-aspnet-core/docker-compose.ci.build.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  ci-build:
+    image: microsoft/aspnetcore-build:1.0-2.0
+    volumes:
+      - .:/src
+    working_dir: /src
+    command: /bin/bash -c "dotnet restore ./OrleansContainer.sln && dotnet publish ./OrleansContainer.sln -c Release -o ./obj/Docker/publish"

--- a/Samples/docker-aspnet-core/docker-compose.dcproj
+++ b/Samples/docker-aspnet-core/docker-compose.dcproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" Sdk="Microsoft.Docker.Sdk">
+  <PropertyGroup Label="Globals">
+    <ProjectVersion>2.0</ProjectVersion>
+    <DockerTargetOS>Linux</DockerTargetOS>
+    <ProjectGuid>66d6545d-bc17-48ce-ab70-8e494ed42606</ProjectGuid>
+    <DockerLaunchBrowser>True</DockerLaunchBrowser>
+    <DockerServiceUrl>http://localhost:{ServicePort}/</DockerServiceUrl>
+    <DockerServiceName>api</DockerServiceName>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="docker-compose.override.yml">
+      <DependentUpon>docker-compose.yml</DependentUpon>
+    </None>
+    <None Include="docker-compose.yml" />
+    <None Include=".dockerignore" />
+    <None Include="docker-compose.ci.build.yml" />
+  </ItemGroup>
+</Project>

--- a/Samples/docker-aspnet-core/docker-compose.override.yml
+++ b/Samples/docker-aspnet-core/docker-compose.override.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  api:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    ports:
+      - "80"

--- a/Samples/docker-aspnet-core/docker-compose.yml
+++ b/Samples/docker-aspnet-core/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  api:
+    image: api
+    build:
+      context: .
+      dockerfile: API/Dockerfile
+  silo:
+    image: silo
+    build:
+      context: .
+      dockerfile: Silo/Dockerfile


### PR DESCRIPTION
The idea is to have a basic sample combining Docker, Orleans and ASP.NET Core.

This sample is pretty simple: a single grain identified by a integer, that can hold a string value. A basic webpage allow user to get and set these grain values.

It uses ASP.NET Docker tooling, so you can build and debug using Docker containers, which is nice. But it seems that if the containers are started with VS, the silo doesn't shutdown gracefully. I validated that if started from Docker CLI the silo shutdowns properly.

I am not an expert in ASP.NET Core, so I may have made mistake here and there.