### PR TITLE
Improve startup time for localhost cluster.

### DIFF
--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -65,6 +65,7 @@ namespace Orleans.Hosting
 
             builder.UseDevelopmentClustering(primarySiloEndpoint ?? new IPEndPoint(IPAddress.Loopback, siloPort));
             builder.Configure<ClusterOptions>(options => options.ClusterId = clusterId);
+            builder.Configure<ClusterMembershipOptions>(options => options.ExpectedClusterSize = 1);
 
             return builder;
         }


### PR DESCRIPTION
The startup time is heavily increased by the delay in the membership oracle. For development we can set the clustersize to 1 and also do not wait. Reduced my startup time from 15 to 3 seconds.