### PR TITLE
Add config option to override MessagingOptions.ResponseTimeout when the debugger is attached

### DIFF
--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -10,20 +10,21 @@ namespace Orleans.Configuration
     {
         /// <summary>
         /// The ResponseTimeout attribute specifies the default timeout before a request is assumed to have failed.
+        ///<seealso cref="ResponseTimeoutWithDebugger"/>
         /// </summary>
         public TimeSpan ResponseTimeout
         {
-            get { return (DebuggerOverridesTimeout && Debugger.IsAttached) ? RESPONSE_TIMEOUT_WITH_DEBUGGER : responseTimeout; }
+            get { return Debugger.IsAttached ? RESPONSE_TIMEOUT_WITH_DEBUGGER : responseTimeout; }
             set { this.responseTimeout = value; }
         }
         public static readonly TimeSpan DEFAULT_RESPONSE_TIMEOUT = TimeSpan.FromSeconds(30);
         private TimeSpan responseTimeout = DEFAULT_RESPONSE_TIMEOUT;
 
         /// <summary>
-        /// By default, the value from<see cref="ResponseTimeout"/> will be ignored and set to 30 minutes
-        /// if the debugger is attached. Set this flag to false to always use <see cref="ResponseTimeout"/>
+        /// If a debugger is attached the value from <see cref="ResponseTimeout"/> will be ignored 
+        /// and the value from this field will be used.
         /// </summary>
-        public bool DebuggerOverridesTimeout { get; set; } = true;
+        public TimeSpan ResponseTimeoutWithDebugger { get; set; } = RESPONSE_TIMEOUT_WITH_DEBUGGER;
         public static readonly TimeSpan RESPONSE_TIMEOUT_WITH_DEBUGGER = TimeSpan.FromMinutes(30);
 
         /// <summary>

--- a/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/MessagingOptions.cs
@@ -11,8 +11,20 @@ namespace Orleans.Configuration
         /// <summary>
         /// The ResponseTimeout attribute specifies the default timeout before a request is assumed to have failed.
         /// </summary>
-        public TimeSpan ResponseTimeout { get; set; } = DEFAULT_RESPONSE_TIMEOUT;
-        public static readonly TimeSpan DEFAULT_RESPONSE_TIMEOUT = Debugger.IsAttached ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(30);
+        public TimeSpan ResponseTimeout
+        {
+            get { return (DebuggerOverridesTimeout && Debugger.IsAttached) ? RESPONSE_TIMEOUT_WITH_DEBUGGER : responseTimeout; }
+            set { this.responseTimeout = value; }
+        }
+        public static readonly TimeSpan DEFAULT_RESPONSE_TIMEOUT = TimeSpan.FromSeconds(30);
+        private TimeSpan responseTimeout = DEFAULT_RESPONSE_TIMEOUT;
+
+        /// <summary>
+        /// By default, the value from<see cref="ResponseTimeout"/> will be ignored and set to 30 minutes
+        /// if the debugger is attached. Set this flag to false to always use <see cref="ResponseTimeout"/>
+        /// </summary>
+        public bool DebuggerOverridesTimeout { get; set; } = true;
+        public static readonly TimeSpan RESPONSE_TIMEOUT_WITH_DEBUGGER = TimeSpan.FromMinutes(30);
 
         /// <summary>
         /// The MaxResendCount attribute specifies the maximal number of resends of the same message.

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -109,6 +109,7 @@ namespace Orleans
             this.timerLogger = loggerFactory.CreateLogger<SafeTimer>();
             this.clientMessagingOptions = clientMessagingOptions.Value;
             this.typeMapRefreshInterval = typeManagementOptions.Value.TypeMapRefreshInterval;
+            this.responseTimeout = clientMessagingOptions.Value.ResponseTimeout;
         }
 
         internal void ConsumeServices(IServiceProvider services)
@@ -145,7 +146,6 @@ namespace Orleans
 
                 clientProviderRuntime = this.ServiceProvider.GetRequiredService<ClientProviderRuntime>();
 
-                responseTimeout = Debugger.IsAttached ? MessagingOptions.DEFAULT_RESPONSE_TIMEOUT : this.clientMessagingOptions.ResponseTimeout;
                 this.localAddress = ConfigUtilities.GetLocalIPAddress(this.clientMessagingOptions.PreferredFamily, this.clientMessagingOptions.NetworkInterfaceName);
 
                 // Client init / sign-on message


### PR DESCRIPTION
Fix for #3830 

Please let me know if what I did is not "option" compatible, but I think this is the cleanest way to implement such flag.