### PR TITLE
Lease based queue balancer fixes

### DIFF
--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Lease/AzureBlobLeaseProvider.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Lease/AzureBlobLeaseProvider.cs
@@ -73,7 +73,7 @@ namespace Orleans.LeaseProviders
                     case 412: statusCode = ResponseCode.LeaseNotAvailable; break;
                     default: statusCode = ResponseCode.TransientFailure; break;
                 }
-                return new AcquireLeaseResult(null, statusCode, e);
+                return new AcquireLeaseResult(new AcquiredLease(leaseRequest.ResourceKey), statusCode, e);
             }
         }
 
@@ -128,7 +128,7 @@ namespace Orleans.LeaseProviders
                     case 412: statusCode = ResponseCode.InvalidToken; break;
                     default: statusCode = ResponseCode.TransientFailure; break;
                 }
-                return new AcquireLeaseResult(null, statusCode, e);
+                return new AcquireLeaseResult(new AcquiredLease(acquiredLease.ResourceKey), statusCode, e);
             }
         }
     }

--- a/src/Orleans.Core/Providers/ILeaseProvider.cs
+++ b/src/Orleans.Core/Providers/ILeaseProvider.cs
@@ -44,6 +44,15 @@ namespace Orleans.LeaseProviders
             this.Token = token;
             this.StartTimeUtc = startTimeUtc;
         }
+
+        /// <summary>
+        /// Consructor
+        /// </summary>
+        /// <param name="resourceKey"></param>
+        public AcquiredLease(string resourceKey)
+        {
+            this.ResourceKey = resourceKey;
+        }
     }
 
     /// <summary>

--- a/src/Orleans.Core/Streams/PersistentStreams/IStreamQueueBalancer.cs
+++ b/src/Orleans.Core/Streams/PersistentStreams/IStreamQueueBalancer.cs
@@ -15,11 +15,9 @@ namespace Orleans.Streams
         /// <summary>
         /// Initialize this instance
         /// </summary>
-        /// <param name="strProviderName"></param>
         /// <param name="queueMapper"></param>
         /// <returns></returns>
-        Task Initialize(string strProviderName,
-            IStreamQueueMapper queueMapper);
+        Task Initialize(IStreamQueueMapper queueMapper);
 
         /// <summary>
         /// Retrieves the latest queue distribution for this balancer.

--- a/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Runtime/Streams/PersistentStream/PersistentStreamPullingManager.cs
@@ -88,7 +88,7 @@ namespace Orleans.Streams
 
             // Remove cast once we cleanup
             queueAdapter = qAdapter.Value;
-            await this.queueBalancer.Initialize(this.streamProviderName, this.adapterFactory.GetStreamQueueMapper());
+            await this.queueBalancer.Initialize(this.adapterFactory.GetStreamQueueMapper());
             queueBalancer.SubscribeToQueueDistributionChangeEvents(this);
 
             List<QueueId> myQueues = queueBalancer.GetMyQueues().ToList();

--- a/src/Orleans.Runtime/Streams/QueueBalancer/ConsistentRingQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/ConsistentRingQueueBalancer.cs
@@ -28,8 +28,7 @@ namespace Orleans.Streams
             ringProvider.SubscribeToRangeChangeEvents(this);
         }
 
