### PR TITLE
Validate IReminderTable during startup if any grains implement IRemindable

### DIFF
--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -38,6 +38,7 @@ using Microsoft.Extensions.Options;
 
 using Orleans.Configuration.Validators;
 using Orleans.Runtime.Configuration;
+using System.Linq;
 
 namespace Orleans.Hosting
 {
@@ -92,7 +93,6 @@ namespace Orleans.Hosting
 
             services.AddLogging();
             services.TryAddSingleton<ITimerRegistry, TimerRegistry>();
-            services.TryAddSingleton<IReminderRegistry, ReminderRegistry>();
             services.TryAddSingleton<GrainRuntime>();
             services.TryAddSingleton<IGrainRuntime, GrainRuntime>();
             services.TryAddSingleton<IGrainCancellationTokenRuntime, GrainCancellationTokenRuntime>();
@@ -142,6 +142,15 @@ namespace Orleans.Hosting
             services.TryAddSingleton<RegistrarManager>();
             services.TryAddSingleton<Factory<Grain, IMultiClusterRegistrationStrategy, ILogConsistencyProtocolServices>>(FactoryUtility.Create<Grain, IMultiClusterRegistrationStrategy, ProtocolServices>);
             services.TryAddSingleton(FactoryUtility.Create<GrainDirectoryPartition>);
+
+            // Reminders
+            services.TryAddSingleton<IReminderRegistry, ReminderRegistry>();
+            if (services.LastOrDefault()?.ServiceType == typeof(IReminderRegistry))
+            {
+                // If the user has not overridden the reminder registry, also add a configuration validator
+                // to ensure that a reminder table is configured if any grains require reminders.
+                services.AddSingleton<IConfigurationValidator, ReminderTableConfigurationValidator>();
+            }
 
             // Placement
             services.AddSingleton<IConfigurationValidator, ActivationCountBasedPlacementOptionsValidator>();

--- a/src/Orleans.Runtime/ReminderService/ReminderTableConfigurationValidator.cs
+++ b/src/Orleans.Runtime/ReminderService/ReminderTableConfigurationValidator.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orleans.Runtime.ReminderService
+{
+    internal class ReminderTableConfigurationValidator : IConfigurationValidator
+    {
+        internal const string ReminderServiceNotConfigured =
+              "The reminder service has not been configured. Reminders can be configured using extension methods from the following packages:"
+              + "\n  * Microsoft.Orleans.Reminders.AzureStorage via ISiloHostBuilder.UseAzureTableReminderService(...)"
+              + "\n  * Microsoft.Orleans.Reminders.AdoNet via ISiloHostBuilder.UseAdoNetReminderService(...)"
+              + "\n  * Microsoft.Orleans.Reminders.DynamoDB via via ISiloHostBuilder.UseDynamoDBReminderService(...)"
+              + "\n  * Microsoft.Orleans.OrleansRuntime via ISiloHostBuilder.UseInMemoryReminderService(...) (Note: for development purposes only)"
+              + "\n  * Others, see: https://www.nuget.org/packages?q=Microsoft.Orleans.Reminders.";
+        private readonly GrainTypeManager grainTypeManager;
+        private readonly IServiceProvider serviceProvider;
+
+        public ReminderTableConfigurationValidator(GrainTypeManager grainTypeManager, IServiceProvider serviceProvider)
+        {
+            this.grainTypeManager = grainTypeManager;
+            this.serviceProvider = serviceProvider;
+        }
+
+        public void ValidateConfiguration()
+        {
+            var reminderTable = this.serviceProvider.GetService<IReminderTable>();
+            if (reminderTable != null) return;
+
+            var allGrains = this.grainTypeManager.GrainClassTypeData.Select(data => data.Value);
+
+            var remindableGrains = new List<Type>();
+            foreach (var grain in allGrains)
+            {
+                if (typeof(IRemindable).IsAssignableFrom(grain.Type))
+                {
+                    remindableGrains.Add(grain.Type);
+                }
+            }
+
+            if (remindableGrains.Count > 0)
+            {
+                var message = new StringBuilder(ReminderServiceNotConfigured);
+                message.AppendLine("\nThe following grain classes require reminders:");
+
+                foreach (var grain in remindableGrains)
+                {
+                    message.AppendLine($"  * {grain.GetParseableName(TypeFormattingOptions.LogFormat)}");
+                }
+
+                throw new OrleansConfigurationException(message.ToString());
+            }
+        }
+    }
+}

--- a/test/NonSilo.Tests/Reminders/ReminderServiceConfigurationTests.cs
+++ b/test/NonSilo.Tests/Reminders/ReminderServiceConfigurationTests.cs
@@ -1,0 +1,46 @@
+﻿using Orleans.ApplicationParts;
+using Orleans.Hosting;
+using Orleans.Metadata;
+using Orleans.Runtime;
+using System.Collections.Generic;
+using UnitTests.Grains;
+using Xunit;
+
+namespace NonSilo.Tests.Reminders
+{
+    [TestCategory("BVT")]
+    [TestCategory("Reminders")]
+    public class ReminderServiceConfigurationTests
+    {
+        /// <summary>
+        /// Tests that if an IRemindable grain is registered, then an IReminderTable must also be registered.
+        /// </summary>
+        [Fact]
+        public void ReminderService_ConfigurationValidatorTest()
+        {
+            var exception = Assert.Throws<OrleansConfigurationException>(() => new SiloHostBuilder()
+                .UseLocalhostClustering()
+                .ConfigureApplicationParts(parts => parts.AddFeatureProvider(new RemindableGrainFeatureProvider()))
+                .Build());
+
+            Assert.Contains(nameof(ReminderTestGrain2), exception.Message);
+
+            var builder = new SiloHostBuilder()
+                .UseLocalhostClustering()
+                .ConfigureApplicationParts(parts => parts.AddFeatureProvider(new RemindableGrainFeatureProvider()))
+                .UseInMemoryReminderService();
+            using (var silo = builder.Build())
+            {
+                Assert.NotNull(silo);
+            }
+        }
+
+        private class RemindableGrainFeatureProvider : IApplicationFeatureProvider<GrainClassFeature>
+        {
+            public void PopulateFeature(IEnumerable<IApplicationPart> parts, GrainClassFeature feature)
+            {
+                feature.Classes.Add(new GrainClassMetadata(typeof(ReminderTestGrain2)));
+            }
+        }
+    }
+}

--- a/test/NonSilo.Tests/SiloHostBuilderTests.cs
+++ b/test/NonSilo.Tests/SiloHostBuilderTests.cs
@@ -68,12 +68,14 @@ namespace NonSilo.Tests
             Assert.Throws<OrleansConfigurationException>(() => new SiloHostBuilder()
                 .Configure<EndpointOptions>(options => options.AdvertisedIPAddress = IPAddress.Loopback)
                 .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>())
+                .UseInMemoryReminderService()
                 .Build());
 
             var builder = new SiloHostBuilder()
                 .Configure<EndpointOptions>(options => options.AdvertisedIPAddress = IPAddress.Loopback)
                 .Configure<ClusterOptions>(options => options.ClusterId = "test")
