### PR TITLE
Improve configuration validators for ADO.NET configuration

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/AdoNetHostingExtensions.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/AdoNetHostingExtensions.cs
@@ -7,6 +7,9 @@ using Orleans.Configuration;
 
 namespace Orleans.Hosting
 {
+    /// <summary>
+    /// Extensions for configuring ADO.NET for clustering.
+    /// </summary>
     public static class AdoNetHostingExtensions
     {
         /// <summary>
@@ -34,6 +37,7 @@ namespace Orleans.Hosting
                     }
 
                     services.AddSingleton<IMembershipTable, AdoNetClusteringTable>();
+                    services.AddSingleton<IConfigurationValidator, AdoNetClusteringSiloOptionsValidator>();
                 });
         }
 
@@ -58,6 +62,7 @@ namespace Orleans.Hosting
                 {
                     configureOptions?.Invoke(services.AddOptions<AdoNetClusteringSiloOptions>());
                     services.AddSingleton<IMembershipTable, AdoNetClusteringTable>();
+                    services.AddSingleton<IConfigurationValidator, AdoNetClusteringSiloOptionsValidator>();
                 });
         }
 
@@ -86,6 +91,7 @@ namespace Orleans.Hosting
                     }
 
                     services.AddSingleton<IGatewayListProvider, AdoNetGatewayListProvider>();
+                    services.AddSingleton<IConfigurationValidator, AdoNetClusteringClientOptionsValidator>();
                 });
         }
 
@@ -110,6 +116,7 @@ namespace Orleans.Hosting
                 {
                     configureOptions?.Invoke(services.AddOptions<AdoNetClusteringClientOptions>());
                     services.AddSingleton<IGatewayListProvider, AdoNetGatewayListProvider>();
+                    services.AddSingleton<IConfigurationValidator, AdoNetClusteringClientOptionsValidator>();
                 });
         }
     }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -33,7 +33,7 @@ namespace Orleans.Runtime.MembershipService
 
             //This initializes all of Orleans operational queries from the database using a well known view
             //and assumes the database with appropriate definitions exists already.
-            orleansQueries = await RelationalOrleansQueries.CreateInstance(clusteringTableOptions.AdoInvariant, clusteringTableOptions.ConnectionString, this.grainReferenceConverter);
+            orleansQueries = await RelationalOrleansQueries.CreateInstance(clusteringTableOptions.Invariant, clusteringTableOptions.ConnectionString, this.grainReferenceConverter);
             
             // even if I am not the one who created the table, 
             // try to insert an initial table version if it is not already there,

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
@@ -44,7 +44,7 @@ namespace Orleans.Runtime.Membership
         public async Task InitializeGatewayListProvider()
         {
             if (logger.IsEnabled(LogLevel.Trace)) logger.Trace("AdoNetClusteringTable.InitializeGatewayListProvider called.");
-            orleansQueries = await RelationalOrleansQueries.CreateInstance(options.AdoInvariant, options.ConnectionString, this.grainReferenceConverter);
+            orleansQueries = await RelationalOrleansQueries.CreateInstance(options.Invariant, options.ConnectionString, this.grainReferenceConverter);
         }
 
         public async Task<IList<Uri>> GetGateways()

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetClusteringConfigurator.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetClusteringConfigurator.cs
@@ -14,7 +14,7 @@ namespace Orleans.AdoNet
                 options =>
                 {
                     var reader = new GlobalConfigurationReader(configuration);
-                    options.AdoInvariant = reader.GetPropertyValue<string>("AdoInvariant");
+                    options.Invariant = reader.GetPropertyValue<string>("AdoInvariant");
                     options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
                 });
             services.AddSingleton<IMembershipTable, AdoNetClusteringTable>();

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetGatewayListProviderConfigurator.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetGatewayListProviderConfigurator.cs
@@ -16,7 +16,7 @@ namespace Orleans.AdoNet.Messaging
                 {
                     var reader = new ClientConfigurationReader(configuration);
                     options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
-                    options.AdoInvariant = reader.GetPropertyValue<string>("AdoInvariant");
+                    options.Invariant = reader.GetPropertyValue<string>("AdoInvariant");
                 });
             services.AddSingleton<IGatewayListProvider, AdoNetGatewayListProvider>();
         }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptions.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptions.cs
