### PR TITLE
Remove inconsistent sub builder pattern in streaming

### DIFF
--- a/src/AWS/Orleans.Streaming.SQS/Hosting/ClientBuilderExtensions.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Hosting/ClientBuilderExtensions.cs
@@ -6,23 +6,13 @@ using OrleansAWSUtils.Streams;
 namespace Orleans.Hosting
 {
     public static class ClientBuilderExtensions
-    {
-
-        /// <summary>
-        /// Configure cluster client to use SQS persistent streams. This will return a configurator which allows further configuration
-        /// </summary>
-        public static ClusterClientSqsStreamConfigurator AddSqsStreams(this IClientBuilder builder, string name)
-        {
-            return new ClusterClientSqsStreamConfigurator(name, builder);
-        }
-
-        /// <summary>
+    {   /// <summary>
         /// Configure cluster client to use SQS persistent streams with default settings
         /// </summary>
         public static IClientBuilder AddSqsStreams(this IClientBuilder builder, string name, Action<SqsOptions> configureOptions)
         {
-            builder.AddSqsStreams(name)
-                .ConfigureSqs(ob=>ob.Configure(configureOptions));
+            builder.AddSqsStreams(name, b=>
+                b.ConfigureSqs(ob=>ob.Configure(configureOptions)));
             return builder;
         }
 
@@ -31,7 +21,8 @@ namespace Orleans.Hosting
         /// </summary>
         public static IClientBuilder AddSqsStreams(this IClientBuilder builder, string name, Action<ClusterClientSqsStreamConfigurator> configure)
         {
-            configure?.Invoke(builder.AddSqsStreams(name));
+            var configurator = new ClusterClientSqsStreamConfigurator(name, builder);
+            configure?.Invoke(configurator);
             return builder;
         }
     }

--- a/src/AWS/Orleans.Streaming.SQS/Hosting/SiloBuilderExtensions.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Hosting/SiloBuilderExtensions.cs
@@ -7,21 +7,14 @@ namespace Orleans.Hosting
 {
     public static class SiloBuilderExtensions
     {
-        /// <summary>
-        /// Configure silo to use SQS persistent streams. This returns a configurator which allows further configuration
-        /// </summary>
-        public static SiloSqsStreamConfigurator AddSqsStreams(this ISiloHostBuilder builder, string name)
-        {
-            return new SiloSqsStreamConfigurator(name, builder);
-        }
 
         /// <summary>
         /// Configure silo to use SQS persistent streams.
         /// </summary>
         public static ISiloHostBuilder AddSqsStreams(this ISiloHostBuilder builder, string name, Action<SqsOptions> configureOptions)
         {
-            builder.AddSqsStreams(name)
-                .ConfigureSqs(ob => ob.Configure(configureOptions));
+            builder.AddSqsStreams(name, b=>
+                b.ConfigureSqs(ob => ob.Configure(configureOptions)));
             return builder;
         }
 
@@ -30,7 +23,8 @@ namespace Orleans.Hosting
         /// </summary>
         public static ISiloHostBuilder AddSqsStreams(this ISiloHostBuilder builder, string name, Action<SiloSqsStreamConfigurator> configure)
         {
-            configure?.Invoke(builder.AddSqsStreams(name));
+            var configurator = new SiloSqsStreamConfigurator(name, builder);
+            configure?.Invoke(configurator);
             return builder;
         }
     }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
@@ -8,16 +8,6 @@ namespace Orleans.Hosting
     public static class ClientBuilderExtensions
     {
         /// <summary>
-        /// Configure cluster client to use azure queue persistent streams. Returns ClusterClientAzureQueueStreamConfigurator for further configuration
-        /// </summary>
-        public static ClusterClientAzureQueueStreamConfigurator<TDataAdapter> AddAzureQueueStreams<TDataAdapter>(this IClientBuilder builder,
-            string name)
-            where TDataAdapter : IAzureQueueDataAdapter
-        {
-            return new ClusterClientAzureQueueStreamConfigurator<TDataAdapter>(name, builder);
-        }
-
-        /// <summary>
         /// Configure cluster client to use azure queue persistent streams. 
         /// </summary>
         public static IClientBuilder AddAzureQueueStreams<TDataAdapter>(this IClientBuilder builder,
@@ -25,7 +15,9 @@ namespace Orleans.Hosting
             Action<ClusterClientAzureQueueStreamConfigurator<TDataAdapter>> configure)
             where TDataAdapter : IAzureQueueDataAdapter
         {
-            configure?.Invoke(builder.AddAzureQueueStreams<TDataAdapter>(name));
+            //the constructor wires up DI with AzureQueueStream, so has to be called regardless configure is null or not
+            var configurator = new ClusterClientAzureQueueStreamConfigurator<TDataAdapter>(name, builder);
+            configure?.Invoke(configurator);
             return builder;
         }
 
@@ -36,8 +28,8 @@ namespace Orleans.Hosting
             string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
             where TDataAdapter : IAzureQueueDataAdapter
         {
-            builder.AddAzureQueueStreams<TDataAdapter>(name)
-                 .ConfigureAzureQueue(configureOptions);
+            builder.AddAzureQueueStreams<TDataAdapter>(name, b=>
+                 b.ConfigureAzureQueue(configureOptions));
             return builder;
         }
     }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
@@ -6,16 +6,7 @@ using Orleans.Streaming;
 namespace Orleans.Hosting
 {
     public static class SiloBuilderExtensions
-    {
-        /// <summary>
-        /// Configure silo to use azure queue persistent streams. This return a configurator which allows further configuration
-        /// </summary>
-        public static SiloAzureQueueStreamConfigurator<TDataAdapter> AddAzureQueueStreams<TDataAdapter>(this ISiloHostBuilder builder, string name)
-           where TDataAdapter : IAzureQueueDataAdapter
-        {
-            return new SiloAzureQueueStreamConfigurator<TDataAdapter>(name,builder);
-        }
-
+    { 
         /// <summary>
         /// Configure silo to use azure queue persistent streams. 
         /// </summary>
@@ -23,7 +14,8 @@ namespace Orleans.Hosting
             Action<SiloAzureQueueStreamConfigurator<TDataAdapter>> configure)
            where TDataAdapter : IAzureQueueDataAdapter
         {
-            configure?.Invoke(builder.AddAzureQueueStreams<TDataAdapter>(name));
+            var configurator = new SiloAzureQueueStreamConfigurator<TDataAdapter>(name, builder);
+            configure?.Invoke(configurator);
             return builder;
         }
 
@@ -33,8 +25,8 @@ namespace Orleans.Hosting
         public static ISiloHostBuilder AddAzureQueueStreams<TDataAdapter>(this ISiloHostBuilder builder, string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
            where TDataAdapter : IAzureQueueDataAdapter
         {
-            builder.AddAzureQueueStreams<TDataAdapter>(name)
-                 .ConfigureAzureQueue(configureOptions);
+            builder.AddAzureQueueStreams<TDataAdapter>(name, b=>
+                 b.ConfigureAzureQueue(configureOptions));
             return builder;
         }
     }

--- a/src/Azure/Orleans.Streaming.EventHubs/Hosting/ClientBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Hosting/ClientBuilderExtensions.cs
@@ -7,15 +7,6 @@ namespace Orleans.Hosting
 {
     public static class ClientBuilderExtensions
     {
-        /// <summary>
-        /// Configure cluster client to use event hub persistent streams. This return a configurator which allows further configuration
-        /// </summary>
-        public static ClusterClientEventHubStreamConfigurator AddEventHubStreams(
-            this IClientBuilder builder,
-            string name)
-        {
-            return new ClusterClientEventHubStreamConfigurator(name, builder);
-        }
 
         /// <summary>
         /// Configure cluster client to use event hub persistent streams.
@@ -25,7 +16,8 @@ namespace Orleans.Hosting
            string name,
            Action<ClusterClientEventHubStreamConfigurator> configure)
         {
-            configure?.Invoke(builder.AddEventHubStreams(name));
+            var configurator = new ClusterClientEventHubStreamConfigurator(name,builder);
+            configure?.Invoke(configurator);
             return builder;
         }
 
@@ -36,7 +28,7 @@ namespace Orleans.Hosting
             this IClientBuilder builder,
             string name, Action<EventHubOptions> configureEventHub)
         {
-            builder.AddEventHubStreams(name).ConfigureEventHub(ob => ob.Configure(configureEventHub));
+            builder.AddEventHubStreams(name, b=>b.ConfigureEventHub(ob => ob.Configure(configureEventHub)));
             return builder;
         }
     }

--- a/src/Azure/Orleans.Streaming.EventHubs/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Hosting/SiloBuilderExtensions.cs
@@ -7,15 +7,6 @@ namespace Orleans.Hosting
 {
     public static class SiloBuilderExtensions
     {
-        /// <summary>
-        /// Configure silo to use event hub persistent streams. This returns a configurator which allows further configuration.
-        /// </summary>
-        public static SiloEventHubStreamConfigurator AddEventHubStreams(
-            this ISiloHostBuilder builder,
-            string name)
-        {
-            return new SiloEventHubStreamConfigurator(name, builder);
-        }
 
         /// <summary>
         /// Configure silo to use event hub persistent streams.
@@ -25,7 +16,8 @@ namespace Orleans.Hosting
             string name,
             Action<SiloEventHubStreamConfigurator> configure)
         {
-            configure?.Invoke(builder.AddEventHubStreams(name));
+            var configurator = new SiloEventHubStreamConfigurator(name, builder);
+            configure?.Invoke(configurator);
             return builder;
         }
 
@@ -36,9 +28,9 @@ namespace Orleans.Hosting
             this ISiloHostBuilder builder,
             string name, Action<EventHubOptions> configureEventHub, Action<AzureTableStreamCheckpointerOptions> configureDefaultCheckpointer)
         {
-            builder.AddEventHubStreams(name)
-                .ConfigureEventHub(ob => ob.Configure(configureEventHub))
-                .UseEventHubCheckpointer(ob => ob.Configure(configureDefaultCheckpointer));
+            builder.AddEventHubStreams(name, b=>
+                    b.ConfigureEventHub(ob => ob.Configure(configureEventHub))
+                    .UseEventHubCheckpointer(ob => ob.Configure(configureDefaultCheckpointer)));
             return builder;
         }
     }

--- a/src/Orleans.Core/Streams/ClientStreamExtensions.cs
+++ b/src/Orleans.Core/Streams/ClientStreamExtensions.cs
@@ -14,12 +14,16 @@ namespace Orleans.Hosting
     /// </summary>
     public static class ClientStreamExtensions
     {
-        public static ClusterClientPersistentStreamConfigurator AddPersistentStreams(
+        public static IClientBuilder AddPersistentStreams(
             this IClientBuilder builder,
             string name,
-            Func<IServiceProvider, string, IQueueAdapterFactory> adapterFactory)
+            Func<IServiceProvider, string, IQueueAdapterFactory> adapterFactory,
+            Action<IClusterClientPersistentStreamConfigurator> configureStream)
         {
-            return new ClusterClientPersistentStreamConfigurator(name, builder, adapterFactory);
+            //the constructor wire up DI with all default components of the streams , so need to be called regardless of configureStream null or not
+            var streamConfigurator = new ClusterClientPersistentStreamConfigurator(name, builder, adapterFactory);
+            configureStream?.Invoke(streamConfigurator);
+            return builder;
         }
 
         /// <summary>

--- a/src/Orleans.Runtime.Abstractions/Hosting/StreamHostingExtensions.cs
+++ b/src/Orleans.Runtime.Abstractions/Hosting/StreamHostingExtensions.cs
@@ -15,9 +15,12 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use persistent streams.
         /// </summary>
-        public static ISiloPersistentStreamConfigurator AddPersistentStreams(this ISiloHostBuilder builder, string name, Func<IServiceProvider, string, IQueueAdapterFactory> adapterFactory)
+        public static ISiloHostBuilder AddPersistentStreams(this ISiloHostBuilder builder, string name,
+            Func<IServiceProvider, string, IQueueAdapterFactory> adapterFactory,
+            Action<ISiloPersistentStreamConfigurator> configureStream)
         {
-            return new SiloPersistentStreamConfigurator(name, builder, adapterFactory);
+            configureStream.Invoke(new SiloPersistentStreamConfigurator(name, builder, adapterFactory));
+            return builder;
         }
 
         /// <summary>

--- a/src/Orleans.Runtime.Abstractions/Hosting/StreamHostingExtensions.cs
+++ b/src/Orleans.Runtime.Abstractions/Hosting/StreamHostingExtensions.cs
@@ -19,7 +19,9 @@ namespace Orleans.Hosting
             Func<IServiceProvider, string, IQueueAdapterFactory> adapterFactory,
             Action<ISiloPersistentStreamConfigurator> configureStream)
         {
-            configureStream.Invoke(new SiloPersistentStreamConfigurator(name, builder, adapterFactory));
+            //the constructor wire up DI with all default components of the streams , so need to be called regardless of configureStream null or not
+            var streamConfigurator = new SiloPersistentStreamConfigurator(name, builder, adapterFactory);
+            configureStream?.Invoke(streamConfigurator);
             return builder;
         }
 

--- a/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Runtime/Streams/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -32,7 +32,7 @@ namespace Orleans.Streams
     /// Selector using round robin algorithm
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal class RoundRobinSelector<T> : IResourceSelector<T>
+    internal class  RoundRobinSelector<T> : IResourceSelector<T>
     {
         private ReadOnlyCollection<T> resources;
         private int lastSelection;

--- a/src/Orleans.Streaming.GCP/Hosting/ClientBuilderExtensions.cs
+++ b/src/Orleans.Streaming.GCP/Hosting/ClientBuilderExtensions.cs
@@ -7,16 +7,6 @@ namespace Orleans.Hosting
 {
     public static class ClientBuilderExtensions
     {
-        /// <summary>
-        /// Configure cluster client to use PubSub persistent streams.
-        /// </summary>
-        public static ClusterClientPubSubStreamConfigurator<TDataAdapter> AddPubSubStreams<TDataAdapter>(
-            this IClientBuilder builder,
-            string name)
-            where TDataAdapter : IPubSubDataAdapter
-        {
-            return new ClusterClientPubSubStreamConfigurator<TDataAdapter>(name, builder);
-        }
 
 
         /// <summary>
@@ -27,8 +17,7 @@ namespace Orleans.Hosting
             string name, Action<PubSubOptions> configurePubSub)
             where TDataAdapter : IPubSubDataAdapter
         {
-            builder.AddPubSubStreams<TDataAdapter>(name)
-                .ConfigurePubSub(ob => ob.Configure(configurePubSub));
+            builder.AddPubSubStreams<TDataAdapter>(name, b=>b.ConfigurePubSub(ob => ob.Configure(configurePubSub)));
             return builder;
         }
 
@@ -40,7 +29,8 @@ namespace Orleans.Hosting
             string name, Action<ClusterClientPubSubStreamConfigurator<TDataAdapter>> configure)
             where TDataAdapter : IPubSubDataAdapter
         {
-            configure?.Invoke(builder.AddPubSubStreams<TDataAdapter>(name));
+            var configurator = new ClusterClientPubSubStreamConfigurator<TDataAdapter>(name, builder);
+            configure?.Invoke(configurator);
             return builder;
         }
     }

--- a/src/Orleans.Streaming.GCP/Hosting/SiloBuilderExtensions.cs
+++ b/src/Orleans.Streaming.GCP/Hosting/SiloBuilderExtensions.cs
@@ -7,16 +7,6 @@ namespace Orleans.Hosting
 {
     public static class SiloBuilderExtensions
     {
-        /// <summary>
-        /// Configure silo to use PubSub persistent streams.
-        /// </summary>
-        public static SiloPubSubStreamConfigurator<TDataAdapter> AddPubSubStreams<TDataAdapter>(
-            this ISiloHostBuilder builder,
-            string name)
-            where TDataAdapter : IPubSubDataAdapter
-        {
-            return new SiloPubSubStreamConfigurator<TDataAdapter>(name, builder);
-        }
 
         /// <summary>
         /// Configure silo to use PubSub persistent streams.
@@ -26,8 +16,8 @@ namespace Orleans.Hosting
             string name, Action<PubSubOptions> configurePubSub)
             where TDataAdapter : IPubSubDataAdapter
         {
-            builder.AddPubSubStreams<TDataAdapter>(name)
-                .ConfigurePubSub(ob => ob.Configure(configurePubSub));
+            builder.AddPubSubStreams<TDataAdapter>(name, b=>
+                b.ConfigurePubSub(ob => ob.Configure(configurePubSub)));
             return builder;
         }
 
@@ -39,7 +29,8 @@ namespace Orleans.Hosting
             string name, Action<SiloPubSubStreamConfigurator<TDataAdapter>> configure)
             where TDataAdapter : IPubSubDataAdapter
         {
-            configure?.Invoke(builder.AddPubSubStreams<TDataAdapter>(name));
+            var configurator = new SiloPubSubStreamConfigurator<TDataAdapter>(name, builder);
+            configure?.Invoke(configurator);
             return builder;
         }
     }

--- a/src/OrleansProviders/Hosting/ClientBuilderExtensions.cs
+++ b/src/OrleansProviders/Hosting/ClientBuilderExtensions.cs
@@ -9,24 +9,15 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure cluster client to use memory streams. This return a configurator for further configuration
         /// </summary>
-        public static ClusterClientMemoryStreamConfigurator<TSerializer> AddMemoryStreams<TSerializer>(
-            this IClientBuilder builder,
-            string name)
-            where TSerializer : class, IMemoryMessageBodySerializer
-        {
-            return new ClusterClientMemoryStreamConfigurator<TSerializer>(name, builder);
-        }
-
-        /// <summary>
-        /// Configure cluster client to use memory streams. This return a configurator for further configuration
-        /// </summary>
         public static IClientBuilder AddMemoryStreams<TSerializer>(
             this IClientBuilder builder,
             string name,
-            Action<ClusterClientMemoryStreamConfigurator<TSerializer>> configure)
+            Action<ClusterClientMemoryStreamConfigurator<TSerializer>> configure = null)
             where TSerializer : class, IMemoryMessageBodySerializer
         {
-            configure?.Invoke(builder.AddMemoryStreams<TSerializer>(name));
+            //the constructor wire up DI with all default components of the streams , so need to be called regardless of configureStream null or not
+            var memoryStreamConfigurator = new ClusterClientMemoryStreamConfigurator<TSerializer>(name, builder);
+            configure?.Invoke(memoryStreamConfigurator);
             return builder;
         }
     }

