### PR TITLE
TestCluster: wait for cluster stabilization before starting tests

### DIFF
--- a/src/Orleans.Runtime/Silo/TestHooks/ITestHooksSystemTarget.cs
+++ b/src/Orleans.Runtime/Silo/TestHooks/ITestHooksSystemTarget.cs
@@ -16,6 +16,7 @@ namespace Orleans.Runtime.TestHooks
         Task<bool> HasStreamProvider(string providerName);
         Task<int> UnregisterGrainForTesting(GrainId grain);
         Task LatchIsOverloaded(bool overloaded, TimeSpan latchPeriod);
+        Task<Dictionary<SiloAddress, SiloStatus>> GetApproximateSiloStatuses();
     }
 
     internal interface ITestHooksSystemTarget : ITestHooks, ISystemTarget

--- a/src/Orleans.Runtime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/Orleans.Runtime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -35,6 +35,7 @@ namespace Orleans.Runtime.TestHooks
     internal class TestHooksSystemTarget : SystemTarget, ITestHooksSystemTarget
     {
         private readonly ISiloHost host;
+        private readonly IMembershipOracle clusteringOracle;
 
         private readonly TestHooksHostEnvironmentStatistics hostEnvironmentStatistics;
 
@@ -46,11 +47,13 @@ namespace Orleans.Runtime.TestHooks
             ISiloHost host,
             ILocalSiloDetails siloDetails,
             ILoggerFactory loggerFactory,
+            IMembershipOracle clusteringOracle,
             TestHooksHostEnvironmentStatistics hostEnvironmentStatistics,
             IOptions<LoadSheddingOptions> loadSheddingOptions)
             : base(Constants.TestHooksSystemTargetId, siloDetails.SiloAddress, loggerFactory)
         {
             this.host = host;
+            this.clusteringOracle = clusteringOracle;
             this.hostEnvironmentStatistics = hostEnvironmentStatistics;
             this.loadSheddingOptions = loadSheddingOptions.Value;
             this.consistentRingProvider = this.host.Services.GetRequiredService<IConsistentRingProvider>();
@@ -116,6 +119,8 @@ namespace Orleans.Runtime.TestHooks
 
             return Task.CompletedTask;
         }
+
+        public Task<Dictionary<SiloAddress, SiloStatus>> GetApproximateSiloStatuses() => Task.FromResult(this.clusteringOracle.GetApproximateSiloStatuses());
 
         private void LatchCpuUsage(float? cpuUsage, TimeSpan latchPeriod)
         {

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -140,39 +140,7 @@ namespace Orleans.TestingHost
                 WriteLog(startMsg);
                 await InitializeAsync();
 
-                // Poll each silo to check that it knows the expected number of active silos.
-                // If any silo does not have the expected number of active silos in its cluster membership oracle, try again.
-                // If the cluster membership has not stabilized after a certain period of time, give up and continue anyway.
-                var totalWait = Stopwatch.StartNew();
-                while (true)
-                {
-                    var silos = this.Silos;
-                    var expectedCount = silos.Count;
-                    var remainingSilos = expectedCount;
-
-                    foreach (var silo in silos)
-                    {
-                        var hooks = this.InternalClient.GetTestHooks(silo);
-                        var statuses = await hooks.GetApproximateSiloStatuses();
-                        var activeCount = statuses.Count(s => s.Value == SiloStatus.Active);
-                        if (activeCount != expectedCount) break;
-                        remainingSilos--;
-                    }
-
-                    if (remainingSilos == 0)
-                    {
-                        totalWait.Stop();
-                        break;
-                    }
-
-                    WriteLog($"{remainingSilos} silos do not have a consistent cluster view, waiting until stabilization.");
-                    await Task.Delay(TimeSpan.FromMilliseconds(100));
-
-                    if (totalWait.Elapsed < TimeSpan.FromSeconds(60))
-                    {
-                        WriteLog($"Warning! {remainingSilos} silos do not have a consistent cluster view after {totalWait.ElapsedMilliseconds}ms, continuing without stabilization.");
-                    }
-                }
+                await WaitForInitialStabilization();
             }
             catch (TimeoutException te)
             {
@@ -203,6 +171,43 @@ namespace Orleans.TestingHost
                 //    string.Format("Exception during test initialization: {0}",
                 //        LogFormatter.PrintException(baseExc)));
                 throw;
+            }
+        }
+
+        private async Task WaitForInitialStabilization()
+        {
+            // Poll each silo to check that it knows the expected number of active silos.
+            // If any silo does not have the expected number of active silos in its cluster membership oracle, try again.
+            // If the cluster membership has not stabilized after a certain period of time, give up and continue anyway.
+            var totalWait = Stopwatch.StartNew();
+            while (true)
+            {
+                var silos = this.Silos;
+                var expectedCount = silos.Count;
+                var remainingSilos = expectedCount;
+
+                foreach (var silo in silos)
+                {
+                    var hooks = this.InternalClient.GetTestHooks(silo);
+                    var statuses = await hooks.GetApproximateSiloStatuses();
+                    var activeCount = statuses.Count(s => s.Value == SiloStatus.Active);
+                    if (activeCount != expectedCount) break;
+                    remainingSilos--;
+                }
+
+                if (remainingSilos == 0)
+                {
+                    totalWait.Stop();
+                    break;
+                }
+
+                WriteLog($"{remainingSilos} silos do not have a consistent cluster view, waiting until stabilization.");
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                if (totalWait.Elapsed < TimeSpan.FromSeconds(60))
+                {
+                    WriteLog($"Warning! {remainingSilos} silos do not have a consistent cluster view after {totalWait.ElapsedMilliseconds}ms, continuing without stabilization.");
+                }
             }
         }
 

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -207,6 +207,7 @@ namespace Orleans.TestingHost
                 if (totalWait.Elapsed < TimeSpan.FromSeconds(60))
                 {
                     WriteLog($"Warning! {remainingSilos} silos do not have a consistent cluster view after {totalWait.ElapsedMilliseconds}ms, continuing without stabilization.");
+                    break;
                 }
             }
         }

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -138,6 +139,40 @@ namespace Orleans.TestingHost
                 string startMsg = "----------------------------- STARTING NEW UNIT TEST SILO HOST: " + GetType().FullName + " -------------------------------------";
                 WriteLog(startMsg);
                 await InitializeAsync();
