### PR TITLE
Make providers use Cluster ID and Service ID from ClusterOptions

### DIFF
--- a/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
+++ b/src/AWS/Orleans.Reminders.DynamoDB/Reminders/DynamoDbReminderStorageOptions.cs
@@ -8,11 +8,6 @@ namespace Orleans.Configuration
     public class DynamoDBReminderStorageOptions
     {
         /// <summary>
-        /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment.
-        /// </summary>
-        public string ServiceId { get; set; } = string.Empty;
-
-        /// <summary>
         /// AccessKey string for DynamoDB Storage
         /// </summary>
         [Redact]

--- a/src/AWS/Orleans.Streaming.SQS/Storage/SQSStorage.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Storage/SQSStorage.cs
@@ -43,10 +43,10 @@ namespace OrleansAWSUtils.Storage
         /// <param name="loggerFactory">logger factory to use</param>
         /// <param name="queueName">The name of the queue</param>
         /// <param name="connectionString">The connection string</param>
-        /// <param name="clusterId">The cluster Id</param>
-        public SQSStorage(ILoggerFactory loggerFactory, string queueName, string connectionString, string clusterId = "")
+        /// <param name="serviceId">The service ID</param>
+        public SQSStorage(ILoggerFactory loggerFactory, string queueName, string connectionString, string serviceId = "")
         {
-            QueueName = string.IsNullOrWhiteSpace(clusterId) ? queueName : $"{clusterId}-{queueName}";
+            QueueName = string.IsNullOrWhiteSpace(serviceId) ? queueName : $"{serviceId}-{queueName}";
             ParseDataConnectionString(connectionString);
             Logger = loggerFactory.CreateLogger<SQSStorage>();
             CreateClient();

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapter.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapter.cs
@@ -11,7 +11,7 @@ namespace OrleansAWSUtils.Streams
 {
     internal class SQSAdapter : IQueueAdapter
     {
-        protected readonly string ClusterId;
+        protected readonly string ServiceId;
         private readonly SerializationManager serializationManager;
         protected readonly string DataConnectionString;
         private readonly IConsistentRingStreamQueueMapper streamQueueMapper;
@@ -22,21 +22,21 @@ namespace OrleansAWSUtils.Streams
 
         public StreamProviderDirection Direction { get { return StreamProviderDirection.ReadWrite; } }
 
-        public SQSAdapter(SerializationManager serializationManager, IConsistentRingStreamQueueMapper streamQueueMapper, ILoggerFactory loggerFactory, string dataConnectionString, string clusterId, string providerName)
+        public SQSAdapter(SerializationManager serializationManager, IConsistentRingStreamQueueMapper streamQueueMapper, ILoggerFactory loggerFactory, string dataConnectionString, string serviceId, string providerName)
         {
             if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
-            if (string.IsNullOrEmpty(clusterId)) throw new ArgumentNullException(nameof(clusterId));
+            if (string.IsNullOrEmpty(serviceId)) throw new ArgumentNullException(nameof(serviceId));
             this.loggerFactory = loggerFactory;
             this.serializationManager = serializationManager;
             DataConnectionString = dataConnectionString;
-            this.ClusterId = clusterId;
+            this.ServiceId = serviceId;
             Name = providerName;
             this.streamQueueMapper = streamQueueMapper;
         }
 
         public IQueueAdapterReceiver CreateReceiver(QueueId queueId)
         {
-            return SQSAdapterReceiver.Create(this.serializationManager, this.loggerFactory, queueId, DataConnectionString, this.ClusterId);
+            return SQSAdapterReceiver.Create(this.serializationManager, this.loggerFactory, queueId, DataConnectionString, this.ServiceId);
         }
 
         public async Task QueueMessageBatchAsync<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext)
@@ -49,7 +49,7 @@ namespace OrleansAWSUtils.Streams
             SQSStorage queue;
             if (!Queues.TryGetValue(queueId, out queue))
             {
-                var tmpQueue = new SQSStorage(this.loggerFactory, queueId.ToString(), DataConnectionString, this.ClusterId);
+                var tmpQueue = new SQSStorage(this.loggerFactory, queueId.ToString(), DataConnectionString, this.ServiceId);
                 await tmpQueue.InitQueueAsync();
                 queue = Queues.GetOrAdd(queueId, tmpQueue);
             }

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
@@ -60,7 +60,7 @@ namespace OrleansAWSUtils.Streams
         /// <summary>Creates the Azure Queue based adapter.</summary>
         public virtual Task<IQueueAdapter> CreateAdapter()
         {
-            var adapter = new SQSAdapter(this.serializationManager, this.streamQueueMapper, this.loggerFactory, this.sqsOptions.ConnectionString, this.clusterOptions.ClusterId, this.providerName);
+            var adapter = new SQSAdapter(this.serializationManager, this.streamQueueMapper, this.loggerFactory, this.sqsOptions.ConnectionString, this.clusterOptions.ServiceId.ToString(), this.providerName);
             return Task.FromResult<IQueueAdapter>(adapter);
         }
 

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
@@ -60,7 +60,7 @@ namespace OrleansAWSUtils.Streams
         /// <summary>Creates the Azure Queue based adapter.</summary>
         public virtual Task<IQueueAdapter> CreateAdapter()
         {
-            var adapter = new SQSAdapter(this.serializationManager, this.streamQueueMapper, this.loggerFactory, this.sqsOptions.ConnectionString, this.sqsOptions.ClusterId ?? this.clusterOptions.ClusterId, this.providerName);
+            var adapter = new SQSAdapter(this.serializationManager, this.streamQueueMapper, this.loggerFactory, this.sqsOptions.ConnectionString, this.clusterOptions.ClusterId, this.providerName);
             return Task.FromResult<IQueueAdapter>(adapter);
         }
 

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterReceiver.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterReceiver.cs
@@ -25,13 +25,13 @@ namespace OrleansAWSUtils.Streams
 
         public QueueId Id { get; private set; }
 
-        public static IQueueAdapterReceiver Create(SerializationManager serializationManager, ILoggerFactory loggerFactory, QueueId queueId, string dataConnectionString, string clusterId)
+        public static IQueueAdapterReceiver Create(SerializationManager serializationManager, ILoggerFactory loggerFactory, QueueId queueId, string dataConnectionString, string serviceId)
         {
             if (queueId == null) throw new ArgumentNullException("queueId");
             if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException("dataConnectionString");
-            if (string.IsNullOrEmpty(clusterId)) throw new ArgumentNullException(nameof(clusterId));
+            if (string.IsNullOrEmpty(serviceId)) throw new ArgumentNullException(nameof(serviceId));
 
-            var queue = new SQSStorage(loggerFactory, queueId.ToString(), dataConnectionString, clusterId);
+            var queue = new SQSStorage(loggerFactory, queueId.ToString(), dataConnectionString, serviceId);
             return new SQSAdapterReceiver(serializationManager, loggerFactory, queueId, queue);
         }
 

--- a/src/AWS/Orleans.Streaming.SQS/Streams/SqsStreamOptions.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SqsStreamOptions.cs
@@ -3,8 +3,6 @@ namespace Orleans.Configuration
 {
     public class SqsOptions
     {
-        public string ClusterId { get; set; }
-
         [Redact]
         public string ConnectionString { get; set; }
     }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -28,6 +28,7 @@ namespace Orleans.Storage
     public class AzureTableGrainStorage : IGrainStorage, IRestExceptionDecoder, ILifecycleParticipant<ISiloLifecycle>
     {
         private readonly AzureTableStorageOptions options;
+        private readonly ClusterOptions clusterOptions;
         private readonly SerializationManager serializationManager;
         private readonly IGrainFactory grainFactory;
         private readonly ITypeResolver typeResolver;
@@ -48,10 +49,11 @@ namespace Orleans.Storage
         private string name;
 
         /// <summary> Default constructor </summary>
-        public AzureTableGrainStorage(string name, AzureTableStorageOptions options, SerializationManager serializationManager, 
+        public AzureTableGrainStorage(string name, AzureTableStorageOptions options, ClusterOptions clusterOptions, SerializationManager serializationManager, 
             IGrainFactory grainFactory, ITypeResolver typeResolver, ILoggerFactory loggerFactory)
         {
             this.options = options;
+            this.clusterOptions = clusterOptions;
             this.name = name;
             this.serializationManager = serializationManager;
             this.grainFactory = grainFactory;
@@ -378,7 +380,7 @@ namespace Orleans.Storage
 
         private string GetKeyString(GrainReference grainReference)
         {
-            var key = String.Format("{0}_{1}", this.options.ServiceId, grainReference.ToKeyString());
+            var key = String.Format("{0}_{1}", this.clusterOptions.ServiceId, grainReference.ToKeyString());
             return AzureStorageUtils.SanitizeTableProperty(key);
         }
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -49,11 +49,11 @@ namespace Orleans.Storage
         private string name;
 
         /// <summary> Default constructor </summary>
-        public AzureTableGrainStorage(string name, AzureTableStorageOptions options, ClusterOptions clusterOptions, SerializationManager serializationManager, 
+        public AzureTableGrainStorage(string name, AzureTableStorageOptions options, IOptions<ClusterOptions> clusterOptions, SerializationManager serializationManager, 
             IGrainFactory grainFactory, ITypeResolver typeResolver, ILoggerFactory loggerFactory)
         {
             this.options = options;
-            this.clusterOptions = clusterOptions;
+            this.clusterOptions = clusterOptions.Value;
             this.name = name;
             this.serializationManager = serializationManager;
             this.grainFactory = grainFactory;

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorageOptions.cs
@@ -15,11 +15,6 @@ namespace Orleans.Configuration
     public class AzureTableStorageOptions
     {
         /// <summary>
-        /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment.
-        /// </summary>
-        public string ServiceId { get; set; } = string.Empty;
-
-        /// <summary>
         /// Azure table connection string
         /// </summary>
         [RedactConnectionString]

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapter.cs
@@ -12,7 +12,7 @@ namespace Orleans.Providers.Streams.AzureQueue
     internal class AzureQueueAdapter<TDataAdapter> : IQueueAdapter
         where TDataAdapter : IAzureQueueDataAdapter
     {
-        protected readonly string DeploymentId;
+        protected readonly string ServiceId;
         private readonly SerializationManager serializationManager;
         protected readonly string DataConnectionString;
         protected readonly TimeSpan? MessageVisibilityTimeout;
@@ -32,16 +32,16 @@ namespace Orleans.Providers.Streams.AzureQueue
             HashRingBasedStreamQueueMapper streamQueueMapper,
             ILoggerFactory loggerFactory,
             string dataConnectionString,
-            string deploymentId,
+            string serviceId,
             string providerName,
             TimeSpan? messageVisibilityTimeout = null)
         {
             if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException(nameof(dataConnectionString));
-            if (string.IsNullOrEmpty(deploymentId)) throw new ArgumentNullException(nameof(deploymentId));
+            if (string.IsNullOrEmpty(serviceId)) throw new ArgumentNullException(nameof(serviceId));
 
             this.serializationManager = serializationManager;
             DataConnectionString = dataConnectionString;
-            DeploymentId = deploymentId;
+            ServiceId = serviceId;
             Name = providerName;
             MessageVisibilityTimeout = messageVisibilityTimeout;
             this.streamQueueMapper = streamQueueMapper;
@@ -51,7 +51,7 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         public IQueueAdapterReceiver CreateReceiver(QueueId queueId)
         {
-            return AzureQueueAdapterReceiver.Create(this.serializationManager, this.loggerFactory, queueId, DataConnectionString, DeploymentId, this.dataAdapter, MessageVisibilityTimeout);
+            return AzureQueueAdapterReceiver.Create(this.serializationManager, this.loggerFactory, queueId, DataConnectionString, ServiceId, this.dataAdapter, MessageVisibilityTimeout);
         }
 
         public async Task QueueMessageBatchAsync<T>(Guid streamGuid, string streamNamespace, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext)
@@ -61,7 +61,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             AzureQueueDataManager queue;
             if (!Queues.TryGetValue(queueId, out queue))
             {
-                var tmpQueue = new AzureQueueDataManager(this.loggerFactory, queueId.ToString(), DeploymentId, DataConnectionString, MessageVisibilityTimeout);
+                var tmpQueue = new AzureQueueDataManager(this.loggerFactory, queueId.ToString(), ServiceId, DataConnectionString, MessageVisibilityTimeout);
                 await tmpQueue.InitQueueAsync();
                 queue = Queues.GetOrAdd(queueId, tmpQueue);
             }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -68,7 +68,7 @@ namespace Orleans.Providers.Streams.AzureQueue
                 this.streamQueueMapper, 
                 this.loggerFactory, 
                 this.options.ConnectionString, 
-                this.clusterOptions.ClusterId, 
+                this.clusterOptions.ServiceId.ToString(), 
                 this.providerName, 
                 this.options.MessageVisibilityTimeout);
             return Task.FromResult<IQueueAdapter>(adapter);

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -68,7 +68,7 @@ namespace Orleans.Providers.Streams.AzureQueue
                 this.streamQueueMapper, 
                 this.loggerFactory, 
                 this.options.ConnectionString, 
-                this.options.ClusterId ?? this.clusterOptions.ClusterId, 
+                this.clusterOptions.ClusterId, 
                 this.providerName, 
                 this.options.MessageVisibilityTimeout);
             return Task.FromResult<IQueueAdapter>(adapter);

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -27,15 +27,15 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         public QueueId Id { get; }
 
-        public static IQueueAdapterReceiver Create(SerializationManager serializationManager, ILoggerFactory loggerFactory, QueueId queueId, string dataConnectionString, string deploymentId, IAzureQueueDataAdapter dataAdapter, TimeSpan? messageVisibilityTimeout = null)
+        public static IQueueAdapterReceiver Create(SerializationManager serializationManager, ILoggerFactory loggerFactory, QueueId queueId, string dataConnectionString, string serviceId, IAzureQueueDataAdapter dataAdapter, TimeSpan? messageVisibilityTimeout = null)
         {
             if (queueId == null) throw new ArgumentNullException(nameof(queueId));
             if (string.IsNullOrEmpty(dataConnectionString)) throw new ArgumentNullException(nameof(dataConnectionString));
-            if (string.IsNullOrEmpty(deploymentId)) throw new ArgumentNullException(nameof(deploymentId));
+            if (string.IsNullOrEmpty(serviceId)) throw new ArgumentNullException(nameof(serviceId));
             if (dataAdapter == null) throw new ArgumentNullException(nameof(dataAdapter));
             if (serializationManager == null) throw new ArgumentNullException(nameof(serializationManager));
 
-            var queue = new AzureQueueDataManager(loggerFactory, queueId.ToString(), deploymentId, dataConnectionString, messageVisibilityTimeout);
+            var queue = new AzureQueueDataManager(loggerFactory, queueId.ToString(), serviceId, dataConnectionString, messageVisibilityTimeout);
             return new AzureQueueAdapterReceiver(serializationManager, loggerFactory, queueId, queue, dataAdapter);
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamOptions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamOptions.cs
@@ -13,9 +13,6 @@ namespace Orleans.Configuration
         [RedactConnectionString]
         public string ConnectionString { get; set; }
 
-        //TODO: should this be here ? I guess it should be because it determine the queue name?
-        public string ClusterId { get; set; }
-
         public TimeSpan? MessageVisibilityTimeout { get; set; }   
     }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -85,14 +85,14 @@ namespace Orleans.AzureUtils
         /// Constructor.
         /// </summary>
         /// <param name="queueName">Name of the queue to be connected to.</param>
-        /// <param name="deploymentId">The deployment id of the Azure service hosting this silo. It will be concatenated to the queueName.</param>
+        /// <param name="serviceId">The service id of the silo. It will be concatenated to the queueName.</param>
         /// <param name="storageConnectionString">Connection string for the Azure storage account used to host this table.</param>
         /// <param name="visibilityTimeout">A TimeSpan specifying the visibility timeout interval</param>
         /// <param name="loggerFactory">logger factory used to create loggers</param>
-        public AzureQueueDataManager(ILoggerFactory loggerFactory, string queueName, string deploymentId, string storageConnectionString, TimeSpan? visibilityTimeout = null)
+        public AzureQueueDataManager(ILoggerFactory loggerFactory, string queueName, string serviceId, string storageConnectionString, TimeSpan? visibilityTimeout = null)
         {
             logger = loggerFactory.CreateLogger<AzureQueueDataManager>();
-            QueueName = deploymentId + "-" + queueName;
+            QueueName = serviceId + "-" + queueName;
             QueueName = SanitizeQueueName(QueueName);
             ValidateQueueName(QueueName);
             connectionString = storageConnectionString;

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
@@ -64,7 +64,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
         public virtual Task<IQueueAdapter> CreateAdapter()
         {
             var adapter = new PubSubAdapter<TDataAdapter>(_adaptorFactory(), SerializationManager, this.loggerFactory, _streamQueueMapper,
-                this.options.ProjectId, this.options.TopicId, this.clusterOptions.ClusterId, this._providerName, this.options.Deadline, this.options.CustomEndpoint);
+                this.options.ProjectId, this.options.TopicId, this.clusterOptions.ServiceId.ToString(), this._providerName, this.options.Deadline, this.options.CustomEndpoint);
             return Task.FromResult<IQueueAdapter>(adapter);
         }
 

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
@@ -64,7 +64,7 @@ namespace Orleans.Providers.GCP.Streams.PubSub
         public virtual Task<IQueueAdapter> CreateAdapter()
         {
             var adapter = new PubSubAdapter<TDataAdapter>(_adaptorFactory(), SerializationManager, this.loggerFactory, _streamQueueMapper,
-                this.options.ProjectId, this.options.TopicId, this.options.ClusterId ?? this.clusterOptions.ClusterId, this._providerName, this.options.Deadline, this.options.CustomEndpoint);
+                this.options.ProjectId, this.options.TopicId, this.clusterOptions.ClusterId, this._providerName, this.options.Deadline, this.options.CustomEndpoint);
             return Task.FromResult<IQueueAdapter>(adapter);
         }
 

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterReceiver.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterReceiver.cs
@@ -23,13 +23,13 @@ namespace Orleans.Providers.GCP.Streams.PubSub
         public QueueId Id { get; }
 
         public static IQueueAdapterReceiver Create(SerializationManager serializationManager, ILoggerFactory loggerFactory, QueueId queueId, string projectId, string topicId,
-            string deploymentId, IPubSubDataAdapter dataAdapter, TimeSpan? deadline = null, string customEndpoint = "")
+            string serviceId, IPubSubDataAdapter dataAdapter, TimeSpan? deadline = null, string customEndpoint = "")
         {
             if (queueId == null) throw new ArgumentNullException(nameof(queueId));
             if (dataAdapter == null) throw new ArgumentNullException(nameof(dataAdapter));
             if (serializationManager == null) throw new ArgumentNullException(nameof(serializationManager));
 
-            var pubSub = new PubSubDataManager(loggerFactory, projectId, topicId, queueId.ToString(), deploymentId, deadline, customEndpoint);
+            var pubSub = new PubSubDataManager(loggerFactory, projectId, topicId, queueId.ToString(), serviceId, deadline, customEndpoint);
             return new PubSubAdapterReceiver(serializationManager, loggerFactory, queueId, topicId, pubSub, dataAdapter);
         }
 

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubDataManager.cs
@@ -30,17 +30,17 @@ namespace Orleans.Providers.GCP.Streams.PubSub
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         private readonly ILogger _logger;
 
-        public PubSubDataManager(ILoggerFactory loggerFactory, string projectId, string topicId, string subscriptionId, string deploymentId, TimeSpan? deadline = null, string customEndpoint = "")
+        public PubSubDataManager(ILoggerFactory loggerFactory, string projectId, string topicId, string subscriptionId, string serviceId, TimeSpan? deadline = null, string customEndpoint = "")
         {
-            if (string.IsNullOrWhiteSpace(deploymentId)) throw new ArgumentNullException(nameof(deploymentId));
+            if (string.IsNullOrWhiteSpace(serviceId)) throw new ArgumentNullException(nameof(serviceId));
             if (string.IsNullOrWhiteSpace(projectId)) throw new ArgumentNullException(nameof(projectId));
             if (string.IsNullOrWhiteSpace(topicId)) throw new ArgumentNullException(nameof(topicId));
             if (string.IsNullOrWhiteSpace(subscriptionId)) throw new ArgumentNullException(nameof(subscriptionId));
 
             _logger = loggerFactory.CreateLogger<PubSubDataManager>();
             _deadline = deadline;
-            topicId = $"{topicId}-{deploymentId}";
-            subscriptionId = $"{projectId}-{deploymentId}";
+            topicId = $"{topicId}-{serviceId}";
+            subscriptionId = $"{projectId}-{serviceId}";
             TopicName = new TopicName(projectId, topicId);
             SubscriptionName = new SubscriptionName(projectId, subscriptionId);
 

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubStreamOptions.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubStreamOptions.cs
@@ -10,8 +10,6 @@ namespace Orleans.Configuration
 
         public string TopicId { get; set; }
 
-        public string ClusterId { get; set; }
-
         public string CustomEndpoint { get; set; }
 
         private TimeSpan? deadline;

--- a/src/Orleans.TestingHost/TestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/TestClusterBuilder.cs
@@ -34,7 +34,7 @@ namespace Orleans.TestingHost
             {
                 InitialSilosCount = initialSilosCount,
                 ClusterId = CreateClusterId(),
-                ServiceId = Guid.Empty,
+                ServiceId = Guid.NewGuid(),
                 UseTestClusterMembership = true,
                 InitializeClientOnDeploy = true,
                 ConfigureFileLogging = true,

--- a/test/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/AWSUtils.Tests/Streaming/SQSAdapterTests.cs
@@ -56,7 +56,6 @@ namespace AWSUtils.Tests.Streaming
             var options = new SqsOptions
             {
                 ConnectionString = AWSTestConstants.DefaultSQSConnectionString,
-                ClusterId = this.clusterId
             };
             var adapterFactory = new SQSAdapterFactory(SQS_STREAM_PROVIDER_NAME, options, new HashRingStreamQueueMapperOptions(), new SimpleQueueCacheOptions(), null, Options.Create(new ClusterOptions()), null, null);
             adapterFactory.Init();

--- a/test/GoogleUtils.Tests/Streaming/PubSubClientStreamTests.cs
+++ b/test/GoogleUtils.Tests/Streaming/PubSubClientStreamTests.cs
@@ -55,7 +55,6 @@ namespace GoogleUtils.Tests.Streaming
                     {
                         options.ProjectId = GoogleTestUtils.ProjectId;
                         options.TopicId = GoogleTestUtils.TopicId;
-                        options.ClusterId = GoogleTestUtils.DeploymentId.ToString();
                         options.Deadline = TimeSpan.FromSeconds(600);
                     });
             }
@@ -70,7 +69,6 @@ namespace GoogleUtils.Tests.Streaming
                     {
                         options.ProjectId = GoogleTestUtils.ProjectId;
                         options.TopicId = GoogleTestUtils.TopicId;
-                        options.ClusterId = GoogleTestUtils.DeploymentId.ToString();
                         options.Deadline = TimeSpan.FromSeconds(600);
                     });
             }

--- a/test/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
+++ b/test/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
@@ -44,7 +44,6 @@ namespace GoogleUtils.Tests.Streaming
                     {
                         options.ProjectId = GoogleTestUtils.ProjectId;
                         options.TopicId = GoogleTestUtils.TopicId;
-                        options.ClusterId = GoogleTestUtils.DeploymentId.ToString();
                         options.Deadline = TimeSpan.FromSeconds(600);
                     }));
             }
@@ -61,7 +60,6 @@ namespace GoogleUtils.Tests.Streaming
                     {
                         options.ProjectId = GoogleTestUtils.ProjectId;
                         options.TopicId = GoogleTestUtils.TopicId;
-                        options.ClusterId = GoogleTestUtils.DeploymentId.ToString();
                         options.Deadline = TimeSpan.FromSeconds(600);
                     }));
             }