--- a/src/OrleansProviders/Hosting/SiloBuilderExtensions.cs
+++ b/src/OrleansProviders/Hosting/SiloBuilderExtensions.cs
@@ -8,22 +8,15 @@ namespace Orleans.Hosting
     public static class SiloBuilderExtensions
     {
         /// <summary>
-        /// Configure silo to use memory streams. This return a configurator which allows further configuration.
-        /// </summary>
-        public static SiloMemoryStreamConfigurator<TSerializer> AddMemoryStreams<TSerializer>(this ISiloHostBuilder builder, string name)
-             where TSerializer : class, IMemoryMessageBodySerializer
-        {
-            return new SiloMemoryStreamConfigurator<TSerializer>(name, builder);
-        }
-
-        /// <summary>
         /// Configure silo to use memory streams.
         /// </summary>
         public static ISiloHostBuilder AddMemoryStreams<TSerializer>(this ISiloHostBuilder builder, string name,
-            Action<SiloMemoryStreamConfigurator<TSerializer>> configure)
+            Action<SiloMemoryStreamConfigurator<TSerializer>> configure = null)
              where TSerializer : class, IMemoryMessageBodySerializer
         {
-            configure?.Invoke(builder.AddMemoryStreams<TSerializer>(name));
+            //the constructor wire up DI with all default components of the streams , so need to be called regardless of configureStream null or not
+            var memoryStreamConfiguretor = new SiloMemoryStreamConfigurator<TSerializer>(name, builder);
+            configure?.Invoke(memoryStreamConfiguretor);
             return builder;
         }
     }

