### PR TITLE
Fix reference to Microsoft.Orleans.Hosting.ServiceFabric in Microsoft.Orleans.ServiceFabric to 2.0.0

### DIFF
--- a/src/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
+++ b/src/Orleans.ServiceFabric/Orleans.ServiceFabric.csproj
@@ -9,6 +9,6 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Orleans.Hosting.ServiceFabric\Orleans.Hosting.ServiceFabric.csproj" />
+    <PackageReference Include="Microsoft.Orleans.Hosting.ServiceFabric" Version="2.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix reference to Microsoft.Orleans.Hosting.ServiceFabric in Microsoft.Orleans.ServiceFabric to 2.0.0 version of the package, so that it doesn't point to a non existing version of the package (2.0.1 or 2.0.2).