### PR TITLE
Reduce allocs in Interner

### DIFF
--- a/src/Orleans.Core.Abstractions/Internal/Interner.cs
+++ b/src/Orleans.Core.Abstractions/Internal/Interner.cs
@@ -92,7 +92,15 @@ namespace Orleans.Core.Abstractions.Internal
             return FindOrCreate(key, creatorFunc, key);
         }
 
-        private T FindOrCreate<TState>(K key, Func<TState, T> creatorFunc, TState state)
+
+        /// <summary>
+        /// Find cached copy of object with specified key, otherwise create new one using the supplied creator-function.
+        /// </summary>
+        /// <param name="key">key to find</param>
+        /// <param name="creatorFunc">function to create new object and store for this key if no cached copy exists</param>
+        /// <param name="state">value passed as an argument to <paramref name="creatorFunc"/></param>
+        /// <returns>Object with specified key - either previous cached copy or newly created</returns>
+        public T FindOrCreate<TState>(K key, Func<TState, T> creatorFunc, TState state)
         {
             T result;
             WeakReference<T> cacheEntry;

--- a/src/Orleans.Core.Abstractions/Internal/Interner.cs
+++ b/src/Orleans.Core.Abstractions/Internal/Interner.cs
@@ -57,6 +57,8 @@ namespace Orleans.Core.Abstractions.Internal
         [NonSerialized]
         private readonly ConcurrentDictionary<K, WeakReference<T>> internCache;
 
+        private static readonly Func<T, T> NoOpCreatorFunc = o => o;
+
         public Interner()
             : this(InternerConstants.SIZE_SMALL)
         {
@@ -87,6 +89,11 @@ namespace Orleans.Core.Abstractions.Internal
         /// <returns>Object with specified key - either previous cached copy or newly created</returns>
         public T FindOrCreate(K key, Func<K, T> creatorFunc)
         {
+            return FindOrCreate(key, creatorFunc, key);
+        }
+
+        private T FindOrCreate<TState>(K key, Func<TState, T> creatorFunc, TState state)
+        {
             T result;
             WeakReference<T> cacheEntry;
 
@@ -96,7 +103,7 @@ namespace Orleans.Core.Abstractions.Internal
             // If no cache entry exists, create and insert a new one using the creator function.
             if (cacheEntry == null)
             {
-                result = creatorFunc(key);
+                result = creatorFunc(state);
                 cacheEntry = new WeakReference<T>(result);
                 internCache[key] = cacheEntry;
                 return result;
@@ -107,7 +114,7 @@ namespace Orleans.Core.Abstractions.Internal
             if (result == null)
             {
                 // Create new object and ensure the entry is still valid by re-inserting it into the cache.
-                result = creatorFunc(key);
+                result = creatorFunc(state);
                 cacheEntry.SetTarget(result);
                 internCache[key] = cacheEntry;
             }
@@ -123,8 +130,7 @@ namespace Orleans.Core.Abstractions.Internal
         public bool TryFind(K key, out T obj)
         {
             obj = null;
-            WeakReference<T> cacheEntry;
-            return internCache.TryGetValue(key, out cacheEntry) && cacheEntry != null && cacheEntry.TryGetTarget(out obj);
+            return internCache.TryGetValue(key, out var cacheEntry) && cacheEntry != null && cacheEntry.TryGetTarget(out obj);
         }
 
         /// <summary>
@@ -135,7 +141,7 @@ namespace Orleans.Core.Abstractions.Internal
         /// <returns>Object with specified key - either previous cached copy or justed passed in</returns>
         public T Intern(K key, T obj)
         {
-            return FindOrCreate(key, _ => obj);
+            return FindOrCreate(key, NoOpCreatorFunc, obj);
         }
 
         public void StopAndClear()


### PR DESCRIPTION
This is a minor improvement, one in a string of several to come. This change reduces the allocs for each call by approximately 300 bytes and reduces RTT (in proc) by ~21us on my machine.

Allocations are like paper cuts: too many and you bleed out.

For this and the other allocation related PRs, the targets are found by profiling, looking at hot spots, and picking the low-hanging fruit.

Before:

 Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
------- |---------:|---------:|---------:|-------:|----------:|
   Ping | 375.3 us | 166.1 us | 9.387 us | 3.4180 |  15.83 KB |

After "Reduce allocs in Interner" commit:

 Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
------- |---------:|---------:|---------:|-------:|----------:|
   Ping | 360.5 us | 200.2 us | 11.31 us | 3.4180 |  15.66 KB |

After "Intern ActivationAddress" commit:

 Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
------- |---------:|---------:|---------:|-------:|----------:|
   Ping | 354.4 us | 119.1 us | 6.731 us | 3.4180 |  15.54 KB |