--- a/test/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
+++ b/test/GoogleUtils.Tests/Streaming/PubSubSubscriptionMultiplicityTests.cs
@@ -46,7 +46,6 @@ namespace GoogleUtils.Tests.Streaming
                     {
                         options.ProjectId = GoogleTestUtils.ProjectId;
                         options.TopicId = GoogleTestUtils.TopicId;
-                        options.ClusterId = GoogleTestUtils.DeploymentId.ToString();
                         options.Deadline = TimeSpan.FromSeconds(600);
                     });
             }
@@ -61,7 +60,6 @@ namespace GoogleUtils.Tests.Streaming
                     {
                         options.ProjectId = GoogleTestUtils.ProjectId;
                         options.TopicId = GoogleTestUtils.TopicId;
-                        options.ClusterId = GoogleTestUtils.DeploymentId.ToString();
                         options.Deadline = TimeSpan.FromSeconds(600);
                     });
             }

--- a/test/Orleans.Transactions.Azure.Test/TestFixture.cs
+++ b/test/Orleans.Transactions.Azure.Test/TestFixture.cs
@@ -32,7 +32,6 @@ namespace Orleans.Transactions.AzureStorage.Tests
                     .UseInClusterTransactionManager()
                     .AddAzureTableGrainStorage(TransactionTestConstants.TransactionStore, builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
-                        options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     }))
                     .UseAzureTransactionLog(options => {

--- a/test/TestExtensions/BaseClusterFixture.cs
+++ b/test/TestExtensions/BaseClusterFixture.cs
@@ -2,7 +2,9 @@ using System;
 using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans;
+using Orleans.Configuration;
 using Orleans.TestingHost;
 
 namespace TestExtensions
@@ -65,5 +67,7 @@ namespace TestExtensions
         {
             this.HostedCluster?.StopAllSilos();
         }
+
+        public Guid GetClientServiceId() => Client.ServiceProvider.GetRequiredService<IOptions<ClusterOptions>>().Value.ServiceId;
     }
 }

