### PR TITLE
Revert #4224

### DIFF
--- a/src/Orleans.CodeGeneration.Build/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
+++ b/src/Orleans.CodeGeneration.Build/build/Microsoft.Orleans.OrleansCodeGenerator.Build.targets
@@ -41,10 +41,9 @@
 
   <!-- This target is run just before Compile for an Orleans Grain Interface Project -->
   <Target Name="GenerateOrleansCode"
-          AfterTargets="ResolveReferences"
-          BeforeTargets="CoreCompile"
+          BeforeTargets="AssignTargetPaths"
           Condition="'$(CodeGeneratorEnabled)' == 'true'"
-          Inputs="@(Compile);@(ReferencePath);$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache"
+          Inputs="@(Compile);@(ReferencePath)"
           Outputs="$(OutputFileName)">
     <PropertyGroup>
       <ExcludeCodeGen>$(DefineConstants);EXCLUDE_CODEGEN</ExcludeCodeGen>


### PR DESCRIPTION
It turns out that the NuGet packages produced after #4224 contain non-codegen'd assemblies.

We will revert it for now while we attempt to rectify the issue