### PR TITLE
Consolidate legacy configuration methods

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/LegacyDynamoDBMembershipConfigurator.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/LegacyDynamoDBMembershipConfigurator.cs
@@ -3,6 +3,7 @@ using Orleans.Configuration;
 using Orleans.Runtime.MembershipService;
 using System;
 using System.Linq;
+using Orleans.Hosting;
 
 namespace Orleans.Clustering.DynamoDB
 {
@@ -15,16 +16,15 @@ namespace Orleans.Clustering.DynamoDB
         private const string ReadCapacityUnitsPropertyName = "ReadCapacityUnits";
         private const string WriteCapacityUnitsPropertyName = "WriteCapacityUnits";
 
-        public void Configure(object configuration, IServiceCollection services)
+        public void Configure(object configuration, ISiloHostBuilder builder)
         {
             var reader = new GlobalConfigurationReader(configuration);
 
-            services.Configure<DynamoDBClusteringOptions>(options =>
+            builder.UseDynamoDBClustering(options =>
             {
                 var cs = reader.GetPropertyValue<string>("DataConnectionString");
                 ParseDataConnectionString(cs, options);
             });
-            services.AddSingleton<IMembershipTable, DynamoDBMembershipTable>();
         }
 
         /// <summary>

--- a/src/AWS/Orleans.Reminders.DynamoDB/LegacySiloReminderConfigurationAdapter.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/LegacySiloReminderConfigurationAdapter.cs
@@ -10,11 +10,11 @@ namespace Orleans.Hosting
     internal class LegacySiloReminderConfigurationAdapter : ILegacyReminderTableAdapter
     {
         /// <inheritdoc />
-        public void Configure(object configuration, IServiceCollection services)
+        public void Configure(object configuration, ISiloHostBuilder builder)
         {
             var reader = new GlobalConfigurationReader(configuration);
             var connectionString = reader.GetPropertyValue<string>("DataConnectionStringForReminders");
-            services.UseDynamoDBReminderService(options => ParseDataConnectionString(connectionString, options));
+            builder.UseDynamoDBReminderService(options => ParseDataConnectionString(connectionString, options));
         }
 
         private const string AccessKeyPropertyName = "AccessKey";

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetClusteringConfigurator.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/LegacyAdoNetClusteringConfigurator.cs
@@ -1,6 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
-
-using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Runtime.MembershipService;
 
 namespace Orleans.AdoNet
@@ -8,16 +6,14 @@ namespace Orleans.AdoNet
     /// <inheritdoc />
     public class LegacyAdoNetClusteringConfigurator : ILegacyMembershipConfigurator
     {
-        public void Configure(object configuration, IServiceCollection services)
+        public void Configure(object configuration, ISiloHostBuilder builder)
         {
-            services.Configure<AdoNetClusteringSiloOptions>(
-                options =>
-                {
-                    var reader = new GlobalConfigurationReader(configuration);
-                    options.Invariant = reader.GetPropertyValue<string>("AdoInvariant");
-                    options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
-                });
-            services.AddSingleton<IMembershipTable, AdoNetClusteringTable>();
+            builder.UseAdoNetClustering(options =>
+            {
+                var reader = new GlobalConfigurationReader(configuration);
+                options.Invariant = reader.GetPropertyValue<string>("AdoInvariant");
+                options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
+            });
         }
     }
 }

--- a/src/AdoNet/Orleans.Reminders.AdoNet/LegacySiloReminderConfigurationAdapter.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/LegacySiloReminderConfigurationAdapter.cs
@@ -8,16 +8,16 @@ namespace Orleans.Hosting
     internal class LegacySiloReminderConfigurationAdapter : ILegacyReminderTableAdapter
     {
         /// <inheritdoc />
-        public void Configure(object configuration, IServiceCollection services)
+        public void Configure(object configuration, ISiloHostBuilder builder)
         {
             var reader = new GlobalConfigurationReader(configuration);
             var connectionString = reader.GetPropertyValue<string>("DataConnectionStringForReminders");
             var invariant = reader.GetPropertyValue<string>("AdoInvariantForReminders");
-            services.UseAdoNetReminderService(ob => ob.Configure(options =>
+            builder.UseAdoNetReminderService(options =>
             {
                 options.ConnectionString = connectionString;
                 options.Invariant = invariant;
-            }));
+            });
         }
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/LegacyAzureMembershipConfigurator.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/LegacyAzureMembershipConfigurator.cs
@@ -11,16 +11,14 @@ namespace Orleans.Runtime.MembershipService
     /// <inheritdoc />
     public class LegacyAzureTableMembershipConfigurator : ILegacyMembershipConfigurator
     {
-        public void Configure(object configuration, IServiceCollection services)
+        public void Configure(object configuration, ISiloHostBuilder builder)
         {
-            services.Configure((Action<AzureStorageClusteringOptions>)(options =>
-                {
-                    var reader = new GlobalConfigurationReader(configuration);
-                    options.MaxStorageBusyRetries = reader.GetPropertyValue<int>("MaxStorageBusyRetries");
-                    options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
-                }));
-            services.AddSingleton<IMembershipTable, AzureBasedMembershipTable>();
-            IServiceCollection temp = services;
+            builder.UseAzureStorageClustering(options =>
+            {
+                var reader = new GlobalConfigurationReader(configuration);
+                options.MaxStorageBusyRetries = reader.GetPropertyValue<int>("MaxStorageBusyRetries");
+                options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
+            });
         }
     }
 }

--- a/src/Azure/Orleans.Reminders.AzureStorage/LegacySiloReminderConfigurationAdapter.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/LegacySiloReminderConfigurationAdapter.cs
@@ -8,11 +8,11 @@ namespace Orleans.Hosting
     internal class LegacySiloReminderConfigurationAdapter : ILegacyReminderTableAdapter
     {
         /// <inheritdoc />
-        public void Configure(object configuration, IServiceCollection services)
+        public void Configure(object configuration, ISiloHostBuilder builder)
         {
             var reader = new GlobalConfigurationReader(configuration);
             var connectionString = reader.GetPropertyValue<string>("DataConnectionStringForReminders");
-            services.UseAzureTableReminderService(connectionString);
+            builder.UseAzureTableReminderService(connectionString);
         }
     }
 }