--- a/test/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
+++ b/test/GoogleUtils.Tests/Streaming/PubSubStreamTests.cs
@@ -39,13 +39,13 @@ namespace GoogleUtils.Tests.Streaming
                     .AddMemoryGrainStorage("MemoryStore", op => op.NumStorageGrains = 1)
                     .AddMemoryGrainStorage("PubSubStorage")
                     .AddSimpleMessageStreamProvider("SMSProvider")
-                    .AddPubSubStreams<PubSubDataAdapter>(PUBSUB_STREAM_PROVIDER_NAME)
-                    .ConfigurePubSub(ob=>ob.Configure(options =>
-                    {
-                        options.ProjectId = GoogleTestUtils.ProjectId;
-                        options.TopicId = GoogleTestUtils.TopicId;
-                        options.Deadline = TimeSpan.FromSeconds(600);
-                    }));
+                    .AddPubSubStreams<PubSubDataAdapter>(PUBSUB_STREAM_PROVIDER_NAME, b=>
+                        b.ConfigurePubSub(ob=>ob.Configure(options =>
+                        {
+                            options.ProjectId = GoogleTestUtils.ProjectId;
+                            options.TopicId = GoogleTestUtils.TopicId;
+                            options.Deadline = TimeSpan.FromSeconds(600);
+                        })));
             }
         }
 
