### PR TITLE
Fix telemetry consumer construction

### DIFF
--- a/src/Orleans.TelemetryConsumers.AI/AITelemetryConsumer.cs
+++ b/src/Orleans.TelemetryConsumers.AI/AITelemetryConsumer.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Runtime;
 
 namespace Orleans.TelemetryConsumers.AI
@@ -16,9 +18,10 @@ namespace Orleans.TelemetryConsumers.AI
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="instrumentationKey">The instrumentation key for ApplicationInsights.</param>
-        public AITelemetryConsumer(string instrumentationKey)
+        /// <param name="options">The instrumentation key for ApplicationInsights.</param>
+        public AITelemetryConsumer(IOptions<ApplicationInsightsTelemetryConsumerOptions> options)
         {
+            var instrumentationKey = options.Value.InstrumentationKey;
             _client = instrumentationKey != null
                 ? new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration { InstrumentationKey = instrumentationKey })
                 : new TelemetryClient();

--- a/src/Orleans.TelemetryConsumers.NewRelic/NRTelemetryConsumerConfigurationExtensions.cs
+++ b/src/Orleans.TelemetryConsumers.NewRelic/NRTelemetryConsumerConfigurationExtensions.cs
@@ -10,28 +10,23 @@ namespace Orleans.Hosting
         /// Adds a metrics telemetric consumer provider of type <see cref="NRTelemetryConsumer"/>.
         /// </summary>
         /// <param name="hostBuilder"></param>
-        /// <param name="instrumentationKey">The instrumentation key for New Relic.</param>
-        public static ISiloHostBuilder AddNewRelicTelemetryConsumer(this ISiloHostBuilder hostBuilder, string instrumentationKey = null)
+        public static ISiloHostBuilder AddNewRelicTelemetryConsumer(this ISiloHostBuilder hostBuilder)
         {
-            return hostBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, instrumentationKey));
+            return hostBuilder.ConfigureServices((context, services) => ConfigureServices(context, services));
         }
 
         /// <summary>
         /// Adds a metrics telemetric consumer provider of type <see cref="NRTelemetryConsumer"/>.
         /// </summary>
         /// <param name="clientBuilder"></param>
-        /// <param name="instrumentationKey">The instrumentation key for New Relic.</param>
-        public static IClientBuilder AddNewRelicTelemetryConsumer(this IClientBuilder clientBuilder, string instrumentationKey = null)
+        public static IClientBuilder AddNewRelicTelemetryConsumer(this IClientBuilder clientBuilder)
         {
-            return clientBuilder.ConfigureServices((context, services) => ConfigureServices(context, services, instrumentationKey));
+            return clientBuilder.ConfigureServices((context, services) => ConfigureServices(context, services));
         }
 
-        private static void ConfigureServices(HostBuilderContext context, IServiceCollection services, string instrumentationKey)
+        private static void ConfigureServices(HostBuilderContext context, IServiceCollection services)
         {
-            services.ConfigureFormatter<NewRelicTelemetryConsumerOptions>();
             services.Configure<TelemetryOptions>(options => options.AddConsumer<NRTelemetryConsumer>());
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
-                services.Configure<NewRelicTelemetryConsumerOptions>(options => options.InstrumentationKey = instrumentationKey);
         }
 
     }

--- a/src/Orleans.TelemetryConsumers.NewRelic/NewRelicTelemetryConsumerOptions.cs
+++ b/src/Orleans.TelemetryConsumers.NewRelic/NewRelicTelemetryConsumerOptions.cs
@@ -1,9 +1,0 @@
-﻿
-namespace Orleans.Configuration
-{
-    public class NewRelicTelemetryConsumerOptions
-    {
-        [Redact]
-        public string InstrumentationKey { get; set; }
-    }
-}


### PR DESCRIPTION
- Delete NewRelicTelemetryConsumerOptions.cs , since NewRelicTelemetryConsumer had a zero arg constructor in 1.5, so not sure why this option is here.
- Wire AITelemetryConsumer with its options 

fix for #4391 