### PR TITLE
Set GrainService.Status to Started in the base implementation of StartInBackground()

### DIFF
--- a/src/Orleans.Runtime/Services/GrainService.cs
+++ b/src/Orleans.Runtime/Services/GrainService.cs
@@ -81,8 +81,15 @@ namespace Orleans.Runtime
             return Task.CompletedTask;
         }
 
-        /// <summary>Deferred part of initialization that executes after the service is already started (to speed up startup)</summary>
-        protected abstract Task StartInBackground();
+        /// <summary>
+        /// Deferred part of initialization that executes after the service is already started (to speed up startup).
+        /// Sets Status to Started.
+        /// </summary>
+        protected virtual Task StartInBackground()
+        {
+            Status = GrainServiceStatus.Started;
+            return Task.CompletedTask;
+        }
 
         /// <summary>Invoked when service is being stopped</summary>
         public virtual Task Stop()


### PR DESCRIPTION
Fixes #4128.
This should help prevent mistakes of not setting the status to started, which leads to not receiving cluster repartitioning notifications.