-                .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>());
+                .ConfigureServices(services => services.AddSingleton<IMembershipTable, NoOpMembershipTable>())
+                .UseInMemoryReminderService();
             using (var silo = builder.Build())
             {
                 Assert.NotNull(silo);

--- a/test/Tester/LocalhostSiloTests.cs
+++ b/test/Tester/LocalhostSiloTests.cs
@@ -22,6 +22,7 @@ namespace Tester
         {
             var silo = new SiloHostBuilder()
                 .AddMemoryGrainStorage("MemoryStore")
+                .UseInMemoryReminderService()
                 .UseLocalhostClustering()
                 .Build();
 
@@ -53,11 +54,13 @@ namespace Tester
         {
             var silo1 = new SiloHostBuilder()
                 .AddMemoryGrainStorage("MemoryStore")
+                .UseInMemoryReminderService()
                 .UseLocalhostClustering(12111, 30001)
                 .Build();
 
             var silo2 = new SiloHostBuilder()
                 .AddMemoryGrainStorage("MemoryStore")
+                .UseInMemoryReminderService()
                 .UseLocalhostClustering(12112, 30002, new IPEndPoint(IPAddress.Loopback, 12111))
                 .Build();
 

--- a/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/TesterInternal/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Linq;
 using Orleans.Runtime.Configuration;
+using Orleans.Hosting;
 
 namespace UnitTests.ActivationsLifeCycleTests
 {
@@ -34,10 +35,20 @@ namespace UnitTests.ActivationsLifeCycleTests
             }
 
             builder.ConfigureLegacyConfiguration();
+            builder.AddSiloBuilderConfigurator<SiloConfigurator>();
             testCluster = builder.Build();
             testCluster.Deploy();
         }
-        
+
+        public class SiloConfigurator : ISiloBuilderConfigurator
+        {
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder.UseInMemoryReminderService();
+            }
+        }
+
+
         public void Dispose()
         {
             testCluster?.StopAllSilos();


### PR DESCRIPTION
Fixes #4278 

This assumes that if the user adds some grain which implements `IRemindable`, then that means they intend to use reminders. That assumption might not be true, but maybe we'll decide it's better to err on the side of caution.

An alternative is late checking, like so:
![image](https://user-images.githubusercontent.com/203839/37763205-9363b48e-2e12-11e8-8fe9-184f8d7eef78.png)

I'm happy with either and looking for input.
