### PR TITLE
In ActivationCountPlacementDirector, place locally if the cache is not ready

### DIFF
--- a/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
+++ b/src/Orleans.Runtime/Placement/ActivationCountPlacementDirector.cs
@@ -39,14 +39,20 @@ namespace Orleans.Runtime.Placement
         // Track created activations on this silo between statistic intervals.
         private readonly ConcurrentDictionary<SiloAddress, CachedLocalStat> localCache = new ConcurrentDictionary<SiloAddress, CachedLocalStat>();
         private readonly ILogger logger;
+        private readonly SiloAddress localAddress;
         private readonly bool useLocalCache = true;
         // For: SelectSiloPowerOfK
         private readonly SafeRandom random = new SafeRandom();
         private int chooseHowMany = 2;
 
-        public ActivationCountPlacementDirector(DeploymentLoadPublisher deploymentLoadPublisher, IOptions<GrainPlacementOptions> options, ILogger<ActivationCountPlacementDirector> logger)
+        public ActivationCountPlacementDirector(
+            ILocalSiloDetails localSiloDetails,
+            DeploymentLoadPublisher deploymentLoadPublisher, 
+            IOptions<GrainPlacementOptions> options, 
+            ILogger<ActivationCountPlacementDirector> logger)
         {
             this.logger = logger;
+            this.localAddress = localSiloDetails.SiloAddress;
 
             SelectSilo = SelectSiloPowerOfK;
             if (options.Value.ActivationCountPlacementChooseOutOf <= 0)
@@ -164,6 +170,10 @@ namespace Orleans.Runtime.Placement
         public override Task<SiloAddress> OnAddActivation(
             PlacementStrategy strategy, PlacementTarget target, IPlacementContext context)
         {
+            // If the cache was not populated, just place locally
+            if (this.localCache.IsEmpty)
+                return Task.FromResult(this.localAddress);
+
             return SelectSilo(strategy, target, context);
         }
 


### PR DESCRIPTION
It's possible that when using `ActivationCountBasedPlacement` strategy, the silo will try to choose a place for an activation before the cache used in the director is populated.

The proposed fix is just to place locally until the cache is ready.