-        public override Task Initialize(string strProviderName,
-            IStreamQueueMapper queueMapper)
+        public override Task Initialize(IStreamQueueMapper queueMapper)
         {
             if (queueMapper == null)
             {

--- a/src/Orleans.Runtime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/DeploymentBasedQueueBalancer.cs
@@ -68,8 +68,7 @@ namespace Orleans.Streams
             return ActivatorUtilities.CreateInstance<DeploymentBasedQueueBalancer>(services, options, deploymentConfiguration);
         }
 
-        public override Task Initialize(string strProviderName,
-            IStreamQueueMapper queueMapper)
+        public override Task Initialize(IStreamQueueMapper queueMapper)
         {
             if (queueMapper == null)
             {

--- a/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -115,8 +115,6 @@ namespace Orleans.Streams
         public static IStreamQueueBalancer Create(IServiceProvider services, string name, IDeploymentConfiguration deploymentConfiguration)
         {
             var options = services.GetRequiredService<IOptionsSnapshot<LeaseBasedQueueBalancerOptions>>().Get(name);
-            if (options == null)
-                throw new KeyNotFoundException($"No lease base queue balancer options was configured for provider {name}, nor was a default configured.");
             return ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancer>(services, name, options, deploymentConfiguration);
         }
         /// <inheritdoc/>
@@ -259,7 +257,7 @@ namespace Orleans.Streams
                 activeBuckets = GetActiveSiloCount(this.siloStatusOracle);
             }
             activeBuckets = Math.Max(1, activeBuckets);
-            this.minimumResponsibility = Math.Max(1, this.allQueues.Count / activeBuckets);
+            this.minimumResponsibility = this.allQueues.Count / activeBuckets;
             //if allQueues count is divisible by active bukets, then every bucket should take the same count of queues, otherwise, there should be one bucket take 1 more queue
             if (this.allQueues.Count % activeBuckets == 0)
                 this.maximumResponsibility = this.minimumResponsibility;

--- a/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -8,8 +8,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.LeaseProviders;
 using Orleans.Runtime;
-using Orleans.Hosting;
 using Orleans.Configuration;
+using Orleans.Timers;
 
 namespace Orleans.Streams
 {
@@ -51,9 +51,10 @@ namespace Orleans.Streams
         public List<T> NextSelection(int newSelectionCount, List<T> existingSelection)
         {
             var selection = new List<T>(newSelectionCount);
-            while (selection.Count < newSelectionCount)
+            int tries = 0;
+            while (selection.Count < newSelectionCount && tries++ < this.resources.Count)
             {
-                this.lastSelection = (++this.lastSelection) % (this.resources.Count - 1);
+                this.lastSelection = (++this.lastSelection) % (this.resources.Count);
                 if(!existingSelection.Contains(this.resources[this.lastSelection]))
                     selection.Add(this.resources[this.lastSelection]);
             }
@@ -87,11 +88,11 @@ namespace Orleans.Streams
         private ReadOnlyCollection<QueueId> allQueues;
         private List<AcquiredQueue> myQueues;
         private bool isStarting;
-        private AsyncTaskSafeTimer renewLeaseTimer;
-        private AsyncTaskSafeTimer tryAcquireMaximumLeaseTimer;
+        private IDisposable renewLeaseTimer;
+        private IDisposable tryAcquireMaximumLeaseTimer;
         private IResourceSelector<QueueId> queueSelector;
-        private int minimumResponsibilty;
-        private int maximumRespobsibility;
+        private int minimumResponsibility;
+        private int maximumResponsibility;
         private IServiceProvider serviceProvider;
         private ILogger logger;
         private ILoggerFactory loggerFactory;
@@ -99,12 +100,7 @@ namespace Orleans.Streams
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="options"></param>
-        /// <param name="serviceProvider"></param>
-        /// <param name="siloStatusOracle"></param>
-        /// <param name="deploymentConfig"></param>
-        /// <param name="loggerFactory"></param>
-        public LeaseBasedQueueBalancer(LeaseBasedQueueBalancerOptions options, IServiceProvider serviceProvider, ISiloStatusOracle siloStatusOracle, IDeploymentConfiguration deploymentConfig, ILoggerFactory loggerFactory)
+        public LeaseBasedQueueBalancer(string name, LeaseBasedQueueBalancerOptions options, IServiceProvider serviceProvider, ISiloStatusOracle siloStatusOracle, IDeploymentConfiguration deploymentConfig, ILoggerFactory loggerFactory)
         {
             this.serviceProvider = serviceProvider;
             this.deploymentConfig = deploymentConfig;
@@ -113,32 +109,33 @@ namespace Orleans.Streams
             this.isStarting = true;
             this.loggerFactory = loggerFactory;
             this.options = options;
-            this.logger = loggerFactory.CreateLogger<LeaseBasedQueueBalancer>();
+            this.logger = loggerFactory.CreateLogger($"{typeof(LeaseBasedQueueBalancer).FullName}-{name}");
         }
 
         public static IStreamQueueBalancer Create(IServiceProvider services, string name, IDeploymentConfiguration deploymentConfiguration)
         {
-            var options = services.GetService<IOptionsSnapshot<LeaseBasedQueueBalancerOptions>>().Get(name);
-            return ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancer>(services, options, deploymentConfiguration);
+            var options = services.GetRequiredService<IOptionsSnapshot<LeaseBasedQueueBalancerOptions>>().Get(name);
+            if (options == null)
+                throw new KeyNotFoundException($"No lease base queue balancer options was configured for provider {name}, nor was a default configured.");
+            return ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancer>(services, name, options, deploymentConfiguration);
         }
         /// <inheritdoc/>
-        public override Task Initialize(string strProviderName, IStreamQueueMapper queueMapper)
+        public override Task Initialize(IStreamQueueMapper queueMapper)
         {
             if (queueMapper == null)
             {
                 throw new ArgumentNullException("queueMapper");
             }
-            var options = this.serviceProvider.GetRequiredService<IOptionsSnapshot<LeaseBasedQueueBalancerOptions>>().Get(strProviderName);
-            if (options == null)
-                throw new KeyNotFoundException($"No lease base queue balancer options was configured for provider {strProviderName}, nor was a default configured.");
-            this.leaseProvider = this.serviceProvider.GetRequiredService(options.LeaseProviderType) as ILeaseProvider;
             this.allQueues = new ReadOnlyCollection<QueueId>(queueMapper.GetAllQueues().ToList());
+            if (this.allQueues.Count == 0)
+                return Task.CompletedTask;
+            this.leaseProvider = this.serviceProvider.GetRequiredService(options.LeaseProviderType) as ILeaseProvider;
             NotifyAfterStart().Ignore();
             //make lease renew frequency to be every half of lease time, to avoid renew failing due to timing issues, race condition or clock difference. 
-            var timerLogger = this.loggerFactory.CreateLogger<AsyncTaskSafeTimer>();
-            this.renewLeaseTimer = new AsyncTaskSafeTimer(timerLogger, this.MaintainAndBalanceQueues, null, this.options.SiloMaturityPeriod, this.options.LeaseLength.Divide(2));
+            ITimerRegistry timerRegistry = this.serviceProvider.GetRequiredService<ITimerRegistry>();
+            this.renewLeaseTimer = timerRegistry.RegisterTimer(null, this.MaintainAndBalanceQueues, null, this.options.SiloMaturityPeriod, this.options.LeaseLength.Divide(2));
             //try to acquire maximum leases every leaseLength 
-            this.tryAcquireMaximumLeaseTimer = new AsyncTaskSafeTimer(timerLogger, this.AcquireLeaseToMeetMaxResponsibilty, null, this.options.SiloMaturityPeriod, this.options.SiloMaturityPeriod);
+            this.tryAcquireMaximumLeaseTimer = timerRegistry.RegisterTimer(null, this.AcquireLeaseToMeetMaxResponsibility, null, this.options.SiloMaturityPeriod, this.options.SiloMaturityPeriod);
             //Selector default to round robin selector now, but we can make a further change to make selector configurable if needed.  Selector algorithm could 
             //be affecting queue balancing stablization time in cluster initializing and auto-scaling
             this.queueSelector = new RoundRobinSelector<QueueId>(this.allQueues);
@@ -157,12 +154,12 @@ namespace Orleans.Streams
             var oldQueues = new HashSet<QueueId>(this.myQueues.Select(queue => queue.QueueId));
             // step 1: renew existing leases 
             await this.RenewLeases();
-            // step 2: if after renewing leases, myQueues count doesn't fall in [minimumResponsibility, maximumResponsibilty] range, act accordingly
-            if (this.myQueues.Count < this.minimumResponsibilty)
+            // step 2: if after renewing leases, myQueues count doesn't fall in [minimumResponsibility, maximumResponsibility] range, act accordingly
+            if (this.myQueues.Count < this.minimumResponsibility)
             {
                 await this.AcquireLeasesToMeetMinResponsibility();
             }
-            else if (this.myQueues.Count > this.maximumRespobsibility)
+            else if (this.myQueues.Count > this.maximumResponsibility)
             {
                 await this.ReleaseLeasesToMeetResponsibility();
             }
@@ -174,24 +171,25 @@ namespace Orleans.Streams
 
         private async Task ReleaseLeasesToMeetResponsibility()
         {
-            var queueCountToRelease = this.myQueues.Count - this.maximumRespobsibility;
+            var queueCountToRelease = this.myQueues.Count - this.maximumResponsibility;
             if (queueCountToRelease <= 0)
                 return;
             var queuesToGiveUp = this.myQueues.GetRange(0, queueCountToRelease);
             await this.leaseProvider.Release(LeaseCategory, queuesToGiveUp.Select(queue => queue.AcquiredLease).ToArray());
             //remove queuesToGiveUp from myQueue list after the balancer released the leases on them
             this.myQueues.RemoveRange(0, queueCountToRelease);
-            this.logger.Info($"ReleaseLeasesToMeetResponsibility: released {queueCountToRelease} queues, current queue Count: {this.myQueues.Count}");
+            this.logger.Info($"Released leases for {queueCountToRelease} queues");
+            this.logger.LogInformation($"I now own leases for {this.myQueues.Count} of an expected {this.minimumResponsibility} to {this.maximumResponsibility} queues.");
         }
 
-        private Task AcquireLeaseToMeetMaxResponsibilty(object state)
+        private Task AcquireLeaseToMeetMaxResponsibility(object state)
         {
-            return AcquireLeasesToMeetExpectation(this.maximumRespobsibility);
+            return AcquireLeasesToMeetExpectation(this.maximumResponsibility);
         }
 
         private Task AcquireLeasesToMeetMinResponsibility()
         {
-            return AcquireLeasesToMeetExpectation(this.minimumResponsibilty);
+            return AcquireLeasesToMeetExpectation(this.minimumResponsibility);
         }
 
         private async Task AcquireLeasesToMeetExpectation(int expectedTotalLeaseCount)
@@ -199,16 +197,18 @@ namespace Orleans.Streams
             int maxAttempts = 5;
             int attempts = 0;
             int leasesToAquire = expectedTotalLeaseCount - this.myQueues.Count;
-            this.logger.Info($"AcquireLeasesToMeetExpectation : Try to acquire {leasesToAquire} queues");
-            while (attempts ++ <= maxAttempts && leasesToAquire > 0)
+            if (leasesToAquire <= 0) return;
+            while (attempts ++ < maxAttempts && leasesToAquire > 0)
             {
+                this.logger.LogDebug($"I have {this.myQueues.Count} queues.  Trying to acquire {leasesToAquire} queues to reach {expectedTotalLeaseCount}");
+                leasesToAquire = expectedTotalLeaseCount - this.myQueues.Count;
                 //select new queues to acquire
-                var expectedQueues = this.queueSelector.NextSelection(leasesToAquire, this.myQueues.Select(queue=>queue.QueueId).ToList()).ToList();
-                var leaseRequests = expectedQueues.Select(queue => new LeaseRequest() {
+                List<QueueId> expectedQueues = this.queueSelector.NextSelection(leasesToAquire, this.myQueues.Select(queue=>queue.QueueId).ToList()).ToList();
+                IEnumerable<LeaseRequest> leaseRequests = expectedQueues.Select(queue => new LeaseRequest() {
                     ResourceKey = queue.ToString(),
                     Duration = this.options.LeaseLength
                 });
-                var results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
+                AcquireLeaseResult[] results = await this.leaseProvider.Acquire(LeaseCategory, leaseRequests.ToArray());
                 //add successfully acquired queue to myQueues list
                 for (int i = 0; i < results.Length; i++)
                 {
@@ -224,11 +224,13 @@ namespace Orleans.Streams
                 }
             }
 
-            this.logger.Info($"AcquireLeasesToMeetExpectation: finished. Now own {this.myQueues.Count} queues. Used attemps : {attempts}, Current minimumReponsibility : {this.minimumResponsibilty}, current maximumResponsibility : {this.maximumRespobsibility}");
+            this.logger.LogInformation($"I now own leases for {this.myQueues.Count} of an expected {this.minimumResponsibility} to {this.maximumResponsibility} queues");
         }
         
         private async Task RenewLeases()
         {
+            if (this.myQueues.Count <= 0)
+                return;
             var results = await this.leaseProvider.Renew(LeaseCategory, this.myQueues.Select(queue => queue.AcquiredLease).ToArray());
             var updatedQueues = new List<AcquiredQueue>();
             //update myQueues list with successfully renewed leases
@@ -242,7 +244,7 @@ namespace Orleans.Streams
             }
             this.myQueues.Clear();
             this.myQueues = updatedQueues;
-            this.logger.Info($"RenewLeases: finished, currently own queues : {this.myQueues.Count}, current minimumResponsibilty : {this.minimumResponsibilty}, current maximunResponsibilty : {this.maximumRespobsibility}");
+            this.logger.LogInformation($"Renewed leases for {this.myQueues.Count} queues.");
         }
 
         private void CalculateResponsibility()
@@ -256,11 +258,12 @@ namespace Orleans.Streams
             {
                 activeBuckets = GetActiveSiloCount(this.siloStatusOracle);
             }
-            this.minimumResponsibilty = this.allQueues.Count / activeBuckets;
+            activeBuckets = Math.Max(1, activeBuckets);
+            this.minimumResponsibility = Math.Max(1, this.allQueues.Count / activeBuckets);
             //if allQueues count is divisible by active bukets, then every bucket should take the same count of queues, otherwise, there should be one bucket take 1 more queue
             if (this.allQueues.Count % activeBuckets == 0)
-                this.maximumRespobsibility = this.minimumResponsibilty;
-            else this.maximumRespobsibility = this.minimumResponsibilty + 1;
+                this.maximumResponsibility = this.minimumResponsibility;
+            else this.maximumResponsibility = this.minimumResponsibility + 1;
         }
 
 
@@ -299,8 +302,8 @@ namespace Orleans.Streams
             this.tryAcquireMaximumLeaseTimer?.Dispose();
             this.tryAcquireMaximumLeaseTimer = null;
             //release all owned leases
-            this.maximumRespobsibility = 0;
-            this.minimumResponsibilty = 0;
+            this.maximumResponsibility = 0;
+            this.minimumResponsibility = 0;
             this.ReleaseLeasesToMeetResponsibility().Ignore();
         }
     }

--- a/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -36,9 +36,9 @@ namespace Orleans.Streams
     {
         private ReadOnlyCollection<T> resources;
         private int lastSelection;
-        public RoundRobinSelector(ReadOnlyCollection<T> resources)
+        public RoundRobinSelector(IEnumerable<T> resources)
         {
-            this.resources = resources;
+            this.resources = new ReadOnlyCollection<T>(resources.Distinct().ToList());
             this.lastSelection = new Random().Next(this.resources.Count);
         }
 
@@ -50,7 +50,7 @@ namespace Orleans.Streams
         /// <returns></returns>
         public List<T> NextSelection(int newSelectionCount, List<T> existingSelection)
         {
-            var selection = new List<T>(newSelectionCount);
+            var selection = new List<T>(Math.Min(newSelectionCount, this.resources.Count));
             int tries = 0;
             while (selection.Count < newSelectionCount && tries++ < this.resources.Count)
             {

--- a/src/Orleans.Runtime/Streams/QueueBalancer/QueueBalancerBaseClass.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/QueueBalancerBaseClass.cs
@@ -20,7 +20,7 @@ namespace Orleans.Streams
         /// <inheritdoc/>
         public abstract IEnumerable<QueueId> GetMyQueues();
         /// <inheritdoc/>
-        public abstract Task Initialize(string strProviderName, IStreamQueueMapper queueMapper);
+        public abstract Task Initialize(IStreamQueueMapper queueMapper);
         /// <inheritdoc/>
         public virtual bool SubscribeToQueueDistributionChangeEvents(IStreamQueueBalanceListener observer)
         {

--- a/src/Orleans.Runtime/Timers/TimerRegistry.cs
+++ b/src/Orleans.Runtime/Timers/TimerRegistry.cs
@@ -18,8 +18,8 @@ namespace Orleans.Timers
 
         public IDisposable RegisterTimer(Grain grain, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
         {
-            var timer = GrainTimer.FromTaskCallback(this.scheduler, this.timerLogger, asyncCallback, state, dueTime, period, activationData: grain.Data);
-            grain.Data.OnTimerCreated(timer);
+            var timer = GrainTimer.FromTaskCallback(this.scheduler, this.timerLogger, asyncCallback, state, dueTime, period, activationData: grain?.Data);
+            grain?.Data.OnTimerCreated(timer);
             timer.Start();
             return timer;
         }

--- a/test/NonSilo.Tests/OrleansRuntime/Streams/ResourceSelectorTestRunner.cs
+++ b/test/NonSilo.Tests/OrleansRuntime/Streams/ResourceSelectorTestRunner.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit;
+using Orleans.Streams;
+
+namespace UnitTests.OrleansRuntime.Streams
+{
+    public abstract class ResourceSelectorTestRunner
+    {
+        private readonly ITestOutputHelper output;
+
+        protected ResourceSelectorTestRunner(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        internal void NextSelectionWillGoThroughEveryResourceIfExistingSelectionEmpty(List<string> resources, IResourceSelector<string> resourceSelector)
+        {
+            Assert.Equal(resources.Distinct().Count(), resources.Count);
+            resources.Sort();
+            List<string> selected = resourceSelector.NextSelection(resources.Count, new List<string>());
+            Assert.Equal(resources.Count, selected.Count);
+            selected = selected.Distinct().ToList();
+            selected.Sort();
+            Assert.Equal(resources.Count, selected.Count);
+            for (int i=0; i<selected.Count; i++)
+            {
+                Assert.Equal(resources[i], selected[i]);
+            }
+        }
+
+        internal void NextSelectionWontGoInfinitely(List<string> resources, IResourceSelector<string> resourceSelector)
+        {
+            Assert.Equal(resources.Distinct().Count(), resources.Count);
+            resources.Sort();
+            List<string> selected = resourceSelector.NextSelection(int.MaxValue, new List<string>());
+            Assert.Equal(resources.Count, selected.Count);
+            selected = selected.Distinct().ToList();
+            selected.Sort();
+            Assert.Equal(resources.Count, selected.Count);
+            for (int i = 0; i < selected.Count; i++)
+            {
+                Assert.Equal(resources[i], selected[i]);
+            }
+        }
+
+        internal void NextSelectionWontReSelectExistingSelections(List<string> resources, IResourceSelector<string> resourceSelector)
+        {
+            Assert.Equal(resources.Distinct().Count(), resources.Count);
+            for (int selectCount = 0; selectCount < resources.Count; selectCount++)
+            {
+                for (int excludeCount = 0; excludeCount < resources.Count; excludeCount++)
+                {
+                    List<string> excluded = resourceSelector.NextSelection(excludeCount, new List<string>());
+                    Assert.Equal(excludeCount, excluded.Count);
+                    excluded = excluded.Distinct().ToList();
+                    Assert.Equal(excludeCount, excluded.Count);
+
+                    List<string> selected = resourceSelector.NextSelection(selectCount, excluded);
+                    int expectedCount = Math.Min(selectCount, resources.Count - excludeCount);
+                    Assert.Equal(expectedCount, selected.Count);
+                    selected = selected.Distinct().ToList();
+                    Assert.Equal(expectedCount, selected.Count);
+                    for (int i = 0; i < selected.Count; i++)
+                    {
+                        Assert.DoesNotContain(selected[i], excluded);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/NonSilo.Tests/OrleansRuntime/Streams/RoundRobinSelectorTests.cs
+++ b/test/NonSilo.Tests/OrleansRuntime/Streams/RoundRobinSelectorTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Orleans.Streams;
+
+namespace UnitTests.OrleansRuntime.Streams
+{
+    [TestCategory("BVT")]
+    public class RoundRobinSelectorTests : ResourceSelectorTestRunner
+    {
+        private const int ResourceCount = 10;
+        private readonly IResourceSelector<string> resourceSelector;
+        private readonly List<string> resources;
+
+        public RoundRobinSelectorTests(ITestOutputHelper output) : base(output)
+        {
+            this.resources = Enumerable.Range(0, ResourceCount).Select(i => $"resource_{i}").ToList();
+            this.resourceSelector = new RoundRobinSelector<string>(this.resources);
+        }
+
+        [Fact]
+        public void NextSelectionWillGoThroughEveryResourceIfExistingSelectionEmptyTest()
+        {
+            base.NextSelectionWillGoThroughEveryResourceIfExistingSelectionEmpty(resources, resourceSelector);
+        }
+
+        [Fact]
+        public void NextSelectionWontGoInfinitelyTest()
+        {
+            base.NextSelectionWontGoInfinitely(resources, resourceSelector);
+        }
+
+        [Fact]
+        public void NextSelectionWontReSelectExistingSelectionsTest()
+        {
+            base.NextSelectionWontReSelectExistingSelections(resources, resourceSelector);
+        }
+
+        [Fact]
+        public void NextSelectionWontReSelectExistingSelectionsWithDuplicatesTest()
+        {
+            var duplicateResources = new List<string>(this.resources);
+            duplicateResources.AddRange(this.resources);
+            var resourceSelectorWithDuplicates = new RoundRobinSelector<string>(duplicateResources);
+            base.NextSelectionWontReSelectExistingSelections(this.resources, resourceSelectorWithDuplicates);
+        }
+    }
+}

--- a/test/ServiceBus.Tests/PluggableQueueBalancerTests.cs
+++ b/test/ServiceBus.Tests/PluggableQueueBalancerTests.cs
@@ -1,10 +1,7 @@
 using System.Threading.Tasks;
 using Orleans.Configuration;
 using Orleans.Hosting;
-using Orleans.Runtime;
-using Orleans.Runtime.Configuration;
 using Orleans.ServiceBus.Providers.Testing;
-using Orleans.Storage;
 using Orleans.TestingHost;
 using Tester.StreamingTests;
 using TestExtensions;
@@ -44,7 +41,7 @@ namespace ServiceBus.Tests
                             {
                                 options.EventHubPartitionCount = TotalQueueCount;
                             }))
-                         .ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s));
+                         .ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n));
                 }
             }
         }

--- a/test/TestExtensions/Runners/GoldenPathLeaseProviderTestRunner.cs
+++ b/test/TestExtensions/Runners/GoldenPathLeaseProviderTestRunner.cs
@@ -96,9 +96,10 @@ namespace TestExtensions.Runners
             var renewResults = await this.leaseProvider.Renew(LeaseCategory, acquiredLeaseWithWrongToken.ToArray());
             for (int i = 0; i < renewResults.Count(); i++)
             {
-                var result = renewResults[i];
+                LeaseRequest request = leaseRequests[i];
+                AcquireLeaseResult result = renewResults[i];
                 Assert.Equal(ResponseCode.InvalidToken, result.StatusCode);
-                Assert.Null(result.AcquiredLease);
+                Assert.Equal(request.ResourceKey, result.AcquiredLease.ResourceKey);
             }
         }
 

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/LeaseBasedQueueBalancer.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/LeaseBasedQueueBalancer.cs
@@ -9,22 +9,19 @@ namespace Tester.StreamingTests
     //Dumb queue balancer only acquire leases once, never renew it, just for testing
     public class LeaseBasedQueueBalancerForTest : IStreamQueueBalancer
     {
-        private ILeaseManagerGrain leaseManagerGrain;
-        private IGrainFactory grainFactory;
-        private string id;
+        private readonly string id;
+        private readonly ILeaseManagerGrain leaseManagerGrain;
         private List<QueueId> ownedQueues;
 
-        public LeaseBasedQueueBalancerForTest(IGrainFactory grainFactory)
+        public LeaseBasedQueueBalancerForTest(string name, IGrainFactory grainFactory)
         {
-            this.grainFactory = grainFactory;
+            this.leaseManagerGrain = grainFactory.GetGrain<ILeaseManagerGrain>(name);
+            this.id = $"{name}-{Guid.NewGuid()}";
         }
 
-        public async Task Initialize(string strProviderName,
-            IStreamQueueMapper queueMapper)
+        public async Task Initialize(IStreamQueueMapper queueMapper)
         {
-            this.leaseManagerGrain = this.grainFactory.GetGrain<ILeaseManagerGrain>(strProviderName);
             await this.leaseManagerGrain.SetQueuesAsLeases(queueMapper.GetAllQueues());
-            this.id = $"{strProviderName}-{Guid.NewGuid()}";
             await GetInitialLease();
         }
 
@@ -61,6 +58,4 @@ namespace Tester.StreamingTests
             return true;
         }
     }
-
-
 }

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
@@ -4,10 +4,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Streams;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Tester.StreamingTests

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -1,28 +1,26 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 using Orleans.Hosting;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using TestExtensions;
-using Xunit;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Tester.StreamingTests
 {
     public class PluggableQueueBalancerTestBase : OrleansTestingBase
     {
+        private readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
         private static Type QueueBalancerType = typeof(LeaseBasedQueueBalancerForTest);
 
         public virtual async Task ShouldUseInjectedQueueBalancerAndBalanceCorrectly(BaseTestClusterFixture fixture, string streamProviderName, int siloCount, int totalQueueCount)
         {
             var leaseManager = fixture.GrainFactory.GetGrain<ILeaseManagerGrain>(streamProviderName);
-            var responsibilityMap = await leaseManager.GetResponsibilityMap();
-            //there should be one StreamQueueBalancer per silo
-            Assert.Equal(responsibilityMap.Count, siloCount);
             var expectedResponsibilityPerBalancer = totalQueueCount / siloCount;
-            foreach (var responsibility in responsibilityMap)
-            {
-                Assert.Equal(expectedResponsibilityPerBalancer, responsibility.Value);
-            }
+            await TestingUtils.WaitUntilAsync(lastTry => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, lastTry), Timeout);
         }
 
         public class SiloBuilderConfigurator : ISiloBuilderConfigurator
@@ -31,6 +29,22 @@ namespace Tester.StreamingTests
             {
                 hostBuilder.ConfigureServices(services => services.AddTransient<LeaseBasedQueueBalancerForTest>());
             }
+        }
+
+        private async Task<bool> CheckLeases(ILeaseManagerGrain leaseManager, int siloCount, int expectedResponsibilityPerBalancer, bool lastTry)
+        {
+            Dictionary<string,int> responsibilityMap = await leaseManager.GetResponsibilityMap();
+            if(lastTry)
+            {
+                //there should be one StreamQueueBalancer per silo
+                Assert.Equal(responsibilityMap.Count, siloCount);
+                foreach (int responsibility in responsibilityMap.Values)
+                {
+                    Assert.Equal(expectedResponsibilityPerBalancer, responsibility);
+                }
+            }
+            return (responsibilityMap.Count == siloCount)
+                && (responsibilityMap.Values.All(responsibility => expectedResponsibilityPerBalancer == responsibility));
         }
     }
 }

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -5,7 +5,6 @@ using Orleans.Hosting;
 using Orleans.TestingHost;
 using TestExtensions;
 using Xunit;
-using Orleans.Configuration;
 
 namespace Tester.StreamingTests
 {

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
@@ -39,7 +39,7 @@ namespace Tester.StreamingTests.PlugableQueueBalancerTests
                         .AddMemoryGrainStorage("PubSubStore")
                         .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName)
                         .ConfigurePartitioning(totalQueueCount)
-                        .ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s));
+                        .ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n));
                         
                 }
             }


### PR DESCRIPTION
- Timers were not on orleans thread so couldn't make grain calls.
- Aqure logic could be too greedy
- logging and spelling cleanup (can you believe -I- fixed spelling?)
- prevented possible devide by 0 issues.