--- a/test/TestExtensions/SerializationTestEnvironment.cs
+++ b/test/TestExtensions/SerializationTestEnvironment.cs
@@ -20,7 +20,11 @@ namespace TestExtensions
 
             var builder = new ClientBuilder()
                 .ConfigureDefaults()
-                .Configure<ClusterOptions>(options => options.ClusterId = nameof(SerializationTestEnvironment))
+                .Configure<ClusterOptions>(options =>
+                {
+                    options.ClusterId = nameof(SerializationTestEnvironment);
+                    options.ServiceId = Guid.NewGuid();
+                })
                 .UseConfiguration(config);
             configureClientBuilder?.Invoke(builder);
             this.Client = builder.Build();

--- a/test/TesterAdoNet/Persistence/PersistenceGrainTests_AdoNetSql.cs
+++ b/test/TesterAdoNet/Persistence/PersistenceGrainTests_AdoNetSql.cs
@@ -74,7 +74,7 @@ namespace Tester.AdoNet.Persistence
 
         private Fixture fixture;
 
-        public PersistenceGrainTests_Sql(ITestOutputHelper output, Fixture fixture) : base(output, fixture, ServiceId)
+        public PersistenceGrainTests_Sql(ITestOutputHelper output, Fixture fixture) : base(output, fixture)
         {
             this.fixture = fixture;
             this.fixture.EnsurePreconditionsMet();

--- a/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
+++ b/test/TesterAzureUtils/GenericGrainsInAzureStorageTests.cs
@@ -37,7 +37,6 @@ namespace Tester.AzureUtils.General
                     hostBuilder
                         .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }));
                 }

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
@@ -55,14 +55,12 @@ namespace Tester.AzureUtils.Persistence
 
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                
                 builder.Options.InitialSilosCount = 4;
                 builder.Options.UseTestClusterMembership = false;
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
                     legacy.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
 
