### PR TITLE
Added test to exersize queue rebalancing while actively streaming

### DIFF
--- a/test/ServiceBus.Tests/Streaming/EHPersistentStreamQueueRebalancingTestRunner.cs
+++ b/test/ServiceBus.Tests/Streaming/EHPersistentStreamQueueRebalancingTestRunner.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Xunit;
+using Xunit.Abstractions;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+using Orleans.Streams;
+using Orleans.LeaseProviders;
+using Tester.StreamingTests;
+using TestExtensions;
+
+namespace ServiceBus.Tests.StreamingTests
+{
+    [TestCategory("EventHub")]
+    public class EHPersistentStreamQueueRebalancingTestRunner : PersistentStreamQueueRebalancingTestRunner, IClassFixture<EHPersistentStreamQueueRebalancingTestRunner.Fixture>
+    {
+        private const string StreamProviderName = "EventHubStreamProvider";
+        private const string EHPath = "ehorleanstest";
+        private const string EHConsumerGroup = "orleansnightly";
+
+        public EHPersistentStreamQueueRebalancingTestRunner(Fixture fixture, ITestOutputHelper output)
+            : base(StreamProviderName, fixture.GrainFactory, output)
+        {
+        }
+
+        public class Fixture : BaseTestClusterFixture
+        {
+            protected override void ConfigureTestCluster(TestClusterBuilder builder)
+            {
+                builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
+            }
+
+            private class MySiloBuilderConfigurator : ISiloBuilderConfigurator
+            {
+                public void Configure(ISiloHostBuilder hostBuilder)
+                {
+                    EHPersistentStreamQueueRebalancingTestRunner.ConfigureSiloHostBuilder(hostBuilder)
+                        .AddEventHubStreams(StreamProviderName)
+                            .ConfigureEventHub(ob => ob.Configure(options =>
+                                {
+                                    options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
+                                    options.ConsumerGroup = EHConsumerGroup;
+                                    options.Path = EHPath;
+
+                                }))
+                            .UseEventHubCheckpointer(ob => ob.Configure(options =>
+                                {
+                                    options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                                    options.PersistInterval = TimeSpan.FromSeconds(1);
+                                }))
+                            .UseClusterConfigDeploymentLeaseBasedBalancer(ob => ob.Configure(options =>
+                            {
+                                options.LeaseProviderType = typeof(ILeaseProvider);
+                                options.LeaseLength = TimeSpan.FromSeconds(2);
+                                options.SiloMaturityPeriod = TimeSpan.FromSeconds(6);
+                            }));
+                }
+            }
+        }
+    }
+}

--- a/test/Tester/StreamingTests/PersistentStreamQueueRebalancingTestRunner.cs
+++ b/test/Tester/StreamingTests/PersistentStreamQueueRebalancingTestRunner.cs
@@ -1,0 +1,72 @@
+﻿
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Orleans;
+using Orleans.Hosting;
+using Orleans.Runtime.Development;
+using Orleans.TestingHost.Utils;
+using UnitTests.GrainInterfaces;
+
+namespace Tester.StreamingTests
+{
+    public abstract class PersistentStreamQueueRebalancingTestRunner
+    {
+        private static TimeSpan Timeout = TimeSpan.FromSeconds(30);
+        private readonly ITestOutputHelper output;
+        private readonly IGrainFactory grainFactory;
+        private readonly string streamProviderName;
+
+        protected PersistentStreamQueueRebalancingTestRunner(string streamProviderName, IGrainFactory grainFactory, ITestOutputHelper output)
+        {
+            this.streamProviderName = streamProviderName;
+            this.output = output;
+            this.grainFactory = grainFactory;
+        }
+
+        public static ISiloHostBuilder ConfigureSiloHostBuilder(ISiloHostBuilder hostBuilder)
+        {
+            return hostBuilder.UseInMemoryLeaseProvider()
+                              .AddMemoryGrainStorage("PubSubStore");
+        }
+
+        [SkippableFact, TestCategory("Functional"), TestCategory("Streams")]
+        public async Task RebalanceQueuesWhileStreamingTest()
+        {
+            var streamGuid = Guid.NewGuid();
+
+            var producer = this.grainFactory.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
+            await producer.BecomeProducer(streamGuid, "bob", this.streamProviderName);
+
+            var consumer = this.grainFactory.GetGrain<ISampleStreaming_ConsumerGrain>(Guid.NewGuid());
+            await consumer.BecomeConsumer(streamGuid, "bob", this.streamProviderName);
+
+            IDevelopmentLeaseProviderGrain leaseProviderGrain = InMemoryLeaseProvider.GetLeaseProviderGrain(this.grainFactory);
+
+            await producer.StartPeriodicProducing();
+            await Task.Delay(TimeSpan.FromSeconds(10));
+            // reset leases to force rebalance
+            await leaseProviderGrain.Reset();
+            await Task.Delay(TimeSpan.FromSeconds(10));
+            // make sure new consumers can subscribe after rebalance.
+            var consumer2 = this.grainFactory.GetGrain<ISampleStreaming_ConsumerGrain>(Guid.NewGuid());
+            await consumer2.BecomeConsumer(streamGuid, "bob", this.streamProviderName);
+            await producer.StopPeriodicProducing();
+
+            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, lastTry), Timeout);
+        }
+
+        private async Task<bool> CheckCounters(ISampleStreaming_ProducerGrain producer, ISampleStreaming_ConsumerGrain consumer, bool assertIsTrue)
+        {
+            int numProduced = await producer.GetNumberProduced();
+            int numConsumed = await consumer.GetNumberConsumed();
+            if (assertIsTrue)
+            {
+                Assert.True(numProduced > 0, "Events were not produced");
+                Assert.Equal(numProduced, numConsumed);
+            }
+            return (numProduced > 0 && numProduced == numConsumed);
+        }
+    }
+}


### PR DESCRIPTION
This tests is a follow-up on stream rebalancing issues raised by @ilyalukyanov in Stream resubscription issues #3484.
It will not compile or pass tests until Lease based queue balancer fixes #4267 is merged.