### PR TITLE
Support retries in ClusterClient.Connect(...)

### DIFF
--- a/src/Orleans.Core/Core/ClusterClient.cs
+++ b/src/Orleans.Core/Core/ClusterClient.cs
@@ -104,7 +104,7 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        public async Task Connect()
+        public async Task Connect(Func<Exception, Task<bool>> retryFilter = null)
         {
             this.ThrowIfDisposedOrAlreadyInitialized();
             using (await this.initLock.LockAsync().ConfigureAwait(false))
@@ -116,8 +116,8 @@ namespace Orleans
                 }
                 
                 this.state = LifecycleState.Starting;
-                await this.runtimeClient.Start().ConfigureAwait(false);
-                await this.clusterClientLifecycle.OnStart();
+                await this.runtimeClient.Start(retryFilter).ConfigureAwait(false);
+                await this.clusterClientLifecycle.OnStart().ConfigureAwait(false);
                 this.state = LifecycleState.Started;
             }
         }

--- a/src/Orleans.Core/Core/IClusterClient.cs
+++ b/src/Orleans.Core/Core/IClusterClient.cs
@@ -32,8 +32,11 @@ namespace Orleans
         /// Starts the client and connects to the configured cluster.
         /// </summary>
         /// <remarks>This method may be called at-most-once per instance.</remarks>
+        /// <param name="retryFilter">
+        /// An optional delegate which determines whether or not the initial connection attempt should be retried.
+        /// </param>
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>
-        Task Connect();
+        Task Connect(Func<Exception, Task<bool>> retryFilter = null);
 
         /// <summary>
         /// Stops the client gracefully, disconnecting from the cluster.

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -42,7 +42,6 @@ namespace Orleans
         internal ClientStatisticsManager ClientStatistics;
         private GrainId clientId;
         private readonly GrainId handshakeClientId;
-        private IGrainTypeResolver grainTypeResolver;
         private ThreadTrackingStatistic incomingMessagesThreadTimeTracking;
         private readonly Func<Message, bool> tryResendMessage;
         private readonly Action<Message> unregisterCallback;
@@ -178,26 +177,39 @@ namespace Orleans
             clientProviderRuntime.StreamingInitialize(implicitSubscriberTable);
         }
 
-        private void UnhandledException(ISchedulingContext context, Exception exception)
-        {
-            logger.Error(ErrorCode.Runtime_Error_100007, "OutsideRuntimeClient caught an UnobservedException.", exception);
-            logger.Assert(ErrorCode.Runtime_Error_100008, context == null, "context should be not null only inside OrleansRuntime and not on the client.");
-        }
-
-        public async Task Start()
+        public async Task Start(Func<Exception, Task<bool>> retryFilter = null)
         {
             // Deliberately avoid capturing the current synchronization context during startup and execute on the default scheduler.
             // This helps to avoid any issues (such as deadlocks) caused by executing with the client's synchronization context/scheduler.
-            await Task.Run(this.StartInternal).ConfigureAwait(false);
+            await Task.Run(() => this.StartInternal(retryFilter)).ConfigureAwait(false);
 
             logger.Info(ErrorCode.ProxyClient_StartDone, "{0} Started OutsideRuntimeClient with Global Client ID: {1}", BARS, CurrentActivationAddress.ToString() + ", client GUID ID: " + handshakeClientId);
         }
-
+        
         // used for testing to (carefully!) allow two clients in the same process
-        private async Task StartInternal()
+        private async Task StartInternal(Func<Exception, Task<bool>> retryFilter)
         {
-            await this.gatewayListProvider.InitializeGatewayListProvider()
-                               .WithTimeout(initTimeout, $"gatewayListProvider.InitializeGatewayListProvider failed due to timeout {initTimeout}");
+            // Initialize the gateway list provider, since information from the cluster is required to successfully
+            // initialize subsequent services.
+            var initializedGatewayProvider = new[] {false};
+            await ExecuteWithRetries(async () =>
+                {
+                    if (!initializedGatewayProvider[0])
+                    {
+                        await this.gatewayListProvider.InitializeGatewayListProvider();
+                        initializedGatewayProvider[0] = true;
+                    }
+
+                    var gateways = await this.gatewayListProvider.GetGateways();
+                    if (gateways.Count == 0)
+                    {
+                        var gatewayProviderType = this.gatewayListProvider.GetType().GetParseableName();
+                        var err = $"Could not find any gateway in {gatewayProviderType}. Orleans client cannot initialize.";
+                        logger.Error(ErrorCode.GatewayManager_NoGateways, err);
+                        throw new OrleansException(err);
+                    }
+                },
+                retryFilter);
 
             var generation = -SiloAddress.AllocateNewGeneration(); // Client generations are negative
             transport = ActivatorUtilities.CreateInstance<ClientMessageCenter>(this.ServiceProvider, localAddress, generation, handshakeClientId);
@@ -225,11 +237,41 @@ namespace Orleans
                     }
                 },
                 ct).Ignore();