-                    legacy.ClusterConfiguration.Globals.ServiceId = Guid.NewGuid();
                     legacy.ClusterConfiguration.Globals.MaxResendCount = 0;
 
                     legacy.ClusterConfiguration.Globals.RegisterStorageProvider<UnitTests.StorageTests.MockStorageProvider>("test1");

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
@@ -59,8 +59,8 @@ namespace Tester.AzureUtils.Persistence
                 builder.Options.UseTestClusterMembership = false;
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
+                    legacy.ClusterConfiguration.Globals.ServiceId = Guid.NewGuid();
                     legacy.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
-
                     legacy.ClusterConfiguration.Globals.MaxResendCount = 0;
 
                     legacy.ClusterConfiguration.Globals.RegisterStorageProvider<UnitTests.StorageTests.MockStorageProvider>("test1");

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureBlobStore.cs
@@ -23,7 +23,6 @@ namespace Tester.AzureUtils.Persistence
     [TestCategory("Persistence"), TestCategory("Azure")]
     public class PersistenceGrainTests_AzureBlobStore : Base_PersistenceGrainTests_AzureStore, IClassFixture<PersistenceGrainTests_AzureBlobStore.Fixture>
     {
-        public static Guid ServiceId = Guid.NewGuid();
         public class Fixture : BaseAzureTestClusterFixture
         {
             private class StorageSiloBuilderConfigurator : ISiloBuilderConfigurator
@@ -33,20 +32,20 @@ namespace Tester.AzureUtils.Persistence
                     hostBuilder.AddAzureBlobGrainStorage("AzureStore", (AzureBlobStorageOptions options) =>
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                    });
-                    hostBuilder.AddAzureBlobGrainStorage("AzureStore1", (AzureBlobStorageOptions options) =>
+                    })
+                    .AddAzureBlobGrainStorage("AzureStore1", (AzureBlobStorageOptions options) =>
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                    });
-                    hostBuilder.AddAzureBlobGrainStorage("AzureStore2", (AzureBlobStorageOptions options) =>
+                    })
+                    .AddAzureBlobGrainStorage("AzureStore2", (AzureBlobStorageOptions options) =>
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                    });
-                    hostBuilder.AddAzureBlobGrainStorage("AzureStore3", (AzureBlobStorageOptions options) =>
+                    })
+                    .AddAzureBlobGrainStorage("AzureStore3", (AzureBlobStorageOptions options) =>
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                    });
-                    hostBuilder.AddAzureBlobGrainStorage("GrainStorageForTest", (AzureBlobStorageOptions options) =>
+                    })
+                    .AddAzureBlobGrainStorage("GrainStorageForTest", (AzureBlobStorageOptions options) =>
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     })
@@ -63,7 +62,7 @@ namespace Tester.AzureUtils.Persistence
                 {
                     legacy.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
 
-                    legacy.ClusterConfiguration.Globals.ServiceId = ServiceId;
+                    legacy.ClusterConfiguration.Globals.ServiceId = Guid.NewGuid();
                     legacy.ClusterConfiguration.Globals.MaxResendCount = 0;
 
                     legacy.ClusterConfiguration.Globals.RegisterStorageProvider<UnitTests.StorageTests.MockStorageProvider>("test1");
@@ -79,7 +78,7 @@ namespace Tester.AzureUtils.Persistence
             }
         }
 
