### PR TITLE
Add Dns name look up clustering for container frameworks

### DIFF
--- a/src/Orleans.Core/Configuration/Options/DnsNameGatewayListProviderOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/DnsNameGatewayListProviderOptions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace Orleans.Configuration
+{
+    /// <summary>
+    /// Options for Configure DnsNameGatewayListProviderOptions
+    /// </summary>
+    public class DnsNameGatewayListProviderOptions
+    {
+        /// <summary>
+        /// Dns name to use
+        /// </summary>
+        public string DnsName { get; set; }
+
+        /// <summary>
+        /// Port to use
+        /// </summary>
+        public int Port { get; set; }
+    }
+}

--- a/src/Orleans.Core/Configuration/Validators/DnsNameGatewayListProviderValidator.cs
+++ b/src/Orleans.Core/Configuration/Validators/DnsNameGatewayListProviderValidator.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace Orleans.Configuration.Validators
+{
+    /// <summary>
+    /// Validates the configuration of the DnsNameGatewayListProvider component
+    /// </summary>
+    internal class DnsNameGatewayListProviderValidator : IConfigurationValidator
+    {
+        private DnsNameGatewayListProviderOptions options;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="options"></param>
+        public DnsNameGatewayListProviderValidator(IOptions<DnsNameGatewayListProviderOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        /// <summary>
+        /// Validation function
+        /// </summary>
+        public void ValidateConfiguration()
+        {
+            if (string.IsNullOrWhiteSpace(this.options.DnsName))
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(DnsNameGatewayListProviderOptions)} value for {nameof(options.DnsName)}.  Resolvable DNS name is required.");
+            }
+
+            if (this.options.Port <= 0)
+            {
+                throw new OrleansConfigurationException($"Invalid {nameof(DnsNameGatewayListProviderOptions)} value for {nameof(options.Port)} must be greater than zero.");
+            }
+        }
+
+    }
+}

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Orleans.ApplicationParts;
 using Orleans.CodeGeneration;
 using Orleans.Messaging;
 using Orleans.Runtime;
+using Orleans.Configuration.Validators;
 
 namespace Orleans
 {
@@ -230,7 +231,7 @@ namespace Orleans
                 {
                     configureOptions?.Invoke(collection.AddOptions<StaticGatewayListProviderOptions>());
                     collection.AddSingleton<IGatewayListProvider, StaticGatewayListProvider>()
-                        .ConfigureFormatter<StaticGatewayListProviderOptions>();
+                              .ConfigureFormatter<StaticGatewayListProviderOptions>();
                 });
         }
 
@@ -263,7 +264,9 @@ namespace Orleans
                     }
 
                     collection.AddSingleton<IGatewayListProvider, DnsNameGatewayListProvider>()
-                        .ConfigureFormatter<DnsNameGatewayListProviderOptions>();
+                              .ConfigureFormatter<DnsNameGatewayListProviderOptions>();
+
+                    collection.AddSingleton<IConfigurationValidator, DnsNameGatewayListProviderValidator>();
                 });
         }
 
@@ -277,7 +280,9 @@ namespace Orleans
                 {
                     configureOptions?.Invoke(collection.AddOptions<DnsNameGatewayListProviderOptions>());
                     collection.AddSingleton<IGatewayListProvider, DnsNameGatewayListProvider>()
-                        .ConfigureFormatter<DnsNameGatewayListProviderOptions>();
+                              .ConfigureFormatter<DnsNameGatewayListProviderOptions>();
+
+                    collection.AddSingleton<IConfigurationValidator, DnsNameGatewayListProviderValidator>();
                 });
         }
 

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -235,6 +235,53 @@ namespace Orleans
         }
 
         /// <summary>
