### PR TITLE
Remove reference to Orleans.Clustering.ServiceFabric from Orleans.ServiceFabric

### DIFF
--- a/src/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
+++ b/src/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
@@ -10,6 +10,5 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Hosting.ServiceFabric\Orleans.Hosting.ServiceFabric.csproj" />
-    <ProjectReference Include="..\Orleans.Clustering.ServiceFabric\Orleans.Clustering.ServiceFabric.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove reference to `Microsoft.Orleans.Clustering.ServiceFabric` from `Microsoft.Orleans.ServiceFabric` meta-package because we pulled the former in 2.0.0 final. Otherwise, `Microsoft.Orleans.ServiceFabric` is trying to pull the non-existing 2.0.0 package.
Fixes #4350.