@@ -55,13 +55,13 @@ namespace GoogleUtils.Tests.Streaming
             {
                 clientBuilder
                     .AddSimpleMessageStreamProvider("SMSProvider")
-                    .AddPubSubStreams<PubSubDataAdapter>(PUBSUB_STREAM_PROVIDER_NAME)
-                    .ConfigurePubSub(ob=>ob.Configure(options =>
-                    {
-                        options.ProjectId = GoogleTestUtils.ProjectId;
-                        options.TopicId = GoogleTestUtils.TopicId;
-                        options.Deadline = TimeSpan.FromSeconds(600);
-                    }));
+                    .AddPubSubStreams<PubSubDataAdapter>(PUBSUB_STREAM_PROVIDER_NAME, b=>
+                        b.ConfigurePubSub(ob=>ob.Configure(options =>
+                        {
+                            options.ProjectId = GoogleTestUtils.ProjectId;
+                            options.TopicId = GoogleTestUtils.TopicId;
+                            options.Deadline = TimeSpan.FromSeconds(600);
+                        })));
             }
         }
 

--- a/test/ServiceBus.Tests/PluggableQueueBalancerTests.cs
+++ b/test/ServiceBus.Tests/PluggableQueueBalancerTests.cs
@@ -35,13 +35,13 @@ namespace ServiceBus.Tests
                     hostBuilder
                         .AddMemoryGrainStorage("PubSubStore")
                         .AddPersistentStreams(StreamProviderName,
-                            EventDataGeneratorAdapterFactory.Create)
+                            EventDataGeneratorAdapterFactory.Create, b=>b
                         .Configure<EventDataGeneratorStreamOptions>(ob => ob.Configure(
                             options =>
                             {
                                 options.EventHubPartitionCount = TotalQueueCount;
                             }))
