### PR TITLE
Second pass at options overrides

### DIFF
--- a/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Streams/SQSAdapterFactory.cs
@@ -8,6 +8,7 @@ using Orleans.Streams;
 using Orleans.Serialization;
 using Orleans.Configuration;
 using Orleans;
+using Orleans.Configuration.Overrides;
 
 namespace OrleansAWSUtils.Streams
 {
@@ -91,7 +92,8 @@ namespace OrleansAWSUtils.Streams
             var sqsOptions = services.GetOptionsByName<SqsOptions>(name);
             var cacheOptions = services.GetOptionsByName<SimpleQueueCacheOptions>(name);
             var queueMapperOptions = services.GetOptionsByName<HashRingStreamQueueMapperOptions>(name);
-            var factory = ActivatorUtilities.CreateInstance<SQSAdapterFactory>(services, name, sqsOptions, cacheOptions, queueMapperOptions);
+            IOptions<ClusterOptions> clusterOptions = services.GetProviderClusterOptions(name);
+            var factory = ActivatorUtilities.CreateInstance<SQSAdapterFactory>(services, name, sqsOptions, cacheOptions, queueMapperOptions, clusterOptions);
             factory.Init();
             return factory;
         }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Configuration.Overrides;
 
 namespace Orleans.Storage
 {
@@ -48,7 +49,8 @@ namespace Orleans.Storage
         public static IGrainStorage Create(IServiceProvider services, string name)
         {
             IOptionsSnapshot<AdoNetGrainStorageOptions> optionsSnapshot = services.GetRequiredService<IOptionsSnapshot<AdoNetGrainStorageOptions>>();
-            return ActivatorUtilities.CreateInstance<AdoNetGrainStorage>(services, Options.Create(optionsSnapshot.Get(name)), name);
+            IOptions<ClusterOptions> clusterOptions = services.GetProviderClusterOptions(name);
+            return ActivatorUtilities.CreateInstance<AdoNetGrainStorage>(services, Options.Create(optionsSnapshot.Get(name)), name, clusterOptions);
         }
     }
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -19,6 +19,7 @@ using Orleans.Runtime.Configuration;
 using Orleans.Serialization;
 using Orleans.Providers.Azure;
 using Orleans.Persistence.AzureStorage;