-        public PersistenceGrainTests_AzureBlobStore(ITestOutputHelper output, Fixture fixture) : base(output, fixture, ServiceId)
+        public PersistenceGrainTests_AzureBlobStore(ITestOutputHelper output, Fixture fixture) : base(output, fixture)
         {
             fixture.EnsurePreconditionsMet();
         }

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureStore.cs
@@ -68,14 +68,14 @@ namespace Tester.AzureUtils.Persistence
             return providerConfig.First();
         }
 
-        public Base_PersistenceGrainTests_AzureStore(ITestOutputHelper output, BaseTestClusterFixture fixture, Guid serviceId)
+        public Base_PersistenceGrainTests_AzureStore(ITestOutputHelper output, BaseTestClusterFixture fixture)
         {
             this.output = output;
             this.logger = fixture.Logger;
             HostedCluster = fixture.HostedCluster;
             GrainFactory = fixture.GrainFactory;
             timingFactor = TestUtils.CalibrateTimings();
-            this.basicPersistenceTestsRunner = new GrainPersistenceTestsRunner(output, fixture, serviceId);
+            this.basicPersistenceTestsRunner = new GrainPersistenceTestsRunner(output, fixture);
         }
 
         public IGrainFactory GrainFactory { get; }

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
@@ -72,7 +72,8 @@ namespace Tester.AzureUtils.Persistence
             }
         }
 