-                         .ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n));
+                         .ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n)));
                 }
             }
         }

--- a/test/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/ServiceBus.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -44,15 +44,15 @@ namespace ServiceBus.Tests.SlowConsumingTests
             {
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
-                    hostBuilder.AddPersistentStreams(StreamProviderName, EHStreamProviderWithCreatedCacheListAdapterFactory.Create)
-                        .Configure<EventHubStreamCachePressureOptions>(ob => ob.Configure(options =>
-                   {
-                       options.SlowConsumingMonitorPressureWindowSize = monitorPressureWindowSize;
-                       options.SlowConsumingMonitorFlowControlThreshold = flowControlThredhold;
-                       options.AveragingCachePressureMonitorFlowControlThreshold = null;
-                   }))
-                   .ConfigureComponent<IStreamQueueCheckpointerFactory>((s,n)=>NoOpCheckpointerFactory.Instance)
-                   .UseDynamicClusterConfigDeploymentBalancer();
+                    hostBuilder.AddPersistentStreams(StreamProviderName, EHStreamProviderWithCreatedCacheListAdapterFactory.Create, b=>
+                        b.Configure<EventHubStreamCachePressureOptions>(ob => ob.Configure(options =>
+                           {
+                               options.SlowConsumingMonitorPressureWindowSize = monitorPressureWindowSize;
+                               options.SlowConsumingMonitorFlowControlThreshold = flowControlThredhold;
+                               options.AveragingCachePressureMonitorFlowControlThreshold = null;
+                           }))
+                           .ConfigureComponent<IStreamQueueCheckpointerFactory>((s,n)=>NoOpCheckpointerFactory.Instance)
+                           .UseDynamicClusterConfigDeploymentBalancer());
                     hostBuilder
                     .AddMemoryGrainStorage("PubSubStore");
                 }

--- a/test/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/ServiceBus.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -43,10 +43,10 @@ namespace ServiceBus.Tests.MonitorTests
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                        .AddPersistentStreams(StreamProviderName, EHStreamProviderForMonitorTestsAdapterFactory.Create)
+                        .AddPersistentStreams(StreamProviderName, EHStreamProviderForMonitorTestsAdapterFactory.Create, b=>b
                         .ConfigureComponent<IStreamQueueCheckpointerFactory>((s, n) => NoOpCheckpointerFactory.Instance)
                         .Configure<StreamStatisticOptions>(ob => ob.Configure(options => options.StatisticMonitorWriteInterval = monitorWriteInterval))
-                        .UseDynamicClusterConfigDeploymentBalancer();
+                        .UseDynamicClusterConfigDeploymentBalancer());
                     hostBuilder
                         .ConfigureServices(services =>
                         {

--- a/test/ServiceBus.Tests/Streaming/EHClientStreamTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHClientStreamTests.cs
@@ -52,7 +52,7 @@ namespace ServiceBus.Tests.StreamingTests
             public void Configure(ISiloHostBuilder hostBuilder)
             {
                 hostBuilder
-                    .AddPersistentStreams(StreamProviderName, TestEventHubStreamAdapterFactory.Create)
+                    .AddPersistentStreams(StreamProviderName, TestEventHubStreamAdapterFactory.Create, b=>b
                     .Configure<EventHubOptions>(ob => ob.Configure(options =>
                       {
                           options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
@@ -63,7 +63,7 @@ namespace ServiceBus.Tests.StreamingTests
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         options.PersistInterval = TimeSpan.FromSeconds(10);
-                    }));
+                    })));
                 hostBuilder
                     .AddMemoryGrainStorage("PubSubStore");
             }
@@ -74,14 +74,14 @@ namespace ServiceBus.Tests.StreamingTests
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
-                    .AddPersistentStreams(StreamProviderName, TestEventHubStreamAdapterFactory.Create)
-                    .Configure<EventHubOptions>(ob=>ob.Configure(
-                    options =>
-                    {
-                        options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
-                        options.ConsumerGroup = EHConsumerGroup;
-                        options.Path = EHPath;
-                    }));
+                    .AddPersistentStreams(StreamProviderName, TestEventHubStreamAdapterFactory.Create, b=>
+                        b.Configure<EventHubOptions>(ob=>ob.Configure(
+                        options =>
+                        {
+                            options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
+                            options.ConsumerGroup = EHConsumerGroup;
+                            options.Path = EHPath;
+                        })));
             }
         }
 

