### PR TITLE
Remove legacy configuration requirement from Service Fabric hosting

### DIFF
--- a/src/Orleans.Clustering.ServiceFabric/FabricMembershipOracle.cs
+++ b/src/Orleans.Clustering.ServiceFabric/FabricMembershipOracle.cs
@@ -5,7 +5,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.Clustering.ServiceFabric.Utilities;
+using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.ServiceFabric;
@@ -25,10 +27,10 @@ namespace Orleans.Clustering.ServiceFabric
         private readonly BlockingCollection<StatusChangeNotification> notifications = new BlockingCollection<StatusChangeNotification>();
         private readonly TimeSpan refreshPeriod = TimeSpan.FromSeconds(5);
         private readonly ILocalSiloDetails localSiloDetails;
-        private readonly GlobalConfiguration globalConfig;
         private readonly IFabricServiceSiloResolver fabricServiceSiloResolver;
         private readonly ILogger log;
         private readonly UnknownSiloMonitor unknownSiloMonitor;
+        private readonly MultiClusterOptions multiClusterOptions;
 
         // Cached collection of active silos.
         private volatile Dictionary<SiloAddress, SiloStatus> activeSilosCache;
@@ -46,22 +48,21 @@ namespace Orleans.Clustering.ServiceFabric
         /// Initializes a new instance of the <see cref="FabricMembershipOracle"/> class.
         /// </summary>
         /// <param name="localSiloDetails">The silo which this instance will provide membership information for.</param>
-        /// <param name="globalConfig">The cluster configuration.</param>
         /// <param name="fabricServiceSiloResolver">The service resolver which this instance will use.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="unknownSiloMonitor">The unknown silo monitor.</param>
         public FabricMembershipOracle(
             ILocalSiloDetails localSiloDetails,
-            GlobalConfiguration globalConfig,
             IFabricServiceSiloResolver fabricServiceSiloResolver,
             ILogger<FabricMembershipOracle> logger,
-            UnknownSiloMonitor unknownSiloMonitor)
+            UnknownSiloMonitor unknownSiloMonitor,
+            IOptions<MultiClusterOptions> multiClusterOptions)
         {
             this.log = logger;
             this.localSiloDetails = localSiloDetails;
-            this.globalConfig = globalConfig;
             this.fabricServiceSiloResolver = fabricServiceSiloResolver;
             this.unknownSiloMonitor = unknownSiloMonitor;
+            this.multiClusterOptions = multiClusterOptions.Value;
             this.silos[this.SiloAddress] = new SiloEntry(SiloStatus.Created, this.SiloName);
         }
 
@@ -91,7 +92,7 @@ namespace Orleans.Clustering.ServiceFabric
                 if (this.multiClusterSilosCache != null) return this.multiClusterSilosCache;
 
                 // Take all the active silos if their count does not exceed the desired number of gateways
-                var maxSize = this.globalConfig.MaxMultiClusterGateways;
+                var maxSize = this.multiClusterOptions.MaxMultiClusterGateways;
                 var gateways = this.silos.Where(entry => entry.Value.Status == SiloStatus.Active).Select(entry => entry.Key);
                 result = new List<SiloAddress>(gateways);
 

--- a/src/Orleans.Hosting.ServiceFabric/Orleans.Hosting.ServiceFabric.csproj
+++ b/src/Orleans.Hosting.ServiceFabric/Orleans.Hosting.ServiceFabric.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Core.Abstractions\Orleans.Core.Abstractions.csproj" />
-    <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Orleans.Hosting.ServiceFabric/OrleansCommunicationListener.cs
+++ b/src/Orleans.Hosting.ServiceFabric/OrleansCommunicationListener.cs
@@ -7,7 +7,6 @@ using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Newtonsoft.Json;
 using Orleans.Configuration;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.ServiceFabric;
 
 namespace Orleans.Hosting.ServiceFabric

