### PR TITLE
Remove duplicate references to AdoNet.targets

### DIFF
--- a/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Microsoft.Orleans.Persistence.AdoNet.targets" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="..\Shared\Storage\AdoNetInvariants.cs" Link="Storage\AdoNetInvariants.cs" />
     <Compile Include="..\Shared\Storage\DbConnectionFactory.cs" Link="Storage\DbConnectionFactory.cs" />
     <Compile Include="..\Shared\Storage\DbExtensions.cs" Link="Storage\DbExtensions.cs" />
@@ -31,13 +27,6 @@
     <Compile Include="..\Shared\Storage\RelationalStorage.cs" Link="Storage\RelationalStorage.cs" />
     <Compile Include="..\Shared\Storage\RelationalStorageExtensions.cs" Link="Storage\RelationalStorageExtensions.cs" />
     <Compile Include="..\Shared\Storage\AdoNetFormatProvider.cs" Link="Storage\AdoNetFormatProvider.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Microsoft.Orleans.Persistence.AdoNet.targets">
-      <PackagePath>build/$(TargetFramework)/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Microsoft.Orleans.Reminders.AdoNet.targets" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="..\Shared\Storage\AdoNetInvariants.cs" Link="Storage\AdoNetInvariants.cs" />
     <Compile Include="..\Shared\Storage\DbConnectionFactory.cs" Link="Storage\DbConnectionFactory.cs" />
     <Compile Include="..\Shared\Storage\DbExtensions.cs" Link="Storage\DbExtensions.cs" />
@@ -31,13 +27,6 @@
     <Compile Include="..\Shared\Storage\RelationalStorage.cs" Link="Storage\RelationalStorage.cs" />
     <Compile Include="..\Shared\Storage\RelationalStorageExtensions.cs" Link="Storage\RelationalStorageExtensions.cs" />
     <Compile Include="..\Shared\Storage\AdoNetFormatProvider.cs" Link="Storage\AdoNetFormatProvider.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Microsoft.Orleans.Reminders.AdoNet.targets">
-      <PackagePath>build/$(TargetFramework)/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a follow-up to #4243.

There are currently build warnings while building `Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.csproj` and `Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.csproj` complaining about duplicate references to `Microsoft.Orleans.Persistence.AdoNet.targets`. This change seems to make build happy, and the content files still get copied to the project folder.

@veikkoeeva Could you double-check please.