### PR TITLE
[WIP] Cluster settings as service, to allow overrides

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
@@ -2,10 +2,23 @@ using System;
 
 namespace Orleans.Configuration
 {
+    public interface IClusterSettings
+    {
+        /// <summary>
+        /// Gets or sets the cluster identity. This used to be called DeploymentId before Orleans 2.0 name.
+        /// </summary>
+        string ClusterId { get; }
+
+        /// <summary>
+        /// Gets or sets a unique identifier for this service, which should survive deployment and redeployment, where as <see cref="ClusterId"/> might not.
+        /// </summary>
+        Guid ServiceId { get; }
+    }
+
     /// <summary>
     /// Configures the Orleans cluster.
     /// </summary>
-    public class ClusterOptions
+    public class ClusterOptions : IClusterSettings
     {
         /// <summary>
         /// Default cluster id for development clusters.

--- a/src/Orleans.Core/Utils/KeyedService.cs
+++ b/src/Orleans.Core/Utils/KeyedService.cs
@@ -85,6 +85,24 @@ namespace Orleans.Runtime
     public static class KeyedServiceExtensions
     {
         /// <summary>
+        /// Acquire a service by key or use default.
+        /// </summary>
+        public static TService GetServiceByKeyOrDefault<TKey, TService>(this IServiceProvider services, TKey key)
+            where TService : class
+        {
+            return services.GetServiceByKey<TKey, TService>(key) ?? services.GetService<TService>();
+        }
+
+        /// <summary>
+        /// Acquire a service by name or use default.
+        /// </summary>
+        public static TService GetServiceByNameOrDefault<TService>(this IServiceProvider services, string key)
+            where TService : class
+        {
+            return services.GetServiceByKeyOrDefault<string, TService>(key);
+        }
+
+        /// <summary>
         /// Register a transient keyed service
         /// </summary>
         public static IServiceCollection AddTransientKeyedService<TKey, TService>(this IServiceCollection collection, TKey key, Func<IServiceProvider, TKey, TService> factory)

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -55,6 +55,7 @@ namespace Orleans.Hosting
 
             // Register system services.
             services.TryAddSingleton<ILocalSiloDetails, LocalSiloDetails>();
+            services.TryAddSingleton<IClusterSettings>(sp => sp.GetRequiredService<IOptions<ClusterOptions>>().Value);
             services.TryAddSingleton<ISiloHost, SiloWrapper>();
             services.TryAddTransient<ILifecycleSubject,LifecycleSubject>();
             services.TryAddSingleton<ISiloLifecycleSubject,SiloLifecycleSubject>();


### PR DESCRIPTION
Prototype to explore a means of overriding cluster options by named component (mostly providers).

Instead of accessing the cluster options directly, we access an IClusterSettings service which is populated via the cluster options.  Since we get the settings from a service, components can try to get the service by name or fall back to the default if a named service is not found.  This allows application developers to register names services that can be used by a component to override the IClusterSettings for that component.
