### PR TITLE
New link in docs to a contribution

### DIFF
--- a/src/Community/Links.md
+++ b/src/Community/Links.md
@@ -18,6 +18,8 @@ title: Links
 [Orleans: Distributed Virtual Actors for Programmability and Scalability](http://research.microsoft.com/pubs/210931/Orleans-MSR-TR-2014-41.pdf)
 
 ## By others
+[Microsoft Orleans v2.0 - A comprehensive guide for beginners and experts alike (PowerPoint)](https://github.com/lmagyar/Presentations/#microsoft-orleans-v20)
+
 [Microsoft Orleans & IoT : Software Actors living on Cloud as avatars for physical devices living in real world](http://www.tinyclr.it/microsoft-orleans-iot--software-actors-living-on-cloud-as-avatars-for-physical-devices-living-in-real-world.aspx)
 
 [Project Orleans: Different Than Erlang, Designed for a Broad Group of Developers](http://thenewstack.io/project-orleans-different-than-erlang-designed-for-a-broad-group-of-developers/)


### PR DESCRIPTION
I've updated my ~150 slide promo infodeck (a combined
presentation/cheatsheet/tutorial) for v2.0. Though some chapters are not
finished (DI, config, ...), the others are quite accurate and detailed.