-        public PersistenceGrainTests_AzureTableGrainStorage(ITestOutputHelper output, Fixture fixture) : base(output, fixture, ServiceId)
+        public PersistenceGrainTests_AzureTableGrainStorage(ITestOutputHelper output, Fixture fixture) : 
+            base(output, fixture)
         {
             fixture.EnsurePreconditionsMet();
         }

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
@@ -26,6 +26,7 @@ namespace Tester.AzureUtils.Persistence
                 builder.Options.UseTestClusterMembership = false;
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
+                    legacy.ClusterConfiguration.Globals.ServiceId = Guid.NewGuid();
                     legacy.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
 
                     legacy.ClusterConfiguration.Globals.MaxResendCount = 0;

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
@@ -52,23 +52,19 @@ namespace Tester.AzureUtils.Persistence
                     hostBuilder
                         .AddAzureTableGrainStorage("GrainStorageForTest", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.DeleteStateOnClear = true;
                         }))
                         .AddAzureTableGrainStorage("AzureStore1", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
                         .AddAzureTableGrainStorage("AzureStore2", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
                         .AddAzureTableGrainStorage("AzureStore3", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
                         .AddMemoryGrainStorage("MemoryStore");

--- a/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
+++ b/test/TesterAzureUtils/Persistence/PersistenceGrainTests_AzureTableGrainStorage.cs
@@ -18,7 +18,6 @@ namespace Tester.AzureUtils.Persistence
     [TestCategory("Persistence"), TestCategory("Azure")]
     public class PersistenceGrainTests_AzureTableGrainStorage : Base_PersistenceGrainTests_AzureStore, IClassFixture<PersistenceGrainTests_AzureTableGrainStorage.Fixture>
     {
-        public static Guid ServiceId = Guid.NewGuid();
         public class Fixture : BaseAzureTestClusterFixture
         {
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
@@ -28,8 +27,6 @@ namespace Tester.AzureUtils.Persistence
                 builder.ConfigureLegacyConfiguration(legacy =>
                 {
                     legacy.ClusterConfiguration.Globals.DataConnectionString = TestDefaultConfiguration.DataConnectionString;
-
-                    legacy.ClusterConfiguration.Globals.ServiceId = ServiceId;
 
                     legacy.ClusterConfiguration.Globals.MaxResendCount = 0;
 

--- a/test/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamFilteringTests.cs
@@ -19,7 +19,7 @@ namespace Tester.AzureUtils.Streaming
     [TestCategory("Streaming"), TestCategory("Filters"), TestCategory("Azure")]
     public class StreamFilteringTests_AQ : StreamFilteringTestsBase, IClassFixture<StreamFilteringTests_AQ.Fixture>, IDisposable
     {
-        private readonly string clusterId;
+        private readonly string serviceId;
         public class Fixture : BaseAzureTestClusterFixture
         {
             public const string StreamProvider = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
@@ -55,7 +55,7 @@ namespace Tester.AzureUtils.Streaming
         public StreamFilteringTests_AQ(Fixture fixture) : base(fixture)
         {
             fixture.EnsurePreconditionsMet();
-            this.clusterId = fixture.HostedCluster.Options.ClusterId;
+            this.serviceId = fixture.HostedCluster.Options.ServiceId.ToString();
             streamProviderName = Fixture.StreamProvider;
         }
 
@@ -63,7 +63,7 @@ namespace Tester.AzureUtils.Streaming
         {
                 AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(NullLoggerFactory.Instance, 
                     streamProviderName,
-                    this.clusterId,
+                    this.serviceId,
                     TestDefaultConfiguration.DataConnectionString).Wait();
             }
 

--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -54,13 +54,11 @@ namespace Tester.AzureUtils.Streaming
                     .AddSimpleMessageStreamProvider(SmsStreamProviderName)
                     .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
-                        options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
                     .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.DeleteStateOnClear = true;
                         }))

--- a/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
+++ b/test/TesterAzureUtils/Streaming/AzureQueueAdapterTests.cs
@@ -54,7 +54,6 @@ namespace Tester.AzureUtils.Streaming
             var options = new AzureQueueOptions
             {
                 ConnectionString = TestDefaultConfiguration.DataConnectionString,
-                ClusterId = this.clusterId,
                 MessageVisibilityTimeout = TimeSpan.FromSeconds(30)
             };
             var adapterFactory = new AzureQueueAdapterFactory<AzureQueueDataAdapterV2>(AZURE_QUEUE_STREAM_PROVIDER_NAME, options,

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -42,7 +42,6 @@ namespace UnitTests.HaloTests.Streaming
                         .AddMemoryGrainStorage("MemoryStore", options => options.NumStorageGrains = 1)
                         .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.DeleteStateOnClear = true;
                         }))
@@ -50,7 +49,6 @@ namespace UnitTests.HaloTests.Streaming
                         .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false)
                         .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.DeleteStateOnClear = true;
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -70,11 +70,11 @@ namespace UnitTests.HaloTests.Streaming
 
             public override void Dispose()
             {
-                var clusterId = this.HostedCluster?.Options.ClusterId;
+                var serviceId = this.HostedCluster?.Options.ServiceId;
                 base.Dispose();
-                if (clusterId != null)
+                if (serviceId != null)
                 {
-                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AzureQueueStreamProviderName, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
+                    AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance, AzureQueueStreamProviderName, serviceId.ToString(), TestDefaultConfiguration.DataConnectionString).Wait();
                 }
             }
         }
@@ -98,10 +98,10 @@ namespace UnitTests.HaloTests.Streaming
 
         public void Dispose()
         {
-            var clusterId = this.HostedCluster?.Options.ClusterId;
-            if (clusterId != null && _streamProvider != null && _streamProvider.Equals(AzureQueueStreamProviderName))
+            var serviceId = this.HostedCluster?.Options.ServiceId;
+            if (serviceId != null && _streamProvider != null && _streamProvider.Equals(AzureQueueStreamProviderName))
             {
-                AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(this.loggerFactory, _streamProvider, clusterId, TestDefaultConfiguration.DataConnectionString).Wait();
+                AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(this.loggerFactory, _streamProvider, serviceId.ToString(), TestDefaultConfiguration.DataConnectionString).Wait();
             }
         }
 

--- a/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLifecycleTests.cs
@@ -62,13 +62,11 @@ namespace UnitTests.StreamingTests
                     .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false)
                     .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
