### PR TITLE
Support treating all descendants of a base class as [Serializable]

### DIFF
--- a/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
+++ b/src/Orleans.CodeGeneration/RoslynCodeGenerator.cs
@@ -20,7 +20,6 @@ using Orleans.ApplicationParts;
 using Orleans.Metadata;
 using GrainInterfaceUtils = Orleans.CodeGeneration.GrainInterfaceUtils;
 using SF = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using TypeInfo = System.Reflection.TypeInfo;
 
 namespace Orleans.CodeGenerator
 {
@@ -357,6 +356,11 @@ namespace Orleans.CodeGenerator
             if (type == null) return false;
             if (type.GetCustomAttribute<KnownBaseTypeAttribute>() != null) return true;
             if (TypeHasKnownBase(type.BaseType)) return true;
+            var interfaces = type.GetInterfaces();
+            foreach (var iface in interfaces)
+            {
+                if (TypeHasKnownBase(iface)) return true;
+            }
 
             return false;
         }

--- a/src/Orleans.Core.Abstractions/CodeGeneration/ConsiderForCodeGenerationAttribute.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/ConsiderForCodeGenerationAttribute.cs
@@ -49,4 +49,12 @@ namespace Orleans.CodeGeneration
         /// <param name="type">The type that the generator should generate code for</param>
         public GenerateSerializerAttribute(Type type) : base(type, true){ }
     }
+
+    /// <summary>
+    /// Indicates that this type and all subtypes are to be considered as [Serializable].
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class KnownBaseTypeAttribute : Attribute
+    {
+    }
 }

--- a/src/Orleans.Core.Abstractions/CodeGeneration/ConsiderForCodeGenerationAttribute.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/ConsiderForCodeGenerationAttribute.cs
@@ -53,7 +53,7 @@ namespace Orleans.CodeGeneration
     /// <summary>
     /// Indicates that this type and all subtypes are to be considered as [Serializable].
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
     public sealed class KnownBaseTypeAttribute : Attribute
     {
     }

--- a/test/NonSilo.Tests/Serialization/SerializerGenerationTests.cs
+++ b/test/NonSilo.Tests/Serialization/SerializerGenerationTests.cs
@@ -35,18 +35,20 @@ namespace UnitTests.Serialization
         }
 
         /// <summary>
-        /// Types with an ancestor class marked with <see cref="KnownBaseTypeAttribute"/> should have serializers generated.
+        /// Types with an ancestor marked with <see cref="KnownBaseTypeAttribute"/> should have serializers generated.
         /// </summary>
         [Fact]
         public void SerializationTests_TypeWithWellKnownBaseClass()
         {
-            Assert.NotNull(this.fixture.SerializationManager.GetSerializer(typeof(DescendantOfWellKnownBaseType)));
+            Assert.NotNull(this.fixture.SerializationManager.GetSerializer(typeof(DescendantOfWellKnownBaseClass)));
+            Assert.NotNull(this.fixture.SerializationManager.GetSerializer(typeof(ImplementsWellKnownInterface)));
             Assert.Null(this.fixture.SerializationManager.GetSerializer(typeof(NotDescendantOfWellKnownBaseType)));
 
             var partManager = this.fixture.Services.GetRequiredService<IApplicationPartManager>();
             var serializerFeature = new SerializerFeature();
             partManager.PopulateFeature(serializerFeature);
-            Assert.Contains(serializerFeature.SerializerTypes, s => s.Target == typeof(DescendantOfWellKnownBaseType));
+            Assert.Contains(serializerFeature.SerializerTypes, s => s.Target == typeof(DescendantOfWellKnownBaseClass));
+            Assert.Contains(serializerFeature.SerializerTypes, s => s.Target == typeof(ImplementsWellKnownInterface));
             Assert.DoesNotContain(serializerFeature.SerializerTypes, s => s.Target == typeof(NotDescendantOfWellKnownBaseType));
         }
     }

--- a/test/NonSilo.Tests/Serialization/SerializerGenerationTests.cs
+++ b/test/NonSilo.Tests/Serialization/SerializerGenerationTests.cs
@@ -1,5 +1,10 @@
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.ApplicationParts;
+using Orleans.Serialization;
 using Orleans.UnitTest.GrainInterfaces;
 using TestExtensions;
+using UnitTests.GrainInterfaces;
 using Xunit;
 
 // ReSharper disable NotAccessedVariable
@@ -10,6 +15,7 @@ namespace UnitTests.Serialization
     /// Test the built-in serializers
     /// </summary>
     [Collection(TestEnvironmentFixture.DefaultCollection)]
