### PR TITLE
Specify default ClusterId & simplify related extension methods

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
@@ -8,14 +8,14 @@ namespace Orleans.Configuration
     public class ClusterOptions
     {
         /// <summary>
-        /// Default cluster id for development clusters.
+        /// Default <see cref="ClusterId"/> value.
         /// </summary>
-        internal const string DevelopmentClusterId = "dev";
+        internal const string DefaultClusterId = "default";
 
         /// <summary>
         /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
         /// </summary>
-        public string ClusterId { get; set; }
+        public string ClusterId { get; set; } = DefaultClusterId;
 
         /// <summary>
         /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment, where as <see cref="ClusterId"/> might not.

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -154,14 +154,9 @@ namespace Orleans
         /// <param name="gatewayPort">The local silo's gateway port.</param>
         public static IClientBuilder UseLocalhostClustering(
             this IClientBuilder builder,
-            int gatewayPort = 30000,
-            string clusterId = ClusterOptions.DevelopmentClusterId)
+            int gatewayPort = 30000)
         {
-            return builder.UseStaticClustering(new IPEndPoint(IPAddress.Loopback, gatewayPort))
-                .ConfigureCluster(options =>
-                {
-                    if (!string.IsNullOrWhiteSpace(clusterId)) options.ClusterId = clusterId;
-                });
+            return builder.UseStaticClustering(new IPEndPoint(IPAddress.Loopback, gatewayPort));
         }
 
         /// <summary>
@@ -170,11 +165,7 @@ namespace Orleans
         /// <param name="gatewayPorts">The local silo gateway port.</param>
         public static IClientBuilder UseLocalhostClustering(this IClientBuilder builder, params int[] gatewayPorts)
         {
-            return builder.UseStaticClustering(gatewayPorts.Select(p => new IPEndPoint(IPAddress.Loopback, p)).ToArray())
-                .ConfigureCluster(options =>
-                {
-                    options.ClusterId = ClusterOptions.DevelopmentClusterId;
-                });
+            return builder.UseStaticClustering(gatewayPorts.Select(p => new IPEndPoint(IPAddress.Loopback, p)).ToArray());
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -122,8 +122,7 @@ namespace Orleans.Hosting
             this ISiloHostBuilder builder,
             int siloPort = EndpointOptions.DEFAULT_SILO_PORT,
             int gatewayPort = EndpointOptions.DEFAULT_GATEWAY_PORT,
-            IPEndPoint primarySiloEndpoint = null,
-            string clusterId = ClusterOptions.DevelopmentClusterId)
+            IPEndPoint primarySiloEndpoint = null)
         {
             builder.Configure<EndpointOptions>(options =>
             {
@@ -133,7 +132,6 @@ namespace Orleans.Hosting
             });
 
             builder.UseDevelopmentClustering(primarySiloEndpoint ?? new IPEndPoint(IPAddress.Loopback, siloPort));
-            builder.Configure(options => options.ClusterId = clusterId);
 
             return builder;
         }
@@ -155,23 +153,21 @@ namespace Orleans.Hosting
         /// </summary>
         public static ISiloHostBuilder UseDevelopmentClustering(
             this ISiloHostBuilder builder,
-            Action<DevelopmentClusterMembershipOptions> configureOptions,
-            string clusterId = ClusterOptions.DevelopmentClusterId)
+            Action<DevelopmentClusterMembershipOptions> configureOptions)
         {
             return builder
-                .Configure(options => options.ClusterId = clusterId)
                 .ConfigureServices(
-                services =>
-                {
-                    if (configureOptions != null)
+                    services =>
                     {
-                        services.Configure(configureOptions);
-                    }
+                        if (configureOptions != null)
+                        {
+                            services.Configure(configureOptions);
+                        }
 
-                    services
-                        .AddSingleton<GrainBasedMembershipTable>()
-                        .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();
-                });
+                        services
+                            .AddSingleton<GrainBasedMembershipTable>()
+                            .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();
+                    });
         }
 
         /// <summary>
@@ -179,8 +175,7 @@ namespace Orleans.Hosting
         /// </summary>
         public static ISiloHostBuilder UseDevelopmentClustering(
             this ISiloHostBuilder builder,
-            Action<OptionsBuilder<DevelopmentClusterMembershipOptions>> configureOptions,
-            string clusterId = ClusterOptions.DevelopmentClusterId)
+            Action<OptionsBuilder<DevelopmentClusterMembershipOptions>> configureOptions)
         {
             return builder.ConfigureServices(
                 services =>


### PR DESCRIPTION
The rationale is that ClusterId only needs to be set when there's more than one cluster using the same storage (membership, reminders, persistence, multi-cluster channel).