@@ -11,6 +11,6 @@
         /// <summary>
         /// The invariant name of the connector for gatewayProvider's database.
         /// </summary>
-        public string AdoInvariant { get; set; }
+        public string Invariant { get; set; }
     }
 }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptionsValidator.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptionsValidator.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+using Orleans.Runtime.MembershipService;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Validates <see cref="AdoNetClusteringClientOptions"/> configuration.
+    /// </summary>
+    public class AdoNetClusteringClientOptionsValidator : IConfigurationValidator
+    {
+        private readonly AdoNetClusteringClientOptions options;
+
+        public AdoNetClusteringClientOptionsValidator(IOptions<AdoNetClusteringClientOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        /// <inheritdoc />
+        public void ValidateConfiguration()
+        {
+            if (string.IsNullOrWhiteSpace(this.options.Invariant))
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringClientOptions)} values for {nameof(AdoNetClusteringTable)}. {nameof(options.Invariant)} is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(this.options.ConnectionString))
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringClientOptions)} values for {nameof(AdoNetClusteringTable)}. {nameof(options.ConnectionString)} is required.");
+            }
+        }
+    }
+}

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringSiloOptions.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringSiloOptions.cs
@@ -14,6 +14,6 @@
         /// <summary>
         /// The invariant name of the connector for membership's database.
         /// </summary>
-        public string AdoInvariant { get; set; }
+        public string Invariant { get; set; }
     }
 }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetReminderTableOptionsValidator.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetReminderTableOptionsValidator.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+using Orleans.Runtime.MembershipService;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Validates <see cref="AdoNetClusteringSiloOptions"/> configuration.
+    /// </summary>
+    public class AdoNetClusteringSiloOptionsValidator : IConfigurationValidator
+    {
+        private readonly AdoNetClusteringSiloOptions options;
+
+        public AdoNetClusteringSiloOptionsValidator(IOptions<AdoNetClusteringSiloOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        /// <inheritdoc />
+        public void ValidateConfiguration()
+        {
+            if (string.IsNullOrWhiteSpace(this.options.Invariant))
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringSiloOptions)} values for {nameof(AdoNetClusteringTable)}. {nameof(options.Invariant)} is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(this.options.ConnectionString))
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringSiloOptions)} values for {nameof(AdoNetClusteringTable)}. {nameof(options.ConnectionString)} is required.");
+            }
+        }
+    }
+}

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
@@ -78,10 +78,16 @@ namespace Orleans.Configuration
         /// <inheritdoc cref="IConfigurationValidator"/>
         public void ValidateConfiguration()
         {
+            if (string.IsNullOrWhiteSpace(this.options.Invariant))
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainStorageOptions)} values for {nameof(AdoNetGrainStorage)} \"{name}\". {nameof(options.Invariant)} is required.");
+            }
+
             if (string.IsNullOrWhiteSpace(this.options.ConnectionString))
             {
-                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainStorageOptions)} values for {nameof(AdoNetGrainStorage)} \"{name}\". ConnectionString is required.");
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainStorageOptions)} values for {nameof(AdoNetGrainStorage)} \"{name}\". {nameof(options.ConnectionString)} is required.");
             }
+
             if (options.UseXmlFormat&&options.UseJsonFormat)
             {
                 throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainStorageOptions)} values for {nameof(AdoNetGrainStorage)} \"{name}\". {nameof(options.UseXmlFormat)} and {nameof(options.UseJsonFormat)} cannot both be set to true");

--- a/src/AdoNet/Orleans.Reminders.AdoNet/LegacySiloReminderConfigurationAdapter.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/LegacySiloReminderConfigurationAdapter.cs
@@ -12,7 +12,8 @@ namespace Orleans.Hosting
         {
             var reader = new GlobalConfigurationReader(configuration);
             var connectionString = reader.GetPropertyValue<string>("DataConnectionStringForReminders");
-            services.UseAdoNetReminderService(connectionString);
+            var invariant = reader.GetPropertyValue<string>("AdoInvariantForReminders");
+            services.UseAdoNetReminderService(connectionString, invariant);
         }
     }
 }