+using Orleans.Configuration.Overrides;
 
 namespace Orleans.Storage
 {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterFactory.cs
@@ -7,6 +7,7 @@ using Orleans.Serialization;
 using Orleans.Streams;
 using Orleans.Providers.Streams.Common;
 using Orleans.Configuration;
+using Orleans.Configuration.Overrides;
 
 namespace Orleans.Providers.Streams.AzureQueue
 {
@@ -101,7 +102,8 @@ namespace Orleans.Providers.Streams.AzureQueue
             var azureQueueOptions = services.GetOptionsByName<AzureQueueOptions>(name);
             var queueMapperOptions = services.GetOptionsByName<HashRingStreamQueueMapperOptions>(name);
             var cacheOptions = services.GetOptionsByName<SimpleQueueCacheOptions>(name);
-            var factory = ActivatorUtilities.CreateInstance<AzureQueueAdapterFactory<TDataAdapter>>(services, name, azureQueueOptions, queueMapperOptions, cacheOptions);
+            IOptions<ClusterOptions> clusterOptions = services.GetProviderClusterOptions(name);
+            var factory = ActivatorUtilities.CreateInstance<AzureQueueAdapterFactory<TDataAdapter>>(services, name, azureQueueOptions, queueMapperOptions, cacheOptions, clusterOptions);
             factory.Init();
             return factory;
         }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -6,6 +6,7 @@ using Orleans.Streaming.EventHubs;
 using Orleans.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Orleans.Configuration.Overrides;
 
 namespace Orleans.ServiceBus.Providers
 {
@@ -32,7 +33,8 @@ namespace Orleans.ServiceBus.Providers
         public static IStreamQueueCheckpointerFactory CreateFactory(IServiceProvider services, string providerName)
         {
             var options = services.GetOptionsByName<AzureTableStreamCheckpointerOptions>(providerName);
-            return ActivatorUtilities.CreateInstance<EventHubCheckpointerFactory>(services, providerName, options);
+            IOptions<ClusterOptions> clusterOptions = services.GetProviderClusterOptions(providerName);
+            return ActivatorUtilities.CreateInstance<EventHubCheckpointerFactory>(services, providerName, options, clusterOptions);
         }
     }
 

--- a/src/Orleans.Core/Configuration/OptionsOverrides.cs
+++ b/src/Orleans.Core/Configuration/OptionsOverrides.cs
@@ -1,0 +1,52 @@
+﻿
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+
+namespace Orleans.Configuration.Overrides
+{
+    public static class OptionsOverrides
+    {
+        /// <summary>
+        /// Gets <see cref="ClusterOptions"/> which may have been overridden on a per-provider basis.
+        /// Note: This is intended for migration purposes as a means to handle previously inconsistent behaviors in how providers used ServiceId and ClusterId.
+        /// </summary>
+        public static IOptions<ClusterOptions> GetProviderClusterOptions(this IServiceProvider services, string providerName) => services.GetOverridableOption<ClusterOptions>(providerName);
+
+        /// <summary>
+        /// Add an override <see cref="ClusterOptions"/> on a per-provider basis.
+        /// Note: This is intended for migration purposes as a means to handle previously inconsistent behaviors in how providers used ServiceId and ClusterId.
+        /// </summary>
+        public static IClientBuilder AddProviderClusterOptions(this IClientBuilder builder, string providerName, Action<OptionsBuilder<ClusterOptions>> configureOptions) => builder.ConfigureServices(services => services.AddOptionsOverride<ClusterOptions>(providerName, configureOptions));
+
+        /// <summary>
+        /// Add an override <see cref="ClusterOptions"/> on a per-provider basis.
+        /// Note: This is intended for migration purposes as a means to handle previously inconsistent behaviors in how providers used ServiceId and ClusterId.
+        /// </summary>
+        public static IClientBuilder AddProviderClusterOptions(this IClientBuilder builder, string providerName, Action<ClusterOptions> configureOptions) => builder.ConfigureServices(services => services.AddOptionsOverride<ClusterOptions>(providerName, ob => ob.Configure(configureOptions)));
+
+        /// <summary>
+        /// Gets option that can be overriden by named service.
+        /// </summary>
+        private static IOptions<TOptions> GetOverridableOption<TOptions>(this IServiceProvider services, string key)
+            where TOptions : class, new()
+        {
+            TOptions option = services.GetServiceByName<TOptions>(key);
+            return option != null
+                ? Options.Create(option)
+                : services.GetRequiredService<IOptions<TOptions>>();
+        }
+
+        /// <summary>
+        /// Add an override for an option via a named service.
+        /// </summary>
+        internal static IServiceCollection AddOptionsOverride<TOptions>(this IServiceCollection collection, string name, Action<OptionsBuilder<TOptions>> configureOptions)
+            where TOptions : class, new()
+        {
+            configureOptions?.Invoke(collection.AddOptions<TOptions>(name));
+            return collection.ConfigureNamedOptionForLogging<TOptions>(name)
+                             .AddSingletonNamedService(name, (sp, n) => sp.GetRequiredService<IOptionsSnapshot<TOptions>>().Get(n));
+        }
+    }
+}

--- a/src/Orleans.Core/Utils/KeyedService.cs
+++ b/src/Orleans.Core/Utils/KeyedService.cs
@@ -86,25 +86,6 @@ namespace Orleans.Runtime
 
     public static class KeyedServiceExtensions
     {
-
-        /// <summary>
-        /// Gets <see cref="ClusterOptions"/> which may have been overridden on a per-provider basis.
-        /// Note: This is intended for migration purposes as a means to handle previously inconsistent behaviors in how providers used ServiceId and ClusterId.
-        /// </summary>
-        public static IOptions<ClusterOptions> GetProviderClusterOptions(this IServiceProvider services, string key) => services.GetOverridableOption<ClusterOptions>(key);
-
-        /// <summary>
-        /// Gets option that can be overriden by named service.
-        /// </summary>
-        private static IOptions<TOptions> GetOverridableOption<TOptions>(this IServiceProvider services, string key)
-            where TOptions : class, new()
-        {
-            TOptions option = services.GetServiceByName<TOptions>(key);
-            return option != null
-                ? Options.Create(option)
-                : services.GetRequiredService<IOptions<TOptions>>();
-        }
-
         /// <summary>
         /// Register a transient keyed service
         /// </summary>

--- a/src/Orleans.Runtime/Configuration/Overrides/SiloOptionsOverrides.cs
+++ b/src/Orleans.Runtime/Configuration/Overrides/SiloOptionsOverrides.cs
@@ -1,0 +1,24 @@
+﻿
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Hosting;
+using Orleans.Runtime;
+
+namespace Orleans.Configuration.Overrides
+{
+    public static class SiloOptionsOverrides
+    {
+        /// <summary>
+        /// Add an override <see cref="ClusterOptions"/> on a per-provider basis.
+        /// Note: This is intended for migration purposes as a means to handle previously inconsistent behaviors in how providers used ServiceId and ClusterId.
+        /// </summary>
+        public static ISiloHostBuilder AddProviderClusterOptions(this ISiloHostBuilder builder, string providerName, Action<OptionsBuilder<ClusterOptions>> configureOptions) => builder.ConfigureServices(services => services.AddOptionsOverride<ClusterOptions>(providerName, configureOptions));
+
+        /// <summary>
+        /// Add an override <see cref="ClusterOptions"/> on a per-provider basis.
+        /// Note: This is intended for migration purposes as a means to handle previously inconsistent behaviors in how providers used ServiceId and ClusterId.
+        /// </summary>
+        public static ISiloHostBuilder AddProviderClusterOptions(this ISiloHostBuilder builder, string providerName, Action<ClusterOptions> configureOptions) => builder.ConfigureServices(services => services.AddOptionsOverride<ClusterOptions>(providerName, ob => ob.Configure(configureOptions)));
+    }
+}

--- a/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
+++ b/src/Orleans.Streaming.GCP/Providers/Streams/PubSub/PubSubAdapterFactory.cs
@@ -7,6 +7,7 @@ using Orleans.Providers.Streams.Common;
 using Orleans.Serialization;
 using Orleans.Streams;
 using Orleans.Configuration;
+using Orleans.Configuration.Overrides;
 
 namespace Orleans.Providers.GCP.Streams.PubSub
 {
@@ -79,7 +80,8 @@ namespace Orleans.Providers.GCP.Streams.PubSub
             var pubsubOptions = services.GetOptionsByName<PubSubOptions>(name);
             var cacheOptions = services.GetOptionsByName<SimpleQueueCacheOptions>(name);
             var queueMapperOptions = services.GetOptionsByName<HashRingStreamQueueMapperOptions>(name);
-            var factory = ActivatorUtilities.CreateInstance<PubSubAdapterFactory<TDataAdapter>>(services, name, pubsubOptions, queueMapperOptions, cacheOptions);
+            IOptions<ClusterOptions> clusterOptions = services.GetProviderClusterOptions(name);
+            var factory = ActivatorUtilities.CreateInstance<PubSubAdapterFactory<TDataAdapter>>(services, name, pubsubOptions, queueMapperOptions, cacheOptions, clusterOptions);
             factory.Init();
             return factory;
         }


### PR DESCRIPTION
- Added registration functions that use named options and register the options for logging
- Updated named components that use cluster options to support the overrides.

Unclear what to do about unnamed components that use cluster options.  At this time they are not being overridden.  Maybe we can use the component name, or abstraction name?  (IReminderTable?, for instance).  What to do with unnamed components is for discussion and planning possible additional pass, should not block this PR.