### PR TITLE
Do not add "-dev" version suffix to Release build if suffix isn't set.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -106,7 +106,6 @@
   <!-- Versioning properties -->
   <PropertyGroup>
     <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.0.0</VersionPrefix>
-    <VersionSuffix Condition=" '$(VersionSuffix)'=='' ">dev</VersionSuffix>
   </PropertyGroup>
 
   <!-- For Debug builds generated a date/time dependent version suffix -->


### PR DESCRIPTION
Without this fix, final builds of 2.0.0 are marked as "2.0.0-dev".