### PR TITLE
Remove per-call timer allocation

### DIFF
--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -1,111 +1,48 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Orleans.Configuration;
 using Orleans.Transactions;
 
 namespace Orleans.Runtime
 {
-    /// <summary>
-    /// This interface is for use with the Orleans timers.
-    /// </summary>
-    internal interface ITimebound
+    internal class CallbackData
     {
-        /// <summary>
-        /// This method is called by the timer when the time out is reached.
-        /// </summary>
-        void OnTimeout();
-        TimeSpan RequestedTimeout();
-    }
-
-    internal class CallbackData : ITimebound, IDisposable
-    {
-        private readonly Action<Message, TaskCompletionSource<object>> callback;
-        private readonly Func<Message, bool> resendFunc;
-        private readonly Action<Message> unregister;
+        private readonly SharedCallbackData shared;
         private readonly TaskCompletionSource<object> context;
-        private readonly MessagingOptions messagingOptions;
+        private ValueStopwatch stopwatch;
 
-        private bool alreadyFired;
-        private TimeSpan timeout;
-        private SafeTimer timer;
-        private ITimeInterval timeSinceIssued;
-        private readonly ILogger logger;
-        private readonly ILogger timerLogger;
-        private readonly ApplicationRequestsStatisticsGroup requestStatistics;
+        public CallbackData(
+            SharedCallbackData shared,
+            TaskCompletionSource<object> ctx, 
+            Message msg)
+        {
+            this.shared = shared;
+            this.context = ctx;
+            this.Message = msg;
+            this.TransactionInfo = TransactionContext.GetTransactionInfo();
+            this.stopwatch = ValueStopwatch.StartNew();
+        }
+
         public ITransactionInfo TransactionInfo { get; set; }
 
         public Message Message { get; set; } // might hold metadata used by response pipeline
 
-        public CallbackData(
-            Action<Message, TaskCompletionSource<object>> callback, 
-            Func<Message, bool> resendFunc, 
-            TaskCompletionSource<object> ctx, 
-            Message msg, 
-            Action<Message> unregisterDelegate,
-            MessagingOptions messagingOptions,
-            ILogger logger,
-            ILogger timerLogger,
-            ApplicationRequestsStatisticsGroup requestStatistics)
+        public bool IsCompleted { get; private set; }
+
+        public bool IsExpired(long currentTimestamp)
         {
-            // We are never called without a callback func, but best to double check.
-            if (callback == null) throw new ArgumentNullException(nameof(callback));
-            // We are never called without a resend func, but best to double check.
-            if (resendFunc == null) throw new ArgumentNullException(nameof(resendFunc));
-            this.logger = logger;
-            this.callback = callback;
-            this.resendFunc = resendFunc;
-            context = ctx;
-            Message = msg;
-            unregister = unregisterDelegate;
-            alreadyFired = false;
-            this.messagingOptions = messagingOptions;
-            this.TransactionInfo = TransactionContext.GetTransactionInfo();
-            this.timerLogger = timerLogger;
-            this.requestStatistics = requestStatistics;
+            return currentTimestamp - this.stopwatch.GetRawTimestamp() > this.shared.ResponseTimeoutStopwatchTicks;
         }
 
-        /// <summary>
-        /// Start this callback timer
-        /// </summary>
-        /// <param name="time">Timeout time</param>
-        public void StartTimer(TimeSpan time)
+        public void OnTimeout(TimeSpan timeout)
         {
-            if (time < TimeSpan.Zero)
-                throw new ArgumentOutOfRangeException(nameof(time), "The timeout parameter is negative.");
-            timeout = time;
-            if (this.requestStatistics.CollectApplicationRequestsStats)
-            {
-                timeSinceIssued = TimeIntervalFactory.CreateTimeInterval(true);
-                timeSinceIssued.Start();
-            }
-
-            TimeSpan firstPeriod = timeout;
-            TimeSpan repeatPeriod = Constants.INFINITE_TIMESPAN; // Single timeout period --> No repeat
-            if (messagingOptions.ResendOnTimeout && messagingOptions.MaxResendCount > 0)
-            {
-                firstPeriod = repeatPeriod = timeout.Divide(messagingOptions.MaxResendCount + 1);
-            }
-            // Start time running
-            DisposeTimer();
-            timer = new SafeTimer(this.timerLogger, TimeoutCallback, null, firstPeriod, repeatPeriod);
-
-        }
-
-        private void TimeoutCallback(object obj)
-        {
-            OnTimeout();
-        }
-
-        public void OnTimeout()
-        {
-            if (alreadyFired)
+            if (this.IsCompleted)
                 return;
-            var msg = Message; // Local working copy
+            var msg = this.Message; // Local working copy
 
             string messageHistory = msg.GetTargetHistory();
             string errorMsg = $"Response did not arrive on time in {timeout} for message: {msg}. Target History is: {messageHistory}.";
-            logger.Warn(ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
+            this.shared.Logger.Warn(ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
 
             var error = Message.CreatePromptExceptionResponse(msg, new TimeoutException(errorMsg));
             OnFail(msg, error, "OnTimeout - Resend {0} for {1}", true);
@@ -113,14 +50,14 @@ namespace Orleans.Runtime
 
         public void OnTargetSiloFail()
         {
-            if (alreadyFired)
+            if (this.IsCompleted)
                 return;
 
-            var msg = Message;
+            var msg = this.Message;
             var messageHistory = msg.GetTargetHistory();
             string errorMsg = 
                 $"The target silo became unavailable for message: {msg}. Target History is: {messageHistory}. See {Constants.TroubleshootingHelpLink} for troubleshooting help.";
-            logger.Warn(ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
+            this.shared.Logger.Warn(ErrorCode.Runtime_Error_100157, "{0} About to break its promise.", errorMsg);
 
             var error = Message.CreatePromptExceptionResponse(msg, new SiloUnavailableException(errorMsg));
             OnFail(msg, error, "On silo fail - Resend {0} for {1}");
@@ -128,95 +65,73 @@ namespace Orleans.Runtime
 
         public void DoCallback(Message response)
         {
-            if (alreadyFired)
+            if (this.IsCompleted)
                 return;
+            var requestStatistics = this.shared.RequestStatistics;
             lock (this)
             {
-                if (alreadyFired)
+                if (this.IsCompleted)
                     return;
 
                 if (response.Result == Message.ResponseTypes.Rejection && response.RejectionType == Message.RejectionTypes.Transient)
                 {
-                    if (resendFunc(Message))
+                    if (this.shared.ShouldResend(this.Message))
                     {
                         return;
                     }
                 }
 
-                alreadyFired = true;
-                DisposeTimer();
-                if (this.requestStatistics.CollectApplicationRequestsStats)
+                this.IsCompleted = true;
+                if (requestStatistics.CollectApplicationRequestsStats)
                 {
-                    timeSinceIssued.Stop();
+                    this.stopwatch.Stop();
                 }
-                unregister?.Invoke(Message);
+
+                this.shared.Unregister(this.Message);
             }
-            if (this.requestStatistics.CollectApplicationRequestsStats)
+
+            if (requestStatistics.CollectApplicationRequestsStats)
             {
-                this.requestStatistics.OnAppRequestsEnd(timeSinceIssued.Elapsed);
+                requestStatistics.OnAppRequestsEnd(this.stopwatch.Elapsed);
             }
+
             // do callback outside the CallbackData lock. Just not a good practice to hold a lock for this unrelated operation.
-            callback(response, context);
-        }
-
-        public void Dispose()
-        {
-            DisposeTimer();
-            GC.SuppressFinalize(this);
-        }
-
-        private void DisposeTimer()
-        {
-            try
-            {
-                var tmp = timer;
-                if (tmp != null)
-                {
-                    timer = null;
-                    tmp.Dispose();
-                }
-            }
-            catch (Exception) { } // Ignore any problems with Dispose
+            this.shared.ResponseCallback(response, this.context);
         }
 
         private void OnFail(Message msg, Message error, string resendLogMessageFormat, bool isOnTimeout = false)
         {
+            var requestStatistics = this.shared.RequestStatistics;
             lock (this)
             {
-                if (alreadyFired)
+                if (this.IsCompleted)
                     return;
 
-                if (messagingOptions.ResendOnTimeout && resendFunc(msg))
+                if (this.shared.MessagingOptions.ResendOnTimeout && this.shared.ShouldResend(msg))
                 {
-                    if (logger.IsEnabled(LogLevel.Debug)) logger.Debug(resendLogMessageFormat, msg.ResendCount, msg);
+                    if (this.shared.Logger.IsEnabled(LogLevel.Debug)) this.shared.Logger.Debug(resendLogMessageFormat, msg.ResendCount, msg);
                     return;
                 }
 
-                alreadyFired = true;
-                DisposeTimer();
-                if (this.requestStatistics.CollectApplicationRequestsStats)
+                this.IsCompleted = true;
+                if (requestStatistics.CollectApplicationRequestsStats)
                 {
-                    timeSinceIssued.Stop();
+                    this.stopwatch.Stop();
                 }
 
-                unregister?.Invoke(Message);
+                this.shared.Unregister(this.Message);
             }
             
-            if (this.requestStatistics.CollectApplicationRequestsStats)
+            if (requestStatistics.CollectApplicationRequestsStats)
             {
-                this.requestStatistics.OnAppRequestsEnd(timeSinceIssued.Elapsed);
+                requestStatistics.OnAppRequestsEnd(this.stopwatch.Elapsed);
                 if (isOnTimeout)
                 {
-                    this.requestStatistics.OnAppRequestsTimedOut();
+                    requestStatistics.OnAppRequestsTimedOut();
                 }
             }
 
-            callback(error, context);
-        }
-
-        public TimeSpan RequestedTimeout()
-        {
-            return timeout;
+            this.shared.ResponseCallback(error, this.context);
         }
     }
 }

--- a/src/Orleans.Core/Runtime/IRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/IRuntimeClient.cs
@@ -49,7 +49,7 @@ namespace Orleans.Runtime
         /// <param name="timeout">New response timeout value</param>
         void SetResponseTimeout(TimeSpan timeout);
 
-        void SendRequest(GrainReference target, InvokeMethodRequest request, TaskCompletionSource<object> context, Action<Message, TaskCompletionSource<object>> callback, string debugContext = null, InvokeMethodOptions options = InvokeMethodOptions.None, string genericArguments = null);
+        void SendRequest(GrainReference target, InvokeMethodRequest request, TaskCompletionSource<object> context, string debugContext = null, InvokeMethodOptions options = InvokeMethodOptions.None, string genericArguments = null);
 
         void SendResponse(Message request, Response response);
 

--- a/src/Orleans.Core/Runtime/SharedCallbackData.cs
+++ b/src/Orleans.Core/Runtime/SharedCallbackData.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using Orleans.Serialization;
+
+namespace Orleans.Runtime
+{
+    internal class SharedCallbackData
+    {
+        private readonly SerializationManager serializationManager;
+        public readonly Func<Message, bool> ShouldResend;
+        public readonly Action<Message> Unregister;
+        public readonly ILogger Logger;
+        public readonly MessagingOptions MessagingOptions;
+        public long ResponseTimeoutStopwatchTicks;
+
+        public SharedCallbackData(
+            Func<Message, bool> resendFunc,
+            Action<Message> unregister,
+            ILogger logger,
+            MessagingOptions messagingOptions,
+            SerializationManager serializationManager,
+            ApplicationRequestsStatisticsGroup requestStatistics)
+        {
+            RequestStatistics = requestStatistics;
+            this.ShouldResend = resendFunc;
+            this.Unregister = unregister;
+            this.serializationManager = serializationManager;
+            this.Logger = logger;
+            this.MessagingOptions = messagingOptions;
+            this.ResponseTimeout = messagingOptions.ResponseTimeout;
+        }
+
+        public ApplicationRequestsStatisticsGroup RequestStatistics { get; }
+
+        public TimeSpan ResponseTimeout
+        {
+            get => this.MessagingOptions.ResponseTimeout;
+            set
+            {
+                this.MessagingOptions.ResponseTimeout = value;
+                this.ResponseTimeoutStopwatchTicks = (long)(value.TotalSeconds * Stopwatch.Frequency);
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        public void ResponseCallback(Message message, TaskCompletionSource<object> context)
+        {
+            Response response;
+            if (message.Result != Message.ResponseTypes.Rejection)
+            {
+                try
+                {
+                    response = (Response)message.GetDeserializedBody(this.serializationManager);
+                }
+                catch (Exception exc)
+                {
+                    //  catch the Deserialize exception and break the promise with it.
+                    response = Response.ExceptionResponse(exc);
+                }
+            }
+            else
+            {
+                Exception rejection;
+                switch (message.RejectionType)
+                {
+                    case Message.RejectionTypes.GatewayTooBusy:
+                        rejection = new GatewayTooBusyException();
+                        break;
+                    case Message.RejectionTypes.DuplicateRequest:
+                        return; // Ignore duplicates
+
+                    default:
+                        rejection = message.GetDeserializedBody(this.serializationManager) as Exception;
+                        if (rejection == null)
+                        {
+                            if (string.IsNullOrEmpty(message.RejectionInfo))
+                            {
+                                message.RejectionInfo = "Unable to send request - no rejection info available";
+                            }
+                            rejection = new OrleansMessageRejectionException(message.RejectionInfo);
+                        }
+                        break;
+                }
+                response = Response.ExceptionResponse(rejection);
+            }
+
+            if (!response.ExceptionFlag)
+            {
+                context.TrySetResult(response.Data);
+            }
+            else
+            {
+                context.TrySetException(response.Exception);
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Timers/ValueStopwatch.cs
+++ b/src/Orleans.Core/Timers/ValueStopwatch.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Diagnostics;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// Non-allocating stopwatch for timing durations.
+    /// </summary>
+    internal struct ValueStopwatch
+    {
+        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double) Stopwatch.Frequency;
+        private long value;
+
+        /// <summary>
+        /// Starts a new instance.
+        /// </summary>
+        /// <returns>A new, running stopwatch.</returns>
+        public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+        
+        private ValueStopwatch(long timestamp)
+        {
+            this.value = timestamp;
+        }
+
+        /// <summary>
+        /// Returns true if this instance is running or false otherwise.
+        /// </summary>
+        public bool IsRunning => this.value > 0;
+        
+        /// <summary>
+        /// Returns the elapsed time.
+        /// </summary>
+        public TimeSpan Elapsed => TimeSpan.FromTicks(this.ElapsedTicks);
+
+        /// <summary>
+        /// Returns the elapsed ticks.
+        /// </summary>
+        public long ElapsedTicks
+        {
+            get
+            {
+                // A positive timestamp value indicates the start time of a running stopwatch,
+                // a negative value indicates the negative total duration of a stopped stopwatch.
+                var timestamp = this.value;
+                
+                long delta;
+                if (this.IsRunning)
+                {
+                    // The stopwatch is still running.
+                    var start = timestamp;
+                    var end = Stopwatch.GetTimestamp();
+                    delta = end - start;
+                }
+                else
+                {
+                    // The stopwatch has been stopped.
+                    delta = -timestamp;
+                }
+
+                return (long) (delta * TimestampToTicks);
+            }
+        }
+
+        /// <summary>
+        /// Gets the raw counter value for this instance.
+        /// </summary>
+        /// <remarks> 
+        /// A positive timestamp value indicates the start time of a running stopwatch,
+        /// a negative value indicates the negative total duration of a stopped stopwatch.
+        /// </remarks>
+        /// <returns>The raw counter value.</returns>
+        public long GetRawTimestamp() => this.value;
+
+        /// <summary>
+        /// Starts the stopwatch.
+        /// </summary>
+        public void Start()
+        {
+            var timestamp = this.value;
+            
+            // If already started, do nothing.
+            if (this.IsRunning) return;
+
+            // Stopwatch is stopped, therefore value is zero or negative.
+            // Add the negative value to the current timestamp to start the stopwatch again.
+            var newValue = Stopwatch.GetTimestamp() + timestamp;
+            if (newValue == 0) newValue = 1;
+            this.value = newValue;
+        }
+
+        /// <summary>
+        /// Restarts this stopwatch, begining from zero time elapsed.
+        /// </summary>
+        public void Restart() => this.value = Stopwatch.GetTimestamp();
+
+        /// <summary>
+        /// Stops this stopwatch.
+        /// </summary>
+        public void Stop()
+        {
+            var timestamp = this.value;
+
+            // If already stopped, do nothing.
+            if (!this.IsRunning) return;
+
+            var end = Stopwatch.GetTimestamp();
+            var delta = end - timestamp;
+
+            this.value = -delta;
+        }
+    }
+}


### PR DESCRIPTION
* Split `CallbackData` into `CallbackData` & `SharedCallbackData` to reduce the weight of each `CallbackData` and the cost associated with creating it.
* Avoid starting a .NET Timer for every grain call, instead, use a single timer in the runtime client and expire calls in succession

The timer period is set to 1 second in this PR - I figure that is a fine interval, but we could reduce it as we see fit, or make it configurable.

These callback timers were causing significant contention (due to how .NET's Timer class is implemented) and allocating ~400 bytes per call

cc @dVakulen - we talked about this back in January & Dmytro has an implementation of a timer wheel which may be suitable to use for Grain timers (which this PR doesn't address)