### PR TITLE
Remove [Obsolete] attributes from most legacy types

### DIFF
--- a/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ClientConfiguration.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading;
 using System.Xml;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Providers;
 
 namespace Orleans.Runtime.Configuration
@@ -19,6 +18,7 @@ namespace Orleans.Runtime.Configuration
     [Serializable]
     public class ClientConfiguration : MessagingConfiguration, IStatisticsConfiguration
     {
+        internal const string DEPRECATE_DEPLOYMENT_ID_MESSAGE = "DeploymentId is the same as ClusterId. Please use ClusterId instead of DeploymentId.";
         /// <summary>
         /// Specifies the type of the gateway provider.
         /// </summary>
@@ -78,7 +78,7 @@ namespace Orleans.Runtime.Configuration
         /// <summary>
         /// Deployment Id. This is the same as ClusterId and has been deprecated in favor of it.
         /// </summary>
-        [Obsolete("DeploymentId is the same as ClusterId.")]
+        [Obsolete(DEPRECATE_DEPLOYMENT_ID_MESSAGE)]
         public string DeploymentId
         {
             get => this.ClusterId;

--- a/src/Orleans.Core.Legacy/Configuration/ConfigurationExtensions.cs
+++ b/src/Orleans.Core.Legacy/Configuration/ConfigurationExtensions.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using Orleans.Providers.Streams.SimpleMessageStream;
-using Orleans.Streams;
 
 namespace Orleans.Runtime.Configuration
 {
@@ -14,7 +11,6 @@ namespace Orleans.Runtime.Configuration
         /// Configures all cluster nodes to use the specified startup class for dependency injection.
         /// </summary>
         /// <typeparam name="TStartup">Startup type</typeparam>
-        [Obsolete("Using ISiloHostBuilder.ConfigureServices(Action configureServices) or ISiloHostBuilder.UseServiceProviderFactory(IServiceProviderFactory factory)")]
         public static void UseStartupType<TStartup>(this ClusterConfiguration config) 
         {
             var startupName = typeof(TStartup).AssemblyQualifiedName;

--- a/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
+++ b/src/Orleans.Core.Legacy/Configuration/GlobalConfiguration.cs
@@ -237,7 +237,7 @@ namespace Orleans.Runtime.Configuration
         /// <summary>
         /// Deployment Id. This is the same as ClusterId and has been deprecated in favor of it.
         /// </summary>
-        [Obsolete("DeploymentId is the same as ClusterId.")]
+        [Obsolete(ClientConfiguration.DEPRECATE_DEPLOYMENT_ID_MESSAGE)]
         public string DeploymentId
         {
             get => this.ClusterId;

--- a/src/Orleans.Core.Legacy/Core/GrainClient.cs
+++ b/src/Orleans.Core.Legacy/Core/GrainClient.cs
@@ -15,16 +15,12 @@ namespace Orleans
     /// Client runtime for connecting to Orleans system
     /// </summary>
     /// TODO: Make this class non-static and inject it where it is needed.
-    [Obsolete(DeprecationMessage)]
     public static class GrainClient
     {
-        private const string DeprecationMessage = "Deprecated in favor of ClientBuilder.";
-
         /// <summary>
         /// Whether the client runtime has already been initialized
         /// </summary>
         /// <returns><c>true</c> if client runtime is already initialized</returns>
-        [Obsolete(DeprecationMessage)]
         public static bool IsInitialized => isFullyInitialized && client.IsInitialized;
 
         internal static ClientConfiguration CurrentConfig => client.Configuration();
@@ -36,14 +32,11 @@ namespace Orleans
 
         private static readonly object initLock = new Object();
 
-        [Obsolete(DeprecationMessage)]
         public static IClusterClient Instance => client;
         
-        [Obsolete(DeprecationMessage)]
         public static IGrainFactory GrainFactory => GetGrainFactory();
 
         /// <summary>delegate to configure logging, default to none logger configured</summary>
-        [Obsolete(DeprecationMessage)]
         public static Action<ILoggingBuilder> ConfigureLoggingDelegate { get; set; } = builder => { };
         private static IGrainFactory GetGrainFactory()
         {
@@ -58,7 +51,6 @@ namespace Orleans
         /// <summary>
         /// Initializes the client runtime from the standard client configuration file.
         /// </summary>
-        [Obsolete(DeprecationMessage)]
         public static void Initialize()
         {
             ClientConfiguration config = ClientConfiguration.StandardLoad();
@@ -80,7 +72,6 @@ namespace Orleans
         /// If an error occurs reading the specified configuration file, the initialization fails.
         /// </summary>
         /// <param name="configFilePath">A relative or absolute pathname for the client configuration file.</param>
-        [Obsolete(DeprecationMessage)]
         public static void Initialize(string configFilePath)
         {
             Initialize(new FileInfo(configFilePath));
@@ -92,7 +83,6 @@ namespace Orleans
         /// </summary>
         /// <param name="configFile">The client configuration file.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
-        [Obsolete(DeprecationMessage)]
         public static void Initialize(FileInfo configFile)
         {
             ClientConfiguration config;
@@ -123,7 +113,6 @@ namespace Orleans
         /// If the configuration object is null, the initialization fails.
         /// </summary>
         /// <param name="config">A ClientConfiguration object.</param>
-        [Obsolete(DeprecationMessage)]
         public static void Initialize(ClientConfiguration config)
         {
             if (config == null)
@@ -145,11 +134,6 @@ namespace Orleans
         /// </summary>
         /// <param name="gatewayAddress">IP address and port of the gateway silo</param>
         /// <param name="overrideConfig">Whether the specified gateway endpoint should override / replace the values from config file, or be additive</param>
-        [Obsolete(
-             "This method is obsolete and will be removed in a future release. If it is needed, reimplement this method "
-             + "according to its source: "
-             + "https://github.com/dotnet/orleans/blob/8f067e77f115c0599eff00c2bdc6f37f2adbc58d/src/Orleans/Core/GrainClient.cs#L173"
-         )]
         public static void Initialize(IPEndPoint gatewayAddress, bool overrideConfig = true)
         {
             var config = ClientConfiguration.StandardLoad();
@@ -227,7 +211,6 @@ namespace Orleans
         /// <summary>
         /// Uninitializes client runtime.
         /// </summary>
-        [Obsolete(DeprecationMessage)]
         public static void Uninitialize()
         {
             lock (initLock)
@@ -239,7 +222,6 @@ namespace Orleans
         /// <summary>
         /// Test hook to uninitialize client without cleanup
         /// </summary>
-        [Obsolete(DeprecationMessage)]
         public static void HardKill()
         {
             lock (initLock)
@@ -297,7 +279,6 @@ namespace Orleans
         /// </summary>
         /// <param name="timeout"></param>
         /// <exception cref="InvalidOperationException">Thrown if Orleans runtime is not correctly initialized before this call.</exception>
-        [Obsolete(DeprecationMessage)]
         public static void SetResponseTimeout(TimeSpan timeout)
         {
             CheckInitialized();
@@ -309,7 +290,6 @@ namespace Orleans
         /// </summary>
         /// <returns>The response timeout.</returns>
         /// <exception cref="InvalidOperationException">Thrown if Orleans runtime is not correctly initialized before this call.</exception>
-        [Obsolete(DeprecationMessage)]
         public static TimeSpan GetResponseTimeout()
         {
             CheckInitialized();
@@ -325,7 +305,6 @@ namespace Orleans
         /// and a <see cref="IGrain"/> which is the GrainReference this request is being sent through
         /// </summary>
         /// <remarks>This callback method should return promptly and do a minimum of work, to avoid blocking calling thread or impacting throughput.</remarks>
-        [Obsolete(DeprecationMessage + " Please use the AddClientInvokeCallback extension method on IClientBuilder.")]
         public static ClientInvokeCallback ClientInvokeCallback
         {
             get
@@ -349,14 +328,12 @@ namespace Orleans
             }
         }
 
-        [Obsolete(DeprecationMessage)]
         public static IStreamProvider GetStreamProvider(string name)
         {
             CheckInitialized();
             return client.GetStreamProvider(name);
         }
 
-        [Obsolete(DeprecationMessage + " Please use the AddClusterConnectionLostHandler extension method on IClientBuilder.")]
         public static event ConnectionToClusterLostHandler ClusterConnectionLost
         {
             add

--- a/src/Orleans.Core.Legacy/Logging/LegacyClass/ILogConsumer.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyClass/ILogConsumer.cs
@@ -1,4 +1,3 @@
-using Orleans.Logging.Legacy;
 using System;
 using System.Net;
 
@@ -40,7 +39,6 @@ namespace Orleans.Runtime
     /// <summary>
     /// An interface used to consume log entries. 
     /// </summary>
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageStringForLegacyLoggingInfrastructure)]
     public interface ILogConsumer
     {
         /// <summary>
@@ -69,7 +67,6 @@ namespace Orleans.Runtime
     /// <summary>
     /// An interface used to consume log entries, when a Flush function is also supported. 
     /// </summary>
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageStringForLegacyLoggingInfrastructure)]
     public interface IFlushableLogConsumer : ILogConsumer
     {
         /// <summary>Flush any pending log writes.</summary>
@@ -79,7 +76,6 @@ namespace Orleans.Runtime
     /// <summary>
     /// An interface used to consume log entries, when a Close function is also supported. 
     /// </summary>
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageStringForLegacyLoggingInfrastructure)]
     public interface ICloseableLogConsumer : ILogConsumer
     {
         /// <summary>Close this log.</summary>

--- a/src/Orleans.Core.Legacy/Logging/LegacyClass/Logger.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyClass/Logger.cs
@@ -8,7 +8,6 @@ namespace Orleans.Runtime
     /// Interface of Orleans runtime for logging services. 
     /// </summary>
     [Serializable]
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageStringForLegacyLoggingInfrastructure)]
     public abstract class Logger
     {
         /// <summary> Current SeverityLevel set for this logger. </summary>

--- a/src/Orleans.Core.Legacy/Logging/LegacyClass/LoggerExtensions.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyClass/LoggerExtensions.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 
 namespace Orleans.Runtime
 {
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageStringForLegacyLoggingInfrastructure)]
     public static class LoggerExtensions
     {
         private static readonly object[] EmptyObjectArray = new object[0];

--- a/src/Orleans.Core.Legacy/Logging/LegacyClass/LoggerWrapper.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyClass/LoggerWrapper.cs
@@ -1,13 +1,8 @@
 ﻿using Microsoft.Extensions.Logging;
-using Orleans.Logging.Legacy;
 using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Threading;
 
 namespace Orleans.Runtime
 {
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageStringForLegacyLoggingInfrastructure)]
     internal class LoggerWrapper<T> : Logger
     {
         private readonly LoggerWrapper logger;
@@ -35,7 +30,7 @@ namespace Orleans.Runtime
             this.logger.Log(errorCode, sev, format, args, exception);
         }
     }
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageStringForLegacyLoggingInfrastructure)]
+
     internal class LoggerWrapper : Logger
     {
         public override Severity SeverityLevel => this.maxSeverityLevel;

--- a/src/Orleans.Core.Legacy/Logging/LegacyClass/TelemetryLogConsumer.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyClass/TelemetryLogConsumer.cs
@@ -8,7 +8,6 @@ namespace Orleans.Extensions.Logging
     /// <summary>
     /// Forward trace log calls to the telemetry abstractions. This will be replaced by an ILoggerProvider in the future.
     /// </summary>
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageStringForLegacyLoggingInfrastructure)]
     public class TelemetryLogConsumer : ILogConsumer, IFlushableLogConsumer, ICloseableLogConsumer
     {
         private readonly ITelemetryProducer telemetryProducer;

--- a/src/Orleans.Core.Legacy/Logging/LegacyFileLogConsumer.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyFileLogConsumer.cs
@@ -9,7 +9,6 @@ namespace Orleans.Logging.Legacy
     /// <summary>
     /// LegacyFileLogConsumer, which logs message into a file in orleans logging message style
     /// </summary>
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageString)]
     public class LegacyFileLogConsumer : ICloseableLogConsumer, IFlushableLogConsumer
     {
         private StreamWriter logOutput;

--- a/src/Orleans.Core.Legacy/Logging/LegacyOrleansLogger.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyOrleansLogger.cs
@@ -13,7 +13,6 @@ namespace Orleans.Logging.Legacy
     /// LegacyOrleansLogger supports legacy Orleans logging features, including <see cref="ILogConsumer"/>, <see cref="ICloseableLogConsumer"/>,
     /// <see cref="IFlushableLogConsumer"/>, <see cref="Severity"/>. 
     /// </summary>
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageString)]
     public class LegacyOrleansLogger : ILogger
     {
         private readonly TimeSpan flushInterval = Debugger.IsAttached ? TimeSpan.FromMilliseconds(10) : TimeSpan.FromSeconds(1);

--- a/src/Orleans.Core.Legacy/Logging/LegacyOrleansLoggerProvider.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyOrleansLoggerProvider.cs
@@ -14,7 +14,6 @@ namespace Orleans.Logging.Legacy
     /// <see cref="ICloseableLogConsumer"/>, <see cref="IFlushableLogConsumer"/>, <see cref="Severity"/>. 
     /// LegacyOrleansLoggerProvider also supports configuration on those legacy features.
     /// </summary>
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageString)]
     public class LegacyOrleansLoggerProvider : ILoggerProvider
     {
         /// <summary>
@@ -71,7 +70,6 @@ namespace Orleans.Logging.Legacy
     /// <summary>
     /// Orleans severity overrides on a per logger base
     /// </summary>
-    [Obsolete("Use Microsoft.Extensions.Logging.LoggerFilterRule")]
     public class OrleansLoggerSeverityOverrides
     {
         /// <summary>

--- a/src/Orleans.Core.Legacy/Logging/LegacyOrleansLoggingFactoryExtensions.cs
+++ b/src/Orleans.Core.Legacy/Logging/LegacyOrleansLoggingFactoryExtensions.cs
@@ -16,7 +16,6 @@ namespace Orleans.Logging.Legacy
         /// <param name="ipEndPoint">IP endpoint this logger is associated with</param>
         /// <param name="eventBulkingOptions">config for event bulking feature</param>
         /// <returns></returns>
-        [Obsolete(OrleansLoggingUtils.ObsoleteMessageString)]
         public static ILoggingBuilder AddLegacyOrleansLogging(
             this ILoggingBuilder builder,
             IEnumerable<ILogConsumer> logConsumers,
@@ -38,7 +37,6 @@ namespace Orleans.Logging.Legacy
         /// <param name="ipEndPoint">IP endpoint this logger is associated with</param>
         /// <param name="eventBulkingOptions">config for event bulking feature</param>
         /// <returns></returns>
-        [Obsolete(OrleansLoggingUtils.ObsoleteMessageString)]
         public static ILoggingBuilder AddLegacyOrleansLogging(
             this ILoggingBuilder builder,
             IEnumerable<ILogConsumer> logConsumers,

--- a/src/Orleans.Core.Legacy/Logging/LoggerExtensionMethods.cs
+++ b/src/Orleans.Core.Legacy/Logging/LoggerExtensionMethods.cs
@@ -9,7 +9,6 @@ using System.Text;
 
 namespace Orleans.Runtime
 {
-    [Obsolete(OrleansLoggingUtils.ObsoleteMessageStringForLegacyLoggingInfrastructure)]
     public static class LoggerExtensionMethods
     {
         /// <summary>

--- a/src/Orleans.Core.Legacy/Logging/OrleansLoggingUtils.cs
+++ b/src/Orleans.Core.Legacy/Logging/OrleansLoggingUtils.cs
@@ -10,9 +10,6 @@ namespace Orleans.Logging.Legacy
     /// </summary>
     public class OrleansLoggingUtils
     {
-        internal const string ObsoleteMessageStringForLegacyLoggingInfrastructure = "Deprecated in favor of Microsoft.Extension.Logging";
-        internal const string ObsoleteMessageString =
-                "The Microsoft.Orleans.Logging.Legacy namespace was kept to facilitate migration from Orleans 1.x but will be removed in the near future. It is recommended that you use the Microsoft.Extensions.Logging infrastructure and providers directly instead of Microsoft.Orleans.Logging.Legacy.Logger and Microsoft.Orleans.Logging.Legacy.ILogConsumer";
         /// <summary>The method to call during logging to format the log info into a string, which is orleans legacy logging style</summary>
         /// <param name="timestamp">Timestamp of the log message.</param>
         /// <param name="severity">The severity of the message being traced.</param>
@@ -24,7 +21,6 @@ namespace Orleans.Logging.Legacy
         /// <param name="errorCode">Numeric event code for this log entry. May be zero, meaning 'Unspecified'.</param>
         /// <param name="includeStackTrace">determine include stack trace or not</param>
         /// <returns></returns>
-        [Obsolete(ObsoleteMessageString)]
         public static string FormatLogMessageToLegacyStyle(
             DateTime timestamp,
             Severity severity,


### PR DESCRIPTION
Fixes #4252.

I only left ` [Obsolete]` on `StatisticsWriteLogStatisticsToTable`, `StatisticsProviderName`, and `StatisticsWriteLogStatisticsToTable` because the underlying functionality has been removed; and on `ClientConfiguration.DeploymentId` and `GlobalConfiguration.DeploymentId` to disambiguate `DeploymentId` vs. `ClusterId`.