### PR TITLE
Enable SystemTarget routing in the Gateway

### DIFF
--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -185,7 +185,7 @@ namespace Orleans.Messaging
             bool startRequired = false;
 
             // If there's a specific gateway specified, use it
-            if (msg.TargetSilo != null)
+            if (msg.TargetSilo != null && GatewayManager.GetLiveGateways().Contains(msg.TargetSilo.ToGatewayUri()))
             {
                 Uri addr = msg.TargetSilo.ToGatewayUri();
                 lock (lockable)

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -180,7 +180,7 @@ namespace Orleans.Runtime.Messaging
             // it to this address...
             // EXCEPT if the value is equal to the current GatewayAdress: in this case we will return
             // null and the local dispatcher will forward the Message to a local SystemTarget activation
-            if (msg.TargetGrain.IsSystemTarget && !msg.TargetSilo.Matches(this.gatewayAddress))
+            if (msg.TargetGrain.IsSystemTarget && !this.gatewayAddress.Matches(msg.TargetSilo))
                 return msg.TargetSilo;
 
             // for responses from ClientAddressableObject to ClientGrain try to use clientsReplyRoutingCache for sending replies directly back.

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -170,6 +170,19 @@ namespace Orleans.Runtime.Messaging
 
         internal SiloAddress TryToReroute(Message msg)
         {
+            // ** Special routing rule for system target here **
+            // When a client make a request/response to/from a SystemTarget, the TargetSilo can be set to either 
+            //  - the GatewayAddress of the target silo (for example, when the client want get the cluster typemap)
+            //  - the "internal" Silo-to-Silo address, if the client want to send a message to a specific SystemTarget
+            //    activation that is on a silo on which there is no gateway available (or if the client is not
+            //    connected to that gateway)
+            // So, if the TargetGrain is a SystemTarget we always trust the value from Message.TargetSilo and forward
+            // it to this address...
+            // EXCEPT if the value is equal to the current GatewayAdress: in this case we will return
+            // null and the local dispatcher will forward the Message to a local SystemTarget activation
+            if (msg.TargetGrain.IsSystemTarget && !msg.TargetSilo.Matches(this.gatewayAddress))
+                return msg.TargetSilo;
+
             // for responses from ClientAddressableObject to ClientGrain try to use clientsReplyRoutingCache for sending replies directly back.
             if (!msg.SendingGrain.IsClient || !msg.TargetGrain.IsClient) return null;
 
@@ -242,9 +255,12 @@ namespace Orleans.Runtime.Messaging
             {
                 clientsReplyRoutingCache.RecordClientRoute(msg.SendingGrain, msg.SendingSilo);
             }
-            
+
             msg.TargetSilo = null;
-            msg.SendingSilo = gatewayAddress; // This makes sure we don't expose wrong silo addresses to the client. Client will only see silo address of the Gateway it is connected to.
+            // Override the SendingSilo only if the sending grain is not 
+            // a system target
+            if (!msg.SendingGrain.IsSystemTarget)
+                msg.SendingSilo = gatewayAddress;
             QueueRequest(client, msg);
             return true;
         }

--- a/src/Orleans.TestingHost/ClientExtensions.cs
+++ b/src/Orleans.TestingHost/ClientExtensions.cs
@@ -13,8 +13,10 @@ namespace Orleans.TestingHost
         /// <returns>Test hooks for the specified silo.</returns>
         public static ITestHooks GetTestHooks(this IClusterClient client, SiloHandle silo)
         {
+            // Use the siloAddress here, not the gateway address, since we may be targeting a silo on which we are not 
+            // connected to the gateway
             var internalClient = (IInternalClusterClient) client;
-            return internalClient.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.GatewayAddress);
+            return internalClient.GetSystemTarget<ITestHooksSystemTarget>(Constants.TestHooksSystemTargetId, silo.SiloAddress);
         }
     }
 }

--- a/test/Tester/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Tester/StreamingTests/SystemTargetRouteTests.cs
@@ -57,7 +57,7 @@ namespace Tester.StreamingTests
             this.fixture = fixture;
         }
 
-        [Fact(Skip = "Failes due to system target routing issues"), TestCategory("Functional"), TestCategory("Streaming")]
+        [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task PersistentStreamingOverSingleGatewayTest()
         {
             const int streamCount = 100;

--- a/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -270,7 +270,6 @@ namespace UnitTests.ActivationsLifeCycleTests
             {
                 // Disable retries in this case, to make test more predictable.
                 legacy.ClusterConfiguration.Globals.MaxForwardCount = 0;
-                legacy.ClientConfiguration.Gateways.RemoveAt(1);
                 // Disable reminder service for this test: when the secondary silo starts it may
                 // not see right away the activation from the primary silo. This request should be forwarded 
                 // to the correct activation, but since we deactivate forwarding, the secondary silo will

--- a/test/TesterInternal/TestUtils.cs
+++ b/test/TesterInternal/TestUtils.cs
@@ -78,7 +78,9 @@ namespace UnitTests.TestHelper
         /// <param name="siloHandle">The target silo that should provide this information from it's cache</param>
         internal static Task<DetailedGrainReport> GetDetailedGrainReport(IInternalGrainFactory grainFactory, GrainId grainId, SiloHandle siloHandle)
         {
-            var siloControl = grainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, siloHandle.GatewayAddress);
+            // Use the siloAddress here, not the gateway address, since we may be targeting a silo on which we are not 
+            // connected to the gateway
+            var siloControl = grainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlId, siloHandle.SiloAddress);
             return siloControl.GetDetailedGrainReport(grainId);
         }
     }


### PR DESCRIPTION
Fix for #1069 

Currently, gateways override the value of `Message.SendingSilo` by their own `GatewayAddress` when sending message to clients, so they can always trust this value when responding to messages.

This is an issue when clients need to send a response to a SystemTarget activation when this activation is not on a silo that has a gateway (or when the client is not connected to that gateway).

This is a workaround, and more work should be done on client messaging routing in the future, but the idea is:

- Gateways will not override `Message.SendingSilo` value if they are proxying a message from a SystemTarget activated on another silo
- Client will no longer trust blindly the value received from `Message.SendingSilo`, so they will check that this is a valid gateway address. If this is not a valid gateway address, they will send it to any connected gateway
- Gateway will do some routing for SystemTarget since the value from `Message.TargetSilo` can be a valid Silo-to-Silo address