### PR TITLE
Do not build a NuGet package for Orleans.TestingHost.Legacy

### DIFF
--- a/src/Orleans.TestingHost.Legacy/Orleans.TestingHost.Legacy.csproj
+++ b/src/Orleans.TestingHost.Legacy/Orleans.TestingHost.Legacy.csproj
@@ -12,6 +12,10 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Core.Legacy\Orleans.Core.Legacy.csproj" />
     <ProjectReference Include="..\Orleans.Runtime.Legacy\Orleans.Runtime.Legacy.csproj" />


### PR DESCRIPTION
I don't think we want to publish this package, as the assembly is only used for our legacy tests, and may easily confuse people.