### PR TITLE
WIP - More aggressively cleanup system target stream producers.

### DIFF
--- a/src/Orleans.Runtime/Streams/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Runtime/Streams/PubSub/PubSubRendezvousGrain.cs
@@ -29,7 +29,6 @@ namespace Orleans.Streams
         private static readonly CounterStatistic counterConsumersAdded;
         private static readonly CounterStatistic counterConsumersRemoved;
         private static readonly CounterStatistic counterConsumersTotal;
-        private readonly ISiloStatusOracle siloStatusOracle;
 
         static PubSubRendezvousGrain()
         {
@@ -39,11 +38,6 @@ namespace Orleans.Streams
             counterConsumersAdded   = CounterStatistic.FindOrCreate(StatisticNames.STREAMS_PUBSUB_CONSUMERS_ADDED);
             counterConsumersRemoved = CounterStatistic.FindOrCreate(StatisticNames.STREAMS_PUBSUB_CONSUMERS_REMOVED);
             counterConsumersTotal   = CounterStatistic.FindOrCreate(StatisticNames.STREAMS_PUBSUB_CONSUMERS_TOTAL);
-        }
-
-        public PubSubRendezvousGrain(ISiloStatusOracle siloStatusOracle)
-        {
-            this.siloStatusOracle = siloStatusOracle;
         }
 
         public override Task OnActivateAsync()
@@ -413,7 +407,7 @@ namespace Orleans.Streams
             {
                 var grainRef = producer.Producer as GrainReference;
                 // if producer is a system target on and unavailable silo, remove it.
-                if (grainRef == null || grainRef.GrainId.IsSystemTarget && siloStatusOracle.GetApproximateSiloStatus(grainRef.SystemTargetSilo).IsUnavailable())
+                if (grainRef == null || grainRef.GrainId.IsSystemTarget)
                 {
                     RemoveProducer(producer);
                 }


### PR DESCRIPTION
This is part of a follow-up on stream rebalancing issues raised by @ilyalukyanov in Stream resubscription issues #3484.

The concern was that inactive system target stream producers were not being cleaned up in the pubsub state, leading to streams that could no longer be subscribed to or unsubscribed from.

There is an issue here, though I am unconvinced it is the cause of the behaviors @ilyalukyanov is seeing.  This conclusion comes from the fact that in @ilyalukyanov's scenario, silos were being killed, so the system target stream producers on those silo, by the existing logic, should be cleaned up.  The system target stream producers that where rebalanced would have unregistered as part of the queue rebalancing.  Only if the unregister operation had failed would this bug manifest.  That would have shown up in the logs.

This PR is marked WIP, because it's not yet obvious that this is the right fix.  It's not clear under what conditions the OrleansMessageRejectionException is returned.  The GetApproximateSiloStatus check implies that it was expected that there was a possibility for OrleansMessageRejectionException to be received when the producer was still valid, and I've yet been unable to rule this out.  The cost of getting this wrong is that healthy producers could be removed, thus no longer be notified of subscription changes on that stream.