### PR TITLE
Fix client connection retry

### DIFF
--- a/test/Tester/ClientConnectionTests/ClusterClientTests.cs
+++ b/test/Tester/ClientConnectionTests/ClusterClientTests.cs
@@ -41,7 +41,7 @@ namespace Tester.ClientConnectionTests
 
             Task<bool> RetryFunc(Exception exception)
             {
-                Assert.IsType<OrleansException>(exception);
+                Assert.IsType<SiloUnavailableException>(exception);
                 exceptions.Add(exception);
                 gatewayProvider.Gateways = new List<Uri> {gwEndpoint.ToGatewayUri()}.AsReadOnly();
                 return Task.FromResult(true);


### PR DESCRIPTION
Fixes #4427 

Exceptions in `RefreshGrainTypeResolver` are ignored, which is fine for the refresh case but not fine for the startup case.