### PR TITLE
Revert "Reduce allocs in Interner (#4395)"

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/ActivationAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/ActivationAddress.cs
@@ -1,16 +1,13 @@
 using System;
-using Orleans.Core.Abstractions.Internal;
 
 namespace Orleans.Runtime
 {
     [Serializable]
     internal class ActivationAddress
     {
-        private static readonly Interner<ValueTuple<SiloAddress, GrainId, ActivationId>, ActivationAddress> interner =
-            new Interner<(SiloAddress, GrainId, ActivationId), ActivationAddress>(128, TimeSpan.FromMinutes(1));
-        public GrainId Grain { get; }
-        public ActivationId Activation { get; }
-        public SiloAddress Silo { get; }
+        public GrainId Grain { get; private set; }
+        public ActivationId Activation { get; private set; }
+        public SiloAddress Silo { get; private set; }
 
         public bool IsComplete
         {
@@ -35,7 +32,7 @@ namespace Orleans.Runtime
             // Silo part is not mandatory
             if (grain == null) throw new ArgumentNullException("grain");
 
-            return interner.FindOrCreate((silo, grain, activation), key => new ActivationAddress(key.Item1, key.Item2, key.Item3));
+            return new ActivationAddress(silo, grain, activation);
         }
 
         public override bool Equals(object obj)

--- a/src/Orleans.Core.Abstractions/Internal/Interner.cs
+++ b/src/Orleans.Core.Abstractions/Internal/Interner.cs
@@ -57,8 +57,6 @@ namespace Orleans.Core.Abstractions.Internal
         [NonSerialized]
         private readonly ConcurrentDictionary<K, WeakReference<T>> internCache;
 
-        private static readonly Func<T, T> NoOpCreatorFunc = o => o;
-
         public Interner()
             : this(InternerConstants.SIZE_SMALL)
         {
@@ -89,19 +87,6 @@ namespace Orleans.Core.Abstractions.Internal
         /// <returns>Object with specified key - either previous cached copy or newly created</returns>
         public T FindOrCreate(K key, Func<K, T> creatorFunc)
         {
-            return FindOrCreate(key, creatorFunc, key);
-        }
-
-
-        /// <summary>
-        /// Find cached copy of object with specified key, otherwise create new one using the supplied creator-function.
-        /// </summary>
-        /// <param name="key">key to find</param>
-        /// <param name="creatorFunc">function to create new object and store for this key if no cached copy exists</param>
-        /// <param name="state">value passed as an argument to <paramref name="creatorFunc"/></param>
-        /// <returns>Object with specified key - either previous cached copy or newly created</returns>
-        public T FindOrCreate<TState>(K key, Func<TState, T> creatorFunc, TState state)
-        {
             T result;
             WeakReference<T> cacheEntry;
 
@@ -111,7 +96,7 @@ namespace Orleans.Core.Abstractions.Internal
             // If no cache entry exists, create and insert a new one using the creator function.
             if (cacheEntry == null)
             {
-                result = creatorFunc(state);
+                result = creatorFunc(key);
                 cacheEntry = new WeakReference<T>(result);
                 internCache[key] = cacheEntry;
                 return result;
@@ -122,7 +107,7 @@ namespace Orleans.Core.Abstractions.Internal
             if (result == null)
             {
                 // Create new object and ensure the entry is still valid by re-inserting it into the cache.
-                result = creatorFunc(state);
+                result = creatorFunc(key);
                 cacheEntry.SetTarget(result);
                 internCache[key] = cacheEntry;
             }
@@ -138,7 +123,8 @@ namespace Orleans.Core.Abstractions.Internal
         public bool TryFind(K key, out T obj)
         {
             obj = null;
-            return internCache.TryGetValue(key, out var cacheEntry) && cacheEntry != null && cacheEntry.TryGetTarget(out obj);
+            WeakReference<T> cacheEntry;
+            return internCache.TryGetValue(key, out cacheEntry) && cacheEntry != null && cacheEntry.TryGetTarget(out obj);
         }
 
         /// <summary>
@@ -149,7 +135,7 @@ namespace Orleans.Core.Abstractions.Internal
         /// <returns>Object with specified key - either previous cached copy or justed passed in</returns>
         public T Intern(K key, T obj)
         {
-            return FindOrCreate(key, NoOpCreatorFunc, obj);
+            return FindOrCreate(key, _ => obj);
         }
 
         public void StopAndClear()


### PR DESCRIPTION
This reverts commit 10c3834c61c59f9285d525617926d2533c87654c.
Looks like #4395 caused a performance regression.