+        /// Configures the client to use dns name lookup clustering.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="dnsName">The gateway destination dns name.</param>
+        /// <param name="port">The gateway port.</param>
+        public static IClientBuilder UseDnsNameLookupClustering(this IClientBuilder builder, string dnsName, int port)
+        {
+            return builder.UseDnsNameLookupClustering(options =>
+            {
+                options.DnsName = dnsName;
+                options.Port = port;
+            });
+        }
+
+        /// <summary>
+        /// Configures the client to use dns name lookup clustering.
+        /// </summary>
+        public static IClientBuilder UseDnsNameLookupClustering(this IClientBuilder builder, Action<DnsNameGatewayListProviderOptions> configureOptions)
+        {
+            return builder.ConfigureServices(
+                collection =>
+                {
+                    if (configureOptions != null)
+                    {
+                        collection.Configure(configureOptions);
+                    }
+
+                    collection.AddSingleton<IGatewayListProvider, DnsNameGatewayListProvider>()
+                        .ConfigureFormatter<DnsNameGatewayListProviderOptions>();
+                });
+        }
+
+        /// <summary>
+        /// Configures the client to use dns name lookup clustering.
+        /// </summary>
+        public static IClientBuilder UseDnsNameLookupClustering(this IClientBuilder builder, Action<OptionsBuilder<DnsNameGatewayListProviderOptions>> configureOptions)
+        {
+            return builder.ConfigureServices(
+                collection =>
+                {
+                    configureOptions?.Invoke(collection.AddOptions<DnsNameGatewayListProviderOptions>());
+                    collection.AddSingleton<IGatewayListProvider, DnsNameGatewayListProvider>()
+                        .ConfigureFormatter<DnsNameGatewayListProviderOptions>();
+                });
+        }
+
+        /// <summary>
         /// Returns the <see cref="ApplicationPartManager"/> for this builder.
         /// </summary>
         /// <param name="builder">The builder.</param>

--- a/src/Orleans.Core/Messaging/DnsNameGatewayListProvider.cs
+++ b/src/Orleans.Core/Messaging/DnsNameGatewayListProvider.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime;
+
+namespace Orleans.Messaging
+{
+    /// <summary>
+    /// This Gateway list provider looks up ip addresses based on a dns
+    /// name.  This is ideal for container environments (kubernetes, swarm)
+    /// as well as Service Fabric using the dns feature.
+    /// </summary>
+    public class DnsNameGatewayListProvider : IGatewayListProvider
+    {
+        private readonly DnsNameGatewayListProviderOptions options;
+        private readonly TimeSpan maxStaleness;
+
+        public DnsNameGatewayListProvider(IOptions<DnsNameGatewayListProviderOptions> options, IOptions<GatewayOptions> gatewayOptions)
+        {
+            this.options = options.Value;
+            this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
+        }
+
+        #region Implementation of IGatewayListProvider
+
+        public Task InitializeGatewayListProvider() => Task.CompletedTask;
+
+
+        public Task<IList<Uri>> GetGateways()
+        {
+            var endpointUris = Dns.GetHostEntry(this.options.DnsName)
+                                            .AddressList
+                                            .Select(a => new IPEndPoint(a, this.options.Port).ToGatewayUri())
+                                            .ToList();
+
+            return Task.FromResult<IList<Uri>>(endpointUris);
+        }
+
+        public TimeSpan MaxStaleness
+        {
+            get => this.maxStaleness;
+        }
+
+        public bool IsUpdatable
+        {
+            get => true;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Docker/Kubernetes can communicate with other containers using DNS name lookup.  When the silo containers are scaled and there are multiple instances, we can use Dns.GetHostEntry to look up the multiple addresses and pass it to UseStaticClustering().

The problem is that this list is static so as I scale up and down, or as containers shutdown and restart, the client only has a static list of gateways.  We should do a continuous DNS resolution so the client will have the most recent list of IPs.
```
builder.UseDnsNameLookupClustering("mysilocontainer", 40000);
```
I had created a web UI Orleans client in a container and the silo in another container.  After scaling the silo container up and down and failing out some of the original containers, the client could no longer connect with the silo because it has a stale IP list.