### PR TITLE
Stop packaging Microsoft.Orleans.OrleansGCPUtils

### DIFF
--- a/src/Orleans.Streaming.GCP/Orleans.Streaming.GCP.csproj
+++ b/src/Orleans.Streaming.GCP/Orleans.Streaming.GCP.csproj
@@ -10,6 +10,11 @@
     <AssemblyName>Orleans.Streaming.GCP</AssemblyName>
     <RootNamespace>Orleans.Providers.GCP</RootNamespace>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- Cannot release a stable version of this package that depends on a prerelease version of Google.Cloud.PubSub.V1. -->
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="$(GoogleCloudPubSubV1Version)" />

--- a/src/Orleans.Streaming.GCP/Orleans.Streaming.GCP.csproj
+++ b/src/Orleans.Streaming.GCP/Orleans.Streaming.GCP.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Microsoft.Orleans.OrleansGCPUtils</PackageId>
-    <Title>Microsoft Orleans Google Cloud Platform Utilities</Title>
-    <Description>Library of utility types for Google Cloud Platform of Microsoft Orleans.</Description>
+    <PackageId>Orleans.Streaming.GCP</PackageId>
+    <Title>Microsoft Orleans stream provider for Google Cloud Platform</Title>
+    <Description>Microsoft Orleans stream provider for Google Cloud Platform PubSub.</Description>
     <PackageTags>$(PackageTags)</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
Stop packaging Microsoft.Orleans.OrleansGCPUtils because it depends on a pre-released version of Google.Cloud.PubSub.V1.
Also rename the package to the proper name.