### PR TITLE
Improves ADO.NET script finding by moving them to project directory

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/Microsoft.Orleans.Clustering.AdoNet.targets
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Microsoft.Orleans.Clustering.AdoNet.targets
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="MicrosoftOrleansClusteringAdoNetCopySqlFiles" BeforeTargets="PrepareForBuild">
+    <!-- These are the source content files needed in the project. Note that $(TargetFramework) cannot be used here since it can be netcoreapp2.0 or somesuch. -->
+    <ItemGroup>
+      <MicrosoftOrleansClusteringAdoNetItems Include="$(MSBuildThisFileDirectory)..\..\lib\netstandard2.0\**\*.sql" />
+    </ItemGroup>
+
+    <!-- The user may have modified the *.sql files fit for deployment. So they shouldn't be overwritten when Nuget restore is made. -->
+    <Copy
+      SourceFiles="@(MicrosoftOrleansClusteringAdoNetItems)"
+      DestinationFolder="$(MSBuildProjectDirectory)/OrleansAdoNetContent/%(RecursiveDir)"
+      Condition="!(Exists(@(Packages->'$(TargetDir)%(Filename)%(Extension)')))"
+      OverwriteReadOnlyFiles="false"
+      Retries="2"
+      RetryDelayMilliseconds="400"/>
+  </Target>
+</Project>

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
@@ -83,5 +83,9 @@
       <Pack>true</Pack>
       <PackagePath>lib\$(TargetFramework)\SQLServer\</PackagePath>
     </None>
+    <Content Include="Microsoft.Orleans.Clustering.AdoNet.targets">
+      <PackagePath>build/$(TargetFramework)/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
 </Project>

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Microsoft.Orleans.Persistence.AdoNet.targets
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Microsoft.Orleans.Persistence.AdoNet.targets
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="MicrosoftOrleansPersistenceAdoNetCopySqlFiles" BeforeTargets="PrepareForBuild">
+    <!-- These are the source content files needed in the project. Note that $(TargetFramework) cannot be used here since it can be netcoreapp2.0 or somesuch. -->
+    <ItemGroup>
+      <MicrosoftOrleansPersistenceAdoNetItems Include="$(MSBuildThisFileDirectory)..\..\lib\netstandard2.0\**\*.sql" />
+    </ItemGroup>
+
+    <!-- The user may have modified the *.sql files fit for deployment. So they shouldn't be overwritten. -->
+    <Copy
+      SourceFiles="@(MicrosoftOrleansPersistenceAdoNetItems)"
+      DestinationFolder="$(MSBuildProjectDirectory)/OrleansAdoNetContent/%(RecursiveDir)"
+      Condition="!(Exists(@(Packages->'$(TargetDir)%(Filename)%(Extension)')))"
+      OverwriteReadOnlyFiles="false"
+      Retries="2"
+      RetryDelayMilliseconds="400"/>
+  </Target>
+</Project>

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Microsoft.Orleans.Persistence.AdoNet.targets" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\Shared\Storage\AdoNetInvariants.cs" Link="Storage\AdoNetInvariants.cs" />
     <Compile Include="..\Shared\Storage\DbConnectionFactory.cs" Link="Storage\DbConnectionFactory.cs" />
     <Compile Include="..\Shared\Storage\DbExtensions.cs" Link="Storage\DbExtensions.cs" />
@@ -27,6 +31,13 @@
     <Compile Include="..\Shared\Storage\RelationalStorage.cs" Link="Storage\RelationalStorage.cs" />
     <Compile Include="..\Shared\Storage\RelationalStorageExtensions.cs" Link="Storage\RelationalStorageExtensions.cs" />
     <Compile Include="..\Shared\Storage\AdoNetFormatProvider.cs" Link="Storage\AdoNetFormatProvider.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Microsoft.Orleans.Persistence.AdoNet.targets">
+      <PackagePath>build/$(TargetFramework)/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -80,5 +91,9 @@
       <Pack>true</Pack>
       <PackagePath>lib\$(TargetFramework)\SQLServer\</PackagePath>
     </None>
+    <Content Include="Microsoft.Orleans.Persistence.AdoNet.targets">
+      <PackagePath>build/$(TargetFramework)/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
 </Project>

--- a/src/AdoNet/Orleans.Reminders.AdoNet/Microsoft.Orleans.Reminders.AdoNet.targets
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/Microsoft.Orleans.Reminders.AdoNet.targets
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="MicrosoftOrleansRemindersAdoNetCopySqlFiles" BeforeTargets="PrepareForBuild">
+    <!-- These are the source content files needed in the project. Note that $(TargetFramework) cannot be used here since it can be netcoreapp2.0 or somesuch. -->
+    <ItemGroup>
+      <MicrosoftOrleansRemindersAdoNetItems Include="$(MSBuildThisFileDirectory)..\..\lib\netstandard2.0\**\*.sql" />
+    </ItemGroup>
+
+    <!-- The user may have modified the *.sql files fit for deployment. So they shouldn't be overwritten. -->
+    <Copy
+      SourceFiles="@(MicrosoftOrleansRemindersAdoNetItems)"
+      DestinationFolder="$(MSBuildProjectDirectory)/OrleansAdoNetContent/%(RecursiveDir)"
+      Condition="!(Exists(@(Packages->'$(TargetDir)%(Filename)%(Extension)')))"
+      OverwriteReadOnlyFiles="false"
+      Retries="2"
+      RetryDelayMilliseconds="400"/>
+  </Target>
+</Project>

--- a/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Microsoft.Orleans.Reminders.AdoNet.targets" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\Shared\Storage\AdoNetInvariants.cs" Link="Storage\AdoNetInvariants.cs" />
     <Compile Include="..\Shared\Storage\DbConnectionFactory.cs" Link="Storage\DbConnectionFactory.cs" />
     <Compile Include="..\Shared\Storage\DbExtensions.cs" Link="Storage\DbExtensions.cs" />
@@ -27,6 +31,13 @@
     <Compile Include="..\Shared\Storage\RelationalStorage.cs" Link="Storage\RelationalStorage.cs" />
     <Compile Include="..\Shared\Storage\RelationalStorageExtensions.cs" Link="Storage\RelationalStorageExtensions.cs" />
     <Compile Include="..\Shared\Storage\AdoNetFormatProvider.cs" Link="Storage\AdoNetFormatProvider.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Microsoft.Orleans.Reminders.AdoNet.targets">
+      <PackagePath>build/$(TargetFramework)/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -78,6 +89,10 @@
       <Pack>true</Pack>
       <PackagePath>lib\$(TargetFramework)\SQLServer\</PackagePath>
     </None>
+    <Content Include="Microsoft.Orleans.Reminders.AdoNet.targets">
+      <PackagePath>build/$(TargetFramework)/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Currently since they're split and located in Nuget cache directory "far away"
from the project. Using nuget locals all -list, reveals the location is
something such as
C:\Users\<username>\.nuget\packages\microsoft.orleans.*.adonet\2.0.0-beta3\lib\netstandard2.0.

This improves the situation such that upon Nuget restore the files re copied to
project directory to \OrleansAdoNetContent where each supported ADO.NET provider
has its own directory.

Further, this makes it easier later to implement helper methods, such as automatic
database deployment, schema naming, filegroup additions and layout updates even with
large amounts of data.

Fixes #3864.