### PR TITLE
Dedup option formatters and add more logging to streaming

### DIFF
--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionFormatter.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionFormatter.cs
@@ -32,6 +32,28 @@ namespace Orleans
         IOptionFormatter<T> Resolve(string name);
     }
 
+    public class OptionsFormatterComparer : IEqualityComparer<IOptionFormatter>
+    {
+        public static OptionsFormatterComparer Instance  = new OptionsFormatterComparer();
+        public bool Equals(IOptionFormatter x, IOptionFormatter y)
+        {
+            //if name equal and formatted strings are equal, then equal.
+            //perf wise, most formatters will fail at the first condition, which is relately cheap. 
+            //So don't switch order of the two condition
+            if (x.Name.Equals(y.Name)&& x.Format().IEnumerableEquals(y.Format()))
+            {
+                return true;
+            }
+            return false;
+
+        }
+
+        public int GetHashCode(IOptionFormatter obj)
+        {
+            var hashCode = $"{obj.Name}{obj.Format()}";
+            return hashCode.GetHashCode();
+        }
+    }
     /// <summary>
     /// Utility class for option formatting
     /// </summary>

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
@@ -28,7 +28,7 @@ namespace Orleans
             return Task.CompletedTask;
         }
     }
-
+    
     /// <summary>
     /// Base class for client and silo default options loggers.
     /// </summary>
@@ -47,7 +47,9 @@ namespace Orleans
         /// </summary>
         public void LogOptions()
         {
-            this.LogOptions(services.GetServices<IOptionFormatter>());
+            //dedup duplicated log formatters
+            var logFormatters = services.GetServices<IOptionFormatter>().Distinct(OptionsFormatterComparer.Instance);
+            this.LogOptions(logFormatters);
         }
 
         /// <summary>

--- a/src/Orleans.Runtime.Abstractions/Streams/SiloPersistentStreamConfigurator.cs
+++ b/src/Orleans.Runtime.Abstractions/Streams/SiloPersistentStreamConfigurator.cs
@@ -43,6 +43,7 @@ namespace Orleans.Streams
             siloBuilder.ConfigureServices(services =>
             {
                 configureOptions?.Invoke(services.AddOptions<TOptions>(this.name));
+                services.ConfigureNamedOptionForLogging<TOptions>(this.name);
             });
             return this;
         }

--- a/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
+++ b/src/Orleans.Runtime/Silo/SiloProviderRuntime.cs
@@ -27,7 +27,7 @@ namespace Orleans.Runtime.Providers
 
         public IGrainFactory GrainFactory => this.runtimeClient.InternalGrainFactory;
         public IServiceProvider ServiceProvider => this.runtimeClient.ServiceProvider;
-
+        private ILogger logger;
         public Guid ServiceId { get; }
         public string SiloIdentity { get; }
 
@@ -50,7 +50,7 @@ namespace Orleans.Runtime.Providers
             this.runtimeClient = runtimeClient;
             this.ServiceId = clusterOptions.Value.ServiceId;
             this.SiloIdentity = siloDetails.SiloAddress.ToLongString();
-
+            this.logger = this.loggerFactory.CreateLogger<SiloProviderRuntime>();
             this.grainBasedPubSub = new GrainBasedPubSubRuntime(this.GrainFactory);
             var tmp = new ImplicitStreamPubSub(this.runtimeClient.InternalGrainFactory, implicitStreamSubscriberTable);
             this.implictPubSub = tmp;
@@ -121,6 +121,7 @@ namespace Orleans.Runtime.Providers
                 var balancer = this.ServiceProvider.GetServiceByName<IStreamQueueBalancer>(streamProviderName)??this.ServiceProvider.GetService<IStreamQueueBalancer>();
                 if (balancer == null)
                     throw new ArgumentOutOfRangeException("balancerType", $"Cannot create stream queue balancer for StreamProvider: {streamProviderName}.Please configure your stream provider with a queue balancer.");
+                this.logger.LogInformation($"Successfully created queue balancer of type {balancer.GetType()} for stream provider {streamProviderName}");
                 return balancer;
             }
             catch (Exception e)


### PR DESCRIPTION
- Dedup option formatters if ConfigureNamedOptions called twice or ConfigureFormatter called twice.
- Add more logging to streaming. 