### PR TITLE
Test clustering: minor fixups

### DIFF
--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -101,6 +101,7 @@ namespace Orleans.Hosting
                         services.Configure(configureOptions);
                     }
 
+                    services.ConfigureFormatter<DevelopmentClusterMembershipOptions>();
                     services
                         .AddSingleton<GrainBasedMembershipTable>()
                         .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();
@@ -119,6 +120,7 @@ namespace Orleans.Hosting
                 services =>
                 {
                     configureOptions?.Invoke(services.AddOptions<DevelopmentClusterMembershipOptions>());
+                    services.ConfigureFormatter<DevelopmentClusterMembershipOptions>();
                     services
                         .AddSingleton<GrainBasedMembershipTable>()
                         .AddFromExisting<IMembershipTable, GrainBasedMembershipTable>();

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -46,6 +46,10 @@ namespace Orleans.TestingHost
             var hostBuilder = new SiloHostBuilder()
                 .Configure<ClusterOptions>(configuration)
                 .Configure<SiloOptions>(options => options.SiloName = siloName)
+                .Configure<ClusterMembershipOptions>(options =>
+                {
+                    options.ExpectedClusterSize = int.Parse(configuration["InitialSilosCount"]);
+                })
                 .ConfigureHostConfiguration(cb =>
                 {
                     // TODO: Instead of passing the sources individually, just chain the pre-built configuration once we upgrade to Microsoft.Extensions.Configuration 2.1


### PR DESCRIPTION
1. Log `DevelopmentClusterMembershipOptions` when using dev clustering
2. Set `ExpectedClusterSize` from `TestClusterOptions.InitialSilosCount`