### PR TITLE
Avoid costly Message.GetTargetHistory() on gateway reroute

### DIFF
--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -569,15 +569,6 @@ namespace Orleans.Runtime
             }
         }
 
-        /// <summary>
-        /// Reroute a message coming in through a gateway
-        /// </summary>
-        /// <param name="message"></param>
-        internal void RerouteMessage(Message message)
-        {
-            ResendMessageImpl(message);
-        }
-
         internal bool TryResendMessage(Message message)
         {
             if (!message.MayResend(this.messagingOptions.MaxResendCount)) return false;
@@ -601,7 +592,10 @@ namespace Orleans.Runtime
         private void ResendMessageImpl(Message message, ActivationAddress forwardingAddress = null)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.Debug("Resend {0}", message);
-            message.TargetHistory = message.GetTargetHistory();
+            if (message.ForwardCount > 1)
+            {
+                message.TargetHistory = message.GetTargetHistory();
+            }
 
             if (message.TargetGrain.IsSystemTarget)
             {

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -569,6 +569,15 @@ namespace Orleans.Runtime
             }
         }
 
+        /// <summary>
+        /// Reroute a message coming in through a gateway
+        /// </summary>
+        /// <param name="message"></param>
+        internal void RerouteMessage(Message message)
+        {
+            ResendMessageImpl(message);
+        }
+
         internal bool TryResendMessage(Message message)
         {
             if (!message.MayResend(this.messagingOptions.MaxResendCount)) return false;

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -187,7 +187,7 @@ namespace Orleans.Runtime
             // Initialize the message center
             messageCenter = Services.GetRequiredService<MessageCenter>();
             var dispatcher = this.Services.GetRequiredService<Dispatcher>();
-            messageCenter.RerouteHandler = message => dispatcher.SendMessage(message);
+            messageCenter.RerouteHandler = dispatcher.RerouteMessage;
             messageCenter.SniffIncomingMessage = runtimeClient.SniffIncomingMessage;
 
             // Now the router/directory service

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -187,7 +187,7 @@ namespace Orleans.Runtime
             // Initialize the message center
             messageCenter = Services.GetRequiredService<MessageCenter>();
             var dispatcher = this.Services.GetRequiredService<Dispatcher>();
-            messageCenter.RerouteHandler = dispatcher.RerouteMessage;
+            messageCenter.RerouteHandler = message => dispatcher.SendMessage(message);
             messageCenter.SniffIncomingMessage = runtimeClient.SniffIncomingMessage;
 
             // Now the router/directory service


### PR DESCRIPTION
Results in 1.5Kb less allocs per call and ~17us faster RTT

Before: 

 Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
------- |---------:|---------:|---------:|-------:|----------:|
   Ping | 375.3 us | 166.1 us | 9.387 us | 3.4180 |  15.83 KB |

After:

 Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
------- |---------:|---------:|---------:|-------:|----------:|
   Ping | 353.9 us | 6.983 us | 13.78 us | 3.4180 |  14.28 KB |