--- a/src/AdoNet/Orleans.Reminders.AdoNet/LegacySiloReminderConfigurationAdapter.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/LegacySiloReminderConfigurationAdapter.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-
+using Orleans.Configuration;
 using Orleans.Runtime.MembershipService;
 
 namespace Orleans.Hosting
@@ -13,7 +13,11 @@ namespace Orleans.Hosting
             var reader = new GlobalConfigurationReader(configuration);
             var connectionString = reader.GetPropertyValue<string>("DataConnectionStringForReminders");
             var invariant = reader.GetPropertyValue<string>("AdoInvariantForReminders");
-            services.UseAdoNetReminderService(connectionString, invariant);
+            services.UseAdoNetReminderService(ob => ob.Configure(options =>
+            {
+                options.ConnectionString = connectionString;
+                options.Invariant = invariant;
+            }));
         }
     }
 }

--- a/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTableOptionsValidator.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTableOptionsValidator.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+using Orleans.Runtime.ReminderService;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Validates <see cref="AdoNetReminderTableOptions"/> configuration.
+    /// </summary>
+    public class AdoNetReminderTableOptionsValidator : IConfigurationValidator
+    {
+        private readonly AdoNetReminderTableOptions options;
+        
+        public AdoNetReminderTableOptionsValidator(IOptions<AdoNetReminderTableOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        /// <inheritdoc />
+        public void ValidateConfiguration()
+        {
+            if (string.IsNullOrWhiteSpace(this.options.Invariant))
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetReminderTableOptions)} values for {nameof(AdoNetReminderTable)}. {nameof(options.Invariant)} is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(this.options.ConnectionString))
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetReminderTableOptions)} values for {nameof(AdoNetReminderTable)}. {nameof(options.ConnectionString)} is required.");
+            }
+        }
+    }
+}

--- a/src/AdoNet/Orleans.Reminders.AdoNet/SiloHostBuilderReminderExtensions.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/SiloHostBuilderReminderExtensions.cs
@@ -23,10 +23,11 @@ namespace Orleans.Hosting
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>, for chaining.
         /// </returns>
-        public static ISiloHostBuilder UseAdoNetReminderService(this ISiloHostBuilder builder, Action<AdoNetReminderTableOptions> configure)
+        public static ISiloHostBuilder UseAdoNetReminderService(
+            this ISiloHostBuilder builder,
+            Action<AdoNetReminderTableOptions> configureOptions)
         {
-            builder.ConfigureServices(services => services.UseAdoNetReminderService(configure));
-            return builder;
+            return builder.UseAdoNetReminderService(ob => ob.Configure(configureOptions));
         }
 
         /// <summary>
@@ -35,25 +36,19 @@ namespace Orleans.Hosting
         /// <param name="builder">
         /// The builder.
         /// </param>
-        /// <param name="connectionString">
-        /// The storage connection string.
-        /// </param>
-        /// <param name="invariant">
-        /// The ADO.NET invariant name.
+        /// <param name="configure">
+        /// The delegate used to configure the reminder store.
         /// </param>
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>, for chaining.
         /// </returns>
-        public static ISiloHostBuilder UseAdoNetReminderService(this ISiloHostBuilder builder, string connectionString, string invariant)
+        public static ISiloHostBuilder UseAdoNetReminderService(
+            this ISiloHostBuilder builder,
+            Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
         {
-            builder.UseAdoNetReminderService(options =>
-            {
-                options.ConnectionString = connectionString;
-                options.Invariant = invariant;
-            });
-            return builder;
+            return builder.ConfigureServices(services => services.UseAdoNetReminderService(configureOptions));
         }
-
+        
         /// <summary>
         /// Adds reminder storage using ADO.NET.
         /// </summary>
@@ -66,36 +61,12 @@ namespace Orleans.Hosting
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>, for chaining.
         /// </returns>
-        private static void UseAdoNetReminderService(this IServiceCollection services, Action<AdoNetReminderTableOptions> configure)
+        internal static void UseAdoNetReminderService(this IServiceCollection services, Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
         {
             services.AddSingleton<IReminderTable, AdoNetReminderTable>();
             services.ConfigureFormatter<AdoNetReminderTableOptions>();
             services.AddSingleton<IConfigurationValidator, AdoNetReminderTableOptionsValidator>();
-            services.Configure(configure);
-        }
-
-        /// <summary>
-        /// Adds reminder storage using ADO.NET.
-        /// </summary>
-        /// <param name="services">
-        /// The service collection.
-        /// </param>
-        /// <param name="connectionString">
-        /// The storage connection string.
-        /// </param>
-        /// <param name="invariant">
-        /// The ADO.NET invariant name.
-        /// </param>
-        /// <returns>
-        /// The provided <see cref="ISiloHostBuilder"/>, for chaining.
-        /// </returns>
-        internal static void UseAdoNetReminderService(this IServiceCollection services, string connectionString, string invariant)
-        {
-            services.UseAdoNetReminderService(options =>
-            {
-                options.ConnectionString = connectionString;
-                options.Invariant = invariant;
-            });
+            services.Configure(configureOptions);
         }
     }
 }

