### PR TITLE
Fix race condition in ClientMessageCenter

### DIFF
--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -184,6 +184,12 @@ namespace Orleans.Messaging
             GatewayConnection gatewayConnection = null;
             bool startRequired = false;
 
+            if (!Running)
+            {
+                this.logger.Error(ErrorCode.ProxyClient_MsgCtrNotRunning, $"Ignoring {msg} because the Client message center is not running");
+                return;
+            }
+
             // If there's a specific gateway specified, use it
             if (msg.TargetSilo != null)
             {


### PR DESCRIPTION
Fix for #3171 

We could add code to make request fail quicker (not waiting the default timeout) but it a very edge case so I don't think it is worth it.