+
+                // Poll each silo to check that it knows the expected number of active silos.
+                // If any silo does not have the expected number of active silos in its cluster membership oracle, try again.
+                // If the cluster membership has not stabilized after a certain period of time, give up and continue anyway.
+                var totalWait = Stopwatch.StartNew();
+                while (true)
+                {
+                    var silos = this.Silos;
+                    var expectedCount = silos.Count;
+                    var remainingSilos = expectedCount;
+
+                    foreach (var silo in silos)
+                    {
+                        var hooks = this.InternalClient.GetTestHooks(silo);
+                        var statuses = await hooks.GetApproximateSiloStatuses();
+                        var activeCount = statuses.Count(s => s.Value == SiloStatus.Active);
+                        if (activeCount != expectedCount) break;
+                        remainingSilos--;
+                    }
+
+                    if (remainingSilos == 0)
+                    {
+                        totalWait.Stop();
+                        break;
+                    }
+
+                    WriteLog($"{remainingSilos} silos do not have a consistent cluster view, waiting until stabilization.");
+                    await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                    if (totalWait.Elapsed < TimeSpan.FromSeconds(60))
+                    {
+                        WriteLog($"Warning! {remainingSilos} silos do not have a consistent cluster view after {totalWait.ElapsedMilliseconds}ms, continuing without stabilization.");
+                    }
+                }
             }
             catch (TimeoutException te)
             {

--- a/src/Orleans.TestingHost/TestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/TestClusterBuilder.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using Microsoft.Extensions.Configuration;
+using Orleans.Hosting;
+using Orleans.Runtime.TestHooks;
 using Orleans.TestingHost.Utils;
 
 namespace Orleans.TestingHost
@@ -41,6 +43,8 @@ namespace Orleans.TestingHost
                 AssumeHomogenousSilosForTesting = true
             };
 
+            this.AddClientBuilderConfigurator<AddTestHooksApplicationParts>();
+            this.AddSiloBuilderConfigurator<AddTestHooksApplicationParts>();
             this.ConfigureBuilder(ConfigureDefaultPorts);
         }
         
@@ -155,6 +159,19 @@ namespace Orleans.TestingHost
             }
 
             throw new InvalidOperationException("Cannot find enough free ports to spin up a cluster");
+        }
+
+        internal class AddTestHooksApplicationParts : IClientBuilderConfigurator, ISiloBuilderConfigurator
+        {
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+            {
+                clientBuilder.ConfigureApplicationParts(parts => parts.AddFrameworkPart(typeof(ITestHooksSystemTarget).Assembly));
+            }
+
+            public void Configure(ISiloHostBuilder hostBuilder)
+            {
+                hostBuilder.ConfigureApplicationParts(parts => parts.AddFrameworkPart(typeof(ITestHooksSystemTarget).Assembly));
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds a check in `TestCluster` to verify that each silo has observed the expected number of active silos