--- a/src/AdoNet/Orleans.Reminders.AdoNet/SiloHostBuilderReminderExtensions.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/SiloHostBuilderReminderExtensions.cs
@@ -61,12 +61,13 @@ namespace Orleans.Hosting
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>, for chaining.
         /// </returns>
-        public static void UseAdoNetReminderService(this IServiceCollection services, Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
+        public static IServiceCollection UseAdoNetReminderService(this IServiceCollection services, Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
         {
             services.AddSingleton<IReminderTable, AdoNetReminderTable>();
             services.ConfigureFormatter<AdoNetReminderTableOptions>();
             services.AddSingleton<IConfigurationValidator, AdoNetReminderTableOptionsValidator>();
             services.Configure(configureOptions);
+            return services;
         }
     }
 }

--- a/src/AdoNet/Orleans.Reminders.AdoNet/SiloHostBuilderReminderExtensions.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/SiloHostBuilderReminderExtensions.cs
@@ -38,12 +38,19 @@ namespace Orleans.Hosting
         /// <param name="connectionString">
         /// The storage connection string.
         /// </param>
+        /// <param name="invariant">
+        /// The ADO.NET invariant name.
+        /// </param>
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>, for chaining.
         /// </returns>
-        public static ISiloHostBuilder UseAdoNetReminderService(this ISiloHostBuilder builder, string connectionString)
+        public static ISiloHostBuilder UseAdoNetReminderService(this ISiloHostBuilder builder, string connectionString, string invariant)
         {
-            builder.UseAdoNetReminderService(options => options.ConnectionString = connectionString);
+            builder.UseAdoNetReminderService(options =>
+            {
+                options.ConnectionString = connectionString;
+                options.Invariant = invariant;
+            });
             return builder;
         }
 
@@ -59,12 +66,12 @@ namespace Orleans.Hosting
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>, for chaining.
         /// </returns>
-        public static IServiceCollection UseAdoNetReminderService(this IServiceCollection services, Action<AdoNetReminderTableOptions> configure)
+        private static void UseAdoNetReminderService(this IServiceCollection services, Action<AdoNetReminderTableOptions> configure)
         {
             services.AddSingleton<IReminderTable, AdoNetReminderTable>();
             services.ConfigureFormatter<AdoNetReminderTableOptions>();
+            services.AddSingleton<IConfigurationValidator, AdoNetReminderTableOptionsValidator>();
             services.Configure(configure);
-            return services;
         }
 
         /// <summary>
@@ -76,13 +83,19 @@ namespace Orleans.Hosting
         /// <param name="connectionString">
         /// The storage connection string.
         /// </param>
+        /// <param name="invariant">
+        /// The ADO.NET invariant name.
+        /// </param>
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>, for chaining.
         /// </returns>
-        public static IServiceCollection UseAdoNetReminderService(this IServiceCollection services, string connectionString)
+        internal static void UseAdoNetReminderService(this IServiceCollection services, string connectionString, string invariant)
         {
-            services.UseAdoNetReminderService(options => options.ConnectionString = connectionString);
-            return services;
+            services.UseAdoNetReminderService(options =>
+            {
+                options.ConnectionString = connectionString;
+                options.Invariant = invariant;
+            });
         }
     }
 }