--- a/test/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHImplicitSubscriptionStreamRecoveryTests.cs
@@ -41,7 +41,7 @@ namespace ServiceBus.Tests.StreamingTests
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                        .AddEventHubStreams(StreamProviderName)
+                        .AddEventHubStreams(StreamProviderName, b=>b
                         .ConfigureEventHub(ob => ob.Configure(options =>
                           {
                               options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
@@ -54,7 +54,7 @@ namespace ServiceBus.Tests.StreamingTests
                               options.PersistInterval = TimeSpan.FromSeconds(1);
                           }))
                         .UseDynamicClusterConfigDeploymentBalancer()
-                        .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly);
+                        .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly));
                     hostBuilder
                         .AddMemoryGrainStorageAsDefault();
                 }
@@ -64,14 +64,14 @@ namespace ServiceBus.Tests.StreamingTests
             {
                 public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
                 {
-                    clientBuilder.AddEventHubStreams(StreamProviderName)
-                        .ConfigureEventHub(ob=>ob.Configure( options =>
+                    clientBuilder.AddEventHubStreams(StreamProviderName, b=>
+                        b.ConfigureEventHub(ob=>ob.Configure( options =>
                         {
                             options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
                             options.ConsumerGroup = EHConsumerGroup;
                             options.Path = EHPath;
                         }))
-                        .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly);
+                        .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly));
                 }
             }
         }

--- a/test/ServiceBus.Tests/Streaming/EHProgrammaticSubscribeTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHProgrammaticSubscribeTests.cs
@@ -27,7 +27,7 @@ namespace ServiceBus.Tests.Streaming
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                        .AddEventHubStreams(StreamProviderName)
+                        .AddEventHubStreams(StreamProviderName, b=>b
                         .ConfigureEventHub(ob=>ob.Configure(options =>
                         {
                             options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
@@ -38,10 +38,10 @@ namespace ServiceBus.Tests.Streaming
                         {
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.PersistInterval = TimeSpan.FromSeconds(10);
-                        }));
+                        })));
 
                     hostBuilder
-                        .AddEventHubStreams(StreamProviderName2)
+                        .AddEventHubStreams(StreamProviderName2, b=>b
                         .ConfigureEventHub(ob => ob.Configure(options =>
                         {
                             options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
@@ -52,7 +52,7 @@ namespace ServiceBus.Tests.Streaming
                         .UseEventHubCheckpointer(ob => ob.Configure(options => {
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.PersistInterval = TimeSpan.FromSeconds(10);
-                        }));
+                        })));
 
                     hostBuilder
                           .AddMemoryGrainStorage("PubSubStore");

--- a/test/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -42,8 +42,8 @@ namespace ServiceBus.Tests.StreamingTests
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                        .AddPersistentStreams(StreamProviderName, StreamPerPartitionEventHubStreamAdapterFactory.Create)
-                        .Configure<EventHubOptions>(ob => ob.Configure(options =>
+                        .AddPersistentStreams(StreamProviderName, StreamPerPartitionEventHubStreamAdapterFactory.Create, b=>
+                        b.Configure<EventHubOptions>(ob => ob.Configure(options =>
                           {
                               options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
                               options.ConsumerGroup = EHConsumerGroup;
@@ -51,13 +51,12 @@ namespace ServiceBus.Tests.StreamingTests
                           }))
                         .UseStaticClusterConfigDeploymentBalancer()
                         .ConfigureComponent<AzureTableStreamCheckpointerOptions, IStreamQueueCheckpointerFactory>(EventHubCheckpointerFactory.CreateFactory,
-                        ob => ob.Configure(
-                        options =>
-                        {
-
+                            ob => ob.Configure(
+                            options =>
+                            {
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.PersistInterval = TimeSpan.FromSeconds(1);
-                        }));
+                        })));
 
                     hostBuilder
                         .AddMemoryGrainStorage("PubSubStore");
@@ -69,14 +68,14 @@ namespace ServiceBus.Tests.StreamingTests
                 public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
                 {
                     clientBuilder
-                        .AddPersistentStreams(StreamProviderName, StreamPerPartitionEventHubStreamAdapterFactory.Create)
-                        .Configure<EventHubOptions>(ob=>ob.Configure(
-                        options =>
-                        {
-                            options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
-                            options.ConsumerGroup = EHConsumerGroup;
-                            options.Path = EHPath;
-                        }));
+                        .AddPersistentStreams(StreamProviderName, StreamPerPartitionEventHubStreamAdapterFactory.Create, b=>
+                            b.Configure<EventHubOptions>(ob=>ob.Configure(
+                            options =>
+                            {
+                                options.ConnectionString = TestDefaultConfiguration.EventHubConnectionString;
+                                options.ConsumerGroup = EHConsumerGroup;
+                                options.Path = EHPath;
+                            })));
                 }
             }
         }

--- a/test/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -47,7 +47,7 @@ namespace ServiceBus.Tests.StreamingTests
                     {
                         options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                     })
-                    .AddEventHubStreams(StreamProviderName)
+                    .AddEventHubStreams(StreamProviderName, b=>b
                     .ConfigureEventHub(ob=>ob.Configure(
                     options =>
                     {
@@ -61,7 +61,7 @@ namespace ServiceBus.Tests.StreamingTests
                         options.PersistInterval = TimeSpan.FromSeconds(1);
                     }))
                     .UseDynamicClusterConfigDeploymentBalancer()
-                    .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly);
+                    .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly));
             }
         }
 