--- a/src/Orleans.Hosting.ServiceFabric/ServiceFabricConfigurationExtensions.cs
+++ b/src/Orleans.Hosting.ServiceFabric/ServiceFabricConfigurationExtensions.cs
@@ -2,9 +2,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Fabric;
 using System.Fabric.Description;
-using System.Net;
+using Orleans.Configuration;
 using Orleans.ServiceFabric;
-using NodeConfiguration = Orleans.Runtime.Configuration.NodeConfiguration;
 
 namespace Orleans.Hosting
 {
@@ -16,27 +15,18 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configures silo and gateway endpoints from the provided Service Fabric service's configuration.
         /// </summary>
-        /// <param name="configuration">The node configuration.</param>
+        /// <param name="options">The endpoint configuration.</param>
         /// <param name="context">The service context.</param>
-        /// <returns>The node configuration.</returns>
-        public static NodeConfiguration ConfigureServiceFabricSiloEndpoints(this NodeConfiguration configuration, ServiceContext context)
+        public static void ConfigureFromServiceContext(this EndpointOptions options, ServiceContext context)
         {
             // Gather configuration from Service Fabric.
             var activation = context.CodePackageActivationContext;
             var endpoints = activation.GetEndpoints();
             var siloEndpoint = GetEndpoint(endpoints, ServiceFabricConstants.SiloEndpointName);
             var gatewayEndpoint = GetEndpoint(endpoints, ServiceFabricConstants.GatewayEndpointName);
-
-            // Set the endpoints according to Service Fabric configuration.
-            if (string.IsNullOrWhiteSpace(configuration.HostNameOrIPAddress))
-            {
-                configuration.HostNameOrIPAddress = context.NodeContext.IPAddressOrFQDN;
-            }
-
-            configuration.Port = siloEndpoint.Port;
-            configuration.ProxyGatewayEndpoint = new IPEndPoint(configuration.Endpoint.Address, gatewayEndpoint.Port);
-
-            return configuration;
+            
+            options.SiloPort = siloEndpoint.Port;
+            options.GatewayPort = gatewayEndpoint.Port;
         }
 
         /// <summary>

--- a/test/TestServiceFabric/FabricMembershipOracleTests.cs
+++ b/test/TestServiceFabric/FabricMembershipOracleTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Options;
 using Orleans.Clustering.ServiceFabric;
 using Orleans.Configuration;
 using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.ServiceFabric;
 using TestExtensions;
 using Xunit;
@@ -38,10 +37,11 @@ namespace TestServiceFabric
             };
 
             this.resolver = new MockResolver();
-            var globalConfig = new ClusterConfiguration().Globals;
-            globalConfig.HasMultiClusterNetwork = true;
-            globalConfig.MaxMultiClusterGateways = 2;
-            globalConfig.ClusterId = "MegaGoodCluster";
+            var multiClusterOptions = new MultiClusterOptions
+            {
+                HasMultiClusterNetwork = true,
+                MaxMultiClusterGateways = 2
+            };
 
             this.fabricClusteringOptions = new ServiceFabricClusteringOptions();
             this.unknownSiloMonitor = new UnknownSiloMonitor(
@@ -49,10 +49,10 @@ namespace TestServiceFabric
                 new TestOutputLogger<UnknownSiloMonitor>(this.Output));
             this.oracle = new FabricMembershipOracle(
                 this.siloDetails,
-                globalConfig,
                 this.resolver,
                 new NullLogger<FabricMembershipOracle>(),
-                this.unknownSiloMonitor);
+                this.unknownSiloMonitor,
+                Options.Create(multiClusterOptions));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #4109

The method for configuring endpoint options changes from
```C# 
clusterConfig.Defaults.ConfigureServiceFabricSiloEndpoints(this.serviceContext);
builder.UseConfiguration(clusterConfig);
```
to 
```C#
builder.Configure<EndpointOptions>(options =>
  options.ConfigureFromServiceContext(serviceContext));
```