### PR TITLE
Use linked list for activation message queue

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -1091,7 +1091,7 @@ namespace Orleans.Runtime
         {
             lock (activation)
             {
-                List<Message> msgs = activation.DequeueAllWaitingMessages();
+                var msgs = activation.DequeueAllWaitingMessages();
                 if (msgs == null || msgs.Count <= 0) return;
 
                 if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(ErrorCode.Catalog_RerouteAllQueuedMessages, String.Format("RerouteAllQueuedMessages: {0} msgs from Invalid activation {1}.", msgs.Count(), activation));
@@ -1112,7 +1112,7 @@ namespace Orleans.Runtime
         {
             lock (activation)
             {
-                List<Message> msgs = activation.DequeueAllWaitingMessages();
+                var msgs = activation.DequeueAllWaitingMessages();
                 if (msgs == null || msgs.Count <= 0) return;
 
                 if (logger.IsEnabled(LogLevel.Debug))

--- a/src/Orleans.Runtime/Core/Dispatcher.cs
+++ b/src/Orleans.Runtime/Core/Dispatcher.cs
@@ -484,7 +484,7 @@ namespace Orleans.Runtime
         }
 
         internal void ProcessRequestsToInvalidActivation(
-            List<Message> messages,
+            ICollection<Message> messages,
             ActivationAddress oldAddress,
             ActivationAddress forwardingAddress, 
             string failedOperation,


### PR DESCRIPTION
* Instead of a `List<T>`, use a `LinkedList<T>` for an activation's message queue.
* Responses are added to the front of the queue, Requests are added to the back of the queue.