@@ -70,7 +70,7 @@ namespace ServiceBus.Tests.StreamingTests
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
-                    .AddEventHubStreams(StreamProviderName)
+                    .AddEventHubStreams(StreamProviderName, b=>b
                     .ConfigureEventHub(ob => ob.Configure(
                     options =>
                     {
@@ -78,7 +78,7 @@ namespace ServiceBus.Tests.StreamingTests
                         options.ConsumerGroup = EHConsumerGroup;
                         options.Path = EHPath;
                     }))
-                    .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly);
+                    .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly));
             }
         }
 

--- a/test/ServiceBus.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
+++ b/test/ServiceBus.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
@@ -40,7 +40,7 @@ namespace ServiceBus.Tests.StreamingTests
                 {
                     hostBuilder
                         .AddMemoryGrainStorage("PubSubStore")
-                        .AddEventHubStreams(StreamProviderName)
+                        .AddEventHubStreams(StreamProviderName, b=>b
                         .ConfigureEventHub(ob => ob.Configure(
                         options =>
                         {
@@ -54,7 +54,7 @@ namespace ServiceBus.Tests.StreamingTests
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                             options.PersistInterval = TimeSpan.FromSeconds(1);
                         }))
-                        .UseDynamicClusterConfigDeploymentBalancer();
+                        .UseDynamicClusterConfigDeploymentBalancer());
                 }
             }
         }

--- a/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -41,10 +41,10 @@ namespace UnitTests.StreamingTests
                 {
                     hostBuilder
                         .AddPersistentStreams(StreamProviderName,
-                            GeneratorAdapterFactory.Create)
+                            GeneratorAdapterFactory.Create, b => b
                         .Configure<HashRingStreamQueueMapperOptions>(ob=>ob.Configure(options=>options.TotalQueueCount = TotalQueueCount))
                         .UseDynamicClusterConfigDeploymentBalancer()
-                        .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly);
+                        .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly));
                 }
             }
         }

--- a/test/Tester/StreamingTests/ControllableStreamProviderTests.cs
+++ b/test/Tester/StreamingTests/ControllableStreamProviderTests.cs
@@ -32,9 +32,9 @@ namespace UnitTests.StreamingTests
                 {
                     hostBuilder
                         .AddPersistentStreams(StreamProviderName,
-                            ControllableTestAdapterFactory.Create)
+                            ControllableTestAdapterFactory.Create, b=>b
                          .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly)
-                         .UseDynamicClusterConfigDeploymentBalancer();
+                         .UseDynamicClusterConfigDeploymentBalancer());
                 }
             }
         }

--- a/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/test/Tester/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -41,13 +41,13 @@ namespace UnitTests.StreamingTests
                          .AddMemoryGrainStorageAsDefault()
                         .AddMemoryGrainStorage("MemoryStore")
                         .AddPersistentStreams(StreamProviderName,
-                            GeneratorAdapterFactory.Create)
-                        .Configure<HashRingStreamQueueMapperOptions>(ob=>ob.Configure(options =>
-                            {
-                                options.TotalQueueCount = TotalQueueCount;
-                            }))
-                        .UseDynamicClusterConfigDeploymentBalancer()
-                        .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly);
+                            GeneratorAdapterFactory.Create, b=>
+                            b.Configure<HashRingStreamQueueMapperOptions>(ob=>ob.Configure(options =>
+                                {
+                                    options.TotalQueueCount = TotalQueueCount;
+                                }))
+                            .UseDynamicClusterConfigDeploymentBalancer()
+                            .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly));
                 }
             }
         }

--- a/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
+++ b/test/Tester/StreamingTests/MemoryStreamProviderClientTests.cs
@@ -36,15 +36,15 @@ namespace Tester.StreamingTests
             private class MyClientBuilderConfigurator : IClientBuilderConfigurator
             {
                 public void Configure(IConfiguration configuration, IClientBuilder clientBuilder) => clientBuilder
-                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName)
-                    .ConfigurePartitioning(partitionCount);
+                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
+                    .ConfigurePartitioning(partitionCount));
             }
 
             private class MySiloBuilderConfigurator : ISiloBuilderConfigurator
             {
                 public void Configure(ISiloHostBuilder hostBuilder)=> hostBuilder.AddMemoryGrainStorage("PubSubStore")
-                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName)
-                    .ConfigurePartitioning(partitionCount);
+                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
+                    .ConfigurePartitioning(partitionCount));
             }
 
             private static void AdjustConfig(ClusterConfiguration config)

--- a/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
+++ b/test/Tester/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
@@ -37,9 +37,9 @@ namespace Tester.StreamingTests.PlugableQueueBalancerTests
                 {
                     hostBuilder
                         .AddMemoryGrainStorage("PubSubStore")
-                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName)
+                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
                         .ConfigurePartitioning(totalQueueCount)
-                        .ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n));
+                        .ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n)));
                         
                 }
             }

--- a/test/Tester/StreamingTests/PullingAgentManagementTests.cs
+++ b/test/Tester/StreamingTests/PullingAgentManagementTests.cs
@@ -31,11 +31,11 @@ namespace UnitTests.StreamingTests
                 public void Configure(ISiloHostBuilder hostBuilder)
                 {
                     hostBuilder
-                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME)
-                    .ConfigureAzureQueue(ob => ob.Configure(options =>
-                       {
-                           options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                       }));
+                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME, b=>
+                        b.ConfigureAzureQueue(ob => ob.Configure(options =>
+                           {
+                               options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                           })));
 
                     hostBuilder.AddMemoryGrainStorage("PubSubStore");
                 }

