### PR TITLE
Fix for PerfCounterEnvironmentStatistics never reports CpuUsage

### DIFF
--- a/src/Orleans.TelemetryConsumers.Counters/Statistics/HostBuilderExtensions.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/Statistics/HostBuilderExtensions.cs
@@ -1,7 +1,9 @@
 #define LOG_MEMORY_PERF_COUNTERS
 
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration;
 using Orleans.Hosting;
+using Orleans.Runtime;
 
 namespace Orleans.Statistics
 {
@@ -12,7 +14,10 @@ namespace Orleans.Statistics
         /// </summary>
         public static ISiloHostBuilder UsePerfCounterEnvironmentStatistics(this ISiloHostBuilder builder)
         {
-            return builder.ConfigureServices(services => services.AddSingleton<IHostEnvironmentStatistics, PerfCounterEnvironmentStatistics>());
+            return builder.ConfigureServices(services =>
+                services
+                    .AddSingleton<IHostEnvironmentStatistics, PerfCounterEnvironmentStatistics>()
+                    .AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, PerfCounterEnvironmentStatistics>());
         }
     }
 

--- a/src/Orleans.TelemetryConsumers.Counters/Statistics/HostBuilderExtensions.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/Statistics/HostBuilderExtensions.cs
@@ -28,7 +28,10 @@ namespace Orleans.Statistics
         /// </summary>
         public static IClientBuilder UsePerfCounterEnvironmentStatistics(this IClientBuilder builder)
         {
-            return builder.ConfigureServices(services => services.AddSingleton<IHostEnvironmentStatistics, PerfCounterEnvironmentStatistics>());
+            return builder.ConfigureServices(services => 
+                services
+                    .AddSingleton<IHostEnvironmentStatistics, PerfCounterEnvironmentStatistics>()
+                    .AddFromExisting<ILifecycleParticipant<IClusterClientLifecycle>, PerfCounterEnvironmentStatistics>());
         }
     }
 }

--- a/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
+++ b/src/Orleans.TelemetryConsumers.Counters/Statistics/PerfCounterEnvironmentStatistics.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Orleans.Statistics
 {
-    internal class PerfCounterEnvironmentStatistics : IHostEnvironmentStatistics, ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver, IDisposable
+    internal class PerfCounterEnvironmentStatistics : IHostEnvironmentStatistics, ILifecycleParticipant<ISiloLifecycle>, ILifecycleParticipant<IClusterClientLifecycle>, ILifecycleObserver, IDisposable
     {
         private readonly ILogger logger;
         private const float KB = 1024f;
@@ -257,6 +257,11 @@ namespace Orleans.Statistics
         }
 
         public void Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(ServiceLifecycleStage.RuntimeInitialize, this);
+        }
+
+        public void Participate(IClusterClientLifecycle lifecycle)
         {
             lifecycle.Subscribe(ServiceLifecycleStage.RuntimeInitialize, this);
         }


### PR DESCRIPTION
Fix for #4129 