### PR TITLE
Make equality requirements of IApplicationPart explicit.

### DIFF
--- a/src/Orleans.Core/ApplicationParts/AssemblyPart.cs
+++ b/src/Orleans.Core/ApplicationParts/AssemblyPart.cs
@@ -43,15 +43,19 @@ namespace Orleans.ApplicationParts
         /// </returns>
         protected bool Equals(AssemblyPart other)
         {
-            return Equals(this.Assembly, other.Assembly);
+            return Equals(this.Assembly, other?.Assembly);
         }
+
+        /// <inheritdoc />
+        public bool Equals(IApplicationPart other) => this.Equals(other as AssemblyPart);
 
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj.GetType() == this.GetType() && this.Equals((AssemblyPart) obj);
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((AssemblyPart) obj);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Core/ApplicationParts/IApplicationPart.cs
+++ b/src/Orleans.Core/ApplicationParts/IApplicationPart.cs
@@ -1,9 +1,11 @@
+using System;
+
 namespace Orleans.ApplicationParts
 {
     /// <summary>
     /// A part of an Orleans application.
     /// </summary>
-    public interface IApplicationPart
+    public interface IApplicationPart : IEquatable<IApplicationPart>
     {
     }
 }


### PR DESCRIPTION
In the discussion on #4084, we decided to make `IApplicationPart` explicitly implement `IEquatable<IApplicationPart>`