### PR TITLE
Configure cluster ID in multi-cluster tests

### DIFF
--- a/test/TesterInternal/GeoClusterTests/BasicMultiClusterTest.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicMultiClusterTest.cs
@@ -23,7 +23,7 @@ namespace Tests.GeoClusterTests
 
             public ClientWrapper(string name, int gatewayport, string clusterId, Action<ClientConfiguration> customizer, Action<IClientBuilder> clientConfigurator)
                 // use null clusterId, in this test, because we are testing non-geo clients
-                : base(name, gatewayport, null, customizer, clientConfigurator)
+                : base(name, gatewayport, clusterId, customizer, clientConfigurator)
             {
                 this.systemManagement = this.GrainFactory.GetGrain<IManagementGrain>(0);
             }

--- a/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -326,6 +326,7 @@ namespace Tests.GeoClusterTests
                     Assert.True(false, "Error loading client configuration file");
                 }
 
+                config.ClusterId = clusterId;
                 config.GatewayProvider = Orleans.Runtime.Configuration.ClientConfiguration.GatewayProviderType.Config;
                 config.Gateways.Clear();
                 config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, gatewayport));


### PR DESCRIPTION
This is a follow-up tp #4160 to fix multi-cluster tests.