--- a/src/Orleans.Clustering.Consul/LegacyConsulMembershipConfigurator.cs
+++ b/src/Orleans.Clustering.Consul/LegacyConsulMembershipConfigurator.cs
@@ -1,20 +1,19 @@
 using System;
-using Microsoft.Extensions.DependencyInjection;
-
-using Orleans.Configuration;
-using Orleans.Runtime.Membership;
+using Orleans.Hosting;
 
 namespace Orleans.Runtime.MembershipService
 {
     /// <inheritdoc />
     public class LegacyConsulMembershipConfigurator : ILegacyMembershipConfigurator
     {
-        public void Configure(object configuration, IServiceCollection services)
+        public void Configure(object configuration, ISiloHostBuilder builder)
         {
             var reader = new GlobalConfigurationReader(configuration);
 
-            services.Configure<ConsulClusteringSiloOptions>(options => options.Address = new Uri(reader.GetPropertyValue<string>("DataConnectionString")));
-            services.AddSingleton<IMembershipTable, ConsulBasedMembershipTable>();
+            builder.UseConsulClustering(options =>
+            {
+                options.Address = new Uri(reader.GetPropertyValue<string>("DataConnectionString"));
+            });
         }
     }
 }

--- a/src/Orleans.Clustering.ZooKeeper/LegacyZooKeeperMembershipConfigurator.cs
+++ b/src/Orleans.Clustering.ZooKeeper/LegacyZooKeeperMembershipConfigurator.cs
@@ -1,20 +1,18 @@
-using Microsoft.Extensions.DependencyInjection;
-
-using Orleans;
-using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Runtime.MembershipService;
-using Orleans.Runtime.Membership;
 
 namespace OrleansZooKeeperUtils
 {
     /// <inheritdoc />
     public class LegacyZooKeeperMembershipConfigurator : ILegacyMembershipConfigurator
     {
-        public void Configure(object configuration, IServiceCollection services)
+        public void Configure(object configuration, ISiloHostBuilder builder)
         {
             var reader = new GlobalConfigurationReader(configuration);
-            services.Configure<ZooKeeperClusteringSiloOptions>(options => options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString"));
-            services.AddSingleton<IMembershipTable, ZooKeeperBasedMembershipTable>();
+            builder.UseZooKeeperClustering(options =>
+            {
+                options.ConnectionString = reader.GetPropertyValue<string>("DataConnectionString");
+            });
         }
     }
 }

--- a/src/Orleans.Runtime.Abstractions/MembershipService/ILegacyMembershipConfigurator.cs
+++ b/src/Orleans.Runtime.Abstractions/MembershipService/ILegacyMembershipConfigurator.cs
@@ -29,8 +29,8 @@ namespace Orleans.Runtime.MembershipService
         /// Configures the provided <paramref name="builder"/> using <paramref name="configuration"/>.
         /// </summary>
         /// <param name="configuration">The legacy GlobalConfiguration object.</param>
-        /// <param name="services">The silo services collection.</param>
-        void Configure(object configuration, IServiceCollection services);
+        /// <param name="services">The silo builder.</param>
+        void Configure(object configuration, ISiloHostBuilder builder);
     }
 
     /// <summary>

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyClusterConfigurationExtensions.cs
@@ -25,10 +25,7 @@ namespace Orleans.Hosting
         public static ISiloHostBuilder UseConfiguration(this ISiloHostBuilder builder, ClusterConfiguration configuration)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-            return builder.ConfigureServices((context, services) =>
-            {
-                services.AddLegacyClusterConfigurationSupport(configuration);
-            });
+            return builder.AddLegacyClusterConfigurationSupport(configuration);
         }
 
         /// <summary>
