### PR TITLE
WithCodeGeneration: accept ILoggerFactory instead of ILogger

### DIFF
--- a/src/Orleans.CodeGeneration/ApplicationPartManagerCodeGenExtensions.cs
+++ b/src/Orleans.CodeGeneration/ApplicationPartManagerCodeGenExtensions.cs
@@ -19,11 +19,12 @@ namespace Orleans.Hosting
         /// Generates support code for the the provided assembly and adds it to the builder.
         /// </summary>
         /// <param name="manager">The builder.</param>
-        /// <param name="logger">optional logger</param>
+        /// <param name="loggerFactory">The optional logger factory, for outputting code generation diagnostics.</param>
         /// <returns>A builder with support parts added.</returns>
-        public static IApplicationPartManagerWithAssemblies WithCodeGeneration(this IApplicationPartManagerWithAssemblies manager, ILogger logger = null)
+        public static IApplicationPartManagerWithAssemblies WithCodeGeneration(this IApplicationPartManagerWithAssemblies manager, ILoggerFactory loggerFactory = null)
         {
             var stopWatch = Stopwatch.StartNew();
+            loggerFactory = loggerFactory ?? new NullLoggerFactory();
             var tempPartManager = new ApplicationPartManager();
             foreach (var provider in manager.FeatureProviders)
             {
@@ -41,9 +42,10 @@ namespace Orleans.Hosting
             tempPartManager.AddFeatureProvider(new AssemblyAttributeFeatureProvider<SerializerFeature>());
             tempPartManager.AddFeatureProvider(new BuiltInTypesSerializationFeaturePopulator());
             
-            var codeGenerator = new RoslynCodeGenerator(tempPartManager, new NullLoggerFactory());
+            var codeGenerator = new RoslynCodeGenerator(tempPartManager, loggerFactory);
             var generatedAssembly = codeGenerator.GenerateAndLoadForAssemblies(manager.Assemblies);
             stopWatch.Stop();
+            var logger = loggerFactory.CreateLogger("RuntimeCodeGen");
             logger?.LogInformation(0, $"Runtime code generation for assemblies {String.Join(",", manager.Assemblies.ToStrings())} took {stopWatch.ElapsedMilliseconds} milliseconds");
             return manager.AddApplicationPart(generatedAssembly);
         }

--- a/test/RuntimeCodeGen.Tests/RuntimeCodeGenTests.cs
+++ b/test/RuntimeCodeGen.Tests/RuntimeCodeGenTests.cs
@@ -37,7 +37,7 @@ namespace UnitTests
                 ILoggerFactory codeGenLoggerFactory = new LoggerFactory();
                 codeGenLoggerFactory.AddProvider(new FileLoggerProvider("ClientCodeGeneration.log"));
                 clientBuilder.ConfigureApplicationParts(
-                    parts => parts.AddApplicationPart(typeof(IRuntimeCodeGenGrain).Assembly).WithCodeGeneration(codeGenLoggerFactory.CreateLogger("RuntimeCodeGen")));
+                    parts => parts.AddApplicationPart(typeof(IRuntimeCodeGenGrain).Assembly).WithCodeGeneration(codeGenLoggerFactory));
             }
         }
 
@@ -50,7 +50,7 @@ namespace UnitTests
                 codeGenLoggerFactory.AddProvider(new FileLoggerProvider($"{siloName}-CodeGeneration.log"));
                 hostBuilder
                     .ConfigureApplicationParts(parts =>
-                        parts.AddApplicationPart(typeof(IRuntimeCodeGenGrain).Assembly).WithCodeGeneration(codeGenLoggerFactory.CreateLogger("RuntimeCodeGen")));
+                        parts.AddApplicationPart(typeof(IRuntimeCodeGenGrain).Assembly).WithCodeGeneration(codeGenLoggerFactory));
             }
         }
 


### PR DESCRIPTION
Otherwise we can't log diagnostic information about code generation.