### PR TITLE
Add a chatroom app which uses SMS stream as a streaming sample

### DIFF
--- a/Samples/2.0/ChatRoom/ChatRoom.sln
+++ b/Samples/2.0/ChatRoom/ChatRoom.sln
@@ -1,0 +1,54 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.16
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrleansServer", "OrleansServer\OrleansServer.csproj", "{862E276B-06B3-47BD-9BD0-2732BD67BD47}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrleansClient", "OrleansClient\OrleansClient.csproj", "{31BA90B8-8CED-425B-9A4B-189BC294A72E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrainInterfaces", "GrainInterfaces\GrainInterfaces.csproj", "{513AEC9E-AD28-4D5F-A351-7FA8A32421DD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrainImplementation", "GrainImplementation\GrainImplementation.csproj", "{3EB4ECC9-10DD-4C28-A269-350E177966E0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Utils", "Utils\Utils.csproj", "{2BFBB174-20E8-4BC1-925C-2CA7AC0DD0FF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9449CCA9-C306-4E0C-8BD3-D2C4020C92B4}"
+	ProjectSection(SolutionItems) = preProject
+		ReadMe.md = ReadMe.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{862E276B-06B3-47BD-9BD0-2732BD67BD47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{862E276B-06B3-47BD-9BD0-2732BD67BD47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{862E276B-06B3-47BD-9BD0-2732BD67BD47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{862E276B-06B3-47BD-9BD0-2732BD67BD47}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31BA90B8-8CED-425B-9A4B-189BC294A72E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31BA90B8-8CED-425B-9A4B-189BC294A72E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31BA90B8-8CED-425B-9A4B-189BC294A72E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31BA90B8-8CED-425B-9A4B-189BC294A72E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{513AEC9E-AD28-4D5F-A351-7FA8A32421DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{513AEC9E-AD28-4D5F-A351-7FA8A32421DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{513AEC9E-AD28-4D5F-A351-7FA8A32421DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{513AEC9E-AD28-4D5F-A351-7FA8A32421DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EB4ECC9-10DD-4C28-A269-350E177966E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EB4ECC9-10DD-4C28-A269-350E177966E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EB4ECC9-10DD-4C28-A269-350E177966E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EB4ECC9-10DD-4C28-A269-350E177966E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BFBB174-20E8-4BC1-925C-2CA7AC0DD0FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BFBB174-20E8-4BC1-925C-2CA7AC0DD0FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BFBB174-20E8-4BC1-925C-2CA7AC0DD0FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BFBB174-20E8-4BC1-925C-2CA7AC0DD0FF}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AF9A94BE-1875-4E75-8EEF-585AD982074D}
+	EndGlobalSection
+EndGlobal

--- a/Samples/2.0/ChatRoom/GrainImplementation/Channel.cs
+++ b/Samples/2.0/ChatRoom/GrainImplementation/Channel.cs
@@ -27,7 +27,6 @@ namespace GrainImplementation
 
 		public async Task<Guid> Join(string nickname)
 		{
-			if (onlineMembers.Contains(nickname)) return Guid.Empty;
 			onlineMembers.Add(nickname);
 
 			await stream.OnNextAsync(new ChatMsg("System", $"{nickname} joins the chat '{this.GetPrimaryKeyString()}' ..."));
@@ -37,8 +36,6 @@ namespace GrainImplementation
 
 		public async Task<Guid> Leave(string nickname)
 		{
-			if (!onlineMembers.Contains(nickname)) return Guid.Empty;
-
 			onlineMembers.Remove(nickname);
 			await stream.OnNextAsync(new ChatMsg("System", $"{nickname} leaves the chat..."));
 

--- a/Samples/2.0/ChatRoom/GrainImplementation/Channel.cs
+++ b/Samples/2.0/ChatRoom/GrainImplementation/Channel.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GrainInterfaces;
+using GrainInterfaces.Model;
+using Orleans;
+using Orleans.Streams;
+using Utils;
+
+namespace GrainImplementation
+{
+	public class Channel : Grain, IChannel
+	{
+		private readonly List<ChatMsg> messages = new List<ChatMsg>(100);
+		private readonly List<string> onlineMembers = new List<string>(10);
+
+		private IAsyncStream<ChatMsg> stream;
+
+		public override Task OnActivateAsync()
+		{
+			var streamProvider = GetStreamProvider(Constants.ChatRoomStreamProvider);
+
+		    stream = streamProvider.GetStream<ChatMsg>(Guid.NewGuid(), Constants.CharRoomStreamNameSpace);
+            return base.OnActivateAsync();
+		}
+
+		public async Task<Guid> Join(string nickname)
+		{
+			if (onlineMembers.Contains(nickname)) return Guid.Empty;
+			onlineMembers.Add(nickname);
+
+			await stream.OnNextAsync(new ChatMsg("System", $"{nickname} joins the chat '{this.GetPrimaryKeyString()}' ..."));
+
+			return stream.Guid;
+		}
+
+		public async Task<Guid> Leave(string nickname)
+		{
+			if (!onlineMembers.Contains(nickname)) return Guid.Empty;
+
+			onlineMembers.Remove(nickname);
+			await stream.OnNextAsync(new ChatMsg("System", $"{nickname} leaves the chat..."));
+
+			return stream.Guid;
+		}
+
+		public async Task<bool> Message(ChatMsg msg)
+		{
+			messages.Add(msg);
+			await stream.OnNextAsync(msg);
+
+			return true;
+		}
+
+	    public Task<string[]> GetMembers()
+	    {
+	        return Task.FromResult(onlineMembers.ToArray());
+	    }
+
+	    public Task<ChatMsg[]> ReadHistory(int numberOfMessages)
+	    {
+	        var response = messages
+	            .OrderByDescending(x => x.Created)
+	            .Take(numberOfMessages)
+	            .OrderBy(x => x.Created)
+	            .ToArray();
+
+	        return Task.FromResult(response);
+	    }
+    }
+}

--- a/Samples/2.0/ChatRoom/GrainImplementation/GrainImplementation.csproj
+++ b/Samples/2.0/ChatRoom/GrainImplementation/GrainImplementation.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <AssemblyName>GrainImplementation</AssemblyName>
+    <PackageId>GrainImplementation</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="$(OrleansPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GrainInterfaces\GrainInterfaces.csproj" />
+    <ProjectReference Include="..\Utils\Utils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/2.0/ChatRoom/GrainInterfaces/GrainInterfaces.csproj
+++ b/Samples/2.0/ChatRoom/GrainInterfaces/GrainInterfaces.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <AssemblyName>GrainInterfaces</AssemblyName>
+    <PackageId>GrainInterfaces</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="$(OrleansPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/2.0/ChatRoom/GrainInterfaces/IChannel.cs
+++ b/Samples/2.0/ChatRoom/GrainInterfaces/IChannel.cs
@@ -7,9 +7,9 @@ namespace GrainInterfaces
 {
 	public interface IChannel : IGrainWithStringKey
 	{
-		Task<Guid> Join(string nickname);
-		Task<Guid> Leave(string nickname);
-		Task<bool> Message(ChatMsg msg);
+	    Task<Guid> Join(string nickname);
+	    Task<Guid> Leave(string nickname);
+	    Task<bool> Message(ChatMsg msg);
 	    Task<ChatMsg[]> ReadHistory(int numberOfMessages);
 	    Task<string[]> GetMembers();
 	}

--- a/Samples/2.0/ChatRoom/GrainInterfaces/IChannel.cs
+++ b/Samples/2.0/ChatRoom/GrainInterfaces/IChannel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using GrainInterfaces.Model;
+using Orleans;
+
+namespace GrainInterfaces
+{
+	public interface IChannel : IGrainWithStringKey
+	{
+		Task<Guid> Join(string nickname);
+		Task<Guid> Leave(string nickname);
+		Task<bool> Message(ChatMsg msg);
+	    Task<ChatMsg[]> ReadHistory(int numberOfMessages);
+	    Task<string[]> GetMembers();
+	}
+}

--- a/Samples/2.0/ChatRoom/GrainInterfaces/Model/ChatMsg.cs
+++ b/Samples/2.0/ChatRoom/GrainInterfaces/Model/ChatMsg.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace GrainInterfaces.Model
+{
+	[Serializable]
+	public class ChatMsg
+	{
+		public DateTimeOffset Created { get; set; } = DateTimeOffset.Now;
+		public string Author { get; set; } = "Alexey";
+		public string Text { get; set; }
+
+
+		public ChatMsg()
+		{
+		}
+
+		public ChatMsg(string author, string msg)
+		{
+			Author = author;
+			Text = msg;
+		}
+	}
+}

--- a/Samples/2.0/ChatRoom/OrleansClient/OrleansClient.csproj
+++ b/Samples/2.0/ChatRoom/OrleansClient/OrleansClient.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <AssemblyName>OrleansClient</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <PackageId>OrleansClient</PackageId>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="$(OrleansPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GrainInterfaces\GrainInterfaces.csproj" />
+    <ProjectReference Include="..\Utils\Utils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/2.0/ChatRoom/OrleansClient/Program.cs
+++ b/Samples/2.0/ChatRoom/OrleansClient/Program.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using GrainInterfaces;
@@ -9,14 +7,12 @@ using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
-using Orleans.Runtime;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Streams;
 using Utils;
 
 namespace OrleansClient
 {
-	class Program
+    class Program
 	{
         //To make this sample simple
         //In this sample, one client can only join one channel, hence we have a static variable of one channel name.
@@ -192,6 +188,7 @@ namespace OrleansClient
 		    var streamId = await room.Leave(userName);
             var stream = client.GetStreamProvider(Constants.ChatRoomStreamProvider)
 		        .GetStream<ChatMsg>(streamId, Constants.CharRoomStreamNameSpace);
+
             //unsubscribe from the channel/stream since client left, so that client won't
             //receive furture messages from this channel/stream
 		    var subscriptionHandles = await stream.GetAllSubscriptionHandles();

--- a/Samples/2.0/ChatRoom/OrleansClient/Program.cs
+++ b/Samples/2.0/ChatRoom/OrleansClient/Program.cs
@@ -178,8 +178,6 @@ namespace OrleansClient
             joinedChannel = channelName;
 			var room = client.GetGrain<IChannel>(joinedChannel);
 		    var streamId = await room.Join(userName);
-            //empty stream id meaning client already joined this channel, so return 
-		    if (streamId == Guid.Empty) return;
             var stream = client.GetStreamProvider(Constants.ChatRoomStreamProvider)
 		        .GetStream<ChatMsg>(streamId, Constants.CharRoomStreamNameSpace);
             //subscribe to the stream to receiver furthur messages sent to the chatroom
@@ -192,8 +190,6 @@ namespace OrleansClient
 		    PrettyConsole.Line($"Leaving channel {joinedChannel}");
             var room = client.GetGrain<IChannel>(joinedChannel);
 		    var streamId = await room.Leave(userName);
-            //empty stream id meaning client already leaved the channel, so return 
-		    if (streamId == Guid.Empty) return;
             var stream = client.GetStreamProvider(Constants.ChatRoomStreamProvider)
 		        .GetStream<ChatMsg>(streamId, Constants.CharRoomStreamNameSpace);
             //unsubscribe from the channel/stream since client left, so that client won't

--- a/Samples/2.0/ChatRoom/OrleansClient/Program.cs
+++ b/Samples/2.0/ChatRoom/OrleansClient/Program.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using GrainInterfaces;
+using GrainInterfaces.Model;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Streams;
+using Utils;
+
+namespace OrleansClient
+{
+	class Program
+	{
+        //To make this sample simple
+        //In this sample, one client can only join one channel, hence we have a static variable of one channel name.
+        //client can send messages to the channel , and receive messages sent to the channel/stream from other clients. 
+		private static string joinedChannel = "general";
+        private static string userName = "UserWithNoName";
+		public static void Main(string[] args)
+		{
+			var clientInstance = InitializeClient(args).GetAwaiter().GetResult();
+
+			PrettyConsole.Line("==== CLIENT: Initialized ====", ConsoleColor.Cyan);
+			PrettyConsole.Line("CLIENT: Write commands:", ConsoleColor.Cyan);
+
+
+			Menu(clientInstance).GetAwaiter().GetResult();
+
+			PrettyConsole.Line("==== CLIENT: Shutting down ====", ConsoleColor.DarkRed);
+		}
+
+		private static async Task<IClusterClient> InitializeClient(string[] args)
+		{
+			int initializeCounter = 0;
+
+			var initSucceed = false;
+			while (!initSucceed)
+			{
+				try
+				{
+                    var client = new ClientBuilder().Configure<ClusterOptions>(options =>
+                        {
+                            options.ClusterId = Constants.ClusterId;
+                            options.ServiceId = Constants.ServiceId;
+                        })
+                        .UseLocalhostClustering()
+                        .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IChannel).Assembly).WithReferences())
+				        .ConfigureLogging(logging => logging.AddConsole())
+                        .AddSimpleMessageStreamProvider(Constants.ChatRoomStreamProvider)
+				        .Build();
+                    await client.Connect();
+					initSucceed = client.IsInitialized;
+
+					if (initSucceed)
+					{
+						return client;
+					}
+				}
+				catch (Exception exc)
+				{
+					PrettyConsole.Line(exc.Message, ConsoleColor.Cyan);
+					initSucceed = false;
+				}
+
+				if (initializeCounter++ > 10)
+				{
+					return null;
+				}
+
+				PrettyConsole.Line("Client Init Failed. Sleeping 5s...", ConsoleColor.Red);
+				Thread.Sleep(TimeSpan.FromSeconds(5));
+			}
+
+			return null;
+		}
+
+		private static void PrintHints()
+		{
+			var menuColor = ConsoleColor.Magenta;
+			PrettyConsole.Line("Type '/j <channel>' to join specific channel", menuColor);
+		    PrettyConsole.Line("Type '/n <username>' to set your user name", menuColor);
+            PrettyConsole.Line("Type '/l' to leave specific channel", menuColor);
+			PrettyConsole.Line("Type '<any text>' to send a message", menuColor);
+		    PrettyConsole.Line("Type '/h' to re-read channel history", menuColor);
+		    PrettyConsole.Line("Type '/m' to query members in the channel", menuColor);
+            PrettyConsole.Line("Type '/exit' to exit client.", menuColor);
+		}
+
+		private static async Task Menu(IClusterClient client)
+		{
+			string input;
+			PrintHints();
+
+			do
+			{
+				input = Console.ReadLine();
+
+				if (string.IsNullOrWhiteSpace(input)) continue;
+
+				if (input.StartsWith("/j"))
+				{
+					await JoinChannel(client, input.Replace("/j", "").Trim());
+				}
+                else if (input.StartsWith("/n"))
+				{
+				    userName = input.Replace("/n", "").Trim();
+				    PrettyConsole.Line($"Your user name is set to be {userName}", ConsoleColor.DarkGreen);
+                }
+				else if (input.StartsWith("/l"))
+				{
+					await LeaveChannel(client);
+				}
+				else if (input.StartsWith("/h"))
+				{
+				    await ShowCurrentChannelHistory(client);
+				}
+				else if (input.StartsWith("/m"))
+				{
+				    await ShowChannelMembers(client);
+				}
+                else if (!input.StartsWith("/exit"))
+				{
+					await SendMessage(client, input);
+				}
+			} while (input != "/exit");
+		}
+
+	    private static async Task ShowChannelMembers(IClusterClient client)
+	    {
+	        var room = client.GetGrain<IChannel>(joinedChannel);
+	        var members = await room.GetMembers();
+
+	        PrettyConsole.Line($"====== Members for '{joinedChannel}' Channel ======", ConsoleColor.DarkGreen);
+	        foreach (var member in members)
+	        {
+	            PrettyConsole.Line(member, ConsoleColor.DarkGreen);
+	        }
+	        PrettyConsole.Line("============", ConsoleColor.DarkGreen);
+	    }
+
+        private static async Task ShowCurrentChannelHistory(IClusterClient client)
+	    {
+	        var room = client.GetGrain<IChannel>(joinedChannel);
+	        var history = await room.ReadHistory(1000);
+
+	        PrettyConsole.Line($"====== History for '{joinedChannel}' Channel ======", ConsoleColor.DarkGreen);
+	        foreach (var chatMsg in history)
+	        {
+	            PrettyConsole.Line($" ({chatMsg.Created:g}) {chatMsg.Author}> {chatMsg.Text}", ConsoleColor.DarkGreen);
+	        }
+	        PrettyConsole.Line("============", ConsoleColor.DarkGreen);
+	    }
+
+        private static async Task SendMessage(IClusterClient client, string messageText)
+		{
+			var room = client.GetGrain<IChannel>(joinedChannel);
+			await room.Message(new ChatMsg(userName, messageText));
+		}
+
+		private static async Task JoinChannel(IClusterClient client, string channelName)
+		{
+		    PrettyConsole.Line($"Joining to channel {channelName}");
+            joinedChannel = channelName;
+			var room = client.GetGrain<IChannel>(joinedChannel);
+		    var streamId = await room.Join(userName);
+            //empty stream id meaning client already joined this channel, so return 
+		    if (streamId == Guid.Empty) return;
+            var stream = client.GetStreamProvider(Constants.ChatRoomStreamProvider)
+		        .GetStream<ChatMsg>(streamId, Constants.CharRoomStreamNameSpace);
+            //sunscribe to the stream to receiver furthur messages sent to the chatroom
+		    await stream.SubscribeAsync(new StreamObserver(client.ServiceProvider.GetService<ILoggerFactory>()
+		        .CreateLogger($"{joinedChannel} channel")));
+		}
+
+		private static async Task LeaveChannel(IClusterClient client)
+		{
+		    PrettyConsole.Line($"Leaving to channel {joinedChannel}");
+            var room = client.GetGrain<IChannel>(joinedChannel);
+		    var streamId = await room.Leave(userName);
+            //empty stream id meaning client already leaved the channel, so return 
+		    if (streamId == Guid.Empty) return;
+            var stream = client.GetStreamProvider(Constants.ChatRoomStreamProvider)
+		        .GetStream<ChatMsg>(streamId, Constants.CharRoomStreamNameSpace);
+            //unsubscribe from the channel/stream since client left, so that client won't
+            //receive furture messages from this channel/stream
+		    var subscriptionHandles = await stream.GetAllSubscriptionHandles();
+		    foreach (var handle in subscriptionHandles)
+		    {
+		        await handle.UnsubscribeAsync();
+		    }
+		}
+	}
+}

--- a/Samples/2.0/ChatRoom/OrleansClient/Program.cs
+++ b/Samples/2.0/ChatRoom/OrleansClient/Program.cs
@@ -13,34 +13,34 @@ using Utils;
 namespace OrleansClient
 {
     class Program
-	{
+    {
         //To make this sample simple
         //In this sample, one client can only join one channel, hence we have a static variable of one channel name.
         //client can send messages to the channel , and receive messages sent to the channel/stream from other clients. 
-		private static string joinedChannel = "general";
+        private static string joinedChannel = "general";
         private static string userName = "UserWithNoName";
-		public static void Main(string[] args)
-		{
-			var clientInstance = InitializeClient(args).GetAwaiter().GetResult();
+        public static void Main(string[] args)
+        {
+            var clientInstance = InitializeClient(args).GetAwaiter().GetResult();
 
-			PrettyConsole.Line("==== CLIENT: Initialized ====", ConsoleColor.Cyan);
-			PrettyConsole.Line("CLIENT: Write commands:", ConsoleColor.Cyan);
+            PrettyConsole.Line("==== CLIENT: Initialized ====", ConsoleColor.Cyan);
+            PrettyConsole.Line("CLIENT: Write commands:", ConsoleColor.Cyan);
 
 
-			Menu(clientInstance).GetAwaiter().GetResult();
+            Menu(clientInstance).GetAwaiter().GetResult();
 
-			PrettyConsole.Line("==== CLIENT: Shutting down ====", ConsoleColor.DarkRed);
-		}
+            PrettyConsole.Line("==== CLIENT: Shutting down ====", ConsoleColor.DarkRed);
+        }
 
-		private static async Task<IClusterClient> InitializeClient(string[] args)
-		{
-			int initializeCounter = 0;
+        private static async Task<IClusterClient> InitializeClient(string[] args)
+        {
+            int initializeCounter = 0;
 
-			var initSucceed = false;
-			while (!initSucceed)
-			{
-				try
-				{
+            var initSucceed = false;
+            while (!initSucceed)
+            {
+                try
+                {
                     var client = new ClientBuilder().Configure<ClusterOptions>(options =>
                         {
                             options.ClusterId = Constants.ClusterId;
@@ -48,39 +48,39 @@ namespace OrleansClient
                         })
                         .UseLocalhostClustering()
                         .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IChannel).Assembly).WithReferences())
-				        .ConfigureLogging(logging => logging.AddConsole())
+                        .ConfigureLogging(logging => logging.AddConsole())
                         //Depends on your application requirements, you can configure your client with other stream providers, which can provide other features, 
                         //such as persistence or recoverability. For more information, please see http://dotnet.github.io/orleans/Documentation/Orleans-Streams/Stream-Providers.html
                         .AddSimpleMessageStreamProvider(Constants.ChatRoomStreamProvider)
-				        .Build();
+                        .Build();
                     await client.Connect();
-					initSucceed = client.IsInitialized;
+                    initSucceed = client.IsInitialized;
 
-					if (initSucceed)
-					{
-						return client;
-					}
-				}
-				catch (Exception exc)
-				{
-					PrettyConsole.Line(exc.Message, ConsoleColor.Cyan);
-					initSucceed = false;
-				}
+                    if (initSucceed)
+                    {
+                        return client;
+                    }
+                }
+                catch (Exception exc)
+                {
+                    PrettyConsole.Line(exc.Message, ConsoleColor.Cyan);
+                    initSucceed = false;
+                }
 
-				if (initializeCounter++ > 10)
-				{
-					return null;
-				}
+                if (initializeCounter++ > 10)
+                {
+                    return null;
+                }
 
-				PrettyConsole.Line("Client Init Failed. Sleeping 5s...", ConsoleColor.Red);
-				Thread.Sleep(TimeSpan.FromSeconds(5));
-			}
+                PrettyConsole.Line("Client Init Failed. Sleeping 5s...", ConsoleColor.Red);
+                Thread.Sleep(TimeSpan.FromSeconds(5));
+            }
 
-			return null;
-		}
+            return null;
+        }
 
-		private static void PrintHints()
-		{
+        private static void PrintHints()
+        {
             var menuColor = ConsoleColor.Magenta;
             PrettyConsole.Line("Type '/j <channel>' to join specific channel", menuColor);
             PrettyConsole.Line("Type '/n <username>' to set your user name", menuColor);
@@ -89,113 +89,113 @@ namespace OrleansClient
             PrettyConsole.Line("Type '/h' to re-read channel history", menuColor);
             PrettyConsole.Line("Type '/m' to query members in the channel", menuColor);
             PrettyConsole.Line("Type '/exit' to exit client.", menuColor);
-		}
+        }
 
-		private static async Task Menu(IClusterClient client)
-		{
-			string input;
-			PrintHints();
+        private static async Task Menu(IClusterClient client)
+        {
+            string input;
+            PrintHints();
 
-			do
-			{
+            do
+            {
                 input = Console.ReadLine();
 
                 if (string.IsNullOrWhiteSpace(input)) continue;
 
                 if (input.StartsWith("/j"))
                 {
-	                await JoinChannel(client, input.Replace("/j", "").Trim());
+                    await JoinChannel(client, input.Replace("/j", "").Trim());
                 }
                 else if (input.StartsWith("/n"))
                 {
-	                userName = input.Replace("/n", "").Trim();
-	                PrettyConsole.Line($"Your user name is set to be {userName}", ConsoleColor.DarkGreen);
+                    userName = input.Replace("/n", "").Trim();
+                    PrettyConsole.Line($"Your user name is set to be {userName}", ConsoleColor.DarkGreen);
                 }
                 else if (input.StartsWith("/l"))
                 {
-	                await LeaveChannel(client);
+                    await LeaveChannel(client);
                 }
                 else if (input.StartsWith("/h"))
                 {
-	                await ShowCurrentChannelHistory(client);
+                    await ShowCurrentChannelHistory(client);
                 }
                 else if (input.StartsWith("/m"))
                 {
-	                await ShowChannelMembers(client);
+                    await ShowChannelMembers(client);
                 }
                 else if (!input.StartsWith("/exit"))
                 {
-	                await SendMessage(client, input);
+                    await SendMessage(client, input);
                 }
-			} while (input != "/exit");
-		}
+            } while (input != "/exit");
+        }
 
-	    private static async Task ShowChannelMembers(IClusterClient client)
-	    {
-	        var room = client.GetGrain<IChannel>(joinedChannel);
-	        var members = await room.GetMembers();
+        private static async Task ShowChannelMembers(IClusterClient client)
+        {
+            var room = client.GetGrain<IChannel>(joinedChannel);
+            var members = await room.GetMembers();
 
-	        PrettyConsole.Line($"====== Members for '{joinedChannel}' Channel ======", ConsoleColor.DarkGreen);
-	        foreach (var member in members)
-	        {
-	            PrettyConsole.Line(member, ConsoleColor.DarkGreen);
-	        }
-	        PrettyConsole.Line("============", ConsoleColor.DarkGreen);
-	    }
+            PrettyConsole.Line($"====== Members for '{joinedChannel}' Channel ======", ConsoleColor.DarkGreen);
+            foreach (var member in members)
+            {
+                PrettyConsole.Line(member, ConsoleColor.DarkGreen);
+            }
+            PrettyConsole.Line("============", ConsoleColor.DarkGreen);
+        }
 
         private static async Task ShowCurrentChannelHistory(IClusterClient client)
-	    {
-	        var room = client.GetGrain<IChannel>(joinedChannel);
-	        var history = await room.ReadHistory(1000);
+        {
+            var room = client.GetGrain<IChannel>(joinedChannel);
+            var history = await room.ReadHistory(1000);
 
-	        PrettyConsole.Line($"====== History for '{joinedChannel}' Channel ======", ConsoleColor.DarkGreen);
-	        foreach (var chatMsg in history)
-	        {
-	            PrettyConsole.Line($" ({chatMsg.Created:g}) {chatMsg.Author}> {chatMsg.Text}", ConsoleColor.DarkGreen);
-	        }
-	        PrettyConsole.Line("============", ConsoleColor.DarkGreen);
-	    }
+            PrettyConsole.Line($"====== History for '{joinedChannel}' Channel ======", ConsoleColor.DarkGreen);
+            foreach (var chatMsg in history)
+            {
+                PrettyConsole.Line($" ({chatMsg.Created:g}) {chatMsg.Author}> {chatMsg.Text}", ConsoleColor.DarkGreen);
+            }
+            PrettyConsole.Line("============", ConsoleColor.DarkGreen);
+        }
 
         private static async Task SendMessage(IClusterClient client, string messageText)
-		{
-			var room = client.GetGrain<IChannel>(joinedChannel);
-			await room.Message(new ChatMsg(userName, messageText));
-		}
+        {
+            var room = client.GetGrain<IChannel>(joinedChannel);
+            await room.Message(new ChatMsg(userName, messageText));
+        }
 
-		private static async Task JoinChannel(IClusterClient client, string channelName)
-		{
-		    if (joinedChannel == channelName)
-		    {
+        private static async Task JoinChannel(IClusterClient client, string channelName)
+        {
+            if (joinedChannel == channelName)
+            {
                 PrettyConsole.Line($"You already joined channel {channelName}. Double joining a channel, which is implemented as a stream, would result in double subscription to the same stream, " +
                                    $"which would result in receiving duplicated messages. For more information, please refer to Orleans streaming documentation.");
-		        return;
-		    }
-		    PrettyConsole.Line($"Joining to channel {channelName}");
+                return;
+            }
+            PrettyConsole.Line($"Joining to channel {channelName}");
             joinedChannel = channelName;
-			var room = client.GetGrain<IChannel>(joinedChannel);
-		    var streamId = await room.Join(userName);
-            var stream = client.GetStreamProvider(Constants.ChatRoomStreamProvider)
-		        .GetStream<ChatMsg>(streamId, Constants.CharRoomStreamNameSpace);
-            //subscribe to the stream to receiver furthur messages sent to the chatroom
-		    await stream.SubscribeAsync(new StreamObserver(client.ServiceProvider.GetService<ILoggerFactory>()
-		        .CreateLogger($"{joinedChannel} channel")));
-		}
-
-		private static async Task LeaveChannel(IClusterClient client)
-		{
-		    PrettyConsole.Line($"Leaving channel {joinedChannel}");
             var room = client.GetGrain<IChannel>(joinedChannel);
-		    var streamId = await room.Leave(userName);
+            var streamId = await room.Join(userName);
             var stream = client.GetStreamProvider(Constants.ChatRoomStreamProvider)
-		        .GetStream<ChatMsg>(streamId, Constants.CharRoomStreamNameSpace);
+                .GetStream<ChatMsg>(streamId, Constants.CharRoomStreamNameSpace);
+            //subscribe to the stream to receiver furthur messages sent to the chatroom
+            await stream.SubscribeAsync(new StreamObserver(client.ServiceProvider.GetService<ILoggerFactory>()
+                .CreateLogger($"{joinedChannel} channel")));
+        }
+
+        private static async Task LeaveChannel(IClusterClient client)
+        {
+            PrettyConsole.Line($"Leaving channel {joinedChannel}");
+            var room = client.GetGrain<IChannel>(joinedChannel);
+            var streamId = await room.Leave(userName);
+            var stream = client.GetStreamProvider(Constants.ChatRoomStreamProvider)
+                .GetStream<ChatMsg>(streamId, Constants.CharRoomStreamNameSpace);
 
             //unsubscribe from the channel/stream since client left, so that client won't
             //receive furture messages from this channel/stream
-		    var subscriptionHandles = await stream.GetAllSubscriptionHandles();
-		    foreach (var handle in subscriptionHandles)
-		    {
-		        await handle.UnsubscribeAsync();
-		    }
-		}
-	}
+            var subscriptionHandles = await stream.GetAllSubscriptionHandles();
+            foreach (var handle in subscriptionHandles)
+            {
+                await handle.UnsubscribeAsync();
+            }
+        }
+    }
 }

--- a/Samples/2.0/ChatRoom/OrleansClient/StreamObserver.cs
+++ b/Samples/2.0/ChatRoom/OrleansClient/StreamObserver.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GrainInterfaces.Model;
+using Microsoft.Extensions.Logging;
+using Orleans.Streams;
+
+namespace OrleansClient
+{
+    public class StreamObserver : IAsyncObserver<ChatMsg>
+    {
+        private ILogger logger;
+        public StreamObserver(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public Task OnCompletedAsync()
+        {
+            this.logger.LogInformation("Chatroom message stream received stream completed event");
+            return Task.CompletedTask;
+        }
+
+        public Task OnErrorAsync(Exception ex)
+        {
+            this.logger.LogInformation($"Chatroom is experiencing message delivery failure, ex :{ex}");
+            return Task.CompletedTask;
+        }
+
+        public Task OnNextAsync(ChatMsg item, StreamSequenceToken token = null)
+        {
+            this.logger.LogInformation($"=={item.Created}==         {item.Author} said: {item.Text}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Samples/2.0/ChatRoom/OrleansServer/OrleansServer.csproj
+++ b/Samples/2.0/ChatRoom/OrleansServer/OrleansServer.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <AssemblyName>OrleansServer</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <PackageId>OrleansServer</PackageId>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="$(OrleansPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GrainInterfaces\GrainInterfaces.csproj" />
+    <ProjectReference Include="..\GrainImplementation\GrainImplementation.csproj" />
+    <ProjectReference Include="..\Utils\Utils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/2.0/ChatRoom/OrleansServer/Program.cs
+++ b/Samples/2.0/ChatRoom/OrleansServer/Program.cs
@@ -29,7 +29,9 @@ namespace OrleansServer
 		        .ConfigureLogging(logging => logging.AddConsole())
                 //need to configure a grain storage called "PubSubStore" for using streaming with ExplicitSubscribe pubsub type
                 .AddMemoryGrainStorage("PubSubStore")
-		        .AddSimpleMessageStreamProvider(Constants.ChatRoomStreamProvider); 
+                //Depends on your application requirements, you can configure your silo with other stream providers, which can provide other features, 
+                //such as persistence or recoverability. For more information, please see http://dotnet.github.io/orleans/Documentation/Orleans-Streams/Stream-Providers.html
+                .AddSimpleMessageStreamProvider(Constants.ChatRoomStreamProvider); 
 
 
 		    var silo = builder.Build();

--- a/Samples/2.0/ChatRoom/OrleansServer/Program.cs
+++ b/Samples/2.0/ChatRoom/OrleansServer/Program.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Net;
+using System.Runtime.CompilerServices;
+using GrainImplementation;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.Streams;
+using Utils;
+
+namespace OrleansServer
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+		    var builder = new SiloHostBuilder()
+		        .Configure<ClusterOptions>(options =>
+		        {
+		            options.ClusterId = Constants.ClusterId;
+		            options.ServiceId = Constants.ServiceId;
+		        })
+		        .UseLocalhostClustering()
+		        .Configure<EndpointOptions>(options => options.AdvertisedIPAddress = IPAddress.Loopback)
+                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(Channel).Assembly).WithReferences())
+		        .ConfigureLogging(logging => logging.AddConsole())
+                //need to configure a grain storage called "PubSubStore" for using streaming with ExplicitSubscribe pubsub type
+                .AddMemoryGrainStorage("PubSubStore")
+		        .AddSimpleMessageStreamProvider(Constants.ChatRoomStreamProvider); 
+
+
+		    var silo = builder.Build();
+		    silo.StartAsync().Wait();
+
+			Console.WriteLine("Press Enter to close.");
+			Console.ReadLine();
+
+			// shut the silo down after we are done.
+		    silo.StopAsync().Wait();
+		}
+	}
+}

--- a/Samples/2.0/ChatRoom/ReadMe.md
+++ b/Samples/2.0/ChatRoom/ReadMe.md
@@ -1,0 +1,37 @@
+# Chat Room Sample OVerview
+
+This is a simple sample using [Orleans Streaming feature](http://dotnet.github.io/orleans/Documentation/Orleans-Streams/index.html) to build a simple chatroom application. In this application, each client can 
+- set its user name for ther chatroom application
+- join a channel by channel name
+- send messages to the channel
+- query history messages in the channel
+- query members in the channel
+- leave the channel
+
+Each client will
+- receive messages sent to the channel by other clients and itself after joined a channel
+- stop receive messages after leaved the channel
+
+For the purpose to make this sample simple, one client can only join one channel. It cannot join multiple channels at the same time. So to join another channel, the client need to leave the current channel first.
+
+## Running the sample
+From Visual Studio, you can start the OrleansServer project first, wait for it to stablize, and then start multiple OrleansClient projects simultaneously (you can start the project by right click the project -> Debug -> Start new instance).
+
+Alternatively, you can run from the command line:
+
+To start the silo
+```
+OrleansServer\bin\Debug(Release)\net462\OrleansServer.exe
+```
+
+
+To start the client (you will have to use a different command window)
+```
+OrleansClient\bin\Debug(Release)\net462\OrleansClient.exe
+```
+If you build the sample app in debug mode, the exe binary will be in Debug folder. If you build it in release mode, then the exe binary will be in Release folder.
+
+After the client started up, you will see instructions printed on the console, which tells you how to interact with a channel.
+
+## Reference
+This sample is based on [a sample writted by @centur](https://github.com/centur/altnet-streams-demo), but revised with changes.

--- a/Samples/2.0/ChatRoom/Utils/Constants.cs
+++ b/Samples/2.0/ChatRoom/Utils/Constants.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Utils
+{
+	public static class Constants
+	{
+		public const string ChatRoomStreamProvider = "ChatRoom";
+	    public const string CharRoomStreamNameSpace = "YOLO";
+	    public const string ClusterId = "chatroom-deployment1";
+	    public const string ServiceId = "ChatRoomApp";
+
+	}
+}

--- a/Samples/2.0/ChatRoom/Utils/Constants.cs
+++ b/Samples/2.0/ChatRoom/Utils/Constants.cs
@@ -4,10 +4,10 @@ namespace Utils
 {
 	public static class Constants
 	{
-		public const string ChatRoomStreamProvider = "ChatRoom";
-	    public const string CharRoomStreamNameSpace = "YOLO";
-	    public const string ClusterId = "chatroom-deployment1";
-	    public const string ServiceId = "ChatRoomApp";
+        public const string ChatRoomStreamProvider = "ChatRoom";
+        public const string CharRoomStreamNameSpace = "YOLO";
+        public const string ClusterId = "chatroom-deployment1";
+        public const string ServiceId = "ChatRoomApp";
 
 	}
 }

--- a/Samples/2.0/ChatRoom/Utils/PrettyConsole.cs
+++ b/Samples/2.0/ChatRoom/Utils/PrettyConsole.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Utils
+{
+	public static class PrettyConsole
+	{
+		public static void Line(string text, ConsoleColor colour = ConsoleColor.White)
+		{
+			var originalColour = Console.ForegroundColor;
+			Console.ForegroundColor = colour;
+			Console.WriteLine(text);
+			Console.ForegroundColor = originalColour;
+		}
+	}
+}

--- a/Samples/2.0/ChatRoom/Utils/Utils.csproj
+++ b/Samples/2.0/ChatRoom/Utils/Utils.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <AssemblyName>Utils</AssemblyName>
+    <PackageId>Utils</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
# Chat Room Sample OVerview

This is a simple sample using [Orleans Streaming feature](http://dotnet.github.io/orleans/Documentation/Orleans-Streams/index.html) to build a simple chatroom application. In this application, each client can 
- set its user name for ther chatroom application
- join a channel by channel name
- send messages to the channel
- query history messages in the channel
- query members in the channel
- leave the channel

Each client will
- receive messages sent to the channel by other clients and itself after joined a channel
- stop receive messages after leaved the channel

For the purpose to make this sample simple, one client can only join one channel. It cannot join multiple channels at the same time. So to join another channel, the client need to leave the current channel first.

## Running the sample
From Visual Studio, you can start the OrleansServer project first, wait for it to stablize, and then start multiple OrleansClient projects simultaneously (you can start the project by right click the project -> Debug -> Start new instance).

Alternatively, you can run from the command line:

To start the silo
```
OrleansServer\bin\Debug(Release)\net462\OrleansServer.exe
```


To start the client (you will have to use a different command window)
```
OrleansClient\bin\Debug(Release)\net462\OrleansClient.exe
```
If you build the sample app in debug mode, the exe binary will be in Debug folder. If you build it in release mode, then the exe binary will be in Release folder.

After the client started up, you will see instructions printed on the console, which tells you how to interact with a channel.


## Reference
This sample is based on [a sample writted by @centur](https://github.com/centur/altnet-streams-demo), but revised with changes.