--- a/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Tester/StreamingTests/StreamGeneratorProviderTests.cs
@@ -43,10 +43,10 @@ namespace UnitTests.StreamingTests
                 {
                     hostBuilder
                         .ConfigureServices(services => services.AddSingletonNamedService<IStreamGeneratorConfig>(StreamProviderName, (s, n) => GeneratorConfig))
-                        .AddPersistentStreams(StreamProviderName, GeneratorAdapterFactory.Create)
-                        .Configure<HashRingStreamQueueMapperOptions>(ob=>ob.Configure(options => options.TotalQueueCount = TotalQueueCount))
-                        .UseDynamicClusterConfigDeploymentBalancer()
-                        .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly);
+                        .AddPersistentStreams(StreamProviderName, GeneratorAdapterFactory.Create, b=>
+                            b.Configure<HashRingStreamQueueMapperOptions>(ob=>ob.Configure(options => options.TotalQueueCount = TotalQueueCount))
+                            .UseDynamicClusterConfigDeploymentBalancer()
+                            .ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly));
                 }
             }
         }

--- a/test/Tester/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Tester/StreamingTests/SystemTargetRouteTests.cs
@@ -37,16 +37,16 @@ namespace Tester.StreamingTests
             private class MyClientBuilderConfigurator : IClientBuilderConfigurator
             {
                 public void Configure(IConfiguration configuration, IClientBuilder clientBuilder) => clientBuilder
-                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName)
-                    .ConfigurePartitioning(partitionCount);
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
+                    .ConfigurePartitioning(partitionCount));
             }
 
             private class MySiloBuilderConfigurator : ISiloBuilderConfigurator
             {
                 public void Configure(ISiloHostBuilder hostBuilder) => hostBuilder
                     .AddMemoryGrainStorage("PubSubStore")
-                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName)
-                    .ConfigurePartitioning(partitionCount);
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
+                    .ConfigurePartitioning(partitionCount));
             }
         }
 

--- a/test/TesterAzureUtils/Lease/LeaseBasedQueueBalancerTests.cs
+++ b/test/TesterAzureUtils/Lease/LeaseBasedQueueBalancerTests.cs
@@ -61,9 +61,9 @@ namespace Tester.AzureUtils.Lease
             {
                 hostBuilder
                     .ConfigureServices(ConfigureServices)
-                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName)
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
                     .ConfigurePartitioning(totalQueueCount)
-                    .UseClusterConfigDeploymentLeaseBasedBalancer();
+                    .UseClusterConfigDeploymentLeaseBasedBalancer());
 
                 hostBuilder
                     .AddMemoryGrainStorage("PubSubStore");

--- a/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
+++ b/test/TesterAzureUtils/Streaming/AQStreamingTests.cs
@@ -36,13 +36,13 @@ namespace Tester.AzureUtils.Streaming
             {
                 clientBuilder
                     .AddSimpleMessageStreamProvider(SmsStreamProviderName)
-                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName)
-                    .ConfigureAzureQueue(ob=>ob.Configure(
+                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName, b=>
+                    b.ConfigureAzureQueue(ob=>ob.Configure(
                         options =>
                         {
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
-                    .ConfigurePartitioning(partitionCount);
+                    .ConfigurePartitioning(partitionCount));
             }
         }
 
@@ -63,13 +63,13 @@ namespace Tester.AzureUtils.Streaming
                             options.DeleteStateOnClear = true;
                         }))
                     .AddMemoryGrainStorage("MemoryStore")
-                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName)
-                    .ConfigureAzureQueue(ob => ob.Configure(
-                        options =>
-                        {
-                            options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                        }))
-                    .ConfigurePartitioning(partitionCount);
+                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName, c=>
+                        c.ConfigureAzureQueue(ob => ob.Configure(
+                            options =>
+                            {
+                                options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+                            }))
+                        .ConfigurePartitioning(partitionCount));
             }
         }
 

--- a/test/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/TesterAzureUtils/Streaming/DelayedQueueRebalancingTests.cs
@@ -44,13 +44,13 @@ namespace Tester.AzureUtils.Streaming
             public void Configure(ISiloHostBuilder hostBuilder)
             {
                 hostBuilder
-                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(adapterName)
+                    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(adapterName, b=>b
                     .ConfigureAzureQueue(ob => ob.Configure(
                         options =>
                         {
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
-                        .UseDynamicClusterConfigDeploymentBalancer(SILO_IMMATURE_PERIOD);
+                        .UseDynamicClusterConfigDeploymentBalancer(SILO_IMMATURE_PERIOD));
 
                 hostBuilder.AddMemoryGrainStorage("PubSubStore");
             }

--- a/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/TesterAzureUtils/Streaming/HaloStreamSubscribeTests.cs
@@ -52,19 +52,19 @@ namespace UnitTests.HaloTests.Streaming
                             options.DeleteStateOnClear = true;
                             options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
                         }))
-                        .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName)
+                        .AddAzureQueueStreams<AzureQueueDataAdapterV2>(AzureQueueStreamProviderName, b=>b
                         .ConfigureAzureQueue(ob => ob.Configure(
                             options =>
                             {
                                 options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                            }));
+                            })));
                     hostBuilder
-                        .AddAzureQueueStreams<AzureQueueDataAdapterV2>("AzureQueueProvider2")
+                        .AddAzureQueueStreams<AzureQueueDataAdapterV2>("AzureQueueProvider2", b=>b
                         .ConfigureAzureQueue(ob => ob.Configure(
                             options =>
                             {
                                 options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
-                            }));
+                            })));
                 }
             }
 


### PR DESCRIPTION
Remove ISiloHostBuilder and IClientBuilder extensions methods which returns a stream sub builder, instead of a ISiloHostbuilder or IClientBuilder. To keep consistency hence reduce confusion. 