### PR TITLE
[WIP] Shutdown forward workaround

### DIFF
--- a/test/Tester/Forwarding/ShutdownSiloTests.cs
+++ b/test/Tester/Forwarding/ShutdownSiloTests.cs
@@ -5,9 +5,6 @@ using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
-using Orleans.TestingHost.Utils;
-using Orleans.Hosting;
-using Orleans.Configuration;
 
 namespace Tester.Forwarding
 {
@@ -15,27 +12,14 @@ namespace Tester.Forwarding
     {
         public const int NumberOfSilos = 2;
 
-        private class SiloBuilderConfigurator : ISiloBuilderConfigurator
-        {
-            public void Configure(ISiloHostBuilder hostBuilder)
-            {
-                hostBuilder.AddAzureBlobGrainStorage("MemoryStore", (AzureBlobStorageOptions options) =>
-                {
-                    options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                });
-            }
-        }
-
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
-            Assert.True(StorageEmulator.TryStart());
-            builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
             builder.Options.InitialSilosCount = NumberOfSilos;
             builder.ConfigureLegacyConfiguration(legacy =>
             {
-                legacy.ClusterConfiguration.Globals.DefaultPlacementStrategy = "ActivationCountBasedPlacement";
                 legacy.ClusterConfiguration.Globals.NumMissedProbesLimit = 1;
                 legacy.ClusterConfiguration.Globals.NumVotesForDeathDeclaration = 1;
+                legacy.ClientConfiguration.Gateways = legacy.ClientConfiguration.Gateways.Take(1).ToList();
             });
         }
 


### PR DESCRIPTION
Related issue: #2287 

It's not a fix, it's a workaround. Not pretty, but I believe it has some value.

The issue is pretty "simple" when the silo shutdown, it will

1. Deactivate all grain activations 
2. Then forward the pending requests.

The issue is that we do not await step 2. And it is not possible without some heavy code change right now. The proposed workaround is just to add a delay after deactivating grains, so the system has some time to send the pending requests.

Note that it is happening after we set the silo status to "stopping", so other silos should not try to place new activation on it.

I did not enabled `SiloGracefulShutdown_ForwardPendingRequest` since it is still failing sometimes... but at least it pass most of the time now.