+    [TestCategory("BVT"), TestCategory("Serialization")]
     public class SerializerGenerationTests
     {
         private readonly TestEnvironmentFixture fixture;
@@ -19,13 +25,29 @@ namespace UnitTests.Serialization
             this.fixture = fixture;
         }
 
-        [Fact, TestCategory("Functional"), TestCategory("Serialization")]
+        [Fact]
         public void SerializationTests_TypeWithInternalNestedClass()
         {
             var v = new MyTypeWithAnInternalTypeField();
 
             Assert.NotNull(this.fixture.SerializationManager.GetSerializer(typeof (MyTypeWithAnInternalTypeField)));
             Assert.NotNull(this.fixture.SerializationManager.GetSerializer(typeof(MyTypeWithAnInternalTypeField.MyInternalDependency)));
+        }
+
+        /// <summary>
+        /// Types with an ancestor class marked with <see cref="KnownBaseTypeAttribute"/> should have serializers generated.
+        /// </summary>
+        [Fact]
+        public void SerializationTests_TypeWithWellKnownBaseClass()
+        {
+            Assert.NotNull(this.fixture.SerializationManager.GetSerializer(typeof(DescendantOfWellKnownBaseType)));
+            Assert.Null(this.fixture.SerializationManager.GetSerializer(typeof(NotDescendantOfWellKnownBaseType)));
+
+            var partManager = this.fixture.Services.GetRequiredService<IApplicationPartManager>();
+            var serializerFeature = new SerializerFeature();
+            partManager.PopulateFeature(serializerFeature);
+            Assert.Contains(serializerFeature.SerializerTypes, s => s.Target == typeof(DescendantOfWellKnownBaseType));
+            Assert.DoesNotContain(serializerFeature.SerializerTypes, s => s.Target == typeof(NotDescendantOfWellKnownBaseType));
         }
     }
 }

--- a/test/TestExtensions/SerializationTestEnvironment.cs
+++ b/test/TestExtensions/SerializationTestEnvironment.cs
@@ -64,7 +64,7 @@ namespace TestExtensions
 
         internal IInternalGrainFactory InternalGrainFactory => this.RuntimeClient.InternalGrainFactory;
 
-        internal IServiceProvider Services => this.RuntimeClient.ServiceProvider;
+        internal IServiceProvider Services => this.Client.ServiceProvider;
 
         public SerializationManager SerializationManager => this.RuntimeClient.ServiceProvider.GetRequiredService<SerializationManager>();
         

--- a/test/TestGrainInterfaces/SerializerTestTypes.cs
+++ b/test/TestGrainInterfaces/SerializerTestTypes.cs
@@ -39,9 +39,17 @@ namespace UnitTests.GrainInterfaces
     }
 
     [KnownBaseType]
-    public abstract class WellKnownBaseType { }
+    public abstract class WellKnownBaseClass { }
 
-    public class DescendantOfWellKnownBaseType : WellKnownBaseType
+    public class DescendantOfWellKnownBaseClass : WellKnownBaseClass
+    {
+        public int FavouriteNumber { get; set; }
+    }
+
+    [KnownBaseType]
+    public interface IWellKnownBase { }
+
+    public class ImplementsWellKnownInterface : IWellKnownBase
     {
         public int FavouriteNumber { get; set; }
     }

--- a/test/TestGrainInterfaces/SerializerTestTypes.cs
+++ b/test/TestGrainInterfaces/SerializerTestTypes.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Orleans.CodeGeneration;
 using Orleans.Serialization;
 
 namespace UnitTests.GrainInterfaces
@@ -35,5 +36,18 @@ namespace UnitTests.GrainInterfaces
     public class SubClassOverridingAutoProp : BaseClassWithAutoProp
     {
         public new string AutoProp { get => base.AutoProp.ToString(); set => base.AutoProp = int.Parse(value); }
+    }
+
+    [KnownBaseType]
+    public abstract class WellKnownBaseType { }
+
+    public class DescendantOfWellKnownBaseType : WellKnownBaseType
+    {
+        public int FavouriteNumber { get; set; }
+    }
+
+    public class NotDescendantOfWellKnownBaseType
+    {
+        public int FavouriteNumber { get; set; }
     }
 }


### PR DESCRIPTION
Resolves #3910

Adding `[KnownBaseType]` to a base class will cause the code generator to consider that class and all subclasses as `[Serializable]`.

Note: only base *classes* are supported, not interfaces. Supporting interfaces is a simple addition which we can add later but it might add a perf hit during build (branch-out search is more costly). We generally prefer "pay for what you use" but this could have an impact on all users.
