### PR TITLE
Treat defaults in options as authoritative

### DIFF
--- a/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
@@ -175,10 +175,10 @@ namespace Orleans.Runtime.Configuration
             : base(false)
         {
             SourceFile = null;
-            PreferedGatewayIndex = -1;
+            PreferedGatewayIndex = GatewayOptions.DEFAULT_PREFERED_GATEWAY_INDEX;
             Gateways = new List<IPEndPoint>();
             GatewayProvider = GatewayProviderType.None;
-            PreferredFamily = AddressFamily.InterNetwork;
+            PreferredFamily = ClientMessagingOptions.DEFAULT_PREFERRED_FAMILY;
             NetInterface = null;
             Port = 0;
             DNSHostName = Dns.GetHostName();
@@ -187,7 +187,7 @@ namespace Orleans.Runtime.Configuration
             // Assume the ado invariant is for sql server storage if not explicitly specified
             AdoInvariant = Constants.INVARIANT_NAME_SQL_SERVER;
             
-            PropagateActivityId = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
+            PropagateActivityId = MessagingOptions.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
 
             GatewayListRefreshPeriod = GatewayOptions.DEFAULT_GATEWAY_LIST_REFRESH_PERIOD;
             StatisticsProviderName = null;

--- a/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
@@ -505,10 +505,6 @@ namespace Orleans.Runtime.Configuration
 
         internal bool RunsInAzure { get { return this.UseAzureSystemStore && !string.IsNullOrWhiteSpace(this.ClusterId); } }
 
-        private const int DEFAULT_MAX_MULTICLUSTER_GATEWAYS = 10;
-        private const bool DEFAULT_USE_GLOBAL_SINGLE_INSTANCE = true;
-        private static readonly TimeSpan DEFAULT_BACKGROUND_GOSSIP_INTERVAL = TimeSpan.FromSeconds(30);
-        private const int DEFAULT_GLOBAL_SINGLE_INSTANCE_NUMBER_RETRIES = 10;
         private const int DEFAULT_LIVENESS_EXPECTED_CLUSTER_SIZE = 20;
         public static bool ENFORCE_MINIMUM_REQUIREMENT_FOR_AGE_LIMIT = true;
         public static readonly string DEFAULT_MULTICLUSTER_REGISTRATION_STRATEGY = typeof(GlobalSingleInstanceRegistration).Name;
@@ -535,11 +531,11 @@ namespace Orleans.Runtime.Configuration
             this.ValidateInitialConnectivity = ClusterMembershipOptions.DEFAULT_VALIDATE_INITIAL_CONNECTIVITY;
             this.MaxJoinAttemptTime = ClusterMembershipOptions.DEFAULT_LIVENESS_MAX_JOIN_ATTEMPT_TIME;
             this.TypeMapRefreshInterval = TypeManagementOptions.DEFAULT_REFRESH_CLUSTER_INTERFACEMAP_TIME;
-            this.MaxMultiClusterGateways = DEFAULT_MAX_MULTICLUSTER_GATEWAYS;
-            this.BackgroundGossipInterval = DEFAULT_BACKGROUND_GOSSIP_INTERVAL;
-            this.UseGlobalSingleInstanceByDefault = DEFAULT_USE_GLOBAL_SINGLE_INSTANCE;
+            this.MaxMultiClusterGateways = MultiClusterOptions.DEFAULT_MAX_MULTICLUSTER_GATEWAYS;
+            this.BackgroundGossipInterval = MultiClusterOptions.DEFAULT_BACKGROUND_GOSSIP_INTERVAL;
+            this.UseGlobalSingleInstanceByDefault = MultiClusterOptions.DEFAULT_USE_GLOBAL_SINGLE_INSTANCE;
             this.GlobalSingleInstanceRetryInterval = MultiClusterOptions.DEFAULT_GLOBAL_SINGLE_INSTANCE_RETRY_INTERVAL;
-            this.GlobalSingleInstanceNumberRetries = DEFAULT_GLOBAL_SINGLE_INSTANCE_NUMBER_RETRIES;
+            this.GlobalSingleInstanceNumberRetries = MultiClusterOptions.DEFAULT_GLOBAL_SINGLE_INSTANCE_NUMBER_RETRIES;
             this.ExpectedClusterSizeConfigValue = new ConfigValue<int>(DEFAULT_LIVENESS_EXPECTED_CLUSTER_SIZE, true);
             this.ServiceId = Guid.Empty;
             this.ClusterId = "";

--- a/src/Orleans.Core.Legacy/Configuration/NodeConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/NodeConfiguration.cs
@@ -228,7 +228,7 @@ namespace Orleans.Runtime.Configuration
             this.LoadSheddingEnabled = false;
             this.LoadSheddingLimit = LoadSheddingOptions.DEFAULT_LOAD_SHEDDING_LIMIT;
 
-            this.PropagateActivityId = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
+            this.PropagateActivityId = MessagingOptions.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
 
             this.StatisticsMetricsTableWriteInterval = DEFAULT_METRICS_TABLE_WRITE_PERIOD;
             this.StatisticsPerfCountersWriteInterval = SILO_DEFAULT_PERF_COUNTERS_WRITE_PERIOD;

--- a/src/Orleans.Core/Configuration/ConfigUtilities.cs
+++ b/src/Orleans.Core/Configuration/ConfigUtilities.cs
@@ -1,3 +1,4 @@
+using Orleans.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -81,7 +82,7 @@ namespace Orleans.Runtime.Configuration
         internal static bool TryParsePropagateActivityId(XmlElement root, string nodeName, out bool propagateActivityId)
         {
             //set default value to make compiler happy, progateActivityId is only used when this method return true
-            propagateActivityId = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
+            propagateActivityId = MessagingOptions.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
             if (root.HasAttribute("PropagateActivityId"))
             {
                 propagateActivityId = ParseBool(root.GetAttribute("PropagateActivityId"),

--- a/src/Orleans.Core/Configuration/MessagingConfiguration.cs
+++ b/src/Orleans.Core/Configuration/MessagingConfiguration.cs
@@ -1,3 +1,4 @@
+using Orleans.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -122,17 +123,10 @@ namespace Orleans.Runtime.Configuration
         public List<TypeInfo> SerializationProviders { get; private set; }
         public TypeInfo FallbackSerializationProvider { get; set; }
 
-        private static readonly TimeSpan DEFAULT_MAX_SOCKET_AGE = TimeSpan.MaxValue;
         internal const int DEFAULT_MAX_FORWARD_COUNT = 2;
         private const bool DEFAULT_RESEND_ON_TIMEOUT = false;
         private static readonly int DEFAULT_SILO_SENDER_QUEUES = Environment.ProcessorCount;
         private static readonly int DEFAULT_GATEWAY_SENDER_QUEUES = Environment.ProcessorCount;
-        private static readonly int DEFAULT_CLIENT_SENDER_BUCKETS = (int)Math.Pow(2, 13);
-
-        private const int DEFAULT_BUFFER_POOL_BUFFER_SIZE = 4 * 1024;
-        private const int DEFAULT_BUFFER_POOL_MAX_SIZE = 10000;
-        private const int DEFAULT_BUFFER_POOL_PREALLOCATION_SIZE = 250;
-        private const bool DEFAULT_DROP_EXPIRED_MESSAGES = true;
 
         private readonly bool isSiloConfig;
 
@@ -140,21 +134,21 @@ namespace Orleans.Runtime.Configuration
         {
             isSiloConfig = isSilo;
 
-            OpenConnectionTimeout = Constants.DEFAULT_OPENCONNECTION_TIMEOUT;
-            ResponseTimeout = Constants.DEFAULT_RESPONSE_TIMEOUT;
+            OpenConnectionTimeout = NetworkingOptions.DEFAULT_OPENCONNECTION_TIMEOUT;
+            ResponseTimeout = MessagingOptions.DEFAULT_RESPONSE_TIMEOUT;
             MaxResendCount = 0;
             ResendOnTimeout = DEFAULT_RESEND_ON_TIMEOUT;
-            MaxSocketAge = DEFAULT_MAX_SOCKET_AGE;
-            DropExpiredMessages = DEFAULT_DROP_EXPIRED_MESSAGES;
+            MaxSocketAge = NetworkingOptions.DEFAULT_MAX_SOCKET_AGE;
+            DropExpiredMessages = MessagingOptions.DEFAULT_DROP_EXPIRED_MESSAGES;
 
             SiloSenderQueues = DEFAULT_SILO_SENDER_QUEUES;
             GatewaySenderQueues = DEFAULT_GATEWAY_SENDER_QUEUES;
-            ClientSenderBuckets = DEFAULT_CLIENT_SENDER_BUCKETS;
+            ClientSenderBuckets = ClientMessagingOptions.DEFAULT_CLIENT_SENDER_BUCKETS;
             ClientDropTimeout = Constants.DEFAULT_CLIENT_DROP_TIMEOUT;
 
-            BufferPoolBufferSize = DEFAULT_BUFFER_POOL_BUFFER_SIZE;
-            BufferPoolMaxSize = DEFAULT_BUFFER_POOL_MAX_SIZE;
-            BufferPoolPreallocationSize = DEFAULT_BUFFER_POOL_PREALLOCATION_SIZE;
+            BufferPoolBufferSize = MessagingOptions.DEFAULT_BUFFER_POOL_BUFFER_SIZE;
+            BufferPoolMaxSize = MessagingOptions.DEFAULT_BUFFER_POOL_MAX_SIZE;
+            BufferPoolPreallocationSize = MessagingOptions.DEFAULT_BUFFER_POOL_PREALLOCATION_SIZE;
 
             if (isSiloConfig)
             {
@@ -207,7 +201,7 @@ namespace Orleans.Runtime.Configuration
             ResponseTimeout = child.HasAttribute("ResponseTimeout")
                                       ? ConfigUtilities.ParseTimeSpan(child.GetAttribute("ResponseTimeout"),
                                                                  "Invalid ResponseTimeout")
-                                      : Constants.DEFAULT_RESPONSE_TIMEOUT;
+                                      : MessagingOptions.DEFAULT_RESPONSE_TIMEOUT;
 
             if (child.HasAttribute("MaxResendCount"))
             {

--- a/src/Orleans.Core/Configuration/OptionLogger/OptionFormatterExtensionMethods.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/OptionFormatterExtensionMethods.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Linq;
+
 namespace Orleans.Configuration
 {
     /// <summary>

--- a/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientMessagingOptions.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Net.Sockets;
-using Microsoft.Extensions.Options;
 
 namespace Orleans.Configuration
 {
@@ -16,11 +14,14 @@ namespace Orleans.Configuration
         ///  This number should be about 10 to 100 times larger than the expected number of gateway connections.
         ///  If this attribute is not specified, then Math.Pow(2, 13) is used.
         /// </summary>
-        public int ClientSenderBuckets { get; set; } = 8192;
+        public int ClientSenderBuckets { get; set; } = DEFAULT_CLIENT_SENDER_BUCKETS;
+        public const int DEFAULT_CLIENT_SENDER_BUCKETS = 8192;
 
         /// <summary>
         /// </summary>
-        public AddressFamily PreferredFamily { get; set; } = AddressFamily.InterNetwork;
+        public AddressFamily PreferredFamily { get; set; } = DEFAULT_PREFERRED_FAMILY;
+        public const AddressFamily DEFAULT_PREFERRED_FAMILY = AddressFamily.InterNetwork;
+
         /// <summary>
         /// The Interface attribute specifies the name of the network interface to use to work out an IP address for this machine.
         /// </summary>

--- a/src/Orleans.Core/Configuration/Options/ClientStatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClientStatisticsOptions.cs
@@ -1,7 +1,4 @@
 
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
-
 namespace Orleans.Configuration
 {
     /// <summary>

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -1,7 +1,5 @@
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
 
 namespace Orleans.Configuration
 {

--- a/src/Orleans.Core/Configuration/Options/GrainVersioningOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/GrainVersioningOptions.cs
@@ -1,6 +1,4 @@
 
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
 using Orleans.Versions.Compatibility;
 using Orleans.Versions.Selector;
 

--- a/src/Orleans.Core/Configuration/Options/LoadSheddingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/LoadSheddingOptions.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
 
 namespace Orleans.Configuration
 {

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Collections.Generic;
-using Orleans.Runtime;
+using System.Diagnostics;
 
 namespace Orleans.Configuration
 {
@@ -12,7 +11,8 @@ namespace Orleans.Configuration
         /// <summary>
         /// The ResponseTimeout attribute specifies the default timeout before a request is assumed to have failed.
         /// </summary>
-        public TimeSpan ResponseTimeout { get; set; } = Constants.DEFAULT_RESPONSE_TIMEOUT;
+        public TimeSpan ResponseTimeout { get; set; } = DEFAULT_RESPONSE_TIMEOUT;
+        public static readonly TimeSpan DEFAULT_RESPONSE_TIMEOUT = Debugger.IsAttached ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// The MaxResendCount attribute specifies the maximal number of resends of the same message.
@@ -30,27 +30,31 @@ namespace Orleans.Configuration
         /// to the destination before it has timed out on the sender.
         /// Default is true.
         /// </summary>
-        public bool DropExpiredMessages { get; set; } = true;
+        public bool DropExpiredMessages { get; set; } = DEFAULT_DROP_EXPIRED_MESSAGES;
+        public const bool DEFAULT_DROP_EXPIRED_MESSAGES = true;
 
         /// <summary>
         /// The size of a buffer in the messaging buffer pool.
         /// </summary>
-        public int BufferPoolBufferSize { get; set; } = 4 * 1024;
+        public int BufferPoolBufferSize { get; set; } = DEFAULT_BUFFER_POOL_BUFFER_SIZE;
+        public const int DEFAULT_BUFFER_POOL_BUFFER_SIZE = 4 * 1024;
 
         /// <summary>
         /// The maximum size of the messaging buffer pool.
         /// </summary>
-        public int BufferPoolMaxSize { get; set; } = 10000;
+        public int BufferPoolMaxSize { get; set; } = DEFAULT_BUFFER_POOL_MAX_SIZE;
+        public const int DEFAULT_BUFFER_POOL_MAX_SIZE = 10000;
 
         /// <summary>
         /// The initial size of the messaging buffer pool that is pre-allocated.
         /// </summary>
-        public int BufferPoolPreallocationSize { get; set; } = 250;
-
+        public int BufferPoolPreallocationSize { get; set; } = DEFAULT_BUFFER_POOL_PREALLOCATION_SIZE;
+        public const int DEFAULT_BUFFER_POOL_PREALLOCATION_SIZE = 250;
+        
         /// <summary>
         ///  Whether Trace.CorrelationManager.ActivityId settings should be propagated into grain calls.
         /// </summary>
-        public bool PropagateActivityId { get; set; } = DEFAULT_PROPAGATE_ACTIVITY_ID;
-        public const bool DEFAULT_PROPAGATE_ACTIVITY_ID = Constants.DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
+        public bool PropagateActivityId { get; set; } = DEFAULT_PROPAGATE_E2E_ACTIVITY_ID;
+        public const bool DEFAULT_PROPAGATE_E2E_ACTIVITY_ID = false;
     }
 }

--- a/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MultiClusterOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Options;
 
 namespace Orleans.Configuration
 {
@@ -21,7 +20,7 @@ namespace Orleans.Configuration
         /// <summary>
         /// Whether this cluster is configured to be part of a multi-cluster network
         /// </summary>
-        public bool HasMultiClusterNetwork { get; set; } = false;
+        public bool HasMultiClusterNetwork { get; set; }
 
         /// <summary>
         ///A list of cluster ids, to be used if no multi-cluster configuration is found in gossip channels.
@@ -31,23 +30,27 @@ namespace Orleans.Configuration
         /// <summary>
         /// The maximum number of silos per cluster should be designated to serve as gateways.
         /// </summary>
-        public int MaxMultiClusterGateways { get; set; } = 10;
+        public int MaxMultiClusterGateways { get; set; } = DEFAULT_MAX_MULTICLUSTER_GATEWAYS;
+        public const int DEFAULT_MAX_MULTICLUSTER_GATEWAYS = 10;
 
         /// <summary>
         /// The time between background gossips.
         /// </summary>
-        public TimeSpan BackgroundGossipInterval { get; set; } = TimeSpan.FromSeconds(30);
+        public TimeSpan BackgroundGossipInterval { get; set; } = DEFAULT_BACKGROUND_GOSSIP_INTERVAL;
+        public static readonly TimeSpan DEFAULT_BACKGROUND_GOSSIP_INTERVAL = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Whether to use the global single instance protocol as the default
         /// multi-cluster registration strategy.
         /// </summary>
-        public bool UseGlobalSingleInstanceByDefault { get; set; } = true;
+        public bool UseGlobalSingleInstanceByDefault { get; set; } = DEFAULT_USE_GLOBAL_SINGLE_INSTANCE;
+        public const bool DEFAULT_USE_GLOBAL_SINGLE_INSTANCE = true;
 
         /// <summary>
         /// The number of quick retries before going into DOUBTFUL state.
         /// </summary>
-        public int GlobalSingleInstanceNumberRetries { get; set; } = 10;
+        public int GlobalSingleInstanceNumberRetries { get; set; } = DEFAULT_GLOBAL_SINGLE_INSTANCE_NUMBER_RETRIES;
+        public const int DEFAULT_GLOBAL_SINGLE_INSTANCE_NUMBER_RETRIES = 10;
 
         /// <summary>
         /// The time between the slow retries for DOUBTFUL activations.

--- a/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/NetworkingOptions.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
-using Orleans.Runtime;
 
 namespace Orleans.Configuration
 {
@@ -13,12 +10,14 @@ namespace Orleans.Configuration
         /// <summary>
         /// The OpenConnectionTimeout attribute specifies the timeout before a connection open is assumed to have failed
         /// </summary>
-        public TimeSpan OpenConnectionTimeout { get; set; } = Constants.DEFAULT_OPENCONNECTION_TIMEOUT;
+        public TimeSpan OpenConnectionTimeout { get; set; } = DEFAULT_OPENCONNECTION_TIMEOUT;
+        public static readonly TimeSpan DEFAULT_OPENCONNECTION_TIMEOUT = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// The MaxSocketAge attribute specifies how long to keep an open socket before it is closed.
         /// Default is TimeSpan.MaxValue (never close sockets automatically, unles they were broken).
         /// </summary>
-        public TimeSpan MaxSocketAge { get; set; } = TimeSpan.MaxValue;
+        public TimeSpan MaxSocketAge { get; set; } = DEFAULT_MAX_SOCKET_AGE;
+        public static readonly TimeSpan DEFAULT_MAX_SOCKET_AGE = TimeSpan.MaxValue;
     }
 }

--- a/src/Orleans.Core/Configuration/Options/PerformanceTuningOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/PerformanceTuningOptions.cs
@@ -1,7 +1,4 @@
 
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
-
 namespace Orleans.Configuration
 {
     /// <summary>

--- a/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/SerializationProviderOptions.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.Extensions.Options;
 
 namespace Orleans.Configuration
 {

--- a/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/StaticGatewayListProviderOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Options;
 
 namespace Orleans.Configuration
 {

--- a/src/Orleans.Core/Configuration/Options/StatisticsOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/StatisticsOptions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 

--- a/src/Orleans.Core/Configuration/Options/TelemetryOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/TelemetryOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 
 namespace Orleans.Configuration

--- a/src/Orleans.Core/Configuration/Options/TypeManagementOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/TypeManagementOptions.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Options;
 
 namespace Orleans.Configuration
 {

--- a/src/Orleans.Core/Runtime/Constants.cs
+++ b/src/Orleans.Core/Runtime/Constants.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Orleans.Runtime
 {
@@ -54,13 +53,6 @@ namespace Orleans.Runtime
 
         internal const long ReminderTableGrainId = 12345;
 
-        public static readonly TimeSpan DEFAULT_OPENCONNECTION_TIMEOUT = TimeSpan.FromSeconds(5);
-
-        /// <summary>
-        /// The default timeout before a request is assumed to have failed.
-        /// </summary>
-        public static readonly TimeSpan DEFAULT_RESPONSE_TIMEOUT = Debugger.IsAttached ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(30);
-
         /// <summary>
         /// Minimum period for registering a reminder ... we want to enforce a lower bound
         /// </summary>
@@ -71,8 +63,6 @@ namespace Orleans.Runtime
         public static readonly TimeSpan RefreshReminderList = TimeSpan.FromMinutes(5);
 
         public const int LARGE_OBJECT_HEAP_THRESHOLD = 85000;
-
-        public const bool DEFAULT_PROPAGATE_E2E_ACTIVITY_ID = false;
 
         public const int DEFAULT_LOGGER_BULK_MESSAGE_LIMIT = 5;
 

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -139,7 +139,7 @@ namespace Orleans
 
                 clientProviderRuntime = this.ServiceProvider.GetRequiredService<ClientProviderRuntime>();
 
-                responseTimeout = Debugger.IsAttached ? Constants.DEFAULT_RESPONSE_TIMEOUT : this.clientMessagingOptions.ResponseTimeout;
+                responseTimeout = Debugger.IsAttached ? MessagingOptions.DEFAULT_RESPONSE_TIMEOUT : this.clientMessagingOptions.ResponseTimeout;
                 this.localAddress = ConfigUtilities.GetLocalIPAddress(this.clientMessagingOptions.PreferredFamily, this.clientMessagingOptions.NetworkInterfaceName);
 
                 // Client init / sign-on message


### PR DESCRIPTION
This addresses "Configuration Work - Defaults #3949" 

Where possible, all defaults are defined in options and those defaults are authoritative, even in legacy configurations.

For options defined in runtime, single defaults are not possible, so those will be left as they are.