### PR TITLE
Do not run MergeGrainResolverTests with ActivationCountBasedPlacement

### DIFF
--- a/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/HeterogeneousTests.cs
@@ -61,7 +61,8 @@ namespace Tester.HeterogeneousSilosTests
         {
             await MergeGrainResolverTestsImpl("RandomPlacement", typeof(TestGrain));
             await MergeGrainResolverTestsImpl("PreferLocalPlacement", typeof(TestGrain));
-            await MergeGrainResolverTestsImpl("ActivationCountBasedPlacement", typeof(TestGrain));
+            // TODO Check ActivationCountBasedPlacement in tests
+            //await MergeGrainResolverTestsImpl("ActivationCountBasedPlacement", typeof(TestGrain));
         }
 
         private async Task MergeGrainResolverTestsImpl(string defaultPlacementStrategy, params Type[] blackListedTypes)


### PR DESCRIPTION
Due to timing issue in test, `ActivationCountBasedPlacement` can be unreliable