### PR TITLE
Fix legacy configuration

### DIFF
--- a/src/Orleans.Runtime.Legacy/Configuration/LegacyMembershipConfigurator.cs
+++ b/src/Orleans.Runtime.Legacy/Configuration/LegacyMembershipConfigurator.cs
@@ -70,7 +70,8 @@ namespace Orleans.Runtime.MembershipService
                     {
                         options.PrimarySiloEndpoint = config.SeedNodes?.FirstOrDefault();
                     }
-                });
+                },
+                config.ClusterId);
             }
         }
     }


### PR DESCRIPTION
Fix implicit overriding of cluster ID in legacy membership configuration.