--- a/src/AdoNet/Orleans.Reminders.AdoNet/SiloHostBuilderReminderExtensions.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/SiloHostBuilderReminderExtensions.cs
@@ -61,7 +61,7 @@ namespace Orleans.Hosting
         /// <returns>
         /// The provided <see cref="ISiloHostBuilder"/>, for chaining.
         /// </returns>
-        internal static void UseAdoNetReminderService(this IServiceCollection services, Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
+        public static void UseAdoNetReminderService(this IServiceCollection services, Action<OptionsBuilder<AdoNetReminderTableOptions>> configureOptions)
         {
             services.AddSingleton<IReminderTable, AdoNetReminderTable>();
             services.ConfigureFormatter<AdoNetReminderTableOptions>();

--- a/test/TesterAdoNet/MySqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/MySqlMembershipTableTests.cs
@@ -34,7 +34,7 @@ namespace UnitTests.MembershipTests
         {
             var options = new AdoNetClusteringSiloOptions()
             {
-                AdoInvariant = GetAdoInvariant(),
+                Invariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
             return new AdoNetClusteringTable(this.GrainReferenceConverter, this.clusterOptions, Options.Create(options), loggerFactory.CreateLogger<AdoNetClusteringTable>());
@@ -45,7 +45,7 @@ namespace UnitTests.MembershipTests
             var options = new AdoNetClusteringClientOptions()
             {
                 ConnectionString = this.connectionString,
-                AdoInvariant = GetAdoInvariant()
+                Invariant = GetAdoInvariant()
             };
             return new AdoNetGatewayListProvider(loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, Options.Create(options), this.gatewayOptions, this.clusterOptions);
         }

--- a/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
+++ b/test/TesterAdoNet/PostgreSqlMembershipTableTests.cs
@@ -31,7 +31,7 @@ namespace UnitTests.MembershipTests
         {
             var options = new AdoNetClusteringSiloOptions()
             {
-                AdoInvariant = GetAdoInvariant(),
+                Invariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
             return new AdoNetClusteringTable(this.GrainReferenceConverter, this.clusterOptions, Options.Create(options), this.loggerFactory.CreateLogger<AdoNetClusteringTable>());
@@ -42,7 +42,7 @@ namespace UnitTests.MembershipTests
             var options = new AdoNetClusteringClientOptions()
             {
                 ConnectionString = this.connectionString,
-                AdoInvariant = GetAdoInvariant()
+                Invariant = GetAdoInvariant()
             };
             return new AdoNetGatewayListProvider(this.loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter
                 , Options.Create(options), this.gatewayOptions, this.clusterOptions);

--- a/test/TesterAdoNet/SqlServerMembershipTableTests.cs
+++ b/test/TesterAdoNet/SqlServerMembershipTableTests.cs
@@ -33,7 +33,7 @@ namespace UnitTests.MembershipTests
         {
             var options = new AdoNetClusteringSiloOptions()
             {
-                AdoInvariant = GetAdoInvariant(),
+                Invariant = GetAdoInvariant(),
                 ConnectionString = this.connectionString,
             };
             return new AdoNetClusteringTable(this.GrainReferenceConverter, this.clusterOptions, Options.Create(options),  this.loggerFactory.CreateLogger<AdoNetClusteringTable>());
@@ -44,7 +44,7 @@ namespace UnitTests.MembershipTests
             var options = new AdoNetClusteringClientOptions()
             {
                 ConnectionString = this.connectionString,
-                AdoInvariant = GetAdoInvariant()
+                Invariant = GetAdoInvariant()
             };
             return new AdoNetGatewayListProvider(this.loggerFactory.CreateLogger<AdoNetGatewayListProvider>(), this.GrainReferenceConverter, Options.Create(options), gatewayOptions, this.clusterOptions);
         }


### PR DESCRIPTION
* Consolidate naming of ADO.NET invariant option: now it's `Invariant` in all places, instead of being `AdoInvariant` in clustering and `Invariant` everywhere else.
* Add configuration validators for clustering and reminders and improve grain storage validator to check that `Invariant` is set.
* Propagate invariant value from legacy configuration to reminder configuration.
* Add `invariant` parameter on reminder config extension method which takes a connection string.