-            grainTypeResolver = await transport.GetGrainTypeResolver(this.InternalGrainFactory);
+
+            await ExecuteWithRetries(async () =>
+                {
+                    var originalTimeout = this.GetResponseTimeout();
+                    try
+                    {
+                        GrainTypeResolver = await transport.GetGrainTypeResolver(this.InternalGrainFactory);
+                    }
+                    finally
+                    {
+                        this.SetResponseTimeout(originalTimeout);
+                    }
+                },
+                retryFilter);
 
             ClientStatistics.Start(transport, clientId);
+            
+            await ExecuteWithRetries(StreamingInitialize, retryFilter);
 
-            await StreamingInitialize();
+            async Task ExecuteWithRetries(Func<Task> task, Func<Exception, Task<bool>> shouldRetry)
+            {
+                while (true)
+                {
+                    try
+                    {
+                        await task();
+                        return;
+                    }
+                    catch (Exception exception) when (shouldRetry != null)
+                    {
+                        var retry = await shouldRetry(exception);
+                        if (!retry) throw;
+                    }
+                }
+            }
         }
 
         private void RunClientMessagePump(CancellationToken ct)
@@ -824,10 +866,7 @@ namespace Orleans
             GC.SuppressFinalize(this);
         }
 
-        public IGrainTypeResolver GrainTypeResolver
-        {
-            get { return grainTypeResolver; }
-        }
+        public IGrainTypeResolver GrainTypeResolver { get; private set; }
 
         public void BreakOutstandingMessagesToDeadSilo(SiloAddress deadSilo)
         {

--- a/test/Tester/ClientConnectionTests/ClusterClientTests.cs
+++ b/test/Tester/ClientConnectionTests/ClusterClientTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Messaging;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.ClientConnectionTests
+{
+    [TestCategory("Functional")]
+    public class ClusterClientTests : TestClusterPerTest
+    {
+        /// <summary>
+        /// Ensures that <see "ClusterClient.Connect" /> can be retried.
+        /// </summary>
+        [Fact]
+        public async Task ConnectIsRetryableTest()
+        {
+            var gwEndpoint = this.HostedCluster.Client.Configuration().Gateways.First();
+
+            // Create a client with no gateway endpoint and then add a gateway endpoint when the client fails to connect.
+            var gatewayProvider = new MockGatewayListProvider();
+            var client = new ClientBuilder()
+                .Configure<ClusterOptions>(options =>
+                {
+                    var existingClientOptions = this.HostedCluster.ServiceProvider.GetRequiredService<IOptions<ClusterOptions>>().Value;
+                    options.ClusterId = existingClientOptions.ClusterId;
+                    options.ServiceId = existingClientOptions.ServiceId;
+                })
+                .ConfigureServices(services => services.AddSingleton<IGatewayListProvider>(gatewayProvider))
+                .Build();
+            var exceptions = new List<Exception>();
+
+            Task<bool> RetryFunc(Exception exception)
+            {
+                Assert.IsType<OrleansException>(exception);
+                exceptions.Add(exception);
+                gatewayProvider.Gateways = new List<Uri> {gwEndpoint.ToGatewayUri()}.AsReadOnly();
+                return Task.FromResult(true);
+            }
+
+            await client.Connect(RetryFunc);
+            Assert.Single(exceptions);
+        }
+
+        public class MockGatewayListProvider : IGatewayListProvider
+        {
+            public ReadOnlyCollection<Uri> Gateways { get; set; } = new ReadOnlyCollection<Uri>(new List<Uri>());
+
+            public Task InitializeGatewayListProvider() => Task.CompletedTask;
+
+            public Task<IList<Uri>> GetGateways() => Task.FromResult<IList<Uri>>(this.Gateways);
+
+            public TimeSpan MaxStaleness => TimeSpan.FromSeconds(30);
+
+            public bool IsUpdatable => true;
+        }
+    }
+}


### PR DESCRIPTION
For review only.

I didn't propagate the retry delegate all the way up to the API surface, but this is roughly what it might look like.