### PR TITLE
Improve Dictionary allocation

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
@@ -76,18 +76,18 @@ namespace Orleans.Runtime
         {
             var values = CallContextData.Value;
 
-            if (values == null)
+            if (values != null)
             {
-                values = new Dictionary<string, object>();
+                values[key] = value;
             }
             else
             {
-                // Have to copy the actual Dictionary value, mutate it and set it back.
-                // http://blog.stephencleary.com/2013/04/implicit-async-context-asynclocal.html
-                // This is since LLC is only copy-on-write copied only upon LogicalSetData.
-                values = new Dictionary<string, object>(values);
+                values = new Dictionary<string, object>
+                {
+                    { key, value }
+                };
             }
-            values[key] = value;
+
             CallContextData.Value = values;
         }
 

--- a/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
@@ -76,7 +76,11 @@ namespace Orleans.Runtime
         {
             var values = CallContextData.Value;
 
-            if (values != null)
+            if (values == null)
+            {
+                values = new Dictionary<string, object>(1);
+            }
+            else
             {
                 var hadPreviousValue = values.ContainsKey(key);
                 var newValues = new Dictionary<string, object>(values.Count + (hadPreviousValue ? 0 : 1));
@@ -87,11 +91,6 @@ namespace Orleans.Runtime
 
                 values = newValues;
             }
-            else
-            {
-                values = new Dictionary<string, object>(1);
-            }
-
             values[key] = value;
             CallContextData.Value = values;
         }

--- a/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
@@ -78,16 +78,21 @@ namespace Orleans.Runtime
 
             if (values != null)
             {
-                values[key] = value;
+                var hadPreviousValue = values.ContainsKey(key);
+                var newValues = new Dictionary<string, object>(values.Count + (hadPreviousValue ? 0 : 1));
+                foreach (var pair in values)
+                {
+                    newValues.Add(pair.Key, pair.Value);
+                }
+
+                values = newValues;
             }
             else
             {
-                values = new Dictionary<string, object>
-                {
-                    { key, value }
-                };
+                values = new Dictionary<string, object>(1);
             }
 
+            values[key] = value;
             CallContextData.Value = values;
         }
 

--- a/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
@@ -82,6 +82,9 @@ namespace Orleans.Runtime
             }
             else
             {
+                // Have to copy the actual Dictionary value, mutate it and set it back.
+                // This is since AsyncLocal copies link to dictionary, not create a new one.
+                // So we need to make sure that modifying the value, we doesn't affect other threads.
                 var hadPreviousValue = values.ContainsKey(key);
                 var newValues = new Dictionary<string, object>(values.Count + (hadPreviousValue ? 0 : 1));
                 foreach (var pair in values)


### PR DESCRIPTION
https://github.com/dotnet/orleans/issues/4313 
Approach proposed in the ticket couldn't be done. Even if we use AsyncLocal, Value that is stored is a reference type, so when we enter a new thread and AsyncLocal copies Value of instance from previous thread, it copies a link. So when we edit dictionary, we edit the same dictionary that was used in previous thread. That's why need to reallocate dictionary each time we call Set.
It would be great if we could understand that this call of Set method is the first per current thread, but AsyncLocal class doesn't provide such feature. So allocating a dictionary each time we call Set is the only way to make sure that it doesn't depend on dictionaries from other threads. 

But I found similar case in CoreClr repository. They also reallocate dictionary inside AsyncLocal too often. So they added minor improvement that should decrease size of memory allocation.
dotnet/coreclr@9bc06f7
I added the similar improvement to RequestContext.cs.