### PR TITLE
Fix assembly version to 2.0.0 & increment build version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -105,7 +105,8 @@
 
   <!-- Versioning properties -->
   <PropertyGroup>
-    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.0.0</VersionPrefix>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">2.0.3</VersionPrefix>
   </PropertyGroup>
 
   <!-- For Debug builds generated a date/time dependent version suffix -->


### PR DESCRIPTION
Fix assembly version to 2.0.0, so that assemblies stay compatible.
Bump up build default version to 2.0.3 (because we already published [2.0.2 version of Microsoft.Orleans.ServiceFabric](https://www.nuget.org/packages/Microsoft.Orleans.ServiceFabric/2.0.2).