-                        options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
                     .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
-                        options.ServiceId = silo.Value.ServiceId.ToString();
                         options.DeleteStateOnClear = true;
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     }))

--- a/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamLimitTests.cs
@@ -53,13 +53,11 @@ namespace UnitTests.StreamingTests
                     .AddSimpleMessageStreamProvider("SMSProviderDoNotOptimizeForImmutableData", options => options.OptimizeForImmutableData = false)
                     .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
-                        options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
                     .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
-                        options.ServiceId = silo.Value.ServiceId.ToString();
                         options.DeleteStateOnClear = true;
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     }))

--- a/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
+++ b/test/TesterAzureUtils/Streaming/StreamReliabilityTests.cs
@@ -83,7 +83,6 @@ namespace UnitTests.Streaming.Reliability
                 })
                 .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                     {
-                        options.ServiceId = silo.Value.ServiceId.ToString();
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.DeleteStateOnClear = true;
                     }))
@@ -91,7 +90,6 @@ namespace UnitTests.Streaming.Reliability
                 .AddSimpleMessageStreamProvider(SMS_STREAM_PROVIDER_NAME)
                 .AddAzureTableGrainStorage("PubSubStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                 {
-                    options.ServiceId = silo.Value.ServiceId.ToString();
                     options.DeleteStateOnClear = true;
                     options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                 }))