@@ -56,7 +53,14 @@ namespace Orleans.Hosting
             return builder.UseConfiguration(ClusterConfiguration.LocalhostPrimarySilo(siloPort, gatewayPort));
         }
 
-        public static IServiceCollection AddLegacyClusterConfigurationSupport(this IServiceCollection services, ClusterConfiguration configuration)
+        public static ISiloHostBuilder AddLegacyClusterConfigurationSupport(this ISiloHostBuilder builder, ClusterConfiguration configuration)
+        {
+            LegacyMembershipConfigurator.ConfigureServices(configuration.Globals, builder);
+            LegacyRemindersConfigurator.Configure(configuration.Globals, builder);
+            return builder.ConfigureServices(services => AddLegacyClusterConfigurationSupport(services, configuration));
+        }
+
+        private static void AddLegacyClusterConfigurationSupport(IServiceCollection services, ClusterConfiguration configuration)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
@@ -178,9 +182,7 @@ namespace Orleans.Hosting
                 var nodeConfig = configuration.GetOrCreateNodeConfigurationForSilo(siloOptions.Value.SiloName);
                 options.ExcludedGrainTypes.AddRange(nodeConfig.ExcludedGrainTypes);
             });
-
-            LegacyMembershipConfigurator.ConfigureServices(configuration.Globals, services);
-
+            
             services.AddOptions<SchedulingOptions>()
                 .Configure<GlobalConfiguration>((options, config) =>
                 {
@@ -268,7 +270,6 @@ namespace Orleans.Hosting
                 {
                     options.IsRunningAsUnitTest = config.IsRunningAsUnitTest;
                 });
-            LegacyRemindersConfigurator.Configure(configuration.Globals, services);
             
             services.AddOptions<GrainVersioningOptions>()
                 .Configure<GlobalConfiguration>((options, config) =>
@@ -302,8 +303,6 @@ namespace Orleans.Hosting
                     options.CacheTTLExtensionFactor = config.CacheTTLExtensionFactor;
                     options.LazyDeregistrationDelay = config.DirectoryLazyDeregistrationDelay;
                 });
-
-            return services;
         }
 
         public static ClusterConfiguration TryGetClusterConfiguration(this IServiceCollection services)

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyMembershipConfigurator.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyMembershipConfigurator.cs
@@ -16,7 +16,7 @@ namespace Orleans.Runtime.MembershipService
         /// Legacy way to create membership table. Will need to move to a legacy package in the future
         /// </summary>
         /// <returns></returns>
-        internal static void ConfigureServices(GlobalConfiguration configuration, IServiceCollection services)
+        internal static void ConfigureServices(GlobalConfiguration configuration, ISiloHostBuilder builder)
         {
             ILegacyMembershipConfigurator configurator = null;
             switch (configuration.LivenessType)
@@ -52,32 +52,25 @@ namespace Orleans.Runtime.MembershipService
                     break;
             }
 
-            configurator?.Configure(configuration, services);
+            configurator?.Configure(configuration, builder);
         }
 
         private class LegacyGrainBasedMembershipConfigurator : ILegacyMembershipConfigurator
         {
-            public void Configure(object configuration, IServiceCollection services)
+            public void Configure(object configuration, ISiloHostBuilder builder)
             {
-                GlobalConfiguration config = configuration as GlobalConfiguration;
-                if (config == null) throw new ArgumentException($"{nameof(GlobalConfiguration)} expected", nameof(configuration));
-                ConfigureServices(config, services);
-            }
-
-            private void ConfigureServices(GlobalConfiguration configuration, IServiceCollection services)
-            {
-                services.Configure<DevelopmentMembershipOptions>(options => CopyGlobalGrainBasedMembershipOptions(configuration, options));
-                services
-                    .AddSingleton<GrainBasedMembershipTable>()
-                    .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();
-            }
-
-            private static void CopyGlobalGrainBasedMembershipOptions(GlobalConfiguration configuration, DevelopmentMembershipOptions options)
-            {
-                if (configuration.SeedNodes?.Count > 0)
+                if (!(configuration is GlobalConfiguration config))
                 {
-                    options.PrimarySiloEndpoint = configuration.SeedNodes?.FirstOrDefault();
+                    throw new ArgumentException($"{nameof(GlobalConfiguration)} expected", nameof(configuration));
                 }
+
+                builder.UseDevelopmentClustering(options =>
+                {
+                    if (config.SeedNodes?.Count > 0)
+                    {
+                        options.PrimarySiloEndpoint = config.SeedNodes?.FirstOrDefault();
+                    }
+                });
             }
         }
     }

--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyRemindersConfigurator.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyRemindersConfigurator.cs
@@ -20,49 +20,53 @@ namespace Orleans.Runtime.MembershipService
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="services">The service collection.</param>
-        internal static void Configure(GlobalConfiguration configuration, IServiceCollection services)
+        internal static void Configure(GlobalConfiguration configuration, ISiloHostBuilder builder)
         {
             var serviceType = configuration.ReminderServiceType;
 
             switch (serviceType)
             {
                 case GlobalConfiguration.ReminderServiceProviderType.AdoNet:
-                    {
-                        var adapter = LegacyAssemblyLoader.LoadAndCreateInstance<ILegacyReminderTableAdapter>(Constants.ORLEANS_REMINDERS_ADONET);
-                        adapter.Configure(configuration, services);
-                        break;
-                    }
+                {
+                    var adapter = LegacyAssemblyLoader.LoadAndCreateInstance<ILegacyReminderTableAdapter>(Constants.ORLEANS_REMINDERS_ADONET);
+                    adapter.Configure(configuration, builder);
+                    break;
+                }
 
                 case GlobalConfiguration.ReminderServiceProviderType.AzureTable:
-                    {
-                        var adapter = LegacyAssemblyLoader.LoadAndCreateInstance<ILegacyReminderTableAdapter>(Constants.ORLEANS_REMINDERS_AZURESTORAGE);
-                        adapter.Configure(configuration, services);
-                        break;
-                    }
+                {
+                    var adapter = LegacyAssemblyLoader.LoadAndCreateInstance<ILegacyReminderTableAdapter>(Constants.ORLEANS_REMINDERS_AZURESTORAGE);
+                    adapter.Configure(configuration, builder);
+                    break;
+                }
 
                 case GlobalConfiguration.ReminderServiceProviderType.ReminderTableGrain:
-                    services.UseInMemoryReminderService();
+                    builder.UseInMemoryReminderService();
                     break;
+
                 case GlobalConfiguration.ReminderServiceProviderType.MockTable:
+                    builder.ConfigureServices(services =>
                     {
                         services.AddSingleton<IReminderTable, MockReminderTable>();
                         services.AddOptions<MockReminderTableOptions>()
                             .Configure<GlobalConfiguration>((options, config) => { options.OperationDelay = config.MockReminderTableTimeout; });
                         services.ConfigureFormatter<MockReminderTableOptions>();
-                        break;
-                    }
+                    });
+                    break;
 
                 case GlobalConfiguration.ReminderServiceProviderType.Custom:
-                    services.AddSingleton<IReminderTable>(
+                    builder.ConfigureServices(services => services.AddSingleton<IReminderTable>(
                         serviceProvider =>
-                            {
-                                var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("ReminderTableFactory");
-                                return AssemblyLoader.LoadAndCreateInstance<IReminderTable>(configuration.ReminderTableAssembly, logger, serviceProvider);
-                            });
+                        {
+                            var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("ReminderTableFactory");
+                            return AssemblyLoader.LoadAndCreateInstance<IReminderTable>(configuration.ReminderTableAssembly, logger, serviceProvider);
+                        }));
                     break;
+
                 case GlobalConfiguration.ReminderServiceProviderType.NotSpecified:
                 case GlobalConfiguration.ReminderServiceProviderType.Disabled:
                     break;
+
                 default:
                     throw new ArgumentOutOfRangeException(
                         nameof(configuration.ReminderServiceType),

--- a/src/Orleans.TestingHost.Legacy/LegacyTestClusterBuilderExtensions.cs
+++ b/src/Orleans.TestingHost.Legacy/LegacyTestClusterBuilderExtensions.cs
@@ -39,10 +39,7 @@ namespace Orleans.TestingHost
         {
             public override void Configure(ISiloHostBuilder hostBuilder)
             {
-                hostBuilder.ConfigureServices((context, services) =>
-                {
-                    services.AddLegacyClusterConfigurationSupport(this.ClusterConfiguration);
-                });
+                hostBuilder.AddLegacyClusterConfigurationSupport(this.ClusterConfiguration);
             }
         }
 


### PR DESCRIPTION
This removes some duplication in the legacy configuration methods.

By making legacy configuration use `ISiloHostBuilder`, there is less dependence on using `IServiceCollection` methods for provider configuration, as well as less duplication.

This will conflict with #4097, so I'll need to rebase whichever comes second.