--- a/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicLogTestGrainTests.cs
@@ -43,12 +43,10 @@ namespace Tests.GeoClusterTests
                     hostBuilder
                         .AddAzureTableGrainStorageAsDefault(builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
                         .AddAzureTableGrainStorage("AzureStore", builder => builder.Configure<IOptions<ClusterOptions>>((options, silo) =>
                         {
-                            options.ServiceId = silo.Value.ServiceId.ToString();
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
                         .AddMemoryGrainStorageAsDefault()

--- a/test/TesterInternal/GeoClusterTests/BasicMultiClusterTest.cs
+++ b/test/TesterInternal/GeoClusterTests/BasicMultiClusterTest.cs
@@ -45,16 +45,18 @@ namespace Tests.GeoClusterTests
         [SkippableFact, TestCategory("Functional")]
         public void CreateTwoIndependentClusters()
         {
+            var serviceId = Guid.NewGuid();
+
             using (var host = new TestingClusterHost(output))
             {
                 // create cluster A with one silo and clientA
                 var clusterA = "A";
-                host.NewCluster(clusterA, 1);
+                host.NewCluster(serviceId, clusterA, 1);
                 var clientA = host.NewClient(clusterA, 0, ClientWrapper.Factory);
 
                 // create cluster B with 5 silos and clientB
                 var clusterB = "B";
-                host.NewCluster(clusterB, 5);
+                host.NewCluster(serviceId, clusterB, 5);
                 var clientB = host.NewClient(clusterB, 0, ClientWrapper.Factory);
 
                 // call management grain in each cluster to count the silos

--- a/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
+++ b/test/TesterInternal/GeoClusterTests/TestingClusterHost.cs
@@ -161,7 +161,7 @@ namespace Tests.GeoClusterTests
                     customizer?.Invoke(config);
                 };
 
-            NewCluster<TSiloBuilderConfigurator>(clusterId, numSilos, extendedcustomizer);
+            NewCluster<TSiloBuilderConfigurator>(globalServiceId, clusterId, numSilos, extendedcustomizer);
         }
         private class NoOpSiloBuilderConfigurator : ISiloBuilderConfigurator
         {
@@ -187,13 +187,13 @@ namespace Tests.GeoClusterTests
             }
         }
 
-        public void NewCluster(string clusterId, short numSilos,
+        public void NewCluster(Guid serviceId, string clusterId, short numSilos,
             Action<ClusterConfiguration> customizer = null)
         {
-            NewCluster<NoOpSiloBuilderConfigurator>(clusterId, numSilos, customizer);
+            NewCluster<NoOpSiloBuilderConfigurator>(serviceId, clusterId, numSilos, customizer);
         }
 
-        public void NewCluster<TSiloBuilderConfigurator>(string clusterId, short numSilos, Action<ClusterConfiguration> customizer = null)
+        public void NewCluster<TSiloBuilderConfigurator>(Guid serviceId, string clusterId, short numSilos, Action<ClusterConfiguration> customizer = null)
             where TSiloBuilderConfigurator : ISiloBuilderConfigurator, new()
         {
             TestCluster testCluster;
@@ -207,6 +207,7 @@ namespace Tests.GeoClusterTests
                 {
                     Options =
                     {
+                        ServiceId = serviceId,
                         ClusterId = clusterId,
                         BaseSiloPort = GetPortBase(myCount),
                         BaseGatewayPort = GetProxyBase(myCount)

--- a/test/TesterInternal/TestRunners/GrainPersistenceTestRunner.cs
+++ b/test/TesterInternal/TestRunners/GrainPersistenceTestRunner.cs
@@ -17,17 +17,18 @@ namespace TestExtensions.Runners
 {
     public class GrainPersistenceTestsRunner : OrleansTestingBase
     {
-        private readonly Guid serviceId;
         private readonly ITestOutputHelper output;
-        protected TestCluster HostedCluster { get; private set; }
+        private readonly BaseTestClusterFixture fixture;
         protected readonly ILogger logger;
+        protected TestCluster HostedCluster { get; private set; }
+
         public GrainPersistenceTestsRunner(ITestOutputHelper output, BaseTestClusterFixture fixture)
         {
             this.output = output;
+            this.fixture = fixture;
             this.logger = fixture.Logger;
             HostedCluster = fixture.HostedCluster;
             GrainFactory = fixture.GrainFactory;
-            this.serviceId = fixture.GetClientServiceId();
         }
 
         public IGrainFactory GrainFactory { get; }
@@ -286,9 +287,9 @@ namespace TestExtensions.Runners
         [Fact]
         public async Task Grain_GrainStorage_SiloRestart()
         {
-            var initialServiceId = this.serviceId;
+            var initialServiceId = fixture.GetClientServiceId();
 
-            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.Options.ClusterId, this.serviceId);
+            output.WriteLine("ClusterId={0} ServiceId={1}", this.HostedCluster.Options.ClusterId, initialServiceId);
 
             Guid id = Guid.NewGuid();
             IGrainStorageTestGrain grain = this.GrainFactory.GetGrain<IGrainStorageTestGrain>(id);


### PR DESCRIPTION
Make providers use Cluster ID and Service ID from ClusterOptions.
Also fix Azure Queue, SQS, and GCP pubsub providers